### PR TITLE
fix(dashboard): 500 on unauthenticated page load when basic auth is the only provider

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -177,7 +177,13 @@ def _auto_sso_response(request: Request) -> Response | None:
 
     # list_session_providers() already filters on supports_session=True, so
     # token-only credentials (drain/service providers) are never candidates.
-    providers = list_session_providers()
+    # Password-only providers (BasicAuth) have no OAuth redirect flow —
+    # start_login raises NotImplementedError — so they must render the
+    # /login password form instead of auto-redirecting.
+    providers = [
+        p for p in list_session_providers()
+        if not getattr(p, "supports_password", False)
+    ]
     if len(providers) != 1:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None


### PR DESCRIPTION
## Problem
When `dashboard.basic_auth` is the only configured provider, every unauthenticated HTML page load produces an HTTP 500 error. The sequence:
1. User hits `/` while logged out
2. `_auto_sso_response` sees exactly one session provider (BasicAuth) → returns a 302 redirect to `/auth/login`
3. The `/auth/login` handler calls `start_login` on BasicAuthProvider
4. `BasicAuthProvider.start_login` **raises `NotImplementedError`** because password-only providers have no OAuth/SAML redirect flow
5. The unhandled exception surfaces as HTTP 500

## Root Cause
`_auto_sso_response` unconditionally included all session-capable providers as auto-redirect candidates. Password-only providers (`supports_password=True`) — specifically BasicAuth — have no redirect-based login flow, so redirecting to their login endpoint crashes.

## Fix
Filter out password-only providers from the auto-SSO candidate list. When the only session provider is password-based, `_auto_sso_response` returns `None`, allowing the normal `/login` password form to render instead of attempting an impossible redirect.

## Verification
Applied and verified on a live deployment:
- Login page now renders at `/login` instead of crashing
- Password-based login with valid credentials succeeds
- Wrong password returns proper 401
- No regression for OAuth/SAML providers (the filter only removes `supports_password=True` providers)