### PR TITLE
fix(dashboard): resolve /api/messaging/platforms invariants once per request

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5633,10 +5633,36 @@ def _messaging_env_info(key: str) -> dict[str, Any]:
     }
 
 
-def _gateway_platform_config(platform_id: str):
+# Sentinel distinguishing "caller did not pass a config, load one on demand"
+# (legacy single-payload callers like the /test handler) from "caller passed
+# None because a hoisted, request-level config load already failed" (see
+# get_messaging_platforms).
+_CONFIG_UNSET = object()
+
+
+class _GatewayConfigUnavailable(Exception):
+    """Internal signal: the hoisted per-request config load failed.
+
+    Raised inside :func:`_messaging_platform_payload` to route into the same
+    fallback a genuine per-platform config-load exception would hit, without
+    re-loading (and re-failing) the config once per platform.
+    """
+
+
+def _gateway_platform_config(platform_id: str, config=None):
+    """Resolve the gateway config, ``Platform`` enum, and per-platform config.
+
+    ``config`` may be a preloaded :class:`~gateway.config.GatewayConfig` shared
+    across every platform in one request, or ``None`` to load a fresh copy
+    here. Loading is the expensive part (``load_gateway_config`` re-parses the
+    whole config and re-runs plugin requirement checks, hundreds of ms), so
+    hot paths that build many payloads pass a single shared instance instead
+    of paying that cost per platform.
+    """
     from gateway.config import Platform, load_gateway_config
 
-    config = load_gateway_config()
+    if config is None:
+        config = load_gateway_config()
     platform = Platform(platform_id)
     platform_config = config.platforms.get(platform)
     return config, platform, platform_config
@@ -5647,6 +5673,10 @@ def _messaging_platform_payload(
     env_on_disk: dict[str, str],
     runtime: dict | None,
     scoped: bool = False,
+    *,
+    gateway_running: bool | None = None,
+    gateway_config: Any = _CONFIG_UNSET,
+    cli_config: Any = _CONFIG_UNSET,
 ) -> dict[str, Any]:
     platform_id = entry["id"]
     runtime_platforms = runtime.get("platforms") if runtime else {}
@@ -5655,10 +5685,18 @@ def _messaging_platform_payload(
         if isinstance(runtime_platforms, dict)
         else {}
     )
-    gateway_running = (
-        get_running_pid() is not None
-        or get_runtime_status_running_pid(runtime) is not None
-    )
+    # The running PID and the (gateway or CLI) config are identical for every
+    # platform in a request, and each is individually expensive to derive
+    # (get_running_pid shells out to `ps` on macOS; load_gateway_config
+    # re-parses the whole config). Callers that build many payloads at once
+    # (get_messaging_platforms) compute them once inside their _profile_scope
+    # and pass them in; single-payload callers (the /test handler) leave them
+    # unset and let us derive them here.
+    if gateway_running is None:
+        gateway_running = (
+            get_running_pid() is not None
+            or get_runtime_status_running_pid(runtime) is not None
+        )
     env_vars = []
 
     for key in entry["env_vars"]:
