### PR TITLE
Feat/speech router pr2 capabilities

### DIFF
--- a/tests/tools/test_speech_capabilities.py
+++ b/tests/tools/test_speech_capabilities.py
@@ -1,0 +1,50 @@
+"""Tests for tools/speech/capabilities.py (Speech Router RFC, PR2)."""
+
+from tools.speech.capabilities import BUILTIN_CAPABILITIES, get_builtin_capabilities
+from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+
+
+def test_every_builtin_provider_has_capabilities():
+    """Catches drift: a new builtin added to tts_tool.py without a matching
+    capabilities entry here would otherwise silently return None forever."""
+    missing = BUILTIN_TTS_PROVIDERS - set(BUILTIN_CAPABILITIES)
+    assert not missing, f"builtin providers missing capability entries: {missing}"
+
+
+def test_no_unknown_extra_entries():
+    """Catches the opposite drift: a stale entry for a provider that was
+    removed from BUILTIN_TTS_PROVIDERS."""
+    extra = set(BUILTIN_CAPABILITIES) - BUILTIN_TTS_PROVIDERS
+    assert not extra, f"capability entries for non-builtin providers: {extra}"
+
+
+def test_unknown_provider_returns_none():
+    assert get_builtin_capabilities("not-a-real-provider") is None
+
+
+def test_elevenlabs_streaming_is_true():
+    """Grounded in tools.tts_tool.stream_tts_to_speaker (CLI streaming path)."""
+    caps = get_builtin_capabilities("elevenlabs")
+    assert caps is not None
+    assert caps.streaming is True
+
+
+def test_local_providers_flagged_local():
+    for name in ("neutts", "kittentts", "piper"):
+        caps = get_builtin_capabilities(name)
+        assert caps is not None
+        assert caps.local is True, f"{name} should be local=True"
+
+
+def test_cloud_providers_flagged_not_local():
+    for name in ("edge", "elevenlabs", "openai", "minimax", "xai", "mistral", "gemini"):
+        caps = get_builtin_capabilities(name)
+        assert caps is not None
+        assert caps.local is False, f"{name} should be local=False"
+
+
+def test_no_provider_claims_ssml():
+    """This codebase's own prompt text says "Do not use SSML" in two places;
+    no builtin integration here implements it."""
+    for name, caps in BUILTIN_CAPABILITIES.items():
+        assert caps.ssml is False, f"{name} unexpectedly claims ssml=True"

--- a/tests/tools/test_speech_router.py
+++ b/tests/tools/test_speech_router.py
@@ -1,0 +1,27 @@
+"""Tests for tools/speech/router.py (Speech Router RFC, PR1 + PR2)."""
+
+from tools.speech.router import SpeechRouter
+from tools.tts_tool import _get_provider, _load_tts_config
+
+
+def test_resolve_provider_matches_direct_call():
+    """PR1 contract: resolve_provider() must return exactly what the two
+    lines it replaced would have returned."""
+    tts_config = _load_tts_config()
+    expected_provider = _get_provider(tts_config)
+
+    provider, router_tts_config = SpeechRouter().resolve_provider()
+
+    assert provider == expected_provider
+    assert router_tts_config == tts_config
+
+
+def test_get_capabilities_known_builtin():
+    caps = SpeechRouter().get_capabilities("edge")
+    assert caps is not None
+    assert caps.local is False
+    assert caps.streaming is False
+
+
+def test_get_capabilities_unknown_provider():
+    assert SpeechRouter().get_capabilities("not-a-real-provider") is None

--- a/tools/speech/__init__.py
+++ b/tools/speech/__init__.py
@@ -1,0 +1,7 @@
+"""Speech infrastructure: provider-agnostic TTS routing.
+
+See the project's "RFC: Speech Router" design document for the full
+architecture (SpeechChunker, SpeechRouter, SpeechProvider, SpeechPlayer).
+Modules land incrementally, one small PR at a time; this package currently
+only contains SpeechRouter (router.py).
+"""

