### PR TITLE
fix(tools): keep cross-agent file-state coordination alive on remote backends

### DIFF
--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -22,8 +22,10 @@ import tempfile
 import threading
 import time
 import unittest
+from unittest.mock import patch
 
 from tools import file_state
+from tools.file_operations import ReadResult, WriteResult
 from tools.file_tools import (
     read_file_tool,
     write_file_tool,
@@ -184,6 +186,158 @@ class FileToolsIntegrationTests(unittest.TestCase):
         w = json.loads(write_file_tool(path=p, content="hi\n", task_id="agentX"))
         self.assertFalse(w.get("_warning"))
         self.assertNotIn("error", w)
+
+
+class UnstatablePathUnitTests(unittest.TestCase):
+    """Paths the HOST cannot stat — the remote-backend case.
+
+    When TERMINAL_ENV routes file operations to a sandboxed backend
+    (docker, singularity, ssh, modal, daytona), the resolved path names a
+    file inside the sandbox, so ``os.path.getmtime`` on the host raises
+    OSError even though the file exists remotely.  The registry must keep
+    its wall-clock protections (sibling detection, partial-read and
+    write-without-read warnings, delegate reminders) — only the host-mtime
+    drift check is meaningless there.
+    """
+
+    def setUp(self) -> None:
+        file_state.get_registry().clear()
+        self._tmpdir = tempfile.mkdtemp(prefix="hermes_fs_sandbox_")
+        # Never created — getmtime deterministically raises OSError.
+        self._nx = os.path.join(self._tmpdir, "workspace", "app.py")
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        file_state.get_registry().clear()
+
+    def test_record_read_still_records_stamp(self):
+        file_state.record_read("A", self._nx)
+        self.assertEqual(file_state.known_reads("A"), [self._nx])
+
+    def test_note_write_still_records_writer(self):
+        since = time.time() - 1.0
+        file_state.note_write("B", self._nx)
+        out = file_state.writes_since("A", since, [self._nx])
+        self.assertEqual(out, {"B": [self._nx]})
+
+    def test_sibling_write_detected(self):
+        file_state.record_read("A", self._nx)
+        time.sleep(0.01)
+        file_state.note_write("B", self._nx)
+        warn = file_state.check_stale("A", self._nx)
+        self.assertIsNotNone(warn)
+        self.assertIn("B", warn)
+        self.assertIn("sibling", warn.lower())
+
+    def test_write_without_read_flagged(self):
+        file_state.note_write("B", self._nx)
+        warn = file_state.check_stale("A", self._nx)
+        self.assertIsNotNone(warn)
+        self.assertIn("never read", warn)
+
+    def test_partial_read_flagged_on_write(self):
+        file_state.record_read("A", self._nx, partial=True)
+        warn = file_state.check_stale("A", self._nx)
+        self.assertIsNotNone(warn)
+        self.assertIn("partial", warn.lower())
+
+    def test_own_write_then_write_is_clean(self):
+        file_state.record_read("A", self._nx)
+        file_state.note_write("A", self._nx)
+        self.assertIsNone(file_state.check_stale("A", self._nx))
+
+    def test_delegate_reminder_wiring(self):
+        # Mirrors delegate_tool: snapshot parent reads, then ask which of
+        # them a child rewrote after the delegation started.
+        file_state.record_read("parent", self._nx)
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write("child", self._nx)
+        parent_reads = file_state.known_reads("parent")
+        out = file_state.writes_since("parent", since, parent_reads)
+        self.assertIn("child", out)
+        self.assertIn(self._nx, out["child"])
+
+    def test_host_deleted_file_still_not_stale(self):
+        # Preserved semantics: when the stamp DID carry a real host mtime
+        # (file existed locally at read time) and the file has since been
+        # deleted, the write recreates it — not stale.
+        fd, p = tempfile.mkstemp(prefix="hermes_file_state_test_", suffix=".txt")
+        os.close(fd)
+        try:
+            file_state.record_read("A", p)
+            time.sleep(0.01)
+            file_state.note_write("B", p)
+        finally:
+            os.unlink(p)
+        self.assertIsNone(file_state.check_stale("A", p))
+
+
+class _RemoteFileOps:
+    """File ops whose bytes live inside the backend, not on the host FS.
+
+    Stands in for what ``_get_file_ops`` hands back on a remote terminal
+    env: reads and writes succeed against the sandbox while the resolved
+    path stays unstatable from the host.
+    """
+
+    def __init__(self, content: str = "seed\n") -> None:
+        self.content = content
+
+    def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
+        return ReadResult(
+            content=self.content,
+            total_lines=len(self.content.splitlines()),
+            file_size=len(self.content),
+        )
+
+    def write_file(self, path: str, content: str) -> WriteResult:
+        self.content = content
+        return WriteResult(bytes_written=len(content))
+
+
+class UnstatablePathHandlerTests(unittest.TestCase):
+    """The remote-backend case through the real file-tool handlers.
+
+    ``UnstatablePathUnitTests`` pins the registry semantics directly, but
+    production reaches the registry through ``read_file_tool`` /
+    ``write_file_tool`` — so the sibling warning must survive that wiring
+    too when the host cannot stat the path.
+    """
+
+    def setUp(self) -> None:
+        file_state.get_registry().clear()
+        self._tmpdir = tempfile.mkdtemp(prefix="hermes_fs_remote_")
+        # Backend-side path: never created on the host, so every getmtime()
+        # the handlers attempt raises OSError — as it does for a file that
+        # only exists inside the sandbox.
+        self._remote = os.path.join(self._tmpdir, "workspace", "app.py")
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        file_state.get_registry().clear()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_sibling_write_surfaces_warning_through_handler(self, mock_get):
+        mock_get.return_value = _RemoteFileOps()
+
+        r = json.loads(read_file_tool(path=self._remote, task_id="agentA"))
+        self.assertNotIn("error", r)
+
+        w_b = json.loads(
+            write_file_tool(path=self._remote, content="B wrote\n", task_id="agentB")
+        )
+        self.assertNotIn("error", w_b)
+
+        w_a = json.loads(
+            write_file_tool(path=self._remote, content="A stale\n", task_id="agentA")
+        )
+        warn = w_a.get("_warning", "")
+        self.assertTrue(warn, f"expected warning, got: {w_a}")
+        self.assertIn("agentB", warn)
+        self.assertIn("sibling", warn.lower())
 
 
 if __name__ == "__main__":

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -26,6 +26,14 @@ since_ts, paths)`` for the subagent-completion reminder in delegate_tool.
 
 All methods are no-ops when ``HERMES_DISABLE_FILE_STATE_GUARD=1`` is set.
 
