### PR TITLE
fix(tui): strip ANSI from slash-command output before returning to chat

### DIFF
--- a/tests/tui_gateway/test_slash_worker_strip_ansi.py
+++ b/tests/tui_gateway/test_slash_worker_strip_ansi.py
@@ -1,0 +1,55 @@
+"""Regression for #56533: slash-command output returned to a chat bubble must
+not contain raw ANSI escape codes.
+
+``_run`` builds a Rich Console with ``force_terminal=True`` (so tables / bar
+charts lay out correctly), which emits 24-bit color escapes. That captured
+string is delivered to the TUI/Desktop chat bubble as plain text, so the
+escapes must be stripped before returning — otherwise they show up as literal
+``?[38;2;...m`` garbage.
+"""
+
+import types
+
+from tui_gateway import slash_worker
+
+
+def _fake_cli(printer):
+    """A minimal stand-in for HermesCLI: ``_run`` assigns ``.console`` and then
+    calls ``.process_command``, which prints through that console."""
+    cli = types.SimpleNamespace(console=None)
+
+    def process_command(cmd):
+        printer(cli.console)
+
+    cli.process_command = process_command
+    return cli
+
+
+def test_run_strips_ansi_from_rich_colored_output():
+    cli = _fake_cli(lambda console: console.print("[red]hello[/red] [green]world[/green]"))
+    out = slash_worker._run(cli, "/journey")
+
+    # No escape byte survives, but the visible text does.
+    assert "\x1b" not in out
+    assert "hello" in out
+    assert "world" in out
+
+
+def test_run_strips_truecolor_bar_chart_escapes():
+    # Mirrors the /journey bar chart: 24-bit foreground colors are the exact
+    # "?[38;2;...m" sequences the issue reports.
+    def printer(console):
+        console.print("[rgb(255,140,0)]████[/] node-a")
+        console.print("[rgb(0,180,90)]██[/] node-b")
+
+    out = slash_worker._run(_fake_cli(printer), "/journey")
+    assert "\x1b" not in out
+    assert "38;2;" not in out
+    assert "node-a" in out
+    assert "node-b" in out
+
+
+def test_run_preserves_plain_text_unchanged():
+    cli = _fake_cli(lambda console: console.print("no color here"))
+    out = slash_worker._run(cli, "/plain")
+    assert out == "no color here"

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -30,6 +30,7 @@ import psutil
 import cli as cli_mod
 from cli import HermesCLI
 from rich.console import Console
+from tools.ansi_strip import strip_ansi
 
 # Env-overridable so the integration test can drive sub-second timing.
 def _env_float(name: str, default: float) -> float:
@@ -89,6 +90,15 @@ def _run(cli: HermesCLI, command: str) -> str:
     # Rich Console captures its file handle at construction time, so
     # contextlib.redirect_stdout won't affect it. Swap the console's
     # underlying file to our buffer so self.console.print() is captured.
+    #
+    # force_terminal=True makes Rich lay out tables/bar charts with a real
+    # terminal width instead of collapsing to a bare 80-col non-tty fallback,
+    # but it also emits 24-bit ANSI color escapes. This captured string is
+    # returned through the gateway to a chat bubble (TUI/Desktop) that renders
+    # plain text, so the escapes show up as literal "?[38;2;...m" garbage
+    # (issue #56533). Keep force_terminal for the layout and strip the ANSI
+    # from the captured output below, mirroring how terminal_tool /
+    # code_execution_tool clean subprocess output before it leaves the process.
     cli.console = Console(file=buf, force_terminal=True, width=120)
 
     old = getattr(cli_mod, "_cprint", None)
@@ -102,7 +112,7 @@ def _run(cli: HermesCLI, command: str) -> str:
         if old is not None:
             cli_mod._cprint = old
 
-    return buf.getvalue().rstrip()
+    return strip_ansi(buf.getvalue()).rstrip()
 
 
 def main():


### PR DESCRIPTION
## What does this PR do?

`/journey` (and any slash command with rich output) rendered raw ANSI escape codes — literal `?[38;2;...m` garbage — in the TUI and Desktop chat bubbles.

`tui_gateway/slash_worker.py`'s `_run()` builds a Rich `Console(force_terminal=True, width=120)` so tables and bar charts lay out at a real terminal width instead of collapsing to the 80-col non-tty fallback. `force_terminal=True` also makes Rich emit 24-bit ANSI color escapes. That captured string is returned through the gateway to the chat bubble, which renders **plain text** — so the escapes surface as literal garbage.

Fix: strip the escapes from the captured output using the existing `tools.ansi_strip.strip_ansi` helper — the same ECMA-48-complete cleaner that `terminal_tool` and `code_execution_tool` already apply before returning subprocess output. `force_terminal` is kept so the table/bar-chart layout survives; only the color codes are removed.

## Related Issue

Fixes #56533

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/slash_worker.py`: import `strip_ansi` and apply it to the captured buffer in `_run()` (`return strip_ansi(buf.getvalue()).rstrip()`), with a comment explaining why `force_terminal` stays.
- `tests/tui_gateway/test_slash_worker_strip_ansi.py`: new `_run()` tests — colored output loses its escapes but keeps the text; 24-bit `rgb(...)` bar-chart escapes (the exact `38;2;` sequences from the report) are gone; plain text passes through unchanged.

## How to Test

1. `uv run python -m pytest tests/tui_gateway/test_slash_worker_strip_ansi.py -q` → 3 passed, ruff clean.
2. Manual: run `/journey` as a slash command in the TUI or Desktop chat — the bar chart / node list now renders as clean text instead of `?[38;2;...m` sequences.

## Notes

This is the general `_run()` path — the sibling fix `9de4a38ce` (#4128) only covered `/tools list`'s direct-TTY color path. In the gateway→chat-bubble path the consumer can't render ANSI at all, so stripping (not re-rendering) is the correct treatment, matching every other capture-and-return path in the codebase.

## Checklist

- [x] Conventional Commits
- [x] Searched existing PRs — none open for this issue
- [x] Only changes related to this fix
- [x] Tests pass (`tests/tui_gateway/test_slash_worker_strip_ansi.py`, 3 passed; ruff clean)
- [x] Added tests
- [x] Tested on my platform: macOS 14
- [x] Cross-platform impact considered — pure string post-processing, platform-independent