### PR TITLE
fix(mcp): honor subprocess PATHEXT for stdio resolution

### DIFF
--- a/tests/tools/test_mcp_stdio_resolution.py
+++ b/tests/tools/test_mcp_stdio_resolution.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from tools import mcp_tool
+
+
+def test_which_with_subprocess_env_uses_subprocess_pathext_on_windows(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(mcp_tool.os, "name", "nt")
+    monkeypatch.setenv("PATHEXT", ".EXE")
+
+    def fake_which(command, path=None):
+        seen["command"] = command
+        seen["path"] = path
+        seen["pathext"] = os.environ.get("PATHEXT")
+        return "C:/tools/server.CMD"
+
+    with patch("tools.mcp_tool.shutil.which", side_effect=fake_which):
+        resolved = mcp_tool._which_with_subprocess_env(
+            "server",
+            path="C:/tools",
+            env={"PATH": "C:/tools", "PATHEXT": ".CMD"},
+        )
+
+    assert resolved == "C:/tools/server.CMD"
+    assert seen == {"command": "server", "path": "C:/tools", "pathext": ".CMD"}
+    assert os.environ["PATHEXT"] == ".EXE"
+
+
+def test_resolve_stdio_command_passes_subprocess_path_and_pathext(monkeypatch):
+    monkeypatch.setattr(mcp_tool.os, "name", "nt")
+
+    def fake_which(command, path=None):
+        assert command == "server"
+        assert path == "C:/mcp/bin"
+        assert os.environ.get("PATHEXT") == ".BAT"
+        return "C:/mcp/bin/server.BAT"
+
+    with patch("tools.mcp_tool.shutil.which", side_effect=fake_which):
+        command, env = mcp_tool._resolve_stdio_command(
+            "server",
+            {"PATH": "C:/mcp/bin", "PATHEXT": ".BAT"},
+        )
+
+    assert command == "C:/mcp/bin/server.BAT"
+    assert env["PATH"].startswith("C:/mcp/bin")
+    assert env["PATHEXT"] == ".BAT"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -515,6 +515,22 @@ def _prepend_path(env: dict, directory: str) -> dict:
     return updated
 
 
+def _which_with_subprocess_env(command: str, *, path: str | None, env: dict) -> str | None:
+    """Resolve *command* using PATH/PATHEXT from the intended subprocess env."""
+    if os.name != "nt" or "PATHEXT" not in env:
+        return shutil.which(command, path=path)
+
+    previous = os.environ.get("PATHEXT")
+    try:
+        os.environ["PATHEXT"] = str(env.get("PATHEXT") or "")
+        return shutil.which(command, path=path)
+    finally:
+        if previous is None:
+            os.environ.pop("PATHEXT", None)
+        else:
+            os.environ["PATHEXT"] = previous
+
+
 def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     """Resolve a stdio MCP command against the exact subprocess environment.
 
@@ -526,7 +542,11 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
 
     if os.sep not in resolved_command:
         path_arg = resolved_env["PATH"] if "PATH" in resolved_env else None
-        which_hit = shutil.which(resolved_command, path=path_arg)
+        which_hit = _which_with_subprocess_env(
+            resolved_command,
+            path=path_arg,
+            env=resolved_env,
+        )
         if which_hit:
             resolved_command = which_hit
         elif resolved_command in {"npx", "npm", "node"}:


### PR DESCRIPTION
Fixes #56536.\n\n## Summary\n- resolve stdio MCP commands using PATHEXT from the MCP subprocess environment on Windows\n- restore the parent process PATHEXT after lookup\n- add regression coverage for PATH/PATHEXT resolution plumbing\n\n## Tests\n- scripts/run_tests.sh tests/tools/test_mcp_stdio_resolution.py