### PR TITLE
Taubench tool calling eval

### DIFF
--- a/environments/benchmarks/taubench/hermes_agent.py
+++ b/environments/benchmarks/taubench/hermes_agent.py
@@ -1,0 +1,222 @@
+"""
+HermesAgent for tau-bench evaluation.
+
+Implements the tau-bench Agent interface using atroposlib's OpenAIServer for
+inference — the same server HermesAgentLoop uses in training environments.
+Tool execution goes through tau-bench's env.step() so the environment's
+state machine, user simulator, and reward computation work correctly.
+
+Usage:
+    python environments/benchmarks/taubench/run_eval.py \\
+        --model anthropic/claude-sonnet-4-5 --base-url openrouter --env retail
+"""
+
+import asyncio
+import json
+import logging
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Ensure hermes-agent repo root is on sys.path
+_repo_root = Path(__file__).resolve().parent.parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from tau_bench.agents.base import Agent
+from tau_bench.envs.base import Env
+from tau_bench.types import Action, SolveResult, RESPOND_ACTION_NAME
+
+logger = logging.getLogger(__name__)
+
+
+def _message_to_action(message: Dict[str, Any]) -> Action:
+    """Convert an OpenAI-format assistant message to a tau-bench Action."""
+    tool_calls = message.get("tool_calls")
+    if tool_calls and len(tool_calls) > 0 and tool_calls[0].get("function") is not None:
+        tc = tool_calls[0]
+        return Action(
+            name=tc["function"]["name"],
+            kwargs=json.loads(tc["function"]["arguments"]),
+        )
+    return Action(
+        name=RESPOND_ACTION_NAME,
+        kwargs={"content": message.get("content") or ""},
+    )
+
+
+def _normalize_tool_calls(tool_calls) -> List[Dict[str, Any]]:
+    """Normalize tool_calls from OpenAI SDK objects or dicts to plain dicts."""
+    if not tool_calls:
+        return []
+    result = []
+    for tc in tool_calls:
+        if isinstance(tc, dict):
+            result.append({
+                "id": tc.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                "type": "function",
+                "function": {
+                    "name": tc.get("function", {}).get("name", ""),
+                    "arguments": tc.get("function", {}).get("arguments", "{}"),
+                },
+            })
+        else:
+            result.append({
+                "id": getattr(tc, "id", f"call_{uuid.uuid4().hex[:8]}"),
+                "type": "function",
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            })
+    return result
+
+class HermesAgent(Agent):
+    """
+    tau-bench Agent using atroposlib's OpenAIServer for inference.
+
+    Uses the same OpenAIServer abstraction as HermesAgentLoop so inference
+    goes through the same OpenAI-compatible client used in training.
+    Tool execution goes through tau-bench's env.step() — tau-bench tools are
+    retail/airline state-machine operations, not hermes tools.
+
+    Args:
+        server: atroposlib OpenAIServer instance (from build_server() in run_eval.py).
+        system_prompt: Optional system prompt override. Defaults to env.wiki.
+        temperature: Sampling temperature.
+        max_tokens: Optional token limit per generation step.
+        extra_body: Extra params forwarded to chat_completion (e.g. OR preferences).
+    """
+
+    def __init__(
+        self,
+        server,
+        system_prompt: Optional[str] = None,
+        temperature: float = 0.0,
+        max_tokens: Optional[int] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
+    ):
+        self.server = server
+        self.system_prompt = system_prompt
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.extra_body = extra_body
+
+    def solve(
+        self,
+        env: Env,
+        task_index: Optional[int] = None,
+        max_num_steps: int = 30,
+    ) -> SolveResult:
+        """Synchronous entry point required by tau-bench. Runs the async loop."""
+        return asyncio.run(self._solve_async(env, task_index, max_num_steps))
+
+    async def _solve_async(
+        self,
+        env: Env,
+        task_index: Optional[int],
+        max_num_steps: int,
+    ) -> SolveResult:
+        env_reset = env.reset(task_index=task_index)
+        obs = env_reset.observation
+        info = env_reset.info.model_dump()
+        reward = 0.0
+
+        # Patch the user sim's generate_next_message to guard against None returns.
+        # tau-bench's user sim crashes env.step() when the LLM returns None content
+        # (e.g. emits a tool call instead of text). This wraps it to return "" instead.
+        _orig_gen = env.user.generate_next_message
+        def _safe_gen(messages):
+            result = _orig_gen(messages)
+            return result if result is not None else ""
+        env.user.generate_next_message = _safe_gen
+
+        system_content = self.system_prompt if self.system_prompt is not None else env.wiki
+        messages: List[Dict[str, Any]] = [
+            {"role": "system", "content": system_content},
+            {"role": "user", "content": obs},
+        ]
+
+        for step in range(max_num_steps):
+            chat_kwargs: Dict[str, Any] = {
+                "messages": messages,
+                "n": 1,
+                "temperature": self.temperature,
+                "tools": env.tools_info,
+            }
+            if self.max_tokens is not None:
+                chat_kwargs["max_tokens"] = self.max_tokens
+            if self.extra_body:
+                chat_kwargs["extra_body"] = self.extra_body
+
+            try:
+                response = await self.server.chat_completion(**chat_kwargs)
+            except Exception as e:
+                logger.error("chat_completion failed on step %d: %s", step, e)
+                break
+
+            if not response or not response.choices:
+                logger.warning("Empty response on step %d", step)
+                break
+
+            assistant_msg_raw = response.choices[0].message
+
+            if hasattr(assistant_msg_raw, "model_dump"):
+                assistant_msg = assistant_msg_raw.model_dump()
+                # model_dump() returns content=None when absent; normalize to ""
+                if assistant_msg.get("content") is None:
+                    assistant_msg["content"] = ""
+            else:
+                assistant_msg = {
+                    "role": "assistant",
+                    "content": assistant_msg_raw.content or "",
+                    "tool_calls": _normalize_tool_calls(
+                        getattr(assistant_msg_raw, "tool_calls", None)
+                    ),
+                }
+
+            action = _message_to_action(assistant_msg)
+            env_response = env.step(action)
+            reward = env_response.reward
+            info = {**info, **env_response.info.model_dump()}
+
+            if action.name != RESPOND_ACTION_NAME:
+                tool_calls = assistant_msg.get("tool_calls") or []
+                messages.append({
+                    "role": "assistant",
+                    "content": assistant_msg.get("content") or "",
+                    "tool_calls": tool_calls[:1],
+                })
+                if tool_calls:
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": tool_calls[0].get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                        "name": action.name,
+                        "content": env_response.observation,
+                    })
+                else:
+                    messages.append({"role": "user", "content": env_response.observation})
+            else:
+                messages.append({
+                    "role": "assistant",
+                    "content": assistant_msg.get("content") or "",
+                })
+                messages.append({"role": "user", "content": env_response.observation})
+
+            if env_response.done:
+                logger.info("Task complete at step %d, reward=%.3f", step + 1, reward)
+                break
+
+        # Close the underlying httpx client before the event loop shuts down.
+        # Without this, asyncio.run() closes the loop while httpx still has open
+        # connections, producing noisy "Event loop is closed" errors on cleanup.
+        if hasattr(self.server, "openai") and hasattr(self.server.openai, "close"):
+            await self.server.openai.close()
+
+        return SolveResult(
+            reward=reward,
+            info=info,
+            messages=messages,
+            total_cost=None,
+        )

--- a/environments/benchmarks/taubench/hermes_agent.py
+++ b/environments/benchmarks/taubench/hermes_agent.py
@@ -1,222 +1,324 @@
 """
-HermesAgent for tau-bench evaluation.
+HermesAgent for tau2-bench evaluation.
 
-Implements the tau-bench Agent interface using atroposlib's OpenAIServer for
-inference — the same server HermesAgentLoop uses in training environments.
-Tool execution goes through tau-bench's env.step() so the environment's
-state machine, user simulator, and reward computation work correctly.
+Implements the tau2 HalfDuplexAgent interface using litellm with OpenRouter,
+matching the inference path used across the rest of the Hermes Agent codebase.
 
 Usage:
     python environments/benchmarks/taubench/run_eval.py \\
-        --model anthropic/claude-sonnet-4-5 --base-url openrouter --env retail
+        --model anthropic/claude-sonnet-4-5 \\
+        --base-url openrouter \\
+        --env retail
 """
 
-import asyncio
 import json
-import logging
+import os
 import sys
-import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
-# Ensure hermes-agent repo root is on sys.path
+import litellm
+from pydantic import BaseModel
+
 _repo_root = Path(__file__).resolve().parent.parent.parent.parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
