### PR TITLE
fix(state): decode multimodal first-user message in session previews

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2852,10 +2852,10 @@ class SessionDB:
                 )
                 SELECT s.*,
                     COALESCE(
-                        (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                        (SELECT m.content
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                         ORDER BY m.timestamp, m.id LIMIT 1),
+                         ORDER BY m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
                     COALESCE(
@@ -2876,10 +2876,10 @@ class SessionDB:
             query = f"""
                 SELECT s.*,
                     COALESCE(
-                        (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                        (SELECT m.content
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                         ORDER BY m.timestamp, m.id LIMIT 1),
+                         ORDER BY m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
                     COALESCE(
@@ -2898,13 +2898,7 @@ class SessionDB:
         sessions = []
         for row in rows:
             s = dict(row)
-            # Build the preview from the raw substring
-            raw = s.pop("_preview_raw", "").strip()
-            if raw:
-                text = raw[:60]
-                s["preview"] = text + ("..." if len(raw) > 60 else "")
-            else:
-                s["preview"] = ""
+            s["preview"] = self._preview_from_content(s.pop("_preview_raw", None))
             # Drop the internal ordering column so callers see a clean dict.
             s.pop("_effective_last_active", None)
             sessions.append(s)
@@ -2980,10 +2974,10 @@ class SessionDB:
         query = """
             SELECT s.*,
                 COALESCE(
-                    (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                    (SELECT m.content
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                     ORDER BY m.timestamp, m.id LIMIT 1),
+                     ORDER BY m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
                 COALESCE(
@@ -3002,12 +2996,7 @@ class SessionDB:
         runs: List[Dict[str, Any]] = []
         for row in rows:
             s = dict(row)
-            raw = s.pop("_preview_raw", "").strip()
-            if raw:
-                text = raw[:60]
-                s["preview"] = text + ("..." if len(raw) > 60 else "")
-            else:
-                s["preview"] = ""
+            s["preview"] = self._preview_from_content(s.pop("_preview_raw", None))
             runs.append(s)
         return runs
 
@@ -3019,10 +3008,10 @@ class SessionDB:
         query = """
             SELECT s.*,
                 COALESCE(
-                    (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                    (SELECT m.content
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                     ORDER BY m.timestamp, m.id LIMIT 1),
+                     ORDER BY m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
                 COALESCE(
@@ -3038,12 +3027,7 @@ class SessionDB:
         if not row:
             return None
         s = dict(row)
-        raw = s.pop("_preview_raw", "").strip()
-        if raw:
-            text = raw[:60]
-            s["preview"] = text + ("..." if len(raw) > 60 else "")
-        else:
-            s["preview"] = ""
+        s["preview"] = self._preview_from_content(s.pop("_preview_raw", None))
         return s
 
     # =========================================================================
@@ -3091,6 +3075,36 @@ class SessionDB:
                 )
                 return content
         return content
+
+    @classmethod
+    def _preview_from_content(cls, raw: Any, limit: int = 60) -> str:
+        """Build a one-line session preview from a stored message content value.
+
+        Decodes multimodal (sentinel-JSON) content and flattens its text parts,
+        mirroring :meth:`list_recent_user_messages`. This must be done in Python
+        rather than with a SQL ``SUBSTR``: multimodal content is stored with the
+        :attr:`_CONTENT_JSON_PREFIX` sentinel, whose leading NUL byte makes
+        SQLite's text functions (``SUBSTR``/``length``) treat the value as
+        empty, so a SQL-side preview of an image+caption turn comes back blank.
+        """
+        decoded = cls._decode_content(raw)
+        if isinstance(decoded, list):
+            # Multimodal — flatten text parts.
+            text_parts = [
+                p.get("text", "") for p in decoded
+                if isinstance(p, dict) and p.get("type") == "text"
+            ]
+            preview = " ".join(t for t in text_parts if t).strip()
+            if not preview:
+                preview = "[multimodal content]"
+        elif isinstance(decoded, str):
+            preview = decoded
+        else:
+            preview = ""
+        preview = " ".join(preview.split())  # collapse whitespace/newlines
+        if len(preview) > limit:
+            preview = preview[:limit] + "..."
+        return preview
 
     def append_message(
         self,
@@ -5487,10 +5501,10 @@ class SessionDB:
                     """
                     SELECT s.*,
                         COALESCE(
-                            (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                            (SELECT m.content
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                             ORDER BY m.timestamp, m.id LIMIT 1),
+                             ORDER BY m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,
                         COALESCE(
@@ -5516,10 +5530,10 @@ class SessionDB:
                     """
                     SELECT s.*,
                         COALESCE(
-                            (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
+                            (SELECT m.content
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                             ORDER BY m.timestamp, m.id LIMIT 1),
+                             ORDER BY m.id LIMIT 1),
                             ''
                         ) AS _preview_raw,
                         COALESCE(
@@ -5538,8 +5552,7 @@ class SessionDB:
         sessions: List[Dict[str, Any]] = []
         for row in rows:
             session = dict(row)
-            raw = str(session.pop("_preview_raw", "") or "").strip()
-            session["preview"] = raw[:60] + ("..." if len(raw) > 60 else "") if raw else ""
+            session["preview"] = self._preview_from_content(session.pop("_preview_raw", None))
             sessions.append(session)
         return sessions
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4881,3 +4881,61 @@ def test_refresh_compression_lock_requires_holder_and_preserves_reclaimability(d
 
     monkeypatch.setattr(hermes_state.time, "time", lambda: 1016.0)
     assert db.try_acquire_compression_lock("s1", "holder-b", ttl_seconds=10.0) is True
+
+
+class TestSessionPreview:
+    """The session-list preview must decode multimodal first-user messages
+    and pick the opening turn by insertion id, not by (non-monotonic) time.
+    """
+
+    def test_preview_plain_text_first_user_message(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", "user", content="hello there, please fix the bug")
+        rows = db.list_sessions_rich()
+        assert rows[0]["preview"] == "hello there, please fix the bug"
+
+    def test_preview_multimodal_first_user_message_is_not_blank(self, db):
+        # Regression: multimodal content is stored with the sentinel NUL
+        # prefix, so a SQL SUBSTR preview came back empty (SQLite text
+        # functions stop at the NUL). The caption must survive.
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            "user",
+            content=[
+                {"type": "text", "text": "analyze this chart please"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+        )
+        rows = db.list_sessions_rich()
+        assert rows[0]["preview"] == "analyze this chart please"
+
+    def test_preview_multimodal_without_text_falls_back(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            "user",
+            content=[{"type": "image_url", "image_url": {"url": "x"}}],
+        )
+        rows = db.list_sessions_rich()
+        assert rows[0]["preview"] == "[multimodal content]"
+
+    def test_preview_uses_first_user_message_by_id_not_timestamp(self, db):
+        # Non-monotonic wall clock (WSL2 / NTP step / VM resume): the truly
+        # first message can carry a LATER timestamp than a later one. The
+        # preview must follow insertion id, matching get_messages() et al.
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", "user", content="FIRST question", timestamp=1000.0)
+        db.append_message("s1", "user", content="second question", timestamp=1.0)
+        rows = db.list_sessions_rich()
+        assert rows[0]["preview"] == "FIRST question"
+
+    def test_get_session_rich_row_preview_decodes_multimodal(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            "user",
+            content=[{"type": "text", "text": "caption on an image"}],
+        )
+        row = db._get_session_rich_row("s1")
+        assert row["preview"] == "caption on an image"


### PR DESCRIPTION
## What does this PR do?

Fixes blank session previews for any conversation whose first user turn is multimodal (image + caption), plus a related ordering bug in the same subqueries.

The session-list "preview" (first user message) is computed with a raw SQL `SUBSTR(REPLACE(REPLACE(m.content, X'0A',' '), X'0D',' '), 1, 63)`. Multimodal content is persisted with the `_CONTENT_JSON_PREFIX` sentinel (`"\x00json:"`). SQLite's text functions stop at the leading NUL byte, so `length()` and `SUBSTR()` see the value as empty:

```
sqlite> SELECT length(x), SUBSTR(x,1,63) FROM (SELECT x'00' || 'json:[...]' AS x);
0|
```

So the preview comes back blank whenever the first user message is an image + caption, which is routine on Telegram, Desktop, and yuanbao image uploads. It affects all six subqueries: `list_sessions_rich`, `_get_session_rich_row` (the compression-tip projection), `list_cron_job_runs`, and the two Telegram-topic listers. That leaves blank entries in the session sidebar, the `/resume` picker, the cron-run list, and the Telegram topic list.

`list_recent_user_messages` (the `/rewind` picker) already does this correctly: it selects the content and decodes it in Python. That is both the proof of intended behavior and the model for the fix.

Second bug, same subqueries: they `ORDER BY m.timestamp, m.id`. This module deliberately orders messages by the AUTOINCREMENT `id`, never `timestamp`, because `append_message` stamps rows with non-monotonic `time.time()` (WSL2, NTP steps, VM-sleep resume). See the ordering comments elsewhere in the file, and note that `get_messages`, `get_messages_around`, and `list_recent_user_messages` all order by `id`. Under a clock regression the preview subqueries can pick the wrong "opening" message.

## Related Issue

Fixes # <!-- no existing issue; happy to open one if preferred -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`:
  - New `SessionDB._preview_from_content(raw, limit=60)` helper. It decodes content via `_decode_content`, flattens multimodal text parts (with a `[multimodal content]` fallback), collapses whitespace, and truncates. Mirrors `list_recent_user_messages`.
  - The six "first user message" subqueries now select `m.content` (decoded in Python) instead of the NUL-unsafe SQL `SUBSTR`, and `ORDER BY m.id` instead of `m.timestamp, m.id`.
  - The four Python post-processing blocks now call the shared helper.
- `tests/test_hermes_state.py`: `TestSessionPreview` covers multimodal caption preview, the `[multimodal content]` fallback, plain-text unchanged, id-vs-timestamp ordering, and `_get_session_rich_row` multimodal.

Note: like `list_recent_user_messages`, the subquery now returns the first user message's stored content (one row per session, `LIMIT 1`) rather than a 63-char SQL slice. The Python helper bounds the displayed preview.

## How to Test

1. `scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_state/ -q`: 345 pass. Consumers also green: `tests/hermes_cli/test_session_browse.py`, `tests/cron/test_scheduler.py`, `tests/gateway/test_dm_topics.py`, `tests/gateway/test_telegram_topic_mode.py`.
2. To show the fix is load-bearing: revert the `hermes_state.py` hunk and rerun `-k TestSessionPreview`. The multimodal and ordering tests fail (blank preview, wrong message). Restore the hunk and they pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(state):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (searched `session preview`, `multimodal preview`, `preview blank`; none found)
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Documentation (docstrings): the helper is documented; `list_sessions_rich` docstring already says "first 60 chars of first user message"
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A (`scripts/check-windows-footguns.py` clean)
- [x] Tool descriptions/schemas: N/A