### PR TITLE
fix(cli): show npm exit code on silent post-setup failure

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -964,8 +964,11 @@ def _run_post_setup(post_setup_key: str):
             else:
                 from hermes_constants import display_hermes_home
                 _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install --workspaces=false")
-                if result.stderr:
-                    _print_info(f"      {result.stderr.strip()[:200]}")
+                diagnostic = (result.stderr or result.stdout or "").strip()
+                if diagnostic:
+                    _print_info(f"      {diagnostic[:200]}")
+                else:
+                    _print_info(f"      npm exited with code {result.returncode}")
         elif not node_modules.exists():
             _print_warning("    Node.js not found - browser tools require: npm install (in hermes-agent directory)")
             return

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
 import logging
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -1098,6 +1099,32 @@ def test_computer_use_post_setup_missing_override_does_not_accept_default_binary
     run.assert_not_called()
     assert "custom-cua" in seen
     assert "curl" in seen
+
+
+def test_agent_browser_post_setup_reports_empty_npm_exit_code(tmp_path, monkeypatch):
+    """If npm fails without output, post-setup should still show the exit code."""
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "PROJECT_ROOT", tmp_path)
+    messages: list[str] = []
+
+    def fake_which(name: str):
+        if name == "npm":
+            return "/usr/bin/npm"
+        if name == "npx":
+            return "/usr/bin/npx"
+        return None
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], returncode=137, stdout="", stderr="")
+
+    with patch("shutil.which", side_effect=fake_which), \
+         patch("subprocess.run", side_effect=fake_run), \
+         patch("hermes_cli.tools_config._print_info", side_effect=messages.append), \
+         patch("hermes_cli.tools_config._print_warning"):
+        _run_post_setup("browserbase")
+
+    assert any("npm exited with code 137" in message for message in messages)
 
 
 class TestImagegenBackendRegistry:


### PR DESCRIPTION
Fixes #56566.\n\n## Summary\n- report stdout when stderr is empty for npm post-setup failures\n- report the subprocess exit code when npm produces no output\n- add regression coverage for silent npm failure diagnostics\n\n## Tests\n- scripts/run_tests.sh tests/hermes_cli/test_tools_config.py