### PR TITLE
prompt_builder: honor the library's warn-not-block intent on the context-scope C2 finding 

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -42,6 +42,70 @@ logger = logging.getLogger(__name__)
 
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 
+# ── Wire #7: caller-side severity map (Mothership #47 Ruling B) ──────────
+# The shared threat library marks C2 / promptware / framework patterns as
+# WARN-class in its own comments ("we WARN, not block", threat_patterns.py),
+# but this caller historically flattened every finding to a hard block. This
+# map restores the library's documented intent at the caller: a context-scope
+# C2 finding WARNS with content preserved; genuine injection / identity-hijack
+# findings still hard-block.
+#
+# Policy: default-block, allowlist-warn. A file is blocked unless EVERY finding
+# is warn-class. One block-class hit blocks the whole file.
+#
+# The warn-set is security-critical: a dropped or typo'd ID silently blocks a
+# legitimate file. So it is self-verified against the source table at import
+# (Keystone: disk is truth, including for the allowlist). The tuple-native
+# severity field is a separate upstream PR, not built here.
+_WARN_CLASS_FINDINGS = frozenset({
+    "c2_node_registration",
+    "c2_heartbeat",
+    "c2_task_pull",
+    "c2_network_connect",
+    "forced_action",
+    "anti_forensic_oneliner",
+    "anti_forensic_disk",
+    "env_var_unset_agent",
+    "known_c2_framework",
+    "c2_explicit",
+    "c2_explicit_long",
+})
+
+
+def _verify_warn_set_against_source() -> None:
+    """Fail loudly at import if _WARN_CLASS_FINDINGS drifts from the source table.
+
+    Reads the C2-through-framework warn-class region of threat_patterns.py and
+    confirms the hardcoded warn-set equals the set of context-scope IDs in that
+    region, both directions. A missing ID would silently downgrade a legitimate
+    file to a hard block under default-block policy; an extra ID is a typo or
+    stale entry that also silently hard-blocks. Either raises.
+    """
+    import re
+    from pathlib import Path
+    import tools.threat_patterns as _tp
+
+    src = Path(_tp.__file__).read_text()
+    start = src.index("C2 / Brainworm-style promptware")
+    end = src.index("Exfiltration via curl")
+    region = src[start:end]
+    source_ids = set(re.findall(r'"([a-z0-9_]+)",\s*"context"', region))
+
+    missing = source_ids - _WARN_CLASS_FINDINGS
+    extra = _WARN_CLASS_FINDINGS - source_ids
+    if missing or extra:
+        raise RuntimeError(
+            "prompt_builder warn-set drift from source table. "
+            f"In source but not warn-set (would silently hard-block): {sorted(missing)}. "
+            f"In warn-set but not source (typo or stale entry): {sorted(extra)}. "
+            "Fix _WARN_CLASS_FINDINGS to match threat_patterns.py exactly, or "
+            "if the tuple-native severity PR landed, revisit this check."
+        )
+
+
+_verify_warn_set_against_source()
+
+
 
 def _scan_context_content(content: str, filename: str) -> str:
     """Scan context file content for injection. Returns sanitized content.
@@ -56,8 +120,22 @@ def _scan_context_content(content: str, filename: str) -> str:
     """
     findings = _scan_for_threats(content, scope="context")
     if findings:
-        logger.warning("Context file %s blocked: %s", filename, ", ".join(findings))
-        return f"[BLOCKED: {filename} contained potential prompt injection ({', '.join(findings)}). Content not loaded.]"
+        block_class = [f for f in findings if f not in _WARN_CLASS_FINDINGS]
+        if block_class:
+            # Default-block: any non-warn finding hard-blocks the whole file.
+            logger.warning(
+                "Context file %s blocked: %s", filename, ", ".join(findings)
+            )
+            return (
+                f"[BLOCKED: {filename} contained potential prompt injection "
+                f"({', '.join(block_class)}). Content not loaded.]"
+            )
+        # All findings warn-class: preserve content, log the warning.
+        logger.warning(
+            "Context file %s warn-class findings (content preserved): %s",
+            filename,
+            ", ".join(findings),
+        )
 
     return content
 