--- a/tools/speech/capabilities.py
+++ b/tools/speech/capabilities.py
@@ -1,0 +1,168 @@
+"""Static capability metadata for built-in TTS providers.
+
+PR2 of the Speech Router RFC. Nothing consumes this data yet -- SpeechRouter
+does not change its provider-selection behavior because of it. This PR only
+makes capabilities queryable so PR3 (fallback chain) and later PRs
+(streaming) have grounded facts to select on instead of re-deriving them ad
+hoc at call sites.
+
+Values are drawn from what this codebase itself documents or implements,
+not from general knowledge about each provider's public API. Fields marked
+"not verified" in a comment are conservative defaults (False/None) pending
+confirmation -- flag them for correction rather than trusting them blindly.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class SpeechCapabilities:
+    """What a TTS provider can do, independent of how it's configured.
+
+    ``streaming`` means the provider's API can return audio incrementally
+    (confirmed today only for ElevenLabs, see
+    ``tools.tts_tool.stream_tts_to_speaker`` -- CLI/TUI only, not yet wired
+    to SpeechRouter). ``priority`` is an advisory default; an explicit
+    ``tts.router.providers`` order in config.yaml always wins over it.
+    """
+
+    local: bool
+    streaming: bool
+    voice_clone: bool
+    multiple_voices: bool
+    ssml: bool
+    realtime: bool
+    languages: str  # "*" for effectively-any, else a short human note
+    latency_estimate_ms: Optional[int]
+    priority: int  # lower = tried earlier when no explicit order is configured
+
+
+# SSML: none of the ten builtins implement it. Grounded in the two explicit
+# "Do not use SSML" instructions already in this file's own prompt text
+# (search for "Do not use SSML") -- no provider path here ever emits or
+# expects SSML markup today.
+BUILTIN_CAPABILITIES: Dict[str, SpeechCapabilities] = {
+    "edge": SpeechCapabilities(
+        local=False,  # cloud-backed (Microsoft), but free and keyless
+        streaming=False,
+        voice_clone=False,
+        multiple_voices=True,  # 322 voices, 74 languages (website/docs/.../voice-mode.md)
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=1000,  # docs: TTS Provider Comparison table, "~1s"
+        priority=100,  # existing code already treats Edge as the universal last-resort default
+    ),
+    "elevenlabs": SpeechCapabilities(
+        local=False,
+        streaming=True,  # confirmed: stream_tts_to_speaker() + DEFAULT_ELEVENLABS_STREAMING_MODEL_ID
+        voice_clone=True,  # not verified in this codebase's own text -- ElevenLabs' well-documented headline feature, kept True but flagged
+        multiple_voices=True,
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=2000,  # docs: "~2s"
+        priority=10,  # docs list it "Excellent" quality; cheap default to try early when configured
+    ),
+    "openai": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not found in this codebase; direct REST call writes a full file
+        voice_clone=False,
+        multiple_voices=True,  # alloy/echo/fable/onyx/nova/shimmer (DEFAULT_OPENAI_VOICE + config comment)
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=1500,  # docs: "~1.5s"
+        priority=20,
+    ),
+    "minimax": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not verified
+        voice_clone=True,  # module docstring: "MiniMax TTS: High-quality with voice cloning"
+        multiple_voices=True,  # not verified, conservative
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=None,  # not documented
+        priority=30,
+    ),
+    "xai": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not verified (has `optimize_streaming_latency` tuning knob, but that's a
+                            # synchronous-response latency setting, not a chunked/incremental API)
+        voice_clone=False,
+        multiple_voices=True,  # "Grok voices"
+        ssml=False,  # has its own non-SSML expressive-tag syntax instead (_XAI_SPEECH_TAG_RE)
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=None,
+        priority=40,
+    ),
+    "mistral": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not verified
+        voice_clone=False,
+        multiple_voices=True,  # not verified, conservative
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=None,
+        priority=50,
+    ),
+    "gemini": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not verified
+        voice_clone=False,
+        multiple_voices=True,  # module docstring: "30 prebuilt voices"
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=None,
+        priority=50,
+    ),
+    "neutts": SpeechCapabilities(
+        local=True,
+        streaming=False,
+        voice_clone=True,  # config.yaml tts.neutts.ref_audio/ref_text = zero-shot voice cloning
+        multiple_voices=False,  # one reference voice configured at a time
+        ssml=False,
+        realtime=False,
+        languages="en",  # not verified beyond English; conservative
+        latency_estimate_ms=None,  # docs: "Depends on CPU/GPU"
+        priority=60,
+    ),
+    "kittentts": SpeechCapabilities(
+        local=True,
+        streaming=False,
+        voice_clone=False,
+        multiple_voices=False,  # not documented; 25MB model, conservative default
+        ssml=False,
+        realtime=False,
+        languages="en",  # not verified, conservative
+        latency_estimate_ms=None,
+        priority=70,
+    ),
+    "piper": SpeechCapabilities(
+        local=True,
+        streaming=False,
+        voice_clone=False,
+        multiple_voices=True,  # module docstring: "44 languages" implies many voice models
+        ssml=False,
+        realtime=False,
+        languages="*",  # 44 languages per module docstring
+        latency_estimate_ms=None,
+        priority=70,
+    ),
+}
+
+
+def get_builtin_capabilities(provider: str) -> Optional[SpeechCapabilities]:
+    """Return capabilities for a built-in provider name, or None if unknown.
+
+    Command/HTTP-generic and plugin providers are out of scope for this
+    static registry -- their capabilities come from config
+    (``tts.providers.<name>.*``) or, later, a live ``GET /capabilities``
+    probe, not from this hardcoded table.
+    """
+    return BUILTIN_CAPABILITIES.get(provider)

--- a/tools/speech/router.py
+++ b/tools/speech/router.py
@@ -1,13 +1,15 @@
 """Speech Router: single point of provider selection for TTS requests.
 
