### PR TITLE
fix(tui): strip ANSI from slash worker output

### DIFF
--- a/tests/tui_gateway/test_slash_worker_output.py
+++ b/tests/tui_gateway/test_slash_worker_output.py
@@ -1,0 +1,20 @@
+"""Regression tests for slash-worker command output capture."""
+
+from rich.text import Text
+
+
+def test_slash_worker_captures_rich_output_without_ansi_codes():
+    from tui_gateway.slash_worker import _run
+
+    class _CLI:
+        console = None
+
+        def process_command(self, cmd):
+            assert cmd == "/journey"
+            self.console.print(Text("colored journey", style="rgb(255,0,128)"))
+
+    output = _run(_CLI(), "/journey")
+
+    assert output == "colored journey"
+    assert "\x1b[" not in output
+    assert "\033[" not in output

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -89,7 +89,7 @@ def _run(cli: HermesCLI, command: str) -> str:
     # Rich Console captures its file handle at construction time, so
     # contextlib.redirect_stdout won't affect it. Swap the console's
     # underlying file to our buffer so self.console.print() is captured.
-    cli.console = Console(file=buf, force_terminal=True, width=120)
+    cli.console = Console(file=buf, force_terminal=False, color_system=None, width=120)
 
     old = getattr(cli_mod, "_cprint", None)
     if old is not None:


### PR DESCRIPTION
Fixes #56533.\n\nThe TUI/Desktop slash-worker now captures Rich command output with terminal forcing disabled, so styled slash-command output is converted to plain text instead of leaking ANSI escape sequences into chat bubbles.\n\nTests:\n- scripts/run_tests.sh tests/tui_gateway/test_slash_worker_output.py tests/tui_gateway/test_slash_worker_sys_path.py