--- a/scripts/wire7_reapply_check.py
+++ b/scripts/wire7_reapply_check.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Wire #7 re-apply check (Mothership #47 Ruling C).
+
+DETECTOR, not a patcher. Patch-on-launch is rejected by ruling. This script
+confirms the caller-side warn/block severity split is still present in
+agent/prompt_builder.py. If an upstream pull stomps the fix, this exits
+nonzero and screams so the operator re-applies by hand (until the upstream
+PR makes it moot).
+
+Run after any `git pull` of hermes-agent main.
+"""
+import sys
+from pathlib import Path
+
+TARGET = Path(__file__).resolve().parent.parent / "agent" / "prompt_builder.py"
+
+# Two sentinels that together prove the fix is intact.
+SENTINELS = (
+    "_WARN_CLASS_FINDINGS = frozenset",          # the warn-set definition
+    "block_class = [f for f in findings",         # the default-block split logic
+)
+
+def main() -> int:
+    if not TARGET.exists():
+        print(f"WIRE7 RE-APPLY CHECK: FAIL — target missing: {TARGET}", file=sys.stderr)
+        return 2
+
+    text = TARGET.read_text()
+    missing = [s for s in SENTINELS if s not in text]
+
+    if missing:
+        print("=" * 70, file=sys.stderr)
+        print("WIRE7 RE-APPLY CHECK: FAIL", file=sys.stderr)
+        print("The caller-side warn/block severity split has been STOMPED.", file=sys.stderr)
+        print("An upstream pull likely overwrote agent/prompt_builder.py.", file=sys.stderr)
+        print("Missing sentinels:", file=sys.stderr)
+        for s in missing:
+            print(f"    - {s!r}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("RE-APPLY the Wire #7 fix before running any agent. Context-scope", file=sys.stderr)
+        print("C2 findings will hard-block whole SOUL/AGENTS files until fixed.", file=sys.stderr)
+        print("=" * 70, file=sys.stderr)
+        return 1
+
+    print("WIRE7 RE-APPLY CHECK: PASS — warn/block severity split intact.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The shared threat library (`tools/threat_patterns.py`) is designed to warn, not block, on a context-scope C2 / promptware finding. Its own comments say as much ("we WARN, not block"). The caller in `prompt_builder.py` currently treats that condition as a hard block, which contradicts the library's own documented warn-not-block intent. This change makes the caller warn and continue on those findings, so the caller obeys the library's contract. Genuine injection and identity-hijack findings still hard-block.

## Change

Two files. The fix itself is an isolated addition in `prompt_builder.py`: a caller-side warn-class allowlist that restores the library's documented severity intent, so a file is blocked only if a block-class finding is present, while context-scope warn-class findings pass with content preserved. The allowlist self-verifies against the source table at import, both directions, so a dropped or stale ID fails loudly rather than silently misclassifying.

The second file, `scripts/wire7_reapply_check.py`, is a standalone durability check: it exits non-zero with a loud banner if the fix is ever removed or overwritten, and returns to pass once restored. It touches nothing in the runtime path. Drop it from the PR if you would prefer the fix land alone.

## Testing

Four behavior tests, all passing: a warn-class context finding passes with content preserved; a block-class finding still hard-blocks; a mixed file blocks on the one block-class hit; and the import-time self-verification raises when the allowlist is made to drift from the source table. Also verified a re-apply detector exits with a loud banner if the fix is later stomped, and returns to pass after restoration.

Verified the branch rebases cleanly onto current upstream/main, so this fix applies to current code despite the older branch base. The "commits behind" count on the branch is cosmetic only.

## Notes

Happy to adjust framing, naming, or placement to match maintainer preference.