### PR TITLE
feat(models): add claude-fable-5, claude-sonnet-5, fugu-ultra to curated lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -34,9 +34,10 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Anthropic
+    ("anthropic/claude-fable-5",               ""),
     ("anthropic/claude-opus-4.8",              ""),
     ("anthropic/claude-opus-4.8-fast",         "2x price, higher output speed"),
-    ("anthropic/claude-sonnet-4.6",            ""),
+    ("anthropic/claude-sonnet-5",              ""),
     ("anthropic/claude-haiku-4.5",             ""),
     # OpenAI
     ("openai/gpt-5.5",                         ""),
@@ -71,6 +72,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("stepfun/step-3.7-flash",                 ""),
     # NVIDIA
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
+    # Sakana
+    ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
@@ -176,8 +179,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "moa": ["default"],
     "nous": [
         # Anthropic
+        "anthropic/claude-fable-5",
         "anthropic/claude-opus-4.8",
-        "anthropic/claude-sonnet-4.6",
+        "anthropic/claude-sonnet-5",
         "anthropic/claude-haiku-4.5",
         # OpenAI
         "openai/gpt-5.5",
@@ -212,6 +216,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "stepfun/step-3.7-flash",
         # NVIDIA
         "nvidia/nemotron-3-super-120b-a12b",
+        # Sakana
+        "sakana/fugu-ultra",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-16T18:04:33Z",
+  "updated_at": "2026-07-01T20:08:52Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -13,6 +13,10 @@
       },
       "models": [
         {
+          "id": "anthropic/claude-fable-5",
+          "description": ""
+        },
+        {
           "id": "anthropic/claude-opus-4.8",
           "description": ""
         },
@@ -21,7 +25,7 @@
           "description": "2x price, higher output speed"
         },
         {
-          "id": "anthropic/claude-sonnet-4.6",
+          "id": "anthropic/claude-sonnet-5",
           "description": ""
         },
         {
@@ -113,6 +117,10 @@
           "description": ""
         },
         {
+          "id": "sakana/fugu-ultra",
+          "description": ""
+        },
+        {
           "id": "openrouter/pareto-code",
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
         },
@@ -153,10 +161,13 @@
       },
       "models": [
         {
+          "id": "anthropic/claude-fable-5"
+        },
+        {
           "id": "anthropic/claude-opus-4.8"
         },
         {
-          "id": "anthropic/claude-sonnet-4.6"
+          "id": "anthropic/claude-sonnet-5"
         },
         {
           "id": "anthropic/claude-haiku-4.5"
@@ -223,6 +234,9 @@
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b"
+        },
+        {
+          "id": "sakana/fugu-ultra"
         }
       ]
     }


### PR DESCRIPTION
## Summary
Adds `anthropic/claude-fable-5`, `anthropic/claude-sonnet-5`, and `sakana/fugu-ultra` to the curated OpenRouter and Nous Portal model lists.

## Changes
- `hermes_cli/models.py`: `OPENROUTER_MODELS` + `_PROVIDER_MODELS["nous"]`
  - `claude-fable-5` added at the top of the Anthropic block (above `claude-opus-4.8`)
  - `claude-sonnet-5` replaces `claude-sonnet-4.6`
  - `sakana/fugu-ultra` added near the bottom (under a `# Sakana` header, before the routers/free tier)
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (the CLI fetches this live; `deploy-site.yml` publishes it on merge — no Hermes release needed)

## Validation
| | Before | After |
|---|---|---|
| OpenRouter models | 34 | 35 |
| Nous models | 24 | 26 |
| Anthropic top slot | opus-4.8 | fable-5 → opus-4.8 → sonnet-5 → haiku-4.5 |
| sonnet-4.6 | present | replaced by sonnet-5 |
| fugu-ultra | absent | present (near bottom) |

JSON regenerated from source of truth (`models.py`), so the manifest can't drift from the fallback. Invariants asserted: fable-5 above opus-4.8, sonnet-4.6 gone, fugu-ultra near the bottom.

## Infographic
![Model catalog update](https://v3b.fal.media/files/b/0aa08ba0/BrzT8mCxtsNSafiR7u-kN_38UmR0Vz.png)
