### PR TITLE
[codex] Add cyber VC analyst workflow

### DIFF
--- a/skills/note-taking/obsidian/SKILL.md
+++ b/skills/note-taking/obsidian/SKILL.md
@@ -12,11 +12,11 @@ Use this skill for filesystem-first Obsidian vault work: reading notes, listing 
 
 Use a known or resolved vault path before calling file tools.
 
-The documented vault-path convention is the `OBSIDIAN_VAULT_PATH` environment variable, for example from `${HERMES_HOME:-~/.hermes}/.env`. If it is unset, use `~/Documents/Obsidian Vault`.
+The documented vault-path convention is the `OBSIDIAN_VAULT_PATH` environment variable, for example from `${HERMES_HOME:-~/.hermes}/.env`. If it is unset, check `~/Library/Application Support/obsidian/obsidian.json` and use the currently open vault path when available. Only fall back to `~/Documents/Obsidian Vault` if neither source is available.
 
 File tools do not expand shell variables. Do not pass paths containing `$OBSIDIAN_VAULT_PATH` to `read_file`, `write_file`, `patch`, or `search_files`; resolve the vault path first and pass a concrete absolute path. Vault paths may contain spaces, which is another reason to prefer file tools over shell commands.
 
-If the vault path is unknown, `terminal` is acceptable for resolving `OBSIDIAN_VAULT_PATH` or checking whether the fallback path exists. Once the path is known, switch back to file tools.
+If the vault path is unknown, `terminal` is acceptable for resolving `OBSIDIAN_VAULT_PATH`, inspecting `~/Library/Application Support/obsidian/obsidian.json`, or checking whether the fallback path exists. Once the path is known, switch back to file tools.
 
 ## Read a note
 

