### PR TITLE
fix(agent): persist provider cooldowns

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1461,8 +1461,20 @@ def restore_primary_runtime(agent) -> bool:
         agent._fallback_index = 0
         return False
 
-    if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
-        return False  # primary still in rate-limit cooldown, stay on fallback
+    from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+
+    primary_runtime = agent._primary_runtime or {}
+    primary_provider = (primary_runtime.get("provider") or "").strip().lower()
+    primary_key = primary_runtime.get("api_key")
+    manager = get_cooldown_manager()
+    if (
+        getattr(agent, "_rate_limited_until", 0) > time.monotonic()
+        or manager.is_cooling(primary_provider)
+        or manager.is_cooling(
+            build_cooldown_key(primary_provider, primary_key, "rate_limit")
+        )
+    ):
+        return False  # primary still on cooldown, stay on fallback
 
     # ── Reset-aware gate ──
     # The 60s ``_rate_limited_until`` cooldown covers transient rate limits,
@@ -1702,7 +1714,6 @@ def restore_primary_runtime(agent) -> bool:
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
         agent._fallback_index = 0
-        agent._rate_limit_backoff_count = 0  # reset exponential backoff counter
 
         # Reset the stale-call circuit breaker (#58962): the streak measured
         # the FALLBACK provider we're leaving; the restored primary deserves

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1115,10 +1115,18 @@ def restore_primary_runtime(agent) -> bool:
     # leaves _fallback_index >= len(_fallback_chain) while _fallback_activated stays False. The next turn
     # skips this block entirely, stranding the index and silently blocking all future fallback attempts for
     # the session. Fixes #20465.
-    if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
-        return False  # primary still in rate-limit cooldown, stay on fallback
     rt = agent._primary_runtime
     primary_provider = str((rt or {}).get("provider") or "").strip().lower()
+    from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+
+    manager = get_cooldown_manager()
+    if (
+        manager.is_cooling(primary_provider)
+        or manager.is_cooling(
+            build_cooldown_key(primary_provider, (rt or {}).get("api_key"), "rate_limit")
+        )
+    ):
+        return False  # primary still on cooldown, stay on fallback
     primary_model = str((rt or {}).get("model") or "").strip()
     from agent.fallback_cooldown import _is_entitlement_rejected
     if primary_model and _is_entitlement_rejected(agent, primary_provider, primary_model):
@@ -1176,7 +1184,6 @@ def restore_primary_runtime(agent) -> bool:
             agent.reasoning_config = dict(saved_reasoning)
         agent._fallback_activated = False
         agent._fallback_index = 0
-        agent._rate_limit_backoff_count = 0
         # Reset the stale-call circuit breaker: its streak measured the fallback provider.
         from agent.chat_completion_helpers import _reset_stale_streak, rewrite_prompt_model_identity
         _reset_stale_streak(agent)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1712,24 +1712,22 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         current_provider = (getattr(agent, "provider", "") or "").strip().lower()
         primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
         if (not fallback_already_active) or (primary_provider and current_provider == primary_provider):
-            # Exponential backoff: keep upstream's 60s first-hit cooldown and
-            # escalate on CONSECUTIVE rate-limits: 60s → 2m → 4m → 8m → ... →
-            # 4h cap. The first 429 must NOT bench the primary for half an
-            # hour — fast primary restore is the common case; escalation only
-            # punishes providers that keep 429ing.
-            # Counter is reset by restore_primary_runtime on successful restore.
-            backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
-            agent._rate_limit_backoff_count = backoff_count + 1
-            backoff_seconds = min(60 * (2 ** backoff_count), 14400)
-            agent._rate_limited_until = time.monotonic() + backoff_seconds
-            logging.info(
-                "Rate-limit backoff level %d: cooldown %d s (%.1f min, backoff#%d)",
-                backoff_count, backoff_seconds, backoff_seconds / 60, backoff_count + 1,
+            from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+
+            active_key = getattr(agent, "api_key", None)
+            if active_key is None:
+                active_key = getattr(agent, "_api_key", None)
+            reason_text = reason.value if hasattr(reason, "value") else str(reason)
+            cooldown_key = build_cooldown_key(current_provider, active_key, reason_text)
+            cooldown_seconds = get_cooldown_manager().mark_failure(
+                cooldown_key,
+                "billing" if reason == FailoverReason.billing else "rate_limit",
             )
+            # Retain the process-local timestamp for legacy callers/tests;
+            # restore decisions use the durable manager above.
+            agent._rate_limited_until = time.monotonic() + cooldown_seconds
     if agent._fallback_index >= len(agent._fallback_chain):
-        # Chain exhausted.  If we actually walked a non-empty chain and the
-        # failure was NOT a rate-limit/billing event (those already armed
-        # their own 60s cooldown above), arm a short cooldown so the next
+        # If a non-rate-limit chain exhausts, arm a short cooldown so the next
         # turn's restore_primary_runtime stays gated instead of resetting
         # _fallback_index=0 and re-marshaling the whole context across every
         # provider again.  Guards the cross-turn replay storm in #24996.
@@ -1737,11 +1735,24 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             len(agent._fallback_chain) > 0
             and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
         ):
