### PR TITLE
Add gateway push relay contract

### DIFF
--- a/docs/seaclaw-push-relay-contract.md
+++ b/docs/seaclaw-push-relay-contract.md
@@ -1,0 +1,189 @@
+# SeaClaw Push Relay Contract
+
+Hermes emits push **notification intents** only. It does not hold APNs keys,
+certificates, key IDs, team IDs, or provider tokens. A small relay service owns
+APNs credentials and accepts authenticated intent POSTs from Hermes.
+
+## Gateway configuration
+
+```yaml
+push_notifications:
+  enabled: true
+  relay_url: "https://relay.example.com/v1/hermes/notification-intents"
+  relay_token_env: "HERMES_PUSH_RELAY_TOKEN"
+  registration_store: "push_devices.json"
+  redact_body: true
+  timeout_seconds: 3
+  events:
+    - approval.request
+    - clarify.request
+    - message.complete
+    - subagent.complete
+    - background.complete
+    - preview.restart.complete
+```
+
+`HERMES_PUSH_RELAY_TOKEN` is a secret and belongs in `~/.hermes/.env`, never in
+source code. `relay_url` is the exact endpoint Hermes POSTs to.
+
+## iOS registration RPC
+
+SeaClaw registers after it has a live Hermes gateway session. The JSON-RPC
+connection is authenticated by the existing gateway transport/session model.
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "register-push",
+  "method": "push.register",
+  "params": {
+    "session_id": "<live session_id from session.create/resume>",
+    "device_id": "ios-device-stable-id",
+    "platform": "apns",
+    "device_token": "<APNs device token, optional if endpoint_id is set>",
+    "endpoint_id": "<relay-owned endpoint id, optional if device_token is set>",
+    "events": ["approval.request", "clarify.request", "message.complete"],
+    "redact_body": true
+  }
+}
+```
+
+Response never echoes `device_token`:
+
+```json
+{
+  "registration": {
+    "device_id": "ios-device-stable-id",
+    "platform": "apns",
+    "endpoint_id": "relay-endpoint-123",
+    "session_key": "<durable stored_session_id>",
+    "last_live_session_id": "<live session_id>",
+    "events": ["approval.request", "clarify.request", "message.complete"],
+    "redact_body": true,
+    "has_device_token": true,
+    "created_at": "2026-07-01T00:00:00Z",
+    "updated_at": "2026-07-01T00:00:00Z"
+  },
+  "relay": {
+    "enabled": true,
+    "configured": true,
+    "url_configured": true,
+    "token_env": "HERMES_PUSH_RELAY_TOKEN",
+    "token_configured": true
+  }
+}
+```
+
+Use `push.list {session_id}` to inspect registrations for the current session,
+and `push.unregister {session_id, device_id}` to remove one. A registration is
+bound to the durable `session_key`/`stored_session_id`; action callbacks may use
+the included live `session_id` while that turn is active.
+
+## Relay POST shape
+
+Hermes POSTs JSON to `relay_url` with:
+
+```http
+Authorization: Bearer $HERMES_PUSH_RELAY_TOKEN
+Content-Type: application/json
+User-Agent: Hermes-Push-Intent/1
+```
+
+Body:
+
+```json
+{
+  "contract_version": 1,
+  "intent_id": "4f83a4c5b8be4f08b6f4c81725d2a632",
+  "created_at": "2026-07-01T00:00:00Z",
+  "target": {
+    "device_id": "ios-device-stable-id",
+    "platform": "apns",
+    "endpoint_id": "relay-endpoint-123"
+  },
+  "session": {
+    "stored_session_id": "20260701_120000_ab12cd",
+    "session_key": "20260701_120000_ab12cd",
+    "live_session_id": "a1b2c3d4"
+  },
+  "event": {
+    "category": "approval.request",
+    "title": "Hermes approval needed",
+    "body": "Review the pending approval in SeaClaw.",
+    "redacted": true,
+    "row_id": null,
+    "message_id": null
+  },
+  "action_context": {
+    "kind": "approval",
+    "rpc_method": "approval.respond",
+    "params_base": {"session_id": "a1b2c3d4"},
+    "choice_param": "choice",
+    "choices": ["once", "session", "always", "deny"],
+    "fifo_session_keyed": true,
+    "request_id": null
+  }
+}
+```
+
+If `endpoint_id` is absent, `target.device_token` is included instead. The relay
+must treat both as sensitive routing data and should not log raw tokens.
+
+## Implemented event categories
+
+Hermes emits intents for:
+
+| Category | Trigger | Action context |
+| --- | --- | --- |
+| `approval.request` | Terminal/tool approval prompt | `approval.respond` |
+| `clarify.request` | Blocking clarify prompt | `clarify.respond` |
+| `message.complete` | Agent turn completed | none |
+| `subagent.complete` | Delegated child/subagent completion event | none |
+| `background.complete` | Background completion event if emitted by the gateway | none |
+| `preview.restart.complete` | Preview/background restart task completed | none |
+
+Cron deliveries and messaging-platform-only completions are intentionally not
+hooked in this contract yet; they do not flow through the TUI JSON-RPC gateway
+event spine that SeaClaw consumes.
+
+## Action callbacks from iOS
+
+Approval notifications call the existing JSON-RPC method:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "approval-action",
+  "method": "approval.respond",
+  "params": {
+    "session_id": "<live_session_id from intent>",
+    "choice": "once"
+  }
+}
+```
+
+Valid approval choices are `once`, `session`, `always`, and `deny`. Approval
+requests currently have no `request_id`; Hermes resolves them FIFO for the
+durable session key behind the live `session_id`. If multiple approvals are
+pending in one session, SeaClaw cannot target a specific one until Hermes adds
+approval request IDs.
+
+Clarify notifications call:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "clarify-action",
+  "method": "clarify.respond",
+  "params": {
+    "request_id": "<request_id from intent.action_context>",
+    "answer": "User answer"
+  }
+}
+```
+
+When `redact_body` is true, notification title/body are generic. SeaClaw can
+open the app and fetch live gateway state for full content instead of relying on
+the APNs alert body.

--- a/gateway/push_notifications.py
+++ b/gateway/push_notifications.py
@@ -1,0 +1,500 @@
+"""Push notification registration and relay intent helpers.
+
+Hermes never talks to APNs directly.  This module stores profile-local device
+registrations and posts authenticated notification intents to a user-configured
+relay service that owns APNs credentials.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from urllib import request
+from urllib.parse import urlparse
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+CONTRACT_VERSION = 1
+DEFAULT_RELAY_TOKEN_ENV = "HERMES_PUSH_RELAY_TOKEN"
+DEFAULT_STORE_NAME = "push_devices.json"
+DEFAULT_EVENTS = (
+    "approval.request",
+    "clarify.request",
+    "message.complete",
+    "subagent.complete",
+    "background.complete",
+    "preview.restart.complete",
+)
+_EVENTS = frozenset(DEFAULT_EVENTS)
+_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,160}$")
+_ENV_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_CONTROL_RE = re.compile(r"[\r\n\x00]")
+_STORE_LOCK = threading.RLock()
+
+
+class PushRegistrationError(ValueError):
+    """Raised when a push registration request is malformed."""
+
+
+@dataclass(frozen=True)
+class PushConfig:
+    enabled: bool
+    relay_url: str
+    relay_token_env: str
+    relay_token: str
+    events: tuple[str, ...]
+    redact_body: bool
+    timeout_seconds: float
+    store_path: Path
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _coerce_timeout(value: Any) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return 3.0
+    return min(max(parsed, 0.1), 30.0)
+
+
+def _section(raw_config: dict | None) -> dict:
+    if not isinstance(raw_config, dict):
+        return {}
+    if isinstance(raw_config.get("push_notifications"), dict):
+        return raw_config["push_notifications"]
+    gateway = raw_config.get("gateway")
+    if isinstance(gateway, dict) and isinstance(
+        gateway.get("push_notifications"), dict
+    ):
+        return gateway["push_notifications"]
+    return {}
+
+
+def _store_path(raw: Any) -> Path:
+    if isinstance(raw, str) and raw.strip():
+        path = Path(os.path.expandvars(os.path.expanduser(raw.strip())))
+        if not path.is_absolute():
+            path = get_hermes_home() / path
+        return path
+    return get_hermes_home() / DEFAULT_STORE_NAME
+
+
+def _events(raw: Any, default: tuple[str, ...] = DEFAULT_EVENTS) -> tuple[str, ...]:
+    if raw is None:
+        return default
+    if not isinstance(raw, (list, tuple, set)):
+        return default
+    out: list[str] = []
+    for item in raw:
+        event = str(item or "").strip()
+        if event in _EVENTS and event not in out:
+            out.append(event)
+    return tuple(out) if out else default
+
+
+def load_push_config(raw_config: dict | None = None) -> PushConfig:
+    cfg = _section(raw_config)
+    token_env = str(cfg.get("relay_token_env") or DEFAULT_RELAY_TOKEN_ENV).strip()
+    if not _ENV_RE.fullmatch(token_env):
+        token_env = DEFAULT_RELAY_TOKEN_ENV
+    relay_url = str(cfg.get("relay_url") or "").strip()
+    return PushConfig(
+        enabled=_coerce_bool(cfg.get("enabled"), False),
+        relay_url=relay_url,
+        relay_token_env=token_env,
+        relay_token=os.environ.get(token_env, "").strip(),
+        events=_events(cfg.get("events")),
+        redact_body=_coerce_bool(cfg.get("redact_body"), True),
+        timeout_seconds=_coerce_timeout(cfg.get("timeout_seconds")),
+        store_path=_store_path(cfg.get("registration_store")),
+    )
+
+
+def relay_configured(config: PushConfig) -> bool:
+    if not config.enabled or not config.relay_url or not config.relay_token:
+        return False
+    parsed = urlparse(config.relay_url)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _load_store(path: Path) -> dict:
+    if not path.exists():
+        return {"version": 1, "devices": {}}
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f) or {}
+    except Exception as exc:
+        logger.warning("Failed to load push registration store %s: %s", path, exc)
+        return {"version": 1, "devices": {}}
+    devices = data.get("devices")
+    if not isinstance(devices, dict):
+        devices = {}
+    return {"version": 1, "devices": devices}
+
+
+def _save_store(path: Path, store: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(f"{path.suffix}.tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(store, f, indent=2, sort_keys=True)
+        f.write("\n")
+    os.replace(tmp, path)
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _text(value: Any, name: str, *, max_len: int, required: bool = False) -> str:
+    if value is None:
+        if required:
+            raise PushRegistrationError(f"{name} is required")
+        return ""
+    text = str(value).strip()
+    if not text:
+        if required:
+            raise PushRegistrationError(f"{name} is required")
+        return ""
+    if len(text) > max_len:
+        raise PushRegistrationError(f"{name} is too long")
+    if _CONTROL_RE.search(text):
+        raise PushRegistrationError(f"{name} contains control characters")
+    return text
+
+
+def _device_id(params: dict, device_token: str, endpoint_id: str) -> str:
+    raw = str(params.get("device_id") or "").strip()
+    if raw:
+        if not _ID_RE.fullmatch(raw):
+            raise PushRegistrationError(
+                "device_id may only contain letters, digits, _, ., :, or -"
+            )
+        return raw
+    basis = endpoint_id or device_token
+    digest = hashlib.sha256(basis.encode("utf-8")).hexdigest()[:32]
+    return f"device-{digest}"
+
+
+def public_registration(record: dict) -> dict:
+    return {
+        "device_id": record.get("device_id", ""),
+        "platform": record.get("platform", "apns"),
+        "endpoint_id": record.get("endpoint_id") or "",
+        "session_key": record.get("session_key", ""),
+        "last_live_session_id": record.get("last_live_session_id") or "",
+        "events": list(record.get("events") or []),
+        "redact_body": bool(record.get("redact_body", True)),
+        "has_device_token": bool(record.get("device_token")),
+        "created_at": record.get("created_at", ""),
+        "updated_at": record.get("updated_at", ""),
+    }
+
+
+def register_device(
+    params: dict,
+    *,
+    session_key: str,
+    live_session_id: str,
+    raw_config: dict | None = None,
+) -> dict:
+    if not isinstance(params, dict):
+        raise PushRegistrationError("params must be an object")
+    session_key = _text(session_key, "session_key", max_len=256, required=True)
+    live_session_id = _text(live_session_id, "session_id", max_len=128, required=True)
+    device_token = _text(params.get("device_token"), "device_token", max_len=4096)
+    endpoint_id = _text(
+        params.get("endpoint_id") or params.get("device_endpoint"),
+        "endpoint_id",
+        max_len=2048,
+    )
+    if not device_token and not endpoint_id:
+        raise PushRegistrationError("device_token or endpoint_id is required")
+
+    config = load_push_config(raw_config)
+    platform = _text(
+        params.get("platform") or "apns",
+        "platform",
+        max_len=64,
+        required=True,
+    )
+    device_id = _device_id(params, device_token, endpoint_id)
+    now = _utc_now()
+
+    with _STORE_LOCK:
+        store = _load_store(config.store_path)
+        devices = store.setdefault("devices", {})
+        existing = devices.get(device_id) if isinstance(devices.get(device_id), dict) else {}
+        record = {
+            "device_id": device_id,
+            "platform": platform,
+            "device_token": device_token,
+            "endpoint_id": endpoint_id,
+            "session_key": session_key,
+            "last_live_session_id": live_session_id,
+            "events": list(_events(params.get("events"), config.events)),
+            "redact_body": _coerce_bool(params.get("redact_body"), config.redact_body),
+            "created_at": existing.get("created_at") or now,
+            "updated_at": now,
+        }
+        devices[device_id] = record
+        _save_store(config.store_path, store)
+
+    return {
+        "registration": public_registration(record),
+        "relay": {
+            "enabled": config.enabled,
+            "configured": relay_configured(config),
+            "url_configured": bool(config.relay_url),
+            "token_env": config.relay_token_env,
+            "token_configured": bool(config.relay_token),
+        },
+    }
+
+
+def unregister_device(
+    device_id: str,
+    *,
+    session_key: str,
+    raw_config: dict | None = None,
+) -> dict:
+    config = load_push_config(raw_config)
+    normalized = _text(device_id, "device_id", max_len=160, required=True)
+    if not _ID_RE.fullmatch(normalized):
+        raise PushRegistrationError("invalid device_id")
+    session_key = _text(session_key, "session_key", max_len=256, required=True)
+    removed = False
+    with _STORE_LOCK:
+        store = _load_store(config.store_path)
+        devices = store.setdefault("devices", {})
+        record = devices.get(normalized)
+        if isinstance(record, dict) and record.get("session_key") == session_key:
+            devices.pop(normalized, None)
+            removed = True
+            _save_store(config.store_path, store)
+    return {"removed": removed, "device_id": normalized}
+
+
+def list_registrations(*, session_key: str, raw_config: dict | None = None) -> list[dict]:
+    config = load_push_config(raw_config)
+    session_key = _text(session_key, "session_key", max_len=256, required=True)
+    with _STORE_LOCK:
+        store = _load_store(config.store_path)
+        devices = store.get("devices") or {}
+        return [
+            public_registration(record)
+            for record in devices.values()
+            if isinstance(record, dict) and record.get("session_key") == session_key
+        ]
+
+
+def _trim(text: str, max_len: int = 180) -> str:
+    text = " ".join(str(text or "").split())
+    if len(text) <= max_len:
+        return text
+    return f"{text[: max_len - 1].rstrip()}…"
+
+
+def _display_text(event: str, payload: dict, redact_body: bool) -> tuple[str, str]:
+    titles = {
+        "approval.request": "Hermes approval needed",
+        "clarify.request": "Hermes needs clarification",
+        "message.complete": "Hermes response ready",
+        "subagent.complete": "Hermes subagent finished",
+        "background.complete": "Hermes background task finished",
+        "preview.restart.complete": "Hermes preview task finished",
+    }
+    generic = {
+        "approval.request": "Review the pending approval in SeaClaw.",
+        "clarify.request": "Answer the pending question in SeaClaw.",
+        "message.complete": "A response is ready in SeaClaw.",
+        "subagent.complete": "A delegated task finished in SeaClaw.",
+        "background.complete": "A background task finished in SeaClaw.",
+        "preview.restart.complete": "A preview/background task finished in SeaClaw.",
+    }
+    title = titles.get(event, "Hermes notification")
+    if redact_body:
+        return title, generic.get(event, "Open SeaClaw for details.")
+    candidates = (
+        payload.get("description"),
+        payload.get("question"),
+        payload.get("summary"),
+        payload.get("text"),
+        payload.get("rendered"),
+    )
+    body = next((str(c) for c in candidates if c), "")
+    return title, _trim(body) or generic.get(event, "Open SeaClaw for details.")
+
+
+def _action_context(event: str, live_session_id: str, payload: dict) -> dict | None:
+    if event == "approval.request":
+        allow_permanent = _coerce_bool(payload.get("allow_permanent"), True)
+        choices = ["once", "session", "deny"]
+        if allow_permanent:
+            choices.insert(2, "always")
+        return {
+            "kind": "approval",
+            "rpc_method": "approval.respond",
+            "params_base": {"session_id": live_session_id},
+            "choice_param": "choice",
+            "choices": choices,
+            "fifo_session_keyed": True,
+            "request_id": None,
+        }
+    if event == "clarify.request":
+        request_id = str(payload.get("request_id") or "").strip()
+        return {
+            "kind": "clarify",
+            "rpc_method": "clarify.respond",
+            "params_base": {"request_id": request_id},
+            "answer_param": "answer",
+            "choices": list(payload.get("choices") or []),
+            "request_id": request_id,
+        }
+    return None
+
+
+def build_intent(
+    event: str,
+    *,
+    registration: dict,
+    session_key: str,
+    live_session_id: str,
+    payload: dict | None = None,
+) -> dict:
+    if event not in _EVENTS:
+        raise PushRegistrationError(f"unsupported push event: {event}")
+    payload = dict(payload or {})
+    redact_body = bool(registration.get("redact_body", True))
+    title, body = _display_text(event, payload, redact_body)
+    row_id = (
+        payload.get("row_id")
+        or payload.get("message_id")
+        or payload.get("request_id")
+        or payload.get("task_id")
+    )
+    intent = {
+        "contract_version": CONTRACT_VERSION,
+        "intent_id": uuid.uuid4().hex,
+        "created_at": _utc_now(),
+        "target": {
+            "device_id": registration.get("device_id", ""),
+            "platform": registration.get("platform", "apns"),
+        },
+        "session": {
+            "stored_session_id": session_key,
+            "session_key": session_key,
+            "live_session_id": live_session_id or "",
+        },
+        "event": {
+            "category": event,
+            "title": title,
+            "body": body,
+            "redacted": redact_body,
+            "row_id": str(row_id) if row_id else None,
+            "message_id": (
+                str(payload.get("message_id")) if payload.get("message_id") else None
+            ),
+        },
+    }
+    if endpoint_id := str(registration.get("endpoint_id") or "").strip():
+        intent["target"]["endpoint_id"] = endpoint_id
+    elif device_token := str(registration.get("device_token") or "").strip():
+        intent["target"]["device_token"] = device_token
+    if action := _action_context(event, live_session_id, payload):
+        intent["action_context"] = action
+    return intent
+
+
+def _post_intent(config: PushConfig, intent: dict) -> None:
+    body = json.dumps(intent, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    req = request.Request(
+        config.relay_url,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {config.relay_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "Hermes-Push-Intent/1",
+        },
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=config.timeout_seconds) as resp:
+            status = getattr(resp, "status", 200)
+            if status >= 300:
+                logger.warning("Push relay returned HTTP %s", status)
+    except Exception as exc:
+        logger.warning("Push relay delivery failed: %s", exc)
+
+
+Sender = Callable[[PushConfig, dict], None]
+
+
+def notify_event(
+    event: str,
+    *,
+    session_key: str,
+    live_session_id: str,
+    payload: dict | None = None,
+    raw_config: dict | None = None,
+    sender: Sender | None = None,
+    background: bool = True,
+) -> dict:
+    if event not in _EVENTS:
+        return {"queued": 0, "reason": "unsupported_event"}
+    config = load_push_config(raw_config)
+    if not relay_configured(config):
+        return {"queued": 0, "reason": "relay_not_configured"}
+    with _STORE_LOCK:
+        store = _load_store(config.store_path)
+        devices = store.get("devices") or {}
+        records = [
+            dict(record)
+            for record in devices.values()
+            if isinstance(record, dict)
+            and record.get("session_key") == session_key
+            and event in set(record.get("events") or [])
+        ]
+    queued = 0
+    post = sender or _post_intent
+    for record in records:
+        intent = build_intent(
+            event,
+            registration=record,
+            session_key=session_key,
+            live_session_id=live_session_id,
+            payload=payload,
+        )
+        if background and sender is None:
+            threading.Thread(target=post, args=(config, intent), daemon=True).start()
+        else:
+            post(config, intent)
+        queued += 1
+    return {"queued": queued}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1391,6 +1391,26 @@ DEFAULT_CONFIG = {
         "auto_subscribe_on_create": True,
     },
 
+    # Generic push-notification intent relay used by mobile clients such as
+    # SeaClaw. Hermes stores device registrations and POSTs intent envelopes to
+    # a relay service that owns APNs credentials; APNs keys never live here.
+    "push_notifications": {
+        "enabled": False,
+        "relay_url": "",
+        "relay_token_env": "HERMES_PUSH_RELAY_TOKEN",
+        "registration_store": "push_devices.json",
+        "redact_body": True,
+        "timeout_seconds": 3,
+        "events": [
+            "approval.request",
+            "clarify.request",
+            "message.complete",
+            "subagent.complete",
+            "background.complete",
+            "preview.restart.complete",
+        ],
+    },
+
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
@@ -4169,6 +4189,14 @@ OPTIONAL_ENV_VARS = {
     "API_SERVER_KEY": {
         "description": "Bearer token for API server authentication. Required whenever the API server is enabled; server refuses to start without it.",
         "prompt": "API server auth key",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "HERMES_PUSH_RELAY_TOKEN": {
+        "description": "Bearer token Hermes uses to authenticate notification intents with a configured push relay. The relay owns APNs credentials.",
+        "prompt": "Push relay bearer token",
         "url": None,
         "password": True,
         "category": "messaging",

--- a/tests/gateway/test_push_notifications.py
+++ b/tests/gateway/test_push_notifications.py
@@ -1,0 +1,216 @@
+import json
+
+import pytest
+
+from gateway import push_notifications as push
+
+
+def _cfg(tmp_path, **overrides):
+    data = {
+        "enabled": True,
+        "relay_url": "https://relay.example.test/v1/intents",
+        "relay_token_env": "HERMES_PUSH_RELAY_TOKEN",
+        "registration_store": str(tmp_path / "push_devices.json"),
+        "redact_body": True,
+        "events": list(push.DEFAULT_EVENTS),
+    }
+    data.update(overrides)
+    return {"push_notifications": data}
+
+
+def test_register_device_persists_without_echoing_token(tmp_path):
+    result = push.register_device(
+        {
+            "device_id": "ios-device-1",
+            "platform": "apns",
+            "device_token": "apns-token-value",
+            "events": ["approval.request", "clarify.request"],
+        },
+        session_key="stored-session",
+        live_session_id="live-session",
+        raw_config=_cfg(tmp_path),
+    )
+
+    registration = result["registration"]
+    assert registration["device_id"] == "ios-device-1"
+    assert registration["session_key"] == "stored-session"
+    assert registration["last_live_session_id"] == "live-session"
+    assert registration["has_device_token"] is True
+    assert "device_token" not in registration
+
+    store = json.loads((tmp_path / "push_devices.json").read_text())
+    assert store["devices"]["ios-device-1"]["device_token"] == "apns-token-value"
+
+
+@pytest.mark.parametrize(
+    "params,error",
+    [
+        ({"device_id": "../bad", "device_token": "token"}, "device_id"),
+        ({"device_id": "ok"}, "device_token or endpoint_id"),
+        ({"device_id": "ok", "endpoint_id": "bad\nvalue"}, "control characters"),
+    ],
+)
+def test_register_device_rejects_malformed_input(tmp_path, params, error):
+    with pytest.raises(push.PushRegistrationError, match=error):
+        push.register_device(
+            params,
+            session_key="stored-session",
+            live_session_id="live-session",
+            raw_config=_cfg(tmp_path),
+        )
+
+
+def test_build_approval_intent_is_redacted_and_fifo_session_keyed():
+    intent = push.build_intent(
+        "approval.request",
+        registration={
+            "device_id": "ios-device-1",
+            "platform": "apns",
+            "endpoint_id": "relay-endpoint",
+            "redact_body": True,
+        },
+        session_key="stored-session",
+        live_session_id="live-session",
+        payload={
+            "command": "curl -H 'Authorization: token ghp_secret' https://example.test",
+            "description": "Run secret command",
+            "allow_permanent": False,
+        },
+    )
+
+    assert intent["contract_version"] == 1
+    assert intent["target"] == {
+        "device_id": "ios-device-1",
+        "platform": "apns",
+        "endpoint_id": "relay-endpoint",
+    }
+    assert intent["session"]["stored_session_id"] == "stored-session"
+    assert intent["session"]["live_session_id"] == "live-session"
+    assert intent["event"]["category"] == "approval.request"
+    assert intent["event"]["redacted"] is True
+    assert "secret" not in intent["event"]["body"]
+    assert intent["action_context"]["rpc_method"] == "approval.respond"
+    assert intent["action_context"]["params_base"] == {"session_id": "live-session"}
+    assert intent["action_context"]["choices"] == ["once", "session", "deny"]
+    assert intent["action_context"]["fifo_session_keyed"] is True
+    assert intent["action_context"]["request_id"] is None
+
+
+def test_build_clarify_intent_carries_request_id_and_choices():
+    intent = push.build_intent(
+        "clarify.request",
+        registration={
+            "device_id": "ios-device-1",
+            "platform": "apns",
+            "device_token": "apns-token",
+            "redact_body": False,
+        },
+        session_key="stored-session",
+        live_session_id="live-session",
+        payload={
+            "request_id": "clarify-123",
+            "question": "Which branch should I use?",
+            "choices": ["main", "release"],
+        },
+    )
+
+    assert intent["target"]["device_token"] == "apns-token"
+    assert intent["event"]["row_id"] == "clarify-123"
+    assert intent["event"]["body"] == "Which branch should I use?"
+    assert intent["action_context"] == {
+        "kind": "clarify",
+        "rpc_method": "clarify.respond",
+        "params_base": {"request_id": "clarify-123"},
+        "answer_param": "answer",
+        "choices": ["main", "release"],
+        "request_id": "clarify-123",
+    }
+
+
+def test_notify_event_posts_only_registered_events(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_PUSH_RELAY_TOKEN", "relay-secret")
+    config = _cfg(tmp_path)
+    push.register_device(
+        {
+            "device_id": "ios-device-1",
+            "endpoint_id": "relay-endpoint",
+            "events": ["approval.request"],
+            "redact_body": False,
+        },
+        session_key="stored-session",
+        live_session_id="live-session",
+        raw_config=config,
+    )
+    sent = []
+
+    def sender(push_config, intent):
+        sent.append((push_config, intent))
+
+    skipped = push.notify_event(
+        "clarify.request",
+        session_key="stored-session",
+        live_session_id="live-session",
+        payload={"request_id": "clarify-1"},
+        raw_config=config,
+        sender=sender,
+        background=False,
+    )
+    queued = push.notify_event(
+        "approval.request",
+        session_key="stored-session",
+        live_session_id="live-session",
+        payload={"description": "Approve deploy"},
+        raw_config=config,
+        sender=sender,
+        background=False,
+    )
+
+    assert skipped == {"queued": 0}
+    assert queued == {"queued": 1}
+    assert len(sent) == 1
+    assert sent[0][0].relay_token == "relay-secret"
+    assert sent[0][1]["event"]["body"] == "Approve deploy"
+
+
+def test_tui_gateway_push_rpc_methods(tmp_path, monkeypatch):
+    from tui_gateway import server
+
+    config = _cfg(tmp_path, enabled=False)
+    monkeypatch.setattr(server, "_load_cfg", lambda: config)
+    server._sessions["live-session"] = {"session_key": "stored-session"}
+    try:
+        registered = server.handle_request(
+            {
+                "id": "1",
+                "method": "push.register",
+                "params": {
+                    "session_id": "live-session",
+                    "device_id": "ios-device-1",
+                    "endpoint_id": "relay-endpoint",
+                },
+            }
+        )
+        assert registered["result"]["registration"]["device_id"] == "ios-device-1"
+
+        listed = server.handle_request(
+            {
+                "id": "2",
+                "method": "push.list",
+                "params": {"session_id": "live-session"},
+            }
+        )
+        assert [r["device_id"] for r in listed["result"]["registrations"]] == [
+            "ios-device-1"
+        ]
+        assert listed["result"]["relay"]["enabled"] is False
+
+        unregistered = server.handle_request(
+            {
+                "id": "3",
+                "method": "push.unregister",
+                "params": {"session_id": "live-session", "device_id": "ios-device-1"},
+            }
+        )
+        assert unregistered["result"] == {"removed": True, "device_id": "ios-device-1"}
+    finally:
+        server._sessions.pop("live-session", None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -165,6 +165,16 @@ except (ValueError, TypeError):
 _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
+_PUSH_EVENT_TYPES = frozenset(
+    {
+        "approval.request",
+        "clarify.request",
+        "message.complete",
+        "subagent.complete",
+        "background.complete",
+        "preview.restart.complete",
+    }
+)
 
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
@@ -999,6 +1009,28 @@ def _emit(event: str, sid: str, payload: dict | None = None):
     if payload is not None:
         params["payload"] = payload
     write_json({"jsonrpc": "2.0", "method": "event", "params": params})
+    _queue_push_notification(event, sid, payload or {})
+
+
+def _queue_push_notification(event: str, sid: str, payload: dict) -> None:
+    if event not in _PUSH_EVENT_TYPES:
+        return
+    session = _sessions.get(sid) or {}
+    session_key = str(session.get("session_key") or "").strip()
+    if not session_key:
+        return
+    try:
+        from gateway.push_notifications import notify_event
+
+        notify_event(
+            event,
+            session_key=session_key,
+            live_session_id=sid,
+            payload=payload,
+            raw_config=_load_cfg(),
+        )
+    except Exception as exc:
+        logger.warning("Failed to queue push notification intent for %s: %s", event, exc)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -9707,6 +9739,87 @@ def _(rid, params: dict) -> dict:
 
     threading.Thread(target=run, daemon=True).start()
     return _ok(rid, {"task_id": task_id})
+
+
+# ── Methods: push notifications ──────────────────────────────────────
+
+
+@method("push.register")
+def _(rid, params: dict) -> dict:
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    try:
+        from gateway.push_notifications import PushRegistrationError, register_device
+
+        return _ok(
+            rid,
+            register_device(
+                params,
+                session_key=session.get("session_key") or "",
+                live_session_id=params.get("session_id") or "",
+                raw_config=_load_cfg(),
+            ),
+        )
+    except PushRegistrationError as exc:
+        return _err(rid, 4002, str(exc))
+    except Exception as exc:
+        return _err(rid, 5004, str(exc))
+
+
+@method("push.unregister")
+def _(rid, params: dict) -> dict:
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    try:
+        from gateway.push_notifications import PushRegistrationError, unregister_device
+
+        return _ok(
+            rid,
+            unregister_device(
+                params.get("device_id") or "",
+                session_key=session.get("session_key") or "",
+                raw_config=_load_cfg(),
+            ),
+        )
+    except PushRegistrationError as exc:
+        return _err(rid, 4002, str(exc))
+    except Exception as exc:
+        return _err(rid, 5004, str(exc))
+
+
+@method("push.list")
+def _(rid, params: dict) -> dict:
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    try:
+        from gateway.push_notifications import (
+            list_registrations,
+            load_push_config,
+            relay_configured,
+        )
+
+        cfg = load_push_config(_load_cfg())
+        return _ok(
+            rid,
+            {
+                "registrations": list_registrations(
+                    session_key=session.get("session_key") or "",
+                    raw_config=_load_cfg(),
+                ),
+                "relay": {
+                    "enabled": cfg.enabled,
+                    "configured": relay_configured(cfg),
+                    "url_configured": bool(cfg.relay_url),
+                    "token_env": cfg.relay_token_env,
+                    "token_configured": bool(cfg.relay_token),
+                },
+            },
+        )
+    except Exception as exc:
+        return _err(rid, 5004, str(exc))
 
 
 # ── Methods: respond ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a profile-scoped push notification registration store and relay intent sender for SeaClaw-style iOS/APNs relay architecture.
- Add TUI JSON-RPC methods: `push.register`, `push.list`, and `push.unregister`.
- Emit conservative push intents for approval, clarify, turn completion, subagent/background-style completion events.
- Document the iOS registration/action callback contract and relay POST schema in `docs/seaclaw-push-relay-contract.md`.

## Verification
- `scripts/run_tests.sh tests/gateway/test_push_notifications.py tests/gateway/test_tui_approval_redaction.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_drift.py -q`
- `python -m py_compile gateway/push_notifications.py tests/gateway/test_push_notifications.py`

Note: `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` has an unrelated pre-existing failure in `test_browser_manage_connect_default_local_reports_launch_hint` where browser-connect no longer returns the expected “No supported Chromium-family browser executable was found” message.