### PR TITLE
fix(tui): map .js imports to .ts sources in esbuild bundle

### DIFF
--- a/ui-tui/scripts/build.mjs
+++ b/ui-tui/scripts/build.mjs
@@ -2,7 +2,7 @@
 // Bundles src/entry.tsx into a single self-contained dist/entry.js.
 // No runtime node_modules needed.
 import { build } from 'esbuild'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -26,6 +26,36 @@ const stubDevtools = {
   }
 }
 
+// `tsconfig.json` uses `moduleResolution: "nodenext"`, which requires every
+// relative import to spell the `.js` extension (even when the file on disk
+// is `.ts`/`.tsx`). esbuild, by default, does NOT rewrite `.js` -> `.ts` for
+// imports that already carry an explicit extension — it only walks
+// `resolveExtensions` for extensionless imports. Without this plugin every
+// `import x from '../lib/foo.js'` would fail to resolve, even though
+// `foo.ts` is sitting right there. Map `.js` -> `.tsx`/`.ts`/`.jsx` on disk
+// and let esbuild pick up the match. We deliberately do NOT include `.js`
+// in the lookup list — if a `.ts/.tsx/.jsx` rewrite isn't available the
+// resolution is left to esbuild's default path (which handles real `.js`
+// files in `node_modules/` and elsewhere). All returned paths are absolute
+// (esbuild rejects relative paths from resolve plugins).
+const jsToTsPlugin = {
+  name: 'js-to-ts',
+  setup(b) {
+    b.onResolve({ filter: /\.js$/ }, args => {
+      if (args.namespace === 'stub-devtools') return null
+      const base = args.path.replace(/\.js$/, '')
+      const dir = args.resolveDir
+      for (const ext of ['.tsx', '.ts', '.jsx']) {
+        const candidate = resolve(dir, base + ext)
+        if (existsSync(candidate) && statSync(candidate).isFile()) {
+          return { path: candidate }
+        }
+      }
+      return null
+    })
+  }
+}
+
 await build({
   entryPoints: [resolve(root, 'src/entry.tsx')],
   bundle: true,
@@ -44,7 +74,7 @@ await build({
   //     circular async chain that hung the TUI at startup with only ANSI
   //     reset bytes on screen (#31227).
   alias: { '@hermes/ink': resolve(root, 'packages/hermes-ink/src/entry-exports.ts') },
-  plugins: [stubDevtools],
+  plugins: [stubDevtools, jsToTsPlugin],
   // Some transitive deps use CommonJS `require(...)` at runtime. ESM bundles
   // don't get a `require` binding automatically, so we inject one.
   banner: {


### PR DESCRIPTION
## What does this PR do?

Adds an esbuild resolver plugin to `ui-tui/scripts/build.mjs` that maps `.js` import paths to `.ts`/`.tsx`/`.jsx` source files on disk. Fixes the `hermes --tui` rebuild failure on first launch.

## Related Issue

The TUI build script (`scripts/build.mjs`) uses esbuild without a resolver plugin. Combined with `ui-tui/tsconfig.json` adopting `moduleResolution: "nodenext"` (which requires every relative import to spell the `.js` extension even when the file on disk is `.ts`/`.tsx`), this means the first launch on any user install fails with errors like:

```
src/app/useMainApp.ts:27:38: ERROR: Could not resolve "../lib/resizeCoalescer.js"
src/components/appLayout.tsx:21:35: ERROR: Could not resolve "../lib/prompt.js"
src/components/journey.tsx:7:76: ERROR: Could not resolve "../lib/starmapPalette.js"
```

The user has to manually patch the build script before the TUI can start. This PR adds the missing esbuild plugin so the build script works with the existing nodenext module resolution.

Related closed issue: #31227 (different root cause — async `__esm` deadlock — but adjacent area)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/scripts/build.mjs`: add `jsToTsPlugin` esbuild resolver plugin (32 lines including doc comment) and register it in the `plugins` array.

The plugin:

1. Filters for imports ending in `.js`
2. Tries `.tsx`, `.ts`, `.jsx` extensions on disk in order
3. Returns the absolute path of the first match (esbuild rejects relative paths from resolve plugins)
4. Returns `null` to fall through to esbuild's default resolution for real `.js` files (e.g. in `node_modules/`)

## How to Test

1. Wipe `ui-tui/dist/entry.js` (or test on a clean install)
2. Run `hermes --tui`
3. The TUI build should succeed; `dist/entry.js` is produced
4. TUI launches and is interactive

**Verified on:** Windows 11 ARM64 (Snapdragon X Plus), Node.js 22, esbuild 0.28.x. The `jsToTsPlugin` is platform-agnostic — runs in esbuild on Linux, macOS, Windows alike.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tui): map .js imports to .ts sources in esbuild bundle`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` — N/A (no Python changes)
- [x] I've added tests — manual e2e test (build + launch) on Windows ARM64
- [x] I've tested on my platform: Windows 11 ARM64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing change)
- [x] I've considered cross-platform impact — yes, the fix is platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

**Before** (clean install, first `hermes --tui`):

```
Error: Build failed with 3 errors:
src/app/useMainApp.ts:27:38: ERROR: Could not resolve "../lib/resizeCoalescer.js"
src/components/appLayout.tsx:21:35: ERROR: Could not resolve "../lib/prompt.js"
src/components/journey.tsx:7:76: ERROR: Could not resolve "../lib/starmapPalette.js"
```

**After** (same clean install):

```
$ node ui-tui/scripts/build.mjs
  dist\entry.js  3.3mb
Done in 1440ms
built C:\Users\...\ui-tui\dist\entry.js
```

TUI launches and runs as expected.
