### PR TITLE
fix(tui): consume expired clarify responses

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16,6 +16,19 @@ from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
 
 
+def test_expired_clarify_response_is_idempotently_consumed():
+    response = server._methods["clarify.respond"](
+        "rpc-1",
+        {"request_id": "expired-request", "answer": "late answer"},
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "rpc-1",
+        "result": {"status": "expired", "accepted": False},
+    }
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9717,11 +9717,16 @@ def _respond(rid, params, key):
     with _prompt_lock:
         entry = _pending.get(r)
         if not entry:
-            return _err(rid, 4009, f"no pending {key} request")
+            # Late responses can arrive after _block() timed out and removed
+            # the pending prompt, especially when a client reconnect missed the
+            # prompt-clearing event.  Treat them as idempotently consumed so UI
+            # clients do not surface a hard JSON-RPC error or re-arm a dead
+            # prompt.
+            return _ok(rid, {"status": "expired", "accepted": False})
         _, ev = entry
         _answers[r] = params.get(key, "")
         ev.set()
-    return _ok(rid, {"status": "ok"})
+    return _ok(rid, {"status": "ok", "accepted": True})
 
 
 @method("clarify.respond")


### PR DESCRIPTION
Fixes #56558.\n\n## Summary\n- make late responses to expired blocking prompts return a successful expired status instead of JSON-RPC 4009\n- include accepted status in prompt response results\n- add regression coverage for expired clarify responses\n\n## Tests\n- scripts/run_tests.sh tests/test_tui_gateway_server.py -k test_expired_clarify_response_is_idempotently_consumed\n- scripts/run_tests.sh tests/test_tui_gateway_server.py (303 passed, 1 pre-existing/unrelated failure: test_verification_status_outside_workspace_is_not_applicable)