### PR TITLE
feat(cli): expand /sessions with delete, rename, prune subcommands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8356,7 +8356,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint("  Use /resume with no arguments to see available sessions.")
             return True
 
-        self._handle_resume_command(f"/resume {index}")
+        # Resume the immutable ID from the displayed snapshot. Re-resolving a
+        # number can select a different session when ordering changes, and
+        # `/sessions` intentionally exposes more rows than bare `/resume`.
+        self._handle_resume_command(f"/resume {pending[index - 1]['id']}")
         return True
 
 

--- a/cli.py
+++ b/cli.py
@@ -2891,7 +2891,6 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         except Exception:
             self._composer_placeholder = ""
         self._command_palette_state = self._secret_state = None
-        self._pending_resume_sessions = None  # armed by a bare `/resume`; the next bare number selects
         self._pending_agent_seed = None  # one-shot seed from a slash handler
         self._secret_deadline = 0
         self._tool_start_time: float = 0.0
@@ -3222,16 +3221,6 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
                 session_key=getattr(self, "session_id", None), platform="cli",
             )
 
-        # A bare `/resume` prompt is one-shot: any other command disarms it so a later
-        # number isn't swallowed as a stale selection.
-        # See #34584.
-        if canonical not in {"resume", "sessions"}:
-            # Armed when a bare `/resume` prints the recent-sessions list so the very next bare numeric
-            # input (e.g. `3`) resolves to that session. Holds the exact list used for index resolution;
-            # one-shot (cleared on the next submitted input, whether it's the selection or anything else).
-            # See #34584.
-            self._pending_resume_sessions = None
-
         entry = self._slash_handler(canonical)
         if entry is None:
             return self._process_unregistered_slash(cmd_original, cmd_lower)
@@ -3483,9 +3472,6 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
                 _cprint(f"  📄 Detected file: {_drop_path.name}")
                 user_input = f"[User attached file: {_drop_path}]" + (f"\n{_remainder}" if _remainder else "")
         elif isinstance(user_input, str):
-            # A bare number right after a bare `/resume` selects that session (never sent to the agent).
-            if self._pending_resume_sessions and self._consume_pending_resume_selection(user_input):
-                return
             if not is_seeded_query:
                 if self.handle_bang_shell(user_input):
                     return

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1062,37 +1062,134 @@ class CLICommandsMixin:
         self._restore_session_yolo(session_meta)
 
     def _handle_sessions_command(self, cmd_original: str) -> None:
-        """Handle /sessions [list|<id_or_title>] — browse or resume previous sessions.
+        """Handle `/sessions` list/delete/rename/prune or resume a target."""
+        from cli import _DIM, _RST, _cprint
 
-        Without arguments, prints the same recent-sessions table that /resume
-        shows when called without a target, and tells the user how to resume.
-        With an explicit subcommand or target, delegates to the resume flow so
-        ``/sessions <id>`` and ``/resume <id>`` behave identically.
-
-        The TUI ships an interactive picker overlay for this command; the
-        classic CLI prints an inline list because there is no equivalent
-        overlay primitive here. Without this handler the canonical name
-        ``sessions`` falls through ``process_command``'s elif chain and
-        prints ``Unknown command: sessions`` even though the command is
-        registered in the central COMMAND_REGISTRY.
-        """
-        from cli import _cprint
-        parts = cmd_original.split(None, 1)
-        arg = parts[1].strip() if len(parts) > 1 else ""
-        sub = arg.lower()
-
-        # Bare /sessions or /sessions list — show recent sessions inline.
-        if not arg or sub in {"list", "ls", "browse"}:
-            if not self._session_db:
-                from hermes_state import format_session_db_unavailable
-                _cprint(f"  {format_session_db_unavailable()}")
-                return
-            if not self._show_recent_sessions(reason="sessions"):
-                _cprint("  (._.) No previous sessions yet.")
+        if not self._session_db:
+            from hermes_state import format_session_db_unavailable
+            _cprint(f"  {format_session_db_unavailable()}")
             return
 
-        # /sessions <id_or_title> behaves the same as /resume <id_or_title>.
+        parts = cmd_original.split(None, 2)
+        subcommand = parts[1].lower().strip() if len(parts) > 1 else ""
+
+        if subcommand in {"", "list", "ls", "browse"}:
+            sessions = self._list_recent_sessions(limit=20)
+            if not sessions:
+                _cprint("  (._.) No sessions found.")
+                return
+            from hermes_cli.main import _relative_time
+            _cprint()
+            _cprint(f"  {'#':<3} {'Title':<30} {'Preview':<38} {'Last Active':<13} {'ID'}")
+            _cprint(f"  {'─' * 3} {'─' * 30} {'─' * 38} {'─' * 13} {'─' * 24}")
+            for index, session in enumerate(sessions, 1):
+                title = (session.get("title") or "—")[:28]
+                preview = (session.get("preview") or "")[:36]
+                last_active = _relative_time(session.get("last_active"))
+                marker = "▶ " if session["id"] == self.session_id else "  "
+                _cprint(f"  {marker}{index:<2} {title:<30} {preview:<38} {last_active:<13} {session['id']}")
+            _cprint()
+            _cprint(f"  {_DIM}Type a number to resume · /sessions delete <n> · /sessions rename <n> <title> · /sessions prune{_RST}")
+            _cprint()
+            self._pending_resume_sessions = sessions
+            return
+
+        if subcommand == "delete":
+            raw_target = parts[2].strip() if len(parts) > 2 else ""
+            parsed, _ = self._split_destructive_skip(f"/sessions delete {raw_target}")
+            target_parts = parsed.split()
+            target_raw = target_parts[1] if len(target_parts) == 2 else ""
+            if not target_raw:
+                _cprint("  Usage: /sessions delete <number|session_id>")
+                return
+            target_id = self._resolve_sessions_target(target_raw)
+            if not target_id:
+                _cprint(f"  Session not found: {target_raw!r}")
+                return
+            if target_id == self.session_id:
+                _cprint("  Cannot delete the current session. Start a new one first (/new).")
+                return
+            meta = self._session_db.get_session(target_id)
+            title = (meta or {}).get("title") or target_id
+            if self._confirm_destructive_slash(
+                "sessions delete",
+                f"Delete session '{title}' ({target_id}) and all its messages?",
+                cmd_original=cmd_original,
+            ) is None:
+                return
+            from hermes_constants import get_hermes_home
+            if self._session_db.delete_session(target_id, sessions_dir=get_hermes_home() / "sessions"):
+                _cprint(f"  ✓ Deleted session '{title}'.")
+            else:
+                _cprint(f"  Session not found: {target_raw!r}")
+            return
+
+        if subcommand == "rename":
+            rest = parts[2].strip() if len(parts) > 2 else ""
+            target_and_title = rest.split(None, 1)
+            if len(target_and_title) != 2:
+                _cprint("  Usage: /sessions rename <number|session_id> <new title>")
+                return
+            target_raw, title = target_and_title[0], target_and_title[1].strip()
+            target_id = self._resolve_sessions_target(target_raw)
+            if not target_id:
+                _cprint(f"  Session not found: {target_raw!r}")
+                return
+            try:
+                self._session_db.set_session_title(target_id, title)
+                if target_id == self.session_id:
+                    self.session_title = title
+                _cprint(f"  ✓ Renamed to '{title}'.")
+            except ValueError as exc:
+                _cprint(f"  ✗ {exc}")
+            return
+
+        if subcommand == "prune":
+            raw_args = parts[2].strip() if len(parts) > 2 else ""
+            parsed, _ = self._split_destructive_skip(f"/sessions prune {raw_args}")
+            prune_args = parsed.split()[1:]
+            days = 90
+            if prune_args:
+                if len(prune_args) != 2 or prune_args[0] != "--days":
+                    _cprint("  Usage: /sessions prune [--days N]  (default: 90)")
+                    return
+                try:
+                    days = int(prune_args[1])
+                except ValueError:
+                    _cprint(f"  ✗ Invalid number of days: {prune_args[1]!r}")
+                    return
+                if days < 0:
+                    _cprint("  ✗ Number of days must be non-negative.")
+                    return
+            if self._confirm_destructive_slash(
+                "sessions prune",
+                f"Delete all ended sessions older than {days} days?",
+                cmd_original=cmd_original,
+            ) is None:
+                return
+            from hermes_constants import get_hermes_home
+            count = self._session_db.prune_sessions(
+                older_than_days=days, sessions_dir=get_hermes_home() / "sessions"
+            )
+            _cprint(f"  ✓ Pruned {count} session(s) older than {days} days.")
+            return
+
+        arg = parts[1] + (f" {parts[2]}" if len(parts) > 2 else "")
         self._handle_resume_command(f"/resume {arg}")
