### PR TITLE
fix(delegate): block kanban lifecycle tools for delegated children

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -157,6 +157,14 @@ class TestStripBlockedTools(unittest.TestCase):
         result = _strip_blocked_tools(["terminal", "file", "web", "browser"])
         self.assertEqual(sorted(result), ["browser", "file", "terminal", "web"])
 
+    def test_removes_kanban_toolset(self):
+        # Children inherit the parent process env, including the
+        # HERMES_KANBAN_TASK pin -- a child's kanban write would land on the
+        # PARENT's card. The kanban toolset must be stripped whether
+        # inherited or explicitly requested.
+        result = _strip_blocked_tools(["terminal", "kanban", "web"])
+        self.assertEqual(sorted(result), ["terminal", "web"])
+
     def test_empty_input(self):
         result = _strip_blocked_tools([])
         self.assertEqual(result, [])
@@ -1108,6 +1116,15 @@ class TestSubagentCostRollup(unittest.TestCase):
 class TestBlockedTools(unittest.TestCase):
     def test_blocked_tools_constant(self):
         for tool in ["delegate_task", "clarify", "memory", "send_message", "execute_code"]:
+            self.assertIn(tool, DELEGATE_BLOCKED_TOOLS)
+
+    def test_kanban_lifecycle_blocked_for_children(self):
+        # Every tool in the kanban toolset must be blocked so the derived
+        # strip set drops the whole toolset for children: they share the
+        # parent's HERMES_KANBAN_TASK pin, so kanban_complete from a leaf
+        # closes the parent's card mid-task.
+        from toolsets import TOOLSETS
+        for tool in TOOLSETS["kanban"]["tools"]:
             self.assertIn(tool, DELEGATE_BLOCKED_TOOLS)
 
     def test_constants(self):
@@ -3070,6 +3087,62 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+class TestChildKanbanHardDisable(unittest.TestCase):
+    """A delegated child must never hold kanban lifecycle tools, even when the
+    process has HERMES_KANBAN_TASK set (dispatcher-spawned worker). Stripping
+    the toolset NAME from enabled_toolsets is NOT enough: model_tools re-adds
+    'kanban' from that env one layer down, and only disabled_toolsets survives
+    the re-add. Regression for the "delegated leaf closed the parent's card
+    mid-review" incident (a name-strip alone is silently undone)."""
+
+    def test_child_construction_hard_disables_kanban_under_task_env(self):
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["terminal", "kanban", "web"]
+        with patch.dict(os.environ, {"HERMES_KANBAN_TASK": "t_parent_card"}):
+            with patch("run_agent.AIAgent") as MockAgent:
+                MockAgent.return_value = MagicMock()
+                _build_child_agent(
+                    task_index=0,
+                    goal="close my own card please",
+                    context=None,
+                    toolsets=None,  # pure parent inheritance (the live path)
+                    model=None,
+                    max_iterations=10,
+                    parent_agent=parent,
+                    task_count=1,
+                )
+
+        _, kwargs = MockAgent.call_args
+        # The toolset NAME is stripped from the child's enabled set ...
+        self.assertNotIn("kanban", kwargs.get("enabled_toolsets") or [])
+        # ... AND kanban is hard-disabled so the model_tools env re-add cannot
+        # resurrect it one layer down (this is the actual incident fix).
+        self.assertIn("kanban", kwargs.get("disabled_toolsets") or [])
+
+    def test_model_tools_env_readd_is_defeated_by_disabled_toolsets(self):
+        """Mechanism characterization: with HERMES_KANBAN_TASK set,
+        get_tool_definitions re-adds the kanban toolset even when it is NOT in
+        enabled_toolsets; only disabled_toolsets=['kanban'] removes the kanban_*
+        tools again. If the first assertion ever fails, upstream dropped the env
+        re-add and the child guard may no longer be load-bearing."""
+        import model_tools
+        with patch.dict(os.environ, {"HERMES_KANBAN_TASK": "t_card"}):
+            leaked = model_tools.get_tool_definitions(
+                enabled_toolsets=["terminal"], quiet_mode=True)
+            leaked_names = {t["function"]["name"] for t in (leaked or [])}
+            self.assertTrue(
+                any(n.startswith("kanban_") for n in leaked_names),
+                "expected HERMES_KANBAN_TASK to re-add kanban tools")
+            guarded = model_tools.get_tool_definitions(
+                enabled_toolsets=["terminal"], disabled_toolsets=["kanban"],
+                quiet_mode=True)
+            guarded_names = {t["function"]["name"] for t in (guarded or [])}
+            self.assertFalse(
+                any(n.startswith("kanban_") for n in guarded_names),
+                "disabled_toolsets=['kanban'] must strip kanban even under "
+                "HERMES_KANBAN_TASK")
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -50,8 +50,34 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
         "send_message",  # no cross-platform side effects
         "execute_code",  # children should reason step-by-step, not write scripts
         "cronjob",  # no scheduling more work in the parent's name
