### PR TITLE
feat(cli): add safe Shift+Enter terminal setup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -444,6 +444,7 @@ from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
 from hermes_cli.subcommands.model import build_model_parser
 from hermes_cli.subcommands.setup import build_setup_parser
+from hermes_cli.subcommands.terminal_setup import build_terminal_setup_parser
 
 from hermes_cli.subcommands.whatsapp import build_whatsapp_parser
 from hermes_cli.subcommands.slack import build_slack_parser
@@ -3011,6 +3012,13 @@ def cmd_setup(args):
     from hermes_cli.setup import run_setup_wizard
 
     run_setup_wizard(args)
+
+
+def cmd_terminal_setup(args):
+    """Show safe terminal guidance for multiline classic-CLI input."""
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    return run_terminal_setup(args)
 
 
 def cmd_model(args):
@@ -10580,7 +10588,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "model", "monitoring", "pairing", "pets", "plugins", "portal", "profile",
         "project", "proxy",
         "prompt-size",
-        "send", "sessions", "setup",
+        "send", "sessions", "setup", "terminal-setup",
         "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
         # Help-ish invocations — plugin commands not being listed in
@@ -11396,6 +11404,8 @@ def main():
     # =========================================================================
     build_setup_parser(subparsers, cmd_setup=cmd_setup)
 
+    # Informational only: this command never edits terminal or shell config.
+    build_terminal_setup_parser(subparsers, cmd_terminal_setup=cmd_terminal_setup)
 
     # =========================================================================
     # whatsapp command  (parser built in hermes_cli/subcommands/whatsapp.py)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -322,6 +322,7 @@ from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
 from hermes_cli.subcommands.model import build_model_parser
 from hermes_cli.subcommands.setup import build_setup_parser
+from hermes_cli.subcommands.terminal_setup import build_terminal_setup_parser
 
 from hermes_cli.subcommands.whatsapp import build_whatsapp_parser, build_whatsapp_cloud_parser
 from hermes_cli.subcommands.slack import build_slack_parser
