### PR TITLE
fix(codex-runtime): re-running /codex-runtime codex_app_server when already enabled now triggers migration (salvage of #26532 by @simpolism, closes #26529)

### DIFF
--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -153,9 +153,7 @@ def apply(
     # config.yaml without ever running the slash command. The migration is
     # idempotent by design (it replaces its own managed block in place), so
     # re-running is cheap and safe.
-    reapplying_enable = (
-        new_value == current and new_value == "codex_app_server"
-    )
+    reapplying_enable = new_value == current == "codex_app_server"
     if new_value == current and not reapplying_enable:
         return CodexRuntimeStatus(
             success=True,
@@ -199,12 +197,10 @@ def apply(
 
     if reapplying_enable:
         msg_lines = [
-            f"openai_runtime already set to {current} — re-applying migration",
+            f"openai_runtime already set to {current} — re-applying migration"
         ]
     else:
-        msg_lines = [
-            f"openai_runtime: {current} → {new_value}",
-        ]
+        msg_lines = [f"openai_runtime: {current} → {new_value}"]
     if new_value == "codex_app_server":
         ok, ver = _check_binary_cached()
         if ok:

--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -144,8 +144,19 @@ def apply(
             codex_version=ver if ok else None,
         )
 
-    # No change requested
-    if new_value == current:
+    # No-config-change paths. For `auto` we return immediately — disabling
+    # doesn't touch ~/.codex/. For `codex_app_server`, we fall through to
+    # the migration block below: the config value is already correct, but
+    # the world state (managed block in ~/.codex/config.toml, hermes-tools
+    # MCP callback, plugin discovery) may be stale or missing — common
+    # footgun when users pre-set `openai_runtime: codex_app_server` in
+    # config.yaml without ever running the slash command. The migration is
+    # idempotent by design (it replaces its own managed block in place), so
+    # re-running is cheap and safe.
+    reapplying_enable = (
+        new_value == current and new_value == "codex_app_server"
+    )
+    if new_value == current and not reapplying_enable:
         return CodexRuntimeStatus(
             success=True,
             new_value=current,
@@ -172,22 +183,28 @@ def apply(
                 codex_version=None,
             )
 
-    set_runtime(config, new_value)
-    if persist_callback is not None:
-        try:
-            persist_callback(config)
-        except Exception as exc:
-            logger.exception("failed to persist openai_runtime change")
-            return CodexRuntimeStatus(
-                success=False,
-                new_value=new_value,
-                old_value=current,
-                message=f"updated config in memory but persist failed: {exc}",
-            )
+    if not reapplying_enable:
+        set_runtime(config, new_value)
+        if persist_callback is not None:
+            try:
+                persist_callback(config)
+            except Exception as exc:
+                logger.exception("failed to persist openai_runtime change")
+                return CodexRuntimeStatus(
+                    success=False,
+                    new_value=new_value,
+                    old_value=current,
+                    message=f"updated config in memory but persist failed: {exc}",
+                )
 
-    msg_lines = [
-        f"openai_runtime: {current} → {new_value}",
-    ]
+    if reapplying_enable:
+        msg_lines = [
+            f"openai_runtime already set to {current} — re-applying migration",
+        ]
+    else:
+        msg_lines = [
+            f"openai_runtime: {current} → {new_value}",
+        ]
     if new_value == "codex_app_server":
         ok, ver = _check_binary_cached()
         if ok:

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -96,6 +96,56 @@ class TestApply:
         assert r.success
         assert r.message == "openai_runtime already set to auto"
 
+    def test_reapply_codex_app_server_runs_migration(self):
+        """Re-applying codex_app_server when already enabled must still
+        run the migration. Common footgun: user pre-sets
+        `openai_runtime: codex_app_server` in config.yaml, then runs
+        /codex-runtime codex_app_server expecting the migration. Without
+        this, the slash command short-circuits with "already set" and
+        ~/.codex/config.toml never gets the hermes-tools MCP callback
+        or plugin migration — silent partial setup.
+        """
+        cfg = {
+            "model": {"openai_runtime": "codex_app_server"},
+            "mcp_servers": {
+                "filesystem": {"command": "npx", "args": ["-y", "fs-server"]},
+            },
+        }
+        persisted = {}
+
+        def persist(c):
+            persisted.update(c)
+
+        with patch.object(crs, "check_codex_binary_ok",
+                          return_value=(True, "0.130.0")), \
+             patch("hermes_cli.codex_runtime_plugin_migration.migrate") as mig:
+            mig.return_value.migrated = ["filesystem", "hermes-tools"]
+            mig.return_value.migrated_plugins = []
+            mig.return_value.plugin_query_error = None
+            mig.return_value.wrote_permissions_default = ":workspace"
+            mig.return_value.errors = []
+            mig.return_value.target_path = "/fake/.codex/config.toml"
+            r = crs.apply(cfg, "codex_app_server",
+                          persist_callback=persist)
+        assert r.success
+        assert mig.called, "migration must run on reapply, not just first enable"
+        # Re-apply should signal "already set" but still announce migration ran
+        assert "already set" in r.message
+        assert "re-applying migration" in r.message
+        # Migration output still surfaces
+        assert "Migrated 1 MCP server" in r.message
+        assert "filesystem" in r.message
+        assert "Default sandbox: :workspace" in r.message
+        # No config write needed when value is unchanged — the persist
+        # callback should NOT have fired (avoids spurious config.yaml mtimes
+        # on every re-apply).
+        assert persisted == {}, (
+            "persist_callback fired despite no config-value change"
+        )
+        # Caller still needs a fresh session for the cached agent to pick
+        # up any migration-driven changes.
+        assert r.requires_new_session is True
+
     def test_enable_blocked_when_codex_missing(self):
         cfg = {}
         with patch.object(crs, "check_codex_binary_ok",


### PR DESCRIPTION
## Summary
`/codex-runtime codex_app_server` now re-runs the migration when the runtime is already set to `codex_app_server`, instead of silently no-op'ing with "already set".

**Root cause:** `apply()` short-circuits on `new_value == current` before the migration block. That conflates "config value is correct" with "world state is converged" — fine for `auto` (disabling has no side effects) but wrong for `codex_app_server`, where the config value can be correct while the `~/.codex/config.toml` managed block, the hermes-tools MCP callback, and plugin discovery are missing. Users hit this by pre-setting `openai_runtime: codex_app_server` in `config.yaml` (which `hermes profile create --clone` does automatically), then running the slash command expecting migration — silent no-op, bot falls back to `codex_responses`.

## Changes
- `hermes_cli/codex_runtime_switch.py`: on `codex_app_server` re-apply, fall through to the (idempotent) migration block while skipping `set_runtime`/persist — no config-value change, so `config.yaml` is not rewritten and prompt cache is untouched. User-visible message becomes `"already set to codex_app_server — re-applying migration"`. `auto` re-apply keeps the early-return short-circuit.
- `tests/hermes_cli/test_codex_runtime_switch.py`: `test_reapply_codex_app_server_runs_migration` — asserts `migrate()` ran, `persist_callback` did NOT fire, migration output surfaces, `requires_new_session=True`.

## Validation
| scenario | migration runs | config rewritten |
|---|---|---|
| first enable (`auto`→`codex_app_server`) | yes | yes |
| **re-apply (`codex_app_server`→`codex_app_server`)** | **yes (was: no)** | **no** |
| re-apply `auto`→`auto` | no | no |

- RED→GREEN proven: the new test fails on `origin/main` ("migration must run on reapply") and passes with this fix.
- 31/31 tests in `tests/hermes_cli/test_codex_runtime_switch.py` pass.

Salvage of #26532 by @simpolism (also reporter of #26529). Cherry-picked cleanly onto current `main`, authorship preserved. Duplicate #26535 (@aqilaziz) already closed; this is the more thorough implementation.

Closes #26529

---
### Review + follow-up (hermes-pr-review Phase 2)
Ran the full Phase-2 review (targeted + broader test sweep, real unmocked `apply()` smoke, 3-angle + Hermes-specific review): no Critical findings. Prompt-cache invariant verified (reapply does NOT call `set_runtime`/persist and does not touch system prompt/toolsets), `auto`-disable early-return preserved, `migrate()` idempotency (strip-before-write, atomic replace) confirmed.

Follow-up commit `6e761547d` (mine) folds in the two non-blocking clarity findings: collapse the `reapplying_enable` predicate to a chained comparison, and dedupe the `msg_lines` literals. No behavior change; 31/31 tests green.

Also caught + corrected a stale-base artifact before pushing: an earlier working-tree state showed a phantom deletion of an unrelated `scripts/release.py` AUTHOR_MAP entry (branch was cut before that chore PR merged). Rebased onto current `main` so the PR shows only the two intended files.
