### PR TITLE
fix(matrix): stop sync loop on token introspection errors

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2330,6 +2330,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     or "403" in err_str
                     or "unauthorized" in err_str
                     or "forbidden" in err_str
+                    or "introspect" in err_str
                 ):
                     logger.error(
                         "Matrix: permanent auth error: %s — stopping sync", exc

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2230,6 +2230,40 @@ class TestMatrixSyncLoop:
 
         await adapter.disconnect()
         assert adapter._invite_join_tasks == {}
+    @pytest.mark.asyncio
+    async def test_sync_loop_stops_on_introspect_error(self):
+        """Sync loop should stop (not retry forever) on token introspection errors.
+
+        Regression test for #56532: 'Unable to introspect the access token'
+        was not matched by the permanent-auth check, causing an infinite 5s
+        retry loop even though the token itself remained valid.
+        """
+        adapter = _make_adapter()
+        adapter._closing = False
+
+        call_count = 0
+
+        async def _sync_raises(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise Exception("Unable to introspect the access token")
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=_sync_raises)
+        fake_client.sync_store = mock_sync_store
+        adapter._client = fake_client
+
+        await adapter._sync_loop()
+
+        # Should have stopped after the first failure, not retried indefinitely.
+        assert call_count == 1
+        assert adapter._closing is False  # loop exited, not cancelled
+
+
 
 class TestMatrixUploadAndSend:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fix the Matrix sync loop entering an infinite retry loop when token introspection fails.

The permanent-auth check in `_sync_loop` matched `401`, `403`, `unauthorized`, and `forbidden` — but not `introspect`. When the homeserver's token introspection endpoint fails with "Unable to introspect the access token", the error fell through to the catch-all retry branch and retried every 5 seconds indefinitely. The access token itself remained valid (whoami, joined_rooms, and manual sync all returned HTTP 200), but the adapter permanently stopped consuming inbound Matrix events.

## Related Issue

Fixes #56532

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: Add `"introspect"` to the permanent-auth error keyword list in `_sync_loop`'s exception handler (line 2333). This causes the sync loop to stop cleanly instead of retrying forever on token introspection failures.
- `tests/gateway/test_matrix.py`: Add `test_sync_loop_stops_on_introspect_error` regression test that verifies the sync loop exits after a single "Unable to introspect the access token" exception rather than retrying indefinitely.

## How to Test

1. Run the new regression test: `python -m pytest tests/gateway/test_matrix.py::TestMatrixSyncLoop::test_sync_loop_stops_on_introspect_error -v` — should pass
2. Run all sync loop tests: `python -m pytest tests/gateway/test_matrix.py::TestMatrixSyncLoop -v` — should pass 9/9
3. The fix is a single keyword addition; no behavioral change for errors that already matched (401/403/unauthorized/forbidden)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (single keyword addition in error matching, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
