### PR TITLE
fix(telephony): wrap malformed JSON responses

### DIFF
--- a/optional-skills/productivity/telephony/scripts/telephony.py
+++ b/optional-skills/productivity/telephony/scripts/telephony.py
@@ -260,7 +260,10 @@ def _json_request(
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             payload = resp.read().decode("utf-8")
-            return json.loads(payload) if payload else {}
+            try:
+                return json.loads(payload) if payload else {}
+            except json.JSONDecodeError as exc:
+                raise TelephonyError(f"Invalid JSON response from {url}: {exc.msg}") from exc
     except urllib.error.HTTPError as exc:
         body_text = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
         try:

--- a/tests/skills/test_telephony_skill.py
+++ b/tests/skills/test_telephony_skill.py
@@ -67,6 +67,29 @@ def test_upsert_env_updates_existing_values(tmp_path: Path):
     assert "OTHER=keep" in env_text
 
 
+def test_json_request_wraps_malformed_success_body(monkeypatch):
+    mod = load_module()
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"<html>not json"
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+
+    try:
+        mod._json_request("GET", "https://api.example.invalid/test")
+    except mod.TelephonyError as exc:
+        assert "Invalid JSON response from https://api.example.invalid/test" in str(exc)
+    else:
+        raise AssertionError("malformed JSON response should raise TelephonyError")
+
+
 def test_messages_after_checkpoint_returns_only_newer_items():
     mod = load_module()
     messages = [

--- a/tests/skills/test_telephony_skill.py
+++ b/tests/skills/test_telephony_skill.py
@@ -67,6 +67,29 @@ def test_upsert_env_updates_existing_values(tmp_path: Path):
     assert "OTHER=keep" in env_text
 
 
+def test_json_request_wraps_malformed_success_body(monkeypatch):
+    mod = load_module()
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"<html>not json"
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+
+    try:
+        mod._json_request("GET", "https://api.example.invalid/test")
+    except mod.TelephonyError as exc:
+        assert "Invalid JSON response from https://api.example.invalid/test" in str(exc)
+    else:
+        raise AssertionError("malformed JSON response should raise TelephonyError")
+
+
 
 
 def test_twilio_buy_number_saves_env_and_state(tmp_path: Path):


### PR DESCRIPTION
Fixes #56540

What does this PR do?

- Wraps malformed successful JSON bodies from telephony API calls in `TelephonyError`.
- Keeps empty success bodies returning `{}`.
- Leaves existing HTTP error parsing and connection error handling unchanged.
- Adds focused regression coverage for a successful upstream response returning malformed JSON.

Why?

`_json_request()` already converts malformed HTTP error bodies into a controlled `TelephonyError`, but the 2xx success path called `json.loads()` directly. If a provider, proxy, or captive page returns HTML or another malformed body with a success status, callers see an implementation-level `JSONDecodeError` instead of the skill's normal error type.

Proof

- `python -m py_compile optional-skills\\productivity\\telephony\\scripts\\telephony.py tests\\skills\\test_telephony_skill.py`
- Focused local proof script passed:

```text
successful urlopen() returns body: <html>not json
_json_request(GET, https://api.example.invalid/test) raises TelephonyError
focused telephony malformed JSON proof passed
```

Limitations

- `python -m pytest tests\\skills\\test_telephony_skill.py -q` could not run in this checkout because pytest is not installed (`No module named pytest`).
- Repo-local/global autoreview helper was not available in this checkout.