### PR TITLE
fix(desktop): scope messaging sidebar sessions to active profile

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -99,7 +99,13 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // seeds every platform; the sidebar splits the rows per source.
   const refreshMessagingSessions = useCallback(async () => {
     try {
-      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
+      // Scope the fetch to the active profile so switching profiles updates the
+      // messaging sidebar (Telegram, Discord, …) — previously hardcoded to
+      // 'all', which meant the sidebar always showed every profile's chats
+      // regardless of the active profile switcher.
+      const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+
+      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
       })
 
@@ -114,7 +120,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }
-  }, [])
+  }, [profileScope])
 
   // Page a single platform's section independently (mirrors the per-profile
   // pager): fetch that source's next window and merge it back in place, leaving
@@ -122,8 +128,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   const loadMoreMessagingForPlatform = useCallback(async (platform: string) => {
     const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
     const loaded = $messagingSessions.get().filter(inPlatform).length
+    const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
 
-    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', 'all', {
+    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', sessionProfile, {
       source: platform
     })
 
@@ -136,7 +143,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
     const total = result.total ?? incoming.length
     setMessagingPlatformTotals(prev => ({ ...prev, [platform]: Math.max(total, incoming.length) }))
-  }, [])
+  }, [profileScope])
 
   // Cron *jobs* drive the sidebar "Cron jobs" section. Jobs are created
   // synchronously (agent tool call or the cron UI), so refreshing here right

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -47,6 +47,17 @@ describe('Hermes REST session helpers', () => {
     )
   })
 
+  it('forwards a specific profile name to the all-profile session list', async () => {
+    await listAllProfileSessions(50, 1, 'exclude', 'recent', 'remote')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/profiles/sessions?limit=50&offset=0&min_messages=1&archived=exclude&order=recent&profile=remote',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {
     api.mockResolvedValue({ messages: [], session_id: 'session-1' })
 


### PR DESCRIPTION
## What does this PR do?

The messaging sidebar (Telegram, Discord, Slack, etc.) always fetched sessions with `profile='all'`, ignoring the active profile switcher. When a user switched profiles in the desktop app, local recents updated correctly, but the messaging platform sections continued showing chats from every profile — so the Telegram sidebar appeared "stuck" on a single profile's chats.

This fix passes `profileScope` to `listAllProfileSessions` in both `refreshMessagingSessions` and `loadMoreMessagingForPlatform`, matching the existing pattern used by `refreshSessions` for local recents.

## Related Issue

Fixes #56631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-list-actions.ts`: Changed `refreshMessagingSessions` and `loadMoreMessagingForPlatform` to scope the session fetch to the active `profileScope` instead of hardcoding `'all'`. Added `profileScope` to both `useCallback` dependency arrays so they re-fetch when the user switches profiles.
- `apps/desktop/src/hermes.test.ts`: Added test verifying `listAllProfileSessions` forwards a specific profile name in the API request path.

## How to Test

1. Configure Hermes with multiple profiles (e.g., `local`, `remote`, `default`), each with Telegram enabled
2. Open the desktop app and verify the Telegram sidebar shows chats from all profiles initially
3. Switch to a specific profile (e.g., `local`) in the app's profile switcher
4. The Telegram sidebar should now show only chats from the `local` profile
5. Switch to `remote` — the sidebar should update to show only `remote` profile's Telegram chats
6. Switch back to "All profiles" — the sidebar should show chats from all profiles again
7. Should pass: `npx vitest run apps/desktop/src/hermes.test.ts --reporter=verbose`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — the fix is a 3-line behavioral change in session fetch scope (plus comments and dependency arrays). The `listAllProfileSessions` API already supports per-profile filtering; the call sites just weren't using it.
