### PR TITLE
feat: add Ollama Cloud as a web_search/web_extract backend

### DIFF
--- a/plugins/web/ollama/__init__.py
+++ b/plugins/web/ollama/__init__.py
@@ -1,0 +1,14 @@
+"""Ollama Cloud web search + fetch plugin — bundled, auto-loaded.
+
+Registers the Ollama Cloud provider so ``web_search`` and ``web_extract`` can
+route through Ollama's official web_search and web_fetch endpoints.
+"""
+
+from __future__ import annotations
+
+from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Ollama Cloud provider with the plugin context."""
+    ctx.register_web_search_provider(OllamaWebSearchProvider())

--- a/plugins/web/ollama/plugin.yaml
+++ b/plugins/web/ollama/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-ollama
+version: 1.0.0
+description: "Ollama Cloud web search + web fetch. Uses Ollama's official web_search and web_fetch APIs. Requires OLLAMA_API_KEY."
+author: agent
+kind: backend
+provides_web_providers:
+  - ollama

--- a/plugins/web/ollama/provider.py
+++ b/plugins/web/ollama/provider.py
@@ -1,0 +1,218 @@
+"""Ollama Cloud web search + fetch plugin.
+
+Uses Ollama's public web_search and web_fetch REST endpoints:
+  - POST https://ollama.com/api/web_search
+  - POST https://ollama.com/api/web_fetch
+
+Backed by :class:`agent.web_search_provider.WebSearchProvider` and auto-loaded
+as a bundled ``kind: backend`` plugin under ``plugins/web/ollama``.
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "ollama"
+      extract_backend: "ollama"
+      backend: "ollama"
+
+Env vars::
+
+    OLLAMA_API_KEY=...                    # required
+    OLLAMA_WEB_SEARCH_URL=...             # optional override
+    OLLAMA_WEB_FETCH_URL=...              # optional override
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SEARCH_URL = "https://ollama.com/api/web_search"
+_DEFAULT_FETCH_URL = "https://ollama.com/api/web_fetch"
+
+
+def _get_api_key() -> Optional[str]:
+    """Return the configured Ollama API key, or None if unset."""
+    return os.getenv("OLLAMA_API_KEY", "").strip() or None
+
+
+def _search_url() -> str:
+    return os.getenv("OLLAMA_WEB_SEARCH_URL", _DEFAULT_SEARCH_URL).strip().rstrip("/")
+
+
+def _fetch_url() -> str:
+    return os.getenv("OLLAMA_WEB_FETCH_URL", _DEFAULT_FETCH_URL).strip().rstrip("/")
+
+
+def _http_post_json(url: str, payload: Dict[str, Any], api_key: str, timeout: float = 30.0) -> Any:
+    """POST JSON to an Ollama web endpoint and return the parsed response."""
+    data = json.dumps(payload).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            detail = json.loads(body)
+        except Exception:
+            detail = body
+        raise RuntimeError(f"Ollama web API HTTP {exc.code}: {detail}") from exc
+
+
+class OllamaWebSearchProvider(WebSearchProvider):
+    """Ollama Cloud web_search + web_fetch provider."""
+
+    @property
+    def name(self) -> str:
+        return "ollama"
+
+    @property
+    def display_name(self) -> str:
+        return "Ollama Cloud"
+
+    def is_available(self) -> bool:
+        """Return True when ``OLLAMA_API_KEY`` is set to a non-empty value."""
+        return _get_api_key() is not None
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a web search via Ollama Cloud."""
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            api_key = _get_api_key()
+            if not api_key:
+                return {
+                    "success": False,
+                    "error": "OLLAMA_API_KEY environment variable not set. "
+                    "Create an API key at https://ollama.com/settings/keys",
+                }
+
+            safe_limit = max(1, int(limit))
+            logger.info("Ollama Cloud web search: '%s' (limit=%d)", query, safe_limit)
+
+            raw = _http_post_json(
+                _search_url(),
+                {"query": query, "max_results": safe_limit},
+                api_key,
+                timeout=30.0,
+            )
+
+            results = []
+            for i, hit in enumerate(raw.get("results", [])):
+                results.append(
+                    {
+                        "title": str(hit.get("title", "")),
+                        "url": str(hit.get("url", "")),
+                        "description": str(hit.get("content", "")),
+                        "position": i + 1,
+                    }
+                )
+
+            logger.info("Ollama Cloud web search: %d results", len(results))
+            return {"success": True, "data": {"web": results}}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Ollama Cloud web search error: %s", exc)
+            return {"success": False, "error": f"Ollama web search failed: {exc}"}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Fetch content from one or more URLs via Ollama Cloud web_fetch."""
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+
+            api_key = _get_api_key()
+            if not api_key:
+                return [
+                    {
+                        "url": u,
+                        "title": "",
+                        "content": "",
+                        "error": "OLLAMA_API_KEY environment variable not set. "
+                        "Create an API key at https://ollama.com/settings/keys",
+                    }
+                    for u in urls
+                ]
+
+            logger.info("Ollama Cloud web fetch: %d URL(s)", len(urls))
+            results: List[Dict[str, Any]] = []
+            fetch_url = _fetch_url()
+
+            for url in urls:
+                if is_interrupted():
+                    results.append({"url": url, "error": "Interrupted", "title": ""})
+                    continue
+
+                try:
+                    raw = _http_post_json(
+                        fetch_url,
+                        {"url": url},
+                        api_key,
+                        timeout=60.0,
+                    )
+                    content = str(raw.get("content", "") or "")
+                    results.append(
+                        {
+                            "url": url,
+                            "title": str(raw.get("title", "")),
+                            "content": content,
+                            "raw_content": content,
+                            "metadata": {"links": raw.get("links", [])},
+                        }
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Ollama Cloud web fetch error for %s: %s", url, exc)
+                    results.append(
+                        {
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": f"Ollama web fetch failed: {exc}",
+                        }
+                    )
+
+            return results
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Ollama Cloud web fetch error: %s", exc)
+            return [
+                {"url": u, "title": "", "content": "", "error": f"Ollama web fetch failed: {exc}"}
+                for u in urls
+            ]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Ollama Cloud",
+            "badge": "free tier",
+            "tag": "Ollama's official web search + fetch APIs. Free tier included with an Ollama account.",
+            "env_vars": [
+                {
+                    "key": "OLLAMA_API_KEY",
+                    "prompt": "Ollama API key",
+                    "url": "https://ollama.com/settings/keys",
+                },
+            ],
+        }

