### PR TITLE
refactor(tools): extract TTS provider resolution into SpeechRouter

### DIFF
--- a/tools/speech/__init__.py
+++ b/tools/speech/__init__.py
@@ -1,0 +1,7 @@
+"""Speech infrastructure: provider-agnostic TTS routing.
+
+See the project's "RFC: Speech Router" design document for the full
+architecture (SpeechChunker, SpeechRouter, SpeechProvider, SpeechPlayer).
+Modules land incrementally, one small PR at a time; this package currently
+only contains SpeechRouter (router.py).
+"""

--- a/tools/speech/router.py
+++ b/tools/speech/router.py
@@ -1,0 +1,32 @@
+"""Speech Router: single point of provider selection for TTS requests.
+
+PR1 scope (see "RFC: Speech Router"): passthrough only. resolve_provider()
+reproduces exactly what text_to_speech_tool() computed inline before this
+change (_load_tts_config() + _get_provider()). No fallback chain, no
+capability negotiation, no streaming yet -- those land in later PRs. This
+PR only introduces the seam so later PRs have a stable place to grow into.
+"""
+
+from typing import Any, Dict, Tuple
+
+
+class SpeechRouter:
+    """Resolves which TTS provider a synthesis request should use.
+
+    Today this is a thin wrapper around the existing single-provider config
+    read in tools/tts_tool.py. Future PRs add a fallback chain, health
+    checks, and streaming negotiation without changing resolve_provider()'s
+    return shape.
+    """
+
+    def resolve_provider(self) -> Tuple[str, Dict[str, Any]]:
+        """Return (provider_name, tts_config) for the current request.
+
+        Deferred import avoids a circular dependency: tools.tts_tool is the
+        caller, so it is already fully imported by the time this runs.
+        """
+        from tools.tts_tool import _get_provider, _load_tts_config
+
+        tts_config = _load_tts_config()
+        provider = _get_provider(tts_config)
+        return provider, tts_config

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2154,8 +2154,8 @@ def text_to_speech_tool(
     if not text or not text.strip():
         return tool_error("Text is required", success=False)
 
-    tts_config = _load_tts_config()
-    provider = _get_provider(tts_config)
+    from tools.speech.router import SpeechRouter
+    provider, tts_config = SpeechRouter().resolve_provider()
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here


### PR DESCRIPTION
## What does this PR do?

Extracts TTS provider resolution out of `text_to_speech_tool()` into a new
`SpeechRouter` class (`tools/speech/router.py`). This is PR 1 of a planned
series (**Speech Router**) adding fallback between TTS providers, capability
negotiation, and streaming to Hermes's TTS pipeline. See planned series below.

This PR itself is a pure passthrough: `resolve_provider()` reproduces the
exact two lines it replaces (`_load_tts_config()` + `_get_provider()`). No
behavior change. It only introduces the seam so later PRs (fallback chain,
health checks, streaming) have a stable place to grow into without touching
`text_to_speech_tool()`'s callers again.

### Planned series (this is PR 1 of ~8)

1. **This PR** — `SpeechRouter` skeleton, passthrough, zero behavior change
2. Static capability declarations per builtin provider (streaming, voice
   clone, SSML, latency, etc.) — ready, opening next
3. Fallback chain + priority + health-check-based provider skipping
4. Generic HTTP/`command` provider consolidation (local network TTS servers,
   self-hosted engines)
5. "Local speech endpoint" auto-discovery (tries `http://127.0.0.1:<port>`
   before falling back to configured remote providers)
6. Extract sentence-chunking (`takeSpeechChunk` equivalent) into a reusable
   module, generalized beyond the Desktop voice-conversation hook
7. Desktop Settings UI for provider preference/fallback/streaming toggles
8. Conditional per-sentence streaming when a provider supports it (building
   on the existing ElevenLabs streaming path in
   `tools.tts_tool.stream_tts_to_speaker`, currently CLI-only)

Happy to open a tracking issue/discussion with the full design if that's
useful before more of these land — didn't want to front-load a big doc
before there was any code to look at.

## Related Issue

Related to a planned Speech Router initiative (no tracking issue yet —
happy to open one if maintainers want the full design written up first).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `tools/speech/__init__.py` (new package)
- Added `tools/speech/router.py`: `SpeechRouter.resolve_provider()`
- Modified `tools/tts_tool.py`: `text_to_speech_tool()` now delegates
  provider resolution to `SpeechRouter` instead of calling
  `_load_tts_config()` / `_get_provider()` inline

## How to Test

1. `pytest tests/tools/ tests/agent/test_tts_registry.py tests/hermes_cli/test_tts_picker.py tests/hermes_cli/test_plugins_tts_registration.py -q` → 303 passed, same count as `main` (no regressions)
2. `ruff check tools/speech/ tools/tts_tool.py` → clean
3. Manual: `text_to_speech_tool()` output is byte-identical before/after — `resolve_provider()` just relocated the same two lines, didn't change them

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes — this PR has no new testable surface (pure code move); test coverage for the Router lands in PR 2
- [x] I've tested on my platform: Ubuntu (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing behavior changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A yet (will update once the Router actually changes user-visible behavior, PR 3+)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no OS-specific code touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, `text_to_speech_tool`'s schema/docstring unchanged

### Real-world motivation

I run a variant of this exact problem in production for my own personal
Hermes deployment, which is what pushed me toward this RFC instead of a
one-off patch.

**Setup:**
- Personal Hermes runs on an Oracle Cloud VPS (ARM64), used from Telegram
  (mobile), the Desktop app (PC), and a web dashboard I expose on my own
  domain.
- I run a custom voice-cloned engine (F5-TTS) locally on my desktop GPU
  (AMD RX 9060 XT, 16GB), served over FastAPI and exposed to the internet
  through a Cloudflare Tunnel with Access-gated auth.

**What already works today:** the Desktop app's "read aloud" — a local
`mitmproxy` instance on the desktop intercepts the app's own
`/api/audio/speak` call and reroutes it straight to my home GPU, bypassing
the VPS entirely. This path is simple because client and provider are on
the same machine's network.

**The gap this RFC targets:** when the *agent itself* (running on the VPS)
triggers TTS -- not a manual read-aloud -- it has no such shortcut. I
worked around this by hand-writing a `command`-type provider
(`tts.providers.dot-modal`) whose backing shell script implements a
3-tier fallback chain:

1. **Home GPU** -- calls my desktop endpoint with a short (4s) connect
   timeout, so if the desktop is off the failure is fast, not a hang.
   Response is validated (`ffprobe` duration check) before being accepted,
   to guard against a truncated/placeholder clip passing as success.
2. **Modal (serverless GPU), warm** -- if the home GPU is unreachable, and
   a previous call already warmed the Modal container within the last few
   minutes, calls Modal directly (~7s response).
3. **Modal, cold** -- otherwise, fires an async warm-up request to Modal in
   the background (so the *next* call lands in tier 2) and serves *this*
   request synchronously from a local NeuTTS-CPU fallback running on the
   VPS itself, so the user never gets silence while Modal cold-starts
   (~90s).

All three tiers are fed through a shared pre-TTS normalization step
(pt-BR -> English translation + speech-friendly rewriting) and the final
output is always converted to Opus/OGG for Telegram/Desktop voice-bubble
compatibility, regardless of which tier produced it.

One detail worth calling out: tiers 1 and 2/3 don't even run the same
underlying model today (home GPU = F5-TTS, Modal/local-CPU fallback =
NeuTTS) -- they were wired up at different times and I never went back to
reconcile them. That's not an oversight I'm proposing to hide; it's
exactly the kind of heterogeneity `SpeechCapabilities` (PR 2) is meant to
represent explicitly instead of papering over -- a fallback tier is
allowed to be a different engine with different capabilities, as long as
the router knows what it's getting.

This whole chain is the hand-rolled version of "local speech endpoint
auto-discovery + provider fallback" (planned steps 3 and 5 above). I built
it because Hermes core has no first-class concept for it -- this series is
an attempt to make that pattern reusable instead of a bespoke script every
self-hoster reinvents.