### PR TITLE
fix(photon): hide sidecar console window on Windows

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -39,6 +39,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 if TYPE_CHECKING:
     # Type checkers see ``httpx`` as the always-imported module, so every use
     # site type-checks cleanly. The runtime fallback below keeps the optional
@@ -883,6 +885,7 @@ class PhotonAdapter(BasePlatformAdapter):
             stderr=subprocess.STDOUT,
             env=env,
             start_new_session=(sys.platform != "win32"),
+            creationflags=windows_hide_flags(),
         )
 
         # Pump sidecar stderr/stdout into our logger so users see crashes.


### PR DESCRIPTION
## Summary

The Photon platform adapter spawns a Node sidecar (`node.exe`) via `subprocess.Popen` but was missing `creationflags=windows_hide_flags()`. Every other subprocess spawn in the codebase uses this flag; the Photon adapter was the only one that missed it.

On Windows, when `pythonw.exe` (the gateway process) spawns `node.exe` without `CREATE_NO_WINDOW`, Windows allocates a new console for the child process. This console window appears visibly on the user's desktop, titled with the node binary path (e.g. `C:\Users\camer\.vite-plus\bin\node.EXE`).

## Fix

Two-line change in `plugins/platforms/photon/adapter.py`:

1. Import `windows_hide_flags` from `hermes_cli._subprocess_compat` (the same helper used by 20+ other call sites across the codebase).
2. Pass `creationflags=windows_hide_flags()` to the `subprocess.Popen` call at `_start_sidecar()`.

## Test Plan

- [ ] On Windows with Photon enabled, restart the gateway and confirm no visible `node.exe` console window appears on the desktop
- [ ] Confirm the Photon sidecar still starts and `/healthz` comes up normally
- [ ] Confirm iMessage send/receive still works through the sidecar