### PR TITLE
Keep file sync-back safe on Python 3.11

### DIFF
--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -471,3 +471,27 @@ class TestSyncBackSizeCap:
         # Default cap (2 GiB) is far above our tiny tar; extraction should proceed
         mgr.sync_back(hermes_home=tmp_path / ".hermes")
         assert Path(host_file).read_bytes() == b"remote_version"
+
+    def test_sync_back_skips_unsafe_tar_member(self, tmp_path, caplog):
+        """Path traversal entries are ignored during sync-back extraction."""
+        host_file = _write_file(tmp_path / "host_skill.md", b"original")
+
+        def download_fn(dest: Path):
+            with tarfile.open(dest, "w") as tar:
+                info = tarfile.TarInfo(name="../escape.txt")
+                content = b"escaped"
+                info.size = len(content)
+                tar.addfile(info, io.BytesIO(content))
+
+        mgr = _make_manager(
+            tmp_path,
+            file_mapping=[(host_file, "/root/.hermes/skill.md")],
+            bulk_download_fn=download_fn,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+            mgr.sync_back(hermes_home=tmp_path / ".hermes")
+
+        assert not (tmp_path / "escape.txt").exists()
+        assert Path(host_file).read_bytes() == b"original"
+        assert any("unsafe tar member" in r.message for r in caplog.records)

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -46,6 +46,30 @@ BulkDownloadFn = Callable[[Path], None]  # (dest_tar_path) -> writes tar archive
 DeleteFn = Callable[[list[str]], None]  # (remote_paths) -> raises on failure
 GetFilesFn = Callable[[], list[tuple[str, str]]]  # () -> [(host_path, remote_path), ...]
 
+def _safe_tar_members(tar: tarfile.TarFile) -> list[tarfile.TarInfo]:
+    """Return tar members safe to extract into a staging directory.
+
+    Mirrors the important parts of Python 3.12's data filter for the sync-back
+    use case while keeping Python 3.11 compatibility: no absolute paths, no
+    parent traversal, and no links or special files.
+    """
+    members: list[tarfile.TarInfo] = []
+    for member in tar.getmembers():
+        name = member.name
+        parts = [part for part in name.split("/") if part not in ("", ".")]
+        if name.startswith("/") or ".." in parts:
+            logger.warning("sync_back: skipping unsafe tar member %s", name)
+            continue
+        if member.issym() or member.islnk() or member.isdev():
+            logger.warning("sync_back: skipping unsafe tar member %s", name)
+            continue
+        if not (member.isfile() or member.isdir()):
+            logger.warning("sync_back: skipping unsupported tar member %s", name)
+            continue
+        members.append(member)
+    return members
+
+
 
 def iter_sync_files(container_base: str = "/root/.hermes") -> list[tuple[str, str]]:
     """Enumerate all files that should be synced to a remote environment.
@@ -350,7 +374,7 @@ class FileSyncManager:
 
             with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
                 with tarfile.open(tf.name) as tar:
-                    tar.extractall(staging, filter="data")
+                    tar.extractall(staging, members=_safe_tar_members(tar))
 
                 applied = 0
                 upload_only_host_paths = (


### PR DESCRIPTION
## Summary
- replace Python 3.12-only tar.extractall(filter=...) usage with an explicit safe member filter
- keep sync-back extraction protected from traversal, links, devices, and unsupported tar entries on Python 3.11
- add a regression test for unsafe tar members

## Tests
- python -m pytest tests/tools/test_file_sync_back.py -q