### PR TITLE
fix(learning_graph, cli): /journey crash on non-dict metadata + ANSI rendering in CLI

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -49,7 +49,10 @@ def _frontmatter(text: str) -> dict[str, Any]:
 
 
 def _related(fm: dict[str, Any]) -> list[str]:
-    raw = fm.get("related_skills") or (fm.get("metadata", {}).get("hermes", {}) or {}).get("related_skills")
+    meta = fm.get("metadata", {})
+    if not isinstance(meta, dict):
+        meta = {}
+    raw = fm.get("related_skills") or meta.get("hermes", {}).get("related_skills")
     if isinstance(raw, list):
         return [str(r).strip() for r in raw if str(r).strip()]
     if isinstance(raw, str):
@@ -58,7 +61,10 @@ def _related(fm: dict[str, Any]) -> list[str]:
 
 
 def _category(fm: dict[str, Any], skill_md: Path) -> str:
-    cat = fm.get("category") or (fm.get("metadata", {}).get("hermes", {}) or {}).get("category")
+    meta = fm.get("metadata", {})
+    if not isinstance(meta, dict):
+        meta = {}
+    cat = fm.get("category") or meta.get("hermes", {}).get("category")
     if cat:
         return str(cat)
     # …/skills/<category>/<skill>/SKILL.md

--- a/cli.py
+++ b/cli.py
@@ -8642,7 +8642,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         elif canonical == "journey":
             try:
                 import argparse
+                import io
                 import shlex
+                import sys
 
                 from hermes_cli.journey import register_cli as _register_journey_cli
 
@@ -8650,7 +8652,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 _register_journey_cli(parser)
                 argv = shlex.split(cmd_original.split(None, 1)[1]) if len(cmd_original.split(None, 1)) > 1 else []
                 args = parser.parse_args(argv)
-                args.func(args)
+
+                # Capture Rich output and route through _cprint so prompt_toolkit
+                # renders ANSI codes instead of swallowing them.
+                buf = io.StringIO()
+                old_stdout = sys.stdout
+                sys.stdout = buf
+                try:
+                    args.func(args)
+                finally:
+                    sys.stdout = old_stdout
+                output = buf.getvalue()
+                if output:
+                    _cprint(output)
             except SystemExit:
                 pass
             except Exception as exc:


### PR DESCRIPTION
## Description

Two bugs in the `/journey` slash command (and `hermes journey` CLI):

### 1. Crash: `"str" object has no attribute "get"` in `build_learning_graph()`

`_category()` and `_related()` in `agent/learning_graph.py` assumed `fm.get("metadata", {})` always returns a `dict`. However, `parse_frontmatter()` in `agent/skill_utils.py` has a YAML fallback path (lines 150-155) that does a simple `key: value` split, storing everything as strings. When a skill's frontmatter triggers this fallback (e.g. malformed YAML), `metadata` becomes `""` and chained `.get()` calls crash with `AttributeError: 'str' object has no attribute 'get'`.

**Fix:** Add `isinstance(meta, dict)` guard before accessing nested keys. Falls back to empty dict when metadata is a string or any other non-dict type.

### 2. `/journey` output shows raw ANSI escape codes in CLI

`/journey` called `args.func(args)` directly, letting Rich write ANSI sequences to `sys.stdout`. In the Hermes CLI, prompt_toolkit's `patch_stdout` (StdoutProxy) intercepts stdout and passes raw bytes through without parsing ANSI codes, rendering them as literal text (e.g. `?[38;2;...m`).

**Fix:** Redirect `sys.stdout` to a `StringIO`, let Rich render into it, then pass the captured output through `_cprint()` which uses `_PT_ANSI()` — prompt_toolkit's native ANSI parser — so colors render correctly.

## Reproduction

### Bug 1
```python
from agent.learning_graph import build_learning_graph
build_learning_graph()  # AttributeError if any skill has non-dict metadata
```

### Bug 2
Type `/journey` in the Hermes CLI — output shows raw ANSI codes instead of colored text.

## Testing
- `build_learning_graph()` now returns 91 nodes successfully (was crashing)
- `/journey` in CLI now renders colors correctly
- `hermes journey` CLI command also works (uses same code path)
- Existing skills with dict metadata are unaffected (guard is no-op)