@@ -1809,6 +1810,15 @@ def _forward_command(name: str, module: str, attr: str, *, forward_return: bool 
 
 
 cmd_setup = _forward_command("cmd_setup", "hermes_cli.setup", "run_setup_wizard", doc='Interactive setup wizard.')
+
+
+def cmd_terminal_setup(args):
+    """Show safe terminal guidance for multiline classic-CLI input."""
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    return run_terminal_setup(args)
+
+
 cmd_login = _forward_command("cmd_login", "hermes_cli.auth", "login_command", doc='Authenticate Hermes CLI with a provider.')
 cmd_logout = _forward_command("cmd_logout", "hermes_cli.auth", "logout_command", doc='Clear provider authentication.')
 cmd_auth = _forward_command("cmd_auth", "hermes_cli.auth_commands", "auth_command", doc='Manage pooled credentials.')
@@ -2641,7 +2651,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "project", "proxy",
         "prompt-size",
         "resume",
-        "send", "sessions", "setup",
+        "send", "sessions", "setup", "terminal-setup",
         "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
         "vault",
         "webhook", "whatsapp", "whatsapp-cloud", "worktree", "chat", "secrets", "security",
@@ -3227,6 +3237,8 @@ def _build_cli_parser():
         logger.debug("LSP CLI registration failed: %s", _lsp_err)
 
     build_setup_parser(subparsers, cmd_setup=cmd_setup)
+    # Only kitty and Ghostty receive a marked, user-level config block.
+    build_terminal_setup_parser(subparsers, cmd_terminal_setup=cmd_terminal_setup)
     build_whatsapp_parser(subparsers, cmd_whatsapp=cmd_whatsapp)
     build_whatsapp_cloud_parser(subparsers, cmd_whatsapp_cloud=cmd_whatsapp_cloud)
     build_slack_parser(subparsers, cmd_slack=cmd_slack)

--- a/hermes_cli/subcommands/terminal_setup.py
+++ b/hermes_cli/subcommands/terminal_setup.py
@@ -1,0 +1,15 @@
+"""Parser builder for ``hermes terminal-setup``."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_terminal_setup_parser(subparsers, *, cmd_terminal_setup: Callable) -> None:
+    """Attach the informational ``terminal-setup`` subcommand."""
+    parser = subparsers.add_parser(
+        "terminal-setup",
+        help="Show classic CLI multiline-input terminal guidance",
+        description="Show safe, non-destructive terminal guidance for the classic Hermes CLI.",
+    )
+    parser.set_defaults(func=cmd_terminal_setup)

--- a/hermes_cli/subcommands/terminal_setup.py
+++ b/hermes_cli/subcommands/terminal_setup.py
@@ -1,0 +1,26 @@
+"""Parser builder for ``hermes terminal-setup``."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_terminal_setup_parser(subparsers, *, cmd_terminal_setup: Callable) -> None:
+    """Attach the safe ``terminal-setup`` subcommand."""
+    parser = subparsers.add_parser(
+        "terminal-setup",
+        help="Show classic CLI multiline-input terminal guidance",
+        description="Show safe, non-destructive terminal guidance for the classic Hermes CLI.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the managed file change without writing it",
+    )
+    parser.add_argument(
+        "--print",
+        dest="print_config",
+        action="store_true",
+        help="Print a pasteable mapping without writing it",
+    )
+    parser.set_defaults(func=cmd_terminal_setup)

--- a/hermes_cli/terminal_setup.py
+++ b/hermes_cli/terminal_setup.py
@@ -1,0 +1,65 @@
+"""Safe guidance for multiline input in the classic Hermes CLI.
+
+``hermes terminal-setup`` is intentionally informational: terminal keyboard
+shortcuts belong to the user's terminal emulator, so this helper never edits
+terminal, shell, or system configuration.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def detect_terminal() -> str:
+    """Return a best-effort terminal emulator identifier from its environment."""
+    term_program = os.environ.get("TERM_PROGRAM", "").casefold()
+    term = os.environ.get("TERM", "").casefold()
+
+    if os.environ.get("WT_SESSION"):
+        return "windows-terminal"
+    if os.environ.get("VSCODE_PID") or "vscode" in term_program:
+        return "vscode"
+    if "iterm" in term_program or "iterm" in os.environ.get("LC_TERMINAL", "").casefold():
+        return "iterm2"
+    if "kitty" in term or os.environ.get("KITTY_WINDOW_ID"):
+        return "kitty"
+    if "wezterm" in term_program or "wezterm" in os.environ.get("TERM_EMULATOR", "").casefold():
+        return "wezterm"
+    if "ghostty" in term_program or os.environ.get("GHOSTTY_RESOURCES_DIR"):
+        return "ghostty"
+    return "unknown"
+
+
+def _terminal_label(terminal: str) -> str:
+    return {
+        "windows-terminal": "Windows Terminal",
+        "vscode": "VS Code-family integrated terminal",
+        "iterm2": "iTerm2",
+        "kitty": "kitty",
+        "wezterm": "WezTerm",
+        "ghostty": "Ghostty",
+        "unknown": "an unrecognised terminal",
+    }[terminal]
+
+
+def run_terminal_setup(args=None) -> None:  # noqa: ARG001
+    """Print non-destructive classic-CLI multiline-input guidance."""
+    terminal = detect_terminal()
+    print("Hermes terminal setup (classic CLI)")
+    print("This command only prints guidance; it does not change terminal, shell, or system configuration.")
+    print(f"Detected: {_terminal_label(terminal)}.")
+    print()
+    print("For multiline input in the classic `hermes` CLI:")
+    print("  • Shift+Enter works when the terminal emits a distinct modified-Enter sequence.")
+    print("  • Hermes recognises Kitty CSI-u (ESC [ 13 ; 2 u) and xterm modifyOtherKeys")
+    print("    (ESC [ 27 ; 2 ; 13 ~) Shift+Enter sequences.")
+
+    if terminal == "windows-terminal":
+        print("  • In Windows Terminal, use Ctrl+Enter for a newline if Alt+Enter is intercepted.")
+    else:
+        print("  • Alt+Enter is the fallback newline shortcut when the terminal passes it through.")
+
+    print()
+    print("If Shift+Enter submits instead, configure your terminal emulator to send one of")
+    print("the sequences above, then open a new terminal session and retry. No Hermes")
+    print("configuration change is required.")

--- a/hermes_cli/terminal_setup.py
+++ b/hermes_cli/terminal_setup.py
@@ -1,0 +1,397 @@
+"""Safe terminal-side setup for classic Hermes CLI multiline input."""
+
+from __future__ import annotations
+
+import errno
+import inspect
+import os
+import secrets
+import stat
+import sys
+from pathlib import Path
+
+_START = "# >>> hermes terminal-setup >>>"
+_END = "# <<< hermes terminal-setup <<<"
+_SEQUENCE = r"\x1b[13;2u"
+
+
+class SecurePersistenceUnavailable(RuntimeError):
+    """Raised when this platform cannot persist managed config safely."""
+
+
+def detect_terminal() -> str:
+    """Return a best-effort terminal emulator identifier from its environment."""
+    term_program = os.environ.get("TERM_PROGRAM", "").casefold()
+    terminal = os.environ.get("TERM", "").casefold()
+
+    if os.environ.get("WT_SESSION"):
+        return "windows-terminal"
+    if os.environ.get("VSCODE_PID") or "vscode" in term_program:
+        return "vscode"
+    if (
+        "iterm" in term_program
+        or "iterm" in os.environ.get("LC_TERMINAL", "").casefold()
+    ):
+        return "iterm2"
+    if term_program == "apple_terminal":
+        return "apple-terminal"
+    if "kitty" in terminal or os.environ.get("KITTY_WINDOW_ID"):
+        return "kitty"
+    if (
+        "wezterm" in term_program
+        or "wezterm" in os.environ.get("TERM_EMULATOR", "").casefold()
+    ):
+        return "wezterm"
+    if "ghostty" in term_program or os.environ.get("GHOSTTY_RESOURCES_DIR"):
+        return "ghostty"
+    return "unknown"
+
+
+def is_native_windows() -> bool:
+    """Whether Hermes is running with prompt_toolkit's Win32 input backend."""
+    return os.name == "nt"
+
+
+def managed_config_path(terminal: str) -> Path:
+    """Return the user-owned config path for terminals we can edit safely."""
+    config_root = managed_config_root(terminal)
+    if terminal == "kitty":
+        return config_root / "kitty" / "kitty.conf"
+    if terminal == "ghostty":
+        if sys.platform == "darwin" and not os.environ.get("XDG_CONFIG_HOME"):
+            return config_root / "config"
+        return config_root / "ghostty" / "config"
+    raise ValueError(f"{terminal!r} has no managed configuration path")
+
+
+def managed_config_root(terminal: str) -> Path:
+    """Return the absolute user config root for a managed terminal."""
+    if (
+        terminal == "ghostty"
+        and sys.platform == "darwin"
+        and not os.environ.get("XDG_CONFIG_HOME")
+    ):
+        return Path.home() / "Library/Application Support/com.mitchellh.ghostty"
+    xdg_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_home:
+        root = Path(xdg_home)
+        if not root.is_absolute():
+            raise ValueError("XDG_CONFIG_HOME must be an absolute path")
+        if root.is_symlink():
+            raise ValueError(
+                "XDG_CONFIG_HOME config root is a symlink; refusing to modify it"
+            )
+        return root
+    return Path.home() / ".config"
+
+
+def managed_block(terminal: str) -> str:
+    """Return the exact, deliberately narrow mapping managed by Hermes."""
+    mapping = {
+        "kitty": f"map shift+enter send_text all {_SEQUENCE}",
+        "ghostty": f"keybind = shift+enter=text:{_SEQUENCE}",
+    }[terminal]
+    return f"{_START}\n{mapping}\n{_END}"
+
+
+def update_managed_block(content: str, terminal: str) -> str:
+    """Replace Hermes' block, leaving all unrelated user configuration intact."""
+    block = managed_block(terminal)
+    marker_lines = [
+        line for line in content.splitlines() if _START in line or _END in line
+    ]
+    if not marker_lines:
+        separator = "" if not content or content.endswith("\n") else "\n"
+        return f"{content}{separator}{block}\n"
+    if len(marker_lines) != 2 or marker_lines != [_START, _END]:
+        raise ValueError(
+            "invalid Hermes terminal-setup markers; refusing to modify config"
+        )
+    start = content.find(_START)
+    end = content.find(_END, start)
+    end += len(_END)
+    return f"{content[:start]}{block}{content[end:]}"
+
+
+def _snippet(terminal: str) -> str | None:
+    snippets = {
+        "wezterm": """local wezterm = require 'wezterm'
+
+return {
+  keys = {
+    { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString '\\x1b[13;2u' },
+  },
+}""",
+        "iterm2": """iTerm2 → Settings → Profiles → Keys → Key Mappings → +
+Keyboard Shortcut: Shift+Return
+Action: Send Escape Sequence
+Esc+ field (paste this value): [13;2u""",
+        "windows-terminal": """// settings.json: add this object to the existing "actions" array
+{
+  "command": { "action": "sendInput", "input": "\\u001b[13;2u" },
+  "keys": "shift+enter"
+}""",
+        "vscode": """// keybindings.json
+{
+  "key": "shift+enter",
+  "command": "workbench.action.terminal.sendSequence",
+  "args": { "text": "\\u001b[13;2u" },
+  "when": "terminalFocus"
+}""",
+    }
+    return snippets.get(terminal)
+
+
+def _print_intro(terminal: str) -> None:
+    labels = {
+        "windows-terminal": "Windows Terminal",
+        "vscode": "VS Code-family integrated terminal",
+        "iterm2": "iTerm2",
+        "apple-terminal": "Apple Terminal",
+        "kitty": "kitty",
+        "wezterm": "WezTerm",
+        "ghostty": "Ghostty",
+        "unknown": "an unrecognised terminal",
+    }
+    print("Hermes terminal setup (classic CLI)")
+    print(f"Detected: {labels[terminal]}.")
+    print(
+        "Shift+Enter needs a terminal mapping to ESC [ 13 ; 2 u. Hermes never enables"
+    )
+    print(
+        "a global keyboard protocol: only this chord is mapped, preserving Ctrl+C, Esc, and Alt keys."
+    )
+
+
+def _print_windows_notice() -> None:
+    print()
+    print(
+        "Native Windows limitation: prompt_toolkit Win32 backend cannot enable app-side Shift+Enter."
+    )
+    print("Use Ctrl+Enter (or Ctrl+J) for a newline.")
+    print(
+        "Use a mapping only in WSL or a remote Unix host, where the Unix input decoder"
+    )
+    print("receives the sequence.")
+
+
+def _safe_managed_config_path(terminal: str) -> Path:
+    """Resolve a managed path without crossing config-root or symlink boundaries."""
+    root = managed_config_root(terminal)
+    path = managed_config_path(terminal)
+    if not root.is_absolute() or not path.is_absolute():
+        raise ValueError("managed config paths must be absolute")
+    _reject_symlink_components(root, "config root")
+    _reject_symlink_components(path, "managed config path")
+    root = root.resolve()
+    path = path.resolve(strict=False)
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            "managed config path resolves outside its config root"
+        ) from exc
+    return path
+
+
+def _reject_symlink_components(path: Path, label: str) -> None:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            raise ValueError(f"{label} contains a symlink; refusing to modify it")
+
+
+def _secure_persistence_available() -> bool:
+    """Whether this runtime has the descriptor APIs needed for safe writes."""
+    required_flags = ("O_DIRECTORY", "O_NOFOLLOW", "O_CREAT", "O_EXCL")
+    required_operations = (os.open, os.mkdir, os.unlink)
+    required_functions = ("fchmod", "fsync")
+    try:
+        replace_parameters = inspect.signature(os.replace).parameters
+    except (TypeError, ValueError):
+        return False
+    return (
+        os.name != "nt"
+        and all(hasattr(os, flag) for flag in required_flags)
+        and all(hasattr(os, function) for function in required_functions)
+        and all(operation in os.supports_dir_fd for operation in required_operations)
+        and all(
+            parameter in replace_parameters
+            and replace_parameters[parameter].kind
+            is not inspect.Parameter.POSITIONAL_ONLY
+            for parameter in ("src_dir_fd", "dst_dir_fd")
+        )
+    )
+
+
+def _open_directory_no_follow(path: Path) -> int:
+    """Open or create an absolute directory path without traversing symlinks."""
+    if not _secure_persistence_available():
+        raise SecurePersistenceUnavailable(
+            "descriptor-relative no-follow config persistence is unavailable"
+        )
+    if not path.is_absolute():
+        raise ValueError("managed config directories must be absolute")
+
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    directory_fd = os.open(path.anchor, flags)
+    try:
+        for component in path.parts[1:]:
+            try:
+                os.mkdir(component, 0o700, dir_fd=directory_fd)
+            except FileExistsError:
+                pass
+            except OSError as exc:
+                if exc.errno != errno.EEXIST:
+                    raise
+            child_fd = os.open(component, flags, dir_fd=directory_fd)
+            os.close(directory_fd)
+            directory_fd = child_fd
+        return directory_fd
+    except BaseException:
+        os.close(directory_fd)
+        raise
+
+
+def _read_regular_file_no_follow(directory_fd: int, basename: str) -> tuple[str, int]:
+    """Read a regular config file relative to an already-open directory."""
+    try:
+        file_fd = os.open(basename, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory_fd)
+    except FileNotFoundError:
+        return "", 0o600
+    try:
+        metadata = os.fstat(file_fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("managed config target is not a regular file")
+        with os.fdopen(file_fd, "r", encoding="utf-8") as config_file:
+            file_fd = -1
+            return config_file.read(), stat.S_IMODE(metadata.st_mode)
+    finally:
+        if file_fd != -1:
+            os.close(file_fd)
+
+
+def _secure_update_managed_config(path: Path, terminal: str) -> bool:
+    """Atomically update ``path`` without following any directory or target symlink."""
+    basename = path.name
+    if basename in {"", ".", ".."} or len(path.parts) < 2:
+        raise ValueError("managed config target must be a file beneath its config root")
+
+    directory_fd = _open_directory_no_follow(path.parent)
+    temporary_name = ""
+    try:
+        existing, mode = _read_regular_file_no_follow(directory_fd, basename)
+        updated = update_managed_block(existing, terminal)
+        if updated == existing:
+            return False
+
+        temporary_name = f".{basename}.hermes-{secrets.token_hex(16)}.tmp"
+        temporary_fd = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            mode,
+            dir_fd=directory_fd,
+        )
+        try:
+            os.fchmod(temporary_fd, mode)
+            with os.fdopen(temporary_fd, "w", encoding="utf-8") as temporary_file:
+                temporary_fd = -1
+                temporary_file.write(updated)
+                temporary_file.flush()
+                os.fsync(temporary_file.fileno())
+        finally:
+            if temporary_fd != -1:
+                os.close(temporary_fd)
+
+        os.replace(
+            temporary_name,
+            basename,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        temporary_name = ""
+        return True
+    finally:
+        if temporary_name:
+            try:
+                os.unlink(temporary_name, dir_fd=directory_fd)
+            except FileNotFoundError:
+                pass
+        os.close(directory_fd)
+
+
+def _apply_managed_config(terminal: str, *, dry_run: bool, print_config: bool) -> None:
+    path = _safe_managed_config_path(terminal)
+    block = managed_block(terminal)
+
+    if print_config:
+        print(f"\nPaste into {path}:\n{block}")
+    if dry_run:
+        print(f"\nWould update {path} with:\n{block}")
+        return
+    if print_config:
+        return
+    if not _secure_persistence_available():
+        # Preserve marker validation even when this runtime must fail closed.
+        existing = path.read_text(encoding="utf-8") if path.exists() else ""
+        update_managed_block(existing, terminal)
+    try:
+        changed = _secure_update_managed_config(path, terminal)
+    except SecurePersistenceUnavailable as exc:
+        print(
+            f"\nCannot safely update {path}: {exc}. "
+            "No files were written; rerun with --print and paste the mapping manually."
+        )
+        return
+    if not changed:
+        print(f"\nAlready configured: {path}")
+        return
+    print(f"\nUpdated {path}; only the marked Hermes block was changed.")
+
+
+def run_terminal_setup(args=None) -> None:
+    """Configure one safe terminal mapping or print a terminal-specific snippet."""
+    dry_run = bool(getattr(args, "dry_run", False))
+    print_config = bool(getattr(args, "print_config", False))
+    terminal = detect_terminal()
+    _print_intro(terminal)
+
+    if is_native_windows():
+        _print_windows_notice()
+        return
+
+    if terminal in {"kitty", "ghostty"}:
+        _apply_managed_config(terminal, dry_run=dry_run, print_config=print_config)
+    elif snippet := _snippet(terminal):
+        print(
+            "\nPaste this single-chord mapping into your existing configuration; Hermes will not edit it:"
+        )
+        print(snippet)
+        if terminal == "wezterm":
+            print(
+                "Merge the keys entry with existing keys rather than adding a second return table."
+            )
+        elif terminal == "vscode":
+            print(
+                "For VS Code forks, use the equivalent keybindings JSON command if its command ID differs."
+            )
+        elif terminal == "windows-terminal":
+            print(
+                "This requires a Windows Terminal version with the sendInput action; open a new tab afterward."
+            )
+    elif terminal == "apple-terminal":
+        print(
+            "\nApple Terminal cannot distinguish Shift+Enter. Use Option+Enter or Ctrl+J for a newline."
+        )
+    else:
+        print(
+            "\nThis terminal is not recognised. If it supports a per-key mapping, map only Shift+Enter"
+        )
+        print(r"to \x1b[13;2u; otherwise use Option+Enter or Ctrl+J for a newline.")
+
+    if dry_run or print_config:
+        print(
+            "\nNo files were written (--dry-run and --print are compatible preview modes)."
+        )
+    print("Open a new terminal session after changing terminal configuration.")

--- a/tests/hermes_cli/test_terminal_setup.py
+++ b/tests/hermes_cli/test_terminal_setup.py
@@ -1,0 +1,67 @@
+"""Tests for the safe classic-CLI ``hermes terminal-setup`` helper."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def test_detect_terminal_prefers_windows_terminal(monkeypatch):
+    from hermes_cli.terminal_setup import detect_terminal
+
+    monkeypatch.setenv("WT_SESSION", "session-id")
+    monkeypatch.setenv("TERM_PROGRAM", "vscode")
+
+    assert detect_terminal() == "windows-terminal"
+
+
+def test_detect_terminal_identifies_vscode(monkeypatch):
+    from hermes_cli.terminal_setup import detect_terminal
+
+    monkeypatch.delenv("WT_SESSION", raising=False)
+    monkeypatch.setenv("TERM_PROGRAM", "vscode")
+
+    assert detect_terminal() == "vscode"
+
+
+def test_terminal_setup_reports_only_classic_cli_guidance(monkeypatch, capsys):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    monkeypatch.setenv("WT_SESSION", "session-id")
+    run_terminal_setup()
+
+    output = capsys.readouterr().out
+    assert "classic `hermes` CLI" in output
+    assert "does not change terminal, shell, or system configuration" in output
+    assert "Ctrl+Enter" in output
+    assert "TUI" not in output
+
+
+def test_terminal_setup_does_not_write_or_launch_processes(monkeypatch):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    def fail(*_args, **_kwargs):
+        raise AssertionError("terminal-setup must not invoke external processes")
+
+    monkeypatch.setattr("subprocess.run", fail)
+    monkeypatch.setattr("os.system", fail)
+
+    run_terminal_setup()
+
+
+def test_terminal_setup_parser_registers_a_handler():
+    from hermes_cli.subcommands.terminal_setup import build_terminal_setup_parser
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="command")
+    handler = lambda _args: None
+    build_terminal_setup_parser(subparsers, cmd_terminal_setup=handler)
+
+    args = root.parse_args(["terminal-setup"])
+    assert args.command == "terminal-setup"
+    assert args.func is handler
+
+
+def test_terminal_setup_is_a_builtin_subcommand():
+    from hermes_cli.main import _BUILTIN_SUBCOMMANDS
+
+    assert "terminal-setup" in _BUILTIN_SUBCOMMANDS

--- a/tests/hermes_cli/test_terminal_setup.py
+++ b/tests/hermes_cli/test_terminal_setup.py
@@ -1,0 +1,623 @@
+"""Tests for the safe classic-CLI ``hermes terminal-setup`` helper."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def unix_input_backend(monkeypatch):
+    monkeypatch.setattr("hermes_cli.terminal_setup.is_native_windows", lambda: False)
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        ({"WT_SESSION": "session-id", "TERM_PROGRAM": "vscode"}, "windows-terminal"),
+        ({"VSCODE_PID": "123"}, "vscode"),
+        ({"TERM_PROGRAM": "iTerm.app"}, "iterm2"),
+        ({"TERM_PROGRAM": "Apple_Terminal"}, "apple-terminal"),
+        ({"KITTY_WINDOW_ID": "1"}, "kitty"),
+        ({"TERM_PROGRAM": "WezTerm"}, "wezterm"),
+        ({"TERM_PROGRAM": "ghostty"}, "ghostty"),
+        ({}, "unknown"),
+    ],
+)
+def test_detect_terminal(environment, expected, monkeypatch):
+    from hermes_cli.terminal_setup import detect_terminal
+
+    for name in (
+        "WT_SESSION",
+        "VSCODE_PID",
+        "TERM_PROGRAM",
+        "LC_TERMINAL",
+        "TERM",
+        "KITTY_WINDOW_ID",
+        "TERM_EMULATOR",
+        "GHOSTTY_RESOURCES_DIR",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+
+    assert detect_terminal() == expected
+
+
+@pytest.mark.parametrize(
+    ("terminal", "expected"),
+    [
+        ("kitty", Path(".config/kitty/kitty.conf")),
+        ("ghostty", Path(".config/ghostty/config")),
+    ],
+)
+def test_managed_config_path_uses_xdg_home(terminal, expected, monkeypatch, tmp_path):
+    from hermes_cli.terminal_setup import managed_config_path
+
+    xdg = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.Path.home", lambda: tmp_path / "home"
+    )
+
+    assert managed_config_path(terminal) == xdg / expected.relative_to(".config")
+
+
+def test_ghostty_uses_macos_application_support(monkeypatch, tmp_path):
+    from hermes_cli.terminal_setup import managed_config_path
+
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr("hermes_cli.terminal_setup.sys.platform", "darwin")
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.Path.home", lambda: tmp_path / "home"
+    )
+
+    assert (
+        managed_config_path("ghostty")
+        == tmp_path / "home/Library/Application Support/com.mitchellh.ghostty/config"
+    )
+
+
+@pytest.mark.parametrize("terminal", ["kitty", "ghostty"])
+def test_update_managed_block_preserves_content_and_is_idempotent(terminal):
+    from hermes_cli.terminal_setup import managed_block, update_managed_block
+
+    original = "font_size 14\n# personal setting\n"
+    updated = update_managed_block(original, terminal)
+
+    assert updated.startswith(original)
+    assert managed_block(terminal) in updated
+    assert update_managed_block(updated, terminal) == updated
+
+
+def test_update_managed_block_replaces_only_existing_managed_block():
+    from hermes_cli.terminal_setup import managed_block, update_managed_block
+
+    existing = "before\n# >>> hermes terminal-setup >>>\nstale\n# <<< hermes terminal-setup <<<\nafter\n"
+    updated = update_managed_block(existing, "kitty")
+
+    assert updated == f"before\n{managed_block('kitty')}\nafter\n"
+
+
+def test_update_managed_block_refuses_an_unterminated_owned_block():
+    from hermes_cli.terminal_setup import update_managed_block
+
+    with pytest.raises(ValueError, match="markers"):
+        update_managed_block("user setting\n# >>> hermes terminal-setup >>>\n", "kitty")
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "# <<< hermes terminal-setup <<<\n",
+        "# >>> hermes terminal-setup >>>\n",
+        "# <<< hermes terminal-setup <<<\n# >>> hermes terminal-setup >>>\n",
+        "# >>> hermes terminal-setup >>>\n# >>> hermes terminal-setup >>>\n# <<< hermes terminal-setup <<<\n# <<< hermes terminal-setup <<<\n",
+        "# >>> hermes terminal-setup >>>\n# <<< hermes terminal-setup <<<\n# >>> hermes terminal-setup >>>\n# <<< hermes terminal-setup <<<\n",
+        "before # >>> hermes terminal-setup >>>\n# <<< hermes terminal-setup <<<\n",
+    ],
+)
+def test_invalid_managed_markers_are_rejected_without_writing(
+    monkeypatch, tmp_path, content
+):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    config = tmp_path / "xdg/kitty/kitty.conf"
+    config.parent.mkdir(parents=True)
+    config.write_text(content, encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+
+    with pytest.raises(ValueError, match="markers"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert config.read_text(encoding="utf-8") == content
+
+
+def test_relative_xdg_config_home_is_rejected_without_writing(monkeypatch, tmp_path):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", "relative-config")
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+
+    with pytest.raises(ValueError, match="absolute"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert not (tmp_path / "relative-config").exists()
+
+
+def test_xdg_config_root_symlink_is_rejected_without_writing(monkeypatch, tmp_path):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root_link = tmp_path / "xdg-link"
+    root_link.symlink_to(outside, target_is_directory=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(root_link))
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+
+    with pytest.raises(ValueError, match="config root.*symlink"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert not (outside / "kitty").exists()
+
+
+def test_default_config_root_symlink_is_rejected_without_writing(monkeypatch, tmp_path):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    home = tmp_path / "home"
+    outside = tmp_path / "outside"
+    home.mkdir()
+    outside.mkdir()
+    (home / ".config").symlink_to(outside, target_is_directory=True)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr("hermes_cli.terminal_setup.Path.home", lambda: home)
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+
+    with pytest.raises(ValueError, match="config root.*symlink"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert not (outside / "kitty").exists()
+
+
+def test_xdg_config_root_ancestor_symlink_is_rejected_without_writing(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root_link = tmp_path / "root-link"
+    root_link.symlink_to(outside, target_is_directory=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(root_link / "declared"))
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+
+    with pytest.raises(ValueError, match="config root.*symlink"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert not (outside / "declared").exists()
+
+
+def test_macos_ghostty_config_root_symlink_is_rejected_without_writing(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    home = tmp_path / "home"
+    config_root = home / "Library/Application Support/com.mitchellh.ghostty"
+    outside = tmp_path / "outside"
+    config_root.parent.mkdir(parents=True)
+    outside.mkdir()
+    config_root.symlink_to(outside, target_is_directory=True)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setattr("hermes_cli.terminal_setup.Path.home", lambda: home)
+    monkeypatch.setattr("hermes_cli.terminal_setup.sys.platform", "darwin")
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "ghostty")
+
+    with pytest.raises(ValueError, match="config root.*symlink"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert not (outside / "config").exists()
+
+
+def test_symlinked_config_target_is_rejected_without_writing(monkeypatch, tmp_path):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    xdg = tmp_path / "xdg"
+    target = tmp_path / "outside.conf"
+    target.write_text("font_size 14\n", encoding="utf-8")
+    config = xdg / "kitty/kitty.conf"
+    config.parent.mkdir(parents=True)
+    config.symlink_to(target)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+
+    with pytest.raises(ValueError, match="symlink"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert target.read_text(encoding="utf-8") == "font_size 14\n"
+
+
+def test_parent_symlink_escape_is_rejected_without_writing(monkeypatch, tmp_path):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    xdg = tmp_path / "xdg"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    xdg.mkdir()
+    (xdg / "kitty").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+
+    with pytest.raises(ValueError, match="symlink"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert not (outside / "kitty.conf").exists()
+
+
+@pytest.mark.parametrize(
+    ("terminal", "parent", "config"),
+    [
+        ("kitty", "kitty", "kitty.conf"),
+        ("ghostty", "ghostty", "config"),
+    ],
+)
+def test_in_root_config_parent_symlink_is_rejected_without_writing(
+    monkeypatch, tmp_path, terminal, parent, config
+):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    xdg = tmp_path / "xdg"
+    redirected = xdg / "redirected"
+    xdg.mkdir()
+    redirected.mkdir()
+    (xdg / parent).symlink_to(redirected, target_is_directory=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: terminal)
+
+    with pytest.raises(ValueError, match="symlink"):
+        run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    assert not (redirected / config).exists()
+
+
+def test_dry_run_shows_proposed_change_without_writing(monkeypatch, capsys, tmp_path):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    config = tmp_path / "kitty.conf"
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.managed_config_path", lambda _terminal: config
+    )
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.managed_config_root", lambda _terminal: tmp_path
+    )
+
+    run_terminal_setup(argparse.Namespace(dry_run=True, print_config=False))
+
+    output = capsys.readouterr().out
+    assert f"Would update {config}" in output
+    assert "map shift+enter send_text all \\x1b[13;2u" in output
+    assert not config.exists()
+
+
+def test_print_emits_pasteable_config_without_writing(monkeypatch, capsys, tmp_path):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    config = tmp_path / "kitty.conf"
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.managed_config_path", lambda _terminal: config
+    )
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.managed_config_root", lambda _terminal: tmp_path
+    )
+
+    run_terminal_setup(argparse.Namespace(dry_run=False, print_config=True))
+
+    output = capsys.readouterr().out
+    assert "Paste into" in output
+    assert "map shift+enter send_text all \\x1b[13;2u" in output
+    assert not config.exists()
+
+
+def test_dry_run_and_print_are_compatible_and_do_not_write(
+    monkeypatch, capsys, tmp_path
+):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    config = tmp_path / "ghostty/config"
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "ghostty")
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.managed_config_path", lambda _terminal: config
+    )
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.managed_config_root", lambda _terminal: tmp_path
+    )
+
+    run_terminal_setup(argparse.Namespace(dry_run=True, print_config=True))
+
+    output = capsys.readouterr().out
+    assert "Would update" in output
+    assert "Paste into" in output
+    assert not config.exists()
+
+
+def test_unavailable_secure_persistence_prints_guidance_without_writing(
+    monkeypatch, capsys, tmp_path
+):
+    from hermes_cli import terminal_setup
+
+    config = tmp_path / "xdg/kitty/kitty.conf"
+    config.parent.mkdir(parents=True)
+    config.write_text("font_size 14\n", encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup._secure_persistence_available", lambda: False
+    )
+
+    terminal_setup.run_terminal_setup(
+        argparse.Namespace(dry_run=False, print_config=False)
+    )
+
+    output = capsys.readouterr().out
+    assert config.read_text(encoding="utf-8") == "font_size 14\n"
+    assert "Cannot safely update" in output
+    assert "--print" in output
+
+
+def test_secure_persistence_accepts_linux_replace_dir_fds_not_in_support_set(
+    monkeypatch,
+):
+    """Linux exposes replace's dir fds in its signature, not supports_dir_fd."""
+    from types import SimpleNamespace
+
+    from hermes_cli import terminal_setup
+
+    def replace(src, dst, *, src_dir_fd=None, dst_dir_fd=None):
+        pass
+
+    open_operation = object()
+    mkdir_operation = object()
+    unlink_operation = object()
+    linux_os = SimpleNamespace(
+        name="posix",
+        O_DIRECTORY=object(),
+        O_NOFOLLOW=object(),
+        O_CREAT=object(),
+        O_EXCL=object(),
+        open=open_operation,
+        mkdir=mkdir_operation,
+        replace=replace,
+        unlink=unlink_operation,
+        fchmod=object(),
+        fsync=object(),
+        supports_dir_fd={open_operation, mkdir_operation, unlink_operation},
+    )
+    monkeypatch.setattr(terminal_setup, "os", linux_os)
+
+    assert terminal_setup._secure_persistence_available()
+
+
+def test_secure_persistence_requires_keyword_replace_dir_fds(monkeypatch):
+    from types import SimpleNamespace
+
+    from hermes_cli import terminal_setup
+
+    def replace(src, dst, src_dir_fd, dst_dir_fd, /):
+        pass
+
+    open_operation = object()
+    mkdir_operation = object()
+    unlink_operation = object()
+    linux_os = SimpleNamespace(
+        name="posix",
+        O_DIRECTORY=object(),
+        O_NOFOLLOW=object(),
+        O_CREAT=object(),
+        O_EXCL=object(),
+        open=open_operation,
+        mkdir=mkdir_operation,
+        replace=replace,
+        unlink=unlink_operation,
+        fchmod=object(),
+        fsync=object(),
+        supports_dir_fd={open_operation, mkdir_operation, unlink_operation},
+    )
+    monkeypatch.setattr(terminal_setup, "os", linux_os)
+
+    assert not terminal_setup._secure_persistence_available()
+
+
+def test_secure_persistence_does_not_follow_parent_swapped_at_write_seam(
+    monkeypatch, tmp_path
+):
+    """A parent replaced by a symlink at persistence cannot redirect the write."""
+    import os
+
+    from hermes_cli import terminal_setup
+
+    if not terminal_setup._secure_persistence_available():
+        pytest.skip("descriptor-relative no-follow persistence is Unix-only")
+
+    xdg = tmp_path / "xdg"
+    target_parent = xdg / "kitty"
+    outside = tmp_path / "outside"
+    displaced = tmp_path / "displaced-kitty"
+    target_parent.mkdir(parents=True)
+    outside.mkdir()
+    config = target_parent / "kitty.conf"
+    config.write_text("font_size 14\n", encoding="utf-8")
+    swapped = False
+    original_replace = os.replace
+
+    def swap_parent_before_replace(src, dst, *, src_dir_fd=None, dst_dir_fd=None):
+        nonlocal swapped
+        if not swapped and dst == "kitty.conf" and dst_dir_fd is not None:
+            target_parent.rename(displaced)
+            target_parent.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return original_replace(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+
+    monkeypatch.setattr(os, "replace", swap_parent_before_replace)
+
+    terminal_setup._secure_update_managed_config(config, "kitty")
+
+    assert swapped
+    assert not (outside / "kitty.conf").exists()
+    assert "font_size 14" in (displaced / "kitty.conf").read_text(encoding="utf-8")
+    assert terminal_setup.managed_block("kitty") in (
+        displaced / "kitty.conf"
+    ).read_text(encoding="utf-8")
+
+
+def test_default_managed_setup_writes_once_and_preserves_user_content(
+    monkeypatch, capsys, tmp_path
+):
+    import stat
+
+    from hermes_cli import terminal_setup
+
+    if not terminal_setup._secure_persistence_available():
+        pytest.skip("descriptor-relative no-follow persistence is Unix-only")
+
+    run_terminal_setup = terminal_setup.run_terminal_setup
+
+    xdg = tmp_path / "xdg"
+    config = xdg / "kitty/kitty.conf"
+    config.parent.mkdir(parents=True)
+    config.write_text("font_size 14\n", encoding="utf-8")
+    config.chmod(0o640)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "kitty")
+
+    args = argparse.Namespace(dry_run=False, print_config=False)
+    run_terminal_setup(args)
+    first = config.read_text(encoding="utf-8")
+    run_terminal_setup(args)
+
+    assert "font_size 14" in first
+    assert first.count("# >>> hermes terminal-setup >>>") == 1
+    assert config.read_text(encoding="utf-8") == first
+    assert stat.S_IMODE(config.stat().st_mode) == 0o640
+    assert "Updated" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("terminal", "snippet"),
+    [
+        ("wezterm", "wezterm.action.SendString '\\x1b[13;2u'"),
+        ("iterm2", "[13;2u"),
+        ("windows-terminal", '"action": "sendInput"'),
+        ("vscode", '"command": "workbench.action.terminal.sendSequence"'),
+    ],
+)
+def test_print_includes_supported_terminal_snippets(
+    monkeypatch, capsys, terminal, snippet
+):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: terminal)
+    run_terminal_setup(argparse.Namespace(dry_run=False, print_config=True))
+
+    assert snippet in capsys.readouterr().out
+
+
+def test_apple_terminal_and_unknown_explain_fallback(monkeypatch, capsys):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.detect_terminal", lambda: "apple-terminal"
+    )
+    run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+    apple = capsys.readouterr().out
+    assert "cannot distinguish Shift+Enter" in apple
+    assert "Option+Enter" in apple
+
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: "unknown")
+    run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+    assert "Option+Enter" in capsys.readouterr().out
+
+
+def test_native_windows_says_app_side_shift_enter_is_unavailable(monkeypatch, capsys):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.detect_terminal", lambda: "windows-terminal"
+    )
+    monkeypatch.setattr("hermes_cli.terminal_setup.is_native_windows", lambda: True)
+
+    run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    output = capsys.readouterr().out
+    assert "prompt_toolkit Win32 backend" in output
+    assert "Ctrl+Enter" in output
+    assert "WSL or a remote Unix host" in output
+    assert "sendInput" not in output
+
+
+@pytest.mark.parametrize("terminal", ["kitty", "ghostty"])
+def test_native_windows_never_writes_managed_mappings(
+    monkeypatch, capsys, terminal, tmp_path
+):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    config = tmp_path / terminal / "config"
+    monkeypatch.setattr("hermes_cli.terminal_setup.detect_terminal", lambda: terminal)
+    monkeypatch.setattr("hermes_cli.terminal_setup.is_native_windows", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.managed_config_path", lambda _terminal: config
+    )
+    monkeypatch.setattr(
+        "hermes_cli.terminal_setup.managed_config_root", lambda _terminal: tmp_path
+    )
+
+    run_terminal_setup(argparse.Namespace(dry_run=False, print_config=False))
+
+    output = capsys.readouterr().out
+    assert "prompt_toolkit Win32 backend" in output
+    assert "map shift+enter" not in output
+    assert not config.exists()
+
+
+def test_terminal_setup_does_not_launch_external_processes(monkeypatch):
+    from hermes_cli.terminal_setup import run_terminal_setup
+
+    def fail(*_args, **_kwargs):
+        raise AssertionError("terminal-setup must not invoke external processes")
+
+    monkeypatch.setattr("subprocess.run", fail)
+    monkeypatch.setattr("os.system", fail)
+    run_terminal_setup(argparse.Namespace(dry_run=False, print_config=True))
+
+
+def test_terminal_setup_parser_registers_flags_and_handler():
+    from hermes_cli.subcommands.terminal_setup import build_terminal_setup_parser
+
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="command")
+    handler = lambda _args: None
+    build_terminal_setup_parser(subparsers, cmd_terminal_setup=handler)
+
+    args = root.parse_args(["terminal-setup", "--dry-run", "--print"])
+    assert args.command == "terminal-setup"
+    assert args.dry_run is True
+    assert args.print_config is True
+    assert args.func is handler
+
+
+def test_terminal_setup_dispatches_through_real_top_level_parser(monkeypatch):
+    import hermes_cli.main as main
+
+    called = []
+    monkeypatch.setattr(main, "cmd_terminal_setup", lambda args: called.append(args))
+
+    parser, _ = main._build_cli_parser()
+    args = parser.parse_args(["terminal-setup", "--print"])
+    args.func(args)
+
+    assert called and called[0].print_config is True