@@ -5683,7 +5721,11 @@ def _messaging_platform_payload(
         # env-override layer reads os.environ and would leak the root
         # install's tokens into the profile's reported state.
         try:
-            cfg = load_config()
+            if cli_config is None:
+                # The hoisted, request-level load_config() already failed;
+                # don't retry it once per platform.
+                raise _GatewayConfigUnavailable()
+            cfg = load_config() if cli_config is _CONFIG_UNSET else cli_config
             platforms_cfg = cfg.get("platforms") or {}
             plat_cfg = platforms_cfg.get(platform_id)
             if not isinstance(plat_cfg, dict):
@@ -5697,13 +5739,20 @@ def _messaging_platform_payload(
         configured = all(env_on_disk.get(key) for key in entry["required_env"])
     else:
         try:
-            gateway_config, platform, platform_config = _gateway_platform_config(
-                platform_id
+            if gateway_config is None:
+                # The hoisted, request-level load_gateway_config() already
+                # failed; fall through to the env-var fallback below instead
+                # of re-failing the load once per platform. A broken config
+                # yields the same payloads it always did, never a 500.
+                raise _GatewayConfigUnavailable()
+            resolved_config, platform, platform_config = _gateway_platform_config(
+                platform_id,
+                None if gateway_config is _CONFIG_UNSET else gateway_config,
             )
             enabled = bool(platform_config and platform_config.enabled)
             configured = bool(
                 platform_config
-                and gateway_config._is_platform_connected(platform, platform_config)
+                and resolved_config._is_platform_connected(platform, platform_config)
             )
             home_channel = (
                 platform_config.home_channel.to_dict()
@@ -6153,16 +6202,59 @@ async def get_messaging_platforms(profile: Optional[str] = None):
     # Inside _profile_scope, load_env()/read_runtime_status()/get_running_pid()
     # all resolve against the requested profile's HERMES_HOME.
     with _profile_scope(profile) as scoped_dir:
+        scoped = scoped_dir is not None
         env_on_disk = load_env()
         runtime = read_runtime_status()
+        # Build the catalog before touching any config: loading the gateway
+        # config can re-run plugin discovery, which mutates the platform
+        # registry the catalog is derived from. Snapshotting the catalog first
+        # keeps plugin metadata (labels, env vars) stable, matching the order
+        # of operations before the invariants below were hoisted.
+        catalog = _messaging_platform_catalog()
+        # Compute the per-request invariants once and share them across every
+        # payload. Previously each of the ~30 catalog entries derived
+        # gateway_running (get_running_pid shells out to `ps` on macOS) and
+        # loaded the config independently, so a single request paid ~30x the
+        # cost — ~10s on macOS, timing out the dashboard. Both values are
+        # identical for every platform in the catalog, and both must be
+        # resolved INSIDE _profile_scope so they read the requested profile's
+        # HERMES_HOME. Only one of the two configs is ever consumed per mode,
+        # so only that one is loaded.
+        gateway_running = (
+            get_running_pid() is not None
+            or get_runtime_status_running_pid(runtime) is not None
+        )
+        gateway_config: Any = None
+        cli_config: Any = None
+        try:
+            if scoped:
+                cli_config = load_config()
+            else:
+                from gateway.config import load_gateway_config
+
+                gateway_config = load_gateway_config()
+        except Exception:
+            # A broken config must not 500 the whole endpoint; leaving the
+            # relevant config as None makes each payload take the same
+            # fallback it hit when every payload loaded (and failed to load)
+            # the config on its own.
+            _log.exception(
+                "messaging platforms config load failed; using fallback payloads"
+            )
         return {
             "env_path": str(get_env_path()),
             "gateway_start_command": _gateway_display_command(profile, "start"),
             "platforms": [
                 _messaging_platform_payload(
-                    entry, env_on_disk, runtime, scoped=scoped_dir is not None
+                    entry,
+                    env_on_disk,
+                    runtime,
+                    scoped=scoped,
+                    gateway_running=gateway_running,
+                    gateway_config=gateway_config,
+                    cli_config=cli_config,
                 )
-                for entry in _messaging_platform_catalog()
+                for entry in catalog
             ]
         }
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1885,6 +1885,71 @@ class TestWebServerEndpoints:
         assert telegram["enabled"] is False
         assert any(field["key"] == "TELEGRAM_BOT_TOKEN" and field["required"] for field in telegram["env_vars"])
 
+    def test_get_messaging_platforms_resolves_invariants_once(self, monkeypatch):
+        """Per-request invariants must be computed once, not once per platform.
+
+        Regression for the ~10s /api/messaging/platforms latency: each of the
+        ~30 catalog payloads used to call get_running_pid() (shells out to `ps`
+        on macOS) and load_gateway_config() (~360ms full reload) independently.
+        Both are identical for every platform in the catalog, so the endpoint
+        now hoists them to a single call per request and shares them.
+        """
+        import gateway.config as gwconfig
+        from hermes_cli import web_server
+
+        real_load = gwconfig.load_gateway_config
+        load_calls = {"n": 0}
+
+        def counting_load():
+            load_calls["n"] += 1
+            return real_load()
+
+        # Both the endpoint and _gateway_platform_config import
+        # load_gateway_config from gateway.config at call time, so patching the
+        # module attribute counts every payload-path use.
+        monkeypatch.setattr(gwconfig, "load_gateway_config", counting_load)
+
+        pid_calls = {"n": 0}
+
+        def counting_pid(*args, **kwargs):
+            pid_calls["n"] += 1
+            return None
+
+        monkeypatch.setattr(web_server, "get_running_pid", counting_pid)
+
+        resp = self.client.get("/api/messaging/platforms")
+
+        assert resp.status_code == 200
+        platforms = resp.json()["platforms"]
+        assert len(platforms) >= 1  # full catalog still returned
+        assert load_calls["n"] <= 1, (
+            f"load_gateway_config called {load_calls['n']} times; "
+            "expected at most once per request"
+        )
+        assert pid_calls["n"] <= 1, (
+            f"get_running_pid called {pid_calls['n']} times; "
+            "expected at most once per request"
+        )
+
+    def test_get_messaging_platforms_survives_config_load_failure(self, monkeypatch):
+        """A broken gateway config falls back per platform, never 500s."""
+        import gateway.config as gwconfig
+
+        def boom():
+            raise RuntimeError("gateway config is corrupt")
+
+        monkeypatch.setattr(gwconfig, "load_gateway_config", boom)
+
+        resp = self.client.get("/api/messaging/platforms")
+
+        assert resp.status_code == 200
+        platforms = resp.json()["platforms"]
+        telegram = next(p for p in platforms if p["id"] == "telegram")
+        # Fallback path: not enabled, and `configured` derived from env vars
+        # (no token on disk in the isolated test home → False).
+        assert telegram["enabled"] is False
+        assert telegram["configured"] is False
+
     def test_slack_messaging_platform_exposes_user_allowlist(self):
         resp = self.client.get("/api/messaging/platforms")
 

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -133,6 +133,38 @@ class TestProfileScopedMessagingReads:
         )
 
 
+    def test_scoped_read_loads_cli_config_once(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """Scoped reads hoist load_config() to once per request.
+
+        The scoped payload branch used to call load_config() once per catalog
+        entry (~30x per request). The value is identical for every platform,
+        so the endpoint now loads it once inside _profile_scope and shares it.
+        """
+        import hermes_cli.web_server as web_server
+
+        real_load = web_server.load_config
+        calls = {"n": 0}
+
+        def counting_load():
+            calls["n"] += 1
+            return real_load()
+
+        monkeypatch.setattr(web_server, "load_config", counting_load)
+
+        resp = client.get(
+            "/api/messaging/platforms", params={"profile": "worker_alpha"}
+        )
+
+        assert resp.status_code == 200
+        assert len(resp.json()["platforms"]) >= 1
+        assert calls["n"] <= 1, (
+            f"load_config called {calls['n']} times during a scoped read; "
+            "expected at most once per request"
+        )
+
+
 class TestProfileScopedMessagingWrites:
     def test_scoped_write_lands_in_target_profile_env(
         self, client, isolated_profiles

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -12,10 +12,25 @@ call is mocked — we never actually shell out during unit tests.
 
 from __future__ import annotations
 
+import time
 
 import pytest
 
 import tools.lazy_deps as ld
+
+
+@pytest.fixture(autouse=True)
+def _reset_install_failure_cache():
+    """Keep the module-level negative install cache from leaking across tests.
+
+    ``_install_failures`` is a per-process dict; subprocess isolation gives
+    each test a fresh copy in CI, but under ``--no-isolate`` (and a plain
+    ``pytest`` invocation) it would otherwise carry a recorded failure from
+    one test into the next — several tests reuse the ``test.feat`` key.
+    """
+    ld._install_failures.clear()
+    yield
+    ld._install_failures.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +220,100 @@ class TestEnsure:
         )
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
+
+
+# ---------------------------------------------------------------------------
+# Negative cache — failed install attempts short-circuit within a cooldown
+#
+# Without this, a missing-and-uninstallable backend (offline, sandboxed venv,
+# PyPI 404) re-runs the full uv/pip subprocess ladder on every ensure() call.
+# The discord requirements check runs on every load_gateway_config(), which the
+# dashboard's /api/messaging/platforms endpoint fanned out ~30x per request —
+# turning one bad install into ~10s of stacked, doomed pip invocations.
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeCache:
+    def test_failed_install_not_retried_within_cooldown(self, monkeypatch):
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.neg", ("zzzfake>=1",))
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+
+        calls = {"n": 0}
+
+        def fake_install(specs, **kw):
+            calls["n"] += 1
+            return ld._InstallResult(False, "", "ERROR: offline")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        # First call actually attempts the install and fails.
+        with pytest.raises(ld.FeatureUnavailable, match="pip install failed"):
+            ld.ensure("test.neg", prompt=False)
+        # Second call short-circuits via the negative cache — pip is NOT rerun.
+        with pytest.raises(ld.FeatureUnavailable, match="not retrying yet"):
+            ld.ensure("test.neg", prompt=False)
+
+        assert calls["n"] == 1, "pip must run once, not on the cached retry"
+
+    def test_install_reported_success_but_missing_is_cached(self, monkeypatch):
+        # pip claims success but packages stay unimportable → treated as a
+        # failed attempt so the next call short-circuits too.
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.ghost", ("zzzfake>=1",))
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+
+        calls = {"n": 0}
+
+        def fake_install(specs, **kw):
+            calls["n"] += 1
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
+            ld.ensure("test.ghost", prompt=False)
+        with pytest.raises(ld.FeatureUnavailable, match="not retrying yet"):
+            ld.ensure("test.ghost", prompt=False)
+
+        assert calls["n"] == 1
+
+    def test_cache_cleared_when_feature_becomes_available(self, monkeypatch):
+        # A cached failure must not permanently block a feature whose packages
+        # later appear by other means (user ran `hermes tools`, etc.).
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.recover", ("zzzfake>=1",))
+        ld._record_install_failure("test.recover")
+        assert ld._recent_install_failure("test.recover") is True
+
+        # feature_missing() now returns empty → ensure() returns and clears.
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: True)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called"),
+        )
+        ld.ensure("test.recover", prompt=False)  # no raise
+        assert ld._recent_install_failure("test.recover") is False
+
+    def test_successful_install_clears_cache(self, monkeypatch):
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.win", ("zzzfake>=1",))
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        # Missing pre-install, present post-install.
+        states = iter([False, True])
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: next(states))
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda specs, **kw: ld._InstallResult(True, "ok", ""),
+        )
+        ld.ensure("test.win", prompt=False)
+        assert "test.win" not in ld._install_failures
+
+    def test_cooldown_expiry_allows_retry(self, monkeypatch):
+        # A failure older than the cooldown must not block a retry.
+        monkeypatch.setattr(ld, "_INSTALL_FAILURE_COOLDOWN_S", 300.0)
+        ld._install_failures["test.expired"] = time.monotonic() - 301.0
+        assert ld._recent_install_failure("test.expired") is False
+        # Expired entry is pruned on read.
+        assert "test.expired" not in ld._install_failures
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -75,11 +75,66 @@ import site
 import subprocess
 import sys
 import sysconfig
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Per-process negative cache for failed install attempts.
+#
+# When a feature's packages are missing AND the install fails (offline,
+# sandboxed venv with no network, PyPI 404/quarantine), nothing used to
+# remember the failure — so every caller re-ran the full uv/pip subprocess
+# ladder. Discord's requirements check runs on every load_gateway_config(),
+# which the dashboard's /api/messaging/platforms endpoint fanned out per
+# platform; each doomed pip install cost hundreds of ms and stacked into a
+# ~10s, UX-timing-out request.
+#
+# The cache records the monotonic time of the last failed attempt per feature
+# and short-circuits subsequent ensure() calls within a cooldown window,
+# raising FeatureUnavailable immediately instead of shelling out again. It is
+# intentionally per-process and forgetful: the cheap feature_missing() check
+# still runs first (so packages that appeared by other means succeed and clear
+# the entry), a successful install clears the entry, and the cooldown expiry
+# lets a user who fixed their network retry without restarting the process.
+# =============================================================================
+
+_INSTALL_FAILURE_COOLDOWN_S = 300.0
+_install_failures: dict[str, float] = {}
+_install_failures_lock = threading.Lock()
+
+
+def _recent_install_failure(feature: str) -> bool:
+    """Return True if ``feature`` failed to install within the cooldown window.
+
+    Expired entries are pruned on read so a stale failure doesn't linger past
+    its cooldown.
+    """
+    with _install_failures_lock:
+        ts = _install_failures.get(feature)
+        if ts is None:
+            return False
+        if (time.monotonic() - ts) >= _INSTALL_FAILURE_COOLDOWN_S:
+            del _install_failures[feature]
+            return False
+        return True
+
+
+def _record_install_failure(feature: str) -> None:
+    """Remember that a lazy install for ``feature`` just failed."""
+    with _install_failures_lock:
+        _install_failures[feature] = time.monotonic()
+
+
+def _clear_install_failure(feature: str) -> None:
+    """Forget any recorded failure for ``feature`` (install succeeded / deps present)."""
+    with _install_failures_lock:
+        _install_failures.pop(feature, None)
 
 
 # =============================================================================