--- a/skills/research/cyber-vc-analyst/SKILL.md
+++ b/skills/research/cyber-vc-analyst/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: cyber-vc-analyst
+description: "Use when analyzing an early-stage cybersecurity startup or a cybersecurity market theme for venture investment. Produces a structured company IC memo or thematic market memo using vault notes, Return on Security MCP market intelligence when available, and clearly separated facts, inferences, and assumptions."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [cybersecurity, venture, investing, startup, obsidian, mcp, research]
+    category: research
+    related_skills: [obsidian, llm-wiki, native-mcp]
+    config:
+      - key: cyber_vc_analyst.meeting_search_roots
+        description: Vault folders to search first for prior founder and meeting notes before falling back to a broader vault search
+        default:
+          - 4.Resources/Interactions
+          - 4.Resources/People
+          - 4.Resources/Reviews/Daily Notes
+        prompt: Vault folders for prior founder and meeting notes (YAML list)
+      - key: cyber_vc_analyst.company_search_roots
+        description: Vault folders to search first for existing company pages, market maps, and investment notes before falling back to a broader vault search
+        default:
+          - 4.Resources/Companies
+        prompt: Vault folders for company and market notes (YAML list)
+      - key: cyber_vc_analyst.output_root
+        description: Vault folder where final cybersecurity investment memos should be written
+        default: 4.Resources/Companies
+        prompt: Vault output folder for final cybersecurity investment memos
+      - key: cyber_vc_analyst.theme_output_root
+        description: Vault folder where thematic cybersecurity market analyses should be written when the user asks to save them
+        default: 3.Areas/cyber futures frontier
+        prompt: Vault output folder for thematic cybersecurity market analyses
+      - key: cyber_vc_analyst.default_stage
+        description: Default company stage label to use when the evidence is incomplete
+        default: seed
+        prompt: Default company stage label
+      - key: cyber_vc_analyst.default_geography
+        description: Default geography label to use when the evidence is incomplete
+        default: ""
+        prompt: Default geography label
+---
+
+# Cybersecurity Venture Analyst
+
+Produce a structured investment-committee memo for either:
+
+- a pre-seed or seed-stage cybersecurity startup
+- a cybersecurity market theme, category, or architectural shift
+
+The output should be grounded in evidence and reusable inside a long-term
+knowledge base.
+
+This skill combines three evidence streams:
+
+1. prior private context from the user's Obsidian vault
+2. market intelligence from Return on Security MCP when available
+3. public information from Hermes web tools when needed and available
+
+Never blur those sources together. Preserve a clear line between verified fact,
+reasonable inference, and assumption.
+
+## When to Use
+
+Use this skill when the user asks for:
+
+- an investment view on a cybersecurity startup
+- a seed or pre-seed cybersecurity company memo
+- a market thesis on a cybersecurity theme, category, or architecture shift
+- a thematic map of a cyber segment and the likely winners or losers
+- a venture assessment, IC memo, or market map entry for a cyber company
+- comparison-ready notes on founders, product, category, or defensibility
+- a write-back into the user's vault so future analyses compound
+
+Do not use this skill for:
+
+- public-equity valuation or late-stage financial modeling
+- a generic TAM deck with no company-specific assessment
+- technical security due diligence on a product implementation
+- penetration testing, threat hunting, or incident response
+
+## Inputs
+
+Expected user input for company mode:
+
+- company name
+- optional company URL
+- optional founder names
+- optional product description or category hint
+- optional specific notes, folders, or prior memos to include
+
+Expected user input for theme mode:
+
+- theme or category name
+- optional geography
+- optional time horizon
+- optional company set to include or exclude
+- optional specific vault notes, folders, or prior memos to include
+
+If key identifiers are missing, infer cautiously from the conversation and state
+the assumption in the memo.
+
+## Mode Selection
+
+Choose the mode before gathering evidence.
+
+Use **company mode** when the prompt centers on one company, founder team, or
+startup investment decision.
+
+Use **theme mode** when the prompt centers on:
+
+- a cybersecurity category
+- an investment theme
+- a buyer workflow shift
+- an architectural transition
+- a market map or landscape
+- a question about which cyber areas are attractive or crowded
+
+If the prompt mentions both a company and a broader theme, default to company
+mode and use the theme only as context unless the user explicitly asks for a
+thematic memo.
+
+For concrete prompt patterns, read `references/example-invocations.md`.
+
+## Vault Rules
+
+Resolve the Obsidian vault path first using the `obsidian` skill conventions:
+
+- use `OBSIDIAN_VAULT_PATH` when set
+- otherwise read `~/Library/Application Support/obsidian/obsidian.json` and use the
+  currently open vault path when available
+- only fall back to `~/Documents/Obsidian Vault` if neither source is available
+
+Use Hermes file tools once the vault path is known:
+
+- use `search_files` for filename and content search
+- use `read_file` for note inspection
+- use `write_file` for final memo creation or full-note replacement
+- use `patch` only when a targeted anchored update is safer than rewriting
+
+Treat vault notes as private first-party context. They are not public evidence.
+Use them to recover:
+
+- who the user has met
+- what prior conversations imply about the company, founders, and market
+- what the user's existing mental models, market maps, and competitor lists contain
+
+Search order:
+
+1. configured `cyber_vc_analyst.meeting_search_roots`
+2. configured `cyber_vc_analyst.company_search_roots`
+3. broader vault search only if the configured roots are empty or yield little
+
+Prefer targeted searches for:
+
+- company name and aliases
+- founder names
+- product names
+- category phrases
+- competitor names already mentioned in the vault
+- theme names and adjacent category terms when in theme mode
+
+For content searches, prefer `search_files` with `target: "content"` and
+`file_glob: "*.md"`. For note listing, prefer `target: "files"`.
+
+Read only the most relevant notes. Do not scan the whole vault unless the
+configured roots are empty and narrower search failed.
+
+## MCP Rules
+
+Before using broad public search, inspect the available tool list for either:
+
+- `mcp_returnonsecurity_*`
+- `mcp_signal_mcp_*`
+
+If Return on Security MCP tools are available:
+
+- use them as the preferred source for market structure, category context,
+  competitor discovery, trend validation, likely acquirers, and adjacent themes
+- prefer the smallest tool or tool sequence that answers the question
+- cite the MCP-derived point as market intelligence, not as a firsthand company fact
+
+If Return on Security MCP tools are unavailable:
+
+- continue with vault notes plus public sources if Hermes web tools exist
+- explicitly note in the memo that ROS MCP market intelligence was unavailable
+- reduce confidence where the missing market view materially weakens the conclusion
+
+If both ROS MCP and public web tools are unavailable, still produce the memo from
+vault context and user-provided information, but call out the evidence gap.
+
+For setup instructions or alias expectations, read
+`references/mcp-setup.md`.
+
+## Workflow
+
+1. Identify the subject.
+   In company mode, confirm the legal or commonly used company name, website,
+   founders, and claimed category if known. In theme mode, confirm the theme,
+   scope, buyer context, and time horizon.
+
+2. Recover prior vault knowledge.
+   Search configured meeting and company roots first. Pull only notes that
+   materially change the assessment. In theme mode, bias toward category notes,
+   Matter/Readwise intelligence, and any existing company notes relevant to the
+   theme.
+
+3. Gather market context.
+   Use `mcp_returnonsecurity_*` or `mcp_signal_mcp_*` tools when available. If
+   they are absent and public web tools are available, use public sources to
+   fill category, competitive, and market-evolution gaps.
+
+4. Normalize the subject.
+   In company mode, classify the company using the rubric in
+   `references/taxonomy-rubric.md`. In theme mode, classify the theme, the
+   customer problem, the market maturity, and the adjacent categories.
+
+5. Draft the memo.
+   Follow the correct mode-specific output structure in
+   `references/output-template.md`.
+
+6. Distinguish evidence quality.
+   Every major conclusion should separate:
+   - facts
+   - reasonable inferences
+   - assumptions or unknowns
+
+7. Save the memo back to the vault when appropriate.
+   In company mode, write the finished Markdown note under the configured
+   `cyber_vc_analyst.output_root` using the company template's frontmatter and
+   filename rules.
+   In theme mode, save only when the user asks to save or maintain the theme in
+   the vault; write it under `cyber_vc_analyst.theme_output_root` using the
+   thematic template and filename rules.
+
+## Output Rules
+
+The deliverable is a Markdown memo suitable for chat output and optional vault
+storage. It must:
+
+- use the correct mode-specific template
+- avoid marketing language
+- be concise but analytical
+- rate and score where the template asks for ratings or scores
+- state missing information that would change the decision
+- stay comparison-friendly across companies in company mode
+- stay thesis-friendly and market-comparable across themes in theme mode
+
+For all scoring:
+
+- use the rubric anchors in `references/taxonomy-rubric.md`
+- do not inflate uncertain companies toward the middle by default
+- explain each score in one or two direct sentences
+
+When using vault-only evidence, label it clearly as prior private context.
+When using ROS MCP, label it clearly as market intelligence.
+When using public sources, label them as public evidence.
+
+## Vault Write-Back
+
+Write the final company-mode note to:
+
+- `<vault>/<output_root>/<company-slug>.md`
+
+Use lowercase kebab-case for the filename slug.
+
+Prefer `write_file` with the full final Markdown content unless there is a
+strong reason to make a smaller anchored update with `patch`.
+
+Include YAML frontmatter matching the template, including:
+
+- company
+- aliases
+- date
+- stage
+- recommendation
+- overall_score
+- primary_theme
+- secondary_themes
+- cyber_category
+- customer_type
+- buyer
+- geography
+- confidence
+- source_note_paths
+- used_returnonsecurity_mcp
+- tags
+
+If an existing note already exists for the same company:
+
+- read it first
+- preserve useful historical context
+- replace stale conclusions rather than appending contradictory summaries
+- keep the current memo date accurate
+
+Write the final theme-mode note to:
+
+- `<vault>/<theme_output_root>/theme-<theme-slug>.md`
+
+Use theme mode only for market, category, and thesis analysis. Thematic notes
+should include:
+
+- scope
+- geography
+- time_horizon
+- primary_theme
+- related_themes
+- key_companies
+- used_returnonsecurity_mcp
+- source_note_paths
+- confidence
+- tags
+
+Do not store a theme note under `4.Resources/Companies` unless the user
+explicitly asks for that override.
+
+## Common Pitfalls
+
+1. Treating vault notes as public evidence.
+   Keep private context separate from externally verifiable claims.
+
+2. Overstating certainty from thin startup data.
+   If the company is early and evidence is sparse, lower confidence instead of
+   inventing precision.
+
+3. Using generic cyber taxonomy.
+   Force the classification, themes, thesis mapping, and buyer analysis to fit
+   the actual company, not a canned category description.
+
+4. Letting competitor lists become exhaustive.
+   Focus on the set that sharpens the investment view, not every company in the
+   category.
+
+5. Forcing a company memo onto a thematic question.
+   Switch to theme mode when the user is asking about a market or thesis rather
+   than one startup.
+
+6. Writing a memo that cannot be compared later.
+   Preserve the exact section order, rating scales, and frontmatter fields.
+
+7. Depending on a specific ROS MCP tool name.
+   Depend only on the `mcp_returnonsecurity_*` or `mcp_signal_mcp_*` prefixes
+   and choose tools from the actual available list.
+
+## Verification Checklist
+
+- [ ] Vault path resolved before reading or writing notes
+- [ ] Configured search roots used before broader vault search
+- [ ] ROS MCP availability checked via `mcp_returnonsecurity_*` or
+      `mcp_signal_mcp_*` tool prefix
+- [ ] Correct mode selected before drafting
+- [ ] Company memo or thematic memo structure present as required
+- [ ] Major conclusions distinguish facts, inferences, and assumptions
+- [ ] Frontmatter populated when writing back to the vault
+- [ ] Output note saved under the correct company or theme output root
+- [ ] Missing information and confidence gaps stated explicitly

