### PR TITLE
fix(gateway): stop re-sending the 3.2MB pet spritesheet on every pet.info push

### DIFF
--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -167,11 +167,17 @@ export function FloatingPet() {
           }
         }
 
-        const next = await requestGateway<PetInfo>('pet.info', { profile: petProfile() })
+        const current = $petInfo.get()
+        // Tell the gateway which sheet we already hold so it can withhold the
+        // ~3.2MB base64 when nothing changed (issue #54730). Only send it while
+        // we actually have that sheet cached, so a first fetch still gets bytes.
+        const knownRevision = current.enabled && current.spritesheetBase64 ? current.spritesheetRevision : undefined
+        const next = await requestGateway<PetInfo>('pet.info', {
+          profile: petProfile(),
+          ...(knownRevision ? { knownRevision } : {})
+        })
 
         if (!cancelled && next) {
-          const current = $petInfo.get()
-
           if (
             next.enabled &&
             current.enabled &&
@@ -181,6 +187,14 @@ export function FloatingPet() {
             current.spritesheetRevision &&
             current.spritesheetRevision === next.spritesheetRevision
           ) {
+            return
+          }
+
+          // The gateway withheld the sheet because our revision still matched —
+          // keep the cached bytes, just refresh the cheap geometry alongside it.
+          if (next.enabled && next.spritesheetOmitted && current.spritesheetBase64) {
+            setPetInfo({ ...next, spritesheetBase64: current.spritesheetBase64, mime: next.mime ?? current.mime })
+
             return
           }
 

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -24,6 +24,10 @@ export interface PetInfo {
   // Stable sheet revision (`mtime_ns:size`) from the gateway; lets the desktop
   // skip full sprite payload refreshes when the active pet hasn't changed.
   spritesheetRevision?: string
+  // Set by the gateway when it withheld the ~3.2MB `spritesheetBase64` on
+  // purpose because our `knownRevision` still matched (issue #54730). Not a
+  // decode failure — callers must keep their cached sheet rather than blank it.
+  spritesheetOmitted?: boolean
   frameW?: number
   frameH?: number
   framesPerState?: number

--- a/tests/tui_gateway/test_pet_generate_rpc.py
+++ b/tests/tui_gateway/test_pet_generate_rpc.py
@@ -243,3 +243,42 @@ def test_pet_info_meta_avoids_full_payload(monkeypatch):
     assert result["displayName"] == "Meta Pet"
     assert result["scale"] == 0.7
     assert ":" in result["spritesheetRevision"]
+
+
+def test_pet_info_omits_sheet_when_revision_unchanged(monkeypatch):
+    """The ~3.2MB spritesheet is sent on the first/changed fetch but withheld on
+    an unchanged poll that carries the matching ``knownRevision`` (issue #54730).
+    """
+    import hermes_cli.config as cli_config
+    from agent.pet import constants, store
+
+    sheet = Image.new("RGBA", (constants.FRAME_W * 8, constants.FRAME_H * 9), (80, 120, 220, 255))
+    pet = store.register_local_pet(sheet, slug="revgate-pet", display_name="Rev Gate")
+    monkeypatch.setattr(
+        cli_config,
+        "load_config",
+        lambda: {"display": {"pet": {"enabled": True, "slug": pet.slug, "scale": 0.7}}},
+    )
+
+    # First fetch (no knownRevision) carries the full sheet.
+    first = server._methods["pet.info"]("r_first", {})["result"]
+    assert first["enabled"] is True
+    assert first["spritesheetBase64"]
+    assert not first.get("spritesheetOmitted")
+    revision = first["spritesheetRevision"]
+
+    # Unchanged poll echoing that revision omits the heavy bytes but keeps the
+    # cheap geometry + revision so the client can confirm without re-decoding.
+    same = server._methods["pet.info"]("r_same", {"knownRevision": revision})["result"]
+    assert same["enabled"] is True
+    assert same["spritesheetOmitted"] is True
+    assert "spritesheetBase64" not in same
+    assert "mime" not in same
+    assert same["spritesheetRevision"] == revision
+    assert same["frameW"] == constants.FRAME_W
+    assert same["stateRows"] == first["stateRows"]
+
+    # A stale/mismatched revision still gets the full sheet re-sent.
+    stale = server._methods["pet.info"]("r_stale", {"knownRevision": "0:0"})["result"]
+    assert stale["spritesheetBase64"] == first["spritesheetBase64"]
+    assert not stale.get("spritesheetOmitted")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6295,6 +6295,25 @@ def _clone_pet_payload(payload: dict) -> dict:
     return out
 
 
+# Heavy sprite fields worth ~3.2MB on the wire — omitted from ``pet.info`` when
+# the client already holds the current revision (issue #54730). Everything else
+# (geometry, row counts, revision) is cheap and always sent so the caller can
+# confirm nothing changed without re-decoding the sheet.
+_PET_HEAVY_FIELDS = ("spritesheetBase64", "mime")
+
+
+def _strip_pet_sheet_bytes(payload: dict) -> dict:
+    """Return *payload* without the heavy spritesheet bytes.
+
+    The kept ``spritesheetRevision`` lets the client verify its cached sheet is
+    still current; ``spritesheetOmitted`` flags that the bytes were withheld on
+    purpose (not a decode failure) so the caller keeps its existing base64.
+    """
+    out = {k: v for k, v in payload.items() if k not in _PET_HEAVY_FIELDS}
+    out["spritesheetOmitted"] = True
+    return out
+
+
 def _pet_row_frame_counts(spritesheet) -> dict:
     """Real frame count per concrete spritesheet row name."""
     try:
@@ -6435,6 +6454,13 @@ def _(rid, params: dict) -> dict:
     Agent-independent (reads config + disk), so it works on any session and
     before the agent finishes building. Fail-open: returns ``enabled=False``
     on any error rather than erroring the surface.
+
+    Revision gate (issue #54730): the ~3.2MB ``spritesheetBase64`` is the same
+    static asset on every poll. When the caller passes ``knownRevision`` matching
+    the current sheet, the bytes are omitted (``spritesheetOmitted=True``) and
+    only the cheap geometry + revision are returned, so the frequent poll stops
+    re-sending the sheet and stalling the WS write loop. A caller that omits
+    ``knownRevision`` (older clients) still gets the full payload.
     """
     try:
         enabled, pet, scale = _pet_active_selection()
@@ -6442,7 +6468,11 @@ def _(rid, params: dict) -> dict:
         if not enabled or pet is None or not pet.exists:
             return _ok(rid, {"enabled": False})
 
-        return _ok(rid, {"enabled": True, **_pet_sprite_payload(pet, scale=scale)})
+        payload = _pet_sprite_payload(pet, scale=scale)
+        known = params.get("knownRevision") if isinstance(params, dict) else None
+        if known and known == payload.get("spritesheetRevision"):
+            payload = _strip_pet_sheet_bytes(payload)
+        return _ok(rid, {"enabled": True, **payload})
     except Exception as exc:  # noqa: BLE001 - cosmetic, never break the surface
         logger.debug("pet.info failed: %s", exc)
         return _ok(rid, {"enabled": False})


### PR DESCRIPTION
## What does this PR do?

The `pet.info` WebSocket responder returned the full ~3.2MB base64 spritesheet on **every** push (~8×/min per the reported logs). Re-encoding and re-sending that on each state update stalled the WS write loop (`ws write slow (loop stalled >10s)`) and caused disconnect/reconnect storms — the flashing/reconnect behaviour in the issue.

This gates the heavy payload on the revision the client already holds: if the caller passes `knownRevision` matching the current `spritesheetRevision`, the response omits `spritesheetBase64`/`mime` (flagged `spritesheetOmitted`) and sends only the lightweight geometry; otherwise it sends the full payload. Backward-compatible — any caller that doesn't send `knownRevision` (older desktop/TUI, `pet.hatch`, gallery load/sync) always gets the full sheet, so the spritesheet is delivered at least once (first activation, reconnect, profile switch, or revision change).

## Related Issue

Fixes #54730

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: added `_strip_pet_sheet_bytes()`; the `pet.info` handler omits the heavy fields when `knownRevision` matches the current revision.
- `apps/desktop/src/store/pet.ts`: added `spritesheetOmitted?` to `PetInfo`.
- `apps/desktop/src/components/pet/floating-pet.tsx`: the poll now sends `knownRevision` (only when a sheet is cached) and, on an omitted response, keeps the cached sheet while refreshing geometry.

## How to Test

1. Run the desktop app with a pet enabled and watch the WS pushes.
2. **Before:** every `pet.info` carries the full 3.2MB `spritesheetBase64` → WS write stalls / reconnect flapping.
3. **After:** the first push carries the sheet; subsequent unchanged pushes are `spritesheetOmitted` (small), the mascot renders continuously, no reconnect storm.

Added `test_pet_info_omits_sheet_when_revision_unchanged` in `tests/tui_gateway/test_pet_generate_rpc.py`.