+When the resolved path lives inside a remote terminal backend (docker,
+singularity, ssh, modal, daytona, ...) the host cannot stat it.  Stamps
+are then recorded with ``mtime=None`` and staleness falls back to pure
+wall-clock ordering: sibling-write detection, partial-read and
+write-without-read warnings all still fire; only the host-mtime drift
+check (external edits) is skipped, since a host mtime says nothing about
+a sandboxed file.
+
 This module is intentionally separate from ``_read_tracker`` in
 ``file_tools.py`` — that tracker is per-task and handles consecutive-read
 loop detection, which is a different concern.
@@ -45,7 +53,9 @@ from typing import Dict, Iterable, List, Optional, Tuple
 # (mtime, read_ts, partial).  partial=True when read_file returned a
 # windowed view (offset > 1 or limit < total_lines) — writes that happen
 # after a partial read should still warn so the model re-reads in full.
-ReadStamp = Tuple[float, float, bool]
+# mtime is None when the host could not stat the path at stamp time
+# (path resolved inside a remote terminal backend, or file vanished).
+ReadStamp = Tuple[Optional[float], float, bool]
 
 # Number of resolved-path entries retained per agent.  Bounded to keep
 # long sessions from accumulating unbounded state.  On overflow we drop
@@ -104,11 +114,18 @@ class FileStateRegistry:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
-                return
+                # Host can't stat the path (resolved inside a remote
+                # backend, or already gone).  Keep the stamp anyway —
+                # wall-clock ordering still powers sibling detection.
+                mtime = None
         now = time.time()
         with self._state_lock:
             agent_reads = self._reads[task_id]
-            agent_reads[resolved] = (float(mtime), now, bool(partial))
+            agent_reads[resolved] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                bool(partial),
+            )
             _cap_dict(agent_reads, _MAX_PATHS_PER_AGENT)
 
     def note_write(
@@ -130,13 +147,20 @@ class FileStateRegistry:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
-                return
+                # Same as record_read: a host-unstatable path must still
+                # land in the last-writer map, or sibling detection and
+                # the delegate reminder silently vanish on remote backends.
+                mtime = None
         now = time.time()
         with self._state_lock:
             self._last_writer[resolved] = (task_id, now)
             _cap_dict(self._last_writer, _MAX_GLOBAL_WRITERS)
             # Writer's own view is now up-to-date.
-            self._reads[task_id][resolved] = (float(mtime), now, False)
+            self._reads[task_id][resolved] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                False,
+            )
             _cap_dict(self._reads[task_id], _MAX_PATHS_PER_AGENT)
 
     def check_stale(self, task_id: str, resolved: str) -> Optional[str]:
@@ -163,11 +187,22 @@ class FileStateRegistry:
         if stamp is None and last_writer is None:
             return None
 
+        read_mtime: Optional[float] = None
+        if stamp is not None:
+            read_mtime = stamp[0]
+
+        current_mtime: Optional[float] = None
         try:
             current_mtime = os.path.getmtime(resolved)
         except OSError:
-            # File doesn't exist — write will create it; not stale.
-            return None
+            # Host can't stat the path.  If our stamp carried a real host
+            # mtime, the file existed locally at read time and has since
+            # been deleted — the write will recreate it; not stale.
+            # Otherwise the path resolves inside a remote backend where
+            # host stat is meaningless: fall through to the wall-clock
+            # checks below, which don't touch the filesystem.
+            if read_mtime is not None:
+                return None
 
         # Case 1: sibling subagent modified after our last read.
         if last_writer is not None:
