### PR TITLE
fix(mcp): don't inject phantom params for tools named required/properties

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -358,6 +358,62 @@ class TestSchemaConversion:
         # The $ref into the legacy location was rewritten too.
         assert schema["parameters"]["properties"]["payload"]["$ref"] == "#/$defs/Payload"
 
+    def test_property_named_required_does_not_inject_phantom_params(self):
+        """A tool parameter literally named ``required`` must not spawn
+        phantom ``type`` / ``properties`` parameters.
+
+        Regression: the object-shape repair (fill missing ``type``, ensure a
+        ``properties`` dict) used to recurse into the ``properties`` *map* the
+        same way it recurses into a schema node. When a tool declared a
+        parameter literally named ``required`` (or ``properties``), the map
+        itself looked object-shaped to the repair, so it stamped a ``type:
+        object`` and an empty ``properties`` onto the map — surfacing as
+        parameters ``type`` and ``properties`` that the MCP server never
+        declared, which the model could then fill with junk args. Sibling
+        ``_rewrite_local_refs`` already gates ``properties``; this path did
+        not. Real-world repro: a schema-builder / validation MCP tool whose
+        ``required`` parameter is an array of required field names.
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"required": {"type": "boolean"}},
+        })
+
+        assert set(schema["properties"].keys()) == {"required"}
+        assert schema["properties"]["required"] == {"type": "boolean"}
+
+    def test_property_named_properties_does_not_inject_phantom_type(self):
+        """A tool parameter literally named ``properties`` is left untouched."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {"properties": {"type": "string"}},
+        })
+
+        assert set(schema["properties"].keys()) == {"properties"}
+        assert schema["properties"]["properties"] == {"type": "string"}
+
+    def test_property_named_required_is_preserved_when_nested(self):
+        """The phantom-param gate also holds inside nested object properties."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {"required": {"type": "boolean"}},
+                },
+            },
+        })
+
+        nested = schema["properties"]["config"]["properties"]
+        assert set(nested.keys()) == {"required"}
+        assert nested["required"] == {"type": "boolean"}
+
     def test_missing_type_on_object_is_coerced(self):
         """Schemas that describe an object but omit ``type`` get type='object'."""
         from tools.mcp_tool import _normalize_mcp_input_schema

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3854,7 +3854,23 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
         if not isinstance(node, dict):
             return node
 
-        repaired = {k: _repair_object_shape(v) for k, v in node.items()}
+        # Recurse, but treat ``properties`` / ``patternProperties`` as
+        # name -> schema maps: their KEYS are user-facing parameter names, not
+        # JSON Schema meta-keywords. Recursing into such a map as if it were a
+        # schema node makes the object-shape repair below fire on the map
+        # itself whenever a tool declares a parameter literally named
+        # ``required`` or ``properties``, injecting phantom ``type`` /
+        # ``properties`` parameters the server never declared. This mirrors the
+        # identical gate in ``_rewrite_local_refs`` above.
+        repaired = {}
+        for k, v in node.items():
+            if k in ("properties", "patternProperties") and isinstance(v, dict):
+                repaired[k] = {
+                    prop_name: _repair_object_shape(prop_schema)
+                    for prop_name, prop_schema in v.items()
+                }
+            else:
+                repaired[k] = _repair_object_shape(v)
 
         # Coerce missing / null type when the shape is clearly an object
         # (has properties or required but no type).


### PR DESCRIPTION
## What does this PR do?

`_normalize_mcp_input_schema` (via its inner `_repair_object_shape`) can inject **phantom parameters** into an MCP tool's schema when the tool declares a parameter literally named `required` or `properties`.

`_repair_object_shape` recurses into every dict the same way, including the `properties` map, whose keys are user-facing parameter names rather than JSON Schema meta-keywords. The object-shape repair right below it (fill a missing `type`, ensure a `properties` dict exists) then fires on the properties map itself whenever it contains a key named `required` or `properties`. That stamps a `"type": "object"` and an empty `"properties"` onto the map. Both then surface to the model as parameters `type` and `properties` that the MCP server never declared.

Concrete reproduction (running the actual function):

| input `properties` keys | output `properties` keys (before) |
|---|---|
| `["required"]` | `["required", "type", "properties"]` |
| `["properties"]` | `["properties", "type"]` |
| nested `config.properties = ["required"]` | `["required", "type", "properties"]` (nested) |
| `["query"]` (normal) | `["query"]` (unaffected) |

The model can then fill those phantom params with junk arguments. Strict providers can also `400` the malformed intermediate schema, because a `"type": "object"` string value ends up inside the properties map. That is the same failure mode the sibling `_rewrite_local_refs` docstring already warns about.

**Root cause:** `_rewrite_local_refs` was deliberately fixed to special-case `properties` and `patternProperties` during descent (see its docstring and `test_definitions_as_property_name_is_preserved`), but the sibling `_repair_object_shape` was overlooked. One traversal got fixed and the other was missed.

## Related Issue

Fixes # <!-- no existing issue; happy to open one if preferred -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: in `_repair_object_shape`, gate `properties` and `patternProperties` during descent so their keys are treated as user-facing parameter names (iterate the map, recurse only into each property's schema), mirroring the existing gate in `_rewrite_local_refs`. All legitimate repairs (type inference, `required` pruning, nested object coercion) are unchanged.
- `tests/tools/test_mcp_tool.py`: 3 regression tests (`test_property_named_required_does_not_inject_phantom_params`, `test_property_named_properties_does_not_inject_phantom_type`, `test_property_named_required_is_preserved_when_nested`).

## How to Test

1. `scripts/run_tests.sh tests/tools/test_mcp_tool.py -q`: 206 tests pass.
2. To confirm the fix is load-bearing, revert the `tools/mcp_tool.py` hunk and rerun `-k property_named`. The 3 new tests fail, with phantom `type` and `properties` appearing in the output `properties` map. Restore the hunk and they pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(mcp):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (open PRs #36955 / #55082 fix the analogous `definitions` to `$defs` rename in `_rewrite_local_refs`; none touch `_repair_object_shape`)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings): the new gate is documented inline
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A (pure schema logic; `scripts/check-windows-footguns.py` clean)
- [x] Tool descriptions/schemas: N/A