### PR TITLE
fix(docker): honor configured TMPDIR for session snap/cwd artifacts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -242,6 +242,12 @@ terminal:
 #   docker_forward_env:
 #     - "GITHUB_TOKEN"
 #     - "NPM_TOKEN"
+#   # Optional: explicit env vars set at container creation (visible to all
+#   # processes in the container). TMPDIR also controls where Hermes writes
+#   # its session snapshot/cwd artifacts — set it to a writable path if your
+#   # image's /tmp is not writable by the container user.
+#   # docker_env:
+#   #   TMPDIR: "/workspace/tmp"
 #   # Optional: extra flags passed verbatim to docker run (appended after security defaults).
 #   # Useful for adding capabilities (e.g. apt installs needing SETUID) or custom options.
 #   # Example: add a Linux capability not included by default

--- a/tests/tools/test_docker_tempdir.py
+++ b/tests/tools/test_docker_tempdir.py
@@ -1,0 +1,64 @@
+"""DockerEnvironment must place session snap/cwd artifacts on a writable path.
+
+Docker's ``--tmpfs`` replicates the mode/ownership of the image's existing
+mount point, so images whose /tmp is not world-writable get a root:root 0755
+tmpfs at /tmp. A non-root container user (image ``USER`` or
+``docker_run_as_host_user: true``) then can't write the snapshot wrapper or
+cwd marker (EACCES) and session state tracking breaks. A ``TMPDIR`` configured
+via ``terminal.docker_env`` must be honored for these artifacts.
+"""
+
+import subprocess
+
+from tools.environments import docker as docker_env
+
+
+def _mock_docker(monkeypatch):
+    """Intercept docker CLI calls so no real docker daemon is needed.
+
+    Pre-seeds the cgroup-limit probe cache so the throwaway probe container
+    does not run (same pattern as test_docker_environment.py).
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    docker_env._cgroup_limits_ok = True
+
+    def _run(cmd, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if cmd[1] == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fake-container-id\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+
+class TestDockerTempDir:
+    def test_honors_configured_tmpdir_for_session_artifacts(self, monkeypatch):
+        _mock_docker(monkeypatch)
+
+        env = docker_env.DockerEnvironment(
+            image="python:3.11",
+            task_id="test-tmpdir",
+            env={"TMPDIR": "/workspace/tmp/"},
+        )
+
+        assert env.get_temp_dir() == "/workspace/tmp"
+        assert env._snapshot_path == f"/workspace/tmp/hermes-snap-{env._session_id}.sh"
+        assert env._cwd_file == f"/workspace/tmp/hermes-cwd-{env._session_id}.txt"
+
+    def test_defaults_to_tmp_when_tmpdir_not_configured(self, monkeypatch):
+        _mock_docker(monkeypatch)
+        # The HOST TMPDIR must not leak into container artifact paths —
+        # only the explicitly configured docker_env matters.
+        monkeypatch.setenv("TMPDIR", "/host/private/tmp")
+
+        env = docker_env.DockerEnvironment(
+            image="python:3.11",
+            task_id="test-tmpdir-default",
+        )
+
+        assert env.get_temp_dir() == "/tmp"
+        assert env._snapshot_path == f"/tmp/hermes-snap-{env._session_id}.sh"
+        assert env._cwd_file == f"/tmp/hermes-cwd-{env._session_id}.txt"

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -599,12 +599,15 @@ class DockerEnvironment(BaseEnvironment):
     ):
         if cwd == "~":
             cwd = "/root"
+        # Normalized before base init: BaseEnvironment.__init__ calls
+        # get_temp_dir() to place the session snap/cwd artifacts, and our
+        # override reads the configured docker_env TMPDIR from self._env.
+        self._env = _normalize_env_dict(env)
         super().__init__(cwd=cwd, timeout=timeout)
         self._persistent = persistent_filesystem
         self._persist_across_processes = persist_across_processes
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
-        self._env = _normalize_env_dict(env)
         self._container_id: Optional[str] = None
         self._labels: dict[str, str] = {}
         self._image: str = ""
@@ -977,6 +980,22 @@ class DockerEnvironment(BaseEnvironment):
 
         # Initialize session snapshot inside the container
         self.init_session()
+
+    def get_temp_dir(self) -> str:
+        """Return the in-container temp dir for session snap/cwd artifacts.
+
+        /tmp inside the container is not always writable: docker's ``--tmpfs``
+        preserves the mode of the image's existing mount point, so images
+        whose /tmp is not world-writable end up with a root:root 0755 tmpfs.
+        A non-root container user (image ``USER`` or
+        ``docker_run_as_host_user: true``) then gets EACCES writing the
+        snapshot wrapper and cwd marker, which breaks multi-step state
+        (cwd/env tracking) for every command. Honor a ``TMPDIR`` configured
+        via ``terminal.docker_env`` so operators can point the artifacts at a
+        writable path; fall back to the base default (/tmp).
+        """
+        tmpdir = self._env.get("TMPDIR", "").strip().rstrip("/")
+        return tmpdir or super().get_temp_dir()
 
     def _build_init_env_args(self) -> list[str]:
         """Build -e KEY=VALUE args for injecting host env vars into init_session.


