### PR TITLE
fix(kanban): don't resurrect archived boards from concurrent dispatcher connects

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -231,7 +231,12 @@ class GatewayKanbanWatchersMixin:
                             continue
                         seen_db_paths.add(resolved_db_path)
                         try:
-                            conn = _kb.connect(board=slug)
+                            # create=False: this tick's board list can be
+                            # stale — if the board was archived/removed
+                            # between list_boards() and here, a default
+                            # connect() would resurrect it as an empty
+                            # ghost directory. Skip it instead.
+                            conn = _kb.connect(board=slug, create=False)
                         except Exception as exc:
                             logger.debug("kanban notifier: cannot open board %s: %s", slug, exc)
                             continue
@@ -1006,7 +1011,19 @@ class GatewayKanbanWatchersMixin:
                     )
                 disabled_corrupt_boards.pop(slug, None)
             try:
-                conn = _kb.connect(board=slug)
+                try:
+                    # create=False: the slug came from list_boards() at the
+                    # top of this tick; if the board was archived/removed in
+                    # the meantime, a default connect() would recreate its
+                    # directory + an empty kanban.db (ghost board). Skip.
+                    conn = _kb.connect(board=slug, create=False)
+                except ValueError as exc:
+                    logger.debug(
+                        "kanban dispatcher: board %s vanished before tick "
+                        "(archived/removed?); skipping: %s",
+                        slug, exc,
+                    )
+                    return None
                 # `connect()` runs the schema + idempotent migration on
                 # first open per process; the previous explicit
                 # `init_db()` call here busted the per-process cache and
@@ -1097,7 +1114,9 @@ class GatewayKanbanWatchersMixin:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None
                 try:
