### PR TITLE
fix(browser): block dialog responses on private pages

### DIFF
--- a/tests/tools/test_browser_dialog_private_guard.py
+++ b/tests/tools/test_browser_dialog_private_guard.py
@@ -1,0 +1,89 @@
+import json
+from types import SimpleNamespace
+
+from tools import browser_dialog_tool as mod
+
+
+class FakeSupervisor:
+    def __init__(self, snapshot):
+        self._snapshot = snapshot
+        self.responded = False
+
+    def snapshot(self):
+        return self._snapshot
+
+    def respond_to_dialog(self, **kwargs):
+        self.responded = True
+        return {
+            "ok": True,
+            "dialog": {"id": kwargs.get("dialog_id") or "dlg-1"},
+        }
+
+
+def _snapshot(url: str, *, frame_id: str = "frame-1"):
+    dialog = SimpleNamespace(id="dlg-1", frame_id=frame_id)
+    return SimpleNamespace(
+        pending_dialogs=(dialog,),
+        frame_tree={
+            "top": {
+                "frame_id": frame_id,
+                "url": url,
+            },
+            "children": [],
+        },
+    )
+
+
+def test_browser_dialog_blocks_private_page(monkeypatch):
+    supervisor = FakeSupervisor(_snapshot("http://127.0.0.1:8080/admin"))
+    monkeypatch.setattr(mod, "SUPERVISOR_REGISTRY", {"task-1": supervisor})
+    monkeypatch.setattr(
+        "tools.browser_tool._eval_ssrf_guard_active",
+        lambda task_id: True,
+    )
+
+    result = json.loads(
+        mod.browser_dialog("accept", dialog_id="dlg-1", task_id="task-1")
+    )
+
+    assert result["success"] is False
+    assert "private/internal page" in result["error"]
+    assert "127.0.0.1" in result["error"]
+    assert supervisor.responded is False
+
+
+def test_browser_dialog_allows_public_page(monkeypatch):
+    supervisor = FakeSupervisor(_snapshot("https://example.com/confirm"))
+    monkeypatch.setattr(mod, "SUPERVISOR_REGISTRY", {"task-1": supervisor})
+    monkeypatch.setattr(
+        "tools.browser_tool._eval_ssrf_guard_active",
+        lambda task_id: True,
+    )
+
+    result = json.loads(
+        mod.browser_dialog("accept", dialog_id="dlg-1", task_id="task-1")
+    )
+
+    assert result["success"] is True
+    assert supervisor.responded is True
+
+
+def test_browser_dialog_skips_probe_when_guard_inactive(monkeypatch):
+    supervisor = FakeSupervisor(_snapshot("http://127.0.0.1:8080/admin"))
+    monkeypatch.setattr(mod, "SUPERVISOR_REGISTRY", {"task-1": supervisor})
+    monkeypatch.setattr(
+        "tools.browser_tool._eval_ssrf_guard_active",
+        lambda task_id: False,
+    )
+
+    def fail_if_called(url):
+        raise AssertionError("URL safety check should not run when guard is inactive")
+
+    monkeypatch.setattr("tools.browser_tool._is_safe_url", fail_if_called)
+
+    result = json.loads(
+        mod.browser_dialog("accept", dialog_id="dlg-1", task_id="task-1")
+    )
+
+    assert result["success"] is True
+    assert supervisor.responded is True

--- a/tools/browser_dialog_tool.py
+++ b/tools/browser_dialog_tool.py
@@ -79,6 +79,58 @@ BROWSER_DIALOG_SCHEMA: Dict[str, Any] = {
 }
 
 
+def _iter_frame_entries(node: Any):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_frame_entries(value)
+    elif isinstance(node, (list, tuple)):
+        for item in node:
+            yield from _iter_frame_entries(item)
+
+
+def _dialog_frame_url(snapshot: Any, dialog_id: Optional[str]) -> Optional[str]:
+    pending = list(getattr(snapshot, "pending_dialogs", ()) or ())
+    if dialog_id:
+        dialog = next((d for d in pending if getattr(d, "id", None) == dialog_id), None)
+    elif len(pending) == 1:
+        dialog = pending[0]
+    else:
+        return None
+    if dialog is None:
+        return None
+
+    frame_id = getattr(dialog, "frame_id", None)
+    frame_tree = getattr(snapshot, "frame_tree", {}) or {}
+    fallback_top_url = None
+    for frame in _iter_frame_entries(frame_tree):
+        url = frame.get("url")
+        if frame.get("frame_id") == frame_id and url:
+            return str(url)
+        if fallback_top_url is None and frame.get("url"):
+            fallback_top_url = str(frame.get("url"))
+    return fallback_top_url
+
+
+def _blocked_private_dialog_url(snapshot: Any, dialog_id: Optional[str], effective_task_id: str) -> Optional[str]:
+    try:
+        from tools.browser_tool import (  # type: ignore[import-not-found]
+            _eval_ssrf_guard_active,
+            _is_always_blocked_url,
+            _is_safe_url,
+        )
+    except Exception as exc:  # pragma: no cover - defensive import guard
+        logger.debug("browser_dialog private-page guard unavailable: %s", exc)
+        return None
+
+    if not _eval_ssrf_guard_active(effective_task_id):
+        return None
+    url = _dialog_frame_url(snapshot, dialog_id)
+    if url and (_is_always_blocked_url(url) or not _is_safe_url(url)):
+        return url
+    return None
+
+
 def browser_dialog(
     action: str,
     prompt_text: Optional[str] = None,
@@ -97,6 +149,19 @@ def browser_dialog(
                     "browser backend doesn't expose CDP (Camofox, default "
                     "Playwright) or no browser session has been started yet. "
                     "Call browser_navigate or /browser connect first."
+                ),
+            }
+        )
+
+    snapshot = supervisor.snapshot()
+    blocked_url = _blocked_private_dialog_url(snapshot, dialog_id, effective_task_id)
+    if blocked_url:
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    "Blocked browser_dialog on a private/internal page: "
+                    f"{blocked_url}"
                 ),
             }
         )


### PR DESCRIPTION
## Summary

Blocks `browser_dialog` from accepting or dismissing JavaScript dialogs when the active dialog belongs to a private/internal page.

## Why

Recent browser SSRF/private-network hardening sealed normal page interactions, console output, vision/images, and raw CDP calls. `browser_dialog` was still a separate response path: it calls `supervisor.respond_to_dialog(...)` directly, so an agent could accept/dismiss a `confirm`, `prompt`, or `beforeunload` dialog on an internal/private page reached through browser navigation state.

That is still a browser interaction against a private page. For example, accepting a confirm dialog on an internal admin page may trigger a state-changing action even though the normal browser tools would now be blocked on that page.

## Changes

- Inspect the CDP supervisor snapshot before responding to a pending dialog.
- Resolve the selected dialog's frame URL from the supervisor frame tree.
- Reuse the existing browser private-network guard policy.
- Return a blocked error instead of calling `respond_to_dialog()` when the dialog is on a private/internal URL.
- Keep local backend / `allow_private_urls` behavior unchanged because the existing guard gate is respected.

## Tests

```text
python -m pytest tests/tools/test_browser_dialog_private_guard.py -q --timeout-method=thread
3 passed

python -m pytest tests/tools/test_browser_cdp_tool.py -q --timeout-method=thread
20 passed

python -m ruff check tools/browser_dialog_tool.py tests/tools/test_browser_dialog_private_guard.py
All checks passed