--- a/skills/research/cyber-vc-analyst/references/example-invocations.md
+++ b/skills/research/cyber-vc-analyst/references/example-invocations.md
@@ -1,0 +1,156 @@
+# Example Invocations
+
+Use these as prompt shapes when invoking `cyber-vc-analyst`.
+
+For Slack threads, prefer the `!cyber-vc-analyst ...` form because Slack blocks
+native slash commands inside thread replies.
+
+## 1. Standard company memo
+
+```text
+Analyze Noma Security as an early-stage cybersecurity investment.
+Use my vault notes about prior meetings, use Return on Security MCP for market
+intelligence if available, and save the final memo back into my vault.
+```
+
+## 2. Company plus known URL
+
+```text
+Create a cyber VC memo for Permiso using https://permiso.io as the primary
+company reference. Pull in any prior notes from my vault, classify the company,
+map it to investment themes and theses, and give me an Invest / Investigate /
+Monitor / Pass recommendation.
+```
+
+## 3. Founder-led diligence
+
+```text
+Assess whether this startup is venture-backable:
+
+Company: Twine
+Founders: Jane Doe, John Smith
+Category hypothesis: machine identity security
+
+Use any notes in my vault from meetings with the founders, then use ROS market
+intelligence if available to benchmark the market and competitor set.
+```
+
+## 4. Comparison-ready vault entry
+
+```text
+Produce a comparison-ready investment memo for SpecterOps' startup spinout.
+Keep the output normalized so I can compare it against other cyber startups in
+my vault later. Save the memo into the configured output folder.
+```
+
+## 5. Explicit note scope
+
+```text
+Analyze ProjectDiscovery as a cybersecurity investment opportunity.
+Only use vault notes under:
+- 4.Resources/Interactions
+- 4.Resources/Companies
+- 4.Resources/Categories/Matter
+
+If Return on Security MCP is available, use it for category and competitor
+analysis. Otherwise continue and mark that market-intelligence gap explicitly.
+```
+
+## 6. Private-context-first memo
+
+```text
+I met this company recently and want an IC-style note.
+Analyze Token Security as a seed-stage startup. Start with my vault notes, then
+separate private context from public evidence and assumptions throughout the
+memo.
+```
+
+## 7. Red Access Security first pass
+
+```text
+Analyze Red Access Security as an early-stage cybersecurity investment.
+
+Start with my vault notes about any meetings, founder conversations, or prior
+market maps involving Red Access Security. Then use Return on Security MCP for
+market intelligence if it is available.
+
+Produce the full structured cyber VC memo:
+- cybersecurity classification
+- investment themes
+- thesis mapping
+- why now
+- market analysis
+- competitive landscape
+- defensibility
+- venture scoring
+- key risks
+- recommendation
+- knowledge-base tags
+- confidence assessment
+
+Separate facts, reasonable inferences, and assumptions clearly throughout.
+Save the final memo back into my vault in the configured output folder.
+```
+
+## 8. Slack company invocation
+
+```text
+!cyber-vc-analyst Analyze Red Access Security as an early-stage cybersecurity
+investment. Start with my vault notes, use Return on Security MCP if available,
+separate facts, inferences, and assumptions, and save the final memo back into
+4.Resources/Companies.
+```
+
+## 9. Slack thematic invocation
+
+```text
+!cyber-vc-analyst Analyze the machine identity security theme as a venture
+investment area. Use my vault notes plus Return on Security MCP if available.
+Focus on market structure, buyer urgency, representative startups, likely
+winners, hyperscaler risk, and what would make the theme attractive or weak.
+Save the note only if it materially adds to my knowledge base.
+```
+
+## 10. Thematic analysis with write-back
+
+```text
+Analyze the browser security theme as a cyber venture investment area.
+
+Use my vault notes and ROS market intelligence if available. I want a thematic
+memo, not a company memo. Cover market maturity, buyer behavior, representative
+startups, major incumbents, likely acquirers, why now, risks, and what signals
+would increase conviction.
+
+Save the final note into the configured thematic output folder.
+```
+
+## 11. Theme through a named company
+
+```text
+Analyze the agentic AI security theme through the lens of Red Access Security
+and adjacent startups. This is a thematic memo, not just a company memo.
+Use Red Access only as one datapoint in the broader market landscape.
+```
+
+## 12. SOC automation thematic invocation
+
+```text
+Analyze SOC Automation / AI SOC as a cyber venture investment thesis.
+
+Use my vault notes first, then use Return on Security MCP for market
+intelligence if available. Treat this as a thematic memo, not a company memo.
+Cover SOC modernization, agentic investigation, SIEM-to-data-lake shifts,
+buyer urgency, representative startups, incumbents, hyperscaler risk, and what
+would make the theme structurally attractive or weak.
+
+Save the note into the configured thematic output folder.
+```
+
+## Notes
+
+- These prompts are intentionally short. The skill should recover the detailed
+  structure from `SKILL.md` and `references/output-template.md`.
+- If the user already knows the company stage or geography, include it in the
+  prompt to reduce assumptions.
+- If the user wants a market or category view, explicitly say `thematic memo`
+  to avoid falling back to company mode.

--- a/skills/research/cyber-vc-analyst/references/mcp-setup.md
+++ b/skills/research/cyber-vc-analyst/references/mcp-setup.md
@@ -1,0 +1,72 @@
+# Return On Security MCP Setup
+
+This skill expects Return on Security to be configured as an MCP server in the
+active runtime.
+
+In Hermes config, prefer the alias `returnonsecurity`, which usually yields the
+tool prefix:
+
+```text
+mcp_returnonsecurity_
+```
+
+In Codex CLI, a server added as `signal-mcp` will usually yield the tool
+prefix:
+
+```text
+mcp_signal_mcp_
+```
+
+The skill accepts either prefix and should inspect the live tool inventory
+rather than assuming one exact alias.
+
+## Hermes Config Example
+
+Add this to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  returnonsecurity:
+    url: "https://signal.returnonsecurity.com"
+    headers:
+      Authorization: "Bearer <token-if-required>"
+```
+
+If the service uses a different auth scheme, keep the alias the same and update
+only the header values.
+
+## Codex CLI Example
+
+To add and authenticate the same server in Codex:
+
+```bash
+codex mcp add signal-mcp --url https://mcp.returnonsecurity.com/mcp
+codex mcp login signal-mcp
+```
+
+If Safari approves the OAuth request but fails on the localhost callback, copy
+the full `http://127.0.0.1:<port>/callback/...` URL immediately and replay it
+while the Codex listener is still running.
+
+## Notes
+
+- Do not reload MCP mid-analysis unless the user explicitly asks. Reloading MCP
+  changes the tool list and can invalidate prompt caching.
+- If the config was just changed, restart Hermes or run `/reload-mcp` in a
+  separate explicit step before using this skill.
+- In Codex, newly authenticated MCP tools may not appear in the current agent
+  turn. Restart the session if auth succeeded but the tool prefix is still
+  absent from the live tool list.
+- The skill should depend only on the `mcp_returnonsecurity_*` or
+  `mcp_signal_mcp_*` prefixes, not on a specific tool name, because the
+  server's exact tool inventory may evolve.
+
+## Expected Usage
+
+When the tools are present, use them for:
+
+- category and market structure checks
+- competitor and adjacent vendor discovery
+- trend and thematic validation
+- likely buyer and acquirer landscape
+- adjacent architecture shifts in cyber markets

