### PR TITLE
fix(desktop): restore remote file picker attachments

### DIFF
--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -142,12 +142,22 @@ describe('desktop filesystem facade', () => {
     expect(selectPaths).not.toHaveBeenCalled()
   })
 
+  it('uses the local Electron picker for remote file selection', async () => {
+    const remoteSelect = vi.fn(async () => ['/remote/project'])
+    $connection.set({ mode: 'remote' } as never)
+    setDesktopFsRemotePicker({ selectPaths: remoteSelect })
+
+    await expect(selectDesktopPaths({ directories: false, multiple: false })).resolves.toEqual(['/local'])
+
+    expect(selectPaths).toHaveBeenCalledWith({ directories: false, multiple: false })
+    expect(remoteSelect).not.toHaveBeenCalled()
+  })
+
   it('limits the remote picker to single-directory selection', async () => {
     const remoteSelect = vi.fn(async () => ['/remote/project'])
     $connection.set({ mode: 'remote' } as never)
     setDesktopFsRemotePicker({ selectPaths: remoteSelect })
 
-    await expect(selectDesktopPaths({ directories: false, multiple: false })).resolves.toEqual([])
     await expect(selectDesktopPaths({ directories: true })).resolves.toEqual(['/remote/project'])
 
     expect(remoteSelect).toHaveBeenCalledWith({ directories: true, multiple: false })

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -179,7 +179,7 @@ export async function selectDesktopPaths(options?: HermesSelectPathsOptions): Pr
   }
 
   if (!options?.directories) {
-    return []
+    return desktop.selectPaths(options)
   }
 
   return remotePicker ? remotePicker.selectPaths({ ...options, multiple: false }) : []


### PR DESCRIPTION
## What does this PR do?

Restores Desktop paperclip file/image picking while connected to a remote backend.

Remote mode needs two different picker behaviors:

- directory selection should keep using the in-app backend folder picker, so Projects/workspace selection points at the remote filesystem where sessions run
- file selection should still use Electron's native local picker, because the composer attachment flow stages local file/image bytes into the remote gateway before submit

The previous guard treated the remote folder picker as the only allowed remote-mode picker and returned an empty selection for non-directory selection. That made the paperclip file/image picker look like it did nothing.

## Related Issue

No GitHub issue. Reported via support: Desktop `0.17.0 [20b03d9a]` on WSL2, Projects folder selection works, but paperclip file/image selection is a no-op in a new chat.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/desktop-fs.ts`: in remote mode, route non-directory `selectDesktopPaths` calls back to the local Electron picker instead of returning an empty selection.
- `apps/desktop/src/lib/desktop-fs.test.ts`: add coverage that remote file selection uses the local picker while remote directory selection still uses the remote folder picker.

## How to Test

1. In Desktop remote mode, open a new chat and use the paperclip file/image picker.
2. Select a local file or image and confirm it creates an attachment instead of silently doing nothing.
3. Use Projects/folder selection and confirm directory selection still opens the in-app remote folder picker.

Automated check run locally:

- `npm --prefix apps/desktop run test:ui -- src/lib/desktop-fs.test.ts` - 7 passed

Also checked:

- `git diff --cached --check` - clean before commit

Not run:

- `pytest tests/ -q` - intentionally not run for this narrow Desktop support fix.
- `npm --prefix apps/desktop run typecheck` - blocked in this local checkout by missing frontend package/type dependencies such as `@assistant-ui/*`, `@testing-library/react`, and `@tanstack/react-query`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 focused Desktop Vitest coverage

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test output:

`npm --prefix apps/desktop run test:ui -- src/lib/desktop-fs.test.ts` passed with 1 file / 7 tests.
