### PR TITLE
fix(cli): cap diagnostics upload-url response reads

### DIFF
--- a/hermes_cli/diagnostics_upload.py
+++ b/hermes_cli/diagnostics_upload.py
@@ -36,7 +36,38 @@ NAS_BASE = os.environ.get(
 _REQUEST_TIMEOUT = 30
 _UPLOAD_TIMEOUT = 120
 
+# The upload-url response is a tiny signed-upload metadata object. Keep a
+# generous explicit cap so an unexpected proxy/portal response cannot be fully
+# buffered before JSON parsing.
+_UPLOAD_URL_RESPONSE_MAX_BYTES = 64 * 1024
+
 _USER_AGENT = "hermes-agent/debug-share"
+
+
+def _read_capped_response(resp, *, max_bytes: int = _UPLOAD_URL_RESPONSE_MAX_BYTES) -> bytes:
+    """Read at most ``max_bytes`` from a small JSON response.
+
+    Raises ``RuntimeError`` before JSON parsing if the server declares or sends
+    a body larger than the expected small metadata envelope.
+    """
+    content_length = resp.headers.get("Content-Length") if getattr(resp, "headers", None) else None
+    if content_length:
+        try:
+            if int(content_length) > max_bytes:
+                raise RuntimeError(
+                    "diagnostics upload-url response exceeded size limit "
+                    f"({int(content_length)} bytes > {max_bytes} bytes)"
+                )
+        except ValueError:
+            pass
+
+    body = resp.read(max_bytes + 1)
+    if len(body) > max_bytes:
+        raise RuntimeError(
+            "diagnostics upload-url response exceeded size limit "
+            f"({max_bytes} bytes)"
+        )
+    return body
 
 
 def request_upload_url(
@@ -75,7 +106,7 @@ def request_upload_url(
             raise RuntimeError(
                 f"diagnostics upload-url request failed: HTTP {status}"
             )
-        body = resp.read().decode("utf-8")
+        body = _read_capped_response(resp).decode("utf-8")
 
     try:
         result = json.loads(body)

--- a/tests/hermes_cli/test_diagnostics_upload.py
+++ b/tests/hermes_cli/test_diagnostics_upload.py
@@ -91,6 +91,33 @@ class TestRequestUploadUrl:
             with pytest.raises(RuntimeError):
                 request_upload_url()
 
+    def test_declared_oversized_response_raises_before_read(self):
+        from hermes_cli.diagnostics_upload import request_upload_url
+
+        resp = _resp(status=200, body=b"{}")
+        resp.headers = {"Content-Length": str(65 * 1024)}
+        with patch(
+            "hermes_cli.diagnostics_upload.urllib.request.urlopen",
+            return_value=resp,
+        ):
+            with pytest.raises(RuntimeError, match="size limit"):
+                request_upload_url()
+        resp.read.assert_not_called()
+
+    def test_streamed_oversized_response_raises_before_json_parse(self):
+        from hermes_cli import diagnostics_upload as mod
+
+        resp = _resp(status=200, body=b"")
+        resp.headers = {}
+        resp.read.return_value = b"{" + (b"a" * mod._UPLOAD_URL_RESPONSE_MAX_BYTES)
+        with patch(
+            "hermes_cli.diagnostics_upload.urllib.request.urlopen",
+            return_value=resp,
+        ):
+            with pytest.raises(RuntimeError, match="size limit"):
+                mod.request_upload_url()
+        resp.read.assert_called_once_with(mod._UPLOAD_URL_RESPONSE_MAX_BYTES + 1)
+
     def test_base_url_env_override(self, monkeypatch):
         # NAS_BASE is read at import time; re-import the module under the
         # patched env to confirm the override is honoured.


### PR DESCRIPTION
Fixes #56505.\n\nAdds an explicit 64 KiB cap before parsing the opt-in Nous diagnostics upload-url JSON response. The client now rejects oversized Content-Length declarations before reading and rejects streamed responses that exceed the cap.\n\nTests:\n- scripts/run_tests.sh tests/hermes_cli/test_diagnostics_upload.py