### PR TITLE
[codex] Fix journey date labels on Windows

### DIFF
--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -73,7 +73,8 @@ def format_date(ts: Optional[float]) -> str:
     if not ts:
         return "unknown"
     try:
-        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%-d %b %Y")
+        dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+        return f"{dt.day} {dt.strftime('%b %Y')}"
     except (ValueError, OSError, OverflowError):
         return "unknown"
 
@@ -255,7 +256,7 @@ def _period_key(ts: float, granularity: str) -> tuple[int, ...]:
 def _period_label(ts: float, granularity: str) -> str:
     dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     if granularity == "day":
-        return dt.strftime("%-d %b")
+        return f"{dt.day} {dt.strftime('%b')}"
     if granularity == "month":
         return dt.strftime("%b %Y")
     return dt.strftime("%Y")

--- a/tests/agent/test_learning_graph_render.py
+++ b/tests/agent/test_learning_graph_render.py
@@ -175,6 +175,25 @@ def test_format_date_handles_missing():
     assert render.format_date(1_700_000_000) != "unknown"
 
 
+def test_date_labels_avoid_platform_specific_strftime(monkeypatch):
+    class FakeDate:
+        day = 5
+
+        def strftime(self, fmt):
+            if "%-d" in fmt:
+                raise ValueError("Invalid format string")
+            return {"%b": "Jan", "%b %Y": "Jan 2024", "%Y": "2024"}[fmt]
+
+    class FakeDateTime:
+        @classmethod
+        def fromtimestamp(cls, ts, tz=None):
+            return FakeDate()
+
+    monkeypatch.setattr(render, "datetime", FakeDateTime)
+
+    assert render.format_date(1_704_412_800) == "5 Jan 2024"
+    assert render._period_label(1_704_412_800, "day") == "5 Jan"
+
 def test_derive_palette_distinct_memory_hue():
     pal = render.derive_palette("#FFD700", dark=True)
     assert pal["skill"].startswith("#") and pal["memory"].startswith("#")


### PR DESCRIPTION
﻿# Summary

- Fix Windows-incompatible Journey date labels by avoiding strftime with %-d.
- Preserve non-padded day output by formatting dt.day explicitly.
- Add a regression test that simulates Windows rejecting %-d so this is covered on any CI platform.

# Root Cause

hermes journey rendered date labels with strftime format strings using %-d. Windows Python does not support that flag, so Journey crashed with ValueError: Invalid format string while building the busiest-day summary and other date labels.

# Validation

- uv run --extra dev python -m pytest tests\agent\test_learning_graph_render.py
- python -m py_compile agent\learning_graph_render.py tests\agent\test_learning_graph_render.py
- hermes journey on Windows
