### PR TITLE
Feat/speech router pr3 fallback

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -920,6 +920,14 @@ platform_toolsets:
 #     voice: "Kore"
 #     audio_tags: false
 #     persona_prompt_file: ""  # e.g. ~/.hermes/tts/radio-host.md
+#
+#   # Optional: try providers in order, falling through to the next one on
+#   # any failure (timeout, missing package, API error). Omit "router"
+#   # entirely to keep the single-provider behavior above -- fallback is
+#   # opt-in, never automatic. Each name must be a builtin ("edge",
+#   # "elevenlabs", ...) or a tts.providers.<name> command/plugin entry.
+#   router:
+#     providers: ["home-gpu", "elevenlabs", "edge"]
 
 # =============================================================================
 # Voice Transcription (Speech-to-Text)

--- a/tests/tools/test_speech_capabilities.py
+++ b/tests/tools/test_speech_capabilities.py
@@ -1,0 +1,50 @@
+"""Tests for tools/speech/capabilities.py (Speech Router RFC, PR2)."""
+
+from tools.speech.capabilities import BUILTIN_CAPABILITIES, get_builtin_capabilities
+from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+
+
+def test_every_builtin_provider_has_capabilities():
+    """Catches drift: a new builtin added to tts_tool.py without a matching
+    capabilities entry here would otherwise silently return None forever."""
+    missing = BUILTIN_TTS_PROVIDERS - set(BUILTIN_CAPABILITIES)
+    assert not missing, f"builtin providers missing capability entries: {missing}"
+
+
+def test_no_unknown_extra_entries():
+    """Catches the opposite drift: a stale entry for a provider that was
+    removed from BUILTIN_TTS_PROVIDERS."""
+    extra = set(BUILTIN_CAPABILITIES) - BUILTIN_TTS_PROVIDERS
+    assert not extra, f"capability entries for non-builtin providers: {extra}"
+
+
+def test_unknown_provider_returns_none():
+    assert get_builtin_capabilities("not-a-real-provider") is None
+
+
+def test_elevenlabs_streaming_is_true():
+    """Grounded in tools.tts_tool.stream_tts_to_speaker (CLI streaming path)."""
+    caps = get_builtin_capabilities("elevenlabs")
+    assert caps is not None
+    assert caps.streaming is True
+
+
+def test_local_providers_flagged_local():
+    for name in ("neutts", "kittentts", "piper"):
+        caps = get_builtin_capabilities(name)
+        assert caps is not None
+        assert caps.local is True, f"{name} should be local=True"
+
+
+def test_cloud_providers_flagged_not_local():
+    for name in ("edge", "elevenlabs", "openai", "minimax", "xai", "mistral", "gemini"):
+        caps = get_builtin_capabilities(name)
+        assert caps is not None
+        assert caps.local is False, f"{name} should be local=False"
+
+
+def test_no_provider_claims_ssml():
+    """This codebase's own prompt text says "Do not use SSML" in two places;
+    no builtin integration here implements it."""
+    for name, caps in BUILTIN_CAPABILITIES.items():
+        assert caps.ssml is False, f"{name} unexpectedly claims ssml=True"

