### PR TITLE
feat(whatsapp): add passive (read-only) mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -371,10 +371,6 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # WhatsApp (built-in Baileys bridge — run `hermes whatsapp` to pair)
 # WHATSAPP_ENABLED=false
 # WHATSAPP_ALLOWED_USERS=15551234567
-# Passive (read-only) mode: inbound messages are stored in session history as
-# observed context but never trigger the agent — no replies, no model spend.
-# Outbound (cron deliveries, `hermes send`) still works. YAML: whatsapp.passive_mode
-# WHATSAPP_PASSIVE_MODE=false
 
 # Email (IMAP/SMTP — send and receive emails as Hermes)
 # For Gmail: enable 2FA → create App Password at https://myaccount.google.com/apppasswords

--- a/.env.example
+++ b/.env.example
@@ -371,6 +371,10 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # WhatsApp (built-in Baileys bridge — run `hermes whatsapp` to pair)
 # WHATSAPP_ENABLED=false
 # WHATSAPP_ALLOWED_USERS=15551234567
+# Passive (read-only) mode: inbound messages are stored in session history as
+# observed context but never trigger the agent — no replies, no model spend.
+# Outbound (cron deliveries, `hermes send`) still works. YAML: whatsapp.passive_mode
+# WHATSAPP_PASSIVE_MODE=false
 
 # Email (IMAP/SMTP — send and receive emails as Hermes)
 # For Gmail: enable 2FA → create App Password at https://myaccount.google.com/apppasswords

--- a/.env.example
+++ b/.env.example
@@ -410,10 +410,6 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # WhatsApp (built-in Baileys bridge — run `hermes whatsapp` to pair)
 # WHATSAPP_ENABLED=false
 # WHATSAPP_ALLOWED_USERS=15551234567
-# Passive (read-only) mode: inbound messages are stored in session history as
-# observed context but never trigger the agent — no replies, no model spend.
-# Outbound (cron deliveries, `hermes send`) still works. YAML: whatsapp.passive_mode
-# WHATSAPP_PASSIVE_MODE=false
 
 # Email (IMAP/SMTP — send and receive emails as Hermes)
 # For Gmail: enable 2FA → create App Password at https://myaccount.google.com/apppasswords

--- a/.env.example
+++ b/.env.example
@@ -410,6 +410,10 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # WhatsApp (built-in Baileys bridge — run `hermes whatsapp` to pair)
 # WHATSAPP_ENABLED=false
 # WHATSAPP_ALLOWED_USERS=15551234567
+# Passive (read-only) mode: inbound messages are stored in session history as
+# observed context but never trigger the agent — no replies, no model spend.
+# Outbound (cron deliveries, `hermes send`) still works. YAML: whatsapp.passive_mode
+# WHATSAPP_PASSIVE_MODE=false
 
 # Email (IMAP/SMTP — send and receive emails as Hermes)
 # For Gmail: enable 2FA → create App Password at https://myaccount.google.com/apppasswords

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -406,6 +406,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
+        # Passive (read-only) mode: inbound messages are appended to the
+        # session transcript as observed context (observed=True, the same
+        # mechanism used for un-mentioned group chatter) but never dispatched
+        # to the agent — no replies, no model spend. Outbound paths (cron
+        # deliveries, `hermes send`) are unaffected. Useful for note-to-self
+        # capture inboxes where the user wants ingestion without responses.
+        self._passive_mode = str(
+            config.extra.get("passive_mode")
+            or os.getenv("WHATSAPP_PASSIVE_MODE", "")
+        ).strip().lower() in {"1", "true", "yes", "on"}
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
@@ -1251,7 +1261,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         for msg_data in messages:
                             event = await self._build_message_event(msg_data)
                             if event:
-                                if event.message_type == MessageType.TEXT:
+                                if self._passive_mode:
+                                    await self._observe_passive(event)
+                                elif event.message_type == MessageType.TEXT:
                                     self._enqueue_text_event(event)
                                 else:
                                     await self.handle_message(event)
@@ -1266,6 +1278,36 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 await asyncio.sleep(5)
             
             await asyncio.sleep(1)  # Poll interval
