### PR TITLE
fix(tools): checkpoint restore no longer hides a missing pre-rollback…

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3070,11 +3070,22 @@ class GatewaySlashCommandsMixin:
 
         result = mgr.restore(cwd, target_hash)
         if result["success"]:
+            # The default message states a pre-rollback snapshot was taken.
+            # When restore() reports it could not take one, saying so anyway
+            # is the false reassurance this path exists to avoid.
+            if result.get("warning"):
+                return t(
+                    "gateway.rollback.restored_no_snapshot",
+                    hash=result["restored_to"],
+                    reason=result["reason"],
+                    warning=result["warning"],
+                )
             return t(
                 "gateway.rollback.restored",
                 hash=result["restored_to"],
                 reason=result["reason"],
             )
+
         return t("gateway.rollback.restore_failed", error=result["error"])
 
     async def _handle_diff_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -132,7 +132,10 @@ class CLICommandsMixin:
                 print(f"  ✅ Restored {file_path} from checkpoint {result['restored_to']}: {result['reason']}")
             else:
                 print(f"  ✅ Restored to checkpoint {result['restored_to']}: {result['reason']}")
-            print("  A pre-rollback snapshot was saved automatically.")
+            if result.get("warning"):
+                print(f"  ⚠️  {result['warning']}")
+            else:
+                print("  A pre-rollback snapshot was saved automatically.")
 
             # Also undo the last conversation turn so the agent's context
             # matches the restored filesystem state

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Geen kontrolepunte vir {cwd} gevind nie"
     invalid_number:        "Ongeldige kontrolepunt-nommer. Gebruik 1-{max}."
     restored:              "✅ Herstel na kontrolepunt {hash}: {reason}\n'n Voor-terugrol-momentopname is outomaties gestoor."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -297,6 +297,7 @@ gateway:
     none_found:            "لم يُعثر على نقاط تحقّق لـ {cwd}"
     invalid_number:        "رقم نقطة تحقّق غير صالح. استخدم 1-{max}."
     restored:              "✅ استُعيد إلى نقطة التحقّق {hash}: {reason}\nحُفظت لقطة ما قبل التراجع تلقائيًا."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Keine Checkpoints für {cwd} gefunden"
     invalid_number:        "Ungültige Checkpoint-Nummer. Verwenden Sie 1-{max}."
     restored:              "✅ Auf Checkpoint {hash} wiederhergestellt: {reason}\nEin Pre-Rollback-Snapshot wurde automatisch gespeichert."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -289,6 +289,7 @@ gateway:
     none_found:            "No checkpoints found for {cwd}"
     invalid_number:        "Invalid checkpoint number. Use 1-{max}."
     restored:              "✅ Restored to checkpoint {hash}: {reason}\nA pre-rollback snapshot was saved automatically."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -274,6 +274,7 @@ gateway:
     none_found:            "No se encontraron checkpoints para {cwd}"
     invalid_number:        "Número de checkpoint inválido. Usa 1-{max}."
     restored:              "✅ Restaurado al checkpoint {hash}: {reason}\nSe guardó automáticamente un snapshot previo al rollback."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Aucun point de contrôle trouvé pour {cwd}"
     invalid_number:        "Numéro de point de contrôle invalide. Utilisez 1-{max}."
     restored:              "✅ Restauré au point de contrôle {hash} : {reason}\nUn instantané pré-rollback a été enregistré automatiquement."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -281,6 +281,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Níor aimsíodh aon seicphointe do {cwd}"
     invalid_number:        "Uimhir seicphointe neamhbhailí. Úsáid 1-{max}."
     restored:              "✅ Aischurtha go seicphointe {hash}: {reason}\nSábháladh roghchóip réamh-rollback go huathoibríoch."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Nem található ellenőrzőpont ehhez: {cwd}"
     invalid_number:        "Érvénytelen ellenőrzőpont-szám. Használj 1-{max} közötti értéket."
     restored:              "✅ Visszaállítva a(z) {hash} ellenőrzőpontra: {reason}\nA visszaállítás előtti pillanatkép automatikusan elmentve."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Nessun checkpoint trovato per {cwd}"
     invalid_number:        "Numero di checkpoint non valido. Usa 1-{max}."
     restored:              "✅ Ripristinato al checkpoint {hash}: {reason}\nUno snapshot pre-rollback è stato salvato automaticamente."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "{cwd} のチェックポイントが見つかりません"
     invalid_number:        "無効なチェックポイント番号です。1-{max} を使用してください。"
     restored:              "✅ チェックポイント {hash} に復元しました: {reason}\nロールバック前のスナップショットが自動的に保存されました。"
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "{cwd}에 체크포인트를 찾을 수 없습니다"
     invalid_number:        "잘못된 체크포인트 번호입니다. 1-{max}을 사용하세요."
     restored:              "✅ 체크포인트 {hash}(으)로 복원됨: {reason}\n롤백 전 스냅샷이 자동으로 저장되었습니다."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Não foram encontrados checkpoints para {cwd}"
     invalid_number:        "Número de checkpoint inválido. Usa 1-{max}."
     restored:              "✅ Restaurado para o checkpoint {hash}: {reason}\nFoi guardado automaticamente um snapshot anterior ao rollback."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Контрольных точек для {cwd} не найдено"
     invalid_number:        "Недействительный номер контрольной точки. Используйте 1-{max}."
     restored:              "✅ Восстановлено до контрольной точки {hash}: {reason}\nСнимок перед откатом сохранён автоматически."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "{cwd} için kontrol noktası bulunamadı"
     invalid_number:        "Geçersiz kontrol noktası numarası. 1-{max} aralığını kullanın."
     restored:              "✅ {hash} kontrol noktasına geri yüklendi: {reason}\nGeri alma öncesi anlık görüntü otomatik olarak kaydedildi."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "Контрольних точок для {cwd} не знайдено"
     invalid_number:        "Недійсний номер контрольної точки. Використовуйте 1-{max}."
     restored:              "✅ Відновлено до контрольної точки {hash}: {reason}\nЗнімок перед відкатом збережено автоматично."
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "找不到 {cwd} 的檢查點"
     invalid_number:        "無效的檢查點編號。請使用 1-{max}。"
     restored:              "✅ 已還原至檢查點 {hash}：{reason}\n已自動儲存回復前的快照。"
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -277,6 +277,7 @@ Future messages in this room will use that transcript until `/reset` or another 
     none_found:            "未找到 {cwd} 的检查点"
     invalid_number:        "无效的检查点编号。请使用 1-{max}。"
     restored:              "✅ 已恢复到检查点 {hash}：{reason}\n已自动保存回滚前的快照。"