--- a/tests/tools/test_speech_fallback.py
+++ b/tests/tools/test_speech_fallback.py
@@ -1,0 +1,129 @@
+"""Tests for the SpeechRouter fallback chain (Speech Router RFC, PR3).
+
+Nothing here talks to a real TTS engine -- command providers are portable
+shell commands (python -c) so these run identically on Linux/macOS/Windows,
+matching the existing convention in test_tts_command_providers.py.
+"""
+
+import json
+import sys
+from unittest.mock import patch
+
+from tools.speech.router import SpeechRouter
+from tools.tts_tool import text_to_speech_tool
+
+
+def _copy_command() -> str:
+    """Shell command that copies {input_path} bytes -> {output_path}."""
+    interpreter = sys.executable
+    return (
+        f'"{interpreter}" -c "import shutil, sys; '
+        f'shutil.copyfile(sys.argv[1], sys.argv[2])" '
+        f'{{input_path}} {{output_path}}'
+    )
+
+
+def _failing_command() -> str:
+    """Shell command that always exits non-zero, producing no output file."""
+    interpreter = sys.executable
+    return f'"{interpreter}" -c "import sys; sys.exit(1)"'
+
+
+def _config_with_chain(*provider_names: str, providers: dict) -> dict:
+    return {
+        "provider": provider_names[0],
+        "router": {"providers": list(provider_names)},
+        "providers": providers,
+    }
+
+
+class TestResolveProviderChain:
+    def test_no_router_config_returns_single_default_provider(self):
+        cfg = {"provider": "edge"}
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            chain, tts_config = SpeechRouter().resolve_provider_chain()
+        assert chain == ["edge"]
+        assert tts_config == cfg
+
+    def test_empty_router_providers_list_falls_back_to_default(self):
+        cfg = {"provider": "openai", "router": {"providers": []}}
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            chain, _ = SpeechRouter().resolve_provider_chain()
+        assert chain == ["openai"]
+
+    def test_configured_chain_is_returned_in_order(self):
+        cfg = {
+            "provider": "edge",
+            "router": {"providers": ["local-gpu", "cloud-fallback", "edge"]},
+        }
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            chain, _ = SpeechRouter().resolve_provider_chain()
+        assert chain == ["local-gpu", "cloud-fallback", "edge"]
+
+
+class TestTextToSpeechFallback:
+    def test_first_provider_failure_falls_through_to_second(self, tmp_path):
+        cfg = _config_with_chain(
+            "dead-provider", "backup-provider",
+            providers={
+                "dead-provider": {"type": "command", "command": _failing_command()},
+                "backup-provider": {"type": "command", "command": _copy_command()},
+            },
+        )
+        out = tmp_path / "reply.mp3"
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            result_json = text_to_speech_tool(text="hi", output_path=str(out))
+        result = json.loads(result_json)
+
+        assert result["success"] is True
+        assert result["provider"] == "backup-provider"
+
+    def test_default_single_provider_does_not_fallback(self, tmp_path):
+        """No tts.router.providers configured -- a failure must surface
+        immediately, exactly like every pre-Router release. This is the
+        compatibility guardrail: fallback is opt-in, never automatic."""
+        cfg = {
+            "provider": "dead-provider",
+            "providers": {
+                "dead-provider": {"type": "command", "command": _failing_command()},
+            },
+        }
+        out = tmp_path / "reply.mp3"
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            result_json = text_to_speech_tool(text="hi", output_path=str(out))
+        result = json.loads(result_json)
+
+        assert result["success"] is False
+
+    def test_all_providers_failing_returns_last_error(self, tmp_path):
+        cfg = _config_with_chain(
+            "dead-one", "dead-two",
+            providers={
+                "dead-one": {"type": "command", "command": _failing_command()},
+                "dead-two": {"type": "command", "command": _failing_command()},
+            },
+        )
+        out = tmp_path / "reply.mp3"
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            result_json = text_to_speech_tool(text="hi", output_path=str(out))
+        result = json.loads(result_json)
+
+        assert result["success"] is False
+
+    def test_first_provider_success_never_tries_second(self, tmp_path):
+        """A successful first attempt must not touch the fallback provider
+        at all -- fallback only fires on failure."""
+        cfg = _config_with_chain(
+            "primary", "should-never-run",
+            providers={
+                "primary": {"type": "command", "command": _copy_command()},
+                "should-never-run": {"type": "command", "command": _failing_command()},
+            },
+        )
+        out = tmp_path / "reply.mp3"
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            result_json = text_to_speech_tool(text="hi", output_path=str(out))
+        result = json.loads(result_json)
+
+        assert result["success"] is True
+        assert result["provider"] == "primary"