--- a/skills/research/cyber-vc-analyst/references/output-template.md
+++ b/skills/research/cyber-vc-analyst/references/output-template.md
@@ -1,0 +1,324 @@
+# Cyber VC Output Templates
+
+Use the company template for startup-specific investment analysis.
+
+Use the thematic template for category, market, and thesis analysis.
+
+## Company Mode
+
+Use this exact structure for both chat output and the saved company vault note.
+
+### Frontmatter
+
+```yaml
+---
+company: Company Name
+aliases: []
+date: YYYY-MM-DD
+stage: pre-seed | seed | unknown
+recommendation: Invest | High Priority Investigation | Monitor | Pass
+overall_score: 1-5
+primary_theme: ""
+secondary_themes: []
+cyber_category: ""
+customer_type: ""
+buyer: ""
+geography: ""
+confidence: high | medium | low
+source_note_paths: []
+used_returnonsecurity_mcp: true | false
+tags: [cybersecurity, venture]
+---
+```
+
+### Title
+
+```markdown
+# <Company Name> Investment Assessment
+```
+
+### Evidence Labels
+
+Within each section, use short evidence labels where needed:
+
+- `Facts:` externally supported or directly present in prior notes
+- `Reasonable inferences:` conclusions implied by the evidence
+- `Assumptions / unknowns:` open questions, gaps, or assumptions used to complete the view
+
+Do not force all three labels into every paragraph. Use them where they sharpen
+the conclusion.
+
+### Required Section Order
+
+```markdown
+## 1. Executive Summary
+- What the company does
+- The problem it solves
+- Target customers
+- Stage of company
+- One-sentence investment view
+
+## 2. Cybersecurity Classification
+- Primary category
+- Secondary category
+- Technology domains
+- Customer type
+- Buyer
+- Security function
+- NIST CSF functions
+- MITRE ATT&CK relevance
+- Cloud / Identity / Data / Network / Endpoint / AI / Application / Infrastructure alignment
+
+## 3. Investment Themes
+- Applicable listed themes
+- Emerging theme if relevant
+
+## 4. Investment Thesis Mapping
+- Technology Inflection
+- Architectural Shift
+- Threat Evolution
+- Customer Workflow
+- Platform Creation
+- Platform Convergence
+- Platform Fragmentation
+- Regulatory Tailwind
+- Economic Efficiency
+- Data Network Effects
+- Infrastructure Layer
+- Founder-Market Fit
+- Distribution Advantage
+- Category Creation
+
+## 5. Why Now?
+- Technology
+- Customer behavior
+- Enterprise architecture
+- Threat evolution
+- Regulation
+- Economics
+
+## 6. Market Analysis
+- TAM
+- Market maturity
+- Growth drivers
+- Replacement vs new budget
+- Expected market evolution over 5-10 years
+
+## 7. Competitive Landscape
+- Incumbents
+- Startups
+- Open-source alternatives
+- Cloud provider competition
+- Likely acquirers
+- Potential substitutes
+- Differentiation
+
+## 8. Defensibility
+- Technology moat
+- Data moat
+- Network effects
+- Distribution
+- Switching costs
+- Brand
+- Community
+- Regulatory advantage
+- Execution advantage
+- Platform potential
+
+## 9. Venture Assessment
+- Market Opportunity
+- Founder Advantage
+- Technology Differentiation
+- Why Now
+- Defensibility
+- Commercial Potential
+- Platform Potential
+- Acquisition Potential
+- IPO Potential
+- Overall Venture Attractiveness
+
+## 10. Key Risks
+- Technology
+- Execution
+- Competition
+- Pricing
+- Regulatory
+- Go-to-market
+- Platform risk
+- Hyperscaler risk
+- Feature-not-company risk
+
+## 11. Investment Recommendation
+- Invest | High Priority Investigation | Monitor | Pass
+- Concise rationale
+
+## 12. Knowledge Base Tags
+- Primary Theme
+- Secondary Theme
+- Keywords
+- Cybersecurity Taxonomy
+- Technology Stack
+- Customer Segments
+- Geography
+- Funding Stage
+- Investment Themes
+- Potential Competitors
+- Potential Acquirers
+- Relevant Trends
+
+## 13. Confidence
+- Major conclusion confidence levels
+- Missing information that would most improve the decision
+```
+
+### Rating Rules
+
+### Thesis Mapping
+
+Allowed values only:
+
+- `Strong`
+- `Medium`
+- `Weak`
+- `Not Applicable`
+
+Include a one-sentence justification for each thesis.
+
+### Defensibility
+
+Allowed values only:
+
+- `High`
+- `Medium`
+- `Low`
+
+### Venture Assessment
+
+Use integer scores from `1` to `5` only.
+
+- `1` = very weak / structurally unattractive
+- `2` = below average
+- `3` = mixed or incomplete
+- `4` = strong
+- `5` = exceptional
+
+Explain every score in one or two sentences.
+
+### Writing Style
+
+- concise, analytical, and committee-ready
+- no promotional language
+- no founder hagiography
+- no fake precision when evidence is sparse
+- no generic cyber boilerplate if it does not change the investment decision
+
+## Theme Mode
+
+Use this structure for thematic cyber-market analysis and optional vault
+write-back.
+
+### Frontmatter
+
+```yaml
+---
+theme: Theme Name
+date: YYYY-MM-DD
+scope: category | thesis | market map | architecture shift
+geography: global | region | country | unknown
+time_horizon: 12-24 months | 3-5 years | 5-10 years | unknown
+primary_theme: ""
+related_themes: []
+market_maturity: emerging | forming | scaling | mature
+key_companies: []
+used_returnonsecurity_mcp: true | false
+source_note_paths: []
+confidence: high | medium | low
+tags: [cybersecurity, venture, theme]
+---
+```
+
+### Title
+
+```markdown
+# <Theme Name> Thematic Analysis
+```
+
+### Required Section Order
+
+```markdown
+## 1. Theme Summary
+- What the theme is
+- Why investors care
+- One-sentence view on attractiveness
+
+## 2. Scope And Taxonomy
+- Category boundaries
+- Adjacent categories
+- Buyer and customer context
+- Core security functions involved
+
+## 3. Why Now?
+- Technology shifts
+- Threat shifts
+- Enterprise architecture shifts
+- Budget and workflow shifts
+- Regulatory or compliance drivers
+
+## 4. Market Structure
+- Market maturity
+- Budget source
+- Greenfield vs replacement
+- Expected market evolution over 3-10 years
+
+## 5. Company Landscape
+- Representative startups
+- Important incumbents
+- Open-source or hyperscaler substitutes
+- Likely acquirers
+
+## 6. Investment Thesis
+- What makes the theme attractive
+- What would need to be true for outsized returns
+- What kind of company wins in this market
+
+## 7. Competitive Dynamics
+- Crowding
+- Differentiation patterns
+- Platform risk
+- Hyperscaler risk
+- Fragmentation vs convergence
+
+## 8. Risks And Failure Modes
+- Why the theme could disappoint
+- What could compress returns
+- What makes companies in this area look strong but fragile
+
+## 9. Watchlist
+- Companies, signals, or metrics to track
+- What would increase conviction
+- What would reduce conviction
+
+## 10. Knowledge Base Tags
+- Primary theme
+- Related themes
+- Keywords
+- Buyer
+- Customer segment
+- Relevant categories
+- Key companies
+- Relevant trends
+
+## 11. Confidence
+- High / medium / low confidence conclusions
+- Missing information that would most improve the view
+```
+
+### Theme-Mode Rating Rules
+
+Where explicit ratings help, use:
+
+- `Strong`
+- `Medium`
+- `Weak`
+
+Only rate dimensions that are material to the theme.