-            _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0
-            agent._rate_limited_until = max(
-                _existing_cooldown,
-                time.monotonic() + _FALLBACK_EXHAUSTED_COOLDOWN_S,
-            )
+            from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+
+            primary_runtime = agent._primary_runtime or {}
+            # The live key belongs to the final fallback by now, and the
+            # primary snapshot may itself be stale after pool rotation.
+            primary_provider = (primary_runtime.get("provider") or "").strip().lower()
+            # Exhaustion is independent of any one credential. A credential
+            # pool can rotate between this failure and next-turn restoration,
+            # so a provider gate remains durable while a snapshot fingerprint
+            # can become stale.
+            cooldown_key = build_cooldown_key(primary_provider, None, "rate_limit")
+            manager = get_cooldown_manager()
+            if not manager.is_cooling(cooldown_key):
+                manager.mark_failure(
+                    cooldown_key,
+                    "rate_limit",
+                    cooldown_seconds=_FALLBACK_EXHAUSTED_COOLDOWN_S,
+                )
         return False
     fb = agent._fallback_chain[agent._fallback_index]
     agent._fallback_index += 1

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1718,8 +1718,18 @@ def _fallback_chain_exhausted(agent, reason: "FailoverReason | None") -> bool:
     context across every provider again."""
     from agent.fallback_cooldown import _RATE_LIMIT_FAILOVER_REASONS
     if agent._fallback_chain and reason not in _RATE_LIMIT_FAILOVER_REASONS:
-        agent._rate_limited_until = max(
-            getattr(agent, "_rate_limited_until", 0) or 0, time.monotonic() + _FALLBACK_EXHAUSTED_COOLDOWN_S)
+        from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+
+        primary_runtime = agent._primary_runtime or {}
+        primary_provider = (primary_runtime.get("provider") or "").strip().lower()
+        cooldown_key = build_cooldown_key(primary_provider, None, "rate_limit")
+        manager = get_cooldown_manager()
+        if not manager.is_cooling(cooldown_key):
+            manager.mark_failure(
+                cooldown_key,
+                "rate_limit",
+                cooldown_seconds=_FALLBACK_EXHAUSTED_COOLDOWN_S,
+            )
     return False
 
 
@@ -1911,8 +1921,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 f"⚠️ Model fallback: {old_model} via {old_provider} unavailable "
                 f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}.")
             if cooldown_seconds is not None:
-                remaining = max(0, math.ceil(agent._rate_limited_until - time.monotonic()))
-                notice += f" Primary retry eligible in ~{remaining} s; recovery is not guaranteed."
+                notice += f" Primary retry eligible in ~{math.ceil(cooldown_seconds)} s; recovery is not guaranteed."
             _buffer_fallback_notice(agent, notice)
             # ``_fallback_activated`` is also reused by `/model --once` restoration; separate
             # provenance so the restore path only emits a recovery notice after a real fallback.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3444,6 +3444,35 @@ def run_conversation(
                         )
                 
                 _retry.has_retried_429 = False  # Reset on success
+                # A validated response from the original primary proves its
+                # previous rate-limit/billing state recovered. A fallback
+                # response must not clear the primary's persisted history.
+                primary_runtime = getattr(agent, "_primary_runtime", None) or {}
+                primary_provider = (primary_runtime.get("provider") or "").strip().lower()
+                current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+                if (
+                    primary_provider
+                    and current_provider == primary_provider
+                    and not agent._fallback_activated
+                ):
+                    try:
+                        from agent.cooldown_manager import (
+                            build_cooldown_key,
+                            get_cooldown_manager,
+                        )
+
+                        successful_key = getattr(
+                            agent, "api_key", primary_runtime.get("api_key")
+                        )
+                        manager = get_cooldown_manager()
+                        manager.clear(primary_provider)  # provider-scoped billing
+                        manager.clear(
+                            build_cooldown_key(
+                                primary_provider, successful_key, "rate_limit"
+                            )
+                        )
+                    except Exception:
+                        logger.debug("Failed to clear recovered primary cooldown", exc_info=True)
                 # Note: don't clear the retry buffer here — an "API call
                 # success" only means we got bytes back, not that we got
                 # usable content. Empty responses still loop through the

--- a/agent/cooldown_manager.py
+++ b/agent/cooldown_manager.py
@@ -1,0 +1,257 @@
+"""Persistent cooldown tracking for provider failover."""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import contextmanager
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterator, Literal, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _CooldownState:
+    count: int = 0
+    until: float = 0.0
+    reason: str = "rate_limit"
+
+
+def build_cooldown_key(provider: str, api_key: Any, reason: str) -> str:
+    """Build a provider- or provider/key-scoped cooldown key without exposing keys.
+
+    Credential sources may be callbacks or opaque objects.  They are not stable
+    credentials, so never invoke, stringify, or hash them; use provider scope.
+    """
+    provider = (provider or "").strip().lower()
+    if reason == "billing" or not isinstance(api_key, str) or not api_key:
+        return provider
+    fingerprint = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+    return f"{provider}:{fingerprint}"
+
+
+_PERSISTABLE_PROVIDER_SCOPES = frozenset({
+    "ai-gateway", "alibaba", "anthropic", "arcee", "azure-foundry", "bedrock",
+    "copilot", "copilot-acp", "deepseek", "fireworks", "gemini", "gmi",
+    "huggingface", "kilocode", "kimi-coding", "kimi-coding-cn", "lmstudio",
+    "minimax", "minimax-cn", "minimax-oauth", "moa", "nous", "novita",
+    "nvidia", "ollama-cloud", "opencode-go", "opencode-zen", "openai",
+    "openai-api", "openai-codex", "openrouter", "qwen-oauth", "stepfun",
+    "tencent-tokenhub", "vertex", "xai", "xai-oauth", "xiaomi", "zai",
+})
+
+
+def _is_persistable_provider_scope(provider: str) -> bool:
+    """Allow known provider identifiers and configured custom-provider scopes."""
+    return provider in _PERSISTABLE_PROVIDER_SCOPES or provider == "custom" or provider.startswith("custom:")
+
+
+def _is_safe_persisted_key(key: str) -> bool:
+    if not isinstance(key, str):
+        return False
+    provider, separator, fingerprint = key.rpartition(":")
+    if not separator:
+        return _is_persistable_provider_scope(key)
+    return _is_persistable_provider_scope(provider) and len(fingerprint) == 16 and all(
+        char in "0123456789abcdef" for char in fingerprint
+    )
+
+
+class CooldownManager:
+    """Thread-safe cooldown tracker backed by an atomic JSON file."""
+
+    def __init__(
+        self,
+        base_seconds: float = 60.0,
+        multiplier: float = 5.0,
+        max_seconds: float = 3600.0,
+        billing_base_hours: float = 5.0,
+        billing_max_hours: float = 24.0,
+        storage_path: Union[Path, None, Literal[False]] = None,
+    ) -> None:
+        self._base_seconds = base_seconds
+        self._multiplier = multiplier
+        self._max_seconds = max_seconds
+        self._billing_base_hours = billing_base_hours
+        self._billing_max_hours = billing_max_hours
+        self._states: Dict[str, _CooldownState] = {}
+        self._lock = threading.Lock()
+        if storage_path is False:
+            self._storage_path: Optional[Path] = None
+        elif storage_path is None:
+            try:
+                from hermes_constants import get_hermes_home
+                self._storage_path = get_hermes_home() / "cooldowns.json"
+            except Exception:
+                self._storage_path = None
+        else:
+            self._storage_path = Path(storage_path)
+        with self._storage_lock():
+            self._load(persist_discarded=False)
+            self._persist()
+
+    @contextmanager
+    def _storage_lock(self) -> Iterator[None]:
+        """Serialize read-modify-write cycles across Hermes processes."""
+        if self._storage_path is None:
+            yield
+            return
+        lock_path = self._storage_path.with_name(f"{self._storage_path.name}.lock")
+        deadline = time.monotonic() + 10.0
+        while True:
+            try:
+                descriptor = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            except FileExistsError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(f"Timed out waiting for cooldown lock: {lock_path}")
+                time.sleep(0.01)
+            else:
+                break
+        try:
+            yield
+        finally:
+            os.close(descriptor)
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def is_cooling(self, key: str) -> bool:
+        with self._storage_lock():
+            self._load(persist_discarded=False)
+            with self._lock:
+                state = self._states.get(key)
+            return state is not None and time.monotonic() < state.until
+
+    def mark_failure(
+        self,
+        key: str,
+        reason: Literal["rate_limit", "billing"],
+        cooldown_seconds: Optional[float] = None,
+    ) -> float:
+        # Read, calculate, and atomically publish while holding a cross-process
+        # lock so separate Hermes processes preserve each other's cooldowns.
+        with self._storage_lock():
+            self._load(persist_discarded=False)
+            with self._lock:
+                state = self._states.setdefault(key, _CooldownState())
+                if cooldown_seconds is None:
+                    state.count += 1
+                state.reason = reason
+                if cooldown_seconds is not None:
+                    cooldown_seconds = max(0.0, cooldown_seconds)
+                elif reason == "billing":
+                    cooldown_seconds = min(
+                        self._billing_base_hours * (2 ** (state.count - 1)),
+                        self._billing_max_hours,
+                    ) * 3600.0
+                else:
+                    cooldown_seconds = min(
+                        self._base_seconds * (self._multiplier ** (state.count - 1)),
+                        self._max_seconds,
+                    )
+                state.until = time.monotonic() + cooldown_seconds
+                count = state.count
+            self._persist()
+        logger.info("Cooldown: key=%r reason=%s count=%d duration=%.0fs", key, reason, count, cooldown_seconds)
+        return cooldown_seconds
+
+    def clear(self, key: str) -> None:
+        with self._storage_lock():
+            self._load(persist_discarded=False)
+            with self._lock:
+                self._states.pop(key, None)
+            self._persist()
+
+    def get_all_states(self) -> Dict[str, dict]:
+        now = time.monotonic()
+        with self._lock:
+            return {
+                key: {
+                    "count": state.count,
+                    "until": state.until,
+                    "cooling": now < state.until,
+                    "remaining_seconds": max(0.0, state.until - now),
+                }
+                for key, state in self._states.items()
+            }
+
+    def get_cooldown_status(self) -> dict:
+        states = self.get_all_states()
+        return {
+            "total_tracked": len(states),
+            "cooling": [key for key, state in states.items() if state["cooling"]],
+            "expired": [key for key, state in states.items() if not state["cooling"] and state["count"] > 0],
+            "details": states,
+        }
+
+    def _load(self, *, persist_discarded: bool = True) -> None:
+        if self._storage_path is None or not self._storage_path.exists():
+            return
+        try:
+            data = json.loads(self._storage_path.read_text(encoding="utf-8"))
+            now_wall, now_mono = time.time(), time.monotonic()
+            discarded_unsafe = False
+            loaded_states: Dict[str, _CooldownState] = {}
+            for key, entry in data.items():
+                    if not _is_safe_persisted_key(key):
+                        discarded_unsafe = True
+                        continue
+                    remaining = float(entry.get("until_wall", 0)) - now_wall
+                    if remaining > 0:
+                        loaded_states[key] = _CooldownState(
+                            count=int(entry.get("count", 1)),
+                            until=now_mono + remaining,
+                            reason=str(entry.get("reason", "rate_limit")),
+                        )
+            with self._lock:
+                self._states = loaded_states
+            if discarded_unsafe and persist_discarded:
+                self._persist()
+        except Exception as exc:
+            logger.warning("Failed to load cooldown state from %s: %s", self._storage_path, exc)
+
+    def _persist(self) -> None:
+        if self._storage_path is None:
+            return
+        try:
+            now_mono, now_wall = time.monotonic(), time.time()
+            with self._lock:
+                data = {
+                    key: {"reason": state.reason, "count": state.count, "until_wall": now_wall + remaining}
+                    for key, state in self._states.items()
+                    if _is_safe_persisted_key(key) and (remaining := state.until - now_mono) > 0
+                }
+            self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self._storage_path.with_name(
+                f"{self._storage_path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+            )
+            tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            os.replace(tmp_path, self._storage_path)
+        except Exception as exc:
+            logger.warning("Failed to persist cooldown state to %s: %s", self._storage_path, exc)
+
+
+_singleton: Optional[CooldownManager] = None
+_singleton_lock = threading.Lock()
+
+
+def get_cooldown_manager() -> CooldownManager:
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = CooldownManager()
+    return _singleton
+
+
+def set_cooldown_manager(manager: CooldownManager) -> None:
+    global _singleton
+    with _singleton_lock:
+        _singleton = manager

--- a/agent/cooldown_manager.py
+++ b/agent/cooldown_manager.py
@@ -1,0 +1,312 @@
+"""Persistent cooldown tracking for provider failover."""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import contextmanager
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterator, Literal, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _CooldownState:
+    count: int = 0
+    until: float = 0.0
+    reason: str = "rate_limit"
+    last_failure_wall: float = 0.0
+
+
+def build_cooldown_key(provider: str, api_key: Any, reason: str) -> str:
+    """Build a provider- or provider/key-scoped cooldown key without exposing keys.
+
+    Credential sources may be callbacks or opaque objects.  They are not stable
+    credentials, so never invoke, stringify, or hash them; use provider scope.
+    """
+    provider = (provider or "").strip().lower()
+    if reason == "billing" or not isinstance(api_key, str) or not api_key:
+        return provider
+    fingerprint = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+    return f"{provider}:{fingerprint}"
+
+
+_PERSISTABLE_PROVIDER_SCOPES = frozenset({
+    "ai-gateway", "alibaba", "anthropic", "arcee", "azure-foundry", "bedrock",
+    "copilot", "copilot-acp", "deepseek", "fireworks", "gemini", "gmi",
+    "huggingface", "kilocode", "kimi-coding", "kimi-coding-cn", "lmstudio",
+    "minimax", "minimax-cn", "minimax-oauth", "moa", "nous", "novita",
+    "nvidia", "ollama-cloud", "opencode-go", "opencode-zen", "openai",
+    "openai-api", "openai-codex", "openrouter", "qwen-oauth", "stepfun",
+    "tencent-tokenhub", "vertex", "xai", "xai-oauth", "xiaomi", "zai",
+})
+
+
+def _is_persistable_provider_scope(provider: str) -> bool:
+    """Allow known provider identifiers and configured custom-provider scopes."""
+    return provider in _PERSISTABLE_PROVIDER_SCOPES or provider == "custom" or provider.startswith("custom:")
+
+
+def _is_safe_persisted_key(key: str) -> bool:
+    if not isinstance(key, str):
+        return False
+    provider, separator, fingerprint = key.rpartition(":")
+    if not separator:
+        return _is_persistable_provider_scope(key)
+    return _is_persistable_provider_scope(provider) and len(fingerprint) == 16 and all(
+        char in "0123456789abcdef" for char in fingerprint
+    )
+
+
+class CooldownManager:
+    """Thread-safe cooldown tracker backed by an atomic JSON file.
+
+    Failure streaks survive cooldown expiry for seven days; active deadlines do not reset them.
+    """
+
+    _HISTORY_RETENTION_SECONDS = 7 * 24 * 60 * 60
+
+    def __init__(
+        self,
+        base_seconds: float = 60.0,
+        multiplier: float = 5.0,
+        max_seconds: float = 3600.0,
+        billing_base_hours: float = 5.0,
+        billing_max_hours: float = 24.0,
+        storage_path: Union[Path, None, Literal[False]] = None,
+    ) -> None:
+        self._base_seconds = base_seconds
+        self._multiplier = multiplier
+        self._max_seconds = max_seconds
+        self._billing_base_hours = billing_base_hours
+        self._billing_max_hours = billing_max_hours
+        self._states: Dict[str, _CooldownState] = {}
+        self._lock = threading.Lock()
+        if storage_path is False:
+            self._storage_path: Optional[Path] = None
+        elif storage_path is None:
+            try:
+                from hermes_constants import get_hermes_home
+                self._storage_path = get_hermes_home() / "cooldowns.json"
+            except Exception:
+                self._storage_path = None
+        else:
+            self._storage_path = Path(storage_path)
+        with self._storage_lock():
+            self._load(persist_discarded=False)
+            self._persist()
+
+    @contextmanager
+    def _storage_lock(self) -> Iterator[None]:
+        """Serialize read-modify-write cycles across Hermes processes."""
+        if self._storage_path is None:
+            yield
+            return
+        lock_path = self._storage_path.with_name(f"{self._storage_path.name}.lock")
+        deadline = time.monotonic() + 10.0
+        while True:
+            try:
+                descriptor = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            except FileExistsError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(f"Timed out waiting for cooldown lock: {lock_path}")
+                time.sleep(0.01)
+            else:
+                break
+        try:
+            yield
+        finally:
+            os.close(descriptor)
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def is_cooling(self, key: str) -> bool:
+        with self._storage_lock():
+            self._load(persist_discarded=False)
+            with self._lock:
+                state = self._states.get(key)
+            return state is not None and time.monotonic() < state.until
+
+    def mark_failure(
+        self,
+        key: str,
+        reason: Literal["rate_limit", "billing"],
+        cooldown_seconds: Optional[float] = None,
+    ) -> float:
+        # Read, calculate, and atomically publish while holding a cross-process
+        # lock so separate Hermes processes preserve each other's cooldowns.
+        with self._storage_lock():
+            self._load(persist_discarded=False)
+            with self._lock:
+                state = self._states.setdefault(key, _CooldownState())
+                if cooldown_seconds is None:
+                    state.count += 1
+                    state.last_failure_wall = time.time()
+                state.reason = reason
+                if cooldown_seconds is not None:
+                    cooldown_seconds = max(0.0, cooldown_seconds)
+                elif reason == "billing":
+                    cooldown_seconds = min(
+                        self._billing_base_hours * (2 ** (state.count - 1)),
+                        self._billing_max_hours,
+                    ) * 3600.0
+                else:
+                    cooldown_seconds = min(
+                        self._base_seconds * (self._multiplier ** (state.count - 1)),
+                        self._max_seconds,
+                    )
+                state.until = time.monotonic() + cooldown_seconds
+                count = state.count
+            self._persist()
+        logger.info("Cooldown: key=%r reason=%s count=%d duration=%.0fs", key, reason, count, cooldown_seconds)
+        return cooldown_seconds
+
+    def clear(self, key: str) -> None:
+        with self._storage_lock():
+            self._load(persist_discarded=False)
+            with self._lock:
+                self._states.pop(key, None)
+            self._persist()
+
+    def get_all_states(self) -> Dict[str, dict]:
+        now = time.monotonic()
+        with self._lock:
+            return {
+                key: {
+                    "count": state.count,
+                    "until": state.until,
+                    "cooling": now < state.until,
+                    "remaining_seconds": max(0.0, state.until - now),
+                }
+                for key, state in self._states.items()
+            }
+
+    def get_cooldown_status(self) -> dict:
+        states = self.get_all_states()
+        return {
+            "total_tracked": len(states),
+            "cooling": [key for key, state in states.items() if state["cooling"]],
+            "expired": [key for key, state in states.items() if not state["cooling"] and state["count"] > 0],
+            "details": states,
+        }
+
+    def _load(self, *, persist_discarded: bool = True) -> None:
+        if self._storage_path is None or not self._storage_path.exists():
+            return
+        try:
+            data = json.loads(self._storage_path.read_text(encoding="utf-8"))
+            now_wall, now_mono = time.time(), time.monotonic()
+            discarded = False
+            loaded_states: Dict[str, _CooldownState] = {}
+            if data.get("version") == 2:
+                failures = data.get("failures", {})
+                cooldowns = data.get("cooldowns", {})
+            else:
+                failures = data
+                cooldowns = data
+            if not isinstance(failures, dict) or not isinstance(cooldowns, dict):
+                raise ValueError("cooldown state must contain mappings")
+            for key in set(failures) | set(cooldowns):
+                history = failures.get(key, {})
+                if not _is_safe_persisted_key(key) or not isinstance(history, dict):
+                    discarded = True
+                    continue
+                try:
+                    count = int(history.get("count", 0))
+                    last_failure_wall = float(history.get("last_failure_wall", history.get("until_wall", 0)))
+                except (TypeError, ValueError):
+                    discarded = True
+                    continue
+                if count < 0 or (count and now_wall - last_failure_wall > self._HISTORY_RETENTION_SECONDS):
+                    discarded = True
+                    continue
+                deadline = cooldowns.get(key, {})
+                if not isinstance(deadline, dict):
+                    discarded = True
+                    deadline = {}
+                try:
+                    remaining = max(0.0, float(deadline.get("until_wall", 0)) - now_wall)
+                except (TypeError, ValueError):
+                    discarded = True
+                    remaining = 0.0
+                loaded_states[key] = _CooldownState(
+                    count=count,
+                    until=now_mono + remaining,
+                    reason=str(history.get("reason", "rate_limit")),
+                    last_failure_wall=last_failure_wall,
+                )
+            with self._lock:
+                self._states = loaded_states
+            if discarded and persist_discarded:
+                self._persist()
+        except Exception as exc:
+            logger.warning("Failed to load cooldown state from %s: %s", self._storage_path, exc)
+
+    def _persist(self) -> None:
+        if self._storage_path is None:
+            return
+        try:
+            now_mono, now_wall = time.monotonic(), time.time()
+            with self._lock:
+                history = {
+                    key: state
+                    for key, state in self._states.items()
+                    if _is_safe_persisted_key(key)
+                    and state.count > 0
+                    and now_wall - state.last_failure_wall <= self._HISTORY_RETENTION_SECONDS
+                }
+                active = {
+                    key: state
+                    for key, state in self._states.items()
+                    if _is_safe_persisted_key(key) and state.until > now_mono
+                }
+                data = {
+                    "version": 2,
+                    "failures": {
+                        key: {
+                            "reason": state.reason,
+                            "count": state.count,
+                            "last_failure_wall": state.last_failure_wall,
+                        }
+                        for key, state in history.items()
+                    },
+                    "cooldowns": {
+                        key: {"until_wall": now_wall + (state.until - now_mono)}
+                        for key, state in active.items()
+                    },
+                }
+            self._storage_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self._storage_path.with_name(
+                f"{self._storage_path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+            )
+            tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            os.replace(tmp_path, self._storage_path)
+        except Exception as exc:
+            logger.warning("Failed to persist cooldown state to %s: %s", self._storage_path, exc)
+
+
+_singleton: Optional[CooldownManager] = None
+_singleton_lock = threading.Lock()
+
+
+def get_cooldown_manager() -> CooldownManager:
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = CooldownManager()
+    return _singleton
+
+
+def set_cooldown_manager(manager: CooldownManager) -> None:
+    global _singleton
+    with _singleton_lock:
+        _singleton = manager

--- a/agent/fallback_cooldown.py
+++ b/agent/fallback_cooldown.py
@@ -1,7 +1,7 @@
 """Primary rate-limit cooldown arming and per-session model rejection markers, shared by the
 fallback walk (chat_completion_helpers) and restore_primary_runtime (agent_runtime_helpers)."""
 import logging
-import time
+
 
 from agent.error_classifier import FailoverReason
 
@@ -11,22 +11,25 @@ _RATE_LIMIT_FAILOVER_REASONS = frozenset({FailoverReason.rate_limit, FailoverRea
 
 
 def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> int | None:
-    """Arm the primary's exponential cooldown (60s → 2m → ... → 4h cap) on CONSECUTIVE rate-limits;
-    restore_primary_runtime resets the counter. Only when leaving the primary: chain-switching from
-    an active fallback means the primary was not the 429 source, so its cooldown is left alone.
-    Return the armed cooldown in seconds, or None when no cooldown was armed."""
+    """Persist a primary cooldown when leaving it for rate-limit or billing failover."""
     if reason not in _RATE_LIMIT_FAILOVER_REASONS:
         return None
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
     if getattr(agent, "_fallback_activated", False) and not (primary_provider and current_provider == primary_provider):
         return None
-    backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
-    agent._rate_limit_backoff_count = backoff_count + 1
-    backoff_seconds = min(60 * (2 ** backoff_count), 14400)
-    agent._rate_limited_until = time.monotonic() + backoff_seconds
-    logging.info("Rate-limit backoff level %d: cooldown %d s (%.1f min, backoff#%d)", backoff_count, backoff_seconds, backoff_seconds / 60, backoff_count + 1)
-    return backoff_seconds
+    from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+
+    active_key = getattr(agent, "api_key", None)
+    if active_key is None:
+        active_key = getattr(agent, "_api_key", None)
+    reason_text = reason.value if hasattr(reason, "value") else str(reason)
+    cooldown_key = build_cooldown_key(current_provider, active_key, reason_text)
+    cooldown_seconds = get_cooldown_manager().mark_failure(
+        cooldown_key,
+        "billing" if reason == FailoverReason.billing else "rate_limit",
+    )
+    return cooldown_seconds
 
 
 # Codex ChatGPT-account entitlement 400 — the account can never use the named slug, so with

--- a/agent/turn_response_check.py
+++ b/agent/turn_response_check.py
@@ -193,6 +193,26 @@ def check_api_response(
         _last_preflight_pressure = None
 
     _retry.has_retried_429 = False
+    # A validated response from the original primary proves its previous
+    # rate-limit/billing state recovered. A fallback response must not clear
+    # the primary's persisted history.
+    primary_runtime = getattr(agent, "_primary_runtime", None) or {}
+    primary_provider = (primary_runtime.get("provider") or "").strip().lower()
+    current_provider = (getattr(agent, "provider", "") or "").strip().lower()
+    if (
+        primary_provider
+        and current_provider == primary_provider
+        and not agent._fallback_activated
+    ):
+        try:
+            from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+
+            successful_key = getattr(agent, "api_key", primary_runtime.get("api_key"))
+            manager = get_cooldown_manager()
+            manager.clear(primary_provider)  # provider-scoped billing
+            manager.clear(build_cooldown_key(primary_provider, successful_key, "rate_limit"))
+        except Exception:
+            logger.debug("Failed to clear recovered primary cooldown", exc_info=True)
     # Clearing Nous rate-limit state proves the limit reset so other sessions may resume.
     if agent.provider == "nous":
         try:

--- a/evals/provider_fallback/probe_104120.py
+++ b/evals/provider_fallback/probe_104120.py
@@ -98,6 +98,7 @@ server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 threading.Thread(target=server.serve_forever, daemon=True).start()
 url = f"http://127.0.0.1:{server.server_port}/v1"
 from run_agent import AIAgent
+from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
 from agent.error_classifier import classify_api_error
 from agent.agent_runtime_helpers import restore_primary_runtime
 
@@ -148,18 +149,21 @@ for label, model, chain in [
             break
         except Exception as exc:
             classified = classify_api_error(exc)
-            before = getattr(agent, "_rate_limited_until", 0)
-            before_count = getattr(agent, "_rate_limit_backoff_count", 0)
+            primary = agent._primary_runtime or {}
+            cooldown_key = build_cooldown_key(
+                primary.get("provider", ""), primary.get("api_key"), "rate_limit"
+            )
+            before = get_cooldown_manager().get_all_states().get(cooldown_key, {})
             switched = agent._try_activate_fallback(classified.reason)
-            after = getattr(agent, "_rate_limited_until", 0)
+            after = get_cooldown_manager().get_all_states().get(cooldown_key, {})
             transitions.append({
                 "reason": str(classified.reason),
                 "switched": switched,
-                "before_deadline": before,
-                "after_deadline": after,
-                "remaining_seconds": max(0, after - time.monotonic()),
-                "backoff_before": before_count,
-                "backoff_after": getattr(agent, "_rate_limit_backoff_count", 0),
+                "before_deadline": before.get("until", 0),
+                "after_deadline": after.get("until", 0),
+                "remaining_seconds": after.get("remaining_seconds", 0),
+                "backoff_before": before.get("count", 0),
+                "backoff_after": after.get("count", 0),
                 "notice": getattr(agent, "_pending_fallback_notice", [])[:],
                 "active_model": agent.model,
             })

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -477,9 +477,15 @@ class GatewayConfigLoadersMixin:
         if agent is None:
             return
         new_chain = list(chain or [])
-        rate_limited_until = getattr(agent, "_rate_limited_until", 0) or 0
-        if getattr(agent, "_fallback_activated", False) and rate_limited_until > time.monotonic():
-            return
+        if getattr(agent, "_fallback_activated", False):
+            runtime = getattr(agent, "_primary_runtime", None) or {}
+            provider = str(runtime.get("provider") or "").strip().lower()
+            from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+            manager = get_cooldown_manager()
+            if manager.is_cooling(provider) or manager.is_cooling(
+                build_cooldown_key(provider, runtime.get("api_key"), "rate_limit")
+            ):
+                return
         old_chain = list(getattr(agent, "_fallback_chain", []) or [])
         agent._fallback_chain = new_chain
         agent._fallback_model = new_chain[0] if new_chain else None

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -497,7 +497,11 @@ class CLIModelSwitchMixin:
             try:
                 agent._primary_runtime = copy.deepcopy(primary)
                 agent._fallback_activated = True
-                agent._rate_limited_until = 0
+                from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+                provider = str(primary.get("provider") or "").strip().lower()
+                manager = get_cooldown_manager()
+                manager.clear(provider)
+                manager.clear(build_cooldown_key(provider, primary.get("api_key"), "rate_limit"))
                 if agent._restore_primary_runtime():
                     return
             except Exception:

--- a/tests/agent/test_cooldown_manager.py
+++ b/tests/agent/test_cooldown_manager.py
@@ -1,0 +1,176 @@
+"""Regression coverage for persistent provider cooldowns."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import time
+
+from agent.cooldown_manager import CooldownManager, build_cooldown_key
+
+
+def _record_concurrent_failure(storage_path: str, key: str, barrier) -> None:
+    manager = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    barrier.wait()
+    manager.mark_failure(key, "rate_limit")
+
+
+def test_rate_limit_cooldown_escalates_and_persists_without_raw_api_key(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    manager = CooldownManager(
+        base_seconds=10.0,
+        multiplier=2.0,
+        max_seconds=100.0,
+        storage_path=storage_path,
+    )
+    key = build_cooldown_key("OpenAI", "«redacted:sk-…»", "rate_limit")
+
+    assert key == build_cooldown_key("openai", "«redacted:sk-…»", "rate_limit")
+    assert manager.mark_failure(key, "rate_limit") == 10.0
+    assert manager.mark_failure(key, "rate_limit") == 20.0
+    assert manager.is_cooling(key)
+
+    persisted = json.loads(storage_path.read_text(encoding="utf-8"))
+    assert "«redacted:sk-…»" not in json.dumps(persisted)
+    reloaded = CooldownManager(storage_path=storage_path)
+    assert reloaded.is_cooling(key)
+
+
+def test_stale_managers_preserve_and_escalate_persisted_cooldowns(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    first = CooldownManager(
+        base_seconds=10.0,
+        multiplier=2.0,
+        storage_path=storage_path,
+    )
+    # Construct this manager before the first write to model another process.
+    second = CooldownManager(
+        base_seconds=10.0,
+        multiplier=2.0,
+        storage_path=storage_path,
+    )
+    primary_key = build_cooldown_key("openai", "first-secret", "rate_limit")
+    other_key = build_cooldown_key("anthropic", "second-secret", "rate_limit")
+
+    assert first.mark_failure(primary_key, "rate_limit") == 10.0
+    assert second.mark_failure(primary_key, "rate_limit") == 20.0
+    assert second.mark_failure(other_key, "rate_limit") == 10.0
+
+    reloaded = CooldownManager(storage_path=storage_path)
+    assert reloaded.get_all_states()[primary_key]["count"] == 2
+    assert reloaded.is_cooling(other_key)
+
+
+def test_separate_processes_preserve_each_others_cooldowns(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    context = multiprocessing.get_context("spawn")
+    barrier = context.Barrier(2)
+    keys = (
+        build_cooldown_key("openai", "first-secret", "rate_limit"),
+        build_cooldown_key("anthropic", "second-secret", "rate_limit"),
+    )
+    processes = [
+        context.Process(target=_record_concurrent_failure, args=(str(storage_path), key, barrier))
+        for key in keys
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    states = CooldownManager(storage_path=storage_path).get_all_states()
+    assert set(states) == set(keys)
+
+
+def test_running_manager_observes_external_write_and_clear(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    reader = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    writer = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    key = build_cooldown_key("openai", "secret", "rate_limit")
+
+    writer.mark_failure(key, "rate_limit")
+    assert reader.is_cooling(key)
+    writer.clear(key)
+    assert not reader.is_cooling(key)
+
+
+def test_stale_manager_does_not_resurrect_externally_cleared_cooldown(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    first = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    second = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    cleared_key = build_cooldown_key("openai", "first-secret", "rate_limit")
+    other_key = build_cooldown_key("anthropic", "second-secret", "rate_limit")
+
+    first.mark_failure(cleared_key, "rate_limit")
+    second.clear(cleared_key)
+    first.mark_failure(other_key, "rate_limit")
+
+    assert set(CooldownManager(storage_path=storage_path).get_all_states()) == {other_key}
+
+
+def test_billing_key_is_provider_scoped_and_clear_resets_backoff(tmp_path):
+    manager = CooldownManager(
+        base_seconds=10.0,
+        multiplier=2.0,
+        billing_base_hours=1.0,
+        storage_path=tmp_path / "cooldowns.json",
+    )
+    key = build_cooldown_key("anthropic", "sk-private", "billing")
+
+    assert key == "anthropic"
+    assert manager.mark_failure(key, "billing") == 3600.0
+    manager.clear(key)
+    assert manager.mark_failure(key, "rate_limit") == 10.0
+
+
+def test_expired_persisted_cooldown_is_discarded(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    storage_path.write_text(
+        json.dumps({"openai:0123456789abcdef": {
+            "count": 1, "reason": "rate_limit", "until_wall": time.time() - 1,
+        }}),
+        encoding="utf-8",
+    )
+
+    manager = CooldownManager(storage_path=storage_path)
+    assert manager.get_all_states() == {}
+
+
+def test_callable_credential_uses_provider_scope_without_invoking_or_serializing_it(tmp_path):
+    class CredentialSource:
+        def __call__(self):
+            raise AssertionError("cooldown tracking must not invoke credential sources")
+
+        def __str__(self):
+            raise AssertionError("cooldown tracking must not serialize credential sources")
+
+    credential = CredentialSource()
+    key = build_cooldown_key("OpenAI", credential, "rate_limit")
+
+    assert key == "openai"
+    manager = CooldownManager(storage_path=tmp_path / "cooldowns.json")
+    manager.mark_failure(key, "rate_limit")
+    assert "CredentialSource" not in (tmp_path / "cooldowns.json").read_text(encoding="utf-8")
+
+
+def test_load_discards_unknown_colonless_keys_but_keeps_provider_and_fingerprint_keys(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    future = time.time() + 60
+    storage_path.write_text(
+        json.dumps({
+            "raw-unknown-secret": {"count": 1, "reason": "rate_limit", "until_wall": future},
+            "openai": {"count": 1, "reason": "billing", "until_wall": future},
+            "openai:0123456789abcdef": {"count": 1, "reason": "rate_limit", "until_wall": future},
+        }),
+        encoding="utf-8",
+    )
+
+    manager = CooldownManager(storage_path=storage_path)
+
+    assert "raw-unknown-secret" not in manager.get_all_states()
+    assert manager.is_cooling("openai")
+    assert manager.is_cooling("openai:0123456789abcdef")
+    persisted = json.loads(storage_path.read_text(encoding="utf-8"))
+    assert "raw-unknown-secret" not in persisted

--- a/tests/agent/test_cooldown_manager.py
+++ b/tests/agent/test_cooldown_manager.py
@@ -1,0 +1,199 @@
+"""Regression coverage for persistent provider cooldowns."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import time
+
+from agent.cooldown_manager import CooldownManager, build_cooldown_key
+
+
+def _record_concurrent_failure(storage_path: str, key: str, barrier) -> None:
+    manager = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    barrier.wait()
+    manager.mark_failure(key, "rate_limit")
+
+
+def test_rate_limit_cooldown_escalates_and_persists_without_raw_api_key(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    manager = CooldownManager(
+        base_seconds=10.0,
+        multiplier=2.0,
+        max_seconds=100.0,
+        storage_path=storage_path,
+    )
+    key = build_cooldown_key("OpenAI", "«redacted:sk-…»", "rate_limit")
+
+    assert key == build_cooldown_key("openai", "«redacted:sk-…»", "rate_limit")
+    assert manager.mark_failure(key, "rate_limit") == 10.0
+    assert manager.mark_failure(key, "rate_limit") == 20.0
+    assert manager.is_cooling(key)
+
+    persisted = json.loads(storage_path.read_text(encoding="utf-8"))
+    assert "«redacted:sk-…»" not in json.dumps(persisted)
+    reloaded = CooldownManager(storage_path=storage_path)
+    assert reloaded.is_cooling(key)
+
+
+def test_stale_managers_preserve_and_escalate_persisted_cooldowns(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    first = CooldownManager(
+        base_seconds=10.0,
+        multiplier=2.0,
+        storage_path=storage_path,
+    )
+    # Construct this manager before the first write to model another process.
+    second = CooldownManager(
+        base_seconds=10.0,
+        multiplier=2.0,
+        storage_path=storage_path,
+    )
+    primary_key = build_cooldown_key("openai", "first-secret", "rate_limit")
+    other_key = build_cooldown_key("anthropic", "second-secret", "rate_limit")
+
+    assert first.mark_failure(primary_key, "rate_limit") == 10.0
+    assert second.mark_failure(primary_key, "rate_limit") == 20.0
+    assert second.mark_failure(other_key, "rate_limit") == 10.0
+
+    reloaded = CooldownManager(storage_path=storage_path)
+    assert reloaded.get_all_states()[primary_key]["count"] == 2
+    assert reloaded.is_cooling(other_key)
+
+
+def test_separate_processes_preserve_each_others_cooldowns(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    context = multiprocessing.get_context("spawn")
+    barrier = context.Barrier(2)
+    keys = (
+        build_cooldown_key("openai", "first-secret", "rate_limit"),
+        build_cooldown_key("anthropic", "second-secret", "rate_limit"),
+    )
+    processes = [
+        context.Process(target=_record_concurrent_failure, args=(str(storage_path), key, barrier))
+        for key in keys
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    states = CooldownManager(storage_path=storage_path).get_all_states()
+    assert set(states) == set(keys)
+
+
+def test_running_manager_observes_external_write_and_clear(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    reader = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    writer = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    key = build_cooldown_key("openai", "secret", "rate_limit")
+
+    writer.mark_failure(key, "rate_limit")
+    assert reader.is_cooling(key)
+    writer.clear(key)
+    assert not reader.is_cooling(key)
+
+
+def test_stale_manager_does_not_resurrect_externally_cleared_cooldown(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    first = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    second = CooldownManager(base_seconds=10.0, storage_path=storage_path)
+    cleared_key = build_cooldown_key("openai", "first-secret", "rate_limit")
+    other_key = build_cooldown_key("anthropic", "second-secret", "rate_limit")
+
+    first.mark_failure(cleared_key, "rate_limit")
+    second.clear(cleared_key)
+    first.mark_failure(other_key, "rate_limit")
+
+    assert set(CooldownManager(storage_path=storage_path).get_all_states()) == {other_key}
+
+
+def test_billing_key_is_provider_scoped_and_clear_resets_backoff(tmp_path):
+    manager = CooldownManager(
+        base_seconds=10.0,
+        multiplier=2.0,
+        billing_base_hours=1.0,
+        storage_path=tmp_path / "cooldowns.json",
+    )
+    key = build_cooldown_key("anthropic", "sk-private", "billing")
+
+    assert key == "anthropic"
+    assert manager.mark_failure(key, "billing") == 3600.0
+    manager.clear(key)
+    assert manager.mark_failure(key, "rate_limit") == 10.0
+
+
+def test_expired_cooldown_keeps_recent_failure_history(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    storage_path.write_text(
+        json.dumps({"openai:0123456789abcdef": {
+            "count": 1, "reason": "rate_limit", "until_wall": time.time() - 1,
+        }}),
+        encoding="utf-8",
+    )
+
+    manager = CooldownManager(storage_path=storage_path)
+    state = manager.get_all_states()["openai:0123456789abcdef"]
+    assert state["count"] == 1
+    assert state["cooling"] is False
+
+
+def test_real_failure_after_expiry_escalates_and_persists_across_restart(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    key = build_cooldown_key("openai", "secret", "rate_limit")
+    manager = CooldownManager(
+        base_seconds=0.0,
+        multiplier=2.0,
+        storage_path=storage_path,
+    )
+
+    assert manager.mark_failure(key, "rate_limit") == 0.0
+    assert not manager.is_cooling(key)
+    assert CooldownManager(base_seconds=10.0, multiplier=2.0, storage_path=storage_path).mark_failure(
+        key, "rate_limit"
+    ) == 20.0
+
+    persisted = json.loads(storage_path.read_text(encoding="utf-8"))
+    assert persisted["version"] == 2
+    assert persisted["failures"][key]["count"] == 2
+    assert key in persisted["cooldowns"]
+
+
+def test_callable_credential_uses_provider_scope_without_invoking_or_serializing_it(tmp_path):
+    class CredentialSource:
+        def __call__(self):
+            raise AssertionError("cooldown tracking must not invoke credential sources")
+
+        def __str__(self):
+            raise AssertionError("cooldown tracking must not serialize credential sources")
+
+    credential = CredentialSource()
+    key = build_cooldown_key("OpenAI", credential, "rate_limit")
+
+    assert key == "openai"
+    manager = CooldownManager(storage_path=tmp_path / "cooldowns.json")
+    manager.mark_failure(key, "rate_limit")
+    assert "CredentialSource" not in (tmp_path / "cooldowns.json").read_text(encoding="utf-8")
+
+
+def test_load_discards_unknown_colonless_keys_but_keeps_provider_and_fingerprint_keys(tmp_path):
+    storage_path = tmp_path / "cooldowns.json"
+    future = time.time() + 60
+    storage_path.write_text(
+        json.dumps({
+            "raw-unknown-secret": {"count": 1, "reason": "rate_limit", "until_wall": future},
+            "openai": {"count": 1, "reason": "billing", "until_wall": future},
+            "openai:0123456789abcdef": {"count": 1, "reason": "rate_limit", "until_wall": future},
+        }),
+        encoding="utf-8",
+    )
+
+    manager = CooldownManager(storage_path=storage_path)
+
+    assert "raw-unknown-secret" not in manager.get_all_states()
+    assert manager.is_cooling("openai")
+    assert manager.is_cooling("openai:0123456789abcdef")
+    persisted = json.loads(storage_path.read_text(encoding="utf-8"))
+    assert "raw-unknown-secret" not in persisted

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -419,7 +419,6 @@ class TestPerProviderReasoningEcho:
         agent = object.__new__(AIAgent)
         agent._reasoning_echo_flag = True  # primary had opt-in
         agent._fallback_activated = True
-        agent._rate_limited_until = 0
         agent._primary_runtime = {
             "model": "glm-5.2",
             "provider": "custom",

--- a/tests/agent/test_restore_primary_pool_reselect.py
+++ b/tests/agent/test_restore_primary_pool_reselect.py
@@ -77,7 +77,6 @@ class TestRestorePrimaryPoolReselect:
         agent._credential_pool = pool
         agent._fallback_activated = True
         agent._fallback_index = 1
-        agent._rate_limited_until = 0
         agent._use_prompt_caching = False
         agent._use_native_cache_layout = False
         agent.context_compressor = MagicMock()

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -11,7 +11,6 @@ full Feishu session path.
 
 from __future__ import annotations
 
-import time
 from types import SimpleNamespace
 
 
@@ -48,8 +47,11 @@ def test_refresh_fallback_model_rereads_config(tmp_path, monkeypatch):
     assert runner._fallback_model == updated
 
 
-def test_apply_fallback_chain_skips_while_cooldown_holds_fallback():
+def test_apply_fallback_chain_skips_while_persisted_cooldown_holds_fallback(tmp_path):
     """Do not clobber a live fallback activation during its cooldown window."""
+    from agent.cooldown_manager import (
+        CooldownManager, build_cooldown_key, get_cooldown_manager, set_cooldown_manager,
+    )
     from gateway.run import GatewayRunner
 
     live = [{"provider": "deepseek", "model": "deepseek-v4-flash"}]
@@ -58,12 +60,20 @@ def test_apply_fallback_chain_skips_while_cooldown_holds_fallback():
         _fallback_model=live[0],
         _fallback_index=1,
         _fallback_activated=True,
-        _rate_limited_until=time.monotonic() + 30,
+        _primary_runtime={"provider": "custom", "api_key": "primary-key"},
     )
-    GatewayRunner._apply_fallback_chain_to_agent(
-        agent,
-        [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}],
-    )
+    original = get_cooldown_manager()
+    key = build_cooldown_key("custom", "primary-key", "rate_limit")
+    try:
+        manager = CooldownManager(storage_path=tmp_path / "cooldowns.json")
+        manager.mark_failure(key, "rate_limit", cooldown_seconds=30)
+        set_cooldown_manager(CooldownManager(storage_path=tmp_path / "cooldowns.json"))
+        GatewayRunner._apply_fallback_chain_to_agent(
+            agent,
+            [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"}],
+        )
+    finally:
+        set_cooldown_manager(original)
 
     assert agent._fallback_chain == live
     assert agent._fallback_index == 1

--- a/tests/hermes_cli/test_cli_model_once.py
+++ b/tests/hermes_cli/test_cli_model_once.py
@@ -120,7 +120,6 @@ def test_cli_restore_model_runtime_prefers_primary_runtime():
 
     class Agent(_FakeAgent):
         _primary_runtime = None
-        _rate_limited_until = 123
 
         def __init__(self):
             super().__init__()
@@ -134,6 +133,14 @@ def test_cli_restore_model_runtime_prefers_primary_runtime():
 
     stub = _StubCLI()
     stub.agent = Agent()
+    from agent.cooldown_manager import (
+        CooldownManager, build_cooldown_key, get_cooldown_manager, set_cooldown_manager,
+    )
+    original = get_cooldown_manager()
+    manager = CooldownManager(storage_path=False)
+    key = build_cooldown_key("openrouter", "sk-old", "rate_limit")
+    manager.mark_failure(key, "rate_limit", cooldown_seconds=60)
+    set_cooldown_manager(manager)
     snapshot = {
         "model": "old/model",
         "provider": "openrouter",
@@ -146,11 +153,16 @@ def test_cli_restore_model_runtime_prefers_primary_runtime():
         "agent_primary_runtime": {
             "model": "old/model",
             "provider": "openrouter",
+            "api_key": "sk-old",
         },
     }
 
-    cli_mod.HermesCLI._restore_model_runtime_snapshot(stub, snapshot)
+    try:
+        cli_mod.HermesCLI._restore_model_runtime_snapshot(stub, snapshot)
+    finally:
+        set_cooldown_manager(original)
 
     assert stub.agent.model == "old/model"
     assert stub.agent.provider == "openrouter"
+    assert not manager.is_cooling(key)
     assert stub.agent.calls == []

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -1,27 +1,21 @@
-"""Regression tests for #24996 — fallback-switch storm on host memory.
+"""Regression tests for fallback exhaustion cooldowns."""
 
-When every provider in the fallback chain fails non-retryably back-to-back
-(e.g. HTTP 400/402/429 across distinct providers), the within-turn walk is
-bounded (``_fallback_index`` advances monotonically and the loop aborts when
-the chain exhausts).  The damaging mode is *cross-turn*: ``restore_primary_
-runtime`` resets ``_fallback_index = 0`` every turn, so a client that
-re-submits immediately replays the entire chain — re-marshaling the full
-(potentially 80k-token) context once per provider every turn — with no
-throttle on the non-rate-limit path.
-
-The fix arms a short cooldown via the existing ``_rate_limited_until`` gate
-when the chain exhausts on a non-rate-limit failure, so the next turn's
-restore stays gated (and does NOT reset the index) until the cooldown clears.
-Rate-limit / billing failures keep their own 60s cooldown and are unaffected.
-"""
-
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
 from agent.chat_completion_helpers import _FALLBACK_EXHAUSTED_COOLDOWN_S
+from agent.cooldown_manager import (
+    CooldownManager,
+    build_cooldown_key,
+    set_cooldown_manager,
+)
 
 
-def _make_agent(fallback_model=None):
+def _make_agent(fallback_model=None, provider="openrouter"):
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -30,6 +24,7 @@ def _make_agent(fallback_model=None):
         agent = AIAgent(
             api_key="test-key",
             base_url="https://openrouter.ai/api/v1",
+            provider=provider,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -46,187 +41,213 @@ def _mock_client(base_url="https://openrouter.ai/api/v1", api_key="fb-key"):
     return mock
 
 
+def _mock_response(content="ok", finish_reason="stop"):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+class _RateLimitError(Exception):
+    status_code = 429
+
+    def __init__(self):
+        super().__init__("Error code: 429 - rate limit exceeded")
+        self.response = SimpleNamespace(headers={})
+        self.body = {"error": {"message": "rate limit exceeded"}}
+
+
+def _fresh_mgr():
+    mgr = CooldownManager(storage_path=False)
+    set_cooldown_manager(mgr)
+    return mgr
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cooldown_manager():
+    """Do not leak an in-memory cooldown into unrelated agent tests."""
+    from agent.cooldown_manager import get_cooldown_manager
+
+    original = get_cooldown_manager()
+    try:
+        yield
+    finally:
+        set_cooldown_manager(original)
+
+
 class TestExhaustionArmsCooldown:
     def test_non_retryable_exhaustion_arms_cooldown(self):
-        """Walking a non-empty chain to exhaustion on a non-rate-limit
-        failure arms a short ``_rate_limited_until`` cooldown.
-
-        ``time.monotonic`` is frozen inside ``chat_completion_helpers`` so the
-        cooldown math is exact and independent of CI scheduling latency — the
-        previous wall-clock upper bound (``before + window + 1.0``) flaked on
-        loaded runners when the three activation calls took longer than 1s.
-        """
+        """Non-rate-limit exhaustion should arm a cooldown."""
+        mgr = _fresh_mgr()
         fbs = [
             {"provider": "openai", "model": "gpt-4o"},
             {"provider": "zai", "model": "glm-4.7"},
         ]
         agent = _make_agent(fallback_model=fbs)
-        agent._rate_limited_until = 0
-        frozen = 1_000.0
         with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(_mock_client(), "resolved")),
         ):
             assert agent._try_activate_fallback() is True   # -> entry 0
             assert agent._try_activate_fallback() is True   # -> entry 1
-            # Chain now exhausted; a non-rate-limit failure must arm cooldown.
             assert agent._try_activate_fallback() is False
-            cooldown = getattr(agent, "_rate_limited_until", 0)
-        # Cooldown is exactly the short exhaustion window past the frozen clock,
-        # not the 60s rate-limit one.
-        assert cooldown == frozen + _FALLBACK_EXHAUSTED_COOLDOWN_S
 
-    def test_no_chain_does_not_arm_cooldown(self):
-        """An empty chain (no fallback configured) must not arm a cooldown —
-        there is no chain to storm, and gating primary restoration would be
-        pointless punishment."""
-        agent = _make_agent(fallback_model=None)
-        agent._rate_limited_until = 0
-        assert agent._try_activate_fallback() is False
-        assert getattr(agent, "_rate_limited_until", 0) == 0
+        status = mgr.get_cooldown_status()
+        assert len(status["cooling"]) >= 1
 
-    def test_rate_limit_exhaustion_keeps_60s_cooldown(self):
-        """A rate-limit failure already arms its own 60s cooldown; the short
-        exhaustion window must not shrink it."""
-        fbs = [{"provider": "openai", "model": "gpt-4o"}]
-        agent = _make_agent(fallback_model=fbs)
-        agent._rate_limited_until = 0
-        frozen = 1_000.0
-        with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
-        ):
-            # First activation with rate_limit reason arms the 60s cooldown.
-            assert agent._try_activate_fallback(reason=FailoverReason.rate_limit) is True
-            # Chain exhausted on the next call (also rate_limit) -> still False,
-            # and the 60s cooldown must survive (max(), not overwritten down).
-            assert agent._try_activate_fallback(reason=FailoverReason.rate_limit) is False
-            cooldown = getattr(agent, "_rate_limited_until", 0)
-        # ~60s past the frozen clock, far past the short exhaustion window.
-        assert cooldown == frozen + 60
+    def test_exhaustion_uses_provider_gate_after_primary_credential_rotates(self):
+        """A stale primary snapshot must not bypass the exhaustion gate."""
+        mgr = _fresh_mgr()
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_client(api_key="fallback-key"), "resolved")):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_key == "fallback-key"
+            assert agent._try_activate_fallback() is False
 
-    def test_cooldown_never_shrinks_existing_window(self):
-        """If a longer cooldown is already armed, exhaustion must not reduce
-        it (we take the max)."""
-        fbs = [{"provider": "openai", "model": "gpt-4o"}]
-        agent = _make_agent(fallback_model=fbs)
-        frozen = 1_000.0
-        far_future = frozen + 999
-        agent._rate_limited_until = far_future
-        with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
-        ):
+        provider_key = agent._primary_runtime["provider"]
+        assert mgr.is_cooling(provider_key)
+        # A credential pool may rotate the primary between exhaustion and the
+        # next restore. The provider-scoped exhaustion gate must survive that
+        # stale snapshot change.
+        agent._primary_runtime["api_key"] = "rotated-primary-key"
+        assert agent._restore_primary_runtime() is False
+
+    def test_callable_primary_credential_does_not_break_exhaustion_cooldown(self):
+        class CredentialSource:
+            def __call__(self):
+                raise AssertionError("fallback cooldown must not invoke credentials")
+
+            def __str__(self):
+                raise AssertionError("fallback cooldown must not serialize credentials")
+
+        mgr = _fresh_mgr()
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        agent._primary_runtime["api_key"] = CredentialSource()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_client(), "resolved")):
             assert agent._try_activate_fallback() is True
             assert agent._try_activate_fallback() is False
-            cooldown = getattr(agent, "_rate_limited_until", 0)
-        assert cooldown == far_future
 
+        assert mgr.is_cooling(agent._primary_runtime["provider"])
+        assert agent._restore_primary_runtime() is False
 
-class TestRateLimitBackoffEscalation:
-    """Exponential backoff for consecutive rate-limit failures (#29702).
+    def test_no_chain_does_not_arm_cooldown(self):
+        """An empty chain (no fallback configured) must not arm a cooldown."""
+        mgr = _fresh_mgr()
+        agent = _make_agent(fallback_model=None)
+        assert agent._try_activate_fallback() is False
+        status = mgr.get_cooldown_status()
+        assert status["cooling"] == []
 
-    The first rate-limit keeps the historical 60s cooldown; each consecutive
-    rate-limit within one degradation window doubles it (60 → 120 → 240 → ...)
-    capped at 4h (14400s).  A successful primary restore resets the counter.
-    """
-
-    @staticmethod
-    def _back_on_primary(agent, snapshot):
-        """Simulate the primary provider rate-limiting again on a later turn
-        (without a successful restore, which would reset the counter): put
-        the agent's identity back on the primary and reset the turn-scoped
-        fallback chain state."""
-        agent.provider, agent.model, agent.base_url = snapshot
-        agent._fallback_activated = False
-        agent._fallback_index = 0
-
-    def test_backoff_doubles_per_consecutive_rate_limit(self):
-        """Each consecutive primary rate-limit doubles the cooldown:
-        60s, then 120s, then 240s."""
+    def test_rate_limit_exhaustion_arms_cooldown(self):
+        """A rate-limit failure arms an exponential cooldown via CooldownManager."""
+        mgr = _fresh_mgr()
         fbs = [{"provider": "openai", "model": "gpt-4o"}]
         agent = _make_agent(fallback_model=fbs)
-        agent._rate_limited_until = 0
-        snapshot = (agent.provider, agent.model, agent.base_url)
-        frozen = 1_000.0
         with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(_mock_client(), "resolved")),
         ):
-            expected = [60, 120, 240]
-            for n, want in enumerate(expected):
-                self._back_on_primary(agent, snapshot)
-                agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-                assert agent._rate_limited_until == frozen + want, (
-                    f"backoff #{n + 1}: expected {want}s cooldown"
-                )
-                assert agent._rate_limit_backoff_count == n + 1
+            assert agent._try_activate_fallback(reason=FailoverReason.rate_limit) is True
+            assert agent._try_activate_fallback(reason=FailoverReason.rate_limit) is False
 
-    def test_backoff_caps_at_four_hours(self):
-        """Escalation is capped at 14400s (4h) no matter how many
-        consecutive rate-limits occurred."""
-        fbs = [{"provider": "openai", "model": "gpt-4o"}]
-        agent = _make_agent(fallback_model=fbs)
-        agent._rate_limited_until = 0
-        # 60 * 2**10 = 61440s, far past the cap.
-        agent._rate_limit_backoff_count = 10
-        frozen = 1_000.0
+        status = mgr.get_cooldown_status()
+        assert len(status["cooling"]) >= 1
+
+    def test_cooldown_armed_only_once_for_same_provider(self):
+        """Chain-switching while already on fallback must not re-arm cooldown
+        for the primary provider."""
+        mgr = _fresh_mgr()
+        fbs = [
+            {"provider": "openrouter", "model": "model-a"},
+            {"provider": "anthropic", "model": "model-b"},
+        ]
+        agent = _make_agent(fallback_model=fbs, provider="custom")
         with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(_mock_client(), "resolved")),
         ):
             agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-        assert agent._rate_limited_until == frozen + 14400
+            first_cooling = set(mgr.get_cooldown_status()["cooling"])
 
-    def test_backoff_counter_resets_on_successful_primary_restore(self):
-        """A successful restore_primary_runtime resets the backoff counter,
-        so the next rate-limit starts back at the 60s base."""
-        fbs = [{"provider": "openai", "model": "gpt-4o"}]
-        agent = _make_agent(fallback_model=fbs)
-        snapshot = (agent.provider, agent.model, agent.base_url)
-        frozen = 1_000.0
+            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
+            second_cooling = set(mgr.get_cooldown_status()["cooling"])
+
+        assert first_cooling == second_cooling
+
+
+class TestPrimaryCooldownClearOnValidatedSuccess:
+    def test_primary_success_path_clears_escalated_cooldown_and_resets_delay(self):
+        mgr = _fresh_mgr()
+        agent = _make_agent()
+        primary_key = build_cooldown_key(
+            agent._primary_runtime["provider"],
+            agent._primary_runtime["api_key"],
+            "rate_limit",
+        )
+
+        first_delay = mgr.mark_failure(primary_key, "rate_limit")
+        second_delay = mgr.mark_failure(primary_key, "rate_limit")
+        assert second_delay > first_delay
+        assert mgr.get_all_states()[primary_key]["count"] == 2
+
+        agent._interruptible_api_call = lambda api_kwargs: _mock_response("primary recovered")
+
         with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "primary recovered"
+        assert primary_key not in mgr.get_all_states()
+
+        reset_delay = mgr.mark_failure(primary_key, "rate_limit")
+        assert reset_delay == first_delay
+        assert mgr.get_all_states()[primary_key]["count"] == 1
+
+    def test_fallback_success_does_not_clear_primary_cooldown_history(self):
+        mgr = _fresh_mgr()
+        agent = _make_agent(
+            fallback_model=[{"provider": "openrouter", "model": "gpt-4o"}],
+        )
+        primary_key = build_cooldown_key(
+            agent._primary_runtime["provider"],
+            agent._primary_runtime["api_key"],
+            "rate_limit",
+        )
+
+        first_delay = mgr.mark_failure(primary_key, "rate_limit")
+        second_delay = mgr.mark_failure(primary_key, "rate_limit")
+        mgr.mark_failure(agent._primary_runtime["provider"], "billing")
+        assert second_delay > first_delay
+        assert mgr.get_all_states()[primary_key]["count"] == 2
+        assert mgr.get_all_states()[agent._primary_runtime["provider"]]["count"] == 1
+
+        def _fake_api_call(api_kwargs):
+            if not agent._fallback_activated:
+                raise _RateLimitError()
+            return _mock_response("fallback recovered")
+
+        agent._interruptible_api_call = _fake_api_call
+
+        with (
             patch(
                 "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
+                return_value=(_mock_client(api_key="fallback-key"), "gpt-4o"),
             ),
+            patch("run_agent.time.sleep", return_value=None),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
         ):
-            # Two consecutive rate-limits escalate the counter to 2.
-            agent._rate_limited_until = 0
-            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-            self._back_on_primary(agent, snapshot)
-            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-            assert agent._rate_limit_backoff_count == 2
+            result = agent.run_conversation("hello")
 
-        # Cooldown expired; the primary restores successfully.
-        agent._fallback_activated = True
-        agent._rate_limited_until = 0
-        assert agent._restore_primary_runtime() is True
-        assert agent._rate_limit_backoff_count == 0
+        assert result["completed"] is True
+        assert result["final_response"] == "fallback recovered"
+        assert mgr.get_all_states()[primary_key]["count"] == 3
+        assert mgr.get_all_states()[agent._primary_runtime["provider"]]["count"] == 1
 
-        # The next rate-limit is treated as a fresh first failure: 60s.
-        with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
-        ):
-            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-        assert agent._rate_limited_until == frozen + 60
+        next_delay = mgr.mark_failure(primary_key, "rate_limit")
+        assert next_delay > second_delay
+        assert mgr.get_all_states()[primary_key]["count"] == 4

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -1,27 +1,21 @@
-"""Regression tests for #24996 — fallback-switch storm on host memory.
+"""Regression tests for fallback exhaustion cooldowns."""
 
-When every provider in the fallback chain fails non-retryably back-to-back
-(e.g. HTTP 400/402/429 across distinct providers), the within-turn walk is
-bounded (``_fallback_index`` advances monotonically and the loop aborts when
-the chain exhausts).  The damaging mode is *cross-turn*: ``restore_primary_
-runtime`` resets ``_fallback_index = 0`` every turn, so a client that
-re-submits immediately replays the entire chain — re-marshaling the full
-(potentially 80k-token) context once per provider every turn — with no
-throttle on the non-rate-limit path.
-
-The fix arms a short cooldown via the existing ``_rate_limited_until`` gate
-when the chain exhausts on a non-rate-limit failure, so the next turn's
-restore stays gated (and does NOT reset the index) until the cooldown clears.
-Rate-limit / billing failures keep their own 60s cooldown and are unaffected.
-"""
-
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
 from agent.chat_completion_helpers import _FALLBACK_EXHAUSTED_COOLDOWN_S
+from agent.cooldown_manager import (
+    CooldownManager,
+    build_cooldown_key,
+    set_cooldown_manager,
+)
 
 
-def _make_agent(fallback_model=None):
+def _make_agent(fallback_model=None, provider="openrouter"):
     with (
         patch("model_tools.get_tool_definitions", return_value=[]),
         patch("model_tools.check_toolset_requirements", return_value={}),
@@ -30,6 +24,7 @@ def _make_agent(fallback_model=None):
         agent = AIAgent(
             api_key="test-key",
             base_url="https://openrouter.ai/api/v1",
+            provider=provider,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -46,187 +41,225 @@ def _mock_client(base_url="https://openrouter.ai/api/v1", api_key="fb-key"):
     return mock
 
 
+def _mock_response(content="ok", finish_reason="stop"):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+class _RateLimitError(Exception):
+    status_code = 429
+
+    def __init__(self):
+        super().__init__("Error code: 429 - rate limit exceeded")
+        self.response = SimpleNamespace(headers={})
+        self.body = {"error": {"message": "rate limit exceeded"}}
+
+
+def _fresh_mgr():
+    mgr = CooldownManager(storage_path=False)
+    set_cooldown_manager(mgr)
+    return mgr
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cooldown_manager():
+    """Do not leak an in-memory cooldown into unrelated agent tests."""
+    from agent.cooldown_manager import get_cooldown_manager
+
+    original = get_cooldown_manager()
+    try:
+        yield
+    finally:
+        set_cooldown_manager(original)
+
+
 class TestExhaustionArmsCooldown:
     def test_non_retryable_exhaustion_arms_cooldown(self):
-        """Walking a non-empty chain to exhaustion on a non-rate-limit
-        failure arms a short ``_rate_limited_until`` cooldown.
-
-        ``time.monotonic`` is frozen inside ``chat_completion_helpers`` so the
-        cooldown math is exact and independent of CI scheduling latency — the
-        previous wall-clock upper bound (``before + window + 1.0``) flaked on
-        loaded runners when the three activation calls took longer than 1s.
-        """
+        """Non-rate-limit exhaustion should arm a cooldown."""
+        mgr = _fresh_mgr()
         fbs = [
             {"provider": "openai", "model": "gpt-4o"},
             {"provider": "zai", "model": "glm-4.7"},
         ]
         agent = _make_agent(fallback_model=fbs)
-        agent._rate_limited_until = 0
-        frozen = 1_000.0
         with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(_mock_client(), "resolved")),
         ):
             assert agent._try_activate_fallback() is True   # -> entry 0
             assert agent._try_activate_fallback() is True   # -> entry 1
-            # Chain now exhausted; a non-rate-limit failure must arm cooldown.
             assert agent._try_activate_fallback() is False
-            cooldown = getattr(agent, "_rate_limited_until", 0)
-        # Cooldown is exactly the short exhaustion window past the frozen clock,
-        # not the 60s rate-limit one.
-        assert cooldown == frozen + _FALLBACK_EXHAUSTED_COOLDOWN_S
 
-    def test_no_chain_does_not_arm_cooldown(self):
-        """An empty chain (no fallback configured) must not arm a cooldown —
-        there is no chain to storm, and gating primary restoration would be
-        pointless punishment."""
-        agent = _make_agent(fallback_model=None)
-        agent._rate_limited_until = 0
-        assert agent._try_activate_fallback() is False
-        assert getattr(agent, "_rate_limited_until", 0) == 0
+        status = mgr.get_cooldown_status()
+        assert len(status["cooling"]) >= 1
 
-    def test_rate_limit_exhaustion_keeps_60s_cooldown(self):
-        """A rate-limit failure already arms its own 60s cooldown; the short
-        exhaustion window must not shrink it."""
-        fbs = [{"provider": "openai", "model": "gpt-4o"}]
-        agent = _make_agent(fallback_model=fbs)
-        agent._rate_limited_until = 0
-        frozen = 1_000.0
-        with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
-        ):
-            # First activation with rate_limit reason arms the 60s cooldown.
-            assert agent._try_activate_fallback(reason=FailoverReason.rate_limit) is True
-            # Chain exhausted on the next call (also rate_limit) -> still False,
-            # and the 60s cooldown must survive (max(), not overwritten down).
-            assert agent._try_activate_fallback(reason=FailoverReason.rate_limit) is False
-            cooldown = getattr(agent, "_rate_limited_until", 0)
-        # ~60s past the frozen clock, far past the short exhaustion window.
-        assert cooldown == frozen + 60
+    def test_exhaustion_uses_provider_gate_after_primary_credential_rotates(self):
+        """A stale primary snapshot must not bypass the exhaustion gate."""
+        mgr = _fresh_mgr()
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_client(api_key="fallback-key"), "resolved")):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_key == "fallback-key"
+            assert agent._try_activate_fallback() is False
 
-    def test_cooldown_never_shrinks_existing_window(self):
-        """If a longer cooldown is already armed, exhaustion must not reduce
-        it (we take the max)."""
-        fbs = [{"provider": "openai", "model": "gpt-4o"}]
-        agent = _make_agent(fallback_model=fbs)
-        frozen = 1_000.0
-        far_future = frozen + 999
-        agent._rate_limited_until = far_future
-        with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
-        ):
+        provider_key = agent._primary_runtime["provider"]
+        assert mgr.is_cooling(provider_key)
+        # A credential pool may rotate the primary between exhaustion and the
+        # next restore. The provider-scoped exhaustion gate must survive that
+        # stale snapshot change.
+        agent._primary_runtime["api_key"] = "rotated-primary-key"
+        assert agent._restore_primary_runtime() is False
+
+    def test_callable_primary_credential_does_not_break_exhaustion_cooldown(self):
+        class CredentialSource:
+            def __call__(self):
+                raise AssertionError("fallback cooldown must not invoke credentials")
+
+            def __str__(self):
+                raise AssertionError("fallback cooldown must not serialize credentials")
+
+        mgr = _fresh_mgr()
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        agent._primary_runtime["api_key"] = CredentialSource()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_client(), "resolved")):
             assert agent._try_activate_fallback() is True
             assert agent._try_activate_fallback() is False
-            cooldown = getattr(agent, "_rate_limited_until", 0)
-        assert cooldown == far_future
 
+        assert mgr.is_cooling(agent._primary_runtime["provider"])
+        assert agent._restore_primary_runtime() is False
 
-class TestRateLimitBackoffEscalation:
-    """Exponential backoff for consecutive rate-limit failures (#29702).
+    def test_no_chain_does_not_arm_cooldown(self):
+        """An empty chain (no fallback configured) must not arm a cooldown."""
+        mgr = _fresh_mgr()
+        agent = _make_agent(fallback_model=None)
+        assert agent._try_activate_fallback() is False
+        status = mgr.get_cooldown_status()
+        assert status["cooling"] == []
 
-    The first rate-limit keeps the historical 60s cooldown; each consecutive
-    rate-limit within one degradation window doubles it (60 → 120 → 240 → ...)
-    capped at 4h (14400s).  A successful primary restore resets the counter.
-    """
-
-    @staticmethod
-    def _back_on_primary(agent, snapshot):
-        """Simulate the primary provider rate-limiting again on a later turn
-        (without a successful restore, which would reset the counter): put
-        the agent's identity back on the primary and reset the turn-scoped
-        fallback chain state."""
-        agent.provider, agent.model, agent.base_url = snapshot
-        agent._fallback_activated = False
-        agent._fallback_index = 0
-
-    def test_backoff_doubles_per_consecutive_rate_limit(self):
-        """Each consecutive primary rate-limit doubles the cooldown:
-        60s, then 120s, then 240s."""
+    def test_rate_limit_exhaustion_arms_cooldown(self):
+        """A rate-limit failure arms an exponential cooldown via CooldownManager."""
+        mgr = _fresh_mgr()
         fbs = [{"provider": "openai", "model": "gpt-4o"}]
         agent = _make_agent(fallback_model=fbs)
-        agent._rate_limited_until = 0
-        snapshot = (agent.provider, agent.model, agent.base_url)
-        frozen = 1_000.0
         with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(_mock_client(), "resolved")),
         ):
-            expected = [60, 120, 240]
-            for n, want in enumerate(expected):
-                self._back_on_primary(agent, snapshot)
-                agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-                assert agent._rate_limited_until == frozen + want, (
-                    f"backoff #{n + 1}: expected {want}s cooldown"
-                )
-                assert agent._rate_limit_backoff_count == n + 1
+            assert agent._try_activate_fallback(reason=FailoverReason.rate_limit) is True
+            assert agent._try_activate_fallback(reason=FailoverReason.rate_limit) is False
 
-    def test_backoff_caps_at_four_hours(self):
-        """Escalation is capped at 14400s (4h) no matter how many
-        consecutive rate-limits occurred."""
-        fbs = [{"provider": "openai", "model": "gpt-4o"}]
-        agent = _make_agent(fallback_model=fbs)
-        agent._rate_limited_until = 0
-        # 60 * 2**10 = 61440s, far past the cap.
-        agent._rate_limit_backoff_count = 10
-        frozen = 1_000.0
+        status = mgr.get_cooldown_status()
+        assert len(status["cooling"]) >= 1
+
+    def test_exhaustion_gate_does_not_advance_failure_history(self):
+        mgr = _fresh_mgr()
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_client(), "resolved")):
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is False
+
+        provider_key = agent._primary_runtime["provider"]
+        assert mgr.get_all_states()[provider_key]["count"] == 0
+        assert mgr.mark_failure(provider_key, "rate_limit") == 60.0
+        assert mgr.get_all_states()[provider_key]["count"] == 1
+
+    def test_cooldown_armed_only_once_for_same_provider(self):
+        """Chain-switching while already on fallback must not re-arm cooldown
+        for the primary provider."""
+        mgr = _fresh_mgr()
+        fbs = [
+            {"provider": "openrouter", "model": "model-a"},
+            {"provider": "anthropic", "model": "model-b"},
+        ]
+        agent = _make_agent(fallback_model=fbs, provider="custom")
         with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
-        ):
-            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-        assert agent._rate_limited_until == frozen + 14400
-
-    def test_backoff_counter_resets_on_successful_primary_restore(self):
-        """A successful restore_primary_runtime resets the backoff counter,
-        so the next rate-limit starts back at the 60s base."""
-        fbs = [{"provider": "openai", "model": "gpt-4o"}]
-        agent = _make_agent(fallback_model=fbs)
-        snapshot = (agent.provider, agent.model, agent.base_url)
-        frozen = 1_000.0
-        with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
-        ):
-            # Two consecutive rate-limits escalate the counter to 2.
-            agent._rate_limited_until = 0
-            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-            self._back_on_primary(agent, snapshot)
-            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-            assert agent._rate_limit_backoff_count == 2
-
-        # Cooldown expired; the primary restores successfully.
-        agent._fallback_activated = True
-        agent._rate_limited_until = 0
-        assert agent._restore_primary_runtime() is True
-        assert agent._rate_limit_backoff_count == 0
-
-        # The next rate-limit is treated as a fresh first failure: 60s.
-        with (
-            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
-            patch(
-                "agent.auxiliary_client.resolve_provider_client",
-                return_value=(_mock_client(), "resolved"),
-            ),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(_mock_client(), "resolved")),
         ):
             agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-        assert agent._rate_limited_until == frozen + 60
+            first_cooling = set(mgr.get_cooldown_status()["cooling"])
+
+            agent._try_activate_fallback(reason=FailoverReason.rate_limit)
+            second_cooling = set(mgr.get_cooldown_status()["cooling"])
+
+        assert first_cooling == second_cooling
+
+
+class TestPrimaryCooldownClearOnValidatedSuccess:
+    def test_primary_success_path_clears_escalated_cooldown_and_resets_delay(self):
+        mgr = _fresh_mgr()
+        agent = _make_agent()
+        primary_key = build_cooldown_key(
+            agent._primary_runtime["provider"],
+            agent._primary_runtime["api_key"],
+            "rate_limit",
+        )
+
+        first_delay = mgr.mark_failure(primary_key, "rate_limit")
+        second_delay = mgr.mark_failure(primary_key, "rate_limit")
+        assert second_delay > first_delay
+        assert mgr.get_all_states()[primary_key]["count"] == 2
+
+        agent._interruptible_api_call = lambda api_kwargs: _mock_response("primary recovered")
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "primary recovered"
+        assert primary_key not in mgr.get_all_states()
+
+        reset_delay = mgr.mark_failure(primary_key, "rate_limit")
+        assert reset_delay == first_delay
+        assert mgr.get_all_states()[primary_key]["count"] == 1
+
+    def test_fallback_success_does_not_clear_primary_cooldown_history(self):
+        mgr = _fresh_mgr()
+        agent = _make_agent(
+            fallback_model=[{"provider": "openrouter", "model": "gpt-4o"}],
+        )
+        primary_key = build_cooldown_key(
+            agent._primary_runtime["provider"],
+            agent._primary_runtime["api_key"],
+            "rate_limit",
+        )
+
+        first_delay = mgr.mark_failure(primary_key, "rate_limit")
+        second_delay = mgr.mark_failure(primary_key, "rate_limit")
+        mgr.mark_failure(agent._primary_runtime["provider"], "billing")
+        assert second_delay > first_delay
+        assert mgr.get_all_states()[primary_key]["count"] == 2
+        assert mgr.get_all_states()[agent._primary_runtime["provider"]]["count"] == 1
+
+        def _fake_api_call(api_kwargs):
+            if not agent._fallback_activated:
+                raise _RateLimitError()
+            return _mock_response("fallback recovered")
+
+        agent._interruptible_api_call = _fake_api_call
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(api_key="fallback-key"), "gpt-4o"),
+            ),
+            patch("run_agent.time.sleep", return_value=None),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "fallback recovered"
+        assert mgr.get_all_states()[primary_key]["count"] == 3
+        assert mgr.get_all_states()[agent._primary_runtime["provider"]]["count"] == 1
+
+        next_delay = mgr.mark_failure(primary_key, "rate_limit")
+        assert next_delay > second_delay
+        assert mgr.get_all_states()[primary_key]["count"] == 4

--- a/tests/run_agent/test_fallback_credential_isolation.py
+++ b/tests/run_agent/test_fallback_credential_isolation.py
@@ -65,7 +65,6 @@ def _make_agent(provider="openai-codex", model="gpt-5.5",
     }
     agent._config_context_length = None
     agent._credential_pool = _make_pool(provider)
-    agent._rate_limited_until = 0
     agent._transport_cache = {}
     agent._client_kwargs = {
         "api_key": "primary-key",

--- a/tests/run_agent/test_fallback_reasoning_override.py
+++ b/tests/run_agent/test_fallback_reasoning_override.py
@@ -91,7 +91,6 @@ class TestFallbackReasoningOverride:
         agent._fallback_model = None
         agent._transport_cache = {}
         agent._config_context_length = None
-        agent._rate_limited_until = 0
         # During fallback, reasoning was changed to xhigh (fallback model's override)
         agent.model = "claude-opus-4.5"
         agent.provider = "anthropic"

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -12,8 +12,22 @@ Verifies that:
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 from run_agent import AIAgent
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cooldown_manager():
+    """Persistent cooldown state must not bleed between restoration tests."""
+    from agent.cooldown_manager import CooldownManager, get_cooldown_manager, set_cooldown_manager
+
+    original = get_cooldown_manager()
+    set_cooldown_manager(CooldownManager(storage_path=False))
+    try:
+        yield
+    finally:
+        set_cooldown_manager(original)
 
 
 def _make_tool_defs(*names: str) -> list:

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -12,8 +12,22 @@ Verifies that:
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 from run_agent import AIAgent
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cooldown_manager():
+    """Persistent cooldown state must not bleed between restoration tests."""
+    from agent.cooldown_manager import CooldownManager, get_cooldown_manager, set_cooldown_manager
+
+    original = get_cooldown_manager()
+    set_cooldown_manager(CooldownManager(storage_path=False))
+    try:
+        yield
+    finally:
+        set_cooldown_manager(original)
 
 
 def _make_tool_defs(*names: str) -> list:
@@ -734,10 +748,11 @@ class TestRestoreInRunConversation:
 # =============================================================================
 
 class TestRateLimitCooldown:
-    """Verify _restore_primary_runtime() respects the 60s rate-limit cooldown."""
+    """Verify _restore_primary_runtime() respects persistent cooldowns."""
 
     def test_restore_blocked_during_cooldown(self):
-        """While _rate_limited_until is in the future, restore returns False."""
+        """While the primary's manager cooldown is active, restore returns False."""
+        from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
         )
@@ -747,8 +762,10 @@ class TestRateLimitCooldown:
 
         assert agent._fallback_activated is True
 
-        # Manually set cooldown well into the future
-        agent._rate_limited_until = time.monotonic() + 60
+        primary = agent._primary_runtime
+        get_cooldown_manager().mark_failure(
+            build_cooldown_key(primary["provider"], primary["api_key"], "rate_limit"), "rate_limit"
+        )
 
         result = agent._restore_primary_runtime()
         assert result is False
@@ -756,22 +773,26 @@ class TestRateLimitCooldown:
 
 
     def test_cooldown_set_on_rate_limit_reason(self):
-        """_try_activate_fallback with rate_limit reason sets _rate_limited_until."""
+        """_try_activate_fallback with rate_limit reason uses CooldownManager."""
         from agent.error_classifier import FailoverReason
+        from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
         )
-        before = time.monotonic()
         mock_client = _mock_resolve()
         with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
             agent._try_activate_fallback(reason=FailoverReason.rate_limit)
 
-        assert hasattr(agent, "_rate_limited_until")
-        assert agent._rate_limited_until > before + 50  # ~60s from now
+        primary = agent._primary_runtime
+        assert get_cooldown_manager().is_cooling(
+            build_cooldown_key(primary["provider"], primary["api_key"], "rate_limit")
+        )
+
 
     def test_cooldown_not_set_when_already_on_fallback(self):
         """Chain-switching while already on fallback must not reset cooldown."""
         from agent.error_classifier import FailoverReason
+        from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
         agent = _make_agent(
             fallback_model=[
                 {"provider": "openrouter", "model": "model-a"},
@@ -782,14 +803,15 @@ class TestRateLimitCooldown:
         with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
             # First call: leaving primary → cooldown should be set
             agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-            first_cooldown = getattr(agent, "_rate_limited_until", 0)
+            primary = agent._primary_runtime
+            cooldown_key = build_cooldown_key(primary["provider"], primary["api_key"], "rate_limit")
+            first_count = get_cooldown_manager().get_all_states()[cooldown_key]["count"]
 
             # Second call: already on fallback (provider != primary) → cooldown must not advance
             agent._try_activate_fallback(reason=FailoverReason.rate_limit)
-            second_cooldown = getattr(agent, "_rate_limited_until", 0)
+            second_count = get_cooldown_manager().get_all_states()[cooldown_key]["count"]
 
-        # second call should not have extended the cooldown
-        assert second_cooldown == first_cooldown
+        assert second_count == first_count
 
 
 # =============================================================================

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -14,6 +14,18 @@ from agent.error_classifier import FailoverReason
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
+@pytest.fixture(autouse=True)
+def _isolated_cooldown_manager():
+    from agent.cooldown_manager import CooldownManager, get_cooldown_manager, set_cooldown_manager
+
+    original = get_cooldown_manager()
+    set_cooldown_manager(CooldownManager(storage_path=False))
+    try:
+        yield
+    finally:
+        set_cooldown_manager(original)
+
+
 def _make_agent(fallback_model=None):
     """Create a minimal AIAgent with optional fallback config."""
     with (
@@ -176,7 +188,6 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback(FailoverReason.rate_limit) is True
             assert agent.model == "gpt-4o"
             assert agent._fallback_index == 2
-            assert agent._rate_limit_backoff_count == 1
 
     def test_skips_provider_that_raises_to_next(self):
         """If resolve_provider_client raises, skip to next in chain."""

--- a/tests/run_agent/test_reset_aware_primary_restore.py
+++ b/tests/run_agent/test_reset_aware_primary_restore.py
@@ -2,7 +2,7 @@
 rate-limit window actually resets.
 
 ``restore_primary_runtime`` retries the primary at the top of every turn
-once the 60s ``_rate_limited_until`` cooldown clears.  For transient 429s
+once the transient cooldown clears.  For transient 429s
 that is correct, but subscription-window limits (Claude Pro/Max 5-hour
 windows, ChatGPT weekly caps) report reset times hours or days away.  The
 credential pool already knows that timestamp (``last_error_reset_at``),
@@ -16,6 +16,8 @@ later than it does today.
 
 import time
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from run_agent import AIAgent
 from agent.credential_pool import (
@@ -111,6 +113,28 @@ def _make_agent(fallback_model=None):
         )
         agent.client = MagicMock()
         return agent
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cooldown_manager():
+    from agent.cooldown_manager import CooldownManager, get_cooldown_manager, set_cooldown_manager
+
+    original = get_cooldown_manager()
+    set_cooldown_manager(CooldownManager(storage_path=False))
+    try:
+        yield
+    finally:
+        set_cooldown_manager(original)
+
+
+def _mark_primary_cooling(agent):
+    from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+
+    runtime = agent._primary_runtime
+    get_cooldown_manager().mark_failure(
+        build_cooldown_key(runtime["provider"], runtime["api_key"], "rate_limit"),
+        "rate_limit", cooldown_seconds=60,
+    )
 
 
 def _activate_fallback(agent):
@@ -237,7 +261,6 @@ class TestResetAwareRestoreGate:
     def test_stays_on_fallback_until_reset(self):
         agent = _make_agent(fallback_model=self.FB)
         _activate_fallback(agent)
-        agent._rate_limited_until = 0  # 60s transient cooldown already cleared
 
         # Attached pool matches the primary provider and says: nobody can
         # serve until an hour from now.
@@ -252,7 +275,6 @@ class TestResetAwareRestoreGate:
         agent = _make_agent(fallback_model=self.FB)
         original_model = agent.model
         _activate_fallback(agent)
-        agent._rate_limited_until = 0
 
         agent._credential_pool = _FakePool("custom", next_at=None)
 
@@ -265,7 +287,6 @@ class TestResetAwareRestoreGate:
     def test_past_reset_time_does_not_block(self):
         agent = _make_agent(fallback_model=self.FB)
         _activate_fallback(agent)
-        agent._rate_limited_until = 0
 
         agent._credential_pool = _FakePool("custom", next_at=time.time() - 5)
 
@@ -277,7 +298,6 @@ class TestResetAwareRestoreGate:
         """Any exception inside the gate must not break restore."""
         agent = _make_agent(fallback_model=self.FB)
         _activate_fallback(agent)
-        agent._rate_limited_until = 0
 
         agent._credential_pool = _FakePool("custom", raise_on_next=True)
 
@@ -290,7 +310,6 @@ class TestResetAwareRestoreGate:
         fallback provider; the gate must consult the PRIMARY's pool."""
         agent = _make_agent(fallback_model=self.FB)
         _activate_fallback(agent)
-        agent._rate_limited_until = 0
 
         # Attached pool is the fallback provider's (mismatch with "custom").
         agent._credential_pool = _FakePool("openrouter", next_at=None)
@@ -306,7 +325,6 @@ class TestResetAwareRestoreGate:
         """Pool present but no reset info -> existing per-turn retry."""
         agent = _make_agent(fallback_model=self.FB)
         _activate_fallback(agent)
-        agent._rate_limited_until = 0
 
         agent._credential_pool = _FakePool("custom", next_at=None)
 
@@ -318,7 +336,6 @@ class TestResetAwareRestoreGate:
 
         agent = _make_agent(fallback_model=self.FB)
         _activate_fallback(agent)
-        agent._rate_limited_until = 0
         agent._credential_pool = _FakePool("custom", next_at=time.time() + 3600)
 
         with caplog.at_level(logging.INFO, logger="agent.agent_runtime_helpers"):
@@ -331,7 +348,7 @@ class TestResetAwareRestoreGate:
         """The existing 60s monotonic gate fires before the reset-aware one."""
         agent = _make_agent(fallback_model=self.FB)
         _activate_fallback(agent)
-        agent._rate_limited_until = time.monotonic() + 60
+        _mark_primary_cooling(agent)
         pool = _FakePool("custom", next_at=None)
         agent._credential_pool = pool
 

--- a/tests/run_agent/test_switch_model_reasoning_override.py
+++ b/tests/run_agent/test_switch_model_reasoning_override.py
@@ -109,7 +109,6 @@ class TestSwitchModelReasoningOverride:
         agent._fallback_model = None
         agent._transport_cache = {}
         agent._config_context_length = None
-        agent._rate_limited_until = 0
         agent.model = "fallback-model"
         agent.provider = "openai"
         agent.reasoning_config = {"enabled": True, "effort": "medium"}

--- a/tests/tui_gateway/test_model_switch_cooldown.py
+++ b/tests/tui_gateway/test_model_switch_cooldown.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+
+
+def test_one_turn_restore_clears_primary_manager_cooldown(monkeypatch):
+    from agent.cooldown_manager import (
+        CooldownManager, build_cooldown_key, get_cooldown_manager, set_cooldown_manager,
+    )
+    from tui_gateway import model_switch
+
+    monkeypatch.setattr(model_switch, "copy", copy, raising=False)
+    original = get_cooldown_manager()
+    manager = CooldownManager(storage_path=False)
+    key = build_cooldown_key("openrouter", "sk-old", "rate_limit")
+    manager.mark_failure(key, "rate_limit", cooldown_seconds=60)
+    set_cooldown_manager(manager)
+    agent = SimpleNamespace(_primary_runtime=None, _fallback_activated=False)
+    agent._restore_primary_runtime = lambda: not manager.is_cooling(key)
+    try:
+        model_switch._restore_agent_model_runtime(
+            agent,
+            {"primary_runtime": {"provider": "openrouter", "api_key": "sk-old"}},
+        )
+    finally:
+        set_cooldown_manager(original)
+
+    assert not manager.is_cooling(key)

--- a/tui_gateway/model_switch.py
+++ b/tui_gateway/model_switch.py
@@ -40,7 +40,11 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
         try:
             agent._primary_runtime = copy.deepcopy(primary)
             agent._fallback_activated = True
-            agent._rate_limited_until = 0
+            from agent.cooldown_manager import build_cooldown_key, get_cooldown_manager
+            provider = str(primary.get("provider") or "").strip().lower()
+            manager = get_cooldown_manager()
+            manager.clear(provider)
+            manager.clear(build_cooldown_key(provider, primary.get("api_key"), "rate_limit"))
             if agent._restore_primary_runtime():
                 return
         except Exception:


### PR DESCRIPTION
Provider failover used to remember a rate limit only on the running agent. Restarting Hermes—or reloading a fallback chain—could forget that state and retry a provider too soon.

## What changed

- Replace the in-memory timestamp with a persisted cooldown manager.
- Keep consecutive failure history separately from the active deadline, so the next real failure still escalates after a cooldown expires or Hermes restarts.
- Reset a cooldown only after a valid response from the matching primary runtime. A same-provider fallback cannot clear it by accident.
- Keep billing cooldowns provider-wide and rate-limit cooldowns credential-specific, using hashed credential fingerprints.
- Route agent, gateway, CLI, and TUI fallback/model-switch behavior through the same manager. The old `_rate_limited_until` state is gone.

Failure history decays after seven days without activity. That avoids carrying a short outage forward forever while still making repeated failures back off as intended.

## Validation

- Cooldown, fallback, primary-restore, gateway reload, CLI, and TUI model-switch coverage: 81 passed after squash.
- Independent lifecycle review covered expiry/restart escalation, success reset, same-provider behavior, provider/key scope, atomic persistence, and legacy-state removal.
- Ruff, compilation, and whitespace checks pass.

Rebased on current `main` and squashed to one commit.
