### PR TITLE
fix(moa): lift hidden Anthropic aux output cap

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1158,7 +1158,7 @@ class _AnthropicCompletionsAdapter:
         if _skip_mt:
             max_tokens = None
         else:
-            max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens") or 2000
+            max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
         temperature = kwargs.get("temperature")
 
         normalized_tool_choice = None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1141,6 +1141,40 @@ class TestVisionClientFallback:
         assert response.usage.prompt_tokens == 3
         assert response.usage.completion_tokens == 4
 
+    def test_anthropic_auxiliary_client_uses_model_output_limit_by_default(self):
+        from agent.auxiliary_client import AnthropicAuxiliaryClient
+
+        final_message = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="aux response")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=3, output_tokens=4),
+        )
+        messages_api = SimpleNamespace(create=MagicMock())
+        real_client = SimpleNamespace(messages=messages_api)
+        captured_kwargs = {}
+
+        def fake_create_anthropic_message(_client, kwargs):
+            captured_kwargs.update(kwargs)
+            return final_message
+
+        client = AnthropicAuxiliaryClient(
+            real_client,
+            "claude-opus-4-8",
+            "sk-test",
+            "https://api.anthropic.com",
+        )
+
+        with patch(
+            "agent.anthropic_adapter.create_anthropic_message",
+            side_effect=fake_create_anthropic_message,
+        ):
+            response = client.chat.completions.create(
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert response.choices[0].message.content == "aux response"
+        assert captured_kwargs["max_tokens"] == 128_000
+
 
 class TestAuxiliaryPoolAwareness:
     def test_try_nous_uses_pool_entry(self):


### PR DESCRIPTION
## What does this PR do?

Fixes the native Anthropic auxiliary client path so missing `max_tokens` is passed through as `None` instead of being silently replaced with `2000`.

MoA intentionally omits output caps for reference and aggregator calls so each model can use its own maximum. Native Anthropic auxiliary calls were undercutting that by inserting a hidden 2000-token cap before `build_anthropic_kwargs()` could resolve the model-specific output limit, which can make Anthropic MoA aggregators hit `finish_reason="length"` and surface `Response truncated due to output length limit` even after users remove explicit MoA `max_tokens` config.

## Related Issue

N/A. Found from Discord support thread `1521539681895059477`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: stop defaulting native Anthropic auxiliary calls to `max_tokens=2000` when no cap was requested.
- `tests/agent/test_auxiliary_client.py`: add a regression test proving a capless Opus 4.8 auxiliary call resolves to the Anthropic model output limit instead of 2000.

## How to Test

1. Run `scripts/run_tests.sh -j 4 tests/agent/test_auxiliary_client.py -q`.
2. Confirm the regression test captures `max_tokens == 128_000` for `claude-opus-4-8` when the caller omits `max_tokens`.
3. For the support repro, retest the same MoA preset with an Anthropic aggregator and no explicit MoA `max_tokens` entries.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: WSL/Linux via focused pytest

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) -- N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I have considered cross-platform impact per the compatibility guide -- no platform-specific code changed
- [x] I have updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

Focused tests:

`scripts/run_tests.sh -j 4 tests/agent/test_auxiliary_client.py -q`

Result: `281 tests passed, 0 failed`.

Targeted regression tests also passed directly:

`.venv/bin/python -m pytest -q tests/agent/test_auxiliary_client.py::TestVisionClientFallback::test_anthropic_auxiliary_client_uses_model_output_limit_by_default tests/agent/test_auxiliary_client.py::TestVisionClientFallback::test_anthropic_auxiliary_client_aggregates_stream_response`

Result: `2 passed`.