+    restored_no_snapshot:  "✅ Restored to checkpoint {hash}: {reason}\n⚠️  {warning}"
     restore_failed:        "❌ {error}"
 
   diff:

--- a/tests/cli/test_rollback_snapshot_warning.py
+++ b/tests/cli/test_rollback_snapshot_warning.py
@@ -1,0 +1,70 @@
+"""Smoke test for the /rollback CLI message fix.
+
+``CLICommandsMixin._handle_rollback_command`` used to print "A pre-rollback
+snapshot was saved automatically." unconditionally on a successful restore,
+even when ``CheckpointManager.restore()`` could not actually take that
+snapshot (surfaced via the ``result["warning"]`` key added alongside this
+fix). This test exercises the real branching logic with a minimal stand-in
+host object, without needing a full HermesCLI instance.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+from tools.checkpoint_manager import CheckpointManager
+
+
+class _FakeAgent:
+    def __init__(self, mgr):
+        self._checkpoint_mgr = mgr
+
+
+class _FakeHost(CLICommandsMixin):
+    """Minimal object exposing just what _handle_rollback_command touches."""
+
+    def __init__(self, mgr):
+        self.agent = _FakeAgent(mgr)
+        self.conversation_history = []  # skip the undo_last branch
+
+    def _resolve_checkpoint_ref(self, ref, checkpoints):
+        idx = int(ref) - 1
+        return checkpoints[idx]["hash"] if 0 <= idx < len(checkpoints) else None
+
+
+@pytest.fixture()
+def work_dir(tmp_path):
+    d = tmp_path / "project"
+    d.mkdir()
+    (d / "main.py").write_text("v1\n")
+    return d
+
+
+@pytest.fixture()
+def mgr(work_dir, tmp_path, monkeypatch):
+    monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", tmp_path / "checkpoints")
+    monkeypatch.setenv("TERMINAL_CWD", str(work_dir))
+    m = CheckpointManager(enabled=True, max_snapshots=50)
+    m.ensure_checkpoint(str(work_dir), "v1")
+    m.new_turn()
+    (work_dir / "main.py").write_text("v2\n")
+    return m
+
+
+def test_normal_restore_prints_saved_message(mgr, capsys):
+    host = _FakeHost(mgr)
+    host._handle_rollback_command("/rollback 1")
+    out = capsys.readouterr().out
+    assert "A pre-rollback snapshot was saved automatically." in out
+    assert "⚠️" not in out
+
+
+def test_failed_snapshot_prints_warning_not_false_claim(mgr, capsys):
+    host = _FakeHost(mgr)
+    with patch.object(CheckpointManager, "_take", return_value=False):
+        host._handle_rollback_command("/rollback 1")
+    out = capsys.readouterr().out
+    assert "A pre-rollback snapshot was saved automatically." not in out
+    assert "⚠️" in out
+    assert "pre-rollback" in out.lower()

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -1,8 +1,11 @@
 from hermes_state import AsyncSessionDB
 """Tests for gateway /usage command — agent cache lookup and output fields."""
 
+import asyncio
 import threading
 from unittest.mock import MagicMock, patch
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
 
 import pytest
 
@@ -376,3 +379,59 @@ class TestUsageContextBreakdown:
         assert "📊 **Session Token Usage**" in result
         assert "50,000" in result  # total tokens
         assert "Context breakdown" not in result
+
+# ---------------------------------------------------------------------------
+# /rollback — a restore that could not take a pre-rollback snapshot must say
+# so.  The default success message states one was saved automatically, so
+# emitting it regardless is the false reassurance the warning exists to stop.
+# ---------------------------------------------------------------------------
+
+
+class _RollbackHarness(GatewaySlashCommandsMixin):
+    """Minimal host for the mixin: the handler needs nothing else."""
+
+
+def _rollback_event():
+    event = MagicMock()
+    event.get_command_args.return_value = "abc1234"
+    return event
+
+
+def _run_rollback(restore_result):
+    harness = _RollbackHarness()
+    mgr = MagicMock()
+    mgr.restore.return_value = restore_result
+
+    cp_kwargs = {
+        "checkpoints_enabled": True,
+        "checkpoint_max_snapshots": 10,
+        "checkpoint_max_total_size_mb": 100,
+        "checkpoint_max_file_size_mb": 10,
+    }
+    with patch("gateway.run._load_gateway_config", return_value={}), \
+         patch("gateway.run._checkpoint_agent_kwargs", return_value=cp_kwargs), \
+         patch("tools.checkpoint_manager.CheckpointManager", return_value=mgr):
+        return asyncio.run(harness._handle_rollback_command(_rollback_event()))
+
+
+def test_rollback_restore_surfaces_missing_snapshot_warning():
+    warning = "Could not take a pre-rollback snapshot before this restore."
+    out = _run_rollback({
+        "success": True,
+        "restored_to": "abc1234",
+        "reason": "before edit",
+        "warning": warning,
+    })
+
+    assert warning in out
+    assert "snapshot was saved automatically" not in out
+
+
+def test_rollback_restore_keeps_the_snapshot_notice_when_one_was_taken():
+    out = _run_rollback({
+        "success": True,
+        "restored_to": "abc1234",
+        "reason": "before edit",
+    })
+
+    assert "snapshot was saved automatically" in out

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -377,6 +377,40 @@ class TestRestore:
         assert len(all_cps) >= 2
         assert "pre-rollback" in all_cps[0]["reason"]
 
+    def test_restore_no_warning_when_pre_rollback_snapshot_succeeds(self, mgr, work_dir):
+        (work_dir / "main.py").write_text("v1\n")
+        mgr.ensure_checkpoint(str(work_dir), "v1")
+        mgr.new_turn()
+
+        (work_dir / "main.py").write_text("v2\n")
+        cps = mgr.list_checkpoints(str(work_dir))
+
+        result = mgr.restore(str(work_dir), cps[0]["hash"])
+        assert result["success"] is True
+        assert "warning" not in result
+
+    def test_restore_warns_when_pre_rollback_snapshot_fails(self, mgr, work_dir):
+        (work_dir / "main.py").write_text("v1\n")
+        mgr.ensure_checkpoint(str(work_dir), "v1")
+        mgr.new_turn()
+
+        (work_dir / "main.py").write_text("v2\n")
+        cps = mgr.list_checkpoints(str(work_dir))
+
+        # Simulate the size-guard (or any other) failure path inside
+        # _take() without needing to create 50,000 real files.
+        with patch.object(CheckpointManager, "_take", return_value=False):
+            result = mgr.restore(str(work_dir), cps[0]["hash"])
+
+        # Fail-open: the restore still proceeds (consistent with the
+        # project's existing best-effort checkpoint philosophy)...
+        assert result["success"] is True
+        assert (work_dir / "main.py").read_text() == "v1\n"
+        # ...but the caller is now told the safety net did not fire,
+        # instead of this being visible only via a debug-level log line.
+        assert "warning" in result
+        assert "pre-rollback" in result["warning"].lower()
+
     def test_tilde_path_supports_diff_and_restore_flow(
         self, checkpoint_base, fake_home, monkeypatch,
     ):
@@ -536,6 +570,26 @@ class TestDirFileCount:
 
     def test_nonexistent_dir(self, tmp_path):
         assert _dir_file_count(str(tmp_path / "nonexistent")) == 0
+
+    def test_excluded_dir_contents_not_counted(self, work_dir):
+        # A node_modules/ tree big enough to blow through a naive raw
+        # filesystem walk, but which git (and now _dir_file_count) never
+        # descends into.
+        node_modules = work_dir / "node_modules"
+        node_modules.mkdir()
+        for i in range(200):
+            (node_modules / f"pkg_{i}.js").write_text("x")
+
+        # The excluded subtree itself still counts as one entry (the
+        # directory), but its contents must not inflate the total.
+        count = _dir_file_count(str(work_dir))
+        assert count < 10
+
+    def test_non_excluded_files_still_counted(self, work_dir):
+        for i in range(5):
+            (work_dir / f"file_{i}.py").write_text("x")
+        count = _dir_file_count(str(work_dir))
+        assert count >= 7  # main.py + README.md + 5 new files
 
 
 # =========================================================================

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -147,6 +147,14 @@ _GIT_TIMEOUT: int = max(10, min(60, env_int("HERMES_CHECKPOINT_TIMEOUT", 30)))
 # Max files to snapshot — skip huge directories to avoid slowdowns.
 _MAX_FILES = 50_000
 
+# Directory names pruned from _dir_file_count's walk, derived from the
+# directory entries in DEFAULT_EXCLUDES.  These are the same paths git
+# itself ignores via info/exclude (see _init_store), so the size guard
+# below reflects what would actually be checkpointed instead of every
+# file on disk, including huge dependency/build trees that never reach
+# the git index.
+_EXCLUDED_DIR_NAMES = {entry[:-1] for entry in DEFAULT_EXCLUDES if entry.endswith("/")}
+
 # Valid git commit hash pattern: 4–40 hex chars (short or full SHA-1/SHA-256).
 _COMMIT_HASH_RE = re.compile(r'^[0-9a-fA-F]{4,64}$')
 
@@ -635,15 +643,29 @@ def _pre_v2_shadow_repos(base: Path) -> List[Dict]:
 
 
 def _dir_file_count(path: str) -> int:
-    """Quick file count estimate (stops early if over _MAX_FILES)."""
+    """Quick file count estimate (stops early if over _MAX_FILES).
+
+    Skips descending into directories listed in _EXCLUDED_DIR_NAMES, so the
+    count reflects what a checkpoint would actually stage rather than every
+    file on disk.  Without this, a node_modules/ or .venv/ tree routinely
+    pushes a small, normally-sized project over _MAX_FILES, silently
+    disabling checkpoints for it even though git would exclude those paths
+    anyway.
+    """
     count = 0
-    try:
-        for _ in Path(path).rglob("*"):
-            count += 1
-            if count > _MAX_FILES:
-                return count
-    except (PermissionError, OSError):
-        pass
+    stack = [Path(path)]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for dirent in it:
+                    count += 1
+                    if count > _MAX_FILES:
+                        return count
+                    if dirent.is_dir(follow_symlinks=False) and dirent.name not in _EXCLUDED_DIR_NAMES:
+                        stack.append(Path(dirent.path))
+        except (PermissionError, OSError):
+            continue
     return count
 
 
@@ -937,8 +959,16 @@ class CheckpointManager:
             return {"success": False, "error": f"Checkpoint '{commit_hash}' not found",
                     "debug": err or None}
 
-        # Take a pre-rollback snapshot so you can undo the undo.
-        self._take(abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
+        # Take a pre-rollback snapshot so you can undo the undo.  This can
+        # come back False for a harmless reason (nothing changed since the
+        # last checkpoint, which already covers the current state) or for a
+        # real gap (e.g. the size guard skipped it) — either way, surface it
+        # instead of silently proceeding, since the checkout below is about
+        # to overwrite the working tree with no way to tell which case this
+        # was.
+        pre_rollback_taken = self._take(
+            abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})"
+        )
 
         dir_hash = _project_hash(abs_dir)
         index_file = _index_path(store, dir_hash)
@@ -967,6 +997,13 @@ class CheckpointManager:
         }
         if file_path:
             result["file"] = file_path
+        if not pre_rollback_taken:
+            result["warning"] = (
+                "Could not take a pre-rollback snapshot before this restore. "
+                "If nothing had changed since the last checkpoint this is "
+                "harmless; otherwise this restore cannot be undone through "
+                "checkpoint recovery."
+            )
         return result
 
     def get_working_dir_for_path(self, file_path: str) -> str:

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -719,6 +719,38 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
+  it('surfaces the missing-snapshot warning from /rollback restore', async () => {
+    // A restore that could not take a pre-rollback snapshot cannot be undone
+    // through checkpoint recovery, so the warning has to reach the transcript
+    // rather than being dropped alongside the normal success line.
+    patchUiState({ sid: 'sid-abc' })
+    const warning = 'Could not take a pre-rollback snapshot before this restore.'
+    const rpc = vi.fn(() =>
+      Promise.resolve({ reason: 'before edit', restored_to: 'abc1234', success: true, warning })
+    )
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    createSlashHandler(ctx)('/rollback restore abc1234')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(expect.stringContaining(warning))
+  })
+
+  it('says nothing extra when the pre-rollback snapshot succeeded', async () => {
+    patchUiState({ sid: 'sid-abc' })
+    const rpc = vi.fn(() =>
+      Promise.resolve({ reason: 'before edit', restored_to: 'abc1234', success: true })
+    )
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    createSlashHandler(ctx)('/rollback restore abc1234')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(ctx.transcript.sys).not.toHaveBeenCalledWith(expect.stringContaining('\u26a0'))
+  })
+
   it('hot-swaps the live indicator when /indicator <style> succeeds', async () => {
     const rpc = vi.fn(() => Promise.resolve({ value: 'emoji' }))
     const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -280,6 +280,10 @@ export const opsCommands: SlashCommand[] = [
             const detail = r.reason || r.message || r.restored_to || 'restored'
             ctx.transcript.sys(`rollback restored ${target}: ${detail}`)
 
+            if (r.warning) {
+              ctx.transcript.sys(`⚠️  ${r.warning}`)
+            }
+
             if ((r.history_removed ?? 0) > 0) {
               ctx.transcript.setHistoryItems(prev => ctx.transcript.trimLastExchange(prev))
             }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -516,6 +516,9 @@ export interface RollbackRestoreResponse {
   reason?: string
   restored_to?: string
   success?: boolean
+  // Set when the restore succeeded but no pre-rollback snapshot could be
+  // taken, so the operation cannot be undone through checkpoint recovery.
+  warning?: string
 }
 
 // ── Subagent events ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes checkpoint restore silently proceeding without a working safety net
for projects with large dependency or build directories. Before this fix,
a node_modules/, .venv/, or similar tree routinely pushed a normally-sized
project over the file-count guard used to decide whether a checkpoint can
be taken, disabling both automatic checkpointing and the pre-rollback
snapshot inside restore(). The only signal beyond a debug-level log line
was a CLI message that unconditionally claimed a snapshot had been saved,
regardless of whether it actually had.

---

## Root cause
`_dir_file_count()` in `tools/checkpoint_manager.py` walked the raw
filesystem with `Path(path).rglob("*")`, counting every file on disk
including the contents of directories already listed in
`DEFAULT_EXCLUDES` (node_modules/, .venv/, .git/, dist/, build/, target/,
__pycache__/, and others). Git itself excludes exactly these paths via
`info/exclude`, set up in `_init_store()`, so the actual git-tracked file
count for a typical project stays small while the raw filesystem count
can reach into the tens of thousands.

`_take()` uses this raw count against `_MAX_FILES` (50,000) to decide
whether to skip taking a checkpoint. A common Node.js project with
node_modules present, or a Python project with a sizeable virtualenv,
can cross this threshold on the raw count alone, silently disabling
checkpointing for the project going forward.

Separately, `restore()` called `self._take(...)` to create a
pre-rollback snapshot before overwriting the working tree via `git
checkout`, but discarded the return value. If that snapshot failed for
any reason, including the file-count guard above, the checkout still
proceeded, with no way for the caller to know the safety net had not
fired. The only CLI-facing message
(`hermes_cli/cli_commands_mixin.py`) unconditionally printed "A
pre-rollback snapshot was saved automatically." on every successful
restore, regardless of whether that was true.

---

## Behavioral change
Before: a project with a large dependency tree could have checkpointing
silently disabled entirely. Calling restore() on such a project (or on
any existing older checkpoint after the tree grew past the threshold)
would overwrite the working directory with no pre-rollback snapshot and
no indication this had happened, beyond a debug log line no one sees in
normal operation.

After: `_dir_file_count()` no longer descends into directories listed in
`DEFAULT_EXCLUDES`, so the guard reflects what a checkpoint would
actually stage rather than every file on disk. This alone lets
checkpointing work normally for the large majority of real projects.
For the remaining case where a pre-rollback snapshot still cannot be
taken, `restore()` now reports this through a `warning` key in its
result instead of silently discarding it, and the CLI now prints that
warning instead of unconditionally claiming a snapshot was saved.

---

## What changed
**`tools/checkpoint_manager.py`**: added `_EXCLUDED_DIR_NAMES`, derived
from the directory entries in `DEFAULT_EXCLUDES`. Rewrote
`_dir_file_count()` from a flat `rglob` walk to a stack-based
`os.scandir` walk that skips descending into those directory names.
`restore()` now captures the return value of the pre-rollback
`self._take(...)` call and, when it is `False`, adds a `warning` key to
the returned result explaining that the restore could not be undone
through checkpoint recovery.

**`hermes_cli/cli_commands_mixin.py`**: `_handle_rollback_command` now
prints `result["warning"]` when present instead of unconditionally
printing that a pre-rollback snapshot was saved.

**`tests/tools/test_checkpoint_manager.py`**: added
`test_excluded_dir_contents_not_counted` and
`test_non_excluded_files_still_counted` to `TestDirFileCount`, and
`test_restore_no_warning_when_pre_rollback_snapshot_succeeds` and
`test_restore_warns_when_pre_rollback_snapshot_fails` to `TestRestore`.

**`tests/cli/test_rollback_snapshot_warning.py`**: new file (no prior
test coverage existed for `_handle_rollback_command`). Covers the
normal-restore message and the warning path via a minimal stand-in host
object exposing only what the method touches.

---

## What is NOT changed
- The `_MAX_FILES` threshold value itself is untouched
- `git checkout`, `git commit-tree`, `git update-ref`, and the rest of
  the checkpoint store's git-backed storage are untouched
- `gateway/slash_commands.py` and `tui_gateway/server.py`, the other two
  callers of `restore()`, are untouched: the former does not make a
  false claim about the snapshot today, and the latter already forwards
  the full result dict, including the new `warning` key, without
  modification
- Credential pool, fallback, and provider-runtime code are untouched
- All existing checkpoint and CLI tests pass