--- a/tests/tools/test_speech_router.py
+++ b/tests/tools/test_speech_router.py
@@ -1,0 +1,27 @@
+"""Tests for tools/speech/router.py (Speech Router RFC, PR1 + PR2)."""
+
+from tools.speech.router import SpeechRouter
+from tools.tts_tool import _get_provider, _load_tts_config
+
+
+def test_resolve_provider_matches_direct_call():
+    """PR1 contract: resolve_provider() must return exactly what the two
+    lines it replaced would have returned."""
+    tts_config = _load_tts_config()
+    expected_provider = _get_provider(tts_config)
+
+    provider, router_tts_config = SpeechRouter().resolve_provider()
+
+    assert provider == expected_provider
+    assert router_tts_config == tts_config
+
+
+def test_get_capabilities_known_builtin():
+    caps = SpeechRouter().get_capabilities("edge")
+    assert caps is not None
+    assert caps.local is False
+    assert caps.streaming is False
+
+
+def test_get_capabilities_unknown_provider():
+    assert SpeechRouter().get_capabilities("not-a-real-provider") is None

--- a/tools/speech/__init__.py
+++ b/tools/speech/__init__.py
@@ -1,0 +1,7 @@
+"""Speech infrastructure: provider-agnostic TTS routing.
+
+See the project's "RFC: Speech Router" design document for the full
+architecture (SpeechChunker, SpeechRouter, SpeechProvider, SpeechPlayer).
+Modules land incrementally, one small PR at a time; this package currently
+only contains SpeechRouter (router.py).
+"""

