### PR TITLE
fix(config): keep model api_key string typed on save

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4373,6 +4373,18 @@ def clear_model_endpoint_credentials(
     return model_cfg
 
 
+def _normalize_model_api_key_for_save(config: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(config, dict):
+        return config
+    model_cfg = config.get("model")
+    if not isinstance(model_cfg, dict):
+        return config
+    api_key = model_cfg.get("api_key")
+    if api_key is None or isinstance(api_key, (int, float, bool)):
+        model_cfg["api_key"] = ""
+    return config
+
+
 def get_missing_config_fields() -> List[Dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).
@@ -6599,6 +6611,7 @@ def save_config(
                 raw_existing,
                 _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)),
             )
+        normalized = _normalize_model_api_key_for_save(normalized)
 
         # Strip schema-default values so the user's custom settings are not
         # silently reset on every save.  Keys the user explicitly set (paths

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4381,7 +4381,9 @@ def _normalize_model_api_key_for_save(config: Dict[str, Any]) -> Dict[str, Any]:
         return config
     api_key = model_cfg.get("api_key")
     if api_key is None or isinstance(api_key, (int, float, bool)):
-        model_cfg["api_key"] = ""
+        model_cfg.pop("api_key", None)
+    elif isinstance(api_key, str) and not api_key.strip():
+        model_cfg.pop("api_key", None)
     return config
 
 

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -331,7 +331,7 @@ def test_model_flow_nous_does_not_restore_stale_custom_api_key(tmp_path, monkeyp
         )
     )
 
-    stale_config = yaml.safe_load(config_path.read_text()) or {}
+    stale_config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     selected_model = "deepseek/deepseek-v4-flash"
 
     monkeypatch.setattr(
@@ -369,7 +369,7 @@ def test_model_flow_nous_does_not_restore_stale_custom_api_key(tmp_path, monkeyp
 
     hermes_main._model_flow_nous(stale_config, current_model="glm-5.2")
 
-    config = yaml.safe_load(config_path.read_text()) or {}
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     model = config.get("model")
     assert model["provider"] == "nous"
     assert model["default"] == selected_model
@@ -426,7 +426,7 @@ def test_model_flow_openrouter_clears_stale_custom_key(tmp_path, monkeypatch):
 
     hermes_main._model_flow_openrouter({}, current_model="glm-5.2")
 
-    config = yaml.safe_load(config_path.read_text()) or {}
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     model = config["model"]
     assert model["provider"] == "openrouter"
     assert model["default"] == "anthropic/claude-sonnet-4.6"
@@ -461,7 +461,7 @@ def test_model_flow_anthropic_clears_stale_custom_key_and_mode(tmp_path, monkeyp
 
     hermes_main._model_flow_anthropic({}, current_model="glm-5.2")
 
-    config = yaml.safe_load(config_path.read_text()) or {}
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     model = config["model"]
     assert model["provider"] == "anthropic"
     assert model["default"] == "claude-sonnet-4-6"
@@ -871,7 +871,8 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
     cfg_path.write_text(yaml.dump({}))
 
     monkeypatch.setattr(
-        "hermes_cli.config.load_config", lambda: yaml.safe_load(cfg_path.read_text()) or {},
+        "hermes_cli.config.load_config",
+        lambda: yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {},
     )
     saved = {}
     def _save(cfg):

--- a/tests/hermes_cli/test_clear_stale_base_url.py
+++ b/tests/hermes_cli/test_clear_stale_base_url.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-
-from hermes_cli.config import load_config, save_config, save_env_value, get_env_value
+from hermes_cli.config import (
+    get_env_value,
+    load_config,
+    save_config,
+    save_env_value,
+)
 
 
 def _write_provider(provider: str, model: str = "test-model"):
@@ -72,3 +76,18 @@ class TestClearStaleOpenaiBaseUrl:
         result = get_env_value("OPENAI_BASE_URL")
         assert result == "http://localhost:11434/v1", \
             "Should not clear when provider is not configured"
+
+    def test_numeric_model_api_key_normalizes_to_empty_string(self):
+        from hermes_cli.config import _normalize_model_api_key_for_save
+
+        cfg = {
+            "model": {
+                "provider": "custom:example",
+                "default": "test-model",
+                "api_key": 0,
+            }
+        }
+
+        result = _normalize_model_api_key_for_save(cfg)
+
+        assert result["model"]["api_key"] == ""

--- a/tests/hermes_cli/test_clear_stale_base_url.py
+++ b/tests/hermes_cli/test_clear_stale_base_url.py
@@ -77,7 +77,7 @@ class TestClearStaleOpenaiBaseUrl:
         assert result == "http://localhost:11434/v1", \
             "Should not clear when provider is not configured"
 
-    def test_numeric_model_api_key_normalizes_to_empty_string(self):
+    def test_numeric_model_api_key_is_not_saved(self):
         from hermes_cli.config import _normalize_model_api_key_for_save
 
         cfg = {
@@ -90,4 +90,4 @@ class TestClearStaleOpenaiBaseUrl:
 
         result = _normalize_model_api_key_for_save(cfg)
 
-        assert result["model"]["api_key"] == ""
+        assert "api_key" not in result["model"]


### PR DESCRIPTION
## Summary
- normalize stale numeric/null model.api_key values to an empty string before saving config.yaml
- keep custom-provider auth config from persisting integer 0 as a bearer token candidate
- add regression coverage for the numeric api_key case

Fixes #56535.

## Tests
- python -m pytest tests/hermes_cli/test_clear_stale_base_url.py -q