--- a/skills/research/cyber-vc-analyst/references/taxonomy-rubric.md
+++ b/skills/research/cyber-vc-analyst/references/taxonomy-rubric.md
@@ -1,0 +1,284 @@
+# Cyber VC Taxonomy And Scoring Rubric
+
+Use this reference to normalize classification, themes, thesis mapping, and
+venture scores across companies, and to structure market-level thematic
+analysis.
+
+## Cybersecurity Classification
+
+Choose one primary category and at most one secondary category.
+
+Primary category candidates:
+
+- Identity and Access Security
+- Cloud and Infrastructure Security
+- Application Security
+- Data Security
+- Security Operations
+- Threat Intelligence
+- Exposure Management
+- Browser and Workspace Security
+- OT and ICS Security
+- Privacy and Compliance
+- Cryptography and Key Management
+- AI and Model Security
+- Cyber Resilience and Recovery
+
+Technology domain examples:
+
+- cloud
+- identity
+- data
+- network
+- endpoint
+- ai
+- application
+- infrastructure
+- browser
+- ot
+
+Customer type examples:
+
+- enterprise
+- mid-market
+- SMB
+- public sector
+- developer
+- MSSP
+- consumer
+
+Buyer examples:
+
+- CISO
+- CIO
+- Head of Infrastructure
+- Head of Platform Engineering
+- Security Operations leader
+- Identity leader
+- Data platform leader
+- Risk and compliance leader
+- OT security leader
+
+Security function examples:
+
+- prevention
+- detection
+- response
+- recovery
+- governance
+- posture management
+- identity lifecycle
+- policy enforcement
+
+NIST CSF mapping should use only:
+
+- Govern
+- Identify
+- Protect
+- Detect
+- Respond
+- Recover
+
+Use MITRE ATT&CK only when it is genuinely relevant to the product's operating
+surface. Do not force ATT&CK mapping onto compliance or governance products.
+
+## Investment Themes
+
+Mark every applicable theme from the base list:
+
+- AI Security
+- Agentic AI Security
+- Machine Identity
+- Human Identity
+- Cloud Security
+- Application Security
+- Software Supply Chain
+- Data Security
+- Autonomous SOC
+- Threat Intelligence
+- Exposure Management
+- Browser Security
+- Security Operations
+- Cyber Resilience
+- OT / ICS Security
+- Cryptography
+- Privacy
+- Quantum Security
+
+Add an emerging theme only if it is distinct and likely to recur across future
+analyses, for example:
+
+- AI infrastructure control planes
+- non-human identity governance
+- security for autonomous software agents
+- post-perimeter enterprise browsers
+
+## Thesis Mapping Anchors
+
+Use these anchors for `Strong`, `Medium`, `Weak`, and `Not Applicable`.
+
+### Strong
+
+The thesis is a primary driver of why the company could become important.
+
+### Medium
+
+The thesis helps the story but is not the dominant source of upside.
+
+### Weak
+
+The thesis is only loosely supported or mostly narrative packaging.
+
+### Not Applicable
+
+The thesis does not materially fit this company.
+
+## Venture Score Anchors
+
+### Market Opportunity
+
+- `1`: narrow, stagnant, or mostly feature-sized market
+- `3`: credible category with growth, but limited breakout evidence
+- `5`: large, durable category with room for multiple scaled winners
+
+### Founder Advantage
+
+- `1`: little evidence of domain or distribution edge
+- `3`: relevant background but not uniquely advantaged
+- `5`: unusually strong founder-market fit, credibility, or access
+
+### Technology Differentiation
+
+- `1`: mostly repackaging or thin product wedge
+- `3`: real product value but differentiation may be fragile
+- `5`: clear technical edge that is hard to copy quickly
+
+### Why Now
+
+- `1`: timing argument is weak or interchangeable with prior years
+- `3`: some timing support, but not decisive
+- `5`: strong enabling shift in architecture, threat, regulation, or cost
+
+### Defensibility
+
+- `1`: low moat and low switching cost
+- `3`: some moat potential, still forming
+- `5`: credible compounding moat with multiple reinforcing advantages
+
+### Commercial Potential
+
+- `1`: weak buyer urgency or hard path to budget
+- `3`: plausible go-to-market, but sales motion still uncertain
+- `5`: urgent pain, clear buyer, and credible expansion path
+
+### Platform Potential
+
+- `1`: point feature with little adjacency
+- `3`: some expansion vectors
+- `5`: clear control-point or system-of-record potential
+
+### Acquisition Potential
+
+- `1`: unclear buyer universe
+- `3`: several plausible acquirers
+- `5`: obvious strategic value to multiple logical acquirers
+
+### IPO Potential
+
+- `1`: unlikely to support public-company scale
+- `3`: too early to know, but category could support scale
+- `5`: category and product shape fit a potential stand-alone platform company
+
+### Overall Venture Attractiveness
+
+This is not an average. Weight market size, timing, differentiation, founder
+advantage, and the probability of building a large company.
+
+## Defensibility Dimensions
+
+Rate each as `High`, `Medium`, or `Low`.
+
+### Technology moat
+
+Focus on proprietary architecture, hard deployment know-how, and performance
+advantages that would take meaningful time to replicate.
+
+### Data moat
+
+Only rate high if the product actually compounds through hard-to-recreate data,
+not merely because it logs telemetry.
+
+### Network effects
+
+Rare in security. Reserve high only for true multi-party or ecosystem effects.
+
+### Distribution
+
+Consider founder access, channel leverage, community pull, and integration-led
+adoption.
+
+### Switching costs
+
+Consider operational embedding, workflow lock-in, policy depth, and data gravity.
+
+### Brand
+
+Usually low early unless the company already anchors around trust or elite
+practitioner reputation.
+
+### Community
+
+Only rate high when there is real open-source, practitioner, or developer pull.
+
+### Regulatory advantage
+
+Use when regulation creates a durable tailwind or defensible control point.
+
+### Execution advantage
+
+Reflect team quality, speed, and clarity of wedge relative to peers.
+
+### Platform potential
+
+Reflect whether the initial wedge can expand into a broader control plane,
+system of record, or workflow hub.
+
+## Recommendation Thresholds
+
+These are decision aids, not rigid rules.
+
+- `Invest`: clear positive view with strong upside and tolerable unknowns
+- `High Priority Investigation`: strong signal, but one or two critical diligence gaps remain
+- `Monitor`: interesting, but not yet conviction-ready
+- `Pass`: weak wedge, weak market, weak timing, or weak company formation
+
+Prefer `High Priority Investigation` over `Invest` when the company is promising
+but the evidence base is still too thin for committee conviction.
+
+## Theme-Mode Anchors
+
+Use these for market and thematic analysis.
+
+### Theme Attractiveness
+
+- `Strong`: clear tailwinds, meaningful budget, room for durable winners
+- `Medium`: real market signal, but timing, budget, or winner shape is still uncertain
+- `Weak`: interesting narrative, but weak budget, weak urgency, or weak differentiation patterns
+
+### Market Maturity
+
+- `Emerging`: problem forming, budgets and winners still unclear
+- `Forming`: repeatable pain visible, early budgets and vendor clusters appearing
+- `Scaling`: strong demand, recognizable leaders, consolidation patterns forming
+- `Mature`: established buyer motion, lower upside from pure category novelty
+
+### Theme Questions To Answer
+
+A good theme memo should answer:
+
+- What changed to make this theme investable now?
+- Which buyers actually care?
+- Is budget net new, replacement, or bundled into existing platforms?
+- What product shapes are likely to win?
+- Where are hyperscalers and incumbents structurally advantaged?
+- Which startups appear early but directionally important?

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -62,7 +62,8 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-
+| [`kanban-orchestrator`](/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator) | Decomposition playbook + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban worker's system prompt; this skill... | `devops/kanban-orchestrator` |
+| [`kanban-worker`](/docs/user-guide/skills/bundled/devops/devops-kanban-worker) | Pitfalls, examples, and edge cases for Hermes Kanban workers. The lifecycle itself is auto-injected into every worker's system prompt as KANBAN_GUIDANCE (from agent/prompt_builder.py); this skill is what you load when you want deeper det... | `devops/kanban-worker` |
 
 ## dogfood
 