--- a/tools/speech/capabilities.py
+++ b/tools/speech/capabilities.py
@@ -1,0 +1,168 @@
+"""Static capability metadata for built-in TTS providers.
+
+PR2 of the Speech Router RFC. Nothing consumes this data yet -- SpeechRouter
+does not change its provider-selection behavior because of it. This PR only
+makes capabilities queryable so PR3 (fallback chain) and later PRs
+(streaming) have grounded facts to select on instead of re-deriving them ad
+hoc at call sites.
+
+Values are drawn from what this codebase itself documents or implements,
+not from general knowledge about each provider's public API. Fields marked
+"not verified" in a comment are conservative defaults (False/None) pending
+confirmation -- flag them for correction rather than trusting them blindly.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class SpeechCapabilities:
+    """What a TTS provider can do, independent of how it's configured.
+
+    ``streaming`` means the provider's API can return audio incrementally
+    (confirmed today only for ElevenLabs, see
+    ``tools.tts_tool.stream_tts_to_speaker`` -- CLI/TUI only, not yet wired
+    to SpeechRouter). ``priority`` is an advisory default; an explicit
+    ``tts.router.providers`` order in config.yaml always wins over it.
+    """
+
+    local: bool
+    streaming: bool
+    voice_clone: bool
+    multiple_voices: bool
+    ssml: bool
+    realtime: bool
+    languages: str  # "*" for effectively-any, else a short human note
+    latency_estimate_ms: Optional[int]
+    priority: int  # lower = tried earlier when no explicit order is configured
+
+
+# SSML: none of the ten builtins implement it. Grounded in the two explicit
+# "Do not use SSML" instructions already in this file's own prompt text
+# (search for "Do not use SSML") -- no provider path here ever emits or
+# expects SSML markup today.
+BUILTIN_CAPABILITIES: Dict[str, SpeechCapabilities] = {
+    "edge": SpeechCapabilities(
+        local=False,  # cloud-backed (Microsoft), but free and keyless
+        streaming=False,
+        voice_clone=False,
+        multiple_voices=True,  # 322 voices, 74 languages (website/docs/.../voice-mode.md)
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=1000,  # docs: TTS Provider Comparison table, "~1s"
+        priority=100,  # existing code already treats Edge as the universal last-resort default
+    ),
+    "elevenlabs": SpeechCapabilities(
+        local=False,
+        streaming=True,  # confirmed: stream_tts_to_speaker() + DEFAULT_ELEVENLABS_STREAMING_MODEL_ID
+        voice_clone=True,  # not verified in this codebase's own text -- ElevenLabs' well-documented headline feature, kept True but flagged
+        multiple_voices=True,
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=2000,  # docs: "~2s"
+        priority=10,  # docs list it "Excellent" quality; cheap default to try early when configured
+    ),
+    "openai": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not found in this codebase; direct REST call writes a full file
+        voice_clone=False,
+        multiple_voices=True,  # alloy/echo/fable/onyx/nova/shimmer (DEFAULT_OPENAI_VOICE + config comment)
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=1500,  # docs: "~1.5s"
+        priority=20,
+    ),
+    "minimax": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not verified
+        voice_clone=True,  # module docstring: "MiniMax TTS: High-quality with voice cloning"
+        multiple_voices=True,  # not verified, conservative
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=None,  # not documented
+        priority=30,
+    ),
+    "xai": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not verified (has `optimize_streaming_latency` tuning knob, but that's a
+                            # synchronous-response latency setting, not a chunked/incremental API)
+        voice_clone=False,
+        multiple_voices=True,  # "Grok voices"
+        ssml=False,  # has its own non-SSML expressive-tag syntax instead (_XAI_SPEECH_TAG_RE)
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=None,
+        priority=40,
+    ),
+    "mistral": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not verified
+        voice_clone=False,
+        multiple_voices=True,  # not verified, conservative
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=None,
+        priority=50,
+    ),
+    "gemini": SpeechCapabilities(
+        local=False,
+        streaming=False,  # not verified
+        voice_clone=False,
+        multiple_voices=True,  # module docstring: "30 prebuilt voices"
+        ssml=False,
+        realtime=False,
+        languages="*",
+        latency_estimate_ms=None,
+        priority=50,
+    ),
+    "neutts": SpeechCapabilities(
+        local=True,
+        streaming=False,
+        voice_clone=True,  # config.yaml tts.neutts.ref_audio/ref_text = zero-shot voice cloning
+        multiple_voices=False,  # one reference voice configured at a time
+        ssml=False,
+        realtime=False,
+        languages="en",  # not verified beyond English; conservative
+        latency_estimate_ms=None,  # docs: "Depends on CPU/GPU"
+        priority=60,
+    ),
+    "kittentts": SpeechCapabilities(
+        local=True,
+        streaming=False,
+        voice_clone=False,
+        multiple_voices=False,  # not documented; 25MB model, conservative default
+        ssml=False,
+        realtime=False,
+        languages="en",  # not verified, conservative
+        latency_estimate_ms=None,
+        priority=70,
+    ),
+    "piper": SpeechCapabilities(
+        local=True,
+        streaming=False,
+        voice_clone=False,
+        multiple_voices=True,  # module docstring: "44 languages" implies many voice models
+        ssml=False,
+        realtime=False,
+        languages="*",  # 44 languages per module docstring
+        latency_estimate_ms=None,
+        priority=70,
+    ),
+}
+
+
+def get_builtin_capabilities(provider: str) -> Optional[SpeechCapabilities]:
+    """Return capabilities for a built-in provider name, or None if unknown.
+
+    Command/HTTP-generic and plugin providers are out of scope for this
+    static registry -- their capabilities come from config
+    (``tts.providers.<name>.*``) or, later, a live ``GET /capabilities``
+    probe, not from this hardcoded table.
+    """
+    return BUILTIN_CAPABILITIES.get(provider)

--- a/tools/speech/router.py
+++ b/tools/speech/router.py
@@ -1,28 +1,32 @@
 """Speech Router: single point of provider selection for TTS requests.
 
