### PR TITLE
chore: release v0.18.0 (2026.7.1)

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.17.0",
+      "package": "hermes-agent[acp]==0.18.0",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.17.0"
-__release_date__ = "2026.6.19"
+__version__ = "0.18.0"
+__release_date__ = "2026.7.1"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.17.0"
+version = "0.18.0"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -41,6 +41,8 @@ IGNORED_PATTERNS = [
     re.compile(r"^Copilot$", re.IGNORECASE),
     re.compile(r"^Cursor(\s+Agent)?$", re.IGNORECASE),
     re.compile(r"^Codex$", re.IGNORECASE),
+    re.compile(r"^OpenAI Codex$", re.IGNORECASE),
+    re.compile(r"^CommandCode", re.IGNORECASE),
     re.compile(r"^github-advanced-security(\[bot\])?$", re.IGNORECASE),
     re.compile(r"^GitHub\s*Actions?$", re.IGNORECASE),
     re.compile(r"^github-actions(\[bot\])?$", re.IGNORECASE),
@@ -59,6 +61,8 @@ IGNORED_EMAILS = {
     "hermes-audit@example.com",
     "hermes@habibilabs.dev",
     "omx@oh-my-codex.dev",
+    "codex@openai.com",
+    "noreply@commandcode.ai",
 }
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1820,6 +1820,20 @@ AUTHOR_MAP = {
     "afnlegion01@gmail.com": "Afnath-max",  # PR #49129 salvage (opencode-zen catalog refresh + uncapped/live-first picker)
     "sharma.priyanshu96@gmail.com": "ipriyaaanshu",  # PR #51488 salvage (clear stale base_url on gateway model switches; #25107)
     "290881485+mrparker0980@users.noreply.github.com": "mrparker0980",  # @file context-ref expansion anchored to canonical read deny-list
+    # v0.18.0 additions
+    "3483421977@qq.com": "AetherAgents",  # direct email match
+    "SJWATTS89@OUTLOOK.COM": "lEWFkRAD",  # PR #45610 (Windows scheduled task reboot survival)
+    "andhika.prakasiwi@gmail.com": "p-andhika",  # PR #53312 co-author (setup guide button)
+    "annguyen@nousresearch.com": "annguyenNous",  # PR #52844 co-author
+    "carlitosdiazplaza@gmail.com": "talmax1124",  # direct email match
+    "christianpersico98@gmail.com": "chrispersico",  # commit 135f2351 PR author
+    "daniel.laforce@argobox.com": "KeyArgo",  # co-author
+    "joeykerp@gmail.com": "spjoes",  # direct email match
+    "keyargo@argobox.com": "KeyArgo",  # PR #45638 author
+    "lucas.nicolas@proton.me": "Lucas Nicolas",  # PR #54210 co-author (display name)
+    "max.petrusenko.agent@gmail.com": "maxpetrusenko",  # PR #54128 co-author
+    "poli.koltsova@gmail.com": "wnuuee1",  # commit 9fd2b2cb PR author
+    "yosapol@jitrak.dev": "Eji4h",  # direct email match
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1516,7 +1516,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Release v0.18.0 (CalVer v2026.7.1) — "The Judgment Release." Headline: **100% of the P0/P1 backlog across the entire repo is resolved** (~692 priority items), plus Mixture-of-Agents as a first-class selectable model, agent self-verification, `/learn` + `/journey`, scale-to-zero gateway, and Google Vertex AI.

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.17.0 → 0.18.0, `__release_date__` → 2026.7.1
- `pyproject.toml`: version → 0.18.0
- `acp_registry/agent.json`: version + uvx package pin → 0.18.0
- `uv.lock`: regenerated (hermes-agent 0.17.0 → 0.18.0)
- `scripts/release.py`: v0.18.0 AUTHOR_MAP additions
- `scripts/contributor_audit.py`: ignore OpenAI Codex + CommandCode bot identities

## Validation
- Anchored stale-version grep across the 3 version files: zero hits
- `uv lock --check`: clean after regen
- `verify_wheel_data_files.sh`: OK — 88 plugin.yaml manifests ship in the wheel
- Contributor audit: 374 contributors, 0 unknown emails, 0 missing from release notes
- P0/P1 open count at sweep completion: 0 issues / 0 PRs

## Infographic

![hermes-v0.18.0-mission-patch](https://v3b.fal.media/files/b/0aa08b2d/YiaAj8Bdfrw8hRSo89juS_Jk1mdWRM.png)
