### PR TITLE
fix(qqbot): accept reconnect flag in connect

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Summary
- Allow QQBot adapter `connect()` to accept the shared `is_reconnect` keyword argument used by gateway reconnect/startup paths.

## Why
The gateway calls platform adapters with `connect(is_reconnect=...)`. QQBot currently rejects that kwarg and fails startup/reconnect with:

```
TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

## Test Plan
- `python -m py_compile gateway/platforms/qqbot/adapter.py`
- Verified locally on Windows 10: gateway restart connects QQBot successfully and logs `✓ qqbot connected` / `Ready, session_id=...`.

Related: #53443, #52914, #54410
