### PR TITLE
fix(kanban): validate workspace paths at creation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2817,6 +2817,8 @@ def _validate_persistent_workspace_path(
     """Normalize and validate a workspace path before it is persisted."""
     if workspace_path is not None:
         workspace_path = str(workspace_path).strip() or None
+    if workspace_kind == "dir" and not workspace_path:
+        raise ValueError("workspace_path is required for dir workspaces")
     if not workspace_path or workspace_kind not in {"dir", "worktree"}:
         return workspace_path
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2893,6 +2893,24 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    if workspace_path is not None:
+        workspace_path = str(workspace_path).strip() or None
+    if workspace_path and workspace_kind in {"dir", "worktree"}:
+        # Validate persistent workspace paths before writing the task row.
+        # Waiting until dispatch time leaves an unspawnable task in the DB;
+        # quoted absolute paths like '"/tmp/work"' are especially confusing
+        # because the human-visible value looks absolute while Path sees the
+        # leading quote and treats it as relative.
+        if workspace_path[0] in {'"', "'"} or workspace_path[-1] in {'"', "'"}:
+            raise ValueError(
+                "workspace_path must be an absolute, unquoted path "
+                f"for {workspace_kind} workspaces; got {workspace_path!r}"
+            )
+        if not Path(workspace_path).expanduser().is_absolute():
+            raise ValueError(
+                "workspace_path must be absolute for "
+                f"{workspace_kind} workspaces; got {workspace_path!r}"
+            )
 
     # Resolve an optional first-class Project link. A project-linked task is
     # anchored to the project's primary repo as a git worktree, so its branch

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2811,6 +2811,29 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _validate_persistent_workspace_path(
+    workspace_kind: str, workspace_path: Optional[str]
+) -> Optional[str]:
+    """Normalize and validate a workspace path before it is persisted."""
+    if workspace_path is not None:
+        workspace_path = str(workspace_path).strip() or None
+    if not workspace_path or workspace_kind not in {"dir", "worktree"}:
+        return workspace_path
+
+    # Quoted absolute paths look valid to a human but are relative to pathlib.
+    if workspace_path[0] in {'"', "'"} or workspace_path[-1] in {'"', "'"}:
+        raise ValueError(
+            "workspace_path must be an absolute, unquoted path "
+            f"for {workspace_kind} workspaces; got {workspace_path!r}"
+        )
+    if not Path(workspace_path).expanduser().is_absolute():
+        raise ValueError(
+            "workspace_path must be absolute for "
+            f"{workspace_kind} workspaces; got {workspace_path!r}"
+        )
+    return workspace_path
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2895,22 +2918,6 @@ def create_task(
         raise ValueError("branch_name is only valid for worktree workspaces")
     if workspace_path is not None:
         workspace_path = str(workspace_path).strip() or None
-    if workspace_path and workspace_kind in {"dir", "worktree"}:
-        # Validate persistent workspace paths before writing the task row.
-        # Waiting until dispatch time leaves an unspawnable task in the DB;
-        # quoted absolute paths like '"/tmp/work"' are especially confusing
-        # because the human-visible value looks absolute while Path sees the
-        # leading quote and treats it as relative.
-        if workspace_path[0] in {'"', "'"} or workspace_path[-1] in {'"', "'"}:
-            raise ValueError(
-                "workspace_path must be an absolute, unquoted path "
-                f"for {workspace_kind} workspaces; got {workspace_path!r}"
-            )
-        if not Path(workspace_path).expanduser().is_absolute():
-            raise ValueError(
-                "workspace_path must be absolute for "
-                f"{workspace_kind} workspaces; got {workspace_path!r}"
-            )
 
     # Resolve an optional first-class Project link. A project-linked task is
     # anchored to the project's primary repo as a git worktree, so its branch
@@ -3139,6 +3146,10 @@ def create_task(
                             )
                         except Exception:
                             branch_name = None
+
+                workspace_path = _validate_persistent_workspace_path(
+                    workspace_kind, workspace_path
+                )
 
                 conn.execute(
                     """
@@ -6032,6 +6043,11 @@ def decompose_triage_task(
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
 
+        # Resolve and validate every child workspace before the first direct
+        # INSERT. decompose_triage_task intentionally bypasses create_task() to
+        # preserve one atomic transaction, so it must reuse the same creation
+        # invariant (absolute, unquoted path validation) here.
+
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
         # sees a coherent state, and recompute_ready() at the end
@@ -6045,7 +6061,10 @@ def decompose_triage_task(
             # workspace. A child that sets workspace_kind without a path
             # falls back to the root path only when kinds match (so a
             # child can't accidentally point a 'dir' at the root's
-            # worktree path or vice versa).
+            # worktree path or vice versa). Worktree children never share
+            # the root's literal checkout (concurrency safety). The
+            # resolved path is then validated (absolute, unquoted) before
+            # it is persisted.
             child_ws_kind = child.get("workspace_kind") or root_ws_kind
             if child.get("workspace_path"):
                 child_ws_path = child.get("workspace_path")
@@ -6062,6 +6081,9 @@ def decompose_triage_task(
                 child_ws_path = root_ws_path
             else:
                 child_ws_path = None
+            child_ws_path = _validate_persistent_workspace_path(
+                child_ws_kind, child_ws_path
+            )
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -84,6 +84,7 @@ LEGACY_AUTHOR_MAP = {
     "qlskssk@gmail.com": "Soju06",  # agent turn-latency perf PRs
     "m.guttmann@journaway.com": "mguttmann",  # PR #63738 salvage (Anthropic setup-token pool auth normalization)
     "wangzhe00zju@gmail.com": "flyingdoubleG",  # PR #18166 salvage (memory-provider tools honor disabled_toolsets in initial and MCP-refresh injection)
+    "turgut.kural@outlook.com": "TurgutKural",  # PR #56675 (kanban: validate workspace paths at creation).
     "VrtxOmega@pm.me": "VrtxOmega",  # PR #43809 salvage (desktop: WSL folder-picker path bridge)
     "gn00742754@gmail.com": "SemonCat",  # PR #56786 salvage (Slack Agent View manifests and Assistant APIs)
     "KCAYAAI@users.noreply.github.com": "KCAYAAI",  # PR #62248 partial salvage (resume typing after clarify reply)

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2617,23 +2617,33 @@ def test_cli_show_clamps_negative_elapsed(kanban_home):
     assert "0s" in out_show or "0s" in out_runs
 
 
-def test_resolve_workspace_rejects_relative_dir_path(kanban_home):
-    """dir: workspace_path must be absolute. A relative path like
-    '../../../tmp/attacker' would be resolved against the dispatcher's
-    CWD — a confused-deputy escape vector."""
+def test_create_task_rejects_relative_dir_path(kanban_home):
+    """dir: workspace_path must be absolute at creation time. A relative
+    path like '../../../tmp/attacker' would otherwise sit in the DB until
+    dispatch fails against the dispatcher's CWD."""
     conn = kb.connect()
     try:
-        tid = kb.create_task(
-            conn, title="path-trav", assignee="worker",
-            workspace_kind="dir",
-            workspace_path="../../../tmp/attacker",
-        )
-        task = kb.get_task(conn, tid)
-        # Storage is verbatim — that's fine.
-        assert task.workspace_path == "../../../tmp/attacker"
-        # But resolution must refuse.
-        with pytest.raises(ValueError, match=r"non-absolute"):
-            kb.resolve_workspace(task)
+        with pytest.raises(ValueError, match=r"workspace_path must be absolute"):
+            kb.create_task(
+                conn, title="path-trav", assignee="worker",
+                workspace_kind="dir",
+                workspace_path="../../../tmp/attacker",
+            )
+    finally:
+        conn.close()
+
+
+def test_create_task_rejects_quoted_absolute_dir_path(kanban_home, tmp_path):
+    """A path wrapped in literal quotes looks absolute to a human but is
+    relative to pathlib, so reject it before an unspawnable task is persisted."""
+    conn = kb.connect()
+    try:
+        quoted = f'"{tmp_path / "quoted-workspace"}"'
+        with pytest.raises(ValueError, match=r"unquoted path"):
+            kb.create_task(
+                conn, title="quoted", assignee="worker",
+                workspace_kind="dir", workspace_path=quoted,
+            )
     finally:
         conn.close()
 
@@ -2656,17 +2666,16 @@ def test_resolve_workspace_accepts_absolute_dir_path(kanban_home, tmp_path):
         conn.close()
 
 
-def test_resolve_workspace_rejects_relative_worktree_path(kanban_home):
+def test_create_task_rejects_relative_worktree_path(kanban_home):
     """Worktree paths also must be absolute when explicitly set."""
     conn = kb.connect()
     try:
-        tid = kb.create_task(
-            conn, title="wt", assignee="worker",
-            workspace_kind="worktree",
-            workspace_path="../escape",
-        )
-        with pytest.raises(ValueError, match=r"non-absolute"):
-            kb.resolve_workspace(kb.get_task(conn, tid))
+        with pytest.raises(ValueError, match=r"workspace_path must be absolute"):
+            kb.create_task(
+                conn, title="wt", assignee="worker",
+                workspace_kind="worktree",
+                workspace_path="../escape",
+            )
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -228,3 +228,29 @@ def test_decompose_per_child_workspace_override(kanban_home):
         inh = kb.get_task(conn, child_ids[1])
     assert over.workspace_path == "/other/repo"
     assert inh.workspace_path == proj
+
+
+def test_decompose_rejects_invalid_child_workspace_before_inserts(kanban_home):
+    """Direct child inserts share create_task's persistent-path invariant."""
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+        with pytest.raises(ValueError, match="workspace_path must be absolute"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orchestrator",
+                children=[
+                    {"title": "would otherwise be inserted first"},
+                    {
+                        "title": "invalid persistent child",
+                        "workspace_kind": "dir",
+                        "workspace_path": "../relative-child",
+                    },
+                ],
+                author="decomposer",
+            )
+
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+        assert kb.get_task(conn, tid).status == "triage"

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -254,3 +254,49 @@ def test_decompose_rejects_invalid_child_workspace_before_inserts(kanban_home):
 
         assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
         assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_decompose_dir_child_requires_path_atomic(kanban_home):
+    """A dir child with missing/blank path must be rejected atomically."""
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+        # Case 1: missing workspace_path
+        with pytest.raises(ValueError, match="workspace_path is required for dir workspaces"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orchestrator",
+                children=[
+                    {"title": "valid child"},
+                    {
+                        "title": "dir child without path",
+                        "workspace_kind": "dir",
+                    },
+                ],
+                author="decomposer",
+            )
+
+        # Atomicity: no child rows inserted
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+        assert kb.get_task(conn, tid).status == "triage"
+
+        # Case 2: blank workspace_path
+        with pytest.raises(ValueError, match="workspace_path is required for dir workspaces"):
+            kb.decompose_triage_task(
+                conn,
+                tid,
+                root_assignee="orchestrator",
+                children=[
+                    {
+                        "title": "dir child with blank path",
+                        "workspace_kind": "dir",
+                        "workspace_path": "    ",
+                    },
+                ],
+                author="decomposer",
+            )
+
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+        assert kb.get_task(conn, tid).status == "triage"

--- a/tests/hermes_cli/test_kanban_project_link.py
+++ b/tests/hermes_cli/test_kanban_project_link.py
@@ -40,6 +40,36 @@ def test_project_linked_task_gets_deterministic_worktree_and_branch(kanban_conn)
     assert not task.branch_name.startswith("wt/")
 
 
+def test_project_conversion_rejects_relative_workspace_path(kanban_conn):
+    """Project normalization cannot turn a scratch-path bypass into worktree state."""
+    proj = _make_project(name="Relative Path Guard", repo="/tmp/path-guard")
+
+    with pytest.raises(ValueError, match="workspace_path must be absolute"):
+        kb.create_task(
+            kanban_conn,
+            title="invalid project workspace",
+            project_id=proj.slug,
+            workspace_kind="scratch",
+            workspace_path="../relative-worktree",
+        )
+
+
+@pytest.mark.parametrize("workspace_kind", ["dir", "worktree"])
+def test_resolve_workspace_rejects_legacy_relative_path(kanban_conn, workspace_kind):
+    """Dispatch validation remains a safety rail for pre-fix database rows."""
+    tid = kb.create_task(kanban_conn, title="legacy", assignee="worker")
+    kanban_conn.execute(
+        "UPDATE tasks SET workspace_kind = ?, workspace_path = ? WHERE id = ?",
+        (workspace_kind, "../legacy-relative", tid),
+    )
+    kanban_conn.commit()
+
+    task = kb.get_task(kanban_conn, tid)
+    assert task is not None
+    with pytest.raises(ValueError, match="non-absolute"):
+        kb.resolve_workspace(task)
+
+
 def test_explicit_branch_overrides_project_default(kanban_conn):
     proj = _make_project()
     tid = kb.create_task(

--- a/tests/hermes_cli/test_kanban_project_link.py
+++ b/tests/hermes_cli/test_kanban_project_link.py
@@ -101,3 +101,20 @@ def test_unknown_project_id_falls_back_gracefully(kanban_conn):
     task = kb.get_task(kanban_conn, tid)
     assert task.workspace_kind == "scratch"
     assert task.project_id is None
+
+
+def test_dir_workspace_requires_path(kanban_conn):
+    """dir workspaces must have a non-empty workspace_path."""
+    with pytest.raises(ValueError, match="workspace_path is required for dir workspaces"):
+        kb.create_task(kanban_conn, title="missing path", workspace_kind="dir")
+
+
+def test_dir_workspace_rejects_blank_path(kanban_conn):
+    """A whitespace-only workspace_path must be rejected for dir workspaces."""
+    with pytest.raises(ValueError, match="workspace_path is required for dir workspaces"):
+        kb.create_task(
+            kanban_conn,
+            title="blank path",
+            workspace_kind="dir",
+            workspace_path="    ",
+        )


### PR DESCRIPTION
## Summary
- reject relative dir/worktree workspace paths during task creation instead of persisting unspawnable tasks
- reject literal-quoted absolute paths like \/tmp/work\ before dispatcher spawn
- keep valid absolute dir workspaces accepted

## Test
- python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -k 'workspace_path or workspace'