-PR1 introduced resolve_provider() as a passthrough. PR2 adds
-get_capabilities() so callers (and later PRs -- fallback in PR3, streaming
-negotiation in PR8) can ask what a provider can do before using it. Neither
-method changes text_to_speech_tool()'s existing behavior; get_capabilities()
-has no caller yet outside tests.
+PR1 introduced resolve_provider() as a passthrough. PR2 added
+get_capabilities(). PR3 adds resolve_provider_chain(): an ordered list of
+providers to try, driven by the new ``tts.router.providers`` config key.
+When that key is absent -- the default, unopted-in case -- the chain is a
+single item identical to what resolve_provider() always returned, so
+nothing changes for users who haven't touched the new config.
 """
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from tools.speech.capabilities import SpeechCapabilities, get_builtin_capabilities
 
 
 class SpeechRouter:
-    """Resolves which TTS provider a synthesis request should use.
+    """Resolves which TTS provider(s) a synthesis request should try.
 
-    Today this is a thin wrapper around the existing single-provider config
-    read in tools/tts_tool.py. Future PRs add a fallback chain, health
-    checks, and streaming negotiation without changing resolve_provider()'s
-    return shape.
+    Fallback order comes from ``tts.router.providers`` (a list) in
+    config.yaml when present; otherwise the chain has exactly one entry,
+    matching every pre-Router release. Health checking is deliberately not
+    a separate step here -- text_to_speech_tool() moves to the next
+    provider in the chain on any synthesis failure (timeout, exception, or
+    unsuccessful result), so a provider's own configured timeout doubles as
+    its liveness probe. See the Speech Router RFC for why.
     """
 
-    def resolve_provider(self) -> Tuple[str, Dict[str, Any]]:
-        """Return (provider_name, tts_config) for the current request.
+    def resolve_provider_chain(self) -> Tuple[List[str], Dict[str, Any]]:
+        """Return (ordered provider names to try, tts_config).
 
         Deferred import avoids a circular dependency: tools.tts_tool is the
         caller, so it is already fully imported by the time this runs.
@@ -30,8 +34,24 @@ class SpeechRouter:
         from tools.tts_tool import _get_provider, _load_tts_config
 
         tts_config = _load_tts_config()
-        provider = _get_provider(tts_config)
-        return provider, tts_config
+        router_config = tts_config.get("router") or {}
+        configured = router_config.get("providers")
+
+        if configured:
+            chain = [str(name).strip() for name in configured if str(name).strip()]
+            if chain:
+                return chain, tts_config
+
+        return [_get_provider(tts_config)], tts_config
+
+    def resolve_provider(self) -> Tuple[str, Dict[str, Any]]:
+        """Return (provider_name, tts_config) -- the first entry of the chain.
+
+        Kept for callers that only need a single provider; text_to_speech_tool()
+        itself now calls resolve_provider_chain() directly to support fallback.
+        """
+        chain, tts_config = self.resolve_provider_chain()
+        return chain[0], tts_config
 
     def get_capabilities(self, provider: str) -> Optional[SpeechCapabilities]:
         """Return known capabilities for *provider*, or None if unknown.

--- a/tools/speech/router.py
+++ b/tools/speech/router.py
@@ -1,13 +1,15 @@
 """Speech Router: single point of provider selection for TTS requests.
 
