### PR TITLE
fix(security): strip non-provider secrets from inherited child envs

### DIFF
--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -100,6 +100,35 @@ class TestInheritCredentials:
     def test_pythonutf8_set_when_inheriting(self):
         assert _build(inherit_credentials=True).get("PYTHONUTF8") == "1"
 
+    def test_tool_and_messaging_secrets_stripped_when_inheriting(self):
+        """Provider inheritance must not hand unrelated Hermes secrets to child CLIs.
+
+        Codex/Copilot subprocesses may need LLM provider credentials, but they
+        do not need platform bot credentials, webhook/API-server bearer keys,
+        browser backend keys, or service-account JSON paths used by gateway
+        adapters. Those are non-provider Hermes secrets and must stay Tier-1.
+        """
+        non_provider_secrets = {
+            "MATRIX_ACCESS_TOKEN": "matrix-token",
+            "TEAMS_CLIENT_SECRET": "teams-secret",
+            "WEBHOOK_SECRET": "webhook-secret",
+            "API_SERVER_KEY": "api-server-key",
+            "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON": "/home/user/google-chat-sa.json",
+            "BROWSERBASE_API_KEY": "browserbase-key",
+            "FIRECRAWL_API_KEY": "firecrawl-key",
+        }
+        result = _build(
+            {**_PROVIDER_SAMPLE, **non_provider_secrets},
+            inherit_credentials=True,
+        )
+
+        for var in non_provider_secrets:
+            assert var not in result, (
+                f"{var} must be stripped even with inherit_credentials=True"
+            )
+        for var, val in _PROVIDER_SAMPLE.items():
+            assert result.get(var) == val
+
 
 class TestTierInvariants:
     def test_tier1_always_stripped_both_paths(self):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -213,6 +213,44 @@ def _build_provider_env_blocklist() -> frozenset:
 
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
+
+def _build_non_provider_child_secret_blocklist() -> frozenset:
+    """Secrets that must not leak even to provider-inheriting child CLIs.
+
+    ``inherit_credentials=True`` means "this child may need LLM provider
+    credentials" (Codex/Copilot/TUI hosts), not "this child should receive
+    every Hermes tool and messaging credential".  Keep real provider API keys
+    available, but always strip password-shaped tool/messaging env vars such
+    as MATRIX_ACCESS_TOKEN, WEBHOOK_SECRET, TEAMS_CLIENT_SECRET, and browser
+    backend keys.  Those children do not need Hermes platform/tool secrets.
+    """
+    blocked: set[str] = set()
+    provider_keys: set[str] = set()
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        for pconfig in PROVIDER_REGISTRY.values():
+            provider_keys.update(pconfig.api_key_env_vars)
+    except ImportError:
+        pass
+
+    try:
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        for name, metadata in OPTIONAL_ENV_VARS.items():
+            if not metadata.get("password"):
+                continue
+            if name in provider_keys:
+                continue
+            if metadata.get("category") in {"tool", "messaging"}:
+                blocked.add(name)
+    except ImportError:
+        pass
+    return frozenset(blocked)
+
+
+_NON_PROVIDER_CHILD_SECRET_BLOCKLIST = _build_non_provider_child_secret_blocklist()
+
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries
 # VIRTUAL_ENV (and possibly CONDA_PREFIX). If those leak into commands the
@@ -413,7 +451,7 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
     "MODAL_TOKEN_ID",
     "MODAL_TOKEN_SECRET",
     "DAYTONA_API_KEY",
-})
+}) | _NON_PROVIDER_CHILD_SECRET_BLOCKLIST
 
 
 def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str]:


### PR DESCRIPTION
## Summary

This prevents `hermes_subprocess_env(inherit_credentials=True)` from passing non-provider Hermes tool and messaging secrets into model-driving child processes such as Codex/Copilot app-server subprocesses.

## Why

`inherit_credentials=True` is meant to preserve LLM provider credentials for child CLIs that legitimately need to authenticate to a model provider. It should not also hand those children every Hermes platform/tool secret.

Before this change, password-shaped `OPTIONAL_ENV_VARS` in the `tool` and `messaging` categories survived the inherit path unless they were manually listed in `_ALWAYS_STRIP_KEYS`. That allowed secrets such as:

- `MATRIX_ACCESS_TOKEN`
- `TEAMS_CLIENT_SECRET`
- `WEBHOOK_SECRET`
- `API_SERVER_KEY`
- `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON`
- `BROWSERBASE_API_KEY`
- `FIRECRAWL_API_KEY`

to reach unrelated child processes.

This is the same subprocess credential-boundary class as recent env-leak fixes, but on the provider-inheritance path rather than the default stripped path.

## Changes

- Add a derived always-strip blocklist for password-shaped `tool` and `messaging` env vars from `OPTIONAL_ENV_VARS`.
- Exclude real provider API-key env vars from that derived set so `inherit_credentials=True` still preserves LLM provider credentials.
- Union the derived non-provider secret set into `_ALWAYS_STRIP_KEYS`.
- Add regression coverage proving non-provider tool/messaging secrets are stripped even when provider credentials are inherited.

## Tests

```text
python -m pytest tests/tools/test_hermes_subprocess_env.py -q --timeout-method=thread
19 passed

python -m ruff check tools/environments/local.py tests/tools/test_hermes_subprocess_env.py
All checks passed

python -m compileall -q tools/environments/local.py tests/tools/test_hermes_subprocess_env.py