### PR TITLE
fix(cli): bound local model detection response reads

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -245,6 +246,23 @@ def _anthropic_base_url_override_ok(base_url: str) -> bool:
     return False
 
 
+_LOCAL_MODELS_RESPONSE_LIMIT = 1024 * 1024
+
+
+def _read_bounded_response_text(resp, limit: int = _LOCAL_MODELS_RESPONSE_LIMIT) -> str:
+    """Read a small HTTP response body without allowing unbounded buffering."""
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in resp.iter_content(chunk_size=65536):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > limit:
+            raise ValueError(f"response body exceeds {limit} bytes")
+        chunks.append(chunk)
+    return b"".join(chunks).decode(resp.encoding or "utf-8", errors="replace")
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -254,9 +272,10 @@ def _auto_detect_local_model(base_url: str) -> str:
         url = base_url.rstrip("/")
         if not url.endswith("/v1"):
             url += "/v1"
-        resp = requests.get(url + "/models", timeout=5)
+        resp = requests.get(url + "/models", timeout=5, stream=True)
         if resp.ok:
-            models = resp.json().get("data", [])
+            data = json.loads(_read_bounded_response_text(resp) or "{}")
+            models = data.get("data", []) if isinstance(data, dict) else []
             if len(models) == 1:
                 model_id = models[0].get("id", "")
                 if model_id:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1783,6 +1783,46 @@ def test_custom_provider_no_key_gets_placeholder(monkeypatch):
     assert resolved["base_url"] == "http://localhost:8080/v1"
 
 
+def test_auto_detect_local_model_reads_models_response_with_size_cap(monkeypatch):
+    class _Response:
+        ok = True
+        encoding = "utf-8"
+
+        def json(self):  # pragma: no cover - guard against unbounded resp.json()
+            raise AssertionError("resp.json() should not be used")
+
+        def iter_content(self, chunk_size=65536):
+            yield b'{"data":[{"id":"local-model"}]}'
+
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return _Response()
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    assert rp._auto_detect_local_model("http://localhost:8080") == "local-model"
+    assert calls == [("http://localhost:8080/v1/models", {"timeout": 5, "stream": True})]
+
+
+def test_auto_detect_local_model_rejects_oversized_models_response(monkeypatch):
+    class _Response:
+        ok = True
+        encoding = "utf-8"
+
+        def json(self):  # pragma: no cover - guard against unbounded resp.json()
+            raise AssertionError("resp.json() should not be used")
+
+        def iter_content(self, chunk_size=65536):
+            yield b"{"
+            yield b"x" * (rp._LOCAL_MODELS_RESPONSE_LIMIT + 1)
+
+    monkeypatch.setattr("requests.get", lambda *args, **kwargs: _Response())
+
+    assert rp._auto_detect_local_model("http://localhost:8080") == ""
+
+
 def test_auto_detected_nous_auth_failure_falls_through_to_openrouter(monkeypatch):
     """When auto-detect picks Nous but credentials are revoked, fall through to OpenRouter."""
     from hermes_cli.auth import AuthError


### PR DESCRIPTION
Fixes #56559.\n\n## Summary\n- stream local /v1/models auto-detection responses instead of using resp.json()\n- cap the buffered response body before JSON parsing\n- add regression coverage for bounded successful and oversized responses\n\n## Tests\n- scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py -k 'auto_detect_local_model'