+
+    async def _observe_passive(self, event: MessageEvent) -> None:
+        """Record an inbound message as observed context without an agent turn.
+
+        Mirrors the observed-group-chatter pattern: the message lands in the
+        session transcript (and SQLite history) with ``observed: True`` so it
+        stays searchable and available as context, but the agent is never
+        invoked and no reply is sent.
+        """
+        store = getattr(self, "_session_store", None)
+        if not store:
+            return
+        try:
+            from datetime import datetime, timezone
+
+            session_entry = store.get_or_create_session(event.source)
+            entry: Dict[str, Any] = {
+                "role": "user",
+                "content": event.text or "",
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "observed": True,
+            }
+            if event.message_id:
+                entry["message_id"] = event.message_id
+            store.append_to_transcript(session_entry.session_id, entry)
+            logger.debug(
+                "[%s] passive mode: message observed, not dispatched", self.name
+            )
+        except Exception as exc:
+            logger.warning("[%s] passive observe failed: %s", self.name, exc)
 
     # ── Text debounce batching ──────────────────────────────────────
 
@@ -1727,6 +1769,8 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
         os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = str(frc)
+    if "passive_mode" in whatsapp_cfg and not os.getenv("WHATSAPP_PASSIVE_MODE"):
+        os.environ["WHATSAPP_PASSIVE_MODE"] = str(whatsapp_cfg["passive_mode"]).lower()
     if "dm_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_DM_POLICY"):
         os.environ["WHATSAPP_DM_POLICY"] = str(whatsapp_cfg["dm_policy"]).lower()
     af = whatsapp_cfg.get("allow_from")

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1286,6 +1286,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         session transcript (and SQLite history) with ``observed: True`` so it
         stays searchable and available as context, but the agent is never
         invoked and no reply is sent.
+
+        Non-text events keep their capture context: cached media paths from
+        ``event.media_urls`` / ``event.media_types`` are stored both as
+        structured fields and as inline ``[<mime>: <path>]`` references in the
+        content (so a media-only voice note or photo is never persisted as an
+        empty row), and ``event.metadata`` is carried through verbatim.
         """
         store = getattr(self, "_session_store", None)
         if not store:
@@ -1293,15 +1299,33 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             from datetime import datetime, timezone
 
+            content = (event.text or "").strip()
+            media_urls = list(event.media_urls or [])
+            media_types = list(event.media_types or [])
+            if media_urls:
+                refs = " ".join(
+                    f"[{media_types[i] if i < len(media_types) and media_types[i] else 'media'}: {url}]"
+                    for i, url in enumerate(media_urls)
+                )
+                content = f"{refs} {content}".strip()
+            if not content and not event.metadata:
+                # Nothing observable to retain (no text, media, or metadata).
+                return
+
             session_entry = store.get_or_create_session(event.source)
             entry: Dict[str, Any] = {
                 "role": "user",
-                "content": event.text or "",
+                "content": content,
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 "observed": True,
             }
             if event.message_id:
                 entry["message_id"] = event.message_id
+            if media_urls:
+                entry["media_urls"] = media_urls
+                entry["media_types"] = media_types
+            if event.metadata:
+                entry["metadata"] = dict(event.metadata)
             store.append_to_transcript(session_entry.session_id, entry)
             logger.debug(
                 "[%s] passive mode: message observed, not dispatched", self.name

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -749,6 +749,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         session transcript (and SQLite history) with ``observed: True`` so it
         stays searchable and available as context, but the agent is never
         invoked and no reply is sent.
+
+        Non-text events keep their capture context: cached media paths from
+        ``event.media_urls`` / ``event.media_types`` are stored both as
+        structured fields and as inline ``[<mime>: <path>]`` references in the
+        content (so a media-only voice note or photo is never persisted as an
+        empty row), and ``event.metadata`` is carried through verbatim.
         """
         store = getattr(self, "_session_store", None)
         if not store:
@@ -756,15 +762,33 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             from datetime import datetime, timezone
 
+            content = (event.text or "").strip()
+            media_urls = list(event.media_urls or [])
+            media_types = list(event.media_types or [])
+            if media_urls:
+                refs = " ".join(
+                    f"[{media_types[i] if i < len(media_types) and media_types[i] else 'media'}: {url}]"
+                    for i, url in enumerate(media_urls)
+                )
+                content = f"{refs} {content}".strip()
+            if not content and not event.metadata:
+                # Nothing observable to retain (no text, media, or metadata).
+                return
+
             session_entry = store.get_or_create_session(event.source)
             entry: Dict[str, Any] = {
                 "role": "user",
-                "content": event.text or "",
+                "content": content,
                 "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 "observed": True,
             }
             if event.message_id:
                 entry["message_id"] = event.message_id
