### PR TITLE
fix(gateway): suppress fallback status noise in chats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -83,6 +83,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
+    r"|switching\s+to\s+fallback(?::|\s+(?:provider|model))"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
     r")",

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -35,6 +35,10 @@ NOISY_STATUS_MESSAGES = [
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
     "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
     "⏳ Retrying in 4.2s (attempt 1/3)...",
+    "⚠️ Provider unreachable — switching to fallback provider...",
+    "⚠️ Billing or credits exhausted — switching to fallback provider...",
+    "⚠️ Rate limited — switching to fallback provider...",
+    "⚠️ Upstream aggregator rate-limited — switching to fallback model...",
 ]
 
 
@@ -48,6 +52,9 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         "⏳ Retrying in 4.2s (attempt 1/3)...",
         "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
         "⚠️ Max retries (3) exhausted — trying fallback...",
+        "⚠️ Provider unreachable — switching to fallback provider...",
+        "🔐 Authentication failed and could not be refreshed — switching to fallback provider...",
+        "🔄 Primary model failed — switching to fallback: openai / gpt-5.5",
     ]
 
     for message in noisy_messages:


### PR DESCRIPTION
Problem\nHuman-facing chat gateways can receive transient fallback lifecycle messages like “Provider unreachable — switching to fallback provider...” before the final sanitized provider-failure reply. In Discord this reads as duplicate provider errors.\n\nRoot cause\nThe gateway noisy-status filter suppresses retry and max-retry chatter, but did not match fallback activation statuses emitted by the agent loop.\n\nFix\nExtend the chat-surface noisy-status regex to suppress “switching to fallback provider/model” and “switching to fallback:” lifecycle lines. Programmatic/local surfaces still keep raw diagnostics.\n\nValidation\n- uv run --with pytest python -m pytest tests/gateway/test_telegram_noise_filter.py\n\nProduction expectation\nDiscord/Telegram/etc should show the final sanitized provider failure if all retries/fallbacks fail, without posting intermediate fallback activation messages into chat.