### PR TITLE
fix(update): skip unsupported Matrix refresh on Windows

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -332,6 +332,50 @@ class TestRefreshActiveFeatures:
         monkeypatch.setattr(ld, "active_features", lambda: [])
         assert ld.refresh_active_features() == {}
 
+    def test_windows_matrix_refresh_is_skipped_before_pip(self, monkeypatch):
+        # Matrix E2EE pulls python-olm, which has no native Windows wheel/build
+        # path. `hermes update` must not retry that doomed install every run.
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+        monkeypatch.setattr(ld, "active_features", lambda: ["platform.matrix"])
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called for unsupported Matrix on Windows"),
+        )
+
+        result = ld.refresh_active_features()
+
+        assert result["platform.matrix"].startswith("skipped:")
+        assert "unsupported on Windows" in result["platform.matrix"]
+
+    def test_windows_matrix_ensure_fails_before_pip(self, monkeypatch):
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called for unsupported Matrix on Windows"),
+        )
+
+        with pytest.raises(ld.FeatureUnavailable, match="unsupported on Windows"):
+            ld.ensure("platform.matrix", prompt=False)
+
+    def test_windows_matrix_already_satisfied_still_works(self, monkeypatch):
+        # Do not break users who already have a working Matrix dependency set;
+        # only the impossible Windows install/refresh path should be blocked.
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called when Matrix deps are current"),
+        )
+
+        ld.ensure("platform.matrix", prompt=False)
+
     def test_already_current_is_noop(self, monkeypatch):
         monkeypatch.setattr(ld, "active_features", lambda: ["test.feat"])
         monkeypatch.setitem(ld.LAZY_DEPS, "test.feat", ("zzzfake==1.0.0",))

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -453,6 +453,22 @@ def _allow_lazy_installs() -> bool:
     return True
 
 
+def _unsupported_feature_reason(feature: str) -> Optional[str]:
+    """Return why a lazy feature cannot work on this host, or ``None``.
+
+    This is a platform capability gate, not a security policy gate. It keeps
+    known-impossible installs out of both first-use lazy installation and the
+    ``hermes update`` lazy-refresh pass.
+    """
+    if sys.platform == "win32" and feature == "platform.matrix":
+        return (
+            "unsupported on Windows: Matrix E2EE depends on python-olm, "
+            "which has no Windows wheel and requires make + libolm to build "
+            "from sdist. Run Hermes under WSL to use Matrix on Windows."
+        )
+    return None
+
+
 def _spec_is_safe(spec: str) -> bool:
     """Reject pip specs that contain URLs, paths, or shell metacharacters."""
     if not spec or len(spec) > 200:
@@ -739,6 +755,10 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
     if not missing:
         return
 
+    unsupported = _unsupported_feature_reason(feature)
+    if unsupported:
+        raise FeatureUnavailable(feature, missing, unsupported)
+
     # Validate every spec against the allowlist + safety regex. Belt and
     # braces — the keys-in-LAZY_DEPS check above already constrains this.
     for spec in missing:
@@ -869,13 +889,24 @@ def refresh_active_features(*, prompt: bool = False) -> dict[str, str]:
         if not missing:
             results[feature] = "current"
             continue
+
+        unsupported = _unsupported_feature_reason(feature)
+        if unsupported:
+            results[feature] = f"skipped: {unsupported}"
+            continue
+
         try:
             ensure(feature, prompt=prompt)
             results[feature] = "refreshed"
         except FeatureUnavailable as e:
-            # Distinguish "user opted out" from "install failed" so the
-            # update command can render the right message.
-            if "lazy installs disabled" in str(e) or "declined" in str(e):
+            # Distinguish "user opted out" or platform-incompatible features
+            # from install failures so the update command can render the
+            # right non-error message.
+            if (
+                "lazy installs disabled" in str(e)
+                or "declined" in str(e)
+                or e.reason.startswith("unsupported ")
+            ):
                 results[feature] = f"skipped: {e.reason}"
             else:
                 results[feature] = f"failed: {e.reason}"


### PR DESCRIPTION
## Summary
- skip the unsupported `platform.matrix` lazy install/refresh path on native Windows when deps are missing or stale
- keep already-satisfied Matrix installs untouched so existing working environments are not broken
- add regression coverage that verifies Windows Matrix refresh/ensure never shells out to pip for the unsupported install path

## Problem
`hermes update` now refreshes active lazy backends so pin bumps propagate to users who previously enabled those backends. After the Matrix lazy dependency set gained a direct `aiohttp` CVE floor, native Windows installs can detect `platform.matrix` as active/stale and try to reinstall the whole group.

That reinstall pulls `mautrix[encryption]` -> `python-olm`. `python-olm` has no native Windows wheel and requires `make` + `libolm` to build from sdist, so the refresh reports a noisy pip failure on every update even though Matrix is already hidden from native Windows setup surfaces.

## Fix
- add a host capability gate for known-unsupported lazy features
- return `skipped: unsupported on Windows ...` for `platform.matrix` during lazy refresh instead of attempting pip/uv
- only apply the gate after checking whether the feature is already satisfied, preserving any environment where Matrix deps are already present and current

## Test Plan
- `uv run --with pytest pytest tests/tools/test_lazy_deps.py -q`
- `uv run --with pytest --with setuptools pytest tests/test_project_metadata.py tests/test_packaging_metadata.py::test_security_pins_present_in_mirrored_lazy_features -q`
- `uv run python -m py_compile tools/lazy_deps.py tests/tools/test_lazy_deps.py`
- `git diff --check`
