### PR TITLE
fix(acp): clear stale interrupted prompt when a new turn starts

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1383,6 +1383,13 @@ class HermesACPAgent(acp.Agent):
                 return PromptResponse(stop_reason="end_turn")
             state.is_running = True
             state.current_prompt_text = user_text or "[Image attachment]"
+            # A real turn is starting, so any prompt salvaged for a later
+            # /steer after a prior client cancel is now stale — the user moved
+            # on to this turn. Drop it so a /steer on a future idle session
+            # can't resurrect an abandoned prompt. The /steer salvage path
+            # above already consumed and cleared it before reaching here, so
+            # this only discards a value left by an intervening completed turn.
+            state.interrupted_prompt_text = ""
 
         logger.info("Prompt on session %s: %s", session_id, user_text[:100])
 

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -148,6 +148,39 @@ async def test_acp_steer_after_zed_interrupt_replays_interrupted_prompt_with_gui
 
 
 @pytest.mark.asyncio
+async def test_acp_normal_turn_clears_stale_interrupted_prompt():
+    """A completed normal turn must not leave a salvageable prompt behind.
+
+    Regression: interrupted_prompt_text is set only on a running-cancel and
+    cleared only inside the /steer salvage path. If the user cancels a
+    running turn, then sends an ordinary prompt (which runs to completion),
+    the interrupted prompt was never cleared — so a later /steer on the idle
+    session would resurrect and re-run the task the user cancelled and moved
+    on from. Starting any real turn must drop the stale salvage buffer.
+    """
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    # Left over from a prior running-cancel of "refactor the auth module".
+    state.interrupted_prompt_text = "refactor the auth module"
+
+    # An ordinary prompt runs to completion in between.
+    await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="what's the weather")],
+    )
+    assert state.interrupted_prompt_text == ""
+    assert fake.runs == ["what's the weather"]
+
+    # Now /steer on the idle session must run ONLY the steer text, not the
+    # abandoned prompt.
+    fake.runs.clear()
+    await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/steer be concise")],
+    )
+    assert fake.runs == ["be concise"]
+
+
+@pytest.mark.asyncio
 async def test_acp_steer_on_idle_session_runs_as_regular_prompt():
     # /steer on an idle session (no running turn, nothing to salvage) should
     # run the steer payload as a normal user prompt — NOT silently append it


### PR DESCRIPTION
## What does this PR do?

Fixes a state-machine bug in the ACP adapter. A `/steer` on an idle session can resurrect a prompt the user cancelled and moved on from.

`state.interrupted_prompt_text` powers the "Zed-interrupt salvage" feature, which replays an interrupted prompt when `/steer` arrives right after a client cancel (PR #18258). The problem is how the field is managed. It is set only in `cancel()`, when a turn is actively running. It is cleared only inside the `/steer` salvage block. No other path clears it, so this sequence leaks a stale value:

1. Session is running prompt P1 = `"refactor the auth module"`. User hits ESC, so `cancel()` stores `interrupted_prompt_text = "refactor the auth module"`. Turn ends.
2. User sends an ordinary prompt P2 = `"what's the weather"`. It runs to completion. `interrupted_prompt_text` is still `"refactor the auth module"`, because the normal turn never cleared it.
3. User later types `/steer be concise` on the idle session. The salvage block sees the stale value as truthy and runs:
   `"refactor the auth module\n\nUser correction/guidance after interrupt: be concise"` as a real LLM turn.

The user expected to nudge the current (nonexistent) turn. Instead the agent re-executes an abandoned task from two turns ago.

Fix: clear `interrupted_prompt_text` at the turn-start transition, where `is_running` flips to `True`, so starting any real turn drops the stale salvage buffer. The `/steer` salvage path already consumes and clears the field before this point, so legitimate immediate-salvage (steer directly after a client cancel, with no intervening turn) is unaffected.

## Related Issue

Fixes # <!-- no existing issue; happy to open one if preferred -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py`: in `prompt()`, set `state.interrupted_prompt_text = ""` in the `is_running = True` turn-start transition.
- `tests/acp_adapter/test_acp_commands.py`: `test_acp_normal_turn_clears_stale_interrupted_prompt` checks that a running-cancel value is cleared by a completed normal turn, and that a subsequent `/steer` runs only the steer text.

## How to Test

1. `scripts/run_tests.sh tests/acp_adapter/test_acp_commands.py -q`. 7 tests pass, including the existing salvage test `test_acp_steer_after_zed_interrupt_replays_interrupted_prompt_with_guidance`.
2. To prove the fix is load-bearing: revert the `acp_adapter/server.py` hunk and rerun `-k clears_stale`. The new test fails, since `interrupted_prompt_text` still holds the abandoned prompt and `/steer` resurrects it. Restore the hunk and it passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(acp):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (searched `interrupted_prompt_text`, none; open PR #50461 touches idle-cancel `cancel_event` poisoning, a different field and path, and leaves this bug)
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation (README, `docs/`, docstrings): N/A (inline comment explains the clear)
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A (`scripts/check-windows-footguns.py` clean)
- [x] Tool descriptions/schemas: N/A