-                    conn = _kb.connect(board=slug)
+                    # create=False so a probe racing remove_board() cannot
+                    # resurrect a just-archived board (ghost recreation).
+                    conn = _kb.connect(board=slug, create=False)
                     if _kb.has_spawnable_ready(conn):
                         return True
                     if _kb.has_spawnable_review(conn):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -740,6 +740,30 @@ def create_board(
     return meta
 
 
+def _board_is_empty_shell(db_path: Path) -> bool:
+    """Return True when ``db_path`` looks like a ghost shell: a kanban.db
+    holding zero tasks (or one that can't even be read).
+
+    Ghost shells are the residue of the archive/connect race (see
+    :func:`list_boards`): ``connect()`` used to unconditionally
+    ``mkdir`` + open the DB, so a dispatcher tick that raced
+    ``remove_board()`` recreated ``boards/<slug>/kanban.db`` with an
+    empty schema and no ``board.json``. Opened read-only so the probe
+    itself can never create or touch the file; any failure (missing
+    ``tasks`` table, lock timeout, unreadable file) is treated as
+    "empty shell" — a real, in-use board answers this query trivially.
+    """
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2)
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()
+        finally:
+            conn.close()
+        return not row or int(row[0]) == 0
+    except Exception:
+        return True
+
+
 def list_boards(*, include_archived: bool = True) -> list[dict]:
     """Enumerate all boards that exist on disk.
 
@@ -747,6 +771,19 @@ def list_boards(*, include_archived: bool = True) -> list[dict]:
     metadata dir doesn't exist, because its DB is at the legacy path).
     Other boards are discovered by scanning ``boards/`` for subdirectories
     that either contain a ``kanban.db`` or a ``board.json``.
+
+    Ghost-shell guard: a directory holding a ``kanban.db`` but **no**
+    ``board.json`` and **zero** tasks is skipped. Such shells are
+    produced by a race between ``remove_board(archive=True)`` and the
+    gateway dispatch loop — the dispatcher enumerates boards each tick
+    and then ``connect(board=slug)``s each one, and a tick still holding
+    a just-archived slug used to recreate ``boards/<slug>/kanban.db``
+    via ``mkdir(exist_ok=True)``. Without this filter the resurrected
+    shell is listed forever (it has a ``kanban.db``) and every
+    subsequent tick re-touches it, so the archived board "reappears"
+    as an empty ghost. Boards with a ``board.json`` are always listed,
+    even when empty — a freshly ``create_board``-ed board has no tasks
+    yet and must still show up.
 
     Returns a list of metadata dicts, sorted with ``default`` first and
     the rest alphabetically.
@@ -775,6 +812,10 @@ def list_boards(*, include_archived: bool = True) -> list[dict]:
             has_db = (child / "kanban.db").exists()
             has_meta = (child / "board.json").exists()
             if not (has_db or has_meta):
+                continue
+            if has_db and not has_meta and _board_is_empty_shell(child / "kanban.db"):
+                # Ghost shell resurrected by the archive/connect race —
+                # see the docstring. Not a real board; don't surface it.
                 continue
             meta = read_board_metadata(normed)
             if meta.get("archived") and not include_archived:
@@ -1682,6 +1723,7 @@ def connect(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    create: bool = True,
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
@@ -1692,6 +1734,19 @@ def connect(
     fresh installs and test harnesses that construct `connect()`
     directly don't have to remember a separate init step. Subsequent
     connections skip the schema check via a module-level path cache.
+
+    ``create=False`` refuses to materialize a missing **non-default**
+    board: when the board's ``kanban.db`` does not exist on disk, a
+    :class:`ValueError` (``board '<slug>' does not exist``) is raised
+    instead of ``mkdir`` + creating an empty DB. Long-lived pollers
+    (the gateway dispatcher / notifier, which enumerate boards every
+    tick and then connect to each) must pass ``create=False``:
+    otherwise a tick that races ``remove_board(archive=True)`` — the
+    rename happening between the tick's ``list_boards()`` and its
+    ``connect(board=slug)`` — silently resurrects the just-archived
+    board as an empty ghost directory. The ``default`` board is exempt
+    (it is always creatable lazily; there is no configuration where
+    kanban is usable and ``default`` legitimately "does not exist").
 
     Path resolution:
 
@@ -1705,6 +1760,10 @@ def connect(
         path = db_path
     else:
         path = kanban_db_path(board=board)
+    if not create:
+        requested = _normalize_board_slug(board)
+        if requested and requested != DEFAULT_BOARD and not path.exists():
+            raise ValueError(f"board {requested!r} does not exist")
     path.parent.mkdir(parents=True, exist_ok=True)
 
     # Fast path: once THIS process has initialized this path, the expensive

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -311,6 +311,77 @@ class TestBoardCRUD:
 
 
 # ---------------------------------------------------------------------------
+# Archive/connect race — ghost board resurrection
+# ---------------------------------------------------------------------------
+
+class TestArchiveConnectRaceGhosts:
+    """Regressions for the archive/dispatcher race.
+
+    ``remove_board(archive=True)`` renames ``boards/<slug>/`` away while
+    gateway pollers, holding a board list from the top of their tick,
+    still call ``connect(board=slug)`` — which used to ``mkdir`` +
+    create an empty ``kanban.db``, resurrecting the board as a ghost
+    (kanban.db, no board.json, 0 tasks) that ``list_boards()`` then
+    surfaced forever.
+    """
+
+    def test_list_boards_skips_empty_shell(self, fresh_home):
+        # Real board with a task: listed.
+        kb.create_board("real")
+        with kb.connect(board="real") as conn:
+            kb.create_task(conn, title="t", assignee="dev")
+
+        # board.json-only board (fresh create, no tasks yet): listed.
+        kb.create_board("fresh")
+        db = kb.board_dir("fresh") / "kanban.db"
+        if db.exists():
+            db.unlink()
+
+        # Ghost shell: kanban.db with an empty schema, no board.json —
+        # exactly what a racing connect() used to leave behind.
+        ghost_dir = kb.boards_root() / "ghost"
+        kb.connect(db_path=ghost_dir / "kanban.db").close()
+        assert (ghost_dir / "kanban.db").exists()
+        assert not (ghost_dir / "board.json").exists()
+
+        slugs = [b["slug"] for b in kb.list_boards()]
+        assert "real" in slugs
+        assert "fresh" in slugs
+        assert "ghost" not in slugs
+
+    def test_list_boards_keeps_shell_with_metadata(self, fresh_home):
+        # An empty board WITH board.json is a legitimate new board.
+        kb.create_board("brand-new")
+        assert "brand-new" in [b["slug"] for b in kb.list_boards()]
+
+    def test_connect_create_false_raises_and_does_not_create(self, fresh_home):
+        d = kb.board_dir("nosuch")
+        with pytest.raises(ValueError, match="does not exist"):
+            kb.connect(board="nosuch", create=False)
+        assert not d.exists()
+        assert not kb.board_exists("nosuch")
+
+    def test_connect_create_false_after_archive(self, fresh_home):
+        kb.create_board("archived-race")
+        conn = kb.connect(board="archived-race", create=False)  # exists: OK
+        conn.close()
+        kb.remove_board("archived-race", archive=True)
+        with pytest.raises(ValueError, match="does not exist"):
+            kb.connect(board="archived-race", create=False)
+        # The ghost must not have been resurrected.
+        assert not kb.board_dir("archived-race").exists()
+        assert "archived-race" not in [b["slug"] for b in kb.list_boards()]
+
+    def test_connect_create_false_still_creates_default(self, fresh_home):
+        # `default` is exempt: it is always creatable lazily.
+        conn = kb.connect(board="default", create=False)
+        try:
+            assert kb.list_tasks(conn) == []
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
 # Connection isolation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The bug

Archiving a kanban board races the gateway dispatch loop, and the board reappears as an empty "ghost".

**Mechanism** (`hermes_cli/kanban_db.py`):

1. `remove_board(slug, archive=True)` renames `boards/<slug>/` → `boards/_archived/<slug>-<ts>/`.
2. Meanwhile every gateway's dispatcher/notifier (`gateway/kanban_watchers.py`) calls `list_boards()` at the top of each 60s tick and then `connect(board=slug)` for each entry.
3. `connect()` unconditionally does `path.parent.mkdir(parents=True, exist_ok=True)` and opens the sqlite file — so a tick still holding the just-archived slug **recreates** `boards/<slug>/kanban.db` (empty schema, no `board.json`, 0 tasks).
4. `list_boards()` surfaces any directory containing a `kanban.db` OR a `board.json`, so the ghost is listed forever and every subsequent tick re-touches it. The archived board is "back".

## Production evidence

Reproduced twice in production (v0.17 and v0.18, b3bc30237), on a multi-gateway host whose dispatchers tick every 60s:

- 3 archived boards were recreated as ghosts **within ~1–2 seconds of archival** (dir mtime vs. the `_archived/<slug>-<ts>` timestamp).
- The ghost dirs contained `kanban.db` (+ `-wal`/`-shm` lock sidecars) but **no `board.json`** and **zero rows in `tasks`** — exactly the shape `connect()`'s mkdir-and-init leaves behind.
- The boards' dispatcher lock mtimes kept advancing every tick, confirming the loop was continuously re-opening the resurrected shells.

## The fix (two independent layers)

1. **`connect(..., create=True)` keyword** — with `create=False`, a missing *non-default* board raises `ValueError("board '<slug>' does not exist")` (the module's existing missing-board error shape, cf. `remove_board`) instead of materializing the dir/db. The three per-board connects in `gateway/kanban_watchers.py` that iterate a possibly-stale `list_boards()` snapshot (notifier collect, dispatcher `_tick_once_for_board`, `_ready_nonempty` probe) now pass `create=False` and catch-and-skip, so the race can neither resurrect a board nor crash the watcher. The `default` board stays lazily creatable (there is no valid deployment where it legitimately doesn't exist). Default remains `create=True`, so all existing callers — including the intentional recreate-after-remove path covered by `test_remove_clears_init_cache_for_recreated_db` — are unchanged.
2. **`list_boards()` ghost-shell filter** — a discovered dir with a `kanban.db` but **no** `board.json` and an **empty** `tasks` table is skipped (probed via a read-only `sqlite3.connect("file:...?mode=ro", uri=True, timeout=2)`; any probe failure counts as a shell). This stops already-existing ghosts (from older gateways still running pre-fix code) from being surfaced and re-touched forever. Boards with a `board.json` are always listed even when empty, so freshly created boards remain visible.

## Test coverage

New `TestArchiveConnectRaceGhosts` in `tests/hermes_cli/test_kanban_boards.py`:

- ghost shell (kanban.db, no board.json, 0 tasks) excluded from `list_boards()` while a real board with tasks and a metadata-only (`board.json`, no db) board are both included;
- empty board **with** `board.json` still listed;
- `connect(board=..., create=False)` on a nonexistent board raises and does **not** create the directory;
- archive-then-`connect(create=False)` regression: no resurrection, board stays gone;
- `default` board exemption: `create=False` still lazily creates it.

Results: `tests/hermes_cli/test_kanban_boards.py` + `tests/hermes_cli/test_kanban_db.py` → **284 passed**; gateway kanban watcher suites (`test_kanban_notifier*`, `test_kanban_watchers_mixin`, `test_kanban_auto_decompose_live`) → **21 passed, 2 skipped**. The full `-k kanban` sweep shows 17 failures that are byte-identical on the unmodified base commit (pre-existing ordering/env issues, verified via stash-and-rerun diff) — this change introduces no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
