### PR TITLE
fix(gateway): set ended_at on expired gateway sessions to bound state.db growth

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7686,6 +7686,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             await self._cleanup_agent_resources_off_loop(
                                 _cached_agent, context="session expiry"
                             )
+                        # Finalize the state.db session row.  Marking the
+                        # session ended is what keeps state.db bounded — an
+                        # expired session must get an ``ended_at`` so it stops
+                        # counting as live and becomes eligible for later
+                        # pruning.  We must set it here explicitly: the cached
+                        # AIAgent's own ``close()`` would set it, but the agent
+                        # is frequently already soft-evicted by the idle sweep /
+                        # cache-cap enforcer (``_release_evicted_agent_soft``
+                        # preserves the open session for resume and never calls
+                        # ``end_session``), leaving ``_cached_agent`` None and
+                        # the row's ``ended_at`` NULL forever (#54189).
+                        # ``end_session`` is first-reason-wins and no-ops on an
+                        # already-ended row, so a prior ``agent_close`` reason
+                        # is preserved. Runs off the cache lock, mirroring the
+                        # ``session_reset`` path in gateway/session.py.
+                        _sess_db = getattr(self.session_store, "_db", None)
+                        if _sess_db is not None and entry.session_id:
+                            try:
+                                _sess_db.end_session(
+                                    entry.session_id, "session_expired"
+                                )
+                            except Exception as _end_exc:
+                                logger.debug(
+                                    "Session expiry: failed to end_session %s: %s",
+                                    entry.session_id, _end_exc,
+                                )
                         # Drop the cache entry so the AIAgent (and its LLM
                         # clients, tool schemas, memory provider refs) can
                         # be garbage-collected.  Otherwise the cache grows

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -331,3 +331,81 @@ async def test_idle_expiry_clears_last_resolved_model(mock_invoke_hook):
         "session-expiry finalization must only clear the expired session's "
         "own key, not unrelated sessions' cached entries"
     )
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_idle_expiry_sets_ended_at_in_db(mock_invoke_hook, tmp_path):
+    """Regression test for #54189 (unbounded state.db growth).
+
+    When ``_session_expiry_watcher`` permanently finalizes an expired
+    session, it must mark the state.db row ended (set ``ended_at``) so the
+    session stops counting as live and becomes prunable. This must happen
+    even in the common case where the cached AIAgent was already soft-evicted
+    by the idle sweep / cache-cap enforcer — those paths call
+    ``release_clients()`` (which PRESERVES the open session for resume) and
+    never call ``end_session``, so the expiry watcher is the only place left
+    to finalize the DB row. Before the fix the row's ``ended_at`` stayed
+    NULL forever and state.db grew without bound.
+    """
+    from datetime import datetime, timedelta
+
+    from gateway.run import GatewayRunner
+    from hermes_state import SessionDB
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.create_session("sess-expired", source="telegram")
+    assert session_db.get_session("sess-expired")["ended_at"] is None
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._running_agents = {}
+    runner._agent_cache = {}  # empty: the cached agent is already gone (the leak case)
+    runner._agent_cache_lock = None
+    runner._last_session_store_prune_ts = 0.0
+
+    session_key = "agent:main:telegram:dm:42"
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-expired",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    expired_entry.expiry_finalized = False
+
+    runner.session_store = MagicMock()
+    runner.session_store._db = session_db
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._lock = MagicMock()
+    runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+    runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+    runner.session_store._save = MagicMock()
+
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+
+    _orig_sleep = __import__("asyncio").sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    def _hook_and_stop(*a, **kw):
+        runner._running = False
+        return None
+
+    mock_invoke_hook.side_effect = _hook_and_stop
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await runner._session_expiry_watcher(interval=0)
+
+    row = session_db.get_session("sess-expired")
+    assert row["ended_at"] is not None, (
+        "expired session was never marked ended in state.db; ended_at is "
+        "still NULL (regression of #54189 — unbounded state.db growth)"
+    )
+    assert row["end_reason"] == "session_expired"


### PR DESCRIPTION
## What does this PR do?

Fixes unbounded `state.db` growth (659MB / 938 never-ended sessions in ~2 weeks). Expired gateway sessions were finalized in `_session_expiry_watcher` by closing the **cached** agent — but an idle session's agent is almost always soft-evicted first (cache eviction deliberately preserves the row for resume and never calls `end_session`). So when the expiry watcher runs there's no cached agent to close, and the DB row keeps `ended_at IS NULL` forever, accumulating without bound.

This calls the existing `SessionDB.end_session(session_id, "session_expired")` at the finalization point in `_session_expiry_watcher`, independent of whether a cached agent still exists. It's first-reason-wins and no-ops on an already-ended row, so it's safe alongside `agent_close`. I verified the cron / sync-subagent / async-subagent / one-shot / interactive-CLI paths already set `ended_at`, so the expiry watcher was the one real gap.

Scope is intentionally bounded to closing the lifecycle gap. A retention/prune policy for the now-eligible rows (there's already a `maybe_auto_prune_and_vacuum` hook) is left as a follow-up to avoid a design debate here.

## Related Issue

Fixes #54189

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: in `_session_expiry_watcher`'s per-entry finalization, call `end_session(entry.session_id, "session_expired")` (best-effort, logged on failure).

## How to Test

1. Create a gateway session; let its agent get soft-evicted (idle sweep) and then expire.
2. **Before:** the `state.db` session row keeps `ended_at IS NULL`.
3. **After:** the row has `ended_at` set with `end_reason = "session_expired"`.

Added `test_idle_expiry_sets_ended_at_in_db` in `tests/gateway/test_session_boundary_hooks.py` (real `SessionDB`, empty agent cache to reproduce the leak, asserts `ended_at` is set after the watcher runs).
