### PR TITLE
fix: guard primary restore against fallback credential pools

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -56,6 +56,37 @@ def _ra():
     return run_agent
 
 
+def _credential_pool_matches_agent_provider(agent: Any, pool: Any) -> bool:
+    """Return whether a live credential pool belongs to the agent's provider.
+
+    Fallback activation can temporarily attach the fallback provider's pool to
+    the same long-lived agent. Recovery/restore paths must not apply that pool
+    after the runtime has moved back to a different provider, because
+    ``_swap_credential`` adopts both the entry key and entry base_url.
+    """
+    current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+    pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
+    if not current_provider or not pool_provider or current_provider == pool_provider:
+        return True
+
+    # Custom endpoints use two naming conventions for the SAME provider: the
+    # agent carries ``custom`` while the pool is keyed ``custom:<name>``. Accept
+    # that pair only when the agent's current base_url resolves to this pool.
+    if current_provider == "custom" and pool_provider.startswith("custom:"):
+        try:
+            from agent.credential_pool import get_custom_provider_pool_key
+
+            agent_base = (getattr(agent, "base_url", "") or "").strip()
+            return bool(agent_base) and (
+                (get_custom_provider_pool_key(agent_base) or "").strip().lower()
+                == pool_provider
+            )
+        except Exception:
+            return False
+
+    return False
+
+
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
     {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task"}
 )