@@ -737,7 +792,21 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
 
     missing = feature_missing(feature)
     if not missing:
+        # Deps are present (installed by us earlier, by `hermes tools`, or by
+        # the user directly). Drop any stale negative-cache entry and succeed.
+        _clear_install_failure(feature)
         return
+
+    # Negative cache: a recent install attempt for this feature already failed.
+    # Don't pay for another doomed uv/pip subprocess within the cooldown. The
+    # feature_missing() check above runs first, so packages that became
+    # available by other means still succeed and clear the cache above.
+    if _recent_install_failure(feature):
+        raise FeatureUnavailable(
+            feature, missing,
+            "recent install attempt failed; not retrying yet "
+            f"(cooldown {int(_INSTALL_FAILURE_COOLDOWN_S)}s)",
+        )
 
     # Validate every spec against the allowlist + safety regex. Belt and
     # braces — the keys-in-LAZY_DEPS check above already constrains this.
@@ -787,6 +856,9 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
     logger.info("Lazy-installing %s for feature %r", " ".join(missing), feature)
     result = _venv_pip_install(missing)
     if not result.success:
+        # Remember the failure so the next call within the cooldown short-
+        # circuits instead of re-running pip (the whole point of the cache).
+        _record_install_failure(feature)
         # Surface the actual pip error so the user can debug PyPI-side
         # issues (404 quarantine, network down, etc.).
         snippet = (result.stderr or result.stdout or "").strip()
