### PR TITLE
fix(tools): show exit code for post-setup npm failures

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -937,6 +937,16 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
         return False
 
 
+def _print_subprocess_failure_detail(result, *, max_chars: int = 200) -> None:
+    detail = (getattr(result, "stderr", None) or getattr(result, "stdout", None) or "").strip()
+    if detail:
+        _print_info(f"      {detail[:max_chars]}")
+        return
+    returncode = getattr(result, "returncode", None)
+    if returncode is not None:
+        _print_info(f"      exited with code {returncode}")
+
+
 def _run_post_setup(post_setup_key: str):
     """Run post-setup hooks for tools that need extra installation steps."""
     import shutil
@@ -964,8 +974,7 @@ def _run_post_setup(post_setup_key: str):
             else:
                 from hermes_constants import display_hermes_home
                 _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install --workspaces=false")
-                if result.stderr:
-                    _print_info(f"      {result.stderr.strip()[:200]}")
+                _print_subprocess_failure_detail(result)
         elif not node_modules.exists():
             _print_warning("    Node.js not found - browser tools require: npm install (in hermes-agent directory)")
             return
@@ -1069,6 +1078,7 @@ def _run_post_setup(post_setup_key: str):
                 _print_success("    Camofox installed")
             else:
                 _print_warning("    npm install failed - run manually: npm install --workspaces=false")
+                _print_subprocess_failure_detail(result)
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camofox-browser")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1642,6 +1642,18 @@ def _run_cua_driver_installer(
                 pass
 
 
+def _print_subprocess_failure_detail(result, *, max_chars: int = 200) -> None:
+    stderr = (getattr(result, "stderr", None) or "").strip()
+    stdout = (getattr(result, "stdout", None) or "").strip()
+    detail = stderr or stdout
+    if detail:
+        _print_info(f"      {detail[:max_chars]}")
+        return
+    returncode = getattr(result, "returncode", None)
+    if returncode is not None:
+        _print_info(f"      exited with code {returncode}")
+
+
 def _run_post_setup(post_setup_key: str):
     """Run post-setup hooks for tools that need extra installation steps."""
     import shutil
@@ -1675,8 +1687,7 @@ def _run_post_setup(post_setup_key: str):
             else:
                 from hermes_constants import display_hermes_home
                 _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install --workspaces=false")
-                if result.stderr:
-                    _print_info(f"      {result.stderr.strip()[:200]}")
+                _print_subprocess_failure_detail(result)
         elif node_modules.exists():
             # Distinct message for the re-run case so the GUI action log tells
             # the truth ("nothing to do") instead of implying a fresh install.
@@ -1811,6 +1822,7 @@ def _run_post_setup(post_setup_key: str):
                 _print_success("    Camofox installed")
             else:
                 _print_warning("    npm install failed - run manually: npm install --workspaces=false")
+                _print_subprocess_failure_detail(result)
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camofox-browser")

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -15,6 +15,7 @@ from hermes_cli.tools_config import (
     _reconfigure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
+    _print_subprocess_failure_detail,
     _reconfigure_tool,
     _run_post_setup,
     _save_platform_tools,
@@ -26,6 +27,30 @@ from hermes_cli.tools_config import (
     _visible_providers,
     tools_command,
 )
+
+
+def test_print_subprocess_failure_detail_reports_exit_code_when_output_empty(monkeypatch):
+    import hermes_cli.tools_config as tools_config
+
+    lines = []
+    monkeypatch.setattr(tools_config, "_print_info", lambda msg: lines.append(msg))
+
+    _print_subprocess_failure_detail(SimpleNamespace(returncode=127, stdout="", stderr=""))
+
+    assert lines == ["      exited with code 127"]
+
+
+def test_print_subprocess_failure_detail_prefers_stderr(monkeypatch):
+    import hermes_cli.tools_config as tools_config
+
+    lines = []
+    monkeypatch.setattr(tools_config, "_print_info", lambda msg: lines.append(msg))
+
+    _print_subprocess_failure_detail(
+        SimpleNamespace(returncode=1, stdout="stdout detail", stderr="stderr detail")
+    )
+
+    assert lines == ["      stderr detail"]
 
 
 def test_agent_disabled_toolsets_suppresses_across_platforms():

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -17,6 +17,7 @@ from hermes_cli.tools_config import (
     _reconfigure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
+    _print_subprocess_failure_detail,
     _reconfigure_tool,
     _run_post_setup,
     _save_platform_tools,
@@ -31,6 +32,35 @@ from hermes_cli.tools_config import (
 )
 
 
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (SimpleNamespace(returncode=127, stdout="", stderr=""), "exited with code 127"),
+        (SimpleNamespace(returncode=1, stdout="stdout detail", stderr=""), "stdout detail"),
+        (SimpleNamespace(returncode=1, stdout="stdout detail", stderr="\n"), "stdout detail"),
+        (SimpleNamespace(returncode=1, stdout="stdout", stderr="stderr detail"), "stderr detail"),
+    ],
+)
+def test_print_subprocess_failure_detail(monkeypatch, result, expected):
+    import hermes_cli.tools_config as tools_config
+
+    lines = []
+    monkeypatch.setattr(tools_config, "_print_info", lambda msg: lines.append(msg))
+    _print_subprocess_failure_detail(result)
+    assert lines == [f"      {expected}"]
+
+
+@pytest.mark.parametrize("post_setup_key", ["browserbase", "camofox"])
+def test_post_setup_npm_failure_reports_exit_code(monkeypatch, tmp_path, post_setup_key):
+    import hermes_cli.tools_config as tools_config
+
+    lines = []
+    monkeypatch.setattr(tools_config, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr("hermes_constants.find_node_executable", lambda name: "npm")
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: SimpleNamespace(returncode=127, stdout="", stderr=""))
+    monkeypatch.setattr(tools_config, "_print_info", lines.append)
+    _run_post_setup(post_setup_key)
+    assert "      exited with code 127" in lines
 
 
 def test_all_invalid_platform_toolsets_logs_runtime_warning(caplog):


### PR DESCRIPTION
What does this PR do?

- Adds a small post-setup subprocess failure-detail helper.
- Prints captured stderr/stdout when available.
- Prints the subprocess exit code when npm fails with empty stdout/stderr.
- Applies the helper to the `agent_browser` / `browserbase` and `camofox` npm install post-setup paths.

Why?

A failed `npm install --silent --workspaces=false` can produce no captured output. Previously the browser dependency path only printed stderr when it existed, and the Camofox branch printed no subprocess detail. That left users with a generic manual command and no exit code to diagnose the failure.

Fixes #56566

Proof

- `python -m py_compile hermes_cli\tools_config.py tests\hermes_cli\test_tools_config.py`
- Direct proof script:
  - empty stdout/stderr reports `exited with code 127`
  - stderr is still preferred when present
- `git diff --check`

Notes

- `python -m pytest tests\hermes_cli\test_tools_config.py -k subprocess_failure_detail` is blocked in this local checkout because `pytest` is not installed (`No module named pytest`).
- Repo/global `autoreview` helper was not available in this checkout.
- Duplicate search checked `npm install failed exit code post_setup`; no matching existing PR/issue covered this post-setup diagnostic gap.