-PR1 scope (see "RFC: Speech Router"): passthrough only. resolve_provider()
-reproduces exactly what text_to_speech_tool() computed inline before this
-change (_load_tts_config() + _get_provider()). No fallback chain, no
-capability negotiation, no streaming yet -- those land in later PRs. This
-PR only introduces the seam so later PRs have a stable place to grow into.
+PR1 introduced resolve_provider() as a passthrough. PR2 adds
+get_capabilities() so callers (and later PRs -- fallback in PR3, streaming
+negotiation in PR8) can ask what a provider can do before using it. Neither
+method changes text_to_speech_tool()'s existing behavior; get_capabilities()
+has no caller yet outside tests.
 """
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
+
+from tools.speech.capabilities import SpeechCapabilities, get_builtin_capabilities
 
 
 class SpeechRouter:
@@ -30,3 +32,13 @@ class SpeechRouter:
         tts_config = _load_tts_config()
         provider = _get_provider(tts_config)
         return provider, tts_config
+
+    def get_capabilities(self, provider: str) -> Optional[SpeechCapabilities]:
+        """Return known capabilities for *provider*, or None if unknown.
+
+        Only covers the ten built-in providers today (see
+        tools/speech/capabilities.py). Command/HTTP-generic and plugin
+        providers return None here until a later PR adds config-declared
+        and live-probed capability sources.
+        """
+        return get_builtin_capabilities(provider)

--- a/tools/speech/router.py
+++ b/tools/speech/router.py
@@ -1,0 +1,32 @@
+"""Speech Router: single point of provider selection for TTS requests.
+
+PR1 scope (see "RFC: Speech Router"): passthrough only. resolve_provider()
+reproduces exactly what text_to_speech_tool() computed inline before this
+change (_load_tts_config() + _get_provider()). No fallback chain, no
+capability negotiation, no streaming yet -- those land in later PRs. This
+PR only introduces the seam so later PRs have a stable place to grow into.
+"""
+
+from typing import Any, Dict, Tuple
+
+
+class SpeechRouter:
+    """Resolves which TTS provider a synthesis request should use.
+
+    Today this is a thin wrapper around the existing single-provider config
+    read in tools/tts_tool.py. Future PRs add a fallback chain, health
+    checks, and streaming negotiation without changing resolve_provider()'s
+    return shape.
+    """
+
+    def resolve_provider(self) -> Tuple[str, Dict[str, Any]]:
+        """Return (provider_name, tts_config) for the current request.
+
+        Deferred import avoids a circular dependency: tools.tts_tool is the
+        caller, so it is already fully imported by the time this runs.
+        """
+        from tools.tts_tool import _get_provider, _load_tts_config
+
+        tts_config = _load_tts_config()
+        provider = _get_provider(tts_config)
+        return provider, tts_config

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2154,8 +2154,8 @@ def text_to_speech_tool(
     if not text or not text.strip():
         return tool_error("Text is required", success=False)
 
-    tts_config = _load_tts_config()
-    provider = _get_provider(tts_config)
+    from tools.speech.router import SpeechRouter
+    provider, tts_config = SpeechRouter().resolve_provider()
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2140,6 +2140,11 @@ def text_to_speech_tool(
     Reads provider/voice config from ~/.hermes/config.yaml (tts: section).
     The model sends text; the user configures voice and provider.
 
+    When ``tts.router.providers`` lists more than one provider, each is
+    tried in order until one succeeds -- see
+    ``SpeechRouter.resolve_provider_chain()``. Without that config key,
+    exactly one provider is tried (unchanged pre-Router behavior).
+
     On messaging platforms, the returned MEDIA:<path> tag is intercepted
     by the send pipeline and delivered as a native voice message.
     In CLI mode, the file is saved to ~/voice-memos/.
@@ -2155,8 +2160,37 @@ def text_to_speech_tool(
         return tool_error("Text is required", success=False)
 
     from tools.speech.router import SpeechRouter
-    provider, tts_config = SpeechRouter().resolve_provider()
+    provider_chain, tts_config = SpeechRouter().resolve_provider_chain()
 
+    result_json = tool_error("No speech provider configured", success=False)
+    for index, provider in enumerate(provider_chain):
+        result_json = _synthesize_with_provider(text, output_path, provider, tts_config)
+        try:
+            result = json.loads(result_json)
+        except (TypeError, ValueError):
+            result = {}
+        if result.get("success"):
+            return result_json
+        remaining = len(provider_chain) - index - 1
+        logger.warning(
+            "Speech provider '%s' failed (%d fallback(s) remaining): %s",
+            provider, remaining, result.get("error", "unknown error"),
+        )
+
+    return result_json
+
+
+def _synthesize_with_provider(
+    text: str,
+    output_path: Optional[str],
+    provider: str,
+    tts_config: Dict[str, Any],
+) -> str:
+    """Attempt a single synthesis with *provider*. Returns a JSON result
+    string (success or error) -- never raises. text_to_speech_tool() loops
+    this over the provider chain from SpeechRouter and stops at the first
+    success.
+    """
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here
     # so a user's ``tts.providers.openai.command`` can't override the real
@@ -2440,6 +2474,7 @@ def text_to_speech_tool(
         error_msg = f"TTS generation failed ({provider}): {e}"
         logger.error("%s", error_msg, exc_info=True)
         return tool_error(error_msg, success=False)
+
 
 
 # ===========================================================================


### PR DESCRIPTION
## What does this PR do?

PR 3 of the Speech Router series (see #56585 for full motivation/roadmap,
#56590 for PR 2). `SpeechRouter` gains `resolve_provider_chain()`: an
ordered list of providers to try instead of a single one. `text_to_speech_tool()`
now loops the chain, falling through to the next provider on any failure
(exception, timeout, or unsuccessful result), returning the first success.

**Compatibility:** when `tts.router.providers` is absent from config.yaml
-- true for every existing installation -- the chain has exactly one
entry (today's single provider), so a failure surfaces immediately, same
as `main`. Fallback is strictly opt-in, never automatic. Guarded by
`test_default_single_provider_does_not_fallback`.

**No separate health-check endpoint.** A provider's own configured
timeout doubles as its liveness probe -- the synthesis attempt *is* the
check. This mirrors what hand-rolled command-provider fallback scripts
already do in the wild (mine included, see #56585) rather than adding a
new `/health` concept this PR doesn't need yet.

The unchanged single-provider synthesis logic is extracted from
`text_to_speech_tool()` into `_synthesize_with_provider(text, output_path,
provider, tts_config)` so the new loop can call it once per chain entry.
Diff looks larger than it is -- it's a move, not a rewrite; see "How to
Test" for the byte-identical-default-behavior claim.

## Related Issue

Part of the Speech Router series started in #56585.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Modified `tools/speech/router.py`: added `resolve_provider_chain()`;
  `resolve_provider()` now delegates to it (returns `chain[0]`)
- Modified `tools/tts_tool.py`: `text_to_speech_tool()` is now a thin
  fallback loop; the old body moved unchanged into
  `_synthesize_with_provider()`
- Added `tests/tools/test_speech_fallback.py` (7 tests: chain resolution,
  fallthrough on failure, no-fallback-by-default guardrail, all-fail
  error surfacing, success-skips-remaining-providers)
- Modified `cli-config.yaml.example`: documented `tts.router.providers`

## How to Test

1. `pytest tests/tools/test_speech_fallback.py -v` → 7 passed
2. `pytest tests/tools/ tests/agent/test_tts_registry.py tests/hermes_cli/test_tts_picker.py tests/hermes_cli/test_plugins_tts_registration.py -q` → 320 passed (313 baseline + 7 new, zero regressions)
3. `ruff check tools/speech/ tools/tts_tool.py tests/tools/test_speech_fallback.py` → clean
4. Manual: with no `tts.router.providers` set, a provider failure still returns the same error shape as `main` -- no fallback attempted (see guardrail test)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `cli-config.yaml.example` updated; no other user-facing docs affected yet
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — done, `tts.router.providers` documented
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` — N/A, no architecture/workflow doc affected
- [x] Cross-platform impact considered — pure Python, command providers already cross-platform (see test helper docstring)
- [x] Tool descriptions/schemas updated — N/A, `text_to_speech_tool`'s public signature/docstring intent unchanged

## Screenshots / Logs
