### PR TITLE
fix: `hermes journey` crashes on Windows due to `%-d` strftime directive

### DIFF
--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -255,7 +255,7 @@ def _period_key(ts: float, granularity: str) -> tuple[int, ...]:
 def _period_label(ts: float, granularity: str) -> str:
     dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     if granularity == "day":
-        return dt.strftime("%-d %b")
+        return f"{dt.day} {dt.strftime('%b')}"
     if granularity == "month":
         return dt.strftime("%b %Y")
     return dt.strftime("%Y")


### PR DESCRIPTION
## Problem

Running `hermes journey` on Windows crashes with:

```
ValueError: Invalid format string
  File "agent/learning_graph_render.py", line 258, in _period_label
    return dt.strftime("%-d %b")
```

The `%-d` directive (suppress leading zero on day-of-month) is Linux/glibc-specific and does not exist on Windows `strftime`.

## Fix

Use `f"{dt.day} {dt.strftime(%b)}"` instead — `dt.day` is an integer and naturally has no leading zero, so the output is identical cross-platform. No behaviour change on Linux/macOS.

## Testing

- **Reproduced** on Windows 10 with Hermes v0.18.0 (freshly released today)
- **Verified fix**: `hermes journey` now renders the full timeline
- Regression-free on Linux (identical output since `dt.day` is just the numeric day)