### PR TITLE
fix(docker): honour docker_env TMPDIR for session snapshot artifacts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -248,6 +248,11 @@ terminal:
 #   # docker_extra_args:
 #   #   - "--cap-add"
 #   #   - "SETUID"
+#   # Optional: environment variables set inside the container.
+#   # Use TMPDIR to redirect session artifacts (snapshot, cwd) to a
+#   # writable path when the image's /tmp is not world-writable.
+#   # docker_env:
+#   #   TMPDIR: "/workspace/.tmp"
 
 # -----------------------------------------------------------------------------
 # OPTION 4: Singularity/Apptainer container

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -373,6 +373,41 @@ def test_docker_env_appears_in_init_env_args(monkeypatch):
     assert "MY_VAR=my_value" in args_str
 
 
+# ── get_temp_dir tests ────────────────────────────────────────────
+
+
+def test_get_temp_dir_honours_docker_env_tmpdir(monkeypatch):
+    """get_temp_dir() should return TMPDIR from docker_env config."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(env={"TMPDIR": "/custom/tmp"})
+
+    assert env.get_temp_dir() == "/custom/tmp"
+    assert env._snapshot_path.startswith("/custom/tmp/")
+
+
+def test_get_temp_dir_defaults_to_tmp(monkeypatch):
+    """get_temp_dir() should fall back to /tmp when no TMPDIR is set."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env()
+
+    assert env.get_temp_dir() == "/tmp"
+    assert env._snapshot_path.startswith("/tmp/")
+
+
+def test_get_temp_dir_strips_trailing_slash(monkeypatch):
+    """get_temp_dir() should strip trailing slashes from the path."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(env={"TMPDIR": "/custom/tmp/"})
+
+    assert env.get_temp_dir() == "/custom/tmp"
+
+
 def test_forward_env_overrides_docker_env_in_init_args(monkeypatch):
     """docker_forward_env should override docker_env for the same key."""
     env = _make_execute_only_env(forward_env=["MY_KEY"])

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -599,12 +599,14 @@ class DockerEnvironment(BaseEnvironment):
     ):
         if cwd == "~":
             cwd = "/root"
-        super().__init__(cwd=cwd, timeout=timeout)
+        # Normalise docker_env before super().__init__() so the
+        # get_temp_dir() hook can read container-side TMPDIR.
+        self._env = _normalize_env_dict(env)
+        super().__init__(cwd=cwd, timeout=timeout, env=self._env)
         self._persistent = persistent_filesystem
         self._persist_across_processes = persist_across_processes
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
-        self._env = _normalize_env_dict(env)
         self._container_id: Optional[str] = None
         self._labels: dict[str, str] = {}
         self._image: str = ""
@@ -977,6 +979,23 @@ class DockerEnvironment(BaseEnvironment):
 
         # Initialize session snapshot inside the container
         self.init_session()
+
+    # ------------------------------------------------------------------
+    # Temp directory
+    # ------------------------------------------------------------------
+
+    def get_temp_dir(self) -> str:
+        """Return a writable temp dir for session artifacts inside the container.
+
+        Honours ``TMPDIR`` from the ``docker_env`` config (container-side) so
+        that hardened images whose ``/tmp`` is not world-writable can still
+        host session snapshot files.  Falls back to ``/tmp`` when unset.
+        """
+        for env_var in ("TMPDIR", "TMP", "TEMP"):
+            candidate = self.env.get(env_var)
+            if candidate and candidate.startswith("/"):
+                return candidate.rstrip("/") or "/"
+        return "/tmp"
 
     def _build_init_env_args(self) -> list[str]:
         """Build -e KEY=VALUE args for injecting host env vars into init_session.


### PR DESCRIPTION
## What does this PR do?

Fixes session snapshot artifact placement for Docker backends when the container image's `/tmp` is not world-writable.

`DockerEnvironment` inherited `BaseEnvironment.get_temp_dir()` which always returns `/tmp`.  When a hardened or minimal image has `/tmp` with restrictive permissions (e.g. `0755` instead of `1777`), and the container runs as a non-root user (`docker_run_as_host_user: true` or an image `USER`), writing `hermes-snap-*.sh` / `hermes-cwd-*.txt` to `/tmp` fails with `EACCES`, breaking multi-step command state for the entire session.

The fix adds a `get_temp_dir()` override to `DockerEnvironment` that honours `TMPDIR` (then `TMP`, `TEMP`) from the `docker_env` config before falling back to `/tmp`.  This mirrors `LocalEnvironment`'s override for Termux.

## Related Issue

Fixes #56648

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/docker.py`: Move `_env` normalisation before `super().__init__()` so the hook can read container-side env.  Add `get_temp_dir()` override that checks `self.env` for `TMPDIR`/`TMP`/`TEMP`, falling back to `/tmp`.
- `tests/tools/test_docker_environment.py`: Add 3 regression tests — custom TMPDIR, default `/tmp`, trailing-slash stripping.
- `cli-config.yaml.example`: Document `docker_env` with `TMPDIR` example for hardened images.

## How to Test

1. Run `python -m pytest tests/tools/test_docker_environment.py -v -k get_temp_dir` — all 3 new tests should pass.
2. Run `python -m pytest tests/tools/test_docker_environment.py -v` — all 72 tests should pass (no regressions).
3. Run `python -m pytest tests/tools/test_local_tempdir.py -v` — all 3 LocalEnvironment tests should still pass.
4. Functional: configure `terminal.docker_env.TMPDIR: "/workspace/.tmp"` with a hardened image whose `/tmp` is `0755` — session snapshots should land in `/workspace/.tmp/` and multi-step commands should maintain cwd/env state.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Docker backend is Linux-only)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/tools/test_docker_environment.py -v -k get_temp_dir
tests/tools/test_docker_environment.py::test_get_temp_dir_honours_docker_env_tmpdir PASSED
tests/tools/test_docker_environment.py::test_get_temp_dir_defaults_to_tmp PASSED
tests/tools/test_docker_environment.py::test_get_temp_dir_strips_trailing_slash PASSED
3 passed in 0.26s
```
