### PR TITLE
fix(dashboard): redirect password-only auth to /login instead of /auth/login

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,9 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers use /login, not the OAuth redirect flow.
+    if getattr(provider, "supports_password", False):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -192,6 +192,17 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             status_code=404,
             detail=f"Provider does not support interactive login: {provider!r}",
         )
+    # Password-only providers use /login instead of start_login().
+    if getattr(p, "supports_password", False):
+        from urllib.parse import quote as _quote
+        prefix = _prefix(request)
+        safe_next = _validate_post_login_target(next)
+        login_url = (
+            f"{prefix}/login?next={_quote(safe_next, safe='')}"
+            if safe_next
+            else f"{prefix}/login"
+        )
+        return RedirectResponse(url=login_url, status_code=302)
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -593,3 +593,62 @@ def test_unverifiable_token_with_reachable_providers_redirects(_gated_state):
     r = client.get("/api/auth/me")
     assert r.status_code == 401
     assert "unreachable" not in r.text.lower()
+
+
+def _make_basic_provider():
+    import plugins.dashboard_auth.basic as basic_module
+    h = basic_module.hash_password("hunter2")
+    return basic_module.BasicAuthProvider(
+        username="admin",
+        password_hash=h,
+        secret=b"test-secret-must-be-at-least-16b",
+    )
+
+
+def test_basic_auth_unauthenticated_html_redirects_to_login_not_auth_login(
+    _gated_state,
+):
+    """Basic auth should redirect unauthenticated HTML requests to /login."""
+    register_provider(_make_basic_provider())
+    client = _gated_state()
+    r = client.get("/", follow_redirects=False)
+    assert r.status_code == 302
+    location = r.headers["location"]
+    assert not location.startswith("/auth/login"), (
+        f"BasicAuthProvider should never trigger /auth/login redirect "
+        f"(issue #56130). Got: {location!r}"
+    )
+    assert location.startswith("/login"), (
+        f"Expected redirect to /login (password form), got: {location!r}"
+    )
+
+
+def test_basic_auth_direct_auth_login_url_redirects_to_login_page(
+    _gated_state,
+):
+    """Direct /auth/login for basic auth should bounce to /login."""
+    register_provider(_make_basic_provider())
+    client = _gated_state()
+    r = client.get("/auth/login?provider=basic&next=%2F", follow_redirects=False)
+    assert r.status_code == 302, (
+        f"Expected 302, got {r.status_code}: {r.text}"
+    )
+    location = r.headers["location"]
+    assert location.startswith("/login"), (
+        f"Expected redirect to /login, got: {location!r}"
+    )
+    assert "next=" in location, (
+        f"Expected next= to be forwarded in redirect, got: {location!r}"
+    )
+
+
+def test_basic_auth_does_not_suppress_oauth_auto_sso(_gated_state):
+    """OAuth-capable single providers should still use auto-SSO."""
+    register_provider(StubAuthProvider())
+    client = _gated_state()
+    r = client.get("/", follow_redirects=False)
+    assert r.status_code == 302
+    location = r.headers["location"]
+    assert location.startswith("/auth/login?provider=stub"), (
+        f"OAuth provider should still trigger auto-SSO. Got: {location!r}"
+    )


### PR DESCRIPTION
Closes #56130

When `basic_auth` is configured and the dashboard is bound to a non-loopback interface, the unauthenticated redirect was routing to `/auth/login?provider=basic` which calls `BasicAuthProvider.start_login()` — a method that raises `NotImplementedError` (basic auth has no OAuth redirect flow). This produces a 500 before the user can even see the login form.

Fix: detect password-only providers before building the redirect and route directly to `/login?next=<path>` instead.

## Changes

**`hermes_cli/dashboard_auth/middleware.py`** — `_auto_sso_response()`  
Added a guard: if the single registered provider has `supports_password=True`, return `None` (skipping the auto-SSO redirect entirely). The caller falls through to `_unauth_response()` which redirects to `/login` — the password form.

**`hermes_cli/dashboard_auth/routes.py`** — `auth_login()`  
Added a defence-in-depth guard: if the requested provider has `supports_password=True`, immediately redirect to `/login` (preserving `next=`) instead of calling `start_login()`. This covers the case where something navigates directly to `/auth/login?provider=basic` (stale link, copy-paste from logs, etc.).

## Tests

Three new tests added to `tests/hermes_cli/test_dashboard_auth_middleware.py`:

- `test_basic_auth_unauthenticated_html_redirects_to_login_not_auth_login` — regression test for the primary bug: `GET /` with `BasicAuthProvider` registered redirects to `/login`, not `/auth/login`
- `test_basic_auth_direct_auth_login_url_redirects_to_login_page` — defence-in-depth: `GET /auth/login?provider=basic&next=%2F` redirects to `/login?next=...` without 500-ing
- `test_basic_auth_does_not_suppress_oauth_auto_sso` — regression guard: OAuth providers still trigger the auto-SSO redirect as before