-from tau_bench.agents.base import Agent
-from tau_bench.envs.base import Env
-from tau_bench.types import Action, SolveResult, RESPOND_ACTION_NAME
+from environments.tool_call_parsers import get_parser
 
-logger = logging.getLogger(__name__)
+from tau2.agent.base_agent import HalfDuplexAgent, ValidAgentInputMessage
+from tau2.data_model.message import (
+    AssistantMessage,
+    Message,
+    MultiToolMessage,
+    SystemMessage,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+from tau2.environment.tool import Tool
 
 
-def _message_to_action(message: Dict[str, Any]) -> Action:
-    """Convert an OpenAI-format assistant message to a tau-bench Action."""
-    tool_calls = message.get("tool_calls")
-    if tool_calls and len(tool_calls) > 0 and tool_calls[0].get("function") is not None:
-        tc = tool_calls[0]
-        return Action(
-            name=tc["function"]["name"],
-            kwargs=json.loads(tc["function"]["arguments"]),
-        )
-    return Action(
-        name=RESPOND_ACTION_NAME,
-        kwargs={"content": message.get("content") or ""},
+class HermesAgentState(BaseModel):
+    system_messages: list[SystemMessage]
+    messages: list
+
+
+class HermesAgent(HalfDuplexAgent[HermesAgentState]):
+    """
+    tau2 HalfDuplexAgent backed by litellm, using OpenRouter (or any
+    OpenAI-compatible endpoint).
+
+    Registered as "hermes_agent" in the tau2 registry by run_eval.py.
+    """
+
+    SYSTEM_PROMPT = (
+        "You are a customer service agent that helps the user according to the "
+        "<policy> provided below.\n"
+        "In each turn you can either:\n"
+        "- Send a message to the user.\n"
+        "- Make a tool call.\n"
+        "You cannot do both at the same time.\n\n"
+        "Try to be helpful and always follow the policy. "
+        "Always make sure you generate valid JSON only.\n\n"
+        "<policy>\n{domain_policy}\n</policy>"
     )
 
-
-def _normalize_tool_calls(tool_calls) -> List[Dict[str, Any]]:
-    """Normalize tool_calls from OpenAI SDK objects or dicts to plain dicts."""
-    if not tool_calls:
-        return []
-    result = []
-    for tc in tool_calls:
-        if isinstance(tc, dict):
-            result.append({
-                "id": tc.get("id", f"call_{uuid.uuid4().hex[:8]}"),
-                "type": "function",
-                "function": {
-                    "name": tc.get("function", {}).get("name", ""),
-                    "arguments": tc.get("function", {}).get("arguments", "{}"),
-                },
-            })
-        else:
-            result.append({
-                "id": getattr(tc, "id", f"call_{uuid.uuid4().hex[:8]}"),
-                "type": "function",
-                "function": {
-                    "name": tc.function.name,
-                    "arguments": tc.function.arguments,
-                },
-            })
-    return result
-
-class HermesAgent(Agent):
-    """
-    tau-bench Agent using atroposlib's OpenAIServer for inference.
-
-    Uses the same OpenAIServer abstraction as HermesAgentLoop so inference
-    goes through the same OpenAI-compatible client used in training.
-    Tool execution goes through tau-bench's env.step() — tau-bench tools are
-    retail/airline state-machine operations, not hermes tools.
-
-    Args:
-        server: atroposlib OpenAIServer instance (from build_server() in run_eval.py).
-        system_prompt: Optional system prompt override. Defaults to env.wiki.
-        temperature: Sampling temperature.
-        max_tokens: Optional token limit per generation step.
-        extra_body: Extra params forwarded to chat_completion (e.g. OR preferences).
-    """
+    # System prompt variant for qwen3_coder tool format — tools are embedded
+    # directly in the system prompt as <tools> XML instead of passed via the
+    # OpenAI tools= parameter.
+    SYSTEM_PROMPT_QWEN3_CODER = (
+        "You are a customer service agent that helps the user according to the "
+        "<policy> provided below.\n"
+        "In each turn you can either:\n"
+        "- Send a message to the user.\n"
+        "- Make a tool call.\n"
+        "You cannot do both at the same time.\n\n"
+        "Try to be helpful and always follow the policy. "
+        "Always make sure you generate valid JSON only.\n\n"
+        "You may call one or more functions to assist with the user query.\n\n"
+        "You are provided with function signatures within <tools></tools> XML tags:\n"
+        "<tools>\n{tools_json}\n</tools>\n\n"
+        "<policy>\n{domain_policy}\n</policy>"
+    )
 
     def __init__(
         self,
-        server,
-        system_prompt: Optional[str] = None,
+        tools: list[Tool],
+        domain_policy: str,
+        model: str,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
         temperature: float = 0.0,
         max_tokens: Optional[int] = None,
-        extra_body: Optional[Dict[str, Any]] = None,
+        top_p: Optional[float] = None,
+        thinking: bool = False,
+        tool_parser: Optional[str] = None,
     ):
-        self.server = server
-        self.system_prompt = system_prompt
+        super().__init__(tools=tools, domain_policy=domain_policy)
+        self.model = model
+        self.base_url = base_url
+        self.api_key = api_key
         self.temperature = temperature
         self.max_tokens = max_tokens
-        self.extra_body = extra_body
+        self.top_p = top_p
+        self.thinking = thinking
+        self.tool_parser = tool_parser
+        self._parser = get_parser(tool_parser) if tool_parser else None
 
-    def solve(
-        self,
-        env: Env,
-        task_index: Optional[int] = None,
-        max_num_steps: int = 30,
-    ) -> SolveResult:
-        """Synchronous entry point required by tau-bench. Runs the async loop."""
-        return asyncio.run(self._solve_async(env, task_index, max_num_steps))
-
-    async def _solve_async(
-        self,
-        env: Env,
-        task_index: Optional[int],
-        max_num_steps: int,
-    ) -> SolveResult:
-        env_reset = env.reset(task_index=task_index)
-        obs = env_reset.observation
-        info = env_reset.info.model_dump()
-        reward = 0.0
-
-        # Patch the user sim's generate_next_message to guard against None returns.
-        # tau-bench's user sim crashes env.step() when the LLM returns None content
-        # (e.g. emits a tool call instead of text). This wraps it to return "" instead.
-        _orig_gen = env.user.generate_next_message
-        def _safe_gen(messages):
-            result = _orig_gen(messages)
-            return result if result is not None else ""
-        env.user.generate_next_message = _safe_gen
-
-        system_content = self.system_prompt if self.system_prompt is not None else env.wiki
-        messages: List[Dict[str, Any]] = [
-            {"role": "system", "content": system_content},
-            {"role": "user", "content": obs},
-        ]
-
-        for step in range(max_num_steps):
-            chat_kwargs: Dict[str, Any] = {
-                "messages": messages,
-                "n": 1,
-                "temperature": self.temperature,
-                "tools": env.tools_info,
+        # OpenRouter requires specific headers; pass them via litellm extra_headers
+        self._extra_headers: dict = {}
+        if base_url and "openrouter" in base_url.lower():
+            self._extra_headers = {
+                "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+                "X-Title": "Hermes Agent",
             }
-            if self.max_tokens is not None:
-                chat_kwargs["max_tokens"] = self.max_tokens
-            if self.extra_body:
-                chat_kwargs["extra_body"] = self.extra_body
 
-            try:
-                response = await self.server.chat_completion(**chat_kwargs)
-            except Exception as e:
-                logger.error("chat_completion failed on step %d: %s", step, e)
-                break
+    @property
+    def system_prompt(self) -> str:
+        if self.tool_parser == "qwen3_coder" and self.tools:
+            tools_json = json.dumps(
+                [t.openai_schema for t in self.tools], indent=2, ensure_ascii=False
+            )
+            return self.SYSTEM_PROMPT_QWEN3_CODER.format(
+                tools_json=tools_json,
+                domain_policy=self.domain_policy,
+            )
+        return self.SYSTEM_PROMPT.format(domain_policy=self.domain_policy)
 
-            if not response or not response.choices:
-                logger.warning("Empty response on step %d", step)
-                break
-
-            assistant_msg_raw = response.choices[0].message
-
-            if hasattr(assistant_msg_raw, "model_dump"):
-                assistant_msg = assistant_msg_raw.model_dump()
-                # model_dump() returns content=None when absent; normalize to ""
-                if assistant_msg.get("content") is None:
-                    assistant_msg["content"] = ""
-            else:
-                assistant_msg = {
-                    "role": "assistant",
-                    "content": assistant_msg_raw.content or "",
-                    "tool_calls": _normalize_tool_calls(
-                        getattr(assistant_msg_raw, "tool_calls", None)
-                    ),
-                }
-
-            action = _message_to_action(assistant_msg)
-            env_response = env.step(action)
-            reward = env_response.reward
-            info = {**info, **env_response.info.model_dump()}
-
-            if action.name != RESPOND_ACTION_NAME:
-                tool_calls = assistant_msg.get("tool_calls") or []
-                messages.append({
-                    "role": "assistant",
-                    "content": assistant_msg.get("content") or "",
-                    "tool_calls": tool_calls[:1],
-                })
-                if tool_calls:
-                    messages.append({
-                        "role": "tool",
-                        "tool_call_id": tool_calls[0].get("id", f"call_{uuid.uuid4().hex[:8]}"),
-                        "name": action.name,
-                        "content": env_response.observation,
-                    })
-                else:
-                    messages.append({"role": "user", "content": env_response.observation})
-            else:
-                messages.append({
-                    "role": "assistant",
-                    "content": assistant_msg.get("content") or "",
-                })
-                messages.append({"role": "user", "content": env_response.observation})
-
-            if env_response.done:
-                logger.info("Task complete at step %d, reward=%.3f", step + 1, reward)
-                break
-
-        # Close the underlying httpx client before the event loop shuts down.
-        # Without this, asyncio.run() closes the loop while httpx still has open
-        # connections, producing noisy "Event loop is closed" errors on cleanup.
-        if hasattr(self.server, "openai") and hasattr(self.server.openai, "close"):
-            await self.server.openai.close()
-
-        return SolveResult(
-            reward=reward,
-            info=info,
-            messages=messages,
-            total_cost=None,
+    def get_init_state(
+        self, message_history: Optional[list[Message]] = None
+    ) -> HermesAgentState:
+        return HermesAgentState(
+            system_messages=[SystemMessage(role="system", content=self.system_prompt)],
+            messages=list(message_history or []),
         )
+
+    def generate_next_message(
+        self, message: ValidAgentInputMessage, state: HermesAgentState
+    ) -> tuple[AssistantMessage, HermesAgentState]:
+        # Append incoming message(s) to history
+        if isinstance(message, MultiToolMessage):
+            state.messages.extend(message.tool_messages)
+        else:
+            state.messages.append(message)
+
+        # Build litellm-compatible message list
+        all_messages = state.system_messages + state.messages
+        lm_messages = [_to_litellm_message(m) for m in all_messages]
+
+        kwargs = dict(
+            model=self.model,
+            messages=lm_messages,
+            temperature=self.temperature,
+        )
+        if self.tools:
+            kwargs["tools"] = [t.openai_schema for t in self.tools]
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
+        if self.top_p is not None:
+            kwargs["top_p"] = self.top_p
+        # Enable thinking/reasoning mode. OpenRouter exposes this as
+        # `include_reasoning` for nemotron (per supported_parameters in the
+        # model metadata). Pass via extra_body to bypass litellm filtering.
+        if self.thinking:
+            kwargs["extra_body"] = {"include_reasoning": True}
+        # Only pass base_url when model doesn't already have a provider prefix
+        # (litellm uses either the prefix OR base_url, not both)
+        if self.base_url and not self.model.startswith("openrouter/"):
+            kwargs["base_url"] = self.base_url
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self._extra_headers:
+            kwargs["extra_headers"] = self._extra_headers
+
+        response = litellm.completion(**kwargs)
+        assistant_msg = _litellm_response_to_assistant_message(response, parser=self._parser)
+
+        state.messages.append(assistant_msg)
+        return assistant_msg, state
+
+
+# ---------------------------------------------------------------------------
+# Conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_litellm_message(msg) -> dict:
+    """Convert a tau2 message object to a litellm-compatible dict."""
+    if isinstance(msg, SystemMessage):
+        return {"role": "system", "content": msg.content or ""}
+
+    if isinstance(msg, UserMessage):
+        if msg.tool_calls:
+            # User tool calls (tau2 v2 feature — user has tools too)
+            return {
+                "role": "user",
+                "content": msg.content or "",
+                "tool_calls": [_tool_call_to_dict(tc) for tc in msg.tool_calls],
+            }
+        return {"role": "user", "content": msg.content or ""}
+
+    if isinstance(msg, AssistantMessage):
+        d: dict = {"role": "assistant", "content": msg.content or ""}
+        if msg.tool_calls:
+            d["tool_calls"] = [_tool_call_to_dict(tc) for tc in msg.tool_calls]
+        return d
+
+    if isinstance(msg, ToolMessage):
+        return {
+            "role": "tool",
+            "tool_call_id": msg.id,
+            "content": msg.content or "",
+        }
+
+    # Fallback
+    return {"role": getattr(msg, "role", "user"), "content": str(getattr(msg, "content", ""))}
+
+
+def _tool_call_to_dict(tc: ToolCall) -> dict:
+    import json
+    return {
+        "id": tc.id or "call_0",
+        "type": "function",
+        "function": {
+            "name": tc.name,
+            "arguments": json.dumps(tc.arguments),
+        },
+    }
+
+
+def _litellm_response_to_assistant_message(response, parser=None) -> AssistantMessage:
+    """Convert a litellm ModelResponse to a tau2 AssistantMessage."""
+    import json
+
+    choice = response.choices[0]
+    msg = choice.message
+
+    content = msg.content or ""
+    tool_calls_raw = getattr(msg, "tool_calls", None)
+
+    tau2_tool_calls: Optional[list[ToolCall]] = None
+
+    if parser and content:
+        # Use the custom tool parser (e.g. qwen3_coder) to extract tool calls
+        # from the raw text response.
+        parsed_content, parsed_tool_calls = parser.parse(content)
+        if parsed_tool_calls:
+            content = parsed_content or ""
+            tau2_tool_calls = []
+            for tc in parsed_tool_calls:
+                try:
+                    arguments = json.loads(tc.function.arguments or "{}")
+                except json.JSONDecodeError:
+                    arguments = {}
+                tau2_tool_calls.append(
+                    ToolCall(
+                        id=tc.id or "call_0",
+                        name=tc.function.name,
+                        arguments=arguments,
+                        requestor="assistant",
+                    )
+                )
+    elif tool_calls_raw:
+        tau2_tool_calls = []
+        for tc in tool_calls_raw:
+            if hasattr(tc, "function"):
+                name = tc.function.name
+                try:
+                    arguments = json.loads(tc.function.arguments or "{}")
+                except json.JSONDecodeError:
+                    arguments = {}
+                tau2_tool_calls.append(
+                    ToolCall(
+                        id=tc.id or "call_0",
+                        name=name,
+                        arguments=arguments,
+                        requestor="assistant",
+                    )
+                )
+
+    cost = None
+    try:
+        cost = litellm.completion_cost(response)
+    except Exception:
+        pass
+
+    usage = None
+    if hasattr(response, "usage") and response.usage:
+        usage = dict(response.usage)
+
+    return AssistantMessage(
+        role="assistant",
+        content=content if not tau2_tool_calls else None,
+        tool_calls=tau2_tool_calls,
+        cost=cost,
+        usage=usage,
+    )
+
+
+def create_hermes_agent(tools: list[Tool], domain_policy: str, **kwargs) -> HermesAgent:
+    """
+    Factory function registered with the tau2 registry.
+
+    Expected kwargs:
+        model (str): litellm model string
+        base_url (str): API base URL (optional)
+        api_key (str): API key (optional)
+        temperature (float): sampling temperature (default 0.0)
+        top_p (float): nucleus sampling (optional)
+        max_tokens (int): max tokens (optional)
+        thinking (bool): enable reasoning/thinking mode (default False)
+    """
+    return HermesAgent(
+        tools=tools,
+        domain_policy=domain_policy,
+        model=kwargs["model"],
+        base_url=kwargs.get("base_url"),
+        api_key=kwargs.get("api_key"),
+        temperature=kwargs.get("temperature", 0.0),
+        top_p=kwargs.get("top_p"),
+        max_tokens=kwargs.get("max_tokens"),
+        thinking=kwargs.get("thinking", False),
+        tool_parser=kwargs.get("tool_parser"),
+    )

--- a/environments/benchmarks/taubench/hermes_agent.py
+++ b/environments/benchmarks/taubench/hermes_agent.py
@@ -61,6 +61,9 @@ class HermesAgent(HalfDuplexAgent[HermesAgentState]):
         "You cannot do both at the same time.\n\n"
         "Try to be helpful and always follow the policy. "
         "Always make sure you generate valid JSON only.\n\n"
+        "IMPORTANT: You MUST only use the exact tool names provided to you. "
+        "Do NOT invent or guess tool names. If a tool call fails, check the "
+        "available tools list and use the correct name.\n\n"
         "<policy>\n{domain_policy}\n</policy>"
     )
 
@@ -80,6 +83,28 @@ class HermesAgent(HalfDuplexAgent[HermesAgentState]):
         "You are provided with function signatures within <tools></tools> XML tags:\n"
         "<tools>\n{tools_json}\n</tools>\n\n"
         "<policy>\n{domain_policy}\n</policy>"
+    )
+
+    # System prompt variant for Hermes tool format — tools are embedded in the
+    # system prompt as JSON and the model outputs tool calls as \fncall{...}\fn tags
+    # instead of OpenAI tool_calls.
+    # Use @@@TOOLS_JSON@@@ and @@@DOMAIN_POLICY@@@ as placeholders to avoid
+    # conflicts with literal braces in the template (no .format() needed).
+    SYSTEM_PROMPT_HERMES = (
+        "You are a customer service agent that helps the user according to the "
+        "<policy> provided below.\n"
+        "In each turn you can either:\n"
+        "- Send a message to the user.\n"
+        "- Make a tool call.\n"
+        "You cannot do both at the same time.\n\n"
+        "Try to be helpful and always follow the policy. "
+        "Always make sure you generate valid JSON only.\n\n"
+        "You have access to the following functions:\n\n"
+        "@@@TOOLS_JSON@@@\n\n"
+        "To call a function, respond with a single JSON object wrapped in \fncall{...}\fn tags:\n"
+        "```\ncall{\"name\": \"function_name\", \"arguments\": {\"arg\": \"value\"}}\n```\n"
+        "You may make multiple calls by emitting multiple \fncall{...}\fn tags.\n\n"
+        "<policy>\n@@@DOMAIN_POLICY@@@\n</policy>"
     )
 
     def __init__(
@@ -120,11 +145,34 @@ class HermesAgent(HalfDuplexAgent[HermesAgentState]):
             tools_json = json.dumps(
                 [t.openai_schema for t in self.tools], indent=2, ensure_ascii=False
             )
+            # Escape braces for .format(): replace { with {{ and } with }}
+            tools_json_escaped = tools_json.replace("{", "{{").replace("}", "}}")
             return self.SYSTEM_PROMPT_QWEN3_CODER.format(
-                tools_json=tools_json,
+                tools_json=tools_json_escaped,
                 domain_policy=self.domain_policy,
             )
-        return self.SYSTEM_PROMPT.format(domain_policy=self.domain_policy)
+        if self.tool_parser == "hermes" and self.tools:
+            tools_json = json.dumps(
+                [t.openai_schema for t in self.tools], indent=2, ensure_ascii=False
+            )
+            # Use replace instead of format to avoid conflicts with literal braces
+            return (self.SYSTEM_PROMPT_HERMES
+                    .replace("@@@TOOLS_JSON@@@", tools_json)
+                    .replace("@@@DOMAIN_POLICY@@@", self.domain_policy))
+        # Default case: native OpenAI function calling (tools passed via API)
+        prompt = self.SYSTEM_PROMPT.format(domain_policy=self.domain_policy)
+        # Append tool signatures to reinforce correct names AND parameter names.
+        # This helps weaker models that don't strictly read the tools= schema.
+        if self.tools:
+            sigs = []
+            for t in self.tools:
+                schema = t.openai_schema
+                fn = schema.get("function", {})
+                params = fn.get("parameters", {}).get("properties", {})
+                param_str = ", ".join(f"{k}: {v.get('type', '?')}" for k, v in params.items())
+                sigs.append(f"  {t.name}({param_str})")
+            prompt += "\n\nAvailable tools — use ONLY these exact function and parameter names:\n" + "\n".join(sigs)
+        return prompt
 
     def get_init_state(
         self, message_history: Optional[list[Message]] = None
@@ -152,8 +200,11 @@ class HermesAgent(HalfDuplexAgent[HermesAgentState]):
             messages=lm_messages,
             temperature=self.temperature,
         )
-        if self.tools:
+        # Only pass tools via OpenAI tools= parameter when NOT using hermes parser.
+        # For hermes, tools are embedded in the system prompt.
+        if self.tools and self.tool_parser != "hermes":
             kwargs["tools"] = [t.openai_schema for t in self.tools]
+            kwargs["tool_choice"] = "auto"  # Match tau2's default behavior
         if self.max_tokens is not None:
             kwargs["max_tokens"] = self.max_tokens
         if self.top_p is not None:

--- a/environments/benchmarks/taubench/run_eval.py
+++ b/environments/benchmarks/taubench/run_eval.py
@@ -1,0 +1,338 @@
+"""
+Tau-bench evaluation runner for Hermes Agent.
+
+Runs the tau-bench retail or airline evaluation using HermesAgent backed by
+atroposlib's OpenAIServer — the same server abstraction used by HermesAgentLoop
+in our training environments.
+
+Usage:
+    # Against OpenRouter (auto-detects OPENROUTER_API_KEY, sets required headers)
+    python environments/benchmarks/taubench/run_eval.py \\
+        --model anthropic/claude-sonnet-4-5 \\
+        --base-url openrouter \\
+        --env retail
+
+    # Against OpenAI
+    python environments/benchmarks/taubench/run_eval.py \\
+        --model gpt-4o \\
+        --base-url https://api.openai.com/v1 \\
+        --env retail
+
+    # Against a local vLLM server
+    python environments/benchmarks/taubench/run_eval.py \\
+        --model NousResearch/Hermes-3-Llama-3.1-70B \\
+        --base-url http://localhost:8000/v1 \\
+        --env retail \\
+        --num-trials 3
+
+    # Specific tasks only
+    python environments/benchmarks/taubench/run_eval.py \\
+        --model anthropic/claude-sonnet-4-5 \\
+        --base-url openrouter \\
+        --env retail \\
+        --task-ids 0 1 2 5 10
+
+Results are saved to results/taubench/ as JSON.
+
+Dependencies:
+    pip install -e ".[taubench]"
+    (tau-bench: pip install git+https://github.com/sierra-research/tau-bench)
+"""
+
+import argparse
+import json
+import logging
+import os
+import random
+import sys
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from math import comb
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Ensure hermes-agent repo root is on sys.path
+_repo_root = Path(__file__).resolve().parent.parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from atroposlib.envs.server_handling.openai_server import OpenAIServer
+from atroposlib.envs.server_handling.server_manager import APIServerConfig
+
+from tau_bench.envs import get_env
+from tau_bench.types import EnvRunResult
+
+from environments.benchmarks.taubench.hermes_agent import HermesAgent
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def build_server(model: str, base_url: str, api_key: Optional[str]) -> OpenAIServer:
+    """
+    Build an atroposlib OpenAIServer for the given endpoint.
+
+    For OpenRouter, injects HTTP-Referer and X-Title headers into the
+    underlying openai client after construction (APIServerConfig has no
+    default_headers field).
+    """
+    is_openrouter = "openrouter" in base_url.lower()
+
+    if is_openrouter:
+        resolved_key = (
+            api_key
+            or os.environ.get("OPENROUTER_API_KEY")
+            or os.environ.get("OPENAI_API_KEY", "EMPTY")
+        )
+    else:
+        resolved_key = api_key or os.environ.get("OPENAI_API_KEY", "EMPTY")
+
+    config = APIServerConfig(
+        model_name=model,
+        base_url=base_url,
+        api_key=resolved_key,
+    )
+    server = OpenAIServer(config=config)
+
+    if is_openrouter:
+        server.openai = server.openai.with_options(
+            default_headers={
+                "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+                "X-Title": "Hermes Agent",
+            }
+        )
+
+    return server
+
+
+def display_metrics(results: List[EnvRunResult]) -> None:
+    if not results:
+        print("No results to display.")
+        return
+
+    avg_reward = sum(r.reward for r in results) / len(results)
+    print(f"\n{'='*50}")
+    print(f"Results ({len(results)} tasks):")
+    print(f"  Average reward: {avg_reward:.4f}")
+
+    task_results: Dict[int, List[float]] = {}
+    for r in results:
+        task_results.setdefault(r.task_id, []).append(r.reward)
+
+    num_tasks = len(task_results)
+    total_trials = len(results) // num_tasks if num_tasks > 0 else 1
+
+    for k in range(1, min(total_trials + 1, 5)):
+        successes = sum(
+            1 for rewards in task_results.values() if any(r >= 1.0 for r in rewards[:k])
+        )
+        p_k = successes / num_tasks if num_tasks > 0 else 0.0
+        print(f"  Pass@{k}: {p_k:.4f}  ({successes}/{num_tasks} tasks)")
+
+    print(f"{'='*50}\n")
+
+
+def run_eval(
+    model: str,
+    base_url: Optional[str],
+    api_key: Optional[str],
+    env_name: str,
+    task_split: str,
+    user_model: str,
+    user_base_url: Optional[str],
+    user_api_key: Optional[str],
+    num_trials: int,
+    max_concurrency: int,
+    max_num_steps: int,
+    temperature: float,
+    max_tokens: Optional[int],
+    task_ids: Optional[List[int]],
+    start_index: int,
+    end_index: int,
+    log_dir: str,
+    seed: int,
+    shuffle: bool,
+    system_prompt: Optional[str],
+) -> List[EnvRunResult]:
+    random.seed(seed)
+
+    # Expand "openrouter" shorthand to full URL
+    if base_url and base_url.strip().lower() == "openrouter":
+        base_url = OPENROUTER_BASE_URL
+    if not base_url:
+        base_url = "https://api.openai.com/v1"
+
+    os.makedirs(log_dir, exist_ok=True)
+    time_str = datetime.now().strftime("%m%d%H%M%S")
+    ckpt_path = os.path.join(
+        log_dir,
+        f"hermes-{model.split('/')[-1]}-{temperature}_{env_name}_{task_split}_{time_str}.json",
+    )
+
+    # Resolve litellm provider + model for the tau-bench user simulator.
+    # tau-bench's user sim calls litellm.completion(model=..., custom_llm_provider=...).
+    user_effective_base = user_base_url or base_url
+    user_is_openrouter = "openrouter" in user_effective_base.lower()
+
+    if user_is_openrouter:
+        user_provider = "openrouter"
+        if user_model == "gpt-4o":
+            user_model = model  # mirror the agent model
+        if "/" not in user_model:
+            user_model = f"openai/{user_model}"
+        if not os.environ.get("OPENROUTER_API_KEY") and (api_key or user_api_key):
+            os.environ["OPENROUTER_API_KEY"] = user_api_key or api_key
+    else:
+        user_provider = "openai"
+
+    ref_env = get_env(
+        env_name,
+        user_strategy="llm",
+        user_model=user_model,
+        task_split=task_split,
+        user_provider=user_provider,
+    )
+    total_tasks = len(ref_env.tasks)
+
+    if task_ids and len(task_ids) > 0:
+        idxs = task_ids
+    else:
+        end = total_tasks if end_index == -1 else min(end_index, total_tasks)
+        idxs = list(range(start_index, end))
+
+    logger.info(
+        "Running %s eval on %s (%d tasks, %d trials, concurrency=%d)",
+        env_name, model, len(idxs), num_trials, max_concurrency,
+    )
+    logger.info("Results checkpoint: %s", ckpt_path)
+
+    results: List[EnvRunResult] = []
+
+    def _run_task(idx: int, trial: int) -> EnvRunResult:
+        isolated_env = get_env(
+            env_name,
+            user_strategy="llm",
+            user_model=user_model,
+            task_split=task_split,
+            user_provider=user_provider,
+            task_index=idx,
+        )
+        # Build a fresh server per task — each worker runs its own asyncio event
+        # loop via asyncio.run(), and AsyncOpenAI clients are bound to the loop
+        # they were created in. Sharing one client across loops causes hangs.
+        task_server = build_server(model=model, base_url=base_url, api_key=api_key)
+        agent = HermesAgent(
+            server=task_server,
+            system_prompt=system_prompt,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        logger.info("Trial %d | Task %d", trial + 1, idx)
+        try:
+            solve_result = agent.solve(
+                env=isolated_env,
+                task_index=idx,
+                max_num_steps=max_num_steps,
+            )
+            return EnvRunResult(
+                task_id=idx,
+                reward=solve_result.reward,
+                info=solve_result.info,
+                traj=solve_result.messages,
+                trial=trial,
+            )
+        except Exception as e:
+            logger.error("Task %d trial %d failed: %s", idx, trial, traceback.format_exc())
+            return EnvRunResult(
+                task_id=idx,
+                reward=0.0,
+                info={"error": str(e)},
+                traj=[],
+                trial=trial,
+            )
+
+    for trial in range(num_trials):
+        trial_idxs = list(idxs)
+        if shuffle:
+            random.shuffle(trial_idxs)
+
+        with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
+            futures = [executor.submit(_run_task, idx, trial) for idx in trial_idxs]
+            for future in futures:
+                result = future.result()
+                results.append(result)
+                with open(ckpt_path, "w") as f:
+                    json.dump([r.model_dump() for r in results], f, indent=2)
+
+    display_metrics(results)
+    logger.info("Final results saved to %s", ckpt_path)
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run tau-bench evaluation with Hermes Agent",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--model", required=True, help="Model name (e.g., anthropic/claude-sonnet-4-5)")
+    parser.add_argument(
+        "--base-url", default=None,
+        help="OpenAI-compatible API base URL. Use 'openrouter' as shorthand for "
+             "https://openrouter.ai/api/v1 (auto-detects OPENROUTER_API_KEY).",
+    )
+    parser.add_argument(
+        "--api-key", default=None,
+        help="API key. OpenRouter: falls back to OPENROUTER_API_KEY. Others: OPENAI_API_KEY.",
+    )
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--max-tokens", type=int, default=None)
+    parser.add_argument(
+        "--user-model", default="gpt-4o",
+        help="Model for the tau-bench user simulator. Defaults to the agent model when on OpenRouter.",
+    )
+    parser.add_argument("--user-base-url", default=None)
+    parser.add_argument("--user-api-key", default=None)
+    parser.add_argument("--env", default="retail", choices=["retail", "airline"])
+    parser.add_argument("--task-split", default="test", choices=["train", "test", "dev"])
+    parser.add_argument("--num-trials", type=int, default=1)
+    parser.add_argument("--max-concurrency", type=int, default=8)
+    parser.add_argument("--max-num-steps", type=int, default=30)
+    parser.add_argument("--task-ids", type=int, nargs="*", default=None)
+    parser.add_argument("--start-index", type=int, default=0)
+    parser.add_argument("--end-index", type=int, default=-1)
+    parser.add_argument("--seed", type=int, default=10)
+    parser.add_argument("--shuffle", action="store_true")
+    parser.add_argument("--log-dir", default="results/taubench")
+    parser.add_argument("--system-prompt", default=None)
+
+    args = parser.parse_args()
+
+    run_eval(
+        model=args.model,
+        base_url=args.base_url,
+        api_key=args.api_key,
+        env_name=args.env,
+        task_split=args.task_split,
+        user_model=args.user_model,
+        user_base_url=args.user_base_url,
+        user_api_key=args.user_api_key,
+        num_trials=args.num_trials,
+        max_concurrency=args.max_concurrency,
+        max_num_steps=args.max_num_steps,
+        temperature=args.temperature,
+        max_tokens=args.max_tokens,
+        task_ids=args.task_ids,
+        start_index=args.start_index,
+        end_index=args.end_index,
+        log_dir=args.log_dir,
+        seed=args.seed,
+        shuffle=args.shuffle,
+        system_prompt=args.system_prompt,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/environments/benchmarks/taubench/run_eval.py
+++ b/environments/benchmarks/taubench/run_eval.py
@@ -1,312 +1,263 @@
 """
-Tau-bench evaluation runner for Hermes Agent.
+tau2-bench evaluation runner for Hermes Agent.
 
-Runs the tau-bench retail or airline evaluation using HermesAgent backed by
-atroposlib's OpenAIServer — the same server abstraction used by HermesAgentLoop
-in our training environments.
+Runs the tau2-bench retail, airline, telecom, or banking_knowledge evaluation
+using HermesAgent backed by litellm — the same inference path used across the
+rest of the Hermes Agent codebase.
 
 Usage:
-    # Against OpenRouter (auto-detects OPENROUTER_API_KEY, sets required headers)
+    # Against OpenRouter (auto-detects OPENROUTER_API_KEY)
     python environments/benchmarks/taubench/run_eval.py \\
-        --model anthropic/claude-sonnet-4-5 \\
+        --model openrouter/anthropic/claude-sonnet-4-5 \\
         --base-url openrouter \\
         --env retail
 
-    # Against OpenAI
+    # Against OpenAI directly
     python environments/benchmarks/taubench/run_eval.py \\
         --model gpt-4o \\
-        --base-url https://api.openai.com/v1 \\
         --env retail
 
-    # Against a local vLLM server
+    # Local vLLM
     python environments/benchmarks/taubench/run_eval.py \\
-        --model NousResearch/Hermes-3-Llama-3.1-70B \\
+        --model openai/NousResearch/Hermes-3-Llama-3.1-70B \\
         --base-url http://localhost:8000/v1 \\
         --env retail \\
         --num-trials 3
 
     # Specific tasks only
     python environments/benchmarks/taubench/run_eval.py \\
-        --model anthropic/claude-sonnet-4-5 \\
+        --model openrouter/anthropic/claude-sonnet-4-5 \\
         --base-url openrouter \\
         --env retail \\
-        --task-ids 0 1 2 5 10
+        --task-ids task_1 task_2 task_5
 
-Results are saved to results/taubench/ as JSON.
+Results are saved to results/tau2bench/ as JSON.
 
-Dependencies:
-    pip install -e ".[taubench]"
-    (tau-bench: pip install git+https://github.com/sierra-research/tau-bench)
+Dependencies (requires Python 3.12+):
+    pip install "tau2 @ git+https://github.com/sierra-research/tau2-bench.git"
+    # or: pip install -e ".[tau2bench]"
 """
 
 import argparse
-import json
 import logging
 import os
-import random
 import sys
-import traceback
-from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
-from math import comb
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
-# Ensure hermes-agent repo root is on sys.path
 _repo_root = Path(__file__).resolve().parent.parent.parent.parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
-from atroposlib.envs.server_handling.openai_server import OpenAIServer
-from atroposlib.envs.server_handling.server_manager import APIServerConfig
+from tau2.data_model.simulation import Results, TextRunConfig
+from tau2.evaluator.evaluator import EvaluationType
+from tau2.registry import registry
+from tau2.runner.batch import run_tasks
+from tau2.runner.helpers import get_tasks
 
-from tau_bench.envs import get_env
-from tau_bench.types import EnvRunResult
+from environments.benchmarks.taubench.hermes_agent import create_hermes_agent
 
-from environments.benchmarks.taubench.hermes_agent import HermesAgent
-
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+AGENT_NAME = "hermes_agent"
 
 
-def build_server(model: str, base_url: str, api_key: Optional[str]) -> OpenAIServer:
-    """
-    Build an atroposlib OpenAIServer for the given endpoint.
-
-    For OpenRouter, injects HTTP-Referer and X-Title headers into the
-    underlying openai client after construction (APIServerConfig has no
-    default_headers field).
-    """
-    is_openrouter = "openrouter" in base_url.lower()
-
-    if is_openrouter:
-        resolved_key = (
-            api_key
-            or os.environ.get("OPENROUTER_API_KEY")
-            or os.environ.get("OPENAI_API_KEY", "EMPTY")
-        )
-    else:
-        resolved_key = api_key or os.environ.get("OPENAI_API_KEY", "EMPTY")
-
-    config = APIServerConfig(
-        model_name=model,
-        base_url=base_url,
-        api_key=resolved_key,
-    )
-    server = OpenAIServer(config=config)
-
-    if is_openrouter:
-        server.openai = server.openai.with_options(
-            default_headers={
-                "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-                "X-Title": "Hermes Agent",
-            }
-        )
-
-    return server
-
-
-def display_metrics(results: List[EnvRunResult]) -> None:
-    if not results:
-        print("No results to display.")
+def _register_agent(
+    model: str,
+    base_url: Optional[str],
+    api_key: Optional[str],
+    temperature: float,
+    top_p: Optional[float],
+    max_tokens: Optional[int],
+    thinking: bool,
+    tool_parser: Optional[str],
+) -> None:
+    """Register the HermesAgent factory with the tau2 registry (idempotent)."""
+    if registry.get_agent_factory(AGENT_NAME) is not None:
         return
 
-    avg_reward = sum(r.reward for r in results) / len(results)
-    print(f"\n{'='*50}")
-    print(f"Results ({len(results)} tasks):")
-    print(f"  Average reward: {avg_reward:.4f}")
-
-    task_results: Dict[int, List[float]] = {}
-    for r in results:
-        task_results.setdefault(r.task_id, []).append(r.reward)
-
-    num_tasks = len(task_results)
-    total_trials = len(results) // num_tasks if num_tasks > 0 else 1
-
-    for k in range(1, min(total_trials + 1, 5)):
-        successes = sum(
-            1 for rewards in task_results.values() if any(r >= 1.0 for r in rewards[:k])
+    def factory(tools, domain_policy, **kwargs):
+        return create_hermes_agent(
+            tools=tools,
+            domain_policy=domain_policy,
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            thinking=thinking,
+            tool_parser=tool_parser,
         )
-        p_k = successes / num_tasks if num_tasks > 0 else 0.0
-        print(f"  Pass@{k}: {p_k:.4f}  ({successes}/{num_tasks} tasks)")
 
-    print(f"{'='*50}\n")
+    registry.register_agent_factory(factory=factory, name=AGENT_NAME)
+    logger.info("Registered agent factory: %s (model=%s, thinking=%s, tool_parser=%s)", AGENT_NAME, model, thinking, tool_parser)
 
 
 def run_eval(
     model: str,
     base_url: Optional[str],
     api_key: Optional[str],
-    env_name: str,
-    task_split: str,
     user_model: str,
-    user_base_url: Optional[str],
-    user_api_key: Optional[str],
+    env_name: str,
+    task_split: Optional[str],
     num_trials: int,
     max_concurrency: int,
-    max_num_steps: int,
+    max_steps: int,
     temperature: float,
+    top_p: Optional[float],
     max_tokens: Optional[int],
-    task_ids: Optional[List[int]],
+    thinking: bool,
+    tool_parser: Optional[str],
+    task_ids: Optional[list],
     start_index: int,
     end_index: int,
     log_dir: str,
     seed: int,
-    shuffle: bool,
-    system_prompt: Optional[str],
-) -> List[EnvRunResult]:
-    random.seed(seed)
-
-    # Expand "openrouter" shorthand to full URL
+) -> Results:
+    # Resolve OpenRouter shorthand
     if base_url and base_url.strip().lower() == "openrouter":
         base_url = OPENROUTER_BASE_URL
-    if not base_url:
-        base_url = "https://api.openai.com/v1"
 
-    os.makedirs(log_dir, exist_ok=True)
-    time_str = datetime.now().strftime("%m%d%H%M%S")
-    ckpt_path = os.path.join(
-        log_dir,
-        f"hermes-{model.split('/')[-1]}-{temperature}_{env_name}_{task_split}_{time_str}.json",
+    is_openrouter = base_url and "openrouter" in base_url.lower()
+
+    # litellm requires the "openrouter/" prefix to route correctly
+    if is_openrouter and not model.startswith("openrouter/"):
+        model = f"openrouter/{model}"
+    if is_openrouter and not user_model.startswith("openrouter/"):
+        user_model = f"openrouter/{user_model}"
+
+    # Resolve API key
+    if is_openrouter:
+        api_key = api_key or os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        # litellm reads OPENAI_API_KEY for base_url overrides; set it so the
+        # user simulator's generate() call also authenticates correctly.
+        if api_key and not os.environ.get("OPENAI_API_KEY"):
+            os.environ["OPENAI_API_KEY"] = api_key
+    else:
+        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+
+    _register_agent(
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+        thinking=thinking,
+        tool_parser=tool_parser,
     )
 
-    # Resolve litellm provider + model for the tau-bench user simulator.
-    # tau-bench's user sim calls litellm.completion(model=..., custom_llm_provider=...).
-    user_effective_base = user_base_url or base_url
-    user_is_openrouter = "openrouter" in user_effective_base.lower()
-
-    if user_is_openrouter:
-        user_provider = "openrouter"
-        if user_model == "gpt-4o":
-            user_model = model  # mirror the agent model
-        if "/" not in user_model:
-            user_model = f"openai/{user_model}"
-        if not os.environ.get("OPENROUTER_API_KEY") and (api_key or user_api_key):
-            os.environ["OPENROUTER_API_KEY"] = user_api_key or api_key
-    else:
-        user_provider = "openai"
-
-    ref_env = get_env(
-        env_name,
-        user_strategy="llm",
-        user_model=user_model,
-        task_split=task_split,
-        user_provider=user_provider,
+    # Load tasks — task_ids in tau2 are strings like "task_1"
+    tasks = get_tasks(
+        task_set_name=env_name,
+        task_split_name=task_split,
+        task_ids=[str(i) for i in task_ids] if task_ids else None,
     )
-    total_tasks = len(ref_env.tasks)
 
-    if task_ids and len(task_ids) > 0:
-        idxs = task_ids
-    else:
-        end = total_tasks if end_index == -1 else min(end_index, total_tasks)
-        idxs = list(range(start_index, end))
+    if not task_ids and (end_index != -1 or start_index != 0):
+        end = end_index if end_index != -1 else len(tasks)
+        tasks = tasks[start_index:end]
 
     logger.info(
-        "Running %s eval on %s (%d tasks, %d trials, concurrency=%d)",
-        env_name, model, len(idxs), num_trials, max_concurrency,
+        "Running tau2-%s eval: %d tasks, %d trial(s), concurrency=%d",
+        env_name, len(tasks), num_trials, max_concurrency,
     )
-    logger.info("Results checkpoint: %s", ckpt_path)
 
-    results: List[EnvRunResult] = []
+    save_path = Path(log_dir) / f"tau2-{env_name}-{model.split('/')[-1]}.json"
+    save_path.parent.mkdir(parents=True, exist_ok=True)
 
-    def _run_task(idx: int, trial: int) -> EnvRunResult:
-        isolated_env = get_env(
-            env_name,
-            user_strategy="llm",
-            user_model=user_model,
-            task_split=task_split,
-            user_provider=user_provider,
-            task_index=idx,
-        )
-        # Build a fresh server per task — each worker runs its own asyncio event
-        # loop via asyncio.run(), and AsyncOpenAI clients are bound to the loop
-        # they were created in. Sharing one client across loops causes hangs.
-        task_server = build_server(model=model, base_url=base_url, api_key=api_key)
-        agent = HermesAgent(
-            server=task_server,
-            system_prompt=system_prompt,
-            temperature=temperature,
-            max_tokens=max_tokens,
-        )
-        logger.info("Trial %d | Task %d", trial + 1, idx)
-        try:
-            solve_result = agent.solve(
-                env=isolated_env,
-                task_index=idx,
-                max_num_steps=max_num_steps,
-            )
-            return EnvRunResult(
-                task_id=idx,
-                reward=solve_result.reward,
-                info=solve_result.info,
-                traj=solve_result.messages,
-                trial=trial,
-            )
-        except Exception as e:
-            logger.error("Task %d trial %d failed: %s", idx, trial, traceback.format_exc())
-            return EnvRunResult(
-                task_id=idx,
-                reward=0.0,
-                info={"error": str(e)},
-                traj=[],
-                trial=trial,
-            )
+    # Pass api_key/base_url to user sim via llm_args so tau2's generate() authenticates.
+    # When using OpenRouter for the user sim, mirror the agent's key + endpoint.
+    user_llm_args: dict = {}
+    if is_openrouter and api_key:
+        user_llm_args["api_key"] = api_key
+        user_llm_args["base_url"] = base_url
 
-    for trial in range(num_trials):
-        trial_idxs = list(idxs)
-        if shuffle:
-            random.shuffle(trial_idxs)
+    config = TextRunConfig(
+        domain=env_name,
+        agent=AGENT_NAME,
+        user="user_simulator",
+        llm_agent=model,
+        llm_args_agent={},
+        llm_user=user_model,
+        llm_args_user=user_llm_args,
+        num_trials=num_trials,
+        max_steps=max_steps,
+        max_concurrency=max_concurrency,
+        seed=seed,
+    )
 
-        with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
-            futures = [executor.submit(_run_task, idx, trial) for idx in trial_idxs]
-            for future in futures:
-                result = future.result()
-                results.append(result)
-                with open(ckpt_path, "w") as f:
-                    json.dump([r.model_dump() for r in results], f, indent=2)
+    results = run_tasks(
+        config,
+        tasks,
+        save_path=save_path,
+        console_display=True,
+        # ALL: respects each task's reward_basis. NL assertions are skipped
+        # gracefully (scored as pass) rather than raising an error, so tasks
+        # are evaluated only on their actual basis components (DB, ACTION, etc.)
+        evaluation_type=EvaluationType.ALL,
+    )
 
-    display_metrics(results)
-    logger.info("Final results saved to %s", ckpt_path)
+    logger.info("Results saved to %s", save_path)
     return results
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Run tau-bench evaluation with Hermes Agent",
+        description="Run tau2-bench evaluation with Hermes Agent (requires Python 3.12+)",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--model", required=True, help="Model name (e.g., anthropic/claude-sonnet-4-5)")
+    parser.add_argument(
+        "--model", required=True,
+        help="litellm model string, e.g. 'openrouter/anthropic/claude-sonnet-4-5' or 'gpt-4o'",
+    )
     parser.add_argument(
         "--base-url", default=None,
-        help="OpenAI-compatible API base URL. Use 'openrouter' as shorthand for "
-             "https://openrouter.ai/api/v1 (auto-detects OPENROUTER_API_KEY).",
+        help="API base URL. Use 'openrouter' as shorthand for https://openrouter.ai/api/v1.",
     )
-    parser.add_argument(
-        "--api-key", default=None,
-        help="API key. OpenRouter: falls back to OPENROUTER_API_KEY. Others: OPENAI_API_KEY.",
-    )
-    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--api-key", default=None, help="API key (falls back to OPENROUTER_API_KEY / OPENAI_API_KEY)")
+    parser.add_argument("--temperature", type=float, default=1.0,
+                        help="Sampling temperature. NVIDIA used 1.0 for nemotron-super.")
+    parser.add_argument("--top-p", type=float, default=0.95,
+                        help="Nucleus sampling. NVIDIA used 0.95 for nemotron-super.")
     parser.add_argument("--max-tokens", type=int, default=None)
+    parser.add_argument("--thinking", action="store_true", default=False,
+                        help="Enable reasoning/thinking mode (use_reasoning=true). "
+                             "Required to match NVIDIA's reported nemotron-super scores.")
+    parser.add_argument("--tool-parser", default=None,
+                        help="Tool call parser to use (e.g. 'qwen3_coder'). When set, tools are "
+                             "embedded in the system prompt as <tools> XML and responses are parsed "
+                             "from raw text instead of using OpenAI function calling format.")
     parser.add_argument(
-        "--user-model", default="gpt-4o",
-        help="Model for the tau-bench user simulator. Defaults to the agent model when on OpenRouter.",
+        "--user-model", default="qwen/qwen3-235b-a22b-2507:nitro",
+        help="litellm model string for the tau2 user simulator. "
+             "Defaults to qwen/qwen3-235b-a22b-2507:nitro (instruct, non-thinking) to match NVIDIA's eval setup. "
+             "When using --base-url openrouter the openrouter/ prefix is added automatically.",
     )
-    parser.add_argument("--user-base-url", default=None)
-    parser.add_argument("--user-api-key", default=None)
-    parser.add_argument("--env", default="retail", choices=["retail", "airline"])
-    parser.add_argument("--task-split", default="test", choices=["train", "test", "dev"])
+    parser.add_argument(
+        "--env", default="retail",
+        choices=["retail", "airline", "telecom", "banking_knowledge", "mock"],
+    )
+    parser.add_argument(
+        "--task-split", default=None,
+        help="Task split name (e.g. 'base'). Defaults to the domain default.",
+    )
     parser.add_argument("--num-trials", type=int, default=1)
     parser.add_argument("--max-concurrency", type=int, default=8)
-    parser.add_argument("--max-num-steps", type=int, default=30)
-    parser.add_argument("--task-ids", type=int, nargs="*", default=None)
+    parser.add_argument("--max-steps", type=int, default=50)
+    parser.add_argument(
+        "--task-ids", nargs="*", default=None,
+        help="Specific task IDs to run (tau2 task IDs are strings like 'task_1')",
+    )
     parser.add_argument("--start-index", type=int, default=0)
     parser.add_argument("--end-index", type=int, default=-1)
     parser.add_argument("--seed", type=int, default=10)
-    parser.add_argument("--shuffle", action="store_true")
-    parser.add_argument("--log-dir", default="results/taubench")
-    parser.add_argument("--system-prompt", default=None)
+    parser.add_argument("--log-dir", default="results/tau2bench")
 
     args = parser.parse_args()
 
@@ -314,23 +265,22 @@ def main():
         model=args.model,
         base_url=args.base_url,
         api_key=args.api_key,
+        user_model=args.user_model,
         env_name=args.env,
         task_split=args.task_split,
-        user_model=args.user_model,
-        user_base_url=args.user_base_url,
-        user_api_key=args.user_api_key,
         num_trials=args.num_trials,
         max_concurrency=args.max_concurrency,
-        max_num_steps=args.max_num_steps,
+        max_steps=args.max_steps,
         temperature=args.temperature,
+        top_p=args.top_p,
         max_tokens=args.max_tokens,
+        thinking=args.thinking,
+        tool_parser=args.tool_parser,
         task_ids=args.task_ids,
         start_index=args.start_index,
         end_index=args.end_index,
         log_dir=args.log_dir,
         seed=args.seed,
-        shuffle=args.shuffle,
-        system_prompt=args.system_prompt,
     )
 
 

--- a/environments/benchmarks/taubench/run_eval.py
+++ b/environments/benchmarks/taubench/run_eval.py
@@ -131,15 +131,22 @@ def run_eval(
     if is_openrouter and not user_model.startswith("openrouter/"):
         user_model = f"openrouter/{user_model}"
 
-    # Resolve API key
+    # Resolve API key for agent
     if is_openrouter:
         api_key = api_key or os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
-        # litellm reads OPENAI_API_KEY for base_url overrides; set it so the
-        # user simulator's generate() call also authenticates correctly.
         if api_key and not os.environ.get("OPENAI_API_KEY"):
             os.environ["OPENAI_API_KEY"] = api_key
     else:
         api_key = api_key or os.environ.get("OPENAI_API_KEY")
+
+    # Resolve user sim auth — user sim may use OpenRouter even when agent is local.
+    # Check if user_model has openrouter/ prefix or OPENROUTER_API_KEY is set.
+    user_model_is_openrouter = user_model.startswith("openrouter/")
+    if not user_model_is_openrouter and "openrouter" in user_model.lower():
+        user_model = f"openrouter/{user_model}"
+        user_model_is_openrouter = True
+
+    openrouter_key = os.environ.get("OPENROUTER_API_KEY")
 
     _register_agent(
         model=model,
@@ -171,10 +178,12 @@ def run_eval(
     save_path = Path(log_dir) / f"tau2-{env_name}-{model.split('/')[-1]}.json"
     save_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Pass api_key/base_url to user sim via llm_args so tau2's generate() authenticates.
-    # When using OpenRouter for the user sim, mirror the agent's key + endpoint.
+    # Pass auth to user sim. User sim may be on OpenRouter even if agent is local.
     user_llm_args: dict = {}
-    if is_openrouter and api_key:
+    if user_model_is_openrouter and openrouter_key:
+        user_llm_args["api_key"] = openrouter_key
+        user_llm_args["base_url"] = OPENROUTER_BASE_URL
+    elif is_openrouter and api_key:
         user_llm_args["api_key"] = api_key
         user_llm_args["base_url"] = base_url
 

--- a/environments/benchmarks/taubench/run_eval.py
+++ b/environments/benchmarks/taubench/run_eval.py
@@ -131,18 +131,33 @@ def run_eval(
     if is_openrouter and not user_model.startswith("openrouter/"):
         user_model = f"openrouter/{user_model}"
 
+    # For local/custom endpoints (non-OpenRouter), litellm needs the openai/ prefix
+    # if no provider prefix is specified
+    is_custom_endpoint = base_url and not is_openrouter
+    if is_custom_endpoint and not model.startswith("openrouter/") and not model.startswith("openai/") and "/" not in model:
+        model = f"openai/{model}"
+
     # Resolve API key for agent
     if is_openrouter:
         api_key = api_key or os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
         if api_key and not os.environ.get("OPENAI_API_KEY"):
             os.environ["OPENAI_API_KEY"] = api_key
     else:
-        api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        # For custom endpoints (e.g., local vLLM), litellm needs an api_key.
+        # Use provided key, env OPENAI_API_KEY, or "dummy" if not set.
+        api_key = api_key or os.environ.get("OPENAI_API_KEY") or "dummy"
+        if not os.environ.get("OPENAI_API_KEY"):
+            os.environ["OPENAI_API_KEY"] = api_key
 
     # Resolve user sim auth — user sim may use OpenRouter even when agent is local.
     # Check if user_model has openrouter/ prefix or OPENROUTER_API_KEY is set.
     user_model_is_openrouter = user_model.startswith("openrouter/")
     if not user_model_is_openrouter and "openrouter" in user_model.lower():
+        user_model = f"openrouter/{user_model}"
+        user_model_is_openrouter = True
+    # If user_model looks like an OpenRouter model (contains a slash and isn't openai/), add prefix
+    elif not user_model_is_openrouter and "/" in user_model and not user_model.startswith("openai/"):
+        # Check if it's a known OpenRouter model format (provider/model)
         user_model = f"openrouter/{user_model}"
         user_model_is_openrouter = True
 
@@ -180,12 +195,24 @@ def run_eval(
 
     # Pass auth to user sim. User sim may be on OpenRouter even if agent is local.
     user_llm_args: dict = {}
+    # If user model uses openrouter prefix, use OpenRouter auth regardless of agent base_url
     if user_model_is_openrouter and openrouter_key:
         user_llm_args["api_key"] = openrouter_key
         user_llm_args["base_url"] = OPENROUTER_BASE_URL
     elif is_openrouter and api_key:
         user_llm_args["api_key"] = api_key
         user_llm_args["base_url"] = base_url
+    # If user_model has no openrouter prefix but agent is on openrouter, use agent's auth
+    elif is_openrouter and api_key and not user_model_is_openrouter:
+        user_llm_args["api_key"] = api_key
+        user_llm_args["base_url"] = base_url
+    # If user_model looks like an OpenRouter model (e.g. provider/model:version without openrouter/ prefix)
+    # and we have an OpenRouter key, use OpenRouter
+    elif openrouter_key and "/" in user_model and ":" in user_model and not user_model_is_openrouter:
+        user_model = f"openrouter/{user_model}"
+        user_model_is_openrouter = True
+        user_llm_args["api_key"] = openrouter_key
+        user_llm_args["base_url"] = OPENROUTER_BASE_URL
 
     config = TextRunConfig(
         domain=env_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ rl = [
   "wandb>=0.15.0,<1",
 ]
 yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; python_version >= '3.12'"]
+taubench = ["tau-bench @ git+https://github.com/sierra-research/tau-bench.git"]
 all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ rl = [
 ]
 yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; python_version >= '3.12'"]
 taubench = ["tau-bench @ git+https://github.com/sierra-research/tau-bench.git"]
+tau2bench = ["tau2 @ git+https://github.com/sierra-research/tau2-bench.git"]
 all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",


### PR DESCRIPTION
## Problem

Investigation of taubench eval revealed two harness-level issues preventing correct tool use:

1. **Tool name hallucination** — Model invents common function names from training (e.g. `lookup_customer` instead of `get_customer_by_phone`), causing `Error: Tool not found` loops that hit `too_many_errors` termination
2. **Argument schema non-compliance** — Model merges `first_name`+`last_name` into `name`, renames `zip` to `zip_code`, then retries the same wrong args until the error limit

Root cause for both: weaker models don't strictly read the `tools=` API schema parameter passed via litellm. They fall back to "common sense" function signatures from training data.

## Fix

- System prompt now embeds **full tool signatures** (`name(param: type, ...)`) as text reinforcement, so models have a plain-text reference for exact function and parameter names
- Added `IMPORTANT` warning against inventing or guessing tool names
- Added `tool_choice="auto"` to match tau2's default `generate()` behavior (was missing)
- Added hermes tool parser support (`SYSTEM_PROMPT_HERMES`)
- Fixed qwen3_coder brace escaping for `.format()`

## Verification

- **Model Test**: retail task 0 scores **1.0** (was 0.0 before fix), all 5/5 actions pass including the final `exchange_delivered_order_items` write action
- **Telecom**: model now correctly calls `get_customer_by_phone` instead of hallucinated `lookup_customer`
- Unit checks pass: import, tool signatures in prompt, telecom names, empty tools, `tool_choice` present

## Before / After

```
# Before — model hallucinates tool name, retries 10x
[4] assistant CALL: lookup_customer({"phone_number": "555-123-2002"})
[5] tool: Error: Tool 'lookup_customer' not found.
... (repeats until too_many_errors)

# After — model uses correct name from system prompt signatures
[4] assistant CALL: get_customer_by_phone({"phone_number": "555-123-2002"})
[5] tool: {"customer_id": "C123", "name": "John Smith", ...}
```

```
# Before — model uses wrong parameter names
find_user_id_by_name_zip({"name": "Yusuf Rossi", "zip_code": "19122"})
→ Error: got an unexpected keyword argument 'name'

# After — model reads parameter names from system prompt
find_user_id_by_name_zip({"first_name": "Yusuf", "last_name": "Rossi", "zip": "19122"})
→ "yusuf_rossi_9620"
```
