### PR TITLE
fix(tui): gracefully handle late clarify responses after timeout

### DIFF
--- a/tests/tui_gateway/test_respond_expired.py
+++ b/tests/tui_gateway/test_respond_expired.py
@@ -1,0 +1,142 @@
+"""Tests for the blocking prompt factory (_block) and respond (_respond) functions.
+
+Covers:
+- _respond returns expired status when allow_expired=True and request is missing
+- _respond returns 4009 error when allow_expired=False (default) and request is missing
+- _respond works normally when request IS in _pending
+- _block emits {event}.expire on timeout
+- _block does NOT emit expire on normal answer
+"""
+
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from tui_gateway.server import (
+    _answers,
+    _block,
+    _ok,
+    _err,
+    _pending,
+    _pending_prompt_payloads,
+    _prompt_lock,
+    _respond,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_prompt_state():
+    """Ensure _pending and _answers are clean before each test."""
+    with _prompt_lock:
+        _pending.clear()
+        _answers.clear()
+        _pending_prompt_payloads.clear()
+    yield
+    with _prompt_lock:
+        _pending.clear()
+        _answers.clear()
+        _pending_prompt_payloads.clear()
+
+
+class TestRespondExpired:
+    """_respond with allow_expired handles stale clarify answers gracefully."""
+
+    def test_stale_clarify_returns_expired_status(self):
+        """When allow_expired=True and request_id is missing, return ok with status=expired."""
+        result = _respond("r1", {"request_id": "nonexistent"}, "answer", allow_expired=True)
+        assert result == _ok("r1", {"status": "expired"})
+
+    def test_stale_default_returns_4009(self):
+        """When allow_expired=False (default) and request_id is missing, return 4009."""
+        result = _respond("r2", {"request_id": "nonexistent"}, "answer")
+        assert result == _err("r2", 4009, "no pending answer request")
+
+    def test_stale_sudo_returns_4009(self):
+        """sudo.respond does NOT pass allow_expired, so stale requests get 4009."""
+        result = _respond("r3", {"request_id": "nonexistent"}, "password")
+        assert result == _err("r3", 4009, "no pending password request")
+
+    def test_normal_answer_succeeds(self):
+        """When the request IS in _pending, _respond sets the answer and signals."""
+        ev = threading.Event()
+        with _prompt_lock:
+            _pending["rid123"] = ("sid1", ev)
+
+        result = _respond("r4", {"request_id": "rid123", "answer": "hello"}, "answer")
+        assert result == _ok("r4", {"status": "ok"})
+        assert _answers.get("rid123") == "hello"
+        assert ev.is_set()
+
+    def test_normal_answer_with_allow_expired_succeeds(self):
+        """Even with allow_expired=True, a valid request still works normally."""
+        ev = threading.Event()
+        with _prompt_lock:
+            _pending["rid456"] = ("sid2", ev)
+
+        result = _respond(
+            "r5", {"request_id": "rid456", "answer": "world"}, "answer", allow_expired=True
+        )
+        assert result == _ok("r5", {"status": "ok"})
+        assert _answers.get("rid456") == "world"
+        assert ev.is_set()
+
+
+class TestBlockExpire:
+    """_block emits {event}.expire on timeout and does not emit on normal answer."""
+
+    def test_timeout_emits_expire_event(self):
+        """When _block times out, it should emit {event}.expire with the request_id."""
+        emitted = []
+
+        def fake_emit(event, sid, payload=None):
+            emitted.append((event, sid, payload))
+
+        with patch("tui_gateway.server._emit", side_effect=fake_emit):
+            result = _block("clarify", "s1", {"question": "pick one", "choices": ["a", "b"]}, timeout=0.1)
+
+        # Should have emitted the original clarify event and the expire event
+        assert len(emitted) == 2
+        assert emitted[0][0] == "clarify"
+        assert emitted[1][0] == "clarify.expire"
+        expire_payload = emitted[1][2]
+        assert "request_id" in expire_payload
+        # The answer should be empty (timeout)
+        assert result == ""
+
+    def test_normal_answer_no_expire_event(self):
+        """When _block receives an answer before timeout, no expire event is emitted."""
+        emitted = []
+
+        def fake_emit(event, sid, payload=None):
+            emitted.append((event, sid, payload))
+            # When the original event is emitted, simulate a quick answer
+            if event == "clarify":
+                rid = payload.get("request_id", "")
+                with _prompt_lock:
+                    if rid in _pending:
+                        _answers[rid] = "my answer"
+                        _, ev = _pending[rid]
+                        ev.set()
+
+        with patch("tui_gateway.server._emit", side_effect=fake_emit):
+            result = _block("clarify", "s2", {"question": "yes?", "choices": ["y", "n"]}, timeout=5)
+
+        # Only the original event, no expire
+        assert len(emitted) == 1
+        assert emitted[0][0] == "clarify"
+        assert result == "my answer"
+
+    def test_expire_event_carries_correct_request_id(self):
+        """The expire event payload must contain the same request_id as the original."""
+        emitted = []
+
+        def fake_emit(event, sid, payload=None):
+            emitted.append((event, sid, payload))
+
+        with patch("tui_gateway.server._emit", side_effect=fake_emit):
+            _block("clarify", "s3", {"question": "pick"}, timeout=0.05)
+
+        original_rid = emitted[0][2]["request_id"]
+        expire_rid = emitted[1][2]["request_id"]
+        assert original_rid == expire_rid

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1874,11 +1874,13 @@ def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
         _pending_prompt_payloads[rid] = (event, dict(payload))
     try:
         _emit(event, sid, payload)
-        ev.wait(timeout=timeout)
+        answered = ev.wait(timeout=timeout)
     finally:
         with _prompt_lock:
             _pending.pop(rid, None)
             _pending_prompt_payloads.pop(rid, None)
+    if not answered:
+        _emit(f"{event}.expire", sid, {"request_id": rid})
     with _prompt_lock:
         return _answers.pop(rid, "")
 
@@ -9712,11 +9714,13 @@ def _(rid, params: dict) -> dict:
 # ── Methods: respond ─────────────────────────────────────────────────
 
 
-def _respond(rid, params, key):
+def _respond(rid, params, key, *, allow_expired: bool = False):
     r = params.get("request_id", "")
     with _prompt_lock:
         entry = _pending.get(r)
         if not entry:
+            if allow_expired:
+                return _ok(rid, {"status": "expired"})
             return _err(rid, 4009, f"no pending {key} request")
         _, ev = entry
         _answers[r] = params.get(key, "")
@@ -9726,7 +9730,7 @@ def _respond(rid, params, key):
 
 @method("clarify.respond")
 def _(rid, params: dict) -> dict:
-    return _respond(rid, params, "answer")
+    return _respond(rid, params, "answer", allow_expired=True)
 
 
 @method("terminal.read.respond")


### PR DESCRIPTION
## What does this PR do?

When a `clarify` prompt times out server-side (default 300s in `_block`), its entry is popped from `_pending`. If the user then answers the still-visible prompt — common when a WebSocket reconnect during the wait window drops the `tool.complete` signal — `clarify.respond` returns a hard JSON-RPC error 4009 `"no pending answer request"`. Clients surface this raw string to the user, and at least one client (Hermes One desktop fork) re-arms the pending request on the error, creating an infinite retry loop that wedges the chat.

This fix makes two targeted changes:

1. **`_block`**: Captures the `ev.wait()` return value (True = answered, False = timeout). On timeout, emits a `{event}.expire` event with the `request_id` so clients can clear the stale prompt overlay independently of `tool.complete` ordering.

2. **`_respond`**: Adds an `allow_expired` keyword parameter. When `True` and the `request_id` is not in `_pending`, returns `{"status": "expired"}` instead of error 4009. `clarify.respond` is the only method that passes `allow_expired=True` since late answers are expected there due to the long timeout window. Other respond methods (`sudo.respond`, `secret.respond`, `terminal.read.respond`) keep the hard 4009 since stale answers indicate a genuine protocol error.

## Related Issue

Fixes #56558

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: `_block()` — capture `ev.wait()` return value; emit `{event}.expire` on timeout so clients can clear stale prompt overlays
- `tui_gateway/server.py`: `_respond()` — add `allow_expired` keyword parameter; return `{"status": "expired"}` instead of 4009 when `allow_expired=True` and request is missing
- `tui_gateway/server.py`: `clarify.respond` — pass `allow_expired=True` to gracefully handle late answers to expired clarify prompts
- `tests/tui_gateway/test_respond_expired.py` — 8 tests covering expired status, 4009 preserved for non-clarify, normal answer flow, expire event emission, and request_id consistency

## How to Test

1. Run `pytest tests/tui_gateway/test_respond_expired.py -v` — all 8 tests should pass
2. Verify `clarify.respond` with a stale `request_id` returns `{"status": "expired"}` instead of error 4009
3. Verify `sudo.respond` / `secret.respond` with a stale `request_id` still returns error 4009
4. Verify `_block` emits a `clarify.expire` event when the timeout expires without an answer

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (server-side only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