@@ -125,6 +126,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`notion`](/docs/user-guide/skills/bundled/productivity/productivity-notion) | Notion API + ntn CLI: pages, databases, markdown, Workers. | `productivity/notion` |
 | [`ocr-and-documents`](/docs/user-guide/skills/bundled/productivity/productivity-ocr-and-documents) | Extract text from PDFs/scans (pymupdf, marker-pdf). | `productivity/ocr-and-documents` |
 | [`powerpoint`](/docs/user-guide/skills/bundled/productivity/productivity-powerpoint) | Create, read, edit .pptx decks, slides, notes, templates. | `productivity/powerpoint` |
+| [`slack-surfaces`](/docs/user-guide/skills/bundled/productivity/productivity-slack-surfaces) | Operate repo-defined Slack channels and canvases through the standalone slack-surfaces CLI. | `productivity/slack-surfaces` |
 | [`teams-meeting-pipeline`](/docs/user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline) | Operate the Teams meeting summary pipeline via Hermes CLI — summarize meetings, inspect pipeline status, replay jobs, manage Microsoft Graph subscriptions. | `productivity/teams-meeting-pipeline` |
 
 ## research
@@ -133,6 +135,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 |-------|-------------|------|
 | [`arxiv`](/docs/user-guide/skills/bundled/research/research-arxiv) | Search arXiv papers by keyword, author, category, or ID. | `research/arxiv` |
 | [`blogwatcher`](/docs/user-guide/skills/bundled/research/research-blogwatcher) | Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool. | `research/blogwatcher` |
+| [`cyber-vc-analyst`](/docs/user-guide/skills/bundled/research/research-cyber-vc-analyst) | Use when analyzing an early-stage cybersecurity startup or a cybersecurity market theme for venture investment. Produces a structured company IC memo or thematic market memo using vault notes, Return on Security MCP market intelligence w... | `research/cyber-vc-analyst` |
 | [`llm-wiki`](/docs/user-guide/skills/bundled/research/research-llm-wiki) | Karpathy's LLM Wiki: build/query interlinked markdown KB. | `research/llm-wiki` |
 | [`polymarket`](/docs/user-guide/skills/bundled/research/research-polymarket) | Query Polymarket: markets, prices, orderbooks, history. | `research/polymarket` |
 | [`research-paper-writing`](/docs/user-guide/skills/bundled/research/research-research-paper-writing) | Write ML papers for NeurIPS/ICML/ICLR: design→submit. | `research/research-paper-writing` |

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
@@ -32,11 +32,11 @@ Use this skill for filesystem-first Obsidian vault work: reading notes, listing 
 
 Use a known or resolved vault path before calling file tools.
 
-The documented vault-path convention is the `OBSIDIAN_VAULT_PATH` environment variable, for example from `${HERMES_HOME:-~/.hermes}/.env`. If it is unset, use `~/Documents/Obsidian Vault`.
+The documented vault-path convention is the `OBSIDIAN_VAULT_PATH` environment variable, for example from `${HERMES_HOME:-~/.hermes}/.env`. If it is unset, check `~/Library/Application Support/obsidian/obsidian.json` and use the currently open vault path when available. Only fall back to `~/Documents/Obsidian Vault` if neither source is available.
 
 File tools do not expand shell variables. Do not pass paths containing `$OBSIDIAN_VAULT_PATH` to `read_file`, `write_file`, `patch`, or `search_files`; resolve the vault path first and pass a concrete absolute path. Vault paths may contain spaces, which is another reason to prefer file tools over shell commands.
 
-If the vault path is unknown, `terminal` is acceptable for resolving `OBSIDIAN_VAULT_PATH` or checking whether the fallback path exists. Once the path is known, switch back to file tools.
+If the vault path is unknown, `terminal` is acceptable for resolving `OBSIDIAN_VAULT_PATH`, inspecting `~/Library/Application Support/obsidian/obsidian.json`, or checking whether the fallback path exists. Once the path is known, switch back to file tools.
 
 ## Read a note
 