-PR1 scope (see "RFC: Speech Router"): passthrough only. resolve_provider()
-reproduces exactly what text_to_speech_tool() computed inline before this
-change (_load_tts_config() + _get_provider()). No fallback chain, no
-capability negotiation, no streaming yet -- those land in later PRs. This
-PR only introduces the seam so later PRs have a stable place to grow into.
+PR1 introduced resolve_provider() as a passthrough. PR2 adds
+get_capabilities() so callers (and later PRs -- fallback in PR3, streaming
+negotiation in PR8) can ask what a provider can do before using it. Neither
+method changes text_to_speech_tool()'s existing behavior; get_capabilities()
+has no caller yet outside tests.
 """
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
+
+from tools.speech.capabilities import SpeechCapabilities, get_builtin_capabilities
 
 
 class SpeechRouter:
@@ -30,3 +32,13 @@ class SpeechRouter:
         tts_config = _load_tts_config()
         provider = _get_provider(tts_config)
         return provider, tts_config
+
+    def get_capabilities(self, provider: str) -> Optional[SpeechCapabilities]:
+        """Return known capabilities for *provider*, or None if unknown.
+
+        Only covers the ten built-in providers today (see
+        tools/speech/capabilities.py). Command/HTTP-generic and plugin
+        providers return None here until a later PR adds config-declared
+        and live-probed capability sources.
+        """
+        return get_builtin_capabilities(provider)

--- a/tools/speech/router.py
+++ b/tools/speech/router.py
@@ -1,0 +1,32 @@
+"""Speech Router: single point of provider selection for TTS requests.
+
+PR1 scope (see "RFC: Speech Router"): passthrough only. resolve_provider()
+reproduces exactly what text_to_speech_tool() computed inline before this
+change (_load_tts_config() + _get_provider()). No fallback chain, no
+capability negotiation, no streaming yet -- those land in later PRs. This
+PR only introduces the seam so later PRs have a stable place to grow into.
+"""
+
+from typing import Any, Dict, Tuple
+
+
+class SpeechRouter:
+    """Resolves which TTS provider a synthesis request should use.
+
+    Today this is a thin wrapper around the existing single-provider config
+    read in tools/tts_tool.py. Future PRs add a fallback chain, health
+    checks, and streaming negotiation without changing resolve_provider()'s
+    return shape.
+    """
+
+    def resolve_provider(self) -> Tuple[str, Dict[str, Any]]:
+        """Return (provider_name, tts_config) for the current request.
+
+        Deferred import avoids a circular dependency: tools.tts_tool is the
+        caller, so it is already fully imported by the time this runs.
+        """
+        from tools.tts_tool import _get_provider, _load_tts_config
+
+        tts_config = _load_tts_config()
+        provider = _get_provider(tts_config)
+        return provider, tts_config

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2154,8 +2154,8 @@ def text_to_speech_tool(
     if not text or not text.strip():
         return tool_error("Text is required", success=False)
 
-    tts_config = _load_tts_config()
-    provider = _get_provider(tts_config)
+    from tools.speech.router import SpeechRouter
+    provider, tts_config = SpeechRouter().resolve_provider()
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here


### PR DESCRIPTION
## What does this PR do?

PR 2 of the Speech Router series (see #56585 for the full motivation and
planned roadmap). Adds `SpeechCapabilities` -- a small dataclass describing
what a TTS provider can do (streaming, voice cloning, multiple voices,
SSML, realtime, languages, estimated latency) -- and a static registry for
the ten builtin providers in `tools/tts_tool.py`.

Values are sourced from what this codebase already documents or
implements, not from general provider knowledge -- e.g. `streaming=True`
for ElevenLabs is grounded in the existing
`tools.tts_tool.stream_tts_to_speaker()` CLI pipeline, `voice_clone=True`
for MiniMax and NeuTTS comes straight from this file's own docstring and
`ref_audio`/`ref_text` config. Fields I couldn't verify in-repo are
commented as conservative defaults rather than asserted.

`SpeechRouter.get_capabilities()` exposes the registry. Nothing calls it
outside tests yet -- provider selection behavior is still unchanged from
`main`. This is groundwork for PR 3 (fallback chain), which needs
capability data to decide what to try next.

## Related Issue

Part of the Speech Router series started in #56585.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `tools/speech/capabilities.py`: `SpeechCapabilities` dataclass +
  `BUILTIN_CAPABILITIES` registry for the 10 builtin TTS providers
- Modified `tools/speech/router.py`: added `SpeechRouter.get_capabilities()`
- Added `tests/tools/test_speech_capabilities.py` (7 tests, including a
  drift guard that fails if a builtin provider is added/removed from
  `BUILTIN_TTS_PROVIDERS` without a matching capabilities entry)
- Added `tests/tools/test_speech_router.py` (3 tests)

## How to Test

1. `pytest tests/tools/test_speech_capabilities.py tests/tools/test_speech_router.py -v` → 10 passed
2. `pytest tests/tools/ tests/agent/test_tts_registry.py tests/hermes_cli/test_tts_picker.py tests/hermes_cli/test_plugins_tts_registration.py -q` → 313 passed (303 baseline + 10 new, no regressions)
3. `ruff check tools/speech/ tests/tools/test_speech_capabilities.py tests/tools/test_speech_router.py` → clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing behavior changed, values documented inline as code comments
- [x] I've updated `cli-config.yaml.example` — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` — N/A yet (still no user-visible behavior change; will update once the router actually branches on capabilities)
- [x] Cross-platform impact considered — pure Python, no OS-specific code
- [x] Tool descriptions/schemas updated — N/A, no tool signature changed

## Screenshots / Logs