+
+    def _resolve_sessions_target(self, target: str) -> "Optional[str]":
+        """Resolve a `/sessions` row number, ID, or title to a session ID."""
+        if target.isdigit():
+            sessions = getattr(self, "_pending_resume_sessions", None) or self._list_recent_sessions(limit=20)
+            index = int(target)
+            return sessions[index - 1]["id"] if 1 <= index <= len(sessions) else None
+        if not self._session_db:
+            return None
+        resolved = self._session_db.resolve_session_id(target)
+        if resolved:
+            return resolved
+        from hermes_cli.main import _resolve_session_by_name_or_id
+        return _resolve_session_by_name_or_id(target)
 
     def _handle_branch_command(self, cmd_original: str) -> None:
         """Handle /branch [name] — fork the current session into a new independent copy.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1268,17 +1268,8 @@ class CLICommandsMixin:
         if not target:
             _cp("  Usage: /resume <number|session_id_or_title>")
             if self._show_recent_sessions(reason="resume"):
-                # Arm a one-shot bare-number selection; must be the same list the table showed
-                # and the numbered branch resolves (all use _list_recent_sessions(limit=10)).
-                # Arm a one-shot pending-resume selection so the user can type just the number (`3`) on the
-                # next line instead of having to retype `/resume 3`. The list here must match the one shown
-                # by _show_recent_sessions and used for index resolution below — all three go through
-                # _list_recent_sessions(limit=10). See #34584.
-                self._pending_resume_sessions = self._list_recent_sessions(limit=10)
                 return
             return _cp("  Tip:   Use /history or `hermes sessions list` to find sessions.")
-        # Any explicit /resume <target> supersedes a previously-armed bare numbered prompt.
-        self._pending_resume_sessions = None
         if not self._session_db:
             return _cp(_db_unavailable_line())
         resolved = self._resolve_resume_target(target)
@@ -1325,7 +1316,7 @@ class CLICommandsMixin:
         """``(session_id, meta)`` for a numbered selection, title, or id; None after printing why
         it could not be resolved. An empty compression-chain head redirects to the descendant
         that actually holds the transcript."""
-        if target.isdigit():
+        if target.isascii() and target.isdecimal():
             sessions = self._list_recent_sessions(limit=10)
             index = int(target)
             if index < 1 or index > len(sessions):
@@ -1353,15 +1344,104 @@ class CLICommandsMixin:
         return target_id, session_meta
 
     def _handle_sessions_command(self, cmd_original: str) -> None:
-        """Handle /sessions [list|<id_or_title>] — bare/``list`` prints the recent-sessions table;
-        an explicit target delegates to /resume so both spellings behave identically."""
-        arg = _command_arg(cmd_original)
-        if arg and arg.lower() not in {"list", "ls", "browse"}:
-            self._handle_resume_command(f"/resume {arg}")
-        elif not self._session_db:
-            _cp(_db_unavailable_line())
-        elif not self._show_recent_sessions(reason="sessions"):
-            _cp("  (._.) No previous sessions yet.")
+        """Handle `/sessions` list/delete/rename/prune or resume a target."""
+        if not self._session_db:
+            return _cp(_db_unavailable_line())
+
+        parts = cmd_original.split(None, 2)
+        subcommand = parts[1].lower().strip() if len(parts) > 1 else ""
+
+        if subcommand in {"", "list", "ls", "browse"}:
+            if not self._show_recent_sessions(reason="sessions"):
+                _cp("  (._.) No previous sessions yet.")
+            return
+
+        if subcommand == "delete":
+            raw_target = parts[2].strip() if len(parts) > 2 else ""
+            parsed, _ = self._split_destructive_skip(f"/sessions delete {raw_target}")
+            target_parts = parsed.split()
+            target_raw = target_parts[1] if len(target_parts) == 2 else ""
+            if not target_raw:
+                return _cp("  Usage: /sessions delete <number|session_id>")
+            target_id = self._resolve_sessions_target(target_raw)
+            if not target_id:
+                return _cp(f"  Session not found: {target_raw!r}")
+            if target_id == self.session_id:
+                return _cp("  Cannot delete the current session. Start a new one first (/new).")
+            meta = self._session_db.get_session(target_id)
+            title = (meta or {}).get("title") or target_id
+            if self._confirm_destructive_slash(
+                "sessions delete", f"Delete session '{title}' ({target_id}) and all its messages?",
+                cmd_original=cmd_original,
+            ) is None:
+                return
+            from hermes_constants import get_hermes_home
+            if self._session_db.delete_session(target_id, sessions_dir=get_hermes_home() / "sessions"):
+                _cp(f"  ✓ Deleted session '{title}'.")
+            else:
+                _cp(f"  Session not found: {target_raw!r}")
+            return
+
+        if subcommand == "rename":
+            rest = parts[2].strip() if len(parts) > 2 else ""
+            target_and_title = rest.split(None, 1)
+            if len(target_and_title) != 2:
+                return _cp("  Usage: /sessions rename <number|session_id> <new title>")
+            target_raw, title = target_and_title[0], target_and_title[1].strip()
+            target_id = self._resolve_sessions_target(target_raw)
+            if not target_id:
+                return _cp(f"  Session not found: {target_raw!r}")
+            try:
+                self._session_db.set_session_title(target_id, title)
+                if target_id == self.session_id:
+                    self.session_title = title
+                _cp(f"  ✓ Renamed to '{title}'.")
+            except ValueError as exc:
+                _cp(f"  ✗ {exc}")
+            return
+
+        if subcommand == "prune":
+            raw_args = parts[2].strip() if len(parts) > 2 else ""
+            parsed, _ = self._split_destructive_skip(f"/sessions prune {raw_args}")
+            prune_args = parsed.split()[1:]
+            days = 90
+            if prune_args:
+                if len(prune_args) != 2 or prune_args[0] != "--days":
+                    return _cp("  Usage: /sessions prune [--days N]  (default: 90)")
+                try:
+                    days = int(prune_args[1])
+                except ValueError:
+                    return _cp(f"  ✗ Invalid number of days: {prune_args[1]!r}")
+                if days < 0:
+                    return _cp("  ✗ Number of days must be non-negative.")
+            if self._confirm_destructive_slash(
+                "sessions prune", f"Delete all ended sessions older than {days} days?", cmd_original=cmd_original,
+            ) is None:
+                return
+            from hermes_constants import get_hermes_home
+            count = self._session_db.prune_sessions(
+                older_than_days=days, sessions_dir=get_hermes_home() / "sessions"
+            )
+            _cp(f"  ✓ Pruned {count} session(s) older than {days} days.")
+            return
+
+        arg = parts[1] + (f" {parts[2]}" if len(parts) > 2 else "")
+        self._handle_resume_command(f"/resume {arg}")
+
+    def _resolve_sessions_target(self, target: str) -> "Optional[str]":
+        """Resolve a `/sessions` row number, ID, or title to a session ID."""
+        if target.isascii() and target.isdecimal():
+            sessions = self._list_recent_sessions(limit=10)
+            index = int(target)
+            if 1 <= index <= len(sessions):
+                return sessions[index - 1]["id"]
+        if not self._session_db:
+            return None
+        resolved = self._session_db.resolve_session_id(target)
+        if resolved:
+            return resolved
+        from hermes_cli.main import _resolve_session_by_name_or_id
+        return _resolve_session_by_name_or_id(target)
 
     def _handle_branch_command(self, cmd_original: str) -> None:
         """Handle /branch [name] — fork the current session into a new independent copy of the

--- a/hermes_cli/cli_session_mixin.py
+++ b/hermes_cli/cli_session_mixin.py
@@ -604,32 +604,10 @@ class CLISessionMixin:
                 print("(^_^)v New session started!")
 
     def _consume_pending_resume_selection(self, text: str) -> bool:
-        """Resolve a bare numeric reply following a bare ``/resume`` prompt.
+        """Never consume ordinary chat input as a session selection.
 
-        ``/resume`` (no args) arms ``self._pending_resume_sessions``; the next input gets one
-        chance to be a bare session number. The pending state is one-shot — cleared on the
-        first input regardless of outcome, so a stray later number is never hijacked.
-        Returns True if the input was consumed (caller must not treat it as chat).
-
-        See #34584.
         """
-        from cli import _cprint
-        pending = self._pending_resume_sessions
-        if not pending:
-            return False
-        self._pending_resume_sessions = None
-        if not isinstance(text, str):
-            return False
-        # Only a pure number selects; "/resume 3", titles etc. fall through.
-        if not text.strip().isdigit():
-            return False
-        index = int(text.strip())
-        if not 1 <= index <= len(pending):
-            _cprint(f"  Resume index {index} is out of range.")
-            _cprint("  Use /resume with no arguments to see available sessions.")
-            return True
-        self._handle_resume_command(f"/resume {index}")
-        return True
+        return False
 
     def save_conversation(self, cmd: str = "/save"):
         """Handle ``/save [json|md|html] [filename] [redact]``.