@@ -809,12 +881,17 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
 
     still_missing = feature_missing(feature)
     if still_missing:
+        # pip claimed success but the packages aren't importable (wrong venv,
+        # metadata cache, needs a restart). Treat it as a failed attempt so we
+        # don't keep re-running the install that can't take effect this process.
+        _record_install_failure(feature)
         raise FeatureUnavailable(
             feature, still_missing,
             "install reported success but packages still not importable "
             "(may require Python restart)"
         )
 
+    _clear_install_failure(feature)
     logger.info("Lazy install complete for feature %r", feature)
 
 


### PR DESCRIPTION
## Problem

`GET /api/messaging/platforms` takes ~10 seconds on a typical macOS install, timing out dashboard UIs built on it (measured 10.0-10.2s live; an instance without a running gateway answers in 40ms).

The handler builds a payload for each of the ~31 catalog platforms, and each `_messaging_platform_payload()` call independently:

1. derives `gateway_running` via `get_running_pid()`, which shells out to `ps` on macOS, and
2. calls `_gateway_platform_config()` → a full `load_gateway_config()`.

Profiling shows each `load_gateway_config()` costs ~360ms, dominated by `_apply_env_overrides` → plugin registry loop → Discord's `check_discord_requirements()` → `lazy_deps.ensure("platform.discord")` → `_venv_pip_install()`. When discord.py is missing and the install fails (offline, sandboxed venv, user never opted in), **every config load re-runs the uv/pip subprocess ladder** because nothing remembers the failure. 31 platforms × ~360ms ≈ 11s, on every request:

