### PR TITLE
fix(kanban): support governed workspace authorized-file globs

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -691,6 +693,400 @@ def test_complete_goal_mode_allows_when_judge_unavailable(monkeypatch, tmp_path)
         assert kb.get_task(conn2, goal_task_id).status == "done"
     finally:
         conn2.close()
+
+
+def _init_git_workspace(workspace: Path) -> str:
+    workspace.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=workspace, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.name", "Codex"], cwd=workspace, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "codex@example.com"], cwd=workspace, check=True, capture_output=True, text=True)
+    tracked = workspace / "apps" / "mission-control" / "src"
+    tracked.mkdir(parents=True, exist_ok=True)
+    (tracked / "tracked.ts").write_text("export const tracked = 1;\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=workspace, check=True, capture_output=True, text=True)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=workspace,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _create_attempt_workspace(tmp_path: Path, monkeypatch, *, authorized_file: str = "apps/mission-control/src/tracked.ts", absolute_authorized: bool = False):
+    workspace_root = tmp_path / "kanban"
+    workspace = workspace_root / "mc-attempt-worktrees" / "mc-task-1-attempt-1"
+    base_commit_sha = _init_git_workspace(workspace)
+    metadata_dir = workspace_root / ".mc-attempt-metadata"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    metadata_path = metadata_dir / "mc-task-1-attempt-1.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "taskId": "mc-task-1",
+                "attemptNumber": 1,
+                "branchName": "objective/test",
+                "baseCommitSha": base_commit_sha,
+                "canonicalPrefix": "apps/mission-control",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+    if absolute_authorized:
+        return workspace, str(workspace / "apps" / "mission-control" / "src" / "tracked.ts")
+    return workspace, authorized_file
+
+
+def _create_legacy_attempt_workspace(tmp_path: Path, monkeypatch):
+    workspace_root = tmp_path / "kanban"
+    workspace = workspace_root / "mc-attempt-worktrees" / "mc-task-1-attempt-1"
+    base_commit_sha = _init_git_workspace(workspace)
+    metadata_dir = workspace_root / ".mc-attempt-metadata"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    metadata_path = metadata_dir / "mc-task-1-attempt-1.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "taskId": "mc-task-1",
+                "attemptNumber": 1,
+                "branchName": "objective/test",
+                "baseSha": base_commit_sha,
+                "workspacePath": str(workspace),
+                "sourceRepoPath": str(workspace),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+    return workspace
+
+
+def _create_mc_execute_task(monkeypatch, tmp_path, *, body_suffix: str = "", authorized_file: str = "apps/mission-control/src/tracked.ts") -> str:
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "william")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="execute-task",
+            assignee="william",
+            body=(
+                "Task Type: execution\n"
+                "MC Task ID: mc-task-1\n"
+                "Authorized Files:\n"
+                f"- {authorized_file}\n"
+                f"{body_suffix}"
+            ),
+        )
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    return tid
+
+
+def test_complete_rejects_mc_execute_with_summary_only(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "william")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="execute-task",
+            assignee="william",
+            body="Task Type: execution\nMC Task ID: mc-task-1\n",
+        )
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"summary": "Implemented the change."})
+    assert "execution_result JSON" in json.loads(out)["error"]
+
+
+def test_complete_rejects_mc_execute_with_invalid_json_result(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "william")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="execute-task",
+            assignee="william",
+            body="Task Type: execution\nMC Task ID: mc-task-1\n",
+        )
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"summary": "Implemented the change.", "result": "not-json"})
+    assert "valid JSON" in json.loads(out)["error"]
+
+
+def test_complete_rejects_mc_execute_with_wrong_result_kind(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "william")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="execute-task",
+            assignee="william",
+            body="Task Type: execution\nMC Task ID: mc-task-1\n",
+        )
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": "{\"kind\":\"not_execution\"}",
+    })
+    assert "kind='execution_result'" in json.loads(out)["error"]
+
+
+def test_complete_accepts_mc_execute_with_structured_result(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    workspace, authorized_file = _create_attempt_workspace(tmp_path, monkeypatch)
+    tid = _create_mc_execute_task(monkeypatch, tmp_path, authorized_file=authorized_file)
+    (workspace / "apps" / "mission-control" / "src" / "tracked.ts").write_text(
+        "export const tracked = 2;\n",
+        encoding="utf-8",
+    )
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({
+            "kind": "execution_result",
+            "statusNote": "Implemented the change.",
+        }),
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        assert task.result
+        assert json.loads(task.result)["kind"] == "execution_result"
+    finally:
+        conn.close()
+
+
+def test_complete_accepts_mc_execute_with_absolute_authorized_path_and_committed_changes(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    workspace, authorized_file = _create_attempt_workspace(tmp_path, monkeypatch, absolute_authorized=True)
+    tid = _create_mc_execute_task(monkeypatch, tmp_path, authorized_file=authorized_file)
+    tracked = workspace / "apps" / "mission-control" / "src" / "tracked.ts"
+    tracked.write_text("export const tracked = 3;\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "commit", "-m", "update tracked"], cwd=workspace, check=True, capture_output=True, text=True)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({
+            "kind": "execution_result",
+            "statusNote": "Implemented the change.",
+        }),
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        assert task.result
+        assert json.loads(task.result)["kind"] == "execution_result"
+    finally:
+        conn.close()
+
+
+def test_complete_accepts_legacy_attempt_metadata_shape(monkeypatch, tmp_path):
+    workspace = _create_legacy_attempt_workspace(tmp_path, monkeypatch)
+    _create_mc_execute_task(monkeypatch, tmp_path)
+    (workspace / "apps" / "mission-control" / "src" / "tracked.ts").write_text(
+        "export const tracked = 4;\n",
+        encoding="utf-8",
+    )
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({
+            "kind": "execution_result",
+            "statusNote": "Implemented the change.",
+        }),
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+
+
+def test_complete_rejects_mc_execute_with_no_workspace_changes(monkeypatch, tmp_path):
+    _create_attempt_workspace(tmp_path, monkeypatch)
+    _create_mc_execute_task(monkeypatch, tmp_path)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({"kind": "execution_result"}),
+    })
+    assert "No changed files were found" in json.loads(out)["error"]
+
+
+def test_complete_rejects_mc_execute_with_out_of_scope_drift(monkeypatch, tmp_path):
+    workspace, _ = _create_attempt_workspace(tmp_path, monkeypatch)
+    _create_mc_execute_task(monkeypatch, tmp_path)
+    (workspace / "package-lock.json").write_text("{\"lockfileVersion\":3}\n", encoding="utf-8")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({"kind": "execution_result"}),
+    })
+    assert "out-of-scope file drift" in json.loads(out)["error"]
+    assert "package-lock.json" in json.loads(out)["error"]
+
+
+def test_complete_accepts_mc_execute_with_recursive_authorized_glob(monkeypatch, tmp_path):
+    workspace, _ = _create_attempt_workspace(tmp_path, monkeypatch)
+    _create_mc_execute_task(
+        monkeypatch,
+        tmp_path,
+        body_suffix="- apps/mission-control/src/components/objectives/**\n",
+    )
+    objectives_dir = workspace / "apps" / "mission-control" / "src" / "components" / "objectives"
+    objectives_dir.mkdir(parents=True, exist_ok=True)
+    (objectives_dir / "types.ts").write_text("export type ObjectiveId = string;\n", encoding="utf-8")
+    (objectives_dir / "cards" / "detail.tsx").parent.mkdir(parents=True, exist_ok=True)
+    (objectives_dir / "cards" / "detail.tsx").write_text("export const Detail = () => null;\n", encoding="utf-8")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({"kind": "execution_result"}),
+    })
+    assert json.loads(out)["ok"] is True
+
+
+def test_complete_rejects_mc_execute_for_sibling_path_outside_authorized_glob(monkeypatch, tmp_path):
+    workspace, _ = _create_attempt_workspace(tmp_path, monkeypatch)
+    _create_mc_execute_task(
+        monkeypatch,
+        tmp_path,
+        body_suffix="- apps/mission-control/src/components/objectives/**\n",
+    )
+    other_dir = workspace / "apps" / "mission-control" / "src" / "components" / "other"
+    other_dir.mkdir(parents=True, exist_ok=True)
+    (other_dir / "panel.tsx").write_text("export const Panel = () => null;\n", encoding="utf-8")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({"kind": "execution_result"}),
+    })
+    error = json.loads(out)["error"]
+    assert "out-of-scope file drift" in error
+    assert "apps/mission-control/src/components/other/panel.tsx" in error
+
+
+def test_complete_accepts_mc_execute_with_absolute_authorized_glob(monkeypatch, tmp_path):
+    workspace, _ = _create_attempt_workspace(tmp_path, monkeypatch)
+    absolute_glob = (
+        workspace
+        / "apps"
+        / "mission-control"
+        / "src"
+        / "components"
+        / "objectives"
+    )
+    _create_mc_execute_task(
+        monkeypatch,
+        tmp_path,
+        body_suffix=f"- {absolute_glob}/**\n",
+    )
+    objectives_dir = workspace / "apps" / "mission-control" / "src" / "components" / "objectives"
+    objectives_dir.mkdir(parents=True, exist_ok=True)
+    (objectives_dir / "status-buttons.tsx").write_text("export const Buttons = () => null;\n", encoding="utf-8")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({"kind": "execution_result"}),
+    })
+    assert json.loads(out)["ok"] is True
+
+
+def test_complete_rejects_mc_execute_without_authorized_files_scope(monkeypatch, tmp_path):
+    workspace, _ = _create_attempt_workspace(tmp_path, monkeypatch)
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "william")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="execute-task",
+            assignee="william",
+            body="Task Type: execution\nMC Task ID: mc-task-1\n",
+        )
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    (workspace / "apps" / "mission-control" / "src" / "tracked.ts").write_text(
+        "export const tracked = 5;\n",
+        encoding="utf-8",
+    )
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({
+        "summary": "Implemented the change.",
+        "result": json.dumps({"kind": "execution_result"}),
+    })
+    assert "Authorized Files" in json.loads(out)["error"]
 
 
 def test_block_happy_path(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,6 +31,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
+from fnmatch import fnmatchcase
+from pathlib import Path
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -130,6 +133,231 @@ def _stamp_worker_session_metadata(
     stamped = dict(metadata or {})
     stamped["worker_session_id"] = session_id
     return stamped
+
+
+def _split_git_output(stdout: str) -> list[str]:
+    return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+
+def _parse_authorized_files(body: str) -> list[str]:
+    lines = body.splitlines()
+    authorized: list[str] = []
+    collecting = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "Authorized Files:":
+            collecting = True
+            continue
+        if collecting:
+            if stripped.startswith("- "):
+                authorized.append(stripped[2:].strip())
+                continue
+            if stripped:
+                break
+    return authorized
+
+
+def _normalize_repo_relative_path(value: str) -> str:
+    normalized = value.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _derive_canonical_prefix(raw: dict[str, Any], workspace_root: Path) -> str | None:
+    canonical_prefix = raw.get("canonicalPrefix")
+    if isinstance(canonical_prefix, str) and canonical_prefix.strip():
+        return _normalize_repo_relative_path(canonical_prefix)
+
+    if (workspace_root / "apps" / "mission-control").is_dir():
+        return "apps/mission-control"
+
+    source_repo_path = raw.get("sourceRepoPath")
+    workspace_path = raw.get("workspacePath")
+    if not isinstance(source_repo_path, str) or not source_repo_path.strip():
+        return None
+    if not isinstance(workspace_path, str) or not workspace_path.strip():
+        return None
+
+    source_repo = Path(source_repo_path).expanduser().resolve()
+    workspace = Path(workspace_path).expanduser().resolve()
+    try:
+        relative_parts = workspace.relative_to(source_repo).parts
+    except ValueError:
+        return None
+
+    if not relative_parts:
+        return None
+    if relative_parts[0] == "apps" and len(relative_parts) >= 2:
+        return "/".join(relative_parts[:2])
+
+    return relative_parts[0]
+
+
+def _canonicalize_mc_scope_path(value: str, canonical_prefix: str) -> str:
+    normalized = _normalize_repo_relative_path(value)
+    if not normalized:
+        return ""
+    canonical_prefix = _normalize_repo_relative_path(canonical_prefix)
+    canonical_prefix_with_slash = f"{canonical_prefix}/"
+    embedded_index = normalized.rfind(canonical_prefix_with_slash)
+    if embedded_index >= 0:
+        return normalized[embedded_index:]
+    if normalized == canonical_prefix or normalized.startswith(canonical_prefix_with_slash):
+        return normalized
+    if normalized.startswith("apps/"):
+        return normalized
+    return f"{canonical_prefix}/{normalized}"
+
+
+def _scope_entry_has_wildcard(value: str) -> bool:
+    return any(token in value for token in ("*", "?", "["))
+
+
+def _matches_authorized_scope_path(changed_path: str, scope_entry: str) -> bool:
+    if not scope_entry:
+        return False
+    if not _scope_entry_has_wildcard(scope_entry):
+        return changed_path == scope_entry
+
+    if scope_entry.endswith("/**"):
+        prefix = scope_entry[:-3].rstrip("/")
+        return changed_path == prefix or changed_path.startswith(f"{prefix}/")
+
+    return fnmatchcase(changed_path, scope_entry)
+
+
+def _is_mc_changed_file_authorized(changed_path: str, authorized_files: set[str]) -> bool:
+    return any(_matches_authorized_scope_path(changed_path, scope_entry) for scope_entry in authorized_files)
+
+
+def _load_mc_attempt_workspace_metadata(workspace_root: Path) -> tuple[str, str]:
+    stem = workspace_root.name
+    worktree_parent = workspace_root.parent
+    metadata_dir = worktree_parent.parent / ".mc-attempt-metadata"
+    metadata_path = metadata_dir / f"{stem}.json"
+    try:
+        raw = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(
+            f"attempt workspace metadata could not be loaded from {metadata_path}: {exc}"
+        ) from exc
+
+    base_commit_sha = raw.get("baseCommitSha")
+    if not isinstance(base_commit_sha, str) or not base_commit_sha.strip():
+        base_commit_sha = raw.get("baseSha")
+    canonical_prefix = _derive_canonical_prefix(raw, workspace_root)
+    if not isinstance(base_commit_sha, str) or not base_commit_sha.strip():
+        raise RuntimeError(f"attempt workspace metadata at {metadata_path} is missing baseCommitSha")
+    if not isinstance(canonical_prefix, str) or not canonical_prefix.strip():
+        raise RuntimeError(f"attempt workspace metadata at {metadata_path} is missing canonicalPrefix")
+    return base_commit_sha.strip(), _normalize_repo_relative_path(canonical_prefix)
+
+
+def _governed_workspace_changed_files(workspace_root: Path, base_commit_sha: str) -> list[str]:
+    tracked = subprocess.run(
+        ["git", "diff", "--name-only", base_commit_sha, "--"],
+        cwd=str(workspace_root),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    tracked_created = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=A", base_commit_sha, "--"],
+        cwd=str(workspace_root),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=str(workspace_root),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    changed = {
+        _normalize_repo_relative_path(value)
+        for value in [
+            *_split_git_output(tracked.stdout),
+            *_split_git_output(tracked_created.stdout),
+            *_split_git_output(untracked.stdout),
+        ]
+        if _normalize_repo_relative_path(value)
+    }
+    return sorted(changed)
+
+
+def _validate_mc_execute_workspace_scope(body: str) -> str | None:
+    workspace_raw = os.environ.get("HERMES_KANBAN_WORKSPACE")
+    if not workspace_raw:
+        return (
+            "Mission Control execute tasks require HERMES_KANBAN_WORKSPACE so the "
+            "governed worktree can be validated. Block the task instead."
+        )
+    try:
+        workspace_root = Path(workspace_raw).expanduser().resolve()
+    except (OSError, ValueError):
+        return (
+            "Mission Control execute task workspace could not be resolved. "
+            "Block the task instead."
+        )
+    try:
+        base_commit_sha, canonical_prefix = _load_mc_attempt_workspace_metadata(workspace_root)
+        changed_files = _governed_workspace_changed_files(workspace_root, base_commit_sha)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        return (
+            "Mission Control execute task workspace validation failed: "
+            f"{stderr or exc}. Clean up the governed worktree or block the task instead."
+        )
+    except Exception as exc:
+        return (
+            "Mission Control execute task workspace validation failed: "
+            f"{exc}. Clean up the governed worktree or block the task instead."
+        )
+
+    if not changed_files:
+        return (
+            "Mission Control execute tasks must leave changed files in the governed "
+            "worktree since the attempt baseline before completion. No changed files were found under "
+            "$HERMES_KANBAN_WORKSPACE. Apply the change there or block the task instead."
+        )
+
+    authorized_files = {
+        _canonicalize_mc_scope_path(value, canonical_prefix)
+        for value in _parse_authorized_files(body)
+    }
+    if not authorized_files:
+        return (
+            "Mission Control execute task scope could not be validated because the card "
+            "body does not declare Authorized Files. Clean up or block the task instead."
+        )
+
+    out_of_prefix = [
+        value
+        for value in changed_files
+        if value != canonical_prefix and not value.startswith(f"{canonical_prefix}/")
+    ]
+    if out_of_prefix:
+        return (
+            "Mission Control execute task has out-of-scope file drift outside the canonical prefix "
+            f"{canonical_prefix}: {', '.join(out_of_prefix)}. Clean up those files or block the task instead."
+        )
+
+    out_of_scope = [
+        value for value in changed_files
+        if not _is_mc_changed_file_authorized(value, authorized_files)
+    ]
+    if out_of_scope:
+        return (
+            "Mission Control execute task has out-of-scope file drift in the governed "
+            f"worktree: {', '.join(out_of_scope)}. Clean up those files or block the task instead."
+        )
+    return None
 
 
 def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
@@ -598,6 +826,7 @@ def _handle_complete(args: dict, **kw) -> str:
             # Only enforce when a judge is actually reachable — see
             # _goal_judge_available for why an unavailable judge fails open.
             task = kb.get_task(conn, tid)
+            body = str(task.body or "") if task else ""
             if task and task.goal_mode and _goal_judge_available():
                 verdict = "done"
                 reason = ""
@@ -622,6 +851,32 @@ def _handle_complete(args: dict, **kw) -> str:
                         f"or (2) create continuation tasks with parents=[{tid}] "
                         f"and keep this task alive."
                     )
+
+            is_mc_execute = "Task Type: execution" in body and "MC Task ID:" in body
+            if is_mc_execute:
+                if not isinstance(result, str) or not result.strip():
+                    return tool_error(
+                        "Mission Control execute tasks must complete with "
+                        "result=<raw execution_result JSON>. "
+                        "Do not complete with summary only; resubmit with "
+                        "kind='execution_result' or block the task instead."
+                    )
+                try:
+                    parsed = json.loads(result)
+                except Exception:
+                    return tool_error(
+                        "Mission Control execute tasks must provide valid "
+                        "JSON in result. Expected an execution_result payload."
+                    )
+                if not isinstance(parsed, dict) or parsed.get("kind") != "execution_result":
+                    return tool_error(
+                        "Mission Control execute task result must be a JSON "
+                        "object with kind='execution_result'. Resubmit with "
+                        "raw execution_result JSON or block the task instead."
+                    )
+                workspace_scope_error = _validate_mc_execute_workspace_scope(body)
+                if workspace_scope_error:
+                    return tool_error(workspace_scope_error)
 
             try:
                 ok = kb.complete_task(


### PR DESCRIPTION
## Summary
- validate governed Mission Control execution tasks against changed files in the attempt workspace
- support exact authorized paths and recursive glob scopes like `/**`
- reject summary-only or non-`execution_result` completions for MC execute tasks

## Testing
- uv run --with pytest python -m pytest tests/tools/test_kanban_tools.py