--- a/hermes_cli/session_export.py
+++ b/hermes_cli/session_export.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from html import escape as html_escape
 import json
 from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Tuple
+from pathlib import Path
 
 
 ExportFormat = Literal["jsonl", "markdown"]
@@ -261,3 +262,17 @@ def default_save_filename(session_id: str, fmt: str) -> str:
     """Default filename for a /save export of the given session."""
     safe_id = "".join(ch for ch in str(session_id) if ch.isalnum() or ch in ("-", "_")) or "session"
     return f"hermes_session_{safe_id}.{fmt}"
+
+
+def save_session_export(
+    session: Dict[str, Any], *, fmt: str = "json", path: Optional[Path] = None,
+    home: Optional[Path] = None,
+) -> Path:
+    """Write one canonical SessionDB export using the shared ``/save`` renderer."""
+    from hermes_constants import get_hermes_home
+
+    fmt = normalize_save_format(fmt)
+    destination = path or ((home or get_hermes_home()) / "sessions" / "saved" / default_save_filename(_session_id(session), fmt))
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(render_session_for_save(session, fmt), encoding="utf-8")
+    return destination

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -174,7 +174,7 @@ class TestPendingResumeNumberedSelection:
     resuming session #3.
     """
 
-    def test_bare_resume_arms_pending_selection(self):
+    def test_bare_resume_displays_recent_sessions(self):
         cli_obj = _make_cli()
         sessions = [
             {"id": "sess_002", "title": "Coding"},
@@ -186,51 +186,12 @@ class TestPendingResumeNumberedSelection:
         with patch("cli._cprint"):
             cli_obj._handle_resume_command("/resume")
 
-        assert cli_obj._pending_resume_sessions == sessions
+        cli_obj._show_recent_sessions.assert_called_once_with(reason="resume")
 
 
-    def test_pending_number_resumes_selected_session(self):
+    def test_bare_number_is_not_consumed_as_resume_selection(self):
         cli_obj = _make_cli()
-        sessions = [
-            {"id": "sess_002", "title": "Coding"},
-            {"id": "sess_001", "title": "Research"},
-        ]
-        cli_obj._pending_resume_sessions = sessions
-        # _handle_resume_command("/resume 2") re-resolves the index via
-        # _list_recent_sessions, so it must return the same list.
-        cli_obj._list_recent_sessions = MagicMock(return_value=sessions)
-        cli_obj._session_db.get_session.return_value = {"id": "sess_001", "title": "Research"}
-        cli_obj._session_db.get_resume_conversations.return_value = [
-            {"role": "user", "content": "hello"},
-        ], [
-            {"role": "user", "content": "hello"},
-        ]
-        cli_obj._session_db.resolve_resume_session_id.return_value = "sess_001"
-
-        with (
-            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value=None),
-            patch("cli._cprint"),
-        ):
-            consumed = cli_obj._consume_pending_resume_selection("2")
-
-        assert consumed is True
-        assert cli_obj.session_id == "sess_001"
-        # One-shot: prompt is disarmed after consuming.
-        assert cli_obj._pending_resume_sessions is None
-
-
-
-
-    def test_pending_disarmed_by_other_command(self):
-        cli_obj = _make_cli()
-        cli_obj._pending_resume_sessions = [{"id": "sess_002", "title": "Coding"}]
-        # Stub out the help handler so process_command("/help") is cheap.
-        cli_obj.show_help = MagicMock()
-
-        cli_obj.process_command("/help")
-
-        # A non-resume command disarms the one-shot prompt (#34584).
-        assert cli_obj._pending_resume_sessions is None
+        assert cli_obj._consume_pending_resume_selection("2") is False
 
 
 

--- a/tests/cli/test_pending_resume_displayed_id.py
+++ b/tests/cli/test_pending_resume_displayed_id.py
@@ -1,0 +1,18 @@
+"""Regression coverage for preserving the displayed resume-selection snapshot."""
+
+from unittest.mock import MagicMock
+
+from cli import HermesCLI
+
+
+def test_pending_resume_selection_uses_displayed_session_id():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pending_resume_sessions = [
+        {"id": "row-one"},
+        {"id": "row-eleven"},
+    ]
+    cli._handle_resume_command = MagicMock()
+
+    assert cli._consume_pending_resume_selection("2") is True
+
+    cli._handle_resume_command.assert_called_once_with("/resume row-eleven")

--- a/tests/cli/test_slash_dispatch_table.py
+++ b/tests/cli/test_slash_dispatch_table.py
@@ -54,7 +54,6 @@ def test_registry_names_resolve_into_the_table():
 
 def _cli():
     c = HermesCLI.__new__(HermesCLI)
-    c._pending_resume_sessions = ["x"]
     c.session_id = "s1"
     c.config = {}
     return c
@@ -68,13 +67,11 @@ def test_dispatch_return_semantics_and_side_effects():
         m.assert_called_once_with()
         hook.assert_called_once()
         assert hook.call_args.kwargs["command"] == "yolo"
-    assert c._pending_resume_sessions is None  # non-resume command disarms it
 
     c = _cli()
     with patch.object(HermesCLI, "_handle_resume_command") as m:
         assert c.process_command("/resume 2") is True
         m.assert_called_once_with("/resume 2")
-    assert c._pending_resume_sessions == ["x"]
 
     c = _cli()
     assert c.process_command("/exit") is False
@@ -103,4 +100,3 @@ def test_wisdom_convention_handler_receives_original_arguments():
             patch("hermes_cli.plugins.fire_pre_command_hook"):
         assert c.process_command("/wisdom inspect Team-Runbook") is True
         handler.assert_called_once_with("/wisdom inspect Team-Runbook")
-    assert c._pending_resume_sessions is None

--- a/tests/hermes_cli/test_sessions_command.py
+++ b/tests/hermes_cli/test_sessions_command.py
@@ -1,0 +1,115 @@
+"""Behavioral tests for interactive `/sessions` session management."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "current-session"
+    cli.session_title = None
+    cli._pending_resume_sessions = None
+    cli._session_db = MagicMock()
+    cli._session_db.resolve_session_id.side_effect = lambda target: {
+        "archived": "archived-session",
+        "current": "current-session",
+    }.get(target)
+    return cli
+
+
+def _run(cli, command):
+    with (
+        patch("cli._cprint"),
+        patch("cli._DIM", "", create=True),
+        patch("cli._RST", "", create=True),
+    ):
+        cli._handle_sessions_command(command)
+
+
+class TestSessionsList:
+    def test_list_arms_displayed_twentieth_session(self):
+        cli = _make_cli()
+        rows = [
+            {
+                "id": f"session-{index}",
+                "title": f"Session {index}",
+                "preview": "",
+                "last_active": None,
+            }
+            for index in range(1, 21)
+        ]
+        cli._list_recent_sessions = MagicMock(return_value=rows)
+
+        with patch("hermes_cli.main._relative_time", return_value="now"):
+            _run(cli, "/sessions")
+
+        cli._list_recent_sessions.assert_called_once_with(limit=20)
+        assert cli._pending_resume_sessions == rows
+        assert cli._resolve_sessions_target("20") == "session-20"
+
+
+class TestSessionsDelete:
+    def test_delete_strips_confirmation_flag_before_resolving_target(self):
+        cli = _make_cli()
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+        cli._session_db.get_session.return_value = {"title": "Archived"}
+        cli._session_db.delete_session.return_value = True
+
+        with patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            _run(cli, "/sessions delete archived --yes")
+
+        cli._session_db.resolve_session_id.assert_called_once_with("archived")
+        cli._session_db.delete_session.assert_called_once()
+
+    def test_delete_refuses_current_session(self):
+        cli = _make_cli()
+
+        _run(cli, "/sessions delete current")
+
+        cli._session_db.delete_session.assert_not_called()
+
+
+class TestSessionsRename:
+    def test_rename_current_session_updates_in_memory_title(self):
+        cli = _make_cli()
+
+        _run(cli, "/sessions rename current Renamed session")
+
+        cli._session_db.set_session_title.assert_called_once_with(
+            "current-session", "Renamed session"
+        )
+        assert cli.session_title == "Renamed session"
+
+
+class TestSessionsPrune:
+    def test_prune_parses_days_before_inline_confirmation(self):
+        cli = _make_cli()
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+        cli._session_db.prune_sessions.return_value = 3
+
+        with patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            _run(cli, "/sessions prune --days 30 --yes")
+
+        assert cli._session_db.prune_sessions.call_args.kwargs["older_than_days"] == 30
+        assert cli._confirm_destructive_slash.call_args.kwargs["cmd_original"].endswith(
+            "--yes"
+        )
+
+    def test_prune_rejects_negative_days_without_confirmation(self):
+        cli = _make_cli()
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+
+        _run(cli, "/sessions prune --days -1")
+
+        cli._confirm_destructive_slash.assert_not_called()
+        cli._session_db.prune_sessions.assert_not_called()
+
+    def test_prune_rejects_unknown_argument_grammar(self):
+        cli = _make_cli()
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+
+        _run(cli, "/sessions prune 30")
+
+        cli._confirm_destructive_slash.assert_not_called()
+        cli._session_db.prune_sessions.assert_not_called()

