### PR TITLE
security(terminal): strip VERTEX_CREDENTIALS_PATH/GOOGLE_APPLICATION_CREDENTIALS from subprocess env

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -114,6 +114,29 @@ class TestProviderEnvBlocklist:
             "AWS_BEARER_TOKEN_BEDROCK leaked into subprocess env (see #32314)"
         )
 
+    def test_vertex_credentials_path_is_stripped(self):
+        """The Vertex AI service-account JSON path must not leak into
+        subprocesses, even though it is filesystem path metadata rather
+        than a bare API key.
+
+        Regression: ``vertex`` authenticates via OAuth2 (service-account
+        JSON / ADC), not PROVIDER_REGISTRY, and OPTIONAL_ENV_VARS marks
+        VERTEX_CREDENTIALS_PATH as ``password=False`` (it's a path, not a
+        secret string) with ``category="provider"`` — a category the
+        registry-derived loop above never checks — so it fell through both
+        blocklist sources. GOOGLE_APPLICATION_CREDENTIALS (the ADC fallback
+        the adapter also reads) had the same gap. A leaked path discloses
+        the on-disk location of a GCP service-account key to every spawned
+        subprocess (terminal, codex/copilot app-server, browser workers).
+        """
+        result_env = _run_with_env(extra_os_env={
+            "VERTEX_CREDENTIALS_PATH": "/home/user/.config/gcloud/sa-key.json",
+            "GOOGLE_APPLICATION_CREDENTIALS": "/home/user/.config/gcloud/adc.json",
+        })
+
+        assert "VERTEX_CREDENTIALS_PATH" not in result_env
+        assert "GOOGLE_APPLICATION_CREDENTIALS" not in result_env
+
     def test_general_aws_credential_chain_is_preserved(self):
         """The GENERAL AWS credential chain must STILL pass through to
         subprocesses — this is the no-regression guard for #32314.

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -155,6 +155,10 @@ def _build_provider_env_blocklist() -> frozenset:
         "CLAUDE_CODE_OAUTH_TOKEN",
         "LLM_MODEL",
         "GOOGLE_API_KEY",
+        # Path to a GCP service-account JSON, not a bare key, so
+        # OPTIONAL_ENV_VARS marks it password=False and the loop above skips it.
+        "VERTEX_CREDENTIALS_PATH",
+        "GOOGLE_APPLICATION_CREDENTIALS",
         "DEEPSEEK_API_KEY",
         "MISTRAL_API_KEY",
         "GROQ_API_KEY",


### PR DESCRIPTION
## Summary

- `VERTEX_CREDENTIALS_PATH` (added in the recent Vertex AI provider, OAuth2 service-account JSON path) and `GOOGLE_APPLICATION_CREDENTIALS` (the ADC fallback the adapter also reads) were never added to the subprocess-env sanitization blocklist, so they leak into every spawned subprocess (terminal, codex/copilot app-server, browser workers).
- Root cause: Vertex authenticates via OAuth2, not the legacy `PROVIDER_REGISTRY`, so the registry-derived blocklist loop in `_build_provider_env_blocklist()` never sees it. Separately, `VERTEX_CREDENTIALS_PATH` is declared in `OPTIONAL_ENV_VARS` with `password=False` (it's a filesystem path, not a bare secret string) under `category="provider"` — a category the metadata-derived loop only checks for `tool`/`messaging`, or `setting`+`password`. It falls through both automatic sources.
- This is the same leak class already closed for every other provider's credentials in #53503/#55709: a leaked value here discloses the on-disk location of a GCP service-account key to any subprocess a model-driving CLI or tool spawns.
- Fix: add both var names to the hand-maintained `blocked.update({...})` set in `tools/environments/local.py`, alongside the other non-registry provider vars (`GOOGLE_API_KEY`, `XAI_API_KEY`, etc.) that already live there for the same reason.

## Test plan

- [x] Added `test_vertex_credentials_path_is_stripped` to `tests/tools/test_local_env_blocklist.py`, asserting both vars are stripped from subprocess env.
- [x] Ran the full existing `tests/tools/test_local_env_blocklist.py` + `tests/tools/test_hermes_subprocess_env.py` suites (68 tests) — all pass, no regressions.
- [x] Ran `tests/agent/test_vertex_adapter.py` + `tests/hermes_cli/test_vertex_provider.py` (23 tests) — all pass, confirming the adapter/config layer is unaffected.