--- a/tests/tools/test_web_providers_ollama.py
+++ b/tests/tools/test_web_providers_ollama.py
@@ -1,0 +1,189 @@
+"""Tests for the Ollama Cloud web search provider.
+
+Covers:
+- OllamaWebSearchProvider.is_available() env var gating
+- OllamaWebSearchProvider.search() happy path + normalization
+- OllamaWebSearchProvider.extract() happy path
+- Missing API key handling
+- _is_backend_available("ollama") integration
+- _get_backend() recognizes "ollama" as a valid configured backend
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestOllamaProviderIsConfigured:
+    def test_configured_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "osk_test")
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        assert OllamaWebSearchProvider().is_available() is True
+
+    def test_not_configured_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        assert OllamaWebSearchProvider().is_available() is False
+
+    def test_not_configured_when_key_whitespace(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "   ")
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        assert OllamaWebSearchProvider().is_available() is False
+
+    def test_provider_name(self):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        assert OllamaWebSearchProvider().name == "ollama"
+        assert OllamaWebSearchProvider().display_name == "Ollama Cloud"
+
+    def test_implements_web_search_provider(self):
+        from agent.web_search_provider import WebSearchProvider
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        assert issubclass(OllamaWebSearchProvider, WebSearchProvider)
+
+    def test_supports_search_and_extract(self):
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        p = OllamaWebSearchProvider()
+        assert p.supports_search() is True
+        assert p.supports_extract() is True
+
+
+class TestOllamaProviderSearch:
+    _SAMPLE_RESPONSE = {
+        "results": [
+            {"title": "A", "url": "https://a.example.com", "content": "snippet A"},
+            {"title": "B", "url": "https://b.example.com", "content": "snippet B"},
+        ]
+    }
+
+    def test_happy_path_normalizes_results(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "osk_test")
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        def fake_urlopen(req, timeout=None):
+            data = json.dumps(self._SAMPLE_RESPONSE).encode()
+            m = MagicMock()
+            m.read.return_value = data
+            m.__enter__ = lambda s: s
+            m.__exit__ = lambda *a: None
+            return m
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            result = OllamaWebSearchProvider().search("test query", limit=5)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0] == {"title": "A", "url": "https://a.example.com", "description": "snippet A", "position": 1}
+        assert web[1]["position"] == 2
+
+    def test_request_sends_json_with_max_results(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "osk_test")
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["body"] = json.loads(req.data.decode())
+            captured["headers"] = dict(req.header_items())
+            data = json.dumps({"results": []}).encode()
+            m = MagicMock()
+            m.read.return_value = data
+            m.__enter__ = lambda s: s
+            m.__exit__ = lambda *a: None
+            return m
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            OllamaWebSearchProvider().search("q", limit=3)
+
+        assert captured["body"]["query"] == "q"
+        assert captured["body"]["max_results"] == 3
+        assert captured["headers"].get("Authorization") == "Bearer osk_test"
+        assert captured["headers"].get("Content-type") == "application/json"
+
+    def test_missing_key_returns_failure(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        result = OllamaWebSearchProvider().search("q", limit=5)
+        assert result["success"] is False
+        assert "OLLAMA_API_KEY" in result["error"]
+
+    def test_http_error_returns_failure(self, monkeypatch):
+        import urllib.error
+        monkeypatch.setenv("OLLAMA_API_KEY", "osk_test")
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.HTTPError(
+                req.full_url, 429, "Too Many Requests", {}, None
+            )
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            result = OllamaWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "429" in result["error"]
+
+
+class TestOllamaProviderExtract:
+    def test_happy_path(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "osk_test")
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+        response = {"title": "T", "content": "body", "links": ["https://x.com"]}
+
+        def fake_urlopen(req, timeout=None):
+            data = json.dumps(response).encode()
+            m = MagicMock()
+            m.read.return_value = data
+            m.__enter__ = lambda s: s
+            m.__exit__ = lambda *a: None
+            return m
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            results = OllamaWebSearchProvider().extract(["https://example.com"])
+
+        assert len(results) == 1
+        assert results[0]["url"] == "https://example.com"
+        assert results[0]["title"] == "T"
+        assert results[0]["content"] == "body"
+        assert results[0]["raw_content"] == "body"
+        assert results[0]["metadata"]["links"] == ["https://x.com"]
+
+    def test_missing_key_returns_failure_per_url(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        from plugins.web.ollama.provider import OllamaWebSearchProvider
+        results = OllamaWebSearchProvider().extract(["https://example.com"])
+        assert len(results) == 1
+        assert results[0]["error"]
+        assert "OLLAMA_API_KEY" in results[0]["error"]
+
+
+class TestOllamaBackendWiring:
+    def test_is_backend_available_true_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "osk_test")
+        from tools.web_tools import _is_backend_available
+        assert _is_backend_available("ollama") is True
+
+    def test_is_backend_available_false_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        from tools.web_tools import _is_backend_available
+        assert _is_backend_available("ollama") is False
+
+    def test_configured_backend_accepted(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ollama"})
+        monkeypatch.setenv("OLLAMA_API_KEY", "osk_test")
+        assert web_tools._get_backend() == "ollama"
+
+    def test_auto_detect_picks_ollama_when_only_key_set(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        for key in ("FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY",
+                    "TAVILY_API_KEY", "EXA_API_KEY", "SEARXNG_URL", "BRAVE_SEARCH_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("OLLAMA_API_KEY", "osk_test")
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        assert web_tools._get_backend() == "ollama"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -144,7 +144,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "ollama"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -160,6 +160,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
         ("firecrawl", _is_tool_gateway_ready()),
+        ("ollama", _has_env("OLLAMA_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -235,6 +236,8 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "ollama":
+        return _has_env("OLLAMA_API_KEY")
     return False
 
 
@@ -281,6 +284,7 @@ def _web_requires_env() -> list[str]:
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_GATEWAY_URL",
+        "OLLAMA_API_KEY",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",


### PR DESCRIPTION
Adds a bundled backend plugin `plugins/web/ollama` that routes Hermes `web_search` and `web_extract` calls through Ollama's official cloud endpoints:

- `POST https://ollama.com/api/web_search`
- `POST https://ollama.com/api/web_fetch`

Requires `OLLAMA_API_KEY`. Optional URL overrides via `OLLAMA_WEB_SEARCH_URL` and `OLLAMA_WEB_FETCH_URL`.

Also registers `ollama` in `tools/web_tools.py` backend selection/availability checks and adds provider tests.

Tested:
- `scripts/run_tests.sh tests/tools/test_web_providers_ollama.py tests/tools/test_web_providers.py tests/tools/test_web_tools_config.py ...` → 186 tests passed
- End-to-end: `hermes chat -q "Найди в интернете: что такое Ollama web search API" -t web` uses Ollama Cloud for search results.