### PR TITLE
fix: pass request_overrides to background review and curator agents

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -659,6 +659,7 @@ def _run_review_in_thread(
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 skip_memory=True,
+                request_overrides=dict(getattr(agent, "request_overrides", None) or {}),
             )
             review_agent._memory_write_origin = "background_review"
             review_agent._memory_write_context = "background_review"

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1851,6 +1851,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     _api_mode = None
     _resolved_provider = None
     _model_name = ""
+    _request_overrides = None
     try:
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -1867,6 +1868,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         _base_url = _rp.get("base_url")
         _api_mode = _rp.get("api_mode")
         _resolved_provider = _rp.get("provider") or _provider
+        _request_overrides = _rp.get("request_overrides")
     except Exception as e:
         logger.debug("Curator provider resolution failed: %s", e, exc_info=True)
 
@@ -1891,6 +1893,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             platform="curator",
             skip_context_files=True,
             skip_memory=True,
+            request_overrides=dict(_request_overrides or {}),
         )
         # Disable recursive nudges — the curator must never spawn its own review.
         review_agent._memory_nudge_interval = 0

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "turgut.kural@outlook.com": "TurgutKural",  # PR #56653 salvage (fix: pass request_overrides to background review and curator agents so provider-specific extra_body fields like store:false are applied to auxiliary LLM calls)
     "zhangml@tech.icbc.com.cn": "zmlgit",  # PR #54872 salvage (multiplex-profile kanban: route task notifications via the owning profile's adapter + wake the creator agent with a synthetic internal MessageEvent on terminal events)
     "1079826437@qq.com": "nankingjing",  # PR #56404 salvage (gateway: while a state.db compression lock is held for the session, demote busy_input_mode 'interrupt' to 'queue' so a rapid message burst can't interrupt and fork orphaned compression siblings off a stale parent; #56391)
     "ud@arubangles.com": "udatny",  # PR #29433 salvage (subdirectory_hints: catch RuntimeError from Path.expanduser()/Path.home() so a literal ~ in tool-call args — e.g. LLM "~500-700" or ~unknownuser — can't escape the hint walker and crash the conversation loop)


### PR DESCRIPTION
## Bug

Background review and curator agents were not inheriting `request_overrides` from the parent agent or the resolved runtime provider. This caused provider-specific `extra_body` fields (like `store: false` for custom providers) to be missing from their LLM API calls.

**Reproduction:** Configure a custom provider with `extra_body: store: false` (e.g. pioneer provider). Regular chat completions send `store: false` correctly, but background review (skill/memory updates) and curator calls do not — the provider stores these requests when it shouldn't.

## Fix

- **`agent/background_review.py`**: The background review agent now inherits `request_overrides` from the parent agent via `getattr(agent, "request_overrides", None)`.
- **`agent/curator.py`**: The curator agent now extracts `request_overrides` from the resolved runtime provider (`_rp.get("request_overrides")`), matching the behavior of the main agent initialization path.

## Root Cause

Both agent creation sites (`background_review.py:648` and `curator.py:1878`) called `AIAgent(...)` without passing `request_overrides`. Since `init_agent` defaults `request_overrides` to `{}`, the provider's `extra_body` config was silently dropped for these auxiliary LLM calls.

## Testing

- Both files pass `py_compile` syntax check
- The fix is minimal (4 lines added) and follows the existing pattern used in `cli_commands_mixin.py` which already passes `request_overrides` to its background agent