+        # Kanban lifecycle: children run inside the parent's process and
+        # inherit its HERMES_KANBAN_TASK pin, so any kanban write from a
+        # child lands on the PARENT's card (observed live: a delegated leaf
+        # called kanban_complete and closed the parent's task mid-review).
+        # Listing every kanban tool here makes _strip_blocked_tools auto-drop
+        # the whole kanban toolset for children (its tools are exactly these)
+        # -- the same blocklist/strip-set lockstep the cronjob block relies on.
+        "kanban_show",
+        "kanban_list",
+        "kanban_complete",
+        "kanban_block",
+        "kanban_heartbeat",
+        "kanban_comment",
+        "kanban_create",
+        "kanban_link",
+        "kanban_unblock",
     ]
 )
+
+# Toolsets that must be HARD-disabled on every delegated child -- not merely
+# stripped from enabled_toolsets. model_tools.get_tool_definitions RE-ADDS the
+# "kanban" toolset to any process whose env carries HERMES_KANBAN_TASK
+# (dispatcher-spawned workers), and children run in-process and inherit that
+# pin -- so a name-strip alone is silently undone one layer down. The
+# disabled_toolsets subtraction is applied AFTER that re-add, so children must
+# carry it explicitly. Without this a delegated leaf can call kanban_complete
+# and close the PARENT's card (observed live).
+_CHILD_DISABLED_TOOLSETS = ["kanban"]
 
 
 # ---------------------------------------------------------------------------
@@ -1313,6 +1339,10 @@ def _build_child_agent(
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         fallback_model=parent_fallback,
         enabled_toolsets=child_toolsets,
+        # Hard-disable kanban so the model_tools HERMES_KANBAN_TASK re-add
+        # cannot resurrect it for an in-process child (see
+        # _CHILD_DISABLED_TOOLSETS).
+        disabled_toolsets=_CHILD_DISABLED_TOOLSETS,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,
         log_prefix=f"[subagent-{task_index}]",


### PR DESCRIPTION
## What does this PR do?

Prevents children spawned via `delegate_task` from holding kanban lifecycle tools pinned to their **parent's** card.

Children run in-process (ThreadPoolExecutor) and inherit the parent's environment, including the `HERMES_KANBAN_TASK` pin. A delegated leaf that calls `kanban_complete` / `kanban_block` therefore acts on the parent worker's card — we observed a delegated child closing its parent's card mid-task in our production fleet.

Two complementary mechanisms, because a name-strip alone is insufficient:

1. **Blocklist:** the nine kanban tools join `DELEGATE_BLOCKED_TOOLS`. `_strip_blocked_tools` derives its strip set from the blocklist, so the whole `kanban` toolset is dropped from inherited child toolsets — the same blocklist/strip-set lockstep the existing `cronjob` block relies on. The list matches `TOOLSETS["kanban"]["tools"]` exactly (a test enforces the lockstep).
2. **Hard disable:** child construction passes `disabled_toolsets=["kanban"]`. This is load-bearing: `model_tools.get_tool_definitions` **re-adds** the `kanban` toolset to any process whose env carries `HERMES_KANBAN_TASK` (so dispatcher-spawned workers keep their lifecycle surface even with a restricted chat toolset), and an in-process child inherits that env — the name-strip is silently undone one layer down. The `disabled_toolsets` subtraction is applied *after* that re-add, so only it survives.

This also aligns with #56386: toolset scoping is a capability decision the delegation layer makes, and the env-based re-add was a bypass of that boundary for children.

Workers still complete their own cards after consolidating child output; children return text only.

## Related Issue

Fixes #56647

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` — add the nine `kanban_*` tools to `DELEGATE_BLOCKED_TOOLS`; add `_CHILD_DISABLED_TOOLSETS = ["kanban"]` and pass it as `disabled_toolsets` in `_build_child_agent`'s `AIAgent` construction.
- `tests/tools/test_delegate.py` — four regression tests: toolset strip, blocklist/`TOOLSETS["kanban"]` lockstep, child construction under `HERMES_KANBAN_TASK` (asserts kanban both stripped from `enabled_toolsets` and present in `disabled_toolsets`), and a characterization test that the `model_tools` env re-add is defeated by `disabled_toolsets` (if the re-add is ever removed upstream, that test flags the guard for re-evaluation).

## How to Test

1. `pytest tests/tools/test_delegate.py -q` — 155 tests pass (4 new).
   Full suite via `scripts/run_tests.sh`: 37,695 passed, 39 failed — all 39 failures reproduce identically on unmodified `main` in my environment (host-credential and timing-sensitive tests, e.g. `test_anthropic_adapter.py`, `test_gateway_service.py`); this change introduces zero new failures.
2. Unit-level repro of the leak on `main` without this patch:
   ```python
   import os, model_tools
   os.environ["HERMES_KANBAN_TASK"] = "some-card"
   defs = model_tools.get_tool_definitions(enabled_toolsets=["terminal"], quiet_mode=True)
   print([t["function"]["name"] for t in defs if t["function"]["name"].startswith("kanban_")])
   # kanban tools present even though only 'terminal' was enabled
   ```
3. End-to-end: run a kanban dispatcher worker that calls `delegate_task` and instruct the child to "mark the task complete" — with this patch the child has no kanban tools; the parent's card stays open until the parent completes it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (via `scripts/run_tests.sh`; the only failures are pre-existing in my environment and fail identically on unmodified `main` — see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior documented in code comments and tests)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys touched)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific code; tests use `patch.dict(os.environ, ...)`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema changes; toolset availability only)