--- a/tests/hermes_cli/test_sessions_command.py
+++ b/tests/hermes_cli/test_sessions_command.py
@@ -1,0 +1,176 @@
+"""Behavioral tests for interactive `/sessions` session management."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "current-session"
+    cli.session_title = None
+    cli._pending_resume_sessions = None
+    cli._session_db = MagicMock()
+    cli._session_db.resolve_session_id.side_effect = lambda target: {
+        "archived": "archived-session",
+        "current": "current-session",
+    }.get(target)
+    return cli
+
+
+def _run(cli, command):
+    with (
+        patch("cli._cprint"),
+        patch("cli._DIM", "", create=True),
+        patch("cli._RST", "", create=True),
+    ):
+        cli._handle_sessions_command(command)
+
+
+class TestSessionsList:
+    def test_list_uses_existing_recent_session_renderer(self):
+        cli = _make_cli()
+        cli._show_recent_sessions = MagicMock(return_value=True)
+
+        _run(cli, "/sessions")
+
+        cli._show_recent_sessions.assert_called_once_with(reason="sessions")
+
+
+class TestSessionsDelete:
+    def test_delete_by_displayed_row_number(self):
+        cli = _make_cli()
+        cli._list_recent_sessions = MagicMock(return_value=[
+            {"id": "current-session"},
+            {"id": "archived-session"},
+        ])
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+        cli._session_db.get_session.return_value = {"title": "Archived"}
+        cli._session_db.delete_session.return_value = True
+
+        with patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            _run(cli, "/sessions delete 2 --yes")
+
+        cli._session_db.resolve_session_id.assert_not_called()
+        cli._session_db.delete_session.assert_called_once()
+        assert cli._session_db.delete_session.call_args.args[0] == "archived-session"
+
+    def test_delete_out_of_range_number_falls_back_to_session_id(self):
+        cli = _make_cli()
+        cli._list_recent_sessions = MagicMock(return_value=[{"id": "current-session"}])
+        cli._session_db.resolve_session_id.side_effect = lambda target: {
+            "999": "numeric-session",
+        }.get(target)
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+        cli._session_db.get_session.return_value = {"title": "Numeric ID"}
+        cli._session_db.delete_session.return_value = True
+
+        with patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            _run(cli, "/sessions delete 999 --yes")
+
+        cli._session_db.resolve_session_id.assert_called_once_with("999")
+        assert cli._session_db.delete_session.call_args.args[0] == "numeric-session"
+
+    def test_delete_unicode_digit_falls_back_to_session_id(self):
+        cli = _make_cli()
+        cli._session_db.resolve_session_id.side_effect = lambda target: {
+            "²": "superscript-session",
+        }.get(target)
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+        cli._session_db.get_session.return_value = {"title": "Superscript ID"}
+        cli._session_db.delete_session.return_value = True
+
+        with patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            _run(cli, "/sessions delete ² --yes")
+
+        cli._session_db.resolve_session_id.assert_called_once_with("²")
+        assert cli._session_db.delete_session.call_args.args[0] == "superscript-session"
+
+    def test_delete_strips_confirmation_flag_before_resolving_target(self):
+        cli = _make_cli()
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+        cli._session_db.get_session.return_value = {"title": "Archived"}
+        cli._session_db.delete_session.return_value = True
+
+        with patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            _run(cli, "/sessions delete archived --yes")
+
+        cli._session_db.resolve_session_id.assert_called_once_with("archived")
+        cli._session_db.delete_session.assert_called_once()
+
+    def test_delete_refuses_current_session(self):
+        cli = _make_cli()
+
+        _run(cli, "/sessions delete current")
+
+        cli._session_db.delete_session.assert_not_called()
+
+
+class TestSessionsRename:
+    def test_rename_by_displayed_row_number(self):
+        cli = _make_cli()
+        cli._list_recent_sessions = MagicMock(return_value=[
+            {"id": "current-session"},
+            {"id": "archived-session"},
+        ])
+
+        _run(cli, "/sessions rename 2 Renamed archived session")
+
+        cli._session_db.resolve_session_id.assert_not_called()
+        cli._session_db.set_session_title.assert_called_once_with(
+            "archived-session", "Renamed archived session"
+        )
+
+    def test_rename_ascii_row_number(self):
+        cli = _make_cli()
+        cli._list_recent_sessions = MagicMock(return_value=[{"id": "archived-session"}])
+
+        _run(cli, "/sessions rename 1 Renamed archived session")
+
+        cli._session_db.resolve_session_id.assert_not_called()
+        cli._session_db.set_session_title.assert_called_once_with(
+            "archived-session", "Renamed archived session"
+        )
+
+    def test_rename_current_session_updates_in_memory_title(self):
+        cli = _make_cli()
+
+        _run(cli, "/sessions rename current Renamed session")
+
+        cli._session_db.set_session_title.assert_called_once_with(
+            "current-session", "Renamed session"
+        )
+        assert cli.session_title == "Renamed session"
+
+
+class TestSessionsPrune:
+    def test_prune_parses_days_before_inline_confirmation(self):
+        cli = _make_cli()
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+        cli._session_db.prune_sessions.return_value = 3
+
+        with patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            _run(cli, "/sessions prune --days 30 --yes")
+
+        assert cli._session_db.prune_sessions.call_args.kwargs["older_than_days"] == 30
+        assert cli._confirm_destructive_slash.call_args.kwargs["cmd_original"].endswith(
+            "--yes"
+        )
+
+    def test_prune_rejects_negative_days_without_confirmation(self):
+        cli = _make_cli()
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+
+        _run(cli, "/sessions prune --days -1")
+
+        cli._confirm_destructive_slash.assert_not_called()
+        cli._session_db.prune_sessions.assert_not_called()
+
+    def test_prune_rejects_unknown_argument_grammar(self):
+        cli = _make_cli()
+        cli._confirm_destructive_slash = MagicMock(return_value=True)
+
+        _run(cli, "/sessions prune 30")
+
+        cli._confirm_destructive_slash.assert_not_called()
+        cli._session_db.prune_sessions.assert_not_called()

--- a/tests/tui_gateway/test_session_manager_rpc.py
+++ b/tests/tui_gateway/test_session_manager_rpc.py
@@ -1,0 +1,87 @@
+from contextlib import contextmanager
+from pathlib import Path
+
+from tui_gateway import server
+
+
+class _DB:
+    def __init__(self):
+        self.rows = [{"id": f"s{i}", "title": f"Title {i}", "model": "m", "started_at": i,
+                      "last_active": i, "message_count": i, "source": "cli"} for i in range(75)]
+
+    def list_sessions_rich(self, **kwargs):
+        rows = sorted(self.rows, key=lambda row: row["last_active"], reverse=True)
+        query = kwargs.get("search_query")
+        if query:
+            rows = [row for row in rows if query.lower() in row["title"].lower()]
+        return rows[:kwargs["limit"]]
+
+    def set_session_title(self, session_id, title):
+        next(row for row in self.rows if row["id"] == session_id)["title"] = title
+        return True
+
+    def get_session(self, session_id):
+        return next((row for row in self.rows if row["id"] == session_id), None)
+
+    def export_session(self, session_id):
+        row = self.get_session(session_id)
+        return {**row, "messages": []} if row else None
+
+
+def test_session_list_pages_searches_and_keeps_newest_first(monkeypatch):
+    db = _DB()
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    first = server._methods["session.list"]("a", {"limit": 50})["result"]
+    second = server._methods["session.list"]("b", {"limit": 50, "offset": 50})["result"]
+    found = server._methods["session.list"]("c", {"query": "Title 7"})["result"]
+    assert first["has_more"] is True
+    assert [row["id"] for row in first["sessions"][:2]] == ["s74", "s73"]
+    assert len(first["sessions"] + second["sessions"]) == 75
+    assert all("Title 7" in row["title"] for row in found["sessions"])
+
+
+def test_session_rename_and_export_use_database_and_shared_export(monkeypatch, tmp_path):
+    db = _DB()
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setitem(server._sessions, "runtime-1", {
+        "session_key": "s1", "history": [], "created_at": 1, "last_active": 1,
+    })
+    monkeypatch.setitem(server._sessions, "runtime-draft", {
+        "session_key": "draft", "history": [], "created_at": 1, "last_active": 1,
+    })
+
+    live = server._methods["session.active_list"]("live", {})["result"]["sessions"]
+    renamed = server._methods["session.rename"]("a", {"session_id": "s1", "title": "New"})["result"]
+    exported = server._methods["session.export"]("b", {"session_id": "s1"})["result"]
+
+    persisted = next(row for row in live if row["id"] == "runtime-1")
+    draft = next(row for row in live if row["id"] == "runtime-draft")
+    assert persisted["session_key"] == "s1"
+    assert "session_key" not in draft
+    assert renamed == {"session_id": "s1", "title": "New"}
+    assert Path(exported["file"]).is_file()
+    assert Path(exported["file"]).parent == tmp_path / "sessions" / "saved"
+
+
+def test_session_export_writes_to_requested_profile_home(monkeypatch, tmp_path):
+    default_home = tmp_path / "default"
+    profile_home = tmp_path / "profiles" / "secondary"
+    db = _DB()
+
+    @contextmanager
+    def profile_db(_params):
+        yield db
+
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(server, "_profile_db", profile_db)
+    monkeypatch.setattr(server, "_profile_home", lambda profile: profile_home if profile == "secondary" else None)
+
+    exported = server._methods["session.export"](
+        "export", {"session_id": "s1", "profile": "secondary"}
+    )["result"]
+
+    exported_path = Path(exported["file"])
+    assert exported_path.is_file()
+    assert exported_path.parent == profile_home / "sessions" / "saved"
+    assert not (default_home / "sessions" / "saved").exists()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -127,7 +127,8 @@ def _session_row_summary(row: dict, *, tip_row: dict | None = None, resolved_id=
     return {"id": row["id"], **({} if resolved_id is None else {"resolved_id": resolved_id}),
             "title": row.get("title") or "", "preview": tip_row.get("preview") or "",
             "started_at": row.get("started_at") or 0, "message_count": tip_row.get("message_count") or 0,
-            "source": row.get("source") or ""}
+            "source": row.get("source") or "", "model": tip_row.get("model") or row.get("model") or "",
+            "last_active": tip_row.get("last_active") or row.get("last_active") or row.get("started_at") or 0}
 
 
 # Hidden from human listings (sub-agent runs, kanban workers); a deny-list so new platforms surface automatically.
@@ -428,11 +429,16 @@ def _(rid, params: dict, db) -> dict:
     try:
         if title_lookup := _str_param(params, "title"):
             return _session_list_by_title(rid, db, title_lookup)
-        limit = int(params.get("limit", 200) or 200)
-        # Over-fetch: per-source filtering + tip merging must not leave us short. ``include_hidden`` is for
-        # surfaces that OWN hidden sessions (Bots pane, pickers).
-        rows = _listing_rows(db, max(limit * 2, 200), include_hidden=_flag(params, "include_hidden"))[:limit]
-        return _ok(rid, {"sessions": [_session_row_summary(s) for s in rows]})
+        limit = max(1, min(int(params.get("limit", 50) or 50), 200))
+        offset = max(0, int(params.get("offset", 0) or 0))
+        query = _str_param(params, "query")
+        rows = _listing_rows(
+            db, offset + limit + 1, include_hidden=_flag(params, "include_hidden"),
+            exclude_sources=list(_LISTING_DENY_SOURCES), search_query=query or None,
+        )
+        rows = rows[offset:offset + limit + 1]
+        return _ok(rid, {"sessions": [_session_row_summary(s) for s in rows[:limit]],
+                         "has_more": len(rows) > limit})
     except Exception as e:
         return _err(rid, 5006, str(e))
 
@@ -960,6 +966,40 @@ def _(rid, params: dict) -> dict:
         except Exception as e:
             return _err(rid, 5036, f"delete failed: {e}")
     return _ok(rid, {"deleted": target}) if deleted else _err(rid, 4007, "session not found")
+
+
+@method("session.rename")
+@_with_db(5037, session_scoped=False)
+def _(rid, params: dict, db) -> dict:
+    target, title = _str_param(params, "session_id"), _str_param(params, "title")
+    if not target or not title:
+        return _err(rid, 4006, "session_id and title required")
+    try:
+        if not db.set_session_title(target, title) and not db.get_session(target):
+            return _err(rid, 4007, "session not found")
+    except ValueError as e:
+        return _err(rid, 4022, str(e))
+    except Exception as e:
+        return _err(rid, 5037, f"rename failed: {e}")
+    return _ok(rid, {"session_id": target, "title": title})
+
+
+@method("session.export")
+@_with_db(5038, session_scoped=False)
+def _(rid, params: dict, db) -> dict:
+    target = _str_param(params, "session_id")
+    if not target:
+        return _err(rid, 4006, "session_id required")
+    try:
+        data = db.export_session(target)
+        if not data:
+            return _err(rid, 4007, "session not found")
+        from hermes_cli.session_export import save_session_export
+        profile = _str_param(params, "profile") or None
+        path = save_session_export(data, fmt="json", home=_profile_home(profile) or get_hermes_home())
+    except Exception as e:
+        return _err(rid, 5038, f"export failed: {e}")
+    return _ok(rid, {"session_id": target, "file": str(path)})
 
 
 def _title_read(session: dict, db, key: str) -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -171,7 +171,7 @@ _LONG_HANDLERS = frozenset({
     "bot_relay.deliver", "bot_relay.reply", "image.generate", "projects.discover_repos",
     "projects.record_repos", "projects.for_cwd", "projects.tree", "projects.project_sessions",
     "setup.runtime_check", "setup.status", "voice.toggle", "voice.record", "voice.tts", "wake.start",
-    "wake.status", "session.active_list", "session.branch", "session.compress", "session.list",
+    "wake.status", "session.active_list", "session.branch", "session.compress", "session.list", "session.export",
     "session.resume", "session.workspace.move", "shell.exec", "skills.manage", "slash.exec",
     "command.dispatch",  # /goal draft invokes the auxiliary model; never block the RPC reader
 })
@@ -2612,6 +2612,10 @@ def _session_live_title(session: dict, key: str) -> str:
 
 def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     key = _session_lookup_key(session, fallback=sid)
+    persisted_key = ""
+    with contextlib.suppress(Exception), _session_db(session) as db:
+        if db is not None and (not hasattr(db, "get_session") or db.get_session(key)):
+            persisted_key = key
     agent = session.get("agent")
     history = list(session.get("history") or [])
     status = _session_live_status(sid, session)
@@ -2629,7 +2633,8 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
         "last_active": float(session.get("last_active") or session.get("created_at") or now),
         "message_count": len(history),
         "model": str(getattr(agent, "model", "") or _resolve_model()), "preview": preview,
-        "session_key": key, "started_at": float(session.get("created_at") or now), "status": status,
+        **({"session_key": persisted_key} if persisted_key else {}),
+        "started_at": float(session.get("created_at") or now), "status": status,
         "title": _session_live_title(session, key),
     }
 

--- a/ui-tui/src/__tests__/activeSessionSwitcher.harness.test.tsx
+++ b/ui-tui/src/__tests__/activeSessionSwitcher.harness.test.tsx
@@ -1,0 +1,225 @@
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { expect, it, vi } from 'vitest'
+
+import { ActiveSessionSwitcher } from '../components/activeSessionSwitcher.js'
+import type { GatewayClient } from '../gatewayClient.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+function mount(request: ReturnType<typeof vi.fn>) {
+  const stdout = Object.assign(new PassThrough(), { columns: 110, rows: 30, isTTY: false })
+  const stdin = Object.assign(new PassThrough(), { isTTY: true, setRawMode: () => {}, ref: () => {}, unref: () => {} })
+  let output = ''
+  stdout.on('data', chunk => { output += stripAnsi(chunk.toString()) })
+  const onResume = vi.fn()
+
+  const view = renderSync(
+    <ActiveSessionSwitcher currentSessionId="live" gw={{ request } as unknown as GatewayClient}
+      onCancel={() => {}} onClose={async () => ({ closed: true })} onNew={() => {}}
+      onNewPrompt={() => {}} onResume={onResume} onSelect={() => {}} t={DEFAULT_THEME} />,
+    { stdout: stdout as unknown as NodeJS.WriteStream, stdin: stdin as unknown as NodeJS.ReadStream,
+      stderr: new PassThrough() as unknown as NodeJS.WriteStream, patchConsole: false }
+  )
+
+  return { stdin, onResume, output: () => output, cleanup: () => { view.unmount(); view.cleanup() } }
+}
+
+it('filters, navigates, selects, confirms deletion, and exports through the real input harness', async () => {
+  const rows = [
+    { id: 'newest', title: 'Needle newest', message_count: 8, started_at: 20, last_active: 30, model: 'openai/gpt', preview: '' },
+    { id: 'older', title: 'Other older', message_count: 3, started_at: 10, last_active: 10, model: 'anthropic/sonnet', preview: '' }
+  ]
+
+  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method === 'session.active_list') {return { sessions: [{ id: 'live', current: true, status: 'idle' }] }}
+
+    if (method === 'session.list') {
+      const query = String(params.query || '').toLowerCase()
+
+      return { sessions: query ? rows.filter(row => row.title.toLowerCase().includes(query)) : rows, has_more: false }
+    }
+
+    if (method === 'session.delete') {return { deleted: params.session_id }}
+
+    if (method === 'session.rename') {return { session_id: params.session_id, title: params.title }}
+
+    if (method === 'session.export') {return { session_id: params.session_id, file: '/tmp/export.json' }}
+
+    return {}
+  })
+
+  const app = mount(request)
+
+  try {
+    await vi.waitFor(() => expect(app.output()).toContain('Needle newest'))
+    app.stdin.write('\x1b[B')
+    await new Promise(resolve => setTimeout(resolve, 20))
+    app.stdin.write('\r')
+    await vi.waitFor(() => expect(app.onResume).toHaveBeenCalledWith('newest'))
+    app.stdin.write('e')
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.export', { session_id: 'newest' }))
+    await vi.waitFor(() => expect(app.output()).toContain('saved: /tmp/export.json'))
+    app.stdin.write('d')
+    await vi.waitFor(() => expect(app.output()).toContain('press d again to delete'))
+    app.stdin.write('d')
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.delete', { session_id: 'newest' }))
+    app.stdin.write('/')
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    for (const ch of 'Needle') {
+      app.stdin.write(ch)
+      await new Promise(resolve => setTimeout(resolve, 20))
+    }
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.list', expect.objectContaining({ query: 'Needle' })))
+  } finally {
+    app.cleanup()
+  }
+})
+
+it('renames the selected history row inline', async () => {
+  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method === 'session.active_list') {return { sessions: [{ id: 'live', current: true, status: 'idle' }] }}
+
+    if (method === 'session.list') {return { sessions: [{ id: 'old', title: 'Old', message_count: 1,
+      started_at: 1, model: 'm', preview: '' }], has_more: false }}
+
+    if (method === 'session.rename') {return { session_id: params.session_id, title: params.title }}
+
+    return {}
+  })
+
+  const app = mount(request)
+
+  try {
+    await vi.waitFor(() => expect(app.output()).toContain('Old'))
+    app.stdin.write('\x1b[B')
+    await new Promise(resolve => setTimeout(resolve, 20))
+    app.stdin.write('r')
+    await vi.waitFor(() => expect(app.output()).toContain('rename ›'))
+
+    for (const ch of ' renamed') {
+      app.stdin.write(ch)
+      await new Promise(resolve => setTimeout(resolve, 20))
+    }
+
+    app.stdin.write('\r')
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.rename', {
+      session_id: 'old', title: 'Old renamed'
+    }))
+  } finally {
+    app.cleanup()
+  }
+})
+
+it('uses the stored key for persisted live-session management', async () => {
+  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method === 'session.active_list') {
+      return { sessions: [{ id: 'runtime-live', session_key: 'stored-session', current: true, status: 'idle' }] }
+    }
+
+    if (method === 'session.list') {return { sessions: [], has_more: false }}
+
+    if (method === 'session.rename') {return { session_id: params.session_id, title: params.title }}
+
+    if (method === 'session.export') {return { session_id: params.session_id, file: '/tmp/export.json' }}
+
+    return {}
+  })
+
+  const app = mount(request)
+
+  try {
+    await vi.waitFor(() => expect(app.output()).toContain('1 live'))
+    app.stdin.write('\x1b[B')
+    await new Promise(resolve => setTimeout(resolve, 20))
+    app.stdin.write('r')
+    await vi.waitFor(() => expect(app.output()).toContain('rename ›'))
+
+    for (const ch of ' Renamed') {
+      app.stdin.write(ch)
+      await new Promise(resolve => setTimeout(resolve, 20))
+    }
+
+    app.stdin.write('\r')
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.rename', {
+      session_id: 'stored-session', title: 'Renamed'
+    }))
+    app.stdin.write('e')
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.export', {
+      session_id: 'stored-session'
+    }))
+  } finally {
+    app.cleanup()
+  }
+})
+
+it('hides a persisted live session from history so it cannot be delete-armed', async () => {
+  const request = vi.fn(async (method: string) => {
+    if (method === 'session.active_list') {
+      return { sessions: [{ id: 'runtime-live', session_key: 'stored-session', current: true, status: 'idle' }] }
+    }
+
+    if (method === 'session.list') {return { sessions: [{ id: 'stored-session', title: 'Persisted duplicate',
+      message_count: 1, started_at: 1, model: 'm', preview: '' }], has_more: false }}
+
+    return {}
+  })
+
+  const app = mount(request)
+
+  try {
+    await vi.waitFor(() => expect(app.output()).toContain('1 live · 0 resumable'))
+    expect(app.output()).not.toContain('Persisted duplicate')
+    app.stdin.write('\x1b[B')
+    await new Promise(resolve => setTimeout(resolve, 20))
+    app.stdin.write('d')
+    await new Promise(resolve => setTimeout(resolve, 20))
+    expect(app.output()).not.toContain('press d again to delete')
+    expect(request).not.toHaveBeenCalledWith('session.delete', expect.anything())
+  } finally {
+    app.cleanup()
+  }
+})
+
+it('renames a draft through its live runtime and requires saving before export', async () => {
+  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method === 'session.active_list') {
+      return { sessions: [{ id: 'runtime-draft', current: true, status: 'idle' }] }
+    }
+
+    if (method === 'session.list') {return { sessions: [], has_more: false }}
+
+    if (method === 'session.title') {return { title: params.title }}
+
+    return {}
+  })
+
+  const app = mount(request)
+
+  try {
+    await vi.waitFor(() => expect(app.output()).toContain('1 live'))
+    app.stdin.write('\x1b[B')
+    await new Promise(resolve => setTimeout(resolve, 20))
+    app.stdin.write('r')
+    await vi.waitFor(() => expect(app.output()).toContain('rename ›'))
+
+    for (const ch of ' Draft') {
+      app.stdin.write(ch)
+      await new Promise(resolve => setTimeout(resolve, 20))
+    }
+
+    app.stdin.write('\r')
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.title', {
+      session_id: 'runtime-draft', title: 'Draft'
+    }))
+    app.stdin.write('e')
+    await vi.waitFor(() => expect(app.output()).toContain('save before export'))
+    expect(request).not.toHaveBeenCalledWith('session.export', expect.anything())
+  } finally {
+    app.cleanup()
+  }
+})

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -48,6 +48,57 @@ describe('createSlashHandler', () => {
     expect(getOverlayState().sessions).toBe(false)
   })
 
+  it.each(['list', 'delete archived --yes', 'rename archived New title', 'prune --days 30 --yes'])(
+    'routes /sessions %s through the slash worker',
+    async arg => {
+      patchUiState({ sid: 'sid-abc' })
+      const ctx = buildCtx()
+      ctx.gateway.gw.request.mockResolvedValue({ output: 'session command complete' })
+
+      expect(createSlashHandler(ctx)(`/sessions ${arg}`)).toBe(true)
+      expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', {
+        command: `sessions ${arg}`,
+        session_id: 'sid-abc'
+      })
+      await vi.waitFor(() => expect(ctx.transcript.sys).toHaveBeenCalledWith('session command complete'))
+    }
+  )
+
+  it.each(['delete archived', 'prune --days 30'])('requires --yes before forwarding /sessions %s', arg => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)(`/sessions ${arg}`)).toBe(true)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('confirmation required: rerun with --yes')
+  })
+
+  it.each(['sessions', 'session', 'switch', 'resume'])('routes /%s manager commands through the slash worker', async name => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+    ctx.gateway.gw.request.mockResolvedValue({ output: 'session command complete' })
+
+    expect(createSlashHandler(ctx)(`/${name} prune --days 30 --yes`)).toBe(true)
+    expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', {
+      command: 'sessions prune --days 30 --yes',
+      session_id: 'sid-abc'
+    })
+    await vi.waitFor(() => expect(ctx.transcript.sys).toHaveBeenCalledWith('session command complete'))
+  })
+
+  it.each(['ls', 'browse'])('routes /sessions %s through the slash worker', async subcommand => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+    ctx.gateway.gw.request.mockResolvedValue({ output: 'session list' })
+
+    expect(createSlashHandler(ctx)(`/sessions ${subcommand}`)).toBe(true)
+    expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', {
+      command: `sessions ${subcommand}`,
+      session_id: 'sid-abc'
+    })
+    await vi.waitFor(() => expect(ctx.transcript.sys).toHaveBeenCalledWith('session list'))
+  })
+
   it('opens the unified sessions overlay locally even when the current session is busy', () => {
     patchUiState({ busy: true, sid: 'sid-abc' })
     const ctx = buildCtx()

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -48,6 +48,31 @@ describe('createSlashHandler', () => {
     expect(getOverlayState().sessions).toBe(false)
   })
 
+  it.each(['list', 'delete archived --yes', 'rename archived New title', 'prune --days 30 --yes'])(
+    'routes /sessions %s through the slash worker',
+    async arg => {
+      patchUiState({ sid: 'sid-abc' })
+      const ctx = buildCtx()
+      ctx.gateway.gw.request.mockResolvedValue({ output: 'session command complete' })
+
+      expect(createSlashHandler(ctx)(`/sessions ${arg}`)).toBe(true)
+      expect(ctx.gateway.gw.request).toHaveBeenCalledWith('slash.exec', {
+        command: `sessions ${arg}`,
+        session_id: 'sid-abc'
+      })
+      await vi.waitFor(() => expect(ctx.transcript.sys).toHaveBeenCalledWith('session command complete'))
+    }
+  )
+
+  it.each(['delete archived', 'prune --days 30'])('requires --yes before forwarding /sessions %s', arg => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)(`/sessions ${arg}`)).toBe(true)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('confirmation required: rerun with --yes')
+  })
+
   it('opens the unified sessions overlay locally even when the current session is busy', () => {
     patchUiState({ busy: true, sid: 'sid-abc' })
     const ctx = buildCtx()

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -163,8 +163,33 @@ export const sessionCommands: SlashCommand[] = [
     aliases: ['switch', 'session', 'resume'],
     help: 'browse, switch, or resume sessions',
     name: 'sessions',
-    run: (arg, ctx) => {
+    run: (arg, ctx, cmd) => {
       const trimmed = arg.trim()
+      const [subcommand] = trimmed.toLowerCase().split(/\s+/, 1)
+
+      // Keep the interactive picker for bare `/sessions`, but send the CLI
+      // session-management subcommands to the slash worker. Otherwise the TUI
+      // mistakes `/sessions delete …` for a session title and resumes it.
+      if (cmd.startsWith('/sessions ') && ['delete', 'list', 'prune', 'rename'].includes(subcommand)) {
+        const destructive = subcommand === 'delete' || subcommand === 'prune'
+        const confirmed = /(?:^|\s)(?:--yes|-y|now)(?:$|\s)/i.test(trimmed)
+
+        if (destructive && !confirmed) {
+          return ctx.transcript.sys('confirmation required: rerun with --yes')
+        }
+
+        ctx.gateway.gw
+          .request<SlashExecResponse>('slash.exec', { command: cmd.slice(1), session_id: ctx.sid })
+          .then(
+            ctx.guarded<SlashExecResponse>(r => {
+              const body = r.output || '/sessions: no output'
+              ctx.transcript.sys(r.warning ? `warning: ${r.warning}\n${body}` : body)
+            })
+          )
+          .catch(ctx.guardedErr)
+
+        return
+      }
 
       // A new *live* session keeps the current one running in the background
       // (it doesn't close it), so fanning out while busy is allowed — that's

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -183,8 +183,36 @@ export const sessionCommands: SlashCommand[] = [
     aliases: ['switch', 'session', 'resume'],
     help: 'browse, switch, or resume sessions',
     name: 'sessions',
-    run: (arg, ctx) => {
+    run: (arg, ctx, cmd) => {
       const trimmed = arg.trim()
+      const [subcommand] = trimmed.toLowerCase().split(/\s+/, 1)
+
+      // Keep the interactive picker for a bare command, but send every
+      // session-manager spelling (including aliases) to the slash worker.
+      // The Python CLI accepts list/ls/browse, so do not treat those as IDs.
+      const managerSubcommands = ['delete', 'list', 'ls', 'browse', 'prune', 'rename']
+
+      if (managerSubcommands.includes(subcommand)) {
+        const canonicalCommand = `/sessions ${trimmed}`
+        const destructive = subcommand === 'delete' || subcommand === 'prune'
+        const confirmed = /(?:^|\s)(?:--yes|-y|now)(?:$|\s)/i.test(trimmed)
+
+        if (destructive && !confirmed) {
+          return ctx.transcript.sys('confirmation required: rerun with --yes')
+        }
+
+        ctx.gateway.gw
+          .request<SlashExecResponse>('slash.exec', { command: canonicalCommand.slice(1), session_id: ctx.sid })
+          .then(
+            ctx.guarded<SlashExecResponse>(r => {
+              const body = r.output || '/sessions: no output'
+              ctx.transcript.sys(r.warning ? `warning: ${r.warning}\n${body}` : body)
+            })
+          )
+          .catch(ctx.guardedErr)
+
+        return
+      }
 
       // A new *live* session keeps the current one running in the background
       // (it doesn't close it), so fanning out while busy is allowed — that's

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -8,8 +8,11 @@ import type {
   SessionActiveListResponse,
   SessionCloseResponse,
   SessionDeleteResponse,
+  SessionExportResponse,
   SessionListItem,
-  SessionListResponse
+  SessionListResponse,
+  SessionRenameResponse,
+  SessionTitleResponse
 } from '../gatewayTypes.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
@@ -23,6 +26,7 @@ const VISIBLE = 12
 const MIN_WIDTH = 64
 const MAX_WIDTH = 128
 const TITLE_MAX = 64
+const PAGE_SIZE = 50
 
 const STATUS_GLYPH: Record<string, string> = {
   idle: '✓',
@@ -83,11 +87,11 @@ export const relativeSessionAge = (ts?: number) => {
   return `${Math.floor(days)}d ago`
 }
 
-/** Drop already-live sessions from the resumable history list (dedupe by id). */
+/** Drop already-live sessions from the resumable history list. */
 export const resumableHistory = (history: readonly SessionListItem[], live: readonly SessionActiveItem[]) => {
-  const liveIds = new Set(live.map(s => s.id))
+  const liveSessionIds = new Set(live.map(session => session.session_key ?? session.id))
 
-  return history.filter(h => !liveIds.has(h.id))
+  return history.filter(session => !liveSessionIds.has(session.id))
 }
 
 export const resumeRowContextHintSegments: OrchestratorHintSegment[] = [
@@ -311,6 +315,11 @@ export function ActiveSessionSwitcher({
   // different session. Any other key cancels the prompt.
   const [confirmDelete, setConfirmDelete] = useState<null | string>(null)
   const [deleting, setDeleting] = useState(false)
+  const [query, setQuery] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [renameTarget, setRenameTarget] = useState<null | SessionActiveItem | SessionListItem>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [hasMore, setHasMore] = useState(false)
   const initialSelectionAppliedRef = useRef(false)
   // Holds the RAW `session.list` results (pre-dedupe). The quiet 1.5s poll
   // re-derives the resumable list from this against the latest live set, so a
@@ -341,7 +350,7 @@ export function ActiveSessionSwitcher({
     // `quiet` skips the loading spinner (used by the live-status poll);
     // `includeHistory` re-queries the resumable DB list (skipped on the 1.5s
     // poll, which only needs fresh live-session status).
-    async (quiet = false, includeHistory = true) => {
+    async (quiet = false, includeHistory = true, append = false) => {
       if (!quiet) {
         setLoading(true)
       }
@@ -354,7 +363,13 @@ export function ActiveSessionSwitcher({
           gw.request<SessionActiveListResponse>('session.active_list', {
             current_session_id: currentSessionId
           }),
-          includeHistory ? gw.request<SessionListResponse>('session.list', { limit: 200 }) : Promise.resolve(null)
+          includeHistory
+            ? gw.request<SessionListResponse>('session.list', {
+                limit: PAGE_SIZE,
+                offset: append ? rawHistoryRef.current.length : 0,
+                query: query || undefined
+              })
+            : Promise.resolve(null)
         ])
 
         const r = liveRes.status === 'fulfilled' ? asRpcResult<SessionActiveListResponse>(liveRes.value) : null
@@ -378,7 +393,10 @@ export function ActiveSessionSwitcher({
             const parsedHist = asRpcResult<SessionListResponse>(histRes.value)
 
             if (parsedHist) {
-              rawHistoryRef.current = parsedHist.sessions ?? []
+              rawHistoryRef.current = append
+                ? [...rawHistoryRef.current, ...(parsedHist.sessions ?? [])]
+                : (parsedHist.sessions ?? [])
+              setHasMore(Boolean(parsedHist.has_more))
             } else {
               histError = 'invalid response: session.list'
             }
@@ -434,7 +452,7 @@ export function ActiveSessionSwitcher({
         return []
       }
     },
-    [currentSessionId, gw]
+    [currentSessionId, gw, query]
   )
 
   useEffect(() => {
@@ -448,6 +466,12 @@ export function ActiveSessionSwitcher({
 
     return () => clearInterval(timer)
   }, [load])
+
+  const loadMore = useCallback(() => {
+    if (hasMore && !loading) {
+      void load(true, true, true)
+    }
+  }, [hasMore, load, loading])
 
   const submitDraft = useCallback(
     (value: string) => {
@@ -534,6 +558,67 @@ export function ActiveSessionSwitcher({
     [deleting, gw, history, items.length]
   )
 
+  const selectedKind = rowKind(sel)
+  const newSelected = selectedKind === 'new'
+  const draftHasText = Boolean(draft.trim())
+
+  const submitRename = useCallback(
+    (title: string) => {
+      const value = title.trim()
+
+      if (!renameTarget || !value) {
+        return
+      }
+
+      const liveTarget = 'status' in renameTarget
+      const storedId = liveTarget ? renameTarget.session_key : renameTarget.id
+
+      const request = storedId
+        ? gw.request<SessionRenameResponse>('session.rename', { session_id: storedId, title: value })
+        : gw.request<SessionTitleResponse>('session.title', { session_id: renameTarget.id, title: value })
+
+      request
+        .then(raw => {
+          const result = asRpcResult<SessionRenameResponse>(raw)
+
+          if (!result) {
+            throw new Error('invalid response: session.rename')
+          }
+
+          setRenameTarget(null)
+          setRenameValue('')
+          void load(true)
+        })
+        .catch((e: unknown) => setErr(rpcErrorMessage(e)))
+    },
+    [gw, load, renameTarget]
+  )
+
+  const exportSelected = useCallback(() => {
+    const target = selectedKind === 'live' ? items[sel - 1] : history[sel - 1 - items.length]
+
+    if (!target) {
+      return
+    }
+
+    const storedId = selectedKind === 'history'
+      ? target.id
+      : ('session_key' in target ? target.session_key : undefined)
+
+    if (!storedId) {
+      setErr('save before export')
+
+      return
+    }
+
+    gw.request<SessionExportResponse>('session.export', { session_id: storedId })
+      .then(raw => {
+        const result = asRpcResult<SessionExportResponse>(raw)
+        setErr(result?.file ? `saved: ${result.file}` : 'invalid response: session.export')
+      })
+      .catch((e: unknown) => setErr(rpcErrorMessage(e)))
+  }, [gw, history, items, sel, selectedKind])
+
   const handleRowClick = useCallback(
     (index: number) => (event: { stopImmediatePropagation?: () => void }) => {
       event.stopImmediatePropagation?.()
@@ -559,12 +644,8 @@ export function ActiveSessionSwitcher({
     [history, items, onResume, onSelect, rowKind, total]
   )
 
-  const selectedKind = rowKind(sel)
-  const newSelected = selectedKind === 'new'
-  const draftHasText = Boolean(draft.trim())
-
   useInput((ch, key) => {
-    if (pickingModel || deleting) {
+    if (pickingModel || deleting || searching || renameTarget) {
       return
     }
 
@@ -595,6 +676,29 @@ export function ActiveSessionSwitcher({
 
     if (isCtrl('r')) {
       void load()
+
+      return
+    }
+
+    if (ch === '/') {
+      setSearching(true)
+
+      return
+    }
+
+    if (lower === 'r' && selectedKind !== 'new') {
+      const target = selectedKind === 'live' ? items[sel - 1] : history[sel - 1 - items.length]
+
+      if (target) {
+        setRenameTarget(target)
+        setRenameValue(target.title || '')
+      }
+
+      return
+    }
+
+    if (lower === 'e' && selectedKind !== 'new') {
+      exportSelected()
 
       return
     }
@@ -632,6 +736,10 @@ export function ActiveSessionSwitcher({
     }
 
     if (key.downArrow && sel < total - 1) {
+      if (sel >= total - 3) {
+        loadMore()
+      }
+
       return setSel(s => Math.min(total - 1, s + 1))
     }
 
@@ -693,6 +801,14 @@ export function ActiveSessionSwitcher({
         Sessions
       </Text>
       <Text color={t.color.muted}>{sessionsCountLabel(items.length, history.length)}</Text>
+
+      {searching ? (
+        <Box><Text color={t.color.label}>search › </Text><TextInput color={t.color.text} columns={promptColumns}
+          onChange={setQuery} onSubmit={() => setSearching(false)} value={query} /></Box>
+      ) : renameTarget ? (
+        <Box><Text color={t.color.label}>rename › </Text><TextInput color={t.color.text} columns={promptColumns}
+          onChange={setRenameValue} onSubmit={submitRename} value={renameValue} /></Box>
+      ) : null}
 
       {err && <Text color={t.color.label}>error: {err}</Text>}
 
@@ -777,13 +893,13 @@ export function ActiveSessionSwitcher({
 
               <Box {...fixedSessionColumnStyle()} width={11}>
                 <Text color={rowTextColor ?? t.color.muted} wrap="truncate-end">
-                  {relativeSessionAge(h.started_at)}
+                  {relativeSessionAge(h.last_active || h.started_at)}
                 </Text>
               </Box>
 
               <Box {...fixedSessionColumnStyle()} width={18}>
                 <Text color={rowTextColor ?? t.color.muted} wrap="truncate-end">
-                  {h.message_count} msgs
+                  {h.message_count} msgs · {shortModel(h.model)}
                 </Text>
               </Box>
 
@@ -893,6 +1009,7 @@ export function ActiveSessionSwitcher({
         </Box>
       )}
 
+      <Text color={t.color.muted}>/ search · r rename · e export · d delete</Text>
       <OrchestratorHintText segments={orchestratorGlobalHotkeyHintSegments} t={t} />
     </Box>
   )

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -242,15 +242,21 @@ export interface SessionListItem {
   source?: string
   started_at: number
   title: string
+  model?: string
+  last_active?: number
 }
 
 export interface SessionListResponse {
+  has_more?: boolean
   sessions?: SessionListItem[]
 }
 
 export interface SessionDeleteResponse {
   deleted: string
 }
+
+export interface SessionRenameResponse { session_id: string; title: string }
+export interface SessionExportResponse { session_id: string; file: string }
 
 export interface SessionMostRecentResponse {
   session_id?: null | string


### PR DESCRIPTION
Closes #56280

Managing old sessions should not mean leaving Hermes and dropping back to the terminal. This turns `/sessions` into the session manager inside the TUI while keeping the quick command forms for the common cases.

## What changed

- `/sessions` opens the existing session switcher with newest-first sessions, search, paging, title, message count, date, and model.
- Use arrow keys and Enter to open a session.
- `d` asks for confirmation before deleting, `r` renames, and `e` exports through the normal session-export path.
- `/sessions list`, `delete`, `rename`, and `prune` remain available when a panel would be slower.

A few guardrails are intentional: the current live session cannot be deleted, unsaved drafts can be renamed but must be saved before export, and exports stay inside the selected Hermes profile.

## Validation

- Session command, RPC, profile-isolation, and regression tests: 32 passed.
- TUI switcher and slash-command tests: 99 passed.
- TypeScript typecheck, Ink build, Ruff, and whitespace checks pass.

The branch is rebased on current `main` and squashed to one commit.
