### PR TITLE
fix(mcp): re-arm dropped HTTP MCP servers instead of permanent give-up

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -320,3 +320,128 @@ class TestMCPInitialConnectionRetry:
                 await task
 
         asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Fix: remote HTTP MCP servers re-arm instead of permanently giving up
+# ---------------------------------------------------------------------------
+
+class TestMCPReconnectRearm:
+    """After exhausting the reconnect budget, remote HTTP servers enter a
+    dormant re-arm loop (retry forever at max backoff) so a self-healing remote
+    recovers on its own, while stdio servers keep the historical give-up.
+    Regression guard for the incident where Metaview dropped and stayed
+    silently offline for days until a manual Hermes restart."""
+
+    @staticmethod
+    def _patch_fast_sleep():
+        # Neutralise the reconnect backoff sleeps so the loop runs fast, while
+        # still yielding to the event loop each iteration (so shutdown/ready
+        # propagate). Captures the real sleep before patching.
+        _real_sleep = asyncio.sleep
+
+        async def _fast_sleep(*args, **kwargs):
+            await _real_sleep(0)
+
+        return patch("tools.mcp_tool.asyncio.sleep", _fast_sleep)
+
+    def test_http_server_rearms_past_reconnect_cap(self):
+        """A remote HTTP server keeps retrying past the give-up cap."""
+        from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+        stop_at = _MAX_RECONNECT_RETRIES + 5
+        calls = 0
+
+        async def _run():
+            nonlocal calls
+            server = MCPServerTask("test-http-rearm")
+
+            async def fake_run_http(self_inner, config):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    self_inner._ready.set()  # first connection succeeds
+                if calls >= stop_at:
+                    self_inner._shutdown_event.set()  # end the test loop
+                raise ConnectionError("SSE stream closed by remote")
+
+            with self._patch_fast_sleep(), \
+                    patch("tools.mcp_tool._validate_remote_mcp_url", lambda *a, **k: None), \
+                    patch.object(MCPServerTask, "_run_http", fake_run_http):
+                task = asyncio.ensure_future(
+                    server.run({"url": "https://mcp.example.com/mcp"})
+                )
+                await asyncio.wait_for(task, timeout=5)
+
+            # Kept retrying well past the give-up cap (no permanent give-up)
+            # and recorded the dormant re-arm transition.
+            assert calls >= _MAX_RECONNECT_RETRIES + 2
+            assert server._rearm_logged is True
+
+        asyncio.run(_run())
+
+    def test_stdio_server_still_gives_up(self):
+        """A stdio server keeps the historical give-up after the cap."""
+        from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+        calls = 0
+
+        async def _run():
+            nonlocal calls
+            server = MCPServerTask("test-stdio-giveup")
+
+            async def fake_run_stdio(self_inner, config):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    self_inner._ready.set()  # first connection succeeds
+                raise ConnectionError("subprocess died")
+
+            with self._patch_fast_sleep(), \
+                    patch.object(MCPServerTask, "_run_stdio", fake_run_stdio):
+                task = asyncio.ensure_future(server.run({"command": "fake"}))
+                await asyncio.wait_for(task, timeout=5)
+
+            # Gave up after the cap (1st failure + _MAX retries), no re-arm.
+            assert server._rearm_logged is False
+            assert calls == _MAX_RECONNECT_RETRIES + 1
+
+        asyncio.run(_run())
+
+    def test_healthy_session_clears_rearm_state(self):
+        """A healthy (clean) session after dormant re-arm resets the flag."""
+        from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+        calls = 0
+        clean_return_at = _MAX_RECONNECT_RETRIES + 2  # after dormant entered
+
+        async def _run():
+            nonlocal calls
+            server = MCPServerTask("test-http-reset")
+
+            async def fake_run_http(self_inner, config):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    self_inner._ready.set()
+                if calls == clean_return_at:
+                    return  # healthy session ends cleanly -> should reset
+                if calls > clean_return_at:
+                    self_inner._shutdown_event.set()
+                    return
+                raise ConnectionError("SSE stream closed by remote")
+
+            with self._patch_fast_sleep(), \
+                    patch("tools.mcp_tool._validate_remote_mcp_url", lambda *a, **k: None), \
+                    patch.object(MCPServerTask, "_run_http", fake_run_http):
+                task = asyncio.ensure_future(
+                    server.run({"url": "https://mcp.example.com/mcp"})
+                )
+                await asyncio.wait_for(task, timeout=5)
+
+            # Dormant re-arm was entered (calls past the cap), then a healthy
+            # session cleared the flag.
+            assert calls > _MAX_RECONNECT_RETRIES + 1
+            assert server._rearm_logged is False
+
+        asyncio.run(_run())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -50,7 +50,9 @@ Example config::
 Features:
     - Stdio transport (command + args) and HTTP/StreamableHTTP transport (url)
     - SSE transport (transport: sse) for MCP servers using the SSE protocol
-    - Automatic reconnection with exponential backoff (up to 5 retries)
+    - Automatic reconnection with exponential backoff. stdio servers give up
+      after 5 retries; remote HTTP servers fall back to a dormant re-arm loop
+      (retry forever at max backoff) so a self-healing remote always recovers
     - Environment variable filtering for stdio subprocesses (security)
     - Credential stripping in error messages returned to the LLM
     - Configurable per-server timeouts for tool calls and connections
