### PR TITLE
fix(video-gen): require availability for implicit provider fallback

### DIFF
--- a/agent/video_gen_registry.py
+++ b/agent/video_gen_registry.py
@@ -95,6 +95,13 @@ def get_active_provider() -> Optional[VideoGenProvider]:
     with _lock:
         snapshot = dict(_providers)
 
+    def _is_available_safe(p: VideoGenProvider) -> bool:
+        try:
+            return bool(p.is_available())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("video_gen provider %s.is_available() raised %s", p.name, exc)
+            return False
+
     if configured:
         provider = snapshot.get(configured)
         if provider is not None:
@@ -104,9 +111,12 @@ def get_active_provider() -> Optional[VideoGenProvider]:
             configured,
         )
 
-    # Fallback: single-provider case
-    if len(snapshot) == 1:
-        return next(iter(snapshot.values()))
+    # Fallback: single-provider case, but only when that provider is actually
+    # configured enough to service calls. Explicit config above still wins so
+    # the dispatcher can surface a provider-specific setup error.
+    available = [p for p in snapshot.values() if _is_available_safe(p)]
+    if len(available) == 1:
+        return available[0]
 
     return None
 

--- a/tests/agent/test_video_gen_registry.py
+++ b/tests/agent/test_video_gen_registry.py
@@ -74,6 +74,11 @@ class TestGetActiveProvider:
         active = video_gen_registry.get_active_provider()
         assert active is not None and active.name == "solo"
 
+    def test_single_unavailable_provider_is_not_autoresolved(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        video_gen_registry.register_provider(_FakeProvider("solo", available=False))
+        assert video_gen_registry.get_active_provider() is None
+
     def test_no_provider_returns_none(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         assert video_gen_registry.get_active_provider() is None
@@ -97,6 +102,17 @@ class TestGetActiveProvider:
         )
         video_gen_registry.register_provider(_FakeProvider("xai"))
         video_gen_registry.register_provider(_FakeProvider("fal"))
+        active = video_gen_registry.get_active_provider()
+        assert active is not None and active.name == "fal"
+
+    def test_config_selects_unavailable_provider_for_specific_error(self, tmp_path, monkeypatch):
+        import yaml
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"video_gen": {"provider": "fal"}})
+        )
+        video_gen_registry.register_provider(_FakeProvider("fal", available=False))
         active = video_gen_registry.get_active_provider()
         assert active is not None and active.name == "fal"
 


### PR DESCRIPTION
What does this PR do?

- Filters the implicit single-provider `video_gen` fallback through `VideoGenProvider.is_available()`.
- Keeps explicit `video_gen.provider` behavior unchanged, so configured-but-missing-credentials providers still produce provider-specific setup errors instead of silently switching away.
- Adds focused registry tests for both cases.

Why?

`agent/video_gen_registry.py` documented that it mirrors the image generation registry, but the video fallback returned the only registered provider without checking availability. That can auto-select an installed video backend that is missing credentials or dependencies when the user has not configured `video_gen.provider`.

Fixes #56564

Proof

- `python -m py_compile agent\video_gen_registry.py tests\agent\test_video_gen_registry.py`
- Direct proof script:
  - registered one unavailable fake video provider with no `video_gen.provider`; `get_active_provider()` returned `None`
  - configured `video_gen.provider` to that same unavailable provider; `get_active_provider()` still returned it for a provider-specific error path
- `git diff --check`

Notes

- `python -m pytest tests\agent\test_video_gen_registry.py` is blocked in this local checkout because `pytest` is not installed (`No module named pytest`).
- Repo/global `autoreview` helper was not available in this checkout.
- Duplicate search checked `video_gen is_available provider fallback` and `video generation backend configured API key missing`; no matching existing PR/issue covered this fallback behavior.