### PR TITLE
fix(web): guard provider HTTP errors without responses

### DIFF
--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -89,9 +89,10 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             logger.warning("Brave Search HTTP error: %s", exc)
+            status_code = getattr(exc.response, "status_code", "unknown")
             return {
                 "success": False,
-                "error": f"Brave Search returned HTTP {exc.response.status_code}",
+                "error": f"Brave Search returned HTTP {status_code}",
             }
         except httpx.RequestError as exc:
             logger.warning("Brave Search request error: %s", exc)

--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -89,9 +89,10 @@ class SearXNGWebSearchProvider(WebSearchProvider):
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
             logger.warning("SearXNG HTTP error: %s", exc)
+            status_code = getattr(exc.response, "status_code", "unknown")
             return {
                 "success": False,
-                "error": f"SearXNG returned HTTP {exc.response.status_code}",
+                "error": f"SearXNG returned HTTP {status_code}",
             }
         except httpx.RequestError as exc:
             logger.warning("SearXNG request error: %s", exc)

--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -166,6 +166,19 @@ class TestBraveFreeProviderSearch:
         assert result["success"] is False
         assert "429" in result["error"]
 
+    def test_http_error_without_response_returns_failure(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
+
+        err = httpx.HTTPStatusError("boom", request=MagicMock(), response=None)
+
+        with patch("httpx.get", side_effect=err):
+            result = BraveFreeWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "unknown" in result["error"]
+
     def test_request_error_returns_failure(self, monkeypatch):
         import httpx
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -172,6 +172,19 @@ class TestSearXNGSearchProviderSearch:
         assert result["success"] is False
         assert "500" in result["error"]
 
+    def test_http_error_without_response_returns_failure(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        http_err = httpx.HTTPStatusError("boom", request=MagicMock(), response=None)
+
+        with patch("httpx.get", side_effect=http_err):
+            result = SearXNGWebSearchProvider().search("query", limit=5)
+
+        assert result["success"] is False
+        assert "unknown" in result["error"]
+
     def test_request_error_returns_failure(self, monkeypatch):
         import httpx
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")


### PR DESCRIPTION
## Summary
- avoid dereferencing HTTPStatusError.response when Brave/SearXNG error objects have no response
- return structured failure results instead of crashing the agent web tool path
- add provider regressions for response-less HTTPStatusError cases

Fixes #56643.

## Tests
- python -m pytest tests/tools/test_web_providers_brave_free.py::TestBraveFreeProviderSearch tests/tools/test_web_providers_searxng.py::TestSearXNGSearchProviderSearch -q