### PR TITLE
[codex] Bound MiniMax OAuth error responses

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7623,6 +7623,68 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
 # ==================== MiniMax Portal OAuth ====================
 
+_MINIMAX_OAUTH_ERROR_BODY_LIMIT = 16 * 1024
+
+
+def _minimax_response_error_text(
+    response: httpx.Response,
+    *,
+    limit: int = _MINIMAX_OAUTH_ERROR_BODY_LIMIT,
+) -> str:
+    """Return a bounded error body from a streamed MiniMax OAuth response."""
+    limit = max(0, int(limit))
+    chunks: list[bytes] = []
+    total = 0
+    truncated = False
+    try:
+        if getattr(response, "is_stream_consumed", False):
+            text = response.text
+            return text[:limit] + ("...[truncated]" if len(text) > limit else "")
+
+        for chunk in response.iter_bytes():
+            if not chunk:
+                continue
+            remaining = limit + 1 - total
+            if remaining <= 0:
+                truncated = True
+                break
+            if len(chunk) > remaining:
+                chunks.append(chunk[:remaining])
+                total += remaining
+                truncated = True
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        raw = b"".join(chunks)
+        if len(raw) > limit:
+            raw = raw[:limit]
+            truncated = True
+        encoding = response.encoding or "utf-8"
+        text = raw.decode(encoding, errors="replace")
+        return text + ("...[truncated]" if truncated else "")
+    finally:
+        response.close()
+
+
+def _minimax_post_form(
+    client: httpx.Client,
+    url: str,
+    *,
+    data: Dict[str, Any],
+    headers: Dict[str, str],
+) -> httpx.Response:
+    """POST a MiniMax OAuth form without eagerly reading error bodies."""
+    request = client.build_request(
+        "POST",
+        url,
+        data=data,
+        headers=headers,
+    )
+    response = client.send(request, stream=True)
+    if response.status_code == 200:
+        response.read()
+    return response
+
 def _minimax_pkce_pair() -> tuple:
     """Generate (code_verifier, code_challenge_S256, state) for MiniMax OAuth."""
     import secrets
@@ -7638,7 +7700,8 @@ def _minimax_request_user_code(
     client: httpx.Client, *, portal_base_url: str, client_id: str,
     code_challenge: str, state: str,
 ) -> Dict[str, Any]:
