### PR TITLE
feat(gateway): add pre_gateway_dispatch reply action

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10816,6 +10816,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Fire pre_gateway_dispatch plugin hook for user-originated messages.
         # Plugins receive the MessageEvent and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
+        #   {"action": "reply",   "text": ..., "reply_to": bool} -> direct reply, drop
         #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
@@ -10844,6 +10845,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         source.platform.value if source.platform else "unknown",
                         source.chat_id or "unknown",
                     )
+                    return None
+                if _action == "reply":
+                    # Send a direct reply before auth/agent dispatch, then drop.
+                    # Route through _adapter_for_source(source) so a secondary
+                    # profile is answered by its own adapter, not the platform
+                    # default. Rate-limited per platform+chat; invalid text or a
+                    # missing adapter is logged and the message falls through.
+                    _reply_text = _result.get("text")
+                    if not isinstance(_reply_text, str) or not _reply_text.strip():
+                        logger.warning(
+                            "pre_gateway_dispatch reply ignored: invalid text "
+                            "reason=%s platform=%s chat=%s",
+                            _result.get("reason"),
+                            source.platform.value if source.platform else "unknown",
+                            source.chat_id or "unknown",
+                        )
+                        continue
+                    platform_name = source.platform.value if source.platform else "unknown"
+                    rate_key = source.chat_id or source.user_id or "unknown"
+                    if self.pairing_store._is_rate_limited(platform_name, rate_key):
+                        logger.warning(
+                            "pre_gateway_dispatch reply rate-limited: "
+                            "reason=%s platform=%s chat=%s",
+                            _result.get("reason"),
+                            platform_name,
+                            source.chat_id or "unknown",
+                        )
+                        return None
+                    _adapter = self._adapter_for_source(source)
+                    if _adapter is None:
+                        logger.warning(
+                            "pre_gateway_dispatch reply skipped: no adapter "
+                            "reason=%s platform=%s chat=%s",
+                            _result.get("reason"),
+                            source.platform.value if source.platform else "unknown",
+                            source.chat_id or "unknown",
+                        )
+                        return None
+                    _reply_to = event.message_id if _result.get("reply_to") is True else None
+                    try:
+                        await _adapter.send(source.chat_id, _reply_text, reply_to=_reply_to)
+                        self.pairing_store._record_rate_limit(platform_name, rate_key)
+                    except Exception as _reply_exc:
+                        logger.warning(
+                            "pre_gateway_dispatch reply send failed: %s",
+                            _reply_exc,
+                        )
                     return None
                 if _action == "rewrite":
                     _new_text = _result.get("text")

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -167,8 +167,11 @@ VALID_HOOKS: Set[str] = {
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:
     #   {"action": "skip",    "reason": "..."}  -> drop message (no reply)
+    #   {"action": "reply",   "text": "...", "reply_to": bool} -> direct reply, drop
     #   {"action": "rewrite", "text": "..."}    -> replace event.text, continue
     #   {"action": "allow"}  /  None             -> normal dispatch
+    # The reply action delivers via the message's own profile adapter and
+    # short-circuits before auth; it is rate-limited per platform+chat.
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -177,3 +177,180 @@ async def test_internal_events_bypass_hook(monkeypatch):
     # Even though the hook would say skip, internal events bypass it.
     await runner._handle_message(event)
     assert called["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hook_reply_sends_and_short_circuits_before_auth(monkeypatch):
+    """A plugin reply action sends directly and drops the message before auth."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [
+                {
+                    "action": "reply",
+                    "text": "Plugin handled this.",
+                    "reply_to": True,
+                    "reason": "direct-response",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    runner.pairing_store.generate_code.return_value = "12345"
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    assert result is None
+    adapter.send.assert_awaited_once_with(
+        "15551234567@s.whatsapp.net",
+        "Plugin handled this.",
+        reply_to="m1",
+    )
+    runner.pairing_store.generate_code.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hook_reply_to_false_sends_without_reply_anchor(monkeypatch):
+    """reply_to=False sends to the chat without threading to the source message."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "reply", "text": "No anchor", "reply_to": False}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    runner.pairing_store.generate_code.return_value = "12345"
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    assert result is None
+    adapter.send.assert_awaited_once_with(
+        "15551234567@s.whatsapp.net",
+        "No anchor",
+        reply_to=None,
+    )
+    runner.pairing_store.generate_code.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hook_reply_rate_limited_does_not_send(monkeypatch):
+    """Pre-auth direct replies reuse the pairing rate limit to avoid spam."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "reply", "text": "Too fast", "reply_to": True}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    runner.pairing_store._is_rate_limited.return_value = True
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    assert result is None
+    adapter.send.assert_not_awaited()
+    runner.pairing_store._is_rate_limited.assert_called_once_with(
+        "whatsapp", "15551234567@s.whatsapp.net"
+    )
+    runner.pairing_store._record_rate_limit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_text", [None, "", "   ", 123])
+async def test_hook_reply_invalid_text_does_not_send_or_crash(monkeypatch, bad_text):
+    """Invalid reply text fails closed and normal auth dispatch continues."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+    reached_agent = {"value": False}
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "reply", "text": bad_text, "reply_to": True}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        reached_agent["value"] = True
+        return "ok"
+
+    runner._handle_message_with_agent = _capture  # noqa: SLF001
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    assert result == "ok"
+    adapter.send.assert_not_awaited()
+    runner.pairing_store.generate_code.assert_not_called()
+    assert reached_agent["value"] is True
+
+
+@pytest.mark.asyncio
+async def test_hook_reply_missing_adapter_does_not_crash(monkeypatch):
+    """A reply action with no platform adapter is skipped safely."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "reply", "text": "No adapter", "reply_to": True}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, _adapter = _make_runner(Platform.WHATSAPP)
+    runner.adapters = {}
+    runner.pairing_store.generate_code.return_value = "12345"
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+
+
+
+@pytest.mark.asyncio
+async def test_hook_reply_routes_through_source_profile_not_platform_default(monkeypatch):
+    """A reply for a secondary-profile chat is delivered by that profile's
+    adapter, not the platform default.
+
+    Regression for the wrong-profile delivery flagged on #56616: the reply path
+    must resolve the adapter via ``_adapter_for_source(source)`` (which honors
+    ``source.profile`` and ``_profile_adapters``) rather than
+    ``self.adapters.get(source.platform)``, which always returns the default
+    profile's adapter.
+    """
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "reply", "text": "Profile reply", "reply_to": True}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, default_adapter = _make_runner(Platform.WHATSAPP)
+    # A distinct adapter owns the "secondary" profile on the same platform.
+    profile_adapter = SimpleNamespace(send=AsyncMock())
+    runner._profile_adapters = {"secondary": {Platform.WHATSAPP: profile_adapter}}
+
+    event = _make_event("hi")
+    event.source.profile = "secondary"
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    profile_adapter.send.assert_awaited_once_with(
+        "15551234567@s.whatsapp.net",
+        "Profile reply",
+        reply_to="m1",
+    )
+    default_adapter.send.assert_not_called()

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1022,6 +1022,7 @@ def my_callback(event, gateway, session_store, **kwargs):
 |--------|--------|
 | `{"action": "skip", "reason": "..."}` | Drop the message — no agent reply, no pairing flow, no auth. Plugin is assumed to have handled it (e.g. silent-ingested into the transcript). |
 | `{"action": "rewrite", "text": "new text"}` | Replace `event.text`, then continue normal dispatch with the modified event. Useful for collapsing buffered ambient messages into a single prompt. |
+| `{"action": "reply", "text": "...", "reply_to": bool}` | Send `text` straight back to the originating chat **before** auth/agent dispatch, then drop the message (no agent loop). Delivery is routed through the message's own profile via `_adapter_for_source(source)`, so a secondary-profile chat is answered by that profile, not the platform default. `reply_to: true` quotes the inbound message. Rate-limited per platform+chat; empty/invalid `text` or a missing adapter is logged and the message falls through as a no-op. |
 | `{"action": "allow"}` / `None` | Normal dispatch — runs the full auth / pairing / agent-loop chain. |
 
 **Use cases:** Listen-only group chats (only respond when tagged; buffer ambient messages into context); human handover (silent-ingest customer messages while owner handles the chat manually); per-profile rate limiting; policy-driven routing.


### PR DESCRIPTION
## Summary

- Adds a generic `pre_gateway_dispatch` direct-reply action so trusted plugins can send a gateway reply and short-circuit normal auth/agent dispatch.
- Hardens WhatsApp reply-to-bot detection by normalizing WhatsApp ID aliases and handling quoted-message metadata more robustly.
- Extracts quoted text/captions in the WhatsApp bridge so gateway adapters receive richer context for replies.
- Refreshes WhatsApp bridge transitive lockfile dependencies via `npm audit fix`; one Baileys advisory remains because npm reports no automatic fix for the pinned Baileys source.

## Why

This lets gateway plugins handle narrow deterministic workflows before invoking the full agent, without embedding platform-specific shortcuts in the WhatsApp adapter. The WhatsApp changes improve handling of quoted replies and group message metadata while keeping the adapter generic.

## Test plan

```bash
venv/bin/python -m py_compile gateway/run.py plugins/platforms/whatsapp/adapter.py gateway/platforms/whatsapp_common.py
venv/bin/python -m pytest tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_whatsapp_formatting.py tests/gateway/test_whatsapp_group_gating.py -q -o 'addopts='
```

Result locally:

```text
74 passed in 5.02s
```

## Notes

- This PR intentionally contains only generic gateway/WhatsApp infrastructure changes.
- User-specific plugins/configuration are not included.