```
ncalls  cumtime  filename:lineno(function)
     1    0.362  gateway/config.py(load_gateway_config)
     1    0.361  plugins/platforms/discord/adapter.py(check_discord_requirements)
     1    0.358  tools/lazy_deps.py(_venv_pip_install)
     3    0.358  subprocess.py(run)
```

## Fix (two layers)

**1. `hermes_cli/web_server.py` — hoist per-request invariants.** `get_messaging_platforms()` now computes `gateway_running` and loads the config **once per request** (inside `_profile_scope`, so profile-scoped reads still resolve against the requested profile's HERMES_HOME) and shares them across all payloads. Only the config the mode consumes is loaded (`load_config()` when scoped, `load_gateway_config()` when not). Details preserved:
- The catalog is snapshotted before the config load, because loading config can re-run plugin discovery and mutate the registry the catalog derives from.
- A failed config load yields the same env-var fallback payloads each platform produced before (200, never a 500), via a `None`-vs-unset sentinel.
- Single-payload callers (the `/test` handler) are unchanged: they omit the new keyword args and derive everything on demand exactly as before.

**2. `tools/lazy_deps.py` — negative-cache failed installs.** `ensure()` now remembers a failed install attempt per feature (per-process, 300s monotonic cooldown) and raises `FeatureUnavailable` immediately within the window instead of re-running pip. The cheap `feature_missing()` check still runs first, so packages that appear by other means succeed and clear the entry; successful installs clear it too. Non-pip outcomes (lazy installs disabled, user declined, unsafe spec) are deliberately not cached.

## Measurements (patched, real install with missing discord.py)

```
load_gateway_config call 1: 371.7ms   (pays the pip attempt once)
load_gateway_config call 2:   0.2ms
31 consecutive loads:         3.9ms   (was ~11,400ms)
```

End to end the endpoint drops from ~10s per request to <0.5s on the first request and milliseconds after.

## Tests

- `test_get_messaging_platforms_resolves_invariants_once` — call counters assert `load_gateway_config` and `get_running_pid` each run at most once per request.
- `test_get_messaging_platforms_survives_config_load_failure` — broken config returns 200 with fallback payloads.
- `test_scoped_read_loads_cli_config_once` — the profile-scoped branch's hoist.
- `TestNegativeCache` in `tests/tools/test_lazy_deps.py` — pip runs exactly once across consecutive failing `ensure()` calls; cache clears when deps appear, after success, and on cooldown expiry.

Results: `tests/hermes_cli/test_web_server.py` 340 passed; `tests/hermes_cli/test_web_server_messaging_profiles.py` 9 passed; `tests/tools/test_lazy_deps.py` 66 passed; `scripts/run_tests.sh` over the touched files: 415 passed, 0 failed. (One pre-existing, unrelated failure on clean main: `test_matrix.py::test_matrix_markdown_preserves_table_structure`, Markdown package version drift.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)