### PR TITLE
feat(plugins): let pre_llm_call route the turn to a different model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -746,7 +746,10 @@ can:
 
 - Register Python-callback lifecycle hooks:
   `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`,
-  `on_session_start`, `on_session_end`
+  `on_session_start`, `on_session_end`. A `pre_llm_call` callback can inject
+  turn context (`{"context": "..."}`) and/or route the turn to a different
+  model (`{"model": "...", "provider": "..."}`) — enabling task-aware model
+  routing plugins.
 - Register new tools via `ctx.register_tool(...)`
 - Register CLI subcommands via `ctx.register_cli_command(...)` — the
   plugin's argparse tree is wired into `hermes` at startup so

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -38,6 +38,61 @@ from agent.model_metadata import (
 logger = logging.getLogger(__name__)
 
 
+def _apply_pre_llm_call_model_override(agent, new_model: str, new_provider: str) -> None:
+    """Apply a per-turn model override requested by a ``pre_llm_call`` plugin.
+
+    A ``pre_llm_call`` callback may return ``{"model": ..., "provider": ...}``
+    to route THIS turn to a different model (e.g. a coding-tuned model for a
+    coding task). Credentials are resolved through the same pipeline as the
+    ``/model`` command, then the runtime swap is applied.
+
+    Any failure is logged and swallowed so a bad override can never abort the
+    turn — the agent simply keeps its current model. The swap persists like
+    ``/model`` (not turn-scoped), so routing plugins should return a choice on
+    every turn.
+    """
+    try:
+        from hermes_cli.model_switch import switch_model as _resolve_switch
+        from hermes_cli.config import load_config, get_compatible_custom_providers
+        from agent.agent_runtime_helpers import switch_model as _runtime_switch
+
+        _cfg = load_config()
+        result = _resolve_switch(
+            raw_input=new_model,
+            current_provider=agent.provider or "",
+            current_model=agent.model or "",
+            current_base_url=getattr(agent, "base_url", "") or "",
+            current_api_key=getattr(agent, "api_key", "") or "",
+            explicit_provider=new_provider,
+            custom_providers=get_compatible_custom_providers(_cfg),
+            is_global=False,
+        )
+        if not result.success:
+            logger.warning(
+                "pre_llm_call model override to %s/%s failed: %s; keeping %s/%s",
+                new_provider, new_model, result.error_message,
+                agent.provider, agent.model,
+            )
+            return
+        _runtime_switch(
+            agent,
+            result.new_model,
+            result.target_provider,
+            api_key=result.api_key,
+            base_url=result.base_url,
+            api_mode=result.api_mode,
+        )
+        logger.info(
+            "pre_llm_call: routed this turn to %s/%s",
+            result.target_provider, result.new_model,
+        )
+    except Exception as exc:  # never let routing break a turn
+        logger.warning(
+            "pre_llm_call model override error (%s/%s): %s; keeping %s/%s",
+            new_provider, new_model, exc, agent.provider, agent.model,
+        )
+
+
 def _compression_made_progress(
     orig_len: int, new_len: int, orig_tokens: int, new_tokens: int
 ) -> bool:
@@ -452,6 +507,21 @@ def build_turn_context(
                 _ctx_parts.append(r)
         if _ctx_parts:
             plugin_user_context = "\n\n".join(_ctx_parts)
+
+        # Per-turn model routing: a pre_llm_call plugin may return
+        # {"model": "...", "provider": "..."} to route THIS turn to a
+        # different model (e.g. a coding model for a coding task). The first
+        # such result wins. This runs after context injection so a plugin can
+        # do both. See _apply_pre_llm_call_model_override for semantics.
+        _routed = next(
+            (r for r in _pre_results if isinstance(r, dict) and r.get("model")),
+            None,
+        )
+        if _routed:
+            _rm = str(_routed.get("model") or "").strip()
+            _rp = str(_routed.get("provider") or agent.provider or "").strip()
+            if _rm and (_rm != agent.model or _rp != (agent.provider or "")):
+                _apply_pre_llm_call_model_override(agent, _rm, _rp)
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1863,6 +1863,20 @@ class PluginManager:
         system prompt stays identical across turns so cached tokens
         are reused.  All injected context is ephemeral — never
         persisted to session DB.
+
+        A ``pre_llm_call`` callback may ALSO request a per-turn model
+        override — routing THIS turn to a different model (e.g. a
+        coding-tuned model for a coding task) — by returning::
+
+            {"model": "gpt-oss-120b", "provider": "openrouter"}
+            {"context": "...", "model": "...", "provider": "..."}  # both
+
+        ``provider`` is optional (defaults to the current provider).
+        Credentials resolve through the same pipeline as ``/model``; a
+        failed/invalid override is logged and ignored (the turn keeps the
+        current model). The first result carrying ``model`` wins. The swap
+        persists like ``/model``, so a routing plugin should return a choice
+        on every turn.
         """
         kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
         callbacks = self._hooks.get(hook_name, [])

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "anthropic@vkriss.com": "krisiliev-dev",  # PR #56650 (pre_llm_call per-turn model routing)
     "zhangml@tech.icbc.com.cn": "zmlgit",  # PR #54872 salvage (multiplex-profile kanban: route task notifications via the owning profile's adapter + wake the creator agent with a synthetic internal MessageEvent on terminal events)
     "1079826437@qq.com": "nankingjing",  # PR #56404 salvage (gateway: while a state.db compression lock is held for the session, demote busy_input_mode 'interrupt' to 'queue' so a rapid message burst can't interrupt and fork orphaned compression siblings off a stale parent; #56391)
     "ud@arubangles.com": "udatny",  # PR #29433 salvage (subdirectory_hints: catch RuntimeError from Path.expanduser()/Path.home() so a literal ~ in tool-call args — e.g. LLM "~500-700" or ~unknownuser — can't escape the hint walker and crash the conversation loop)

--- a/tests/test_pre_llm_call_model_override.py
+++ b/tests/test_pre_llm_call_model_override.py
@@ -1,0 +1,92 @@
+"""Tests for the per-turn model-override branch of the ``pre_llm_call`` hook.
+
+A ``pre_llm_call`` plugin may return ``{"model": ..., "provider": ...}`` to
+route the current turn to a different model. ``_apply_pre_llm_call_model_override``
+resolves credentials via the shared ``/model`` pipeline and applies the runtime
+swap, swallowing any failure so routing can never abort a turn.
+"""
+
+import types
+
+import agent.turn_context as tc
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.provider = "gemini"
+        self.model = "gemini-2.5-flash"
+        self.base_url = ""
+        self.api_key = "k"
+
+
+def _install_stubs(monkeypatch, *, result, record):
+    """Stub the resolver + runtime swap that the override helper imports."""
+    def _fake_resolve(**kwargs):
+        record["resolve_kwargs"] = kwargs
+        return result
+
+    def _fake_runtime_switch(agent, new_model, new_provider, **kw):
+        record["applied"] = (new_model, new_provider, kw)
+        agent.model, agent.provider = new_model, new_provider
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _fake_resolve)
+    monkeypatch.setattr(
+        "agent.agent_runtime_helpers.switch_model", _fake_runtime_switch
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda *a, **k: {}
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_compatible_custom_providers", lambda *a, **k: []
+    )
+
+
+def test_successful_override_applies_resolved_credentials(monkeypatch):
+    record = {}
+    result = types.SimpleNamespace(
+        success=True, new_model="openai/gpt-oss-120b:free",
+        target_provider="openrouter", api_key="rk",
+        base_url="https://openrouter.ai/api/v1", api_mode="chat_completions",
+        error_message="",
+    )
+    _install_stubs(monkeypatch, result=result, record=record)
+
+    agent = _FakeAgent()
+    tc._apply_pre_llm_call_model_override(agent, "gpt-oss-120b", "openrouter")
+
+    assert record["applied"][0] == "openai/gpt-oss-120b:free"
+    assert record["applied"][1] == "openrouter"
+    assert record["applied"][2]["api_key"] == "rk"
+    assert record["applied"][2]["base_url"] == "https://openrouter.ai/api/v1"
+    assert agent.model == "openai/gpt-oss-120b:free"
+
+
+def test_failed_resolution_keeps_current_model(monkeypatch):
+    record = {}
+    result = types.SimpleNamespace(
+        success=False, new_model="", target_provider="", api_key="",
+        base_url="", api_mode="", error_message="unknown model",
+    )
+    _install_stubs(monkeypatch, result=result, record=record)
+
+    agent = _FakeAgent()
+    tc._apply_pre_llm_call_model_override(agent, "nope", "openrouter")
+
+    assert "applied" not in record          # runtime swap never attempted
+    assert agent.model == "gemini-2.5-flash"  # unchanged
+
+
+def test_resolver_exception_is_swallowed(monkeypatch):
+    def _boom(**kwargs):
+        raise RuntimeError("resolver blew up")
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _boom)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "hermes_cli.config.get_compatible_custom_providers", lambda *a, **k: []
+    )
+
+    agent = _FakeAgent()
+    # Must not raise — a bad override can never abort the turn.
+    tc._apply_pre_llm_call_model_override(agent, "x", "y")
+    assert agent.model == "gemini-2.5-flash"


### PR DESCRIPTION
Resolves #56655.

## What

Let a `pre_llm_call` plugin callback route the current turn to a different model by returning `{"model": ..., "provider": ...}` — alongside (or instead of) the existing `{"context": ...}` injection.

```python
def register(ctx):
    def route(user_message, model, **_):
        if any(k in user_message.lower() for k in ("bug", "traceback", "refactor")):
            return {"model": "openai/gpt-oss-120b:free", "provider": "openrouter"}
        return None
    ctx.register_hook("pre_llm_call", route)
```

## Why

`pre_llm_call` already receives `user_message` and `model`, but its return can only inject context — so plugins can't act on that signal to pick a better model per turn. This makes **task-aware model routing** (e.g. a coding-tuned model for coding turns, a fast model for quick questions) impossible without patching the agent loop directly, which every `hermes update` then clobbers. This is the smallest change that unlocks it via the existing plugin surface.

## How

- `agent/turn_context.py`: after collecting `pre_llm_call` results, the first result carrying `"model"` is applied via the shared `/model` resolution pipeline (`hermes_cli.model_switch.switch_model`) + runtime `switch_model()`. `provider` is optional (defaults to the current provider).
- **Fail-safe:** any resolution/swap error is logged and swallowed — a bad override can never abort a turn; the agent keeps its current model. `switch_model()`'s existing atomic rollback covers partial-swap failures.
- The swap persists like `/model` (not turn-scoped), so a routing plugin should return a choice on every turn — documented in the `invoke_hook` docstring and `AGENTS.md`.

## Backward compatibility

Fully backward compatible. Callbacks returning `{"context": ...}`, a bare string, or `None` behave exactly as before; only the new `"model"` key triggers routing.

## Testing

New `tests/test_pre_llm_call_model_override.py` covers the success path (resolved creds applied), failed resolution (current model kept, no swap), and resolver exception (swallowed, turn continues). All pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
