### PR TITLE
fix(email): strip compound channel prefix before SMTP To header

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -249,6 +249,19 @@ def _domain_of(address: str) -> str:
     return domain.strip().lower()
 
 
+def _strip_channel_prefix(addr: str) -> str:
+    """Strip a ``email:`` platform prefix from a channel identifier.
+
+    The cron delivery pipeline and session keys sometimes carry a compound
+    channel ID like ``email:user@example.com``.  The SMTP ``To`` header
+    requires a bare RFC 5321 address — passing the compound form causes
+    strict servers (Gmail) to reject with ``555 5.5.2``.
+    """
+    if addr.startswith("email:"):
+        return addr[len("email:"):]
+    return addr
+
+
 def _domains_aligned(a: str, b: str) -> bool:
     """Return True if two domains are equal or in an organizational
     parent/subdomain relationship (relaxed DMARC alignment).
@@ -897,6 +910,7 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
+        to_addr = _strip_channel_prefix(to_addr)
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -1012,6 +1026,7 @@ class EmailAdapter(BasePlatformAdapter):
         file_paths: List[str],
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
+        to_addr = _strip_channel_prefix(to_addr)
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -1092,6 +1107,7 @@ class EmailAdapter(BasePlatformAdapter):
         file_name: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
+        to_addr = _strip_channel_prefix(to_addr)
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -1186,6 +1202,8 @@ async def _standalone_send(
 
     if not all([address, password, smtp_host]):
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
+
+    chat_id = _strip_channel_prefix(chat_id)
 
     try:
         msg = MIMEText(message, "plain", "utf-8")

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1775,5 +1775,61 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestStripChannelPrefix(unittest.TestCase):
+    """Regression: compound channel IDs must be stripped before SMTP To."""
+
+    def test_strip_email_prefix(self):
+        from plugins.platforms.email.adapter import _strip_channel_prefix
+        self.assertEqual(_strip_channel_prefix("email:user@example.com"), "user@example.com")
+
+    def test_strip_no_prefix(self):
+        from plugins.platforms.email.adapter import _strip_channel_prefix
+        self.assertEqual(_strip_channel_prefix("user@example.com"), "user@example.com")
+
+    def test_strip_empty(self):
+        from plugins.platforms.email.adapter import _strip_channel_prefix
+        self.assertEqual(_strip_channel_prefix(""), "")
+
+    @patch("plugins.platforms.email.adapter.EmailAdapter._connect_smtp")
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+    }, clear=False)
+    def test_send_email_strips_prefix(self, mock_smtp):
+        """_send_email must strip 'email:' prefix to avoid Gmail 555 5.5.2."""
+        from plugins.platforms.email.adapter import EmailAdapter
+        from gateway.config import PlatformConfig
+        adapter = EmailAdapter(PlatformConfig(enabled=True))
+        mock_server = MagicMock()
+        mock_smtp.return_value = mock_server
+        # Call with compound channel ID — should NOT raise
+        adapter._send_email("email:user@example.com", "Hello")
+        # Verify the SMTP To header was the bare address
+        sent_msg = mock_server.send_message.call_args[0][0]
+        self.assertEqual(sent_msg["To"], "user@example.com")
+
+    @patch("smtplib.SMTP")
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_PORT": "587",
+    }, clear=False)
+    def test_standalone_send_strips_prefix(self, mock_smtp_cls):
+        """_standalone_send must strip 'email:' prefix."""
+        import asyncio
+        from plugins.platforms.email.adapter import _standalone_send
+        from gateway.config import PlatformConfig
+        pconfig = PlatformConfig(enabled=True, extra={"address": "hermes@test.com", "smtp_host": "smtp.test.com"})
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value = mock_server
+        result = asyncio.run(_standalone_send(pconfig, "email:user@test.com", "Hello"))
+        self.assertTrue(result.get("success"))
+        sent_msg = mock_server.send_message.call_args[0][0]
+        self.assertEqual(sent_msg["To"], "user@test.com")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Strips the `email:` platform prefix from compound channel IDs before using them as the SMTP `To` header. When the cron delivery pipeline or session keys carry a compound channel ID like `email:user@example.com`, strict SMTP servers (Gmail) reject the message with `555 5.5.2` because `email:user@example.com` is not a valid RFC 5321 address.

## Related Issue

Fixes #56569

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/email/adapter.py`: Added `_strip_channel_prefix()` helper that strips the `email:` prefix from channel identifiers. Applied it in all 4 SMTP send paths:
  - `EmailAdapter._send_email()` — adapter reply path
  - `EmailAdapter._send_email_with_attachments()` — multi-attachment path
  - `EmailAdapter._send_email_with_attachment()` — single-attachment path
  - `_standalone_send()` — standalone/cron delivery path
- `tests/gateway/test_email.py`: Added `TestStripChannelPrefix` with 5 tests covering prefix stripping, bare addresses, empty strings, and both SMTP send paths with compound IDs

## How to Test

1. Run `python -m pytest tests/gateway/test_email.py::TestStripChannelPrefix -xvs` — all 5 tests should pass
2. Run `python -m pytest tests/gateway/test_email.py -x` — full email test suite (93 tests) should pass
3. Verify that `msg["To"]` receives `user@example.com` (not `email:user@example.com`) when a compound channel ID is passed to any SMTP send path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_email.py -q` and all tests pass (93 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (internal helper, no user-facing docs)
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — N/A (Python stdlib email, no platform-specific code)
- [x] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

```
tests/gateway/test_email.py::TestStripChannelPrefix::test_send_email_strips_prefix PASSED
tests/gateway/test_email.py::TestStripChannelPrefix::test_standalone_send_strips_prefix PASSED
tests/gateway/test_email.py::TestStripChannelPrefix::test_strip_email_prefix PASSED
tests/gateway/test_email.py::TestStripChannelPrefix::test_strip_empty PASSED
tests/gateway/test_email.py::TestStripChannelPrefix::test_strip_no_prefix PASSED
93 passed, 1 warning in 3.97s
```