### PR DESCRIPTION
Closes #56407

Hermes already understands a distinct Shift+Enter sequence, but many terminals send the same byte for Enter and Shift+Enter. This adds a safe way to configure the terminal side without turning on a global keyboard protocol and breaking Ctrl+C, Esc, or Alt keys.

## What changed

- `hermes terminal-setup` detects the terminal and configures only `Shift+Enter → ESC [ 13 ; 2 u` where it is safe to do so.
- Kitty and Ghostty get an idempotent managed config block. The writer refuses malformed ownership and symlinked paths, uses descriptor-relative atomic writes on Unix/macOS, and fails closed when that cannot be done safely.
- `--dry-run` shows the proposed change; `--print` emits a pasteable snippet without writing.
- WezTerm, iTerm2, Windows Terminal, and VS Code get pasteable guidance rather than automatic edits.
- Apple Terminal and unknown terminals get fallback advice. Native Windows clearly uses Ctrl+Enter/Ctrl+J instead, because the Win32 prompt_toolkit backend cannot receive the mapped sequence.

## Validation

- Terminal setup and Shift+Enter behavior: 51 passed after squash on Windows; 2 Unix-only descriptor tests are skipped there.
- Linux Python 3.11 container validation: 49 passed, including secure descriptor-relative persistence and race-path coverage.
- Ruff, formatting, whitespace checks, parser dispatch, and native-Windows `--print` smoke tests pass.

Rebased on current `main` and squashed to one commit.
