### PR TITLE
fix(mini-swe): capture model reasoning into emitted trajectories

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -484,6 +484,14 @@ Complete the user's task step by step."""
                     messages.append({
                         "role": "assistant",
                         "content": assistant_message.content,
+                        # Capture the model's reasoning/thinking so
+                        # _convert_to_hermes_format can wrap it in <think>...</think>.
+                        # Providers expose it as .reasoning_content (DeepSeek/Kimi)
+                        # or .reasoning (OpenRouter); mirror agent/chat_completion_helpers.
+                        "reasoning": (
+                            getattr(assistant_message, "reasoning_content", None)
+                            or getattr(assistant_message, "reasoning", None)
+                        ),
                         "tool_calls": [
                             {
                                 "id": tc.id,
@@ -543,7 +551,12 @@ Complete the user's task step by step."""
                     final_response = assistant_message.content or ""
                     messages.append({
                         "role": "assistant",
-                        "content": final_response
+                        "content": final_response,
+                        # See above: preserve reasoning for the <think> wrapper.
+                        "reasoning": (
+                            getattr(assistant_message, "reasoning_content", None)
+                            or getattr(assistant_message, "reasoning", None)
+                        ),
                     })
                     completed = True
                     print("🎉 Agent finished (no more tool calls)")

--- a/tests/test_mini_swe_runner.py
+++ b/tests/test_mini_swe_runner.py
@@ -2,6 +2,91 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
+def _gpt_turns(result):
+    return [t["value"] for t in result["conversations"] if t["from"] == "gpt"]
+
+
+def test_run_task_captures_reasoning_on_final_message():
+    """Reasoning models' chain-of-thought must land in the trajectory.
+
+    _convert_to_hermes_format wraps a message's ``reasoning`` in
+    ``<think>...</think>``, but run_task never copied ``reasoning`` off the
+    assistant message, so that branch was dead and every emitted trajectory
+    silently dropped the reasoning (and batch_runner discards zero-reasoning
+    samples downstream).
+    """
+    with patch("openai.OpenAI") as mock_openai:
+        client = MagicMock()
+        client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(
+                content="done",
+                tool_calls=[],
+                reasoning="first I inspect, then I answer",
+            ))]
+        )
+        mock_openai.return_value = client
+
+        from mini_swe_runner import MiniSWERunner
+
+        runner = MiniSWERunner(
+            model="deepseek-reasoner",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",
+            env_type="local",
+            max_iterations=1,
+        )
+        runner._create_env = MagicMock()
+        runner._cleanup_env = MagicMock()
+
+        result = runner.run_task("2+2")
+
+    assert result["completed"] is True
+    assert any("<think>first I inspect, then I answer</think>" in v for v in _gpt_turns(result))
+
+
+def test_run_task_captures_reasoning_content_on_tool_call_message():
+    """The ``.reasoning_content`` alias (DeepSeek/Kimi) is captured on a
+    tool-call turn too."""
+    tool_call = SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="terminal", arguments='{"command": "echo hi"}'),
+    )
+    with patch("openai.OpenAI") as mock_openai:
+        client = MagicMock()
+        responses = [
+            SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+                content=None,
+                tool_calls=[tool_call],
+                reasoning_content="I will run the command",
+            ))]),
+            SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+                content="all set", tool_calls=[],
+            ))]),
+        ]
+        client.chat.completions.create.side_effect = responses
+        mock_openai.return_value = client
+
+        from mini_swe_runner import MiniSWERunner
+
+        runner = MiniSWERunner(
+            model="kimi-k2-thinking",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",
+            env_type="local",
+            max_iterations=2,
+        )
+        runner._create_env = MagicMock()
+        runner._cleanup_env = MagicMock()
+        runner._execute_command = MagicMock(
+            return_value={"output": "hi", "exit_code": 0, "error": ""}
+        )
+
+        result = runner.run_task("say hi")
+
+    assert any("<think>I will run the command</think>" in v for v in _gpt_turns(result))
+
+
 def test_run_task_kimi_omits_temperature():
     """Kimi models should NOT have client-side temperature overrides.
 


### PR DESCRIPTION
## What does this PR do?

`mini_swe_runner.py` drops the model's reasoning from every trajectory it emits for a reasoning-capable model.

`_convert_to_hermes_format` wraps an assistant message's reasoning in `<think>...</think>`:

```python
if msg.get("reasoning"):
    content = f"<think>{msg['reasoning']}</think>"
```

But `run_task` builds its assistant messages by copying only `content` and `tool_calls`. It never reads `assistant_message.reasoning` or `.reasoning_content`. So `msg.get("reasoning")` is always falsy, the `<think>` branch is dead code, and the emitted Hermes trajectories lose all chain-of-thought.

Two consequences. First, the `<think>` blocks the converter is designed to produce never appear, so the training data is lower fidelity. Second, `batch_runner.py` drops zero-reasoning samples (`_extract_reasoning_stats` and the `has_any_reasoning` filter), so trajectories from a reasoning model can be thrown away entirely.

The main agent captures this correctly (`agent/chat_completion_helpers.py`: `getattr(message, "reasoning_content", None) or getattr(message, "reasoning", None)`). That confirms `mini_swe_runner` is the outlier and that the converter's `<think>` branch was meant to receive real data.

## Related Issue

Fixes # <!-- no existing issue; happy to open one if preferred -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `mini_swe_runner.py`: capture `reasoning` on both the tool-call assistant message and the final assistant message, using the same `getattr(.reasoning_content) or getattr(.reasoning)` pattern as `agent/chat_completion_helpers.py`. Storing `None` is safe because the converter guards with `if msg.get("reasoning")`.
- `tests/test_mini_swe_runner.py`: regression tests for both the `.reasoning` (OpenRouter) and `.reasoning_content` (DeepSeek/Kimi) aliases, asserting the `<think>...</think>` block reaches the trajectory.

## How to Test

1. Run `scripts/run_tests.sh tests/test_mini_swe_runner.py -q`. 4 tests pass.
2. To show the fix matters, revert the `mini_swe_runner.py` hunk and rerun `-k captures_reasoning`. The 2 new tests fail (no `<think>` in the trajectory). Restore the hunk and they pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(mini-swe):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (searched `mini_swe reasoning`, `swe runner reasoning`, `reasoning trajectory runner`; none matched. The nearby merged mini_swe PRs #11933/#12773 are Kimi-temperature only)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation (README, `docs/`, docstrings): N/A (inline comments explain the capture)
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A (`scripts/check-windows-footguns.py` clean)
- [x] Tool descriptions/schemas: N/A