### PR TITLE
fix(kanban,profiles): strip think blocks before using raw auxiliary LLM output

### DIFF
--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -210,6 +210,15 @@ def specify_task(
     except Exception:
         raw = ""
 
+    # Think-enabled auxiliary models (MiniMax M2.7, DeepSeek, etc.) can emit
+    # inline <think>...</think> reasoning even for this structured-output
+    # prompt. Strip it before both JSON extraction and the raw-text fallback
+    # below — a brace inside the reasoning breaks the greedy first-'{'/last-'}'
+    # slice, and an unterminated block makes the leaked reasoning itself the
+    # fallback task body. Same leak class fixed in agent/title_generator.py.
+    from agent.agent_runtime_helpers import strip_think_blocks
+    raw = strip_think_blocks(None, raw).strip()
+
     parsed = _extract_json_blob(raw)
 
     new_title: Optional[str]

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -257,6 +257,15 @@ def describe_profile(
     except Exception:
         raw = ""
 
+    # Think-enabled auxiliary models (MiniMax M2.7, DeepSeek, etc.) can emit
+    # inline <think>...</think> reasoning even for this structured-output
+    # prompt — max_tokens=400 above makes an unterminated block especially
+    # likely. Strip before both JSON extraction and the raw-text fallback
+    # below, or the leaked reasoning becomes the profile's dashboard-visible
+    # description. Same leak class fixed in agent/title_generator.py.
+    from agent.agent_runtime_helpers import strip_think_blocks
+    raw = strip_think_blocks(None, raw).strip()
+
     parsed = _extract_json_blob(raw)
     if parsed is None:
         # Fall back: take the raw text trimmed to one paragraph.

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -131,6 +131,51 @@ def test_specify_task_falls_back_to_body_only_on_bad_json(kanban_home):
     assert "Goal:" in (t.body or "")
 
 
+def test_specify_task_strips_think_block_from_fallback_body(kanban_home):
+    """A think-enabled auxiliary model's reasoning must not leak into the
+    task body, whether or not it breaks the JSON extraction outright."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="keep title", triage=True)
+
+    content = (
+        "<think>The task mentions a {set} of steps, let me reason about "
+        "this for a bit before answering.</think>\n"
+        '{"title": "Refined", "body": "Concrete plan."}'
+    )
+    p, _ = _patch_aux_client(content)
+    with p:
+        outcome = spec.specify_task(tid)
+
+    assert outcome.ok is True
+    with kb.connect() as conn:
+        t = kb.get_task(conn, tid)
+    assert t.title == "Refined"
+    assert t.body == "Concrete plan."
+    assert "<think>" not in (t.body or "")
+    assert "reason about" not in (t.body or "")
+
+
+def test_specify_task_strips_unterminated_think_block_from_fallback_body(kanban_home):
+    """An unterminated <think> block (truncated by max_tokens) must not
+    become the fallback task body verbatim."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="keep title", triage=True)
+
+    content = "<think>Let me reason about the best plan for this task"
+    p, _ = _patch_aux_client(content)
+    with p:
+        outcome = spec.specify_task(tid)
+
+    # Everything is stripped -> empty raw -> explicit "empty response" failure,
+    # not a leaked-reasoning body.
+    assert outcome.ok is False
+    assert "empty" in outcome.reason.lower()
+    with kb.connect() as conn:
+        t = kb.get_task(conn, tid)
+    assert t.status == "triage"
+    assert "<think>" not in (t.body or "")
+
+
 def test_specify_task_rejects_non_triage_task(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="ready task")

--- a/tests/hermes_cli/test_profile_describer.py
+++ b/tests/hermes_cli/test_profile_describer.py
@@ -160,6 +160,51 @@ def test_describer_handles_malformed_llm_response(profile_env, monkeypatch):
     assert "Plain text description" in (outcome.description or "")
 
 
+def test_describer_strips_think_block_from_fallback_description(profile_env, monkeypatch):
+    """A think-enabled auxiliary model's reasoning must not leak into the
+    profile's dashboard-visible description, whether or not it breaks JSON
+    extraction outright."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+
+    content = (
+        "<think>The profile has a {set} of Python skills, let me reason "
+        "about how to phrase this.</think>\n\n"
+        "Writes Python codebases."
+    )
+    with _patch_aux_client(content), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")
+
+    assert outcome.ok, outcome.reason
+    assert outcome.description == "Writes Python codebases."
+    assert "<think>" not in (outcome.description or "")
+    assert "reason about" not in (outcome.description or "")
+
+
+def test_describer_strips_unterminated_think_block_from_fallback_description(
+    profile_env, monkeypatch
+):
+    """An unterminated <think> block (truncated by max_tokens=400) must not
+    become the fallback description verbatim."""
+    monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: n == "myprof")
+    monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)
+    monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: profile_env)
+
+    content = "<think>Let me reason about the best way to describe this profile"
+    with _patch_aux_client(content), patch(
+        "agent.auxiliary_client.get_auxiliary_extra_body", return_value={}
+    ):
+        outcome = describer.describe_profile("myprof")
+
+    # Everything is stripped -> empty raw -> explicit "empty response"
+    # failure, not a leaked-reasoning description.
+    assert outcome.ok is False
+    assert "empty" in outcome.reason.lower()
+
+
 def test_describer_returns_false_when_profile_missing(profile_env, monkeypatch):
     monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: False)
     monkeypatch.setattr(profiles_mod, "normalize_profile_name", lambda n: n)


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/kanban_specify.py` and `hermes_cli/profile_describer.py` both fall back to the raw auxiliary-model response when `_extract_json_blob()` fails to parse it:

- `kanban_specify.py`: the raw text becomes the promoted kanban task's **body**, visible to every user of that board.
- `profile_describer.py`: the raw text (first `\n\n`-delimited paragraph, `max_tokens=400`) becomes the profile's **dashboard-visible description**.

Think-enabled auxiliary models (MiniMax M2.7, DeepSeek, etc.) can emit inline `<think>...</think>` reasoning even for these structured-output prompts. `_extract_json_blob()` does a naive "first `{` ... last `}`" slice — a brace anywhere inside the reasoning (code snippets, set notation, "the task looks like `{X}`" — all common) breaks the slice and it fails to parse. An **unterminated** think block (token-limit truncation mid-reasoning, especially likely in `profile_describer.py` given its tight `max_tokens=400`) means the JSON never even starts. In both cases, the code falls through to storing the **entire raw response, `<think>` tags included**.

This is the same leak class already fixed once in `agent/title_generator.py` (`3b739b990`, session titles) via the canonical `strip_think_blocks` scrubber. This PR applies the identical fix to the two remaining raw-fallback call sites that never got it.

### Fix

- Route `raw` through `agent.agent_runtime_helpers.strip_think_blocks()` before *both* JSON extraction and the raw-text fallback, in both files — matching `title_generator.py`'s approach exactly.

### Testing

- 4 new regression tests (one closed-`<think>`-pair case + one unterminated-block case, per file), mirroring `title_generator.py`'s existing test coverage:
  - `test_specify_task_strips_think_block_from_fallback_body`
  - `test_specify_task_strips_unterminated_think_block_from_fallback_body`
  - `test_describer_strips_think_block_from_fallback_description`
  - `test_describer_strips_unterminated_think_block_from_fallback_description`
- Full existing suite for both modules passes unmodified: `tests/hermes_cli/test_kanban_specify.py`, `tests/hermes_cli/test_kanban_specify_db.py`, `tests/hermes_cli/test_profile_describer.py` — 44 tests, 0 failures, 0 modified besides the 4 new additions.
- `ruff check` clean on all changed files. `ty check` clean (one pre-existing, unrelated warning on an untouched line in `profile_describer.py`).

## Test plan

- [x] `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_kanban_specify.py tests/hermes_cli/test_profile_describer.py -v` — 34/34 pass
- [x] `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_kanban_specify_db.py -q` — 10/10 pass
- [x] `uv run --frozen --extra dev ruff check hermes_cli/kanban_specify.py hermes_cli/profile_describer.py tests/hermes_cli/test_kanban_specify.py tests/hermes_cli/test_profile_describer.py` — clean
- [x] `uv run --frozen --extra dev ty check hermes_cli/kanban_specify.py hermes_cli/profile_describer.py` — clean (pre-existing unrelated warning noted above)