### PR DESCRIPTION
## What does this PR do?

Makes `DockerEnvironment` honor a `TMPDIR` configured via `terminal.docker_env` when placing its session artifacts (snapshot wrapper `hermes-snap-<id>.sh` and cwd marker `hermes-cwd-<id>.txt`), instead of always using `/tmp`.

Why it matters: the docker hardening args mount `--tmpfs /tmp` (`tools/environments/docker.py:342`), and docker's `--tmpfs` replicates the mode/ownership of the image's existing mount point. On images whose `/tmp` is not world-writable, the tmpfs comes up `root:root 0755` — and a non-root container user (image `USER`, or `docker_run_as_host_user: true`) gets `EACCES` writing the snapshot wrapper. That breaks cwd/env tracking for every command in the session, with no configuration escape hatch.

The fix is the idiomatic one: `BaseEnvironment` already exposes the `get_temp_dir()` hook for exactly this (LocalEnvironment overrides it for Termux). This PR adds the docker override returning the **container-side** `TMPDIR` from `terminal.docker_env`, falling back to `/tmp`. The host `TMPDIR` is deliberately not consulted — a host path is meaningless inside the container (see the regression test pinning that).

Related: #52415 / PR #52420 fix hardcoded `/tmp` for Termux and terminal-adjacent paths (host-side `TMPDIR`); this PR covers the docker backend, which that work cannot reach.

## Related Issue

Fixes #56648

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py` — add `DockerEnvironment.get_temp_dir()` honoring `self._env["TMPDIR"]` (docker_env) with fallback to the base default; move `self._env = _normalize_env_dict(env)` above `super().__init__()` because the base constructor calls the hook to place the artifacts.
- `tests/tools/test_docker_tempdir.py` — new, mirrors `tests/tools/test_local_tempdir.py`: configured `TMPDIR` is honored for `get_temp_dir()` / `_snapshot_path` / `_cwd_file`; without it the default stays `/tmp` and the **host** `TMPDIR` does not leak into container paths.
- `cli-config.yaml.example` — document the `terminal.docker_env` key (previously undocumented) with the `TMPDIR` note.

## How to Test

1. `pytest tests/tools/test_docker_tempdir.py -q` — 2 tests pass (docker CLI mocked; no daemon needed). Also green: `test_docker_environment.py`, `test_docker_find.py`, `test_docker_cgroup_limits.py`, `test_docker_config_migrate.py`, `test_local_tempdir.py`, `test_ssh_environment.py`, `test_daytona_environment.py`, `test_tool_result_storage.py` (189 tests).
   Full suite via `scripts/run_tests.sh`: 37,695 passed, 39 failed — all 39 failures reproduce identically on unmodified `main` in my environment (host-credential and timing-sensitive tests, e.g. `test_anthropic_adapter.py`, `test_gateway_service.py`); this change introduces zero new failures.
2. Live repro: use an image whose `/tmp` is not world-writable (e.g. `FROM debian:stable-slim` + `RUN chmod 0755 /tmp`) with:
   ```yaml
   terminal:
     backend: docker
     docker_image: <that image>
     docker_run_as_host_user: true
   ```
   Without this patch, the first command fails writing `/tmp/hermes-snap-<id>.sh` (`Permission denied`) and cwd/env state breaks. With this patch plus:
   ```yaml
     docker_env:
       TMPDIR: "/workspace/tmp"
   ```
   the artifacts land on the writable path and multi-step state works.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (via `scripts/run_tests.sh`; the only failures are pre-existing in my environment and fail identically on unmodified `main` — see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on the new override; `cli-config.yaml.example` updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — documented the existing (previously undocumented) `docker_env` key; no new keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — paths are container-internal (always POSIX); tests mock the docker CLI
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