@@ -1098,7 +1100,7 @@ class MCPServerTask:
         "_tools", "_error", "_config",
         "_sampling", "_registered_tool_names", "_auth_type", "_refresh_lock",
         "_rpc_lock", "_pending_refresh_tasks",
-        "initialize_result",
+        "initialize_result", "_rearm_logged",
     )
 
     def __init__(self, name: str):
@@ -1129,6 +1131,10 @@ class MCPServerTask:
         # transports for conservative per-server ordering.
         self._rpc_lock = asyncio.Lock()
         self._pending_refresh_tasks: set[asyncio.Task] = set()
+        # True once a remote HTTP server has exhausted its reconnect budget and
+        # entered the dormant re-arm loop. Used only to log the transition once
+        # (not on every re-arm cycle). Reset when a healthy session is restored.
+        self._rearm_logged: bool = False
         # Captures the ``InitializeResult`` returned by
         # ``await session.initialize()`` so downstream code can inspect the
         # server's real advertised capabilities (``.capabilities.resources``,
@@ -1674,6 +1680,15 @@ class MCPServerTask:
                 #    touch the retry counters — this is not a failure.
                 if self._shutdown_event.is_set():
                     break
+                # A clean transport return means we had an established, healthy
+                # session (it lived until a keepalive-triggered reconnect or an
+                # OAuth-recovery event). Reset the failure budget so the
+                # reconnect cap counts CONSECUTIVE failures, not transient blips
+                # accumulated over long uptime — and clear any dormant re-arm
+                # state now that the server is healthy again.
+                retries = 0
+                backoff = 1.0
+                self._rearm_logged = False
                 logger.info(
                     "MCP server '%s': reconnecting (OAuth recovery or "
                     "manual refresh)",
@@ -1753,12 +1768,37 @@ class MCPServerTask:
 
                 retries += 1
                 if retries > _MAX_RECONNECT_RETRIES:
-                    logger.warning(
-                        "MCP server '%s' failed after %d reconnection attempts, "
-                        "giving up: %s",
-                        self.name, _MAX_RECONNECT_RETRIES, exc,
-                    )
-                    return
+                    # stdio (local subprocess) servers keep the historical
+                    # give-up: a crashed subprocess almost never self-heals, so
+                    # retrying forever would just spin.
+                    if not self._is_http():
+                        logger.warning(
+                            "MCP server '%s' failed after %d reconnection "
+                            "attempts, giving up: %s",
+                            self.name, _MAX_RECONNECT_RETRIES, exc,
+                        )
+                        return
+                    # Remote HTTP servers: a drop is almost always the remote
+                    # end closing an idle SSE stream or a transient network
+                    # blip, both of which self-heal. Permanently giving up here
+                    # left servers (e.g. Metaview) silently offline for days
+                    # until a manual Hermes restart. Instead enter a dormant
+                    # re-arm loop: keep retrying at the max backoff until the
+                    # remote recovers (a healthy session resets the budget
+                    # above) or Hermes shuts down. Log the transition once.
+                    if not self._rearm_logged:
+                        logger.warning(
+                            "MCP server '%s' failed after %d reconnection "
+                            "attempts; entering dormant re-arm (retrying every "
+                            "%.0fs until it recovers or Hermes shuts down): %s",
+                            self.name, _MAX_RECONNECT_RETRIES,
+                            _MAX_BACKOFF_SECONDS, exc,
+                        )
+                        self._rearm_logged = True
+                    await asyncio.sleep(_MAX_BACKOFF_SECONDS)
+                    if self._shutdown_event.is_set():
+                        return
+                    continue
 
                 logger.warning(
                     "MCP server '%s' connection lost (attempt %d/%d), "


### PR DESCRIPTION
## Problem

When a remote HTTP/StreamableHTTP MCP server drops and fails its reconnection attempts, `MCPServerTask.run()` hits `retries > _MAX_RECONNECT_RETRIES` and does a hard `return` — permanently abandoning the server until the whole gateway is restarted.

In practice a remote drop is almost always the remote end closing an idle SSE stream or a transient network blip, both of which self-heal within minutes. But once we give up, the server's tools silently vanish from the agent's toolset and never come back on their own. We hit this with a hosted MCP server that stayed offline for days: the agent stopped calling its tools and silently fell back to worse alternatives, with no error surfaced, until someone manually restarted the gateway.

Additionally, the reconnect counter was never reset after a healthy session, so transient blips accumulated over long uptime could eventually trip the give-up cap even when every individual failure had recovered.

## Fix

- **HTTP servers now re-arm instead of giving up.** After exhausting the reconnect budget, a remote HTTP server enters a dormant re-arm loop: it keeps retrying at the max backoff until the remote recovers or the gateway shuts down. The transition is logged once. stdio servers keep the historical give-up (a crashed local subprocess rarely self-heals, so retrying forever would just spin).
- **The failure budget resets after any healthy session** (a clean transport return), so `_MAX_RECONNECT_RETRIES` now counts *consecutive* failures rather than blips accumulated over long uptime, and dormant re-arm state is cleared once the server is healthy again.

## Tests

Added `TestMCPReconnectRearm` in `tests/tools/test_mcp_stability.py`:
- HTTP server keeps retrying past the give-up cap (proves no permanent give-up) and records the dormant re-arm transition.
- stdio server still gives up after the cap (no behavior change).
- A healthy session after dormant re-arm clears the re-arm state.

Full `tests/tools/test_mcp_stability.py` + `tests/tools/test_mcp_tool.py` suite: 215 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)