@@ -189,10 +224,16 @@ class FileStateRegistry:
                         "Re-read the file before writing."
                     )
 
-        # Case 2: external / unknown modification (mtime drifted).
+        # Case 2: external / unknown modification (mtime drifted).  Only
+        # meaningful when both the stamp and the current host stat are
+        # real — skipped for sandboxed paths (see module docstring).
         if stamp is not None:
-            read_mtime, _read_ts, partial = stamp
-            if current_mtime != read_mtime:
+            _read_mtime, _read_ts, partial = stamp
+            if (
+                read_mtime is not None
+                and current_mtime is not None
+                and current_mtime != read_mtime
+            ):
                 return (
                     f"{resolved} was modified since you last read it "
                     "on disk (external edit or unrecorded writer). "


### PR DESCRIPTION
## What does this PR do?

Keeps cross-agent file state coordination working on remote terminal
backends. `FileStateRegistry` in `tools/file_state.py` stamps every read and
write with a host `os.path.getmtime`; when the host can't stat the path,
which is every workspace path under `TERMINAL_ENV=docker / singularity /
ssh / modal / daytona`, `record_read` and `note_write` dropped the stamp
entirely and `check_stale` declared every write safe. The whole registry
became a no-op in remote deployments: no "modified by sibling subagent"
warnings from `write_file`/`patch`, no delegate_task "subagent modified
files you read" reminder, empty `known_reads` telemetry.

The fix records stamps with `mtime=None` when the host stat fails and lets
staleness fall back to wall-clock ordering, which is all that sibling-write
detection, the partial-read warning and the write-without-read warning ever
needed. Only the host-mtime drift check (external edits) is skipped for such
paths, since a host mtime says nothing about a sandboxed file. The registry
stays environment-agnostic and local behavior is unchanged, including the
deleted-file case: a stamp that carried a real mtime still treats a missing
path as not stale.

## Related Issue

Fixes #56656

**Sibling PR, not a duplicate.** #56383 fixes a different failure of the same
registry (the dedup stub and the staleness warning on the local path) and
touches `tools/file_state.py` as well. The two are independent; if both land,
taking #56383 first keeps this one's pick clean.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_state.py`
  - `record_read` / `note_write`: on host-stat `OSError`, record the stamp
    with `mtime=None` instead of returning without recording
  - `check_stale`: on host-stat `OSError`, short-circuit to "not stale" only
    when the read stamp carried a real host mtime (a locally deleted file);
    otherwise fall through to the wall-clock checks. The mtime-drift
    comparison now runs only when both the stamped and the current mtime are
    real
  - `ReadStamp` widened to `Tuple[Optional[float], float, bool]`; module
    docstring documents the remote-backend stamp semantics
- `tests/tools/test_file_state_registry.py`
  - new `UnstatablePathUnitTests` class (8 tests): stamps recorded for
    host-unstatable paths, sibling-write detected, write-without-read and
    partial-read still flagged, own-write clean, delegate reminder wiring,
    plus a regression pin for the local deleted-file semantics
  - new `UnstatablePathHandlerTests` class (1 test), added in response to
    review on this PR: the same sibling-write warning driven through
    `read_file_tool` / `write_file_tool`, the path production actually
    takes into the registry

## How to Test

1. `python -m pytest tests/tools/test_file_state_registry.py -q`, cherry-picked
   onto current main: 16 passed.
2. On `main` without the fix but with the new tests in place: 7 failed,
   9 passed. That is 7 of the 9 new tests failing (both stamp-recording tests,
   sibling-write detection, write-without-read, partial-read, delegate wiring,
   and the handler-level sibling-write warning driven through `read_file_tool`
   / `write_file_tool`). The 2 new tests that pass on `main` pin behavior that
   must not change: own-write-then-write stays clean, and a locally deleted
   file is still not stale. The other 7 passing are the file's pre-existing
   tests, unchanged by this PR.
3. Quick manual check, no backend required:

```python
from tools import file_state

reg = file_state.get_registry()
nx = "/workspace/app.py"  # any path the host can't stat

reg.record_read("agent_a", nx)
reg.note_write("agent_b", nx)
print(reg.check_stale("agent_a", nx))
```

Before: `None`. After: the "modified by sibling subagent" warning.

Verified on Windows 11, Python 3.13.

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31056690490

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. Nearest is #56383, disclosed above.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched suite: 16/16. Full `pytest tests/ -q` in my environment has pre-existing optional-dep collection errors unrelated to this change; the touched path is covered above and by the ubuntu run linked above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): module docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A, no architecture change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): stdlib-only, tests use `tempfile`
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A, no schema change

## Screenshots / Logs

```
$ python -m pytest tests/tools/test_file_state_registry.py -q   # on main, new tests in place
7 failed, 9 passed

$ python -m pytest tests/tools/test_file_state_registry.py -q   # with this PR
16 passed
```
