### PR TITLE
[codex] Bound local model discovery responses

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
+import json
 import os
 import re
 from urllib.parse import urlparse
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_MODEL_DISCOVERY_BODY_LIMIT = 2 * 1024 * 1024
 
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
@@ -245,18 +248,44 @@ def _anthropic_base_url_override_ok(base_url: str) -> bool:
     return False
 
 
+def _read_local_model_discovery_json(response: Any) -> Dict[str, Any]:
+    """Parse a local /models response without buffering an unbounded body."""
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > _LOCAL_MODEL_DISCOVERY_BODY_LIMIT:
+            raise ValueError(
+                "local model discovery response exceeded "
+                f"{_LOCAL_MODEL_DISCOVERY_BODY_LIMIT} bytes"
+            )
+        chunks.append(chunk)
+
+    raw = b"".join(chunks)
+    if not raw.strip():
+        return {}
+    encoding = getattr(response, "encoding", None) or "utf-8"
+    parsed = json.loads(raw.decode(encoding, errors="replace"))
+    if not isinstance(parsed, dict):
+        raise ValueError("local model discovery response was not a JSON object")
+    return parsed
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
         return ""
+    resp = None
     try:
         import requests
         url = base_url.rstrip("/")
         if not url.endswith("/v1"):
             url += "/v1"
-        resp = requests.get(url + "/models", timeout=5)
+        resp = requests.get(url + "/models", timeout=5, stream=True)
         if resp.ok:
-            models = resp.json().get("data", [])
+            models = _read_local_model_discovery_json(resp).get("data", [])
             if len(models) == 1:
                 model_id = models[0].get("id", "")
                 if model_id:
@@ -265,6 +294,10 @@ def _auto_detect_local_model(base_url: str) -> str:
         # Log instead of silently swallowing — aids debugging when
         # local model auto-detection fails unexpectedly.
         logger.debug("Auto-detect model from %s failed: %s", base_url, exc)
+    finally:
+        close = getattr(resp, "close", None)
+        if callable(close):
+            close()
     return ""
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -9,6 +10,8 @@ from urllib.parse import urlparse
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_MODEL_DISCOVERY_BODY_LIMIT = 2 * 1024 * 1024
 
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import (
@@ -291,18 +294,44 @@ def _anthropic_base_url_override_ok(base_url: str) -> bool:
     return False
 
 
+def _read_local_model_discovery_json(response: Any) -> Dict[str, Any]:
+    """Parse a local /models response without buffering an unbounded body."""
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > _LOCAL_MODEL_DISCOVERY_BODY_LIMIT:
+            raise ValueError(
+                "local model discovery response exceeded "
+                f"{_LOCAL_MODEL_DISCOVERY_BODY_LIMIT} bytes"
+            )
+        chunks.append(chunk)
+
+    raw = b"".join(chunks)
+    if not raw.strip():
+        return {}
+    encoding = getattr(response, "encoding", None) or "utf-8"
+    parsed = json.loads(raw.decode(encoding, errors="replace"))
+    if not isinstance(parsed, dict):
+        raise ValueError("local model discovery response was not a JSON object")
+    return parsed
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
         return ""
+    resp = None
     try:
         import requests
         url = base_url.rstrip("/")
         if not url.endswith("/v1"):
             url += "/v1"
-        resp = requests.get(url + "/models", timeout=(2, 3))
+        resp = requests.get(url + "/models", timeout=(2, 3), stream=True)
         if resp.ok:
-            models = resp.json().get("data", [])
+            models = _read_local_model_discovery_json(resp).get("data", [])
             if len(models) == 1:
                 model_id = models[0].get("id", "")
                 if model_id:
@@ -311,6 +340,10 @@ def _auto_detect_local_model(base_url: str) -> str:
         # Log instead of silently swallowing — aids debugging when
         # local model auto-detection fails unexpectedly.
         logger.debug("Auto-detect model from %s failed: %s", base_url, exc)
+    finally:
+        close = getattr(resp, "close", None)
+        if callable(close):
+            close()
     return ""
 
 

--- a/tests/cli/test_runtime_provider_local_model.py
+++ b/tests/cli/test_runtime_provider_local_model.py
@@ -1,0 +1,61 @@
+import json
+
+import requests
+
+from hermes_cli.runtime_provider import (
+    _LOCAL_MODEL_DISCOVERY_BODY_LIMIT,
+    _auto_detect_local_model,
+)
+
+
+class _FakeResponse:
+    def __init__(self, chunks, *, ok=True, encoding="utf-8"):
+        self._chunks = list(chunks)
+        self.ok = ok
+        self.encoding = encoding
+        self.closed = False
+
+    def iter_content(self, chunk_size=1):
+        yield from self._chunks
+
+    def close(self):
+        self.closed = True
+
+    def json(self):
+        raise AssertionError("local model discovery must not call response.json()")
+
+
+def test_auto_detect_local_model_reads_bounded_stream(monkeypatch):
+    response = _FakeResponse(
+        [json.dumps({"data": [{"id": "local-model"}]}).encode("utf-8")]
+    )
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return response
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert _auto_detect_local_model("http://127.0.0.1:8000") == "local-model"
+    assert captured["url"] == "http://127.0.0.1:8000/v1/models"
+    assert captured["kwargs"]["stream"] is True
+    assert response.closed is True
+
+
+def test_auto_detect_local_model_drops_oversized_response(monkeypatch):
+    response = _FakeResponse([b"x" * (_LOCAL_MODEL_DISCOVERY_BODY_LIMIT + 1)])
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return response
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert _auto_detect_local_model("http://localhost:1234/v1") == ""
+    assert captured["url"] == "http://localhost:1234/v1/models"
+    assert captured["kwargs"]["stream"] is True
+    assert response.closed is True

--- a/tests/cli/test_runtime_provider_local_model.py
+++ b/tests/cli/test_runtime_provider_local_model.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 import requests
 
 from hermes_cli.runtime_provider import (
@@ -58,4 +59,17 @@ def test_auto_detect_local_model_drops_oversized_response(monkeypatch):
     assert _auto_detect_local_model("http://localhost:1234/v1") == ""
     assert captured["url"] == "http://localhost:1234/v1/models"
     assert captured["kwargs"]["stream"] is True
+    assert response.closed is True
+
+
+@pytest.mark.parametrize("body", [b"{", b"[]"])
+def test_auto_detect_local_model_drops_invalid_json_shapes(monkeypatch, body):
+    response = _FakeResponse([body])
+
+    def fake_get(_url, **_kwargs):
+        return response
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert _auto_detect_local_model("http://localhost:1234/v1") == ""
     assert response.closed is True


### PR DESCRIPTION
﻿What does this PR do?

- Bounds local/custom `/v1/models` auto-detection responses with a streamed 2 MiB read cap.
- Keeps normal single-model detection behavior for small valid model-list responses.
- Falls back to no detected model on oversized or malformed responses, matching the existing non-fatal auto-detection behavior.
- Adds focused regression coverage proving the code uses `stream=True`, closes the response, and does not call `response.json()`.

Fixes #56559

Proof:

- `python -m py_compile hermes_cli\runtime_provider.py tests\cli\test_runtime_provider_local_model.py` passed.
- `git diff --check` passed.
- Direct proof script passed: a valid small `/models` response detects one model; an oversized streamed response returns `""`, uses `stream=True`, never calls `.json()`, and closes the response.
- `python -m pytest tests\cli\test_runtime_provider_local_model.py -q` could not run locally because the active environment lacks the `pytest` module.
- Autoreview unavailable locally: no repo helper and no global `autoreview` command were found.
