### PR TITLE
fix(telephony): wrap malformed success JSON

### DIFF
--- a/optional-skills/productivity/telephony/scripts/telephony.py
+++ b/optional-skills/productivity/telephony/scripts/telephony.py
@@ -260,7 +260,12 @@ def _json_request(
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             payload = resp.read().decode("utf-8")
-            return json.loads(payload) if payload else {}
+            try:
+                return json.loads(payload) if payload else {}
+            except json.JSONDecodeError as exc:
+                raise TelephonyError(
+                    f"Malformed JSON response from {url}: {payload[:200] or exc.msg}"
+                ) from exc
     except urllib.error.HTTPError as exc:
         body_text = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
         try:

--- a/tests/optional_skills/test_telephony_json_request.py
+++ b/tests/optional_skills/test_telephony_json_request.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "productivity"
+    / "telephony"
+    / "scripts"
+    / "telephony.py"
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def _load_telephony_module():
+    spec = importlib.util.spec_from_file_location("telephony_script_under_test", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+    return module
+
+
+def test_json_request_wraps_malformed_success_json():
+    telephony = _load_telephony_module()
+
+    with patch.object(telephony.urllib.request, "urlopen", return_value=_FakeResponse(b"<html>nope</html>")):
+        with pytest.raises(telephony.TelephonyError, match="Malformed JSON response"):
+            telephony._json_request("GET", "https://example.invalid/api")


### PR DESCRIPTION
Fixes #56540.\n\n## Summary\n- wrap malformed 2xx telephony JSON responses in TelephonyError\n- add regression coverage for malformed success bodies\n\n## Tests\n- scripts/run_tests.sh tests/optional_skills/test_telephony_json_request.py