--- a/website/docs/user-guide/skills/bundled/research/research-cyber-vc-analyst.md
+++ b/website/docs/user-guide/skills/bundled/research/research-cyber-vc-analyst.md
@@ -1,0 +1,344 @@
+---
+title: "Cyber Vc Analyst"
+sidebar_label: "Cyber Vc Analyst"
+description: "Use when analyzing an early-stage cybersecurity startup or a cybersecurity market theme for venture investment"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Cyber Vc Analyst
+
+Use when analyzing an early-stage cybersecurity startup or a cybersecurity market theme for venture investment. Produces a structured company IC memo or thematic market memo using vault notes, Return on Security MCP market intelligence when available, and clearly separated facts, inferences, and assumptions.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/research/cyber-vc-analyst` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `cybersecurity`, `venture`, `investing`, `startup`, `obsidian`, `mcp`, `research` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`llm-wiki`](/docs/user-guide/skills/bundled/research/research-llm-wiki), `native-mcp` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Cybersecurity Venture Analyst
+
+Produce a structured investment-committee memo for either:
+
+- a pre-seed or seed-stage cybersecurity startup
+- a cybersecurity market theme, category, or architectural shift
+
+The output should be grounded in evidence and reusable inside a long-term
+knowledge base.
+
+This skill combines three evidence streams:
+
+1. prior private context from the user's Obsidian vault
+2. market intelligence from Return on Security MCP when available
+3. public information from Hermes web tools when needed and available
+
+Never blur those sources together. Preserve a clear line between verified fact,
+reasonable inference, and assumption.
+
+## When to Use
+
+Use this skill when the user asks for:
+
+- an investment view on a cybersecurity startup
+- a seed or pre-seed cybersecurity company memo
+- a market thesis on a cybersecurity theme, category, or architecture shift
+- a thematic map of a cyber segment and the likely winners or losers
+- a venture assessment, IC memo, or market map entry for a cyber company
+- comparison-ready notes on founders, product, category, or defensibility
+- a write-back into the user's vault so future analyses compound
+
+Do not use this skill for:
+
+- public-equity valuation or late-stage financial modeling
+- a generic TAM deck with no company-specific assessment
+- technical security due diligence on a product implementation
+- penetration testing, threat hunting, or incident response
+
+## Inputs
+
+Expected user input for company mode:
+
+- company name
+- optional company URL
+- optional founder names
+- optional product description or category hint
+- optional specific notes, folders, or prior memos to include
+
+Expected user input for theme mode:
+
+- theme or category name
+- optional geography
+- optional time horizon
+- optional company set to include or exclude
+- optional specific vault notes, folders, or prior memos to include
+
+If key identifiers are missing, infer cautiously from the conversation and state
+the assumption in the memo.
+
+## Mode Selection
+
+Choose the mode before gathering evidence.
+
+Use **company mode** when the prompt centers on one company, founder team, or
+startup investment decision.
+
+Use **theme mode** when the prompt centers on:
+
+- a cybersecurity category
+- an investment theme
+- a buyer workflow shift
+- an architectural transition
+- a market map or landscape
+- a question about which cyber areas are attractive or crowded
+
+If the prompt mentions both a company and a broader theme, default to company
+mode and use the theme only as context unless the user explicitly asks for a
+thematic memo.
+
+For concrete prompt patterns, read `references/example-invocations.md`.
+
+## Vault Rules
+
+Resolve the Obsidian vault path first using the `obsidian` skill conventions:
+
+- use `OBSIDIAN_VAULT_PATH` when set
+- otherwise read `~/Library/Application Support/obsidian/obsidian.json` and use the
+  currently open vault path when available
+- only fall back to `~/Documents/Obsidian Vault` if neither source is available
+
+Use Hermes file tools once the vault path is known:
+
+- use `search_files` for filename and content search
+- use `read_file` for note inspection
+- use `write_file` for final memo creation or full-note replacement
+- use `patch` only when a targeted anchored update is safer than rewriting
+
+Treat vault notes as private first-party context. They are not public evidence.
+Use them to recover:
+
+- who the user has met
+- what prior conversations imply about the company, founders, and market
+- what the user's existing mental models, market maps, and competitor lists contain
+
+Search order:
+
+1. configured `cyber_vc_analyst.meeting_search_roots`
+2. configured `cyber_vc_analyst.company_search_roots`
+3. broader vault search only if the configured roots are empty or yield little
+
+Prefer targeted searches for:
+
+- company name and aliases
+- founder names
+- product names
+- category phrases
+- competitor names already mentioned in the vault
+- theme names and adjacent category terms when in theme mode
+
+For content searches, prefer `search_files` with `target: "content"` and
+`file_glob: "*.md"`. For note listing, prefer `target: "files"`.
+
+Read only the most relevant notes. Do not scan the whole vault unless the
+configured roots are empty and narrower search failed.
+
+## MCP Rules
+
+Before using broad public search, inspect the available tool list for either:
+
+- `mcp_returnonsecurity_*`
+- `mcp_signal_mcp_*`
+
+If Return on Security MCP tools are available:
+
+- use them as the preferred source for market structure, category context,
+  competitor discovery, trend validation, likely acquirers, and adjacent themes
+- prefer the smallest tool or tool sequence that answers the question
+- cite the MCP-derived point as market intelligence, not as a firsthand company fact
+
+If Return on Security MCP tools are unavailable:
+
+- continue with vault notes plus public sources if Hermes web tools exist
+- explicitly note in the memo that ROS MCP market intelligence was unavailable
+- reduce confidence where the missing market view materially weakens the conclusion
+
+If both ROS MCP and public web tools are unavailable, still produce the memo from
+vault context and user-provided information, but call out the evidence gap.
+
+For setup instructions or alias expectations, read
+`references/mcp-setup.md`.
+
+## Workflow
+
+1. Identify the subject.
+   In company mode, confirm the legal or commonly used company name, website,
+   founders, and claimed category if known. In theme mode, confirm the theme,
+   scope, buyer context, and time horizon.
+
+2. Recover prior vault knowledge.
+   Search configured meeting and company roots first. Pull only notes that
+   materially change the assessment. In theme mode, bias toward category notes,
+   Matter/Readwise intelligence, and any existing company notes relevant to the
+   theme.
+
+3. Gather market context.
+   Use `mcp_returnonsecurity_*` or `mcp_signal_mcp_*` tools when available. If
+   they are absent and public web tools are available, use public sources to
+   fill category, competitive, and market-evolution gaps.
+
+4. Normalize the subject.
+   In company mode, classify the company using the rubric in
+   `references/taxonomy-rubric.md`. In theme mode, classify the theme, the
+   customer problem, the market maturity, and the adjacent categories.
+
+5. Draft the memo.
+   Follow the correct mode-specific output structure in
+   `references/output-template.md`.
+
+6. Distinguish evidence quality.
+   Every major conclusion should separate:
+   - facts
+   - reasonable inferences
+   - assumptions or unknowns
+
+7. Save the memo back to the vault when appropriate.
+   In company mode, write the finished Markdown note under the configured
+   `cyber_vc_analyst.output_root` using the company template's frontmatter and
+   filename rules.
+   In theme mode, save only when the user asks to save or maintain the theme in
+   the vault; write it under `cyber_vc_analyst.theme_output_root` using the
+   thematic template and filename rules.
+
+## Output Rules
+
+The deliverable is a Markdown memo suitable for chat output and optional vault
+storage. It must:
+
+- use the correct mode-specific template
+- avoid marketing language
+- be concise but analytical
+- rate and score where the template asks for ratings or scores
+- state missing information that would change the decision
+- stay comparison-friendly across companies in company mode
+- stay thesis-friendly and market-comparable across themes in theme mode
+
+For all scoring:
+
+- use the rubric anchors in `references/taxonomy-rubric.md`
+- do not inflate uncertain companies toward the middle by default
+- explain each score in one or two direct sentences
+
+When using vault-only evidence, label it clearly as prior private context.
+When using ROS MCP, label it clearly as market intelligence.
+When using public sources, label them as public evidence.
+
+## Vault Write-Back
+
+Write the final company-mode note to:
+
+- `<vault>/<output_root>/<company-slug>.md`
+
+Use lowercase kebab-case for the filename slug.
+
+Prefer `write_file` with the full final Markdown content unless there is a
+strong reason to make a smaller anchored update with `patch`.
+
+Include YAML frontmatter matching the template, including:
+
+- company
+- aliases
+- date
+- stage
+- recommendation
+- overall_score
+- primary_theme
+- secondary_themes
+- cyber_category
+- customer_type
+- buyer
+- geography
+- confidence
+- source_note_paths
+- used_returnonsecurity_mcp
+- tags
+
+If an existing note already exists for the same company:
+
+- read it first
+- preserve useful historical context
+- replace stale conclusions rather than appending contradictory summaries
+- keep the current memo date accurate
+
+Write the final theme-mode note to:
+
+- `<vault>/<theme_output_root>/theme-<theme-slug>.md`
+
+Use theme mode only for market, category, and thesis analysis. Thematic notes
+should include:
+
+- scope
+- geography
+- time_horizon
+- primary_theme
+- related_themes
+- key_companies
+- used_returnonsecurity_mcp
+- source_note_paths
+- confidence
+- tags
+
+Do not store a theme note under `4.Resources/Companies` unless the user
+explicitly asks for that override.
+
+## Common Pitfalls
+
+1. Treating vault notes as public evidence.
+   Keep private context separate from externally verifiable claims.
+
+2. Overstating certainty from thin startup data.
+   If the company is early and evidence is sparse, lower confidence instead of
+   inventing precision.
+
+3. Using generic cyber taxonomy.
+   Force the classification, themes, thesis mapping, and buyer analysis to fit
+   the actual company, not a canned category description.
+
+4. Letting competitor lists become exhaustive.
+   Focus on the set that sharpens the investment view, not every company in the
+   category.
+
+5. Forcing a company memo onto a thematic question.
+   Switch to theme mode when the user is asking about a market or thesis rather
+   than one startup.
+
+6. Writing a memo that cannot be compared later.
+   Preserve the exact section order, rating scales, and frontmatter fields.
+
+7. Depending on a specific ROS MCP tool name.
+   Depend only on the `mcp_returnonsecurity_*` or `mcp_signal_mcp_*` prefixes
+   and choose tools from the actual available list.
+
+## Verification Checklist
+
+- [ ] Vault path resolved before reading or writing notes
+- [ ] Configured search roots used before broader vault search
+- [ ] ROS MCP availability checked via `mcp_returnonsecurity_*` or
+      `mcp_signal_mcp_*` tool prefix
+- [ ] Correct mode selected before drafting
+- [ ] Company memo or thematic memo structure present as required
+- [ ] Major conclusions distinguish facts, inferences, and assumptions
+- [ ] Frontmatter populated when writing back to the vault
+- [ ] Output note saved under the correct company or theme output root
+- [ ] Missing information and confidence gaps stated explicitly

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -60,7 +60,6 @@ const sidebars: SidebarsConfig = {
           label: 'Core',
           items: [
             'user-guide/features/tools',
-            'user-guide/features/tool-search',
             'user-guide/features/skills',
             'user-guide/features/lsp',
             'user-guide/features/curator',
@@ -190,6 +189,16 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'category',
+                  label: 'devops',
+                  key: 'skills-bundled-devops',
+                  collapsed: true,
+                  items: [
+                    'user-guide/skills/bundled/devops/devops-kanban-orchestrator',
+                    'user-guide/skills/bundled/devops/devops-kanban-worker',
+                  ],
+                },
+                {
+                  type: 'category',
                   label: 'dogfood',
                   key: 'skills-bundled-dogfood',
                   collapsed: true,
@@ -269,6 +278,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/productivity/productivity-notion',
                     'user-guide/skills/bundled/productivity/productivity-ocr-and-documents',
                     'user-guide/skills/bundled/productivity/productivity-powerpoint',
+                    'user-guide/skills/bundled/productivity/productivity-slack-surfaces',
                     'user-guide/skills/bundled/productivity/productivity-teams-meeting-pipeline',
                   ],
                 },
@@ -280,6 +290,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/bundled/research/research-arxiv',
                     'user-guide/skills/bundled/research/research-blogwatcher',
+                    'user-guide/skills/bundled/research/research-cyber-vc-analyst',
                     'user-guide/skills/bundled/research/research-llm-wiki',
                     'user-guide/skills/bundled/research/research-polymarket',
                     'user-guide/skills/bundled/research/research-research-paper-writing',
@@ -534,6 +545,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/productivity/productivity-shopify',
                     'user-guide/skills/optional/productivity/productivity-siyuan',
                     'user-guide/skills/optional/productivity/productivity-telephony',
+                    'user-guide/skills/optional/productivity/productivity-vault-para-triage',
                   ],
                 },
                 {


### PR DESCRIPTION
## What changed

- adds a new bundled `cyber-vc-analyst` skill for early-stage cybersecurity company analysis and thematic investment analysis
- adds references for taxonomy, output templates, MCP setup, and invocation examples
- updates the Obsidian skill to resolve the active vault from `~/Library/Application Support/obsidian/obsidian.json` before falling back to `~/Documents/Obsidian Vault`
- regenerates the relevant bundled skill docs and sidebar/catalog entries

## Why it changed

This adds a reusable workflow for venture-style cyber investment analysis inside Hermes while keeping the evidence model explicit:

- private vault context
- Return on Security MCP market intelligence
- public evidence when needed

It also fixes a practical vault-resolution gap that came up during validation, where relying only on `OBSIDIAN_VAULT_PATH` or the fallback path was not enough for the user's actual local Obsidian setup.

## User / developer impact

- users can trigger a normalized company IC memo or thematic memo from one bundled skill
- thematic notes now default to `3.Areas/cyber futures frontier`
- the skill recognizes Return on Security MCP under either Hermes-style or Codex-style naming conventions
- the Obsidian skill is more reliable on machines where the active vault is discoverable from Obsidian config rather than environment variables

## Validation

- authenticated and validated `signal-mcp` OAuth flow in Codex
- confirmed ROS MCP-backed company analysis for Red Access
- confirmed ROS MCP-backed thematic analysis flow for `SOC Automation / AI SOC`
- regenerated bundled skill docs successfully