-    response = client.post(
+    response = _minimax_post_form(
+        client,
         f"{portal_base_url}/oauth/code",
         data={
             "response_type": "code",
@@ -7655,8 +7718,9 @@ def _minimax_request_user_code(
         },
     )
     if response.status_code != 200:
+        body = _minimax_response_error_text(response)
         raise AuthError(
-            f"MiniMax OAuth authorization failed: {response.text or response.reason_phrase}",
+            f"MiniMax OAuth authorization failed: {body or response.reason_phrase}",
             provider="minimax-oauth", code="authorization_failed",
         )
     payload = response.json()
@@ -7704,7 +7768,8 @@ def _minimax_poll_token(
     interval = max(2.0, (interval_ms or 2000) / 1000.0)
 
     while _time.time() < deadline:
-        response = client.post(
+        response = _minimax_post_form(
+            client,
             f"{portal_base_url}/oauth/token",
             data={
                 "grant_type": MINIMAX_OAUTH_GRANT_TYPE,
@@ -7717,17 +7782,22 @@ def _minimax_poll_token(
                 "Accept": "application/json",
             },
         )
-        try:
-            payload = response.json() if response.text else {}
-        except Exception:
-            payload = {}
-
+        error_text = ""
         if response.status_code != 200:
-            msg = (payload.get("base_resp", {}) or {}).get("status_msg") or response.text
+            error_text = _minimax_response_error_text(response)
+            try:
+                payload = json.loads(error_text) if error_text else {}
+            except Exception:
+                payload = {}
+            msg = (payload.get("base_resp", {}) or {}).get("status_msg") or error_text
             raise AuthError(
                 f"MiniMax OAuth error: {msg or 'unknown'}",
                 provider="minimax-oauth", code="token_exchange_failed",
             )
+        try:
+            payload = response.json() if response.text else {}
+        except Exception:
+            payload = {}
 
         status = payload.get("status")
         if status == "error":
@@ -7863,7 +7933,8 @@ def _refresh_minimax_oauth_state(
     portal_base_url = state["portal_base_url"]
     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
                       follow_redirects=True) as client:
-        response = client.post(
+        response = _minimax_post_form(
+            client,
             f"{portal_base_url}/oauth/token",
             data={
                 "grant_type": "refresh_token",
@@ -7876,11 +7947,12 @@ def _refresh_minimax_oauth_state(
             },
         )
     if response.status_code != 200:
-        body = response.text.lower()
-        relogin = any(m in body for m in
+        body = _minimax_response_error_text(response)
+        body_lower = body.lower()
+        relogin = any(m in body_lower for m in
                       ("invalid_grant", "refresh_token_reused", "invalid_refresh_token"))
         raise AuthError(
-            f"MiniMax OAuth refresh failed: {response.text or response.reason_phrase}",
+            f"MiniMax OAuth refresh failed: {body or response.reason_phrase}",
             provider="minimax-oauth", code="refresh_failed",
             relogin_required=relogin,
         )

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -22,6 +22,7 @@ import pytest
 from hermes_cli.auth import (
     PROVIDER_REGISTRY,
     AuthError,
+    _MINIMAX_OAUTH_ERROR_BODY_LIMIT,
     MINIMAX_OAUTH_CLIENT_ID,
     MINIMAX_OAUTH_GLOBAL_BASE,
     MINIMAX_OAUTH_GLOBAL_INFERENCE,
@@ -45,12 +46,23 @@ def _make_httpx_response(status_code: int, body: dict | None = None, text: str =
     """Return a minimal mock that quacks like httpx.Response."""
     resp = MagicMock()
     resp.status_code = status_code
+    body_text = json.dumps(body) if body is not None else text
     if body is not None:
         resp.json.return_value = body
-        resp.text = json.dumps(body)
     else:
         resp.json.side_effect = Exception("No body")
-        resp.text = text
+    resp.text = body_text
+    resp.content = body_text.encode("utf-8")
+    resp.encoding = "utf-8"
+    resp.is_stream_consumed = status_code == 200
+    resp.iter_bytes.return_value = [resp.content]
+
+    def _read():
+        resp.is_stream_consumed = True
+        return resp.content
+
+    resp.read.side_effect = _read
+    resp.close.return_value = None
     resp.reason_phrase = "OK" if status_code == 200 else "Error"
     return resp
 
@@ -127,7 +139,7 @@ def test_request_user_code_happy_path():
     })
 
     client = MagicMock()
-    client.post.return_value = mock_response
+    client.send.return_value = mock_response
 
     result = _minimax_request_user_code(
         client,
@@ -142,10 +154,13 @@ def test_request_user_code_happy_path():
     assert result["state"] == state
 
     # Verify correct endpoint was called
-    call_args = client.post.call_args
-    assert "/oauth/code" in call_args[0][0]
+    call_args = client.build_request.call_args
+    assert call_args[0][0] == "POST"
+    assert "/oauth/code" in call_args[0][1]
     headers = call_args[1].get("headers", {})
     assert "x-request-id" in headers
+    client.send.assert_called_once_with(client.build_request.return_value, stream=True)
+    mock_response.read.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +176,7 @@ def test_request_user_code_state_mismatch_raises():
     })
 
     client = MagicMock()
-    client.post.return_value = mock_response
+    client.send.return_value = mock_response
 
     with pytest.raises(AuthError) as exc_info:
         _minimax_request_user_code(
@@ -186,7 +201,7 @@ def test_request_user_code_non_200_raises():
     mock_response.text = "Bad Request"
 
     client = MagicMock()
-    client.post.return_value = mock_response
+    client.send.return_value = mock_response
 
     with pytest.raises(AuthError) as exc_info:
         _minimax_request_user_code(
@@ -198,6 +213,35 @@ def test_request_user_code_non_200_raises():
         )
 
     assert exc_info.value.code == "authorization_failed"
+    client.send.assert_called_once_with(client.build_request.return_value, stream=True)
+    mock_response.iter_bytes.assert_called_once()
+    mock_response.close.assert_called_once()
+
+
+def test_request_user_code_non_200_bounds_error_body():
+    large_body = "x" * (_MINIMAX_OAUTH_ERROR_BODY_LIMIT + 1024)
+    mock_response = _make_httpx_response(503, text=large_body)
+
+    client = MagicMock()
+    client.send.return_value = mock_response
+
+    with pytest.raises(AuthError) as exc_info:
+        _minimax_request_user_code(
+            client,
+            portal_base_url=MINIMAX_OAUTH_GLOBAL_BASE,
+            client_id=MINIMAX_OAUTH_CLIENT_ID,
+            code_challenge="challenge",
+            state="state",
+        )
+
+    message = str(exc_info.value)
+    assert exc_info.value.code == "authorization_failed"
+    assert "...[truncated]" in message
+    assert large_body not in message
+    assert len(message) < _MINIMAX_OAUTH_ERROR_BODY_LIMIT + 256
+    client.send.assert_called_once_with(client.build_request.return_value, stream=True)
+    mock_response.iter_bytes.assert_called_once()
+    mock_response.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +265,7 @@ def test_poll_token_pending_then_success():
     success_resp = _make_httpx_response(200, success_body)
 
     client = MagicMock()
-    client.post.side_effect = [pending_resp, pending_resp, success_resp]
+    client.send.side_effect = [pending_resp, pending_resp, success_resp]
 
     with patch("time.sleep"):  # don't actually sleep
         result = _minimax_poll_token(
@@ -237,7 +281,8 @@ def test_poll_token_pending_then_success():
     assert result["status"] == "success"
     assert result["access_token"] == "access-abc"
     assert result["refresh_token"] == "refresh-xyz"
-    assert client.post.call_count == 3
+    assert client.send.call_count == 3
+    assert all(call.kwargs.get("stream") is True for call in client.send.call_args_list)
 
 
 # ---------------------------------------------------------------------------
@@ -250,7 +295,7 @@ def test_poll_token_error_raises():
     error_resp = _make_httpx_response(200, error_body)
 
     client = MagicMock()
-    client.post.return_value = error_resp
+    client.send.return_value = error_resp
 
     with pytest.raises(AuthError) as exc_info:
         _minimax_poll_token(
@@ -290,7 +335,7 @@ def test_poll_token_timeout_raises():
 
     client = MagicMock()
     pending_resp = _make_httpx_response(200, {"status": "pending"})
-    client.post.return_value = pending_resp
+    client.send.return_value = pending_resp
 
     import hermes_cli.auth as auth_module
     with patch.object(auth_module, "time") as mock_time_mod:
@@ -365,7 +410,7 @@ def test_refresh_updates_access_token():
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
         mock_client_instance.__exit__ = MagicMock(return_value=False)
-        mock_client_instance.post.return_value = mock_resp
+        mock_client_instance.send.return_value = mock_resp
         mock_client_class.return_value = mock_client_instance
 
         # Patch _minimax_save_auth_state to avoid touching the auth store
@@ -404,7 +449,7 @@ def test_refresh_updates_access_token_absolute_ms_expired_in():
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
         mock_client_instance.__exit__ = MagicMock(return_value=False)
-        mock_client_instance.post.return_value = mock_resp
+        mock_client_instance.send.return_value = mock_resp
         mock_client_class.return_value = mock_client_instance
 
         with patch("hermes_cli.auth._minimax_save_auth_state"):
@@ -441,7 +486,7 @@ def test_refresh_reuse_triggers_relogin_required():
         mock_client_instance = MagicMock()
         mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
         mock_client_instance.__exit__ = MagicMock(return_value=False)
-        mock_client_instance.post.return_value = bad_resp
+        mock_client_instance.send.return_value = bad_resp
         mock_client_class.return_value = mock_client_instance
 
         with pytest.raises(AuthError) as exc_info:
@@ -701,7 +746,7 @@ def test_token_provider_refreshes_when_near_expiry():
         mock_instance = MagicMock()
         mock_instance.__enter__ = MagicMock(return_value=mock_instance)
         mock_instance.__exit__ = MagicMock(return_value=False)
-        mock_instance.post.return_value = mock_resp
+        mock_instance.send.return_value = mock_resp
         mock_client_class.return_value = mock_instance
 
         token = provider()
@@ -786,7 +831,7 @@ def test_token_provider_quarantines_state_on_terminal_refresh():
         mock_instance = MagicMock()
         mock_instance.__enter__ = MagicMock(return_value=mock_instance)
         mock_instance.__exit__ = MagicMock(return_value=False)
-        mock_instance.post.return_value = bad_resp
+        mock_instance.send.return_value = bad_resp
         mock_client_class.return_value = mock_instance
 
         with pytest.raises(AuthError) as exc_info:


### PR DESCRIPTION
What does this PR do?

- Sends MiniMax OAuth form requests through a streamed `httpx` request helper.
- Keeps successful OAuth responses eager-read so existing JSON parsing behavior stays unchanged.
- Reads non-200 authorization, polling, and refresh responses through a bounded error-body helper before raising `AuthError`.
- Adds a regression test that exercises an oversized MiniMax authorization error body and verifies it is truncated and closed.

Why?

MiniMax OAuth failures should not allow an oversized upstream error body to be materialized before Hermes fails the auth flow. The fix keeps useful error text while bounding the body retained by the CLI.

Fixes #56548

Proof

- `python -m py_compile hermes_cli\auth.py tests\test_minimax_oauth.py`
- Direct MiniMax OAuth request-path proof passed: a 503 response is sent with `stream=True`, `read()` is not called, `iter_bytes()` is used once, the message contains `...[truncated]`, and the response is closed.
- Direct helper proof passed: `_minimax_response_error_text()` caps a body larger than `_MINIMAX_OAUTH_ERROR_BODY_LIMIT` and appends the truncation marker.
- `python -m pytest tests\test_minimax_oauth.py -q` could not run locally because the active Hermes venv does not have `pytest` installed.
- Autoreview was not available in this checkout (`.agents\skills\autoreview\scripts\autoreview` missing; no global `autoreview` command found).