+            if media_urls:
+                entry["media_urls"] = media_urls
+                entry["media_types"] = media_types
+            if event.metadata:
+                entry["metadata"] = dict(event.metadata)
             store.append_to_transcript(session_entry.session_id, entry)
             logger.debug(
                 "[%s] passive mode: message observed, not dispatched", self.name

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -269,6 +269,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._bridge_script: str = extra.get("bridge_script", str(self._DEFAULT_BRIDGE_DIR / "bridge.js"))
         self._session_path = Path(extra.get("session_path", get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")))
         self._reply_prefix: Optional[str] = extra.get("reply_prefix")
+        # Passive (read-only) mode: inbound messages are appended to the
+        # session transcript as observed context (observed=True, the same
+        # mechanism used for un-mentioned group chatter) but never dispatched
+        # to the agent - no replies, no model spend. Outbound paths (cron
+        # deliveries, `hermes send`) are unaffected. Useful for note-to-self
+        # capture inboxes where the user wants ingestion without responses.
+        self._passive_mode = str(
+            extra.get("passive_mode")
+            or _wenv("WHATSAPP_PASSIVE_MODE", "")
+        ).strip().lower() in {"1", "true", "yes", "on"}
         self._dm_policy = str(extra.get("dm_policy") or _wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         self._allow_from = self._coerce_allow_list(self._select_dm_allowlist(extra, ("WHATSAPP_ALLOWED_USERS",), _wenv))
         self._group_policy = str(extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
@@ -706,7 +716,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             if event:
                                 # Fire-and-forget: a slow bridge /read must not delay dispatch.
                                 asyncio.create_task(self._send_read_receipt(msg_data))
-                                if event.message_type == MessageType.TEXT:
+                                if self._passive_mode:
+                                    await self._observe_passive(event)
+                                elif event.message_type == MessageType.TEXT:
                                     self._enqueue_text_event(event)
                                 else:
                                     await self.handle_message(event)
@@ -729,6 +741,38 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     logger.warning("[%s] WhatsApp read receipt failed with HTTP %s", self.name, resp.status)
         except Exception as exc:
             logger.warning("[%s] WhatsApp read receipt failed: %s", self.name, exc)
+
+    async def _observe_passive(self, event: MessageEvent) -> None:
+        """Record an inbound message as observed context without an agent turn.
+
+        Mirrors the observed-group-chatter pattern: the message lands in the
+        session transcript (and SQLite history) with ``observed: True`` so it
+        stays searchable and available as context, but the agent is never
+        invoked and no reply is sent.
+        """
+        store = getattr(self, "_session_store", None)
+        if not store:
+            return
+        try:
+            from datetime import datetime, timezone
+
+            session_entry = store.get_or_create_session(event.source)
+            entry: Dict[str, Any] = {
+                "role": "user",
+                "content": event.text or "",
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "observed": True,
+            }
+            if event.message_id:
+                entry["message_id"] = event.message_id
+            store.append_to_transcript(session_entry.session_id, entry)
+            logger.debug(
+                "[%s] passive mode: message observed, not dispatched", self.name
+            )
+        except Exception as exc:
+            logger.warning("[%s] passive observe failed: %s", self.name, exc)
+
+    # ── Text debounce batching ──────────────────────────────────────
 
     _SPLIT_THRESHOLD = 6000  # WhatsApp supports ~65K chars; generous threshold
 
@@ -958,7 +1002,7 @@ def interactive_setup() -> None:
 
 
 # config.yaml whatsapp: key → env var. Env vars take precedence over YAML.
-_YAML_LOWERCASE_KEYS = (("require_mention", "WHATSAPP_REQUIRE_MENTION"), ("dm_policy", "WHATSAPP_DM_POLICY"), ("group_policy", "WHATSAPP_GROUP_POLICY"))
+_YAML_LOWERCASE_KEYS = (("passive_mode", "WHATSAPP_PASSIVE_MODE"), ("require_mention", "WHATSAPP_REQUIRE_MENTION"), ("dm_policy", "WHATSAPP_DM_POLICY"), ("group_policy", "WHATSAPP_GROUP_POLICY"))
 _YAML_LIST_KEYS = (("free_response_chats", "WHATSAPP_FREE_RESPONSE_CHATS"), ("allow_from", "WHATSAPP_ALLOWED_USERS"), ("group_allow_from", "WHATSAPP_GROUP_ALLOWED_USERS"))
 
 

--- a/tests/gateway/test_whatsapp_passive_mode.py
+++ b/tests/gateway/test_whatsapp_passive_mode.py
@@ -77,6 +77,73 @@ class TestObservePassive:
         adapter.handle_message.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_media_only_event_preserves_capture_context(self):
+        """A photo/voice note without text must not persist as an empty row.
+
+        Regression for media-only events: ``_build_message_event()`` puts
+        cached media paths in ``media_urls``/``media_types`` and inbound
+        details in ``metadata`` — the observed entry must retain all of them.
+        """
+        adapter = _make_adapter(passive_mode=True)
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-1"
+        store = MagicMock()
+        store.get_or_create_session.return_value = session_entry
+        adapter._session_store = store
+
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.PHOTO,
+            source=MagicMock(),
+            message_id="wa-img-1",
+            media_urls=["/tmp/wa-cache/photo.jpg"],
+            media_types=["image/jpeg"],
+            metadata={"sender_name": "Samuel"},
+        )
+        await adapter._observe_passive(event)
+
+        (_, entry), _ = store.append_to_transcript.call_args
+        assert entry["content"] == "[image/jpeg: /tmp/wa-cache/photo.jpg]"
+        assert entry["media_urls"] == ["/tmp/wa-cache/photo.jpg"]
+        assert entry["media_types"] == ["image/jpeg"]
+        assert entry["metadata"] == {"sender_name": "Samuel"}
+        assert entry["observed"] is True
+
+    @pytest.mark.asyncio
+    async def test_media_with_caption_keeps_both(self):
+        adapter = _make_adapter(passive_mode=True)
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-1"
+        store = MagicMock()
+        store.get_or_create_session.return_value = session_entry
+        adapter._session_store = store
+
+        event = MessageEvent(
+            text="the whiteboard from today",
+            message_type=MessageType.PHOTO,
+            source=MagicMock(),
+            media_urls=["/tmp/wa-cache/board.jpg"],
+            media_types=["image/jpeg"],
+        )
+        await adapter._observe_passive(event)
+
+        (_, entry), _ = store.append_to_transcript.call_args
+        assert entry["content"] == (
+            "[image/jpeg: /tmp/wa-cache/board.jpg] the whiteboard from today"
+        )
+
+    @pytest.mark.asyncio
+    async def test_truly_empty_event_is_not_persisted(self):
+        adapter = _make_adapter(passive_mode=True)
+        store = MagicMock()
+        adapter._session_store = store
+
+        event = MessageEvent(text="", source=MagicMock())
+        await adapter._observe_passive(event)
+
+        store.append_to_transcript.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_missing_session_store_is_a_noop(self):
         adapter = _make_adapter(passive_mode=True)
         # No _session_store attribute at all — must not raise.
@@ -162,3 +229,34 @@ class TestYamlConfigBridge:
         monkeypatch.setenv("WHATSAPP_PASSIVE_MODE", "false")
         _apply_yaml_config({}, {"passive_mode": True})
         assert os.environ["WHATSAPP_PASSIVE_MODE"] == "false"
+
+
+class TestLoaderEndToEnd:
+    """Verify the configured value through the production dispatch path.
+
+    ``load_gateway_config()`` (gateway/config.py) discovers platform plugins
+    and runs their ``apply_yaml_config_fn`` hooks — this is the path a real
+    gateway start takes, unlike calling ``_apply_yaml_config`` directly.
+    """
+
+    def test_passive_mode_bridged_by_load_gateway_config(
+        self, tmp_path, monkeypatch
+    ):
+        from gateway.config import load_gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "whatsapp:\n"
+            "  enabled: false\n"
+            "  passive_mode: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("WHATSAPP_PASSIVE_MODE", raising=False)
+
+        try:
+            load_gateway_config()
+            assert os.environ.get("WHATSAPP_PASSIVE_MODE") == "true"
+        finally:
+            os.environ.pop("WHATSAPP_PASSIVE_MODE", None)

--- a/tests/gateway/test_whatsapp_passive_mode.py
+++ b/tests/gateway/test_whatsapp_passive_mode.py
@@ -1,0 +1,164 @@
+"""Tests for WhatsApp passive (read-only) mode.
+
+When ``whatsapp.passive_mode`` / ``WHATSAPP_PASSIVE_MODE`` is enabled, inbound
+messages are appended to the session transcript as observed context
+(``observed: True``) but never dispatched to the agent — no replies, no model
+spend. Outbound paths (cron deliveries, ``hermes send``) are unaffected.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+class _AsyncCM:
+    """Minimal async context manager returning a fixed value."""
+
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _make_adapter(passive_mode: bool):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = MagicMock()
+    adapter._passive_mode = passive_mode
+    adapter._bridge_port = 19876
+    adapter._bridge_process = None
+    adapter._bridge_log_fh = None
+    adapter._running = False
+    adapter._http_session = None
+    adapter._shutting_down = False
+    return adapter
+
+
+def _text_event(text="note to self", message_id="wa-msg-1"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=MagicMock(),
+        message_id=message_id,
+    )
+
+
+class TestObservePassive:
+    @pytest.mark.asyncio
+    async def test_appends_observed_entry_without_agent_dispatch(self):
+        adapter = _make_adapter(passive_mode=True)
+        adapter.handle_message = AsyncMock()
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-1"
+        store = MagicMock()
+        store.get_or_create_session.return_value = session_entry
+        adapter._session_store = store
+
+        event = _text_event()
+        await adapter._observe_passive(event)
+
+        store.get_or_create_session.assert_called_once_with(event.source)
+        (session_id, entry), _ = store.append_to_transcript.call_args
+        assert session_id == "sess-1"
+        assert entry["role"] == "user"
+        assert entry["content"] == "note to self"
+        assert entry["observed"] is True
+        assert entry["message_id"] == "wa-msg-1"
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_session_store_is_a_noop(self):
+        adapter = _make_adapter(passive_mode=True)
+        # No _session_store attribute at all — must not raise.
+        await adapter._observe_passive(_text_event())
+
+    @pytest.mark.asyncio
+    async def test_store_errors_are_swallowed(self):
+        adapter = _make_adapter(passive_mode=True)
+        store = MagicMock()
+        store.get_or_create_session.side_effect = RuntimeError("db locked")
+        adapter._session_store = store
+        # Must not raise — poll loop keeps running.
+        await adapter._observe_passive(_text_event())
+
+
+class TestPollDispatch:
+    def _run_one_poll(self, adapter, event):
+        """Drive a single _poll_messages iteration delivering one message."""
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=[{"body": "hi"}])
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=_AsyncCM(mock_resp))
+        adapter._http_session = mock_session
+        adapter._running = True
+        adapter._build_message_event = AsyncMock(return_value=event)
+
+        def _stop(*args, **kwargs):
+            adapter._running = False
+
+        return _stop
+
+    @pytest.mark.asyncio
+    async def test_passive_mode_observes_instead_of_dispatching(self):
+        adapter = _make_adapter(passive_mode=True)
+        event = _text_event()
+        stop = self._run_one_poll(adapter, event)
+        adapter._observe_passive = AsyncMock(side_effect=stop)
+        adapter._enqueue_text_event = MagicMock()
+        adapter.handle_message = AsyncMock()
+
+        with patch(
+            "plugins.platforms.whatsapp.adapter.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await adapter._poll_messages()
+
+        adapter._observe_passive.assert_awaited_once_with(event)
+        adapter._enqueue_text_event.assert_not_called()
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_active_mode_dispatch_unchanged(self):
+        adapter = _make_adapter(passive_mode=False)
+        event = _text_event()
+        stop = self._run_one_poll(adapter, event)
+        adapter._observe_passive = AsyncMock()
+        adapter._enqueue_text_event = MagicMock(side_effect=stop)
+        adapter.handle_message = AsyncMock()
+
+        with patch(
+            "plugins.platforms.whatsapp.adapter.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await adapter._poll_messages()
+
+        adapter._enqueue_text_event.assert_called_once_with(event)
+        adapter._observe_passive.assert_not_awaited()
+
+
+class TestYamlConfigBridge:
+    def test_passive_mode_yaml_key_sets_env(self, monkeypatch):
+        from plugins.platforms.whatsapp.adapter import _apply_yaml_config
+
+        monkeypatch.delenv("WHATSAPP_PASSIVE_MODE", raising=False)
+        _apply_yaml_config({}, {"passive_mode": True})
+        assert os.environ["WHATSAPP_PASSIVE_MODE"] == "true"
+        monkeypatch.delenv("WHATSAPP_PASSIVE_MODE", raising=False)
+
+    def test_env_var_takes_precedence_over_yaml(self, monkeypatch):
+        from plugins.platforms.whatsapp.adapter import _apply_yaml_config
+
+        monkeypatch.setenv("WHATSAPP_PASSIVE_MODE", "false")
+        _apply_yaml_config({}, {"passive_mode": True})
+        assert os.environ["WHATSAPP_PASSIVE_MODE"] == "false"


### PR DESCRIPTION
## What does this PR do?

Adds a **passive (read-only) mode** to the WhatsApp Baileys adapter: `whatsapp.passive_mode` in config.yaml (env `WHATSAPP_PASSIVE_MODE`).

When enabled, inbound messages are appended to the session transcript as observed context (`observed: True` — the same mechanism already used for un-mentioned group chatter) but are **never dispatched to the agent**: no replies, no model spend. Outbound paths (cron deliveries, `hermes send`) are unaffected, so proactive messages like a morning-brief cron still deliver on the same channel.

**Why:** when WhatsApp runs as a note-to-self capture inbox (`WHATSAPP_MODE=self-chat`), every note currently triggers a full agent turn and a conversational reply. For a capture workflow this is noise and cost: the user wants notes silently recorded — searchable in history, available as context for cron digests — without the agent answering each one. There is currently no listen-only toggle: both bridge modes (`bot`, `self-chat`) reply, and `require_mention`-style gating only applies to groups, not DMs/self-chat.

Reusing the observed-context mechanism (rather than dropping messages at the bridge) keeps the messages in SQLite history and leaves the existing dispatch path byte-for-byte identical when the flag is off. Default is off; no behavior change for existing deployments.

## Related Issue

No existing issue found (searched open/closed issues and PRs for passive/read-only/listen-only/observe WhatsApp variants).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py`
  - `__init__`: parse `passive_mode` from `config.extra` / `WHATSAPP_PASSIVE_MODE`
  - `_poll_messages`: route events to `_observe_passive()` when the flag is set (before text-batching/dispatch)
  - new `_observe_passive()`: `get_or_create_session()` + `append_to_transcript()` with `observed: True`; store errors are logged and swallowed so the poll loop keeps running
  - `_apply_yaml_config`: bridge `whatsapp.passive_mode` → `WHATSAPP_PASSIVE_MODE` (env takes precedence, matching the other keys)
- `.env.example`: document `WHATSAPP_PASSIVE_MODE`
- `tests/gateway/test_whatsapp_passive_mode.py`: 7 tests — observe path (transcript entry shape, no agent dispatch, missing-store no-op, store-error swallowed), poll dispatch routing (passive vs. active unchanged), yaml→env bridging (incl. env precedence)

## How to Test

1. `hermes config set whatsapp.passive_mode true` && restart the gateway
2. Send a message to the bot (or a note-to-self in self-chat mode) → no reply arrives; the message appears in session history flagged `observed`
3. `hermes send -t whatsapp:<jid> "test"` and cron deliveries → still send normally
4. `pytest tests/gateway/ -q -k whatsapp` → passes (349 passed, 3 skipped)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/ -q` (via `uv sync --locked --extra all --extra dev`, Python 3.11, macOS): 8470 passed, 8 failed — the failure set is **byte-identical on clean `main`** (verified with a full-suite run on the same machine: 8 failed, 8508 passed), so none are introduced by this change. They are local-environment/order-dependent: 2 macOS quirks (`/private/var` symlink repr in `test_background_command`, `test_shutdown_forensics`) and 6 Telegram `MARKDOWN_V2`-enum-repr failures that pass when their files run in isolation on both `main` and this branch. All 349 WhatsApp tests (`-k whatsapp`) pass, including the 7 added here.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (dev/tests) + Ubuntu 26.04 VPS (live deployment of this patch on v0.17.0, self-chat mode: notes observed, no replies, cron delivery verified)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `.env.example` + docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (platform keys are documented in `.env.example`; the yaml example has no whatsapp block)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python change in the adapter, no OS-specific code paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
