### PR TITLE
fix(debug): trim debug env flag whitespace

### DIFF
--- a/tests/tools/test_debug_helpers.py
+++ b/tests/tools/test_debug_helpers.py
@@ -102,6 +102,11 @@ class TestDebugSessionEnabled:
             ds = DebugSession("t", env_var="TEST_DEBUG")
         assert ds.enabled is True
 
+    def test_env_var_strips_surrounding_whitespace(self, tmp_path):
+        with patch.dict(os.environ, {"TEST_DEBUG": " true "}):
+            ds = DebugSession("t", env_var="TEST_DEBUG")
+        assert ds.enabled is True
+
     def test_env_var_false_disables(self):
         with patch.dict(os.environ, {"TEST_DEBUG": "false"}):
             ds = DebugSession("t", env_var="TEST_DEBUG")

--- a/tools/debug_helpers.py
+++ b/tools/debug_helpers.py
@@ -42,7 +42,7 @@ class DebugSession:
 
     def __init__(self, tool_name: str, *, env_var: str) -> None:
         self.tool_name = tool_name
-        self.enabled = os.getenv(env_var, "false").lower() == "true"
+        self.enabled = os.getenv(env_var, "false").strip().lower() == "true"
         self.session_id = str(uuid.uuid4()) if self.enabled else ""
         self.log_dir = get_hermes_home() / "logs"
         self._calls: list[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary

Trim surrounding whitespace before evaluating debug environment flags in `DebugSession`.

This keeps existing accepted values unchanged (`true`, case-insensitive), while making values such as `" true "` behave the same as `"true"`.

## Tests

- `.\.venv\Scripts\python.exe -m pytest tests\tools\test_debug_helpers.py::TestDebugSessionEnabled::test_env_var_strips_surrounding_whitespace -q`
- `.\.venv\Scripts\python.exe -m pytest tests\tools\test_debug_helpers.py -q`
- `.\.venv\Scripts\python.exe -m ruff check tools\debug_helpers.py tests\tools\test_debug_helpers.py`
- `git diff --check`

Note: `scripts/run_tests.sh` could not be executed directly in this Windows environment because `bash` is not installed; the equivalent targeted pytest runs above passed in the project `.venv`.