@@ -699,34 +730,14 @@ def recover_with_credential_pool(
     # that seeded the pool.
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
-    if current_provider and pool_provider and current_provider != pool_provider:
-        # Custom endpoints use two naming conventions for the SAME provider:
-        # the agent carries the generic ``custom`` label while the pool is
-        # keyed ``custom:<name>`` (see CUSTOM_POOL_PREFIX). A literal string
-        # compare treats them as a mismatch and skips recovery for every
-        # custom-provider user — 401s/429s then burn the full retry cycle
-        # with no rotation or refresh. Accept the pair as matching only when
-        # the agent's CURRENT base_url actually resolves to this pool key,
-        # so a fallback provider (or a different custom endpoint) still
-        # triggers the guard.
-        _custom_match = False
-        if current_provider == "custom" and pool_provider.startswith("custom:"):
-            try:
-                from agent.credential_pool import get_custom_provider_pool_key
-                _agent_base = (getattr(agent, "base_url", "") or "").strip()
-                _custom_match = bool(_agent_base) and (
-                    (get_custom_provider_pool_key(_agent_base) or "").strip().lower()
-                    == pool_provider
-                )
-            except Exception:
-                _custom_match = False
-        if not _custom_match:
-            _ra().logger.warning(
-                "Credential pool provider mismatch: pool=%s, agent=%s — "
-                "skipping pool mutation to avoid cross-provider contamination",
-                pool_provider, current_provider,
-            )
-            return False, has_retried_429
+    if not _credential_pool_matches_agent_provider(agent, pool):
+        _ra().logger.warning(
+            "Credential pool provider mismatch: pool=%s, agent=%s — "
+            "skipping pool mutation to avoid cross-provider contamination",
+            pool_provider,
+            current_provider,
+        )
+        return False, has_retried_429
 
     effective_reason = classified_reason
     if effective_reason is None:
@@ -1181,7 +1192,21 @@ def restore_primary_runtime(agent) -> bool:
         # When the pool is absent, empty, or the entry has no usable key, we
         # keep the snapshot key (the existing behavior).  Fixes #25205.
         pool = getattr(agent, "_credential_pool", None)
-        if pool is not None and pool.has_available():
+        if pool is not None and not _credential_pool_matches_agent_provider(agent, pool):
+            pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
+            current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+            logger.warning(
+                "Restore skipped credential pool provider mismatch: pool=%s, "
+                "agent=%s — detaching pool and keeping primary runtime snapshot credential",
+                pool_provider,
+                current_provider,
+            )
+            # A mismatched pool may belong to a fallback provider from the last
+            # turn. Detach instead of applying or reloading here: restore must be
+            # deterministic and the existing no-pool path safely keeps the
+            # primary snapshot credential.
+            agent._credential_pool = None
+        elif pool is not None and pool.has_available():
             entry = pool.select()
             if entry is not None:
                 entry_key = (

--- a/tests/agent/test_restore_primary_pool_reselect.py
+++ b/tests/agent/test_restore_primary_pool_reselect.py
@@ -25,6 +25,8 @@ def _make_entry(
     label: str,
     access_token: str,
     *,
+    provider: str = "openai-codex",
+    base_url: str = "https://chatgpt.com/backend-api/codex",
     source: str = "device_code",
     priority: int = 0,
     last_status: str | None = None,
@@ -33,25 +35,30 @@ def _make_entry(
     return {
         "id": label,
         "label": label,
-        "provider": "openai-codex",
+        "provider": provider,
         "auth_type": AUTH_TYPE_OAUTH,
         "source": source,
         "priority": priority,
         "access_token": access_token,
         "refresh_token": f"rt-{label}",
-        "base_url": "https://chatgpt.com/backend-api/codex",
+        "base_url": base_url,
         "last_status": last_status,
         "last_status_at": last_status_at,
     }
 
 
-def _build_mock_pool(entries: list[dict], *, strategy: str = "round_robin"):
+def _build_mock_pool(
+    entries: list[dict],
+    *,
+    provider: str = "openai-codex",
+    strategy: str = "round_robin",
+):
     """Build a mock CredentialPool with the given entries."""
     from agent.credential_pool import CredentialPool
 
     pool = CredentialPool(
-        provider="openai-codex",
-        entries=[PooledCredential.from_dict("openai-codex", e) for e in entries],
+        provider=provider,
+        entries=[PooledCredential.from_dict(provider, e) for e in entries],
     )
     pool._strategy = strategy
     return pool
@@ -220,3 +227,65 @@ class TestRestorePrimaryPoolReselect:
         assert result is True
         assert "custom-endpoint.example.com" in agent.base_url
         assert "custom-endpoint.example.com" in agent._client_kwargs["base_url"]
+
+    def test_restore_skips_pool_from_fallback_provider(self):
+        """Restoring primary must not reselect a credential from a fallback provider pool."""
+        entries = [
+            _make_entry(
+                "openrouter-entry",
+                "openrouter-key",
+                provider="openrouter",
+                base_url="https://openrouter.ai/api/v1",
+                priority=0,
+            ),
+        ]
+        pool = _build_mock_pool(entries, provider="openrouter")
+
+        agent = self._make_agent(pool)
+        result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.provider == "openai-codex"
+        assert agent.base_url == "https://chatgpt.com/backend-api/codex"
+        assert agent.api_key == "original-key-entry-1"
+        assert agent._client_kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert agent._client_kwargs["api_key"] == "original-key-entry-1"
+        assert agent._credential_pool is None
+        agent._replace_primary_openai_client.assert_not_called()
+
+    def test_restore_skips_custom_pool_for_different_custom_endpoint(self):
+        """A custom:<name> pool must match the restored custom base_url before reselect."""
+        pool = MagicMock()
+        pool.provider = "custom:primary"
+        agent = self._make_agent(pool)
+        agent._primary_runtime.update(
+            {
+                "model": "custom-model",
+                "provider": "custom",
+                "base_url": "https://other-custom.example.com/v1",
+                "api_mode": "chat_completions",
+                "api_key": "primary-custom-key",
+                "client_kwargs": {
+                    "api_key": "primary-custom-key",
+                    "base_url": "https://other-custom.example.com/v1",
+                },
+                "compressor_model": "custom-model",
+                "compressor_base_url": "https://other-custom.example.com/v1",
+                "compressor_api_key": "primary-custom-key",
+                "compressor_provider": "custom",
+            }
+        )
+
+        with patch("agent.credential_pool.get_custom_provider_pool_key", return_value="custom:other"):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.provider == "custom"
+        assert agent.base_url == "https://other-custom.example.com/v1"
+        assert agent.api_key == "primary-custom-key"
+        assert agent._client_kwargs["base_url"] == "https://other-custom.example.com/v1"
+        assert agent._client_kwargs["api_key"] == "primary-custom-key"
+        assert agent._credential_pool is None
+        pool.has_available.assert_not_called()
+        pool.select.assert_not_called()
+        agent._replace_primary_openai_client.assert_not_called()


### PR DESCRIPTION
## Summary
- Add a shared provider-match guard for credential-pool mutations.
- During primary runtime restore, detach a leftover fallback-provider credential pool before selecting/swapping credentials.
- Add restore-path regression coverage for plain cross-provider and custom-provider mismatch cases.

## Why
A long-lived agent can activate a fallback provider and temporarily attach that provider's credential pool. On the next turn, `restore_primary_runtime()` restores the primary provider/base URL, then re-selects from the still-attached pool. If that pool belongs to the fallback provider, `_swap_credential()` can overwrite the restored primary route with the fallback entry's key/base URL, causing silent wrong-provider routing/billing.

This keeps the existing same-provider pool re-select behavior for stale primary credentials while preventing cross-provider contamination during restore.

## Test Plan
- `python -m pytest -q tests/agent/test_restore_primary_pool_reselect.py --tb=short` → 9 passed
- `python -m pytest -q tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery tests/run_agent/test_switch_model_pool_reload_52727.py --tb=short` → 17 passed
- `python -m ruff check agent/agent_runtime_helpers.py tests/agent/test_restore_primary_pool_reselect.py` → All checks passed
- `git diff --check` / `git diff --cached --check` → clean

## Related
- Related to #52799, which covers init/model-switch/runtime-resolution pool matching. This PR covers the `restore_primary_runtime()` re-select path.
