### PR TITLE
feat: enable Kitty keyboard protocol at CLI startup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -77,14 +77,16 @@ except (ImportError, AttributeError):
 
 try:
     from hermes_cli.pt_input_extras import (
+        enable_kitty_keyboard_protocol,
         install_ctrl_enter_alias,
         install_ignored_terminal_sequences,
         install_shift_enter_alias,
     )
+    enable_kitty_keyboard_protocol()
     install_shift_enter_alias()
     install_ctrl_enter_alias()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_ignored_terminal_sequences
+    del enable_kitty_keyboard_protocol, install_shift_enter_alias, install_ctrl_enter_alias, install_ignored_terminal_sequences
 except Exception:
     pass
 import threading

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -11,6 +11,38 @@ can be unit-tested without importing the whole CLI runtime.
 
 from __future__ import annotations
 
+import sys
+
+
+def enable_kitty_keyboard_protocol() -> bool:
+    """Enable the Kitty keyboard protocol so the terminal sends distinct
+    byte sequences for Shift+Enter, Ctrl+Enter, etc.
+
+    Sends the CSI > 1 u sequence to push the terminal into kitty protocol
+    mode (level 1 — disambiguate escape keys). This makes Shift+Enter emit
+    \\x1b[13;2u instead of a bare CR, which the existing shift_enter_alias
+    handler then maps to a newline.
+
+    Only sent on POSIX (not Windows). Safe no-op on terminals that don't
+    support it — they ignore the sequence.
+
+    The protocol is automatically disabled when the application exits
+    (prompt_toolkit sends the pop sequence on teardown), but we also
+    register an atexit fallback for safety.
+    """
+    if sys.platform == "win32":
+        return False
+    try:
+        seq = "\x1b[>1u"
+        sys.stdout.write(seq)
+        sys.stdout.flush()
+        # Register pop on exit (prompt_toolkit should handle this, but be safe)
+        import atexit
+        atexit.register(lambda: (sys.stdout.write("\x1b[<1u"), sys.stdout.flush()))
+        return True
+    except Exception:
+        return False
+
 
 def install_shift_enter_alias() -> int:
     """Map Shift+Enter byte sequences to the (Escape, ControlM) key tuple


### PR DESCRIPTION
## Problem

Hermes already parses Kitty keyboard protocol sequences (Shift+Enter, Ctrl+Enter) via `install_shift_enter_alias()` in `pt_input_extras.py`, but never asks the terminal to enable the protocol. Terminals like Ghostty, Kitty, WezTerm, and iTerm2 3.4+ support it but don't send distinct key codes unless the application opts in.

Result: Shift+Enter submits the prompt instead of inserting a newline, even on terminals that support the protocol.

## Solution

Send `CSI > 1 u` (Kitty keyboard protocol level 1 — disambiguate escape keys) at CLI startup. This makes Shift+Enter emit `\x1b[13;2u` instead of bare CR. The existing `install_shift_enter_alias()` handler then maps it to a newline — no new key bindings needed.

Also registers an `atexit` fallback to send the pop sequence (`CSI < 1 u`) on exit, though prompt_toolkit should handle teardown itself.

## Compatibility

- **Safe no-op** on terminals without kitty protocol support (macOS Terminal.app, Windows Terminal without kitty) — they ignore the CSI sequence
- Windows is explicitly excluded (`sys.platform == "win32"` check)
- No config change required — works out of the box

## Test Plan

- [x] Verified on Ghostty (macOS): Shift+Enter inserts a newline, Enter submits
- [x] Verify on macOS Terminal.app: no regression (Enter still submits)
- [x] Verify on iTerm2: Shift+Enter inserts a newline
- [ ] Verify on Windows: no change (excluded by platform check)

## Files Changed

- `hermes_cli/pt_input_extras.py`: add `enable_kitty_keyboard_protocol()` function
- `cli.py`: call it at startup alongside existing `install_shift_enter_alias()` etc.