### PR TITLE
fix: map all Kitty CSI-u control key sequences (Ctrl+C, Esc, etc.)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -77,14 +77,16 @@ except (ImportError, AttributeError):
 
 try:
     from hermes_cli.pt_input_extras import (
+        enable_kitty_keyboard_protocol,
         install_ctrl_enter_alias,
         install_ignored_terminal_sequences,
         install_shift_enter_alias,
     )
+    enable_kitty_keyboard_protocol()
     install_shift_enter_alias()
     install_ctrl_enter_alias()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_ignored_terminal_sequences
+    del enable_kitty_keyboard_protocol, install_shift_enter_alias, install_ctrl_enter_alias, install_ignored_terminal_sequences
 except Exception:
     pass
 import threading

--- a/cli.py
+++ b/cli.py
@@ -80,13 +80,15 @@ try:
         enable_kitty_keyboard_protocol,
         install_ctrl_enter_alias,
         install_ignored_terminal_sequences,
+        install_kitty_control_aliases,
         install_shift_enter_alias,
     )
     enable_kitty_keyboard_protocol()
+    install_kitty_control_aliases()
     install_shift_enter_alias()
     install_ctrl_enter_alias()
     install_ignored_terminal_sequences()
-    del enable_kitty_keyboard_protocol, install_shift_enter_alias, install_ctrl_enter_alias, install_ignored_terminal_sequences
+    del enable_kitty_keyboard_protocol, install_kitty_control_aliases, install_shift_enter_alias, install_ctrl_enter_alias, install_ignored_terminal_sequences
 except Exception:
     pass
 import threading

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -116,28 +116,38 @@ def install_ctrl_enter_alias() -> int:
 
 
 def install_kitty_control_aliases() -> int:
-    """Map Kitty keyboard protocol CSI-u sequences for common control keys
-    (Ctrl+A–Z, Escape) to their corresponding prompt_toolkit ``Keys`` entries.
+    """Map Kitty keyboard protocol CSI-u sequences for all control keys
+    to their corresponding prompt_toolkit ``Keys`` entries.
 
     When :func:`enable_kitty_keyboard_protocol` pushes the terminal into
-    CSI-u mode, *every* modified key is sent as a CSI-u sequence — not just
+    CSI-u mode, *every* key press is sent as a CSI-u sequence — not just
     Shift+Enter and Ctrl+Enter.  prompt_toolkit's stock ``ANSI_SEQUENCES``
     table contains only four CSI-u entries (codepoint 1, modifier 5–8).
     The existing :func:`install_shift_enter_alias` and
     :func:`install_ctrl_enter_alias` cover Enter (codepoint 13), but all
-    other Ctrl+letter combinations (Ctrl+C = ``\\x1b[99;5u``, Ctrl+D =
-    ``\\x1b[100;5u``, …) are unmapped.
+    other Ctrl+key combinations (Ctrl+C = ``\\x1b[99;5u``, Ctrl+D =
+    ``\\x1b[100;5u``, …) and plain Escape (``\\x1b[27u``) are unmapped.
 
     Unmapped CSI-u sequences fall through prompt_toolkit's VT100 parser to
     literal text insertion: the leading ESC fires as ``Keys.Escape``, then
     ``[99;5u`` appears as garbage text in the prompt buffer.  In vi mode
     this is especially disruptive because Escape is the mode-switch key.
 
-    This helper registers CSI-u sequences for all Ctrl+letter keys (a–z,
-    codepoints 97–122, modifier 5 = Ctrl) and plain Escape (codepoint 27,
-    no modifier) so the parser routes them to the correct
-    ``Keys.ControlX`` / ``Keys.Escape`` entries instead of inserting
-    literal text.
+    This helper registers CSI-u sequences for:
+
+    - **Ctrl+A–Z** (codepoints 97–122, modifier 5 = Ctrl)
+    - **Ctrl+0–9** (codepoints 48–57, modifier 5 = Ctrl)
+    - **Ctrl+special chars**: ``@`` (64), ``[`` (91), ``\\`` (92),
+      ``]`` (93), ``^`` (94), ``_`` (95) — all modifier 5 = Ctrl
+    - **Plain Escape** (codepoint 27, no modifier)
+
+    so the parser routes them to the correct ``Keys.ControlX`` /
+    ``Keys.Escape`` entries instead of inserting literal text.
+
+    Sequences for which prompt_toolkit has no corresponding ``Keys`` entry
+    (e.g. Alt+letter = modifier 3, Ctrl+Shift+letter = modifier 6) cannot
+    be mapped and are left untouched.  The parser will still fall through
+    to literal text for those — a limitation of prompt_toolkit's key model.
 
     Also clears the VT100 parser's ``_IS_PREFIX_OF_LONGER_MATCH_CACHE`` so
     the new entries are immediately effective even if a parser has already
@@ -154,8 +164,17 @@ def install_kitty_control_aliases() -> int:
     except Exception:
         return 0
 
-    # Ctrl+A through Ctrl+Z: codepoints 97–122, modifier 5 (Ctrl).
-    _CTRL_LETTERS = {
+    # Map Unicode codepoint → prompt_toolkit Keys for all Ctrl-modified
+    # keys that prompt_toolkit has an enum entry for.
+    #
+    # In the Kitty keyboard protocol, the CSI-u codepoint is the Unicode
+    # code point of the key's base character.  For Ctrl+A the base char is
+    # 'a' (codepoint 97), so the sequence is ESC[97;5u.  For Ctrl+1 the
+    # base char is '1' (codepoint 49), so the sequence is ESC[49;5u.
+    #
+    # Modifier 5 = Ctrl (bit 2 set in the modifier bitmask).
+    _CTRL_CODEPOINTS: dict[int, Keys] = {
+        # Ctrl+A – Ctrl+Z (codepoints 97–122)
         97: Keys.ControlA,
         98: Keys.ControlB,
         99: Keys.ControlC,
@@ -182,10 +201,29 @@ def install_kitty_control_aliases() -> int:
         120: Keys.ControlX,
         121: Keys.ControlY,
         122: Keys.ControlZ,
+        # Ctrl+0 – Ctrl+9 (codepoints 48–57)
+        48: Keys.Control0,
+        49: Keys.Control1,
+        50: Keys.Control2,
+        51: Keys.Control3,
+        52: Keys.Control4,
+        53: Keys.Control5,
+        54: Keys.Control6,
+        55: Keys.Control7,
+        56: Keys.Control8,
+        57: Keys.Control9,
+        # Ctrl+special characters
+        64: Keys.ControlAt,          # Ctrl+@
+        91: Keys.Escape,             # Ctrl+[ — same as Escape
+        92: Keys.ControlBackslash,   # Ctrl+\
+        93: Keys.ControlSquareClose,  # Ctrl+]
+        94: Keys.ControlCircumflex,  # Ctrl+^
+        95: Keys.ControlUnderscore,  # Ctrl+_
+        32: Keys.ControlAt,          # Ctrl+Space — same key as Ctrl+@ (NUL)
     }
 
     changed = 0
-    for codepoint, key in _CTRL_LETTERS.items():
+    for codepoint, key in _CTRL_CODEPOINTS.items():
         seq = f"\x1b[{codepoint};5u"
         if ANSI_SEQUENCES.get(seq) != key:
             ANSI_SEQUENCES[seq] = key

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -115,6 +115,103 @@ def install_ctrl_enter_alias() -> int:
     return changed
 
 
+def install_kitty_control_aliases() -> int:
+    """Map Kitty keyboard protocol CSI-u sequences for common control keys
+    (Ctrl+A–Z, Escape) to their corresponding prompt_toolkit ``Keys`` entries.
+
+    When :func:`enable_kitty_keyboard_protocol` pushes the terminal into
+    CSI-u mode, *every* modified key is sent as a CSI-u sequence — not just
+    Shift+Enter and Ctrl+Enter.  prompt_toolkit's stock ``ANSI_SEQUENCES``
+    table contains only four CSI-u entries (codepoint 1, modifier 5–8).
+    The existing :func:`install_shift_enter_alias` and
+    :func:`install_ctrl_enter_alias` cover Enter (codepoint 13), but all
+    other Ctrl+letter combinations (Ctrl+C = ``\\x1b[99;5u``, Ctrl+D =
+    ``\\x1b[100;5u``, …) are unmapped.
+
+    Unmapped CSI-u sequences fall through prompt_toolkit's VT100 parser to
+    literal text insertion: the leading ESC fires as ``Keys.Escape``, then
+    ``[99;5u`` appears as garbage text in the prompt buffer.  In vi mode
+    this is especially disruptive because Escape is the mode-switch key.
+
+    This helper registers CSI-u sequences for all Ctrl+letter keys (a–z,
+    codepoints 97–122, modifier 5 = Ctrl) and plain Escape (codepoint 27,
+    no modifier) so the parser routes them to the correct
+    ``Keys.ControlX`` / ``Keys.Escape`` entries instead of inserting
+    literal text.
+
+    Also clears the VT100 parser's ``_IS_PREFIX_OF_LONGER_MATCH_CACHE`` so
+    the new entries are immediately effective even if a parser has already
+    been instantiated earlier in the process lifecycle.
+
+    Returns the number of sequences whose mapping was changed.
+    """
+    try:
+        from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+        from prompt_toolkit.input.vt100_parser import (
+            _IS_PREFIX_OF_LONGER_MATCH_CACHE,
+        )
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return 0
+
+    # Ctrl+A through Ctrl+Z: codepoints 97–122, modifier 5 (Ctrl).
+    _CTRL_LETTERS = {
+        97: Keys.ControlA,
+        98: Keys.ControlB,
+        99: Keys.ControlC,
+        100: Keys.ControlD,
+        101: Keys.ControlE,
+        102: Keys.ControlF,
+        103: Keys.ControlG,
+        104: Keys.ControlH,
+        105: Keys.ControlI,
+        106: Keys.ControlJ,
+        107: Keys.ControlK,
+        108: Keys.ControlL,
+        109: Keys.ControlM,
+        110: Keys.ControlN,
+        111: Keys.ControlO,
+        112: Keys.ControlP,
+        113: Keys.ControlQ,
+        114: Keys.ControlR,
+        115: Keys.ControlS,
+        116: Keys.ControlT,
+        117: Keys.ControlU,
+        118: Keys.ControlV,
+        119: Keys.ControlW,
+        120: Keys.ControlX,
+        121: Keys.ControlY,
+        122: Keys.ControlZ,
+    }
+
+    changed = 0
+    for codepoint, key in _CTRL_LETTERS.items():
+        seq = f"\x1b[{codepoint};5u"
+        if ANSI_SEQUENCES.get(seq) != key:
+            ANSI_SEQUENCES[seq] = key
+            changed += 1
+
+    # Plain Escape: codepoint 27, no modifier.
+    #
+    # In kitty protocol level 1, the terminal sends ESC[27u for a bare
+    # Escape key press instead of a raw ESC byte.  Without this mapping the
+    # parser fires Keys.Escape on the leading ESC byte and then inserts
+    # "[27u" as literal text.
+    esc_seq = "\x1b[27u"
+    if ANSI_SEQUENCES.get(esc_seq) != Keys.Escape:
+        ANSI_SEQUENCES[esc_seq] = Keys.Escape
+        changed += 1
+
+    # Invalidate the prefix cache so the parser picks up the new entries.
+    # _IsPrefixOfLongerMatchCache.__missing__ caches results on first
+    # access; if any prefix (e.g. "\x1b[99") was queried before our
+    # additions, it would have a stale is_prefix_of_longer=False that
+    # prevents the parser from waiting for the full sequence.
+    _IS_PREFIX_OF_LONGER_MATCH_CACHE.clear()
+
+    return changed
+
+
 def install_ignored_terminal_sequences() -> int:
     """Map terminal-emitted noise sequences to ``Keys.Ignore`` so they
     are consumed by the VT100 parser before they reach key bindings or

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -11,6 +11,38 @@ can be unit-tested without importing the whole CLI runtime.
 
 from __future__ import annotations
 
+import sys
+
+
+def enable_kitty_keyboard_protocol() -> bool:
+    """Enable the Kitty keyboard protocol so the terminal sends distinct
+    byte sequences for Shift+Enter, Ctrl+Enter, etc.
+
+    Sends the CSI > 1 u sequence to push the terminal into kitty protocol
+    mode (level 1 — disambiguate escape keys). This makes Shift+Enter emit
+    \\x1b[13;2u instead of a bare CR, which the existing shift_enter_alias
+    handler then maps to a newline.
+
+    Only sent on POSIX (not Windows). Safe no-op on terminals that don't
+    support it — they ignore the sequence.
+
+    The protocol is automatically disabled when the application exits
+    (prompt_toolkit sends the pop sequence on teardown), but we also
+    register an atexit fallback for safety.
+    """
+    if sys.platform == "win32":
+        return False
+    try:
+        seq = "\x1b[>1u"
+        sys.stdout.write(seq)
+        sys.stdout.flush()
+        # Register pop on exit (prompt_toolkit should handle this, but be safe)
+        import atexit
+        atexit.register(lambda: (sys.stdout.write("\x1b[<1u"), sys.stdout.flush()))
+        return True
+    except Exception:
+        return False
+
 
 def install_shift_enter_alias() -> int:
     """Map Shift+Enter byte sequences to the (Escape, ControlM) key tuple

--- a/tests/cli/test_kitty_control_aliases.py
+++ b/tests/cli/test_kitty_control_aliases.py
@@ -1,7 +1,7 @@
 """Regression tests for Kitty keyboard protocol CSI-u control key sequences.
 
 When ``enable_kitty_keyboard_protocol()`` pushes the terminal into CSI-u
-mode, *every* modified key is sent as a CSI-u sequence — not just
+mode, *every* key press is sent as a CSI-u sequence — not just
 Shift+Enter and Ctrl+Enter.  prompt_toolkit's stock ``ANSI_SEQUENCES``
 table contains only four CSI-u entries (codepoint 1, modifier 5–8).
 
@@ -35,13 +35,24 @@ def _parse(byte_seq: str):
     return out
 
 
-# ---- Mapping tests --------------------------------------------------------
+def _parse_bulk(byte_seq: str):
+    """Feed *byte_seq* in one shot via ``feed_and_flush``."""
+    out: list = []
+    parser = Vt100Parser(out.append)
+    parser.feed_and_flush(byte_seq)
+    return out
+
+
+# ---- Fixtures -------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
 def _ensure_aliases_installed():
     """Make every test idempotent — install the aliases once per test run."""
     install_kitty_control_aliases()
+
+
+# ---- Mapping tests: Ctrl+A – Ctrl+Z --------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -84,6 +95,60 @@ def test_csi_u_ctrl_letter_mapped(codepoint, expected_key):
     )
 
 
+# ---- Mapping tests: Ctrl+0 – Ctrl+9 --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "codepoint,expected_key",
+    [
+        (48, Keys.Control0),
+        (49, Keys.Control1),
+        (50, Keys.Control2),
+        (51, Keys.Control3),
+        (52, Keys.Control4),
+        (53, Keys.Control5),
+        (54, Keys.Control6),
+        (55, Keys.Control7),
+        (56, Keys.Control8),
+        (57, Keys.Control9),
+    ],
+)
+def test_csi_u_ctrl_number_mapped(codepoint, expected_key):
+    """Each Ctrl+number CSI-u sequence must map to the correct Keys.ControlN."""
+    seq = f"\x1b[{codepoint};5u"
+    assert ANSI_SEQUENCES.get(seq) == expected_key, (
+        f"CSI-u sequence {seq!r} should map to {expected_key}, "
+        f"got {ANSI_SEQUENCES.get(seq)!r}"
+    )
+
+
+# ---- Mapping tests: Ctrl+special chars -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "codepoint,expected_key,name",
+    [
+        (64, Keys.ControlAt, "Ctrl+@"),
+        (91, Keys.Escape, "Ctrl+["),
+        (92, Keys.ControlBackslash, "Ctrl+\\"),
+        (93, Keys.ControlSquareClose, "Ctrl+]"),
+        (94, Keys.ControlCircumflex, "Ctrl+^"),
+        (95, Keys.ControlUnderscore, "Ctrl+_"),
+        (32, Keys.ControlAt, "Ctrl+Space"),
+    ],
+)
+def test_csi_u_ctrl_special_mapped(codepoint, expected_key, name):
+    """Ctrl+special char CSI-u sequences must map to the correct Keys."""
+    seq = f"\x1b[{codepoint};5u"
+    assert ANSI_SEQUENCES.get(seq) == expected_key, (
+        f"CSI-u sequence for {name} ({seq!r}) should map to {expected_key}, "
+        f"got {ANSI_SEQUENCES.get(seq)!r}"
+    )
+
+
+# ---- Mapping test: Plain Escape ------------------------------------------
+
+
 def test_escape_csi_u_mapped():
     """Plain Escape in kitty protocol is ESC[27u — must map to Keys.Escape."""
     assert ANSI_SEQUENCES.get("\x1b[27u") == Keys.Escape
@@ -108,6 +173,13 @@ def test_escape_parses_as_single_keypress():
     assert result[0].key == Keys.Escape
 
 
+def test_ctrl_c_bulk_feed_matches_char_feed():
+    """Both char-by-char and bulk feed must produce the same result."""
+    char_result = _parse("\x1b[99;5u")
+    bulk_result = _parse_bulk("\x1b[99;5u")
+    assert [kp.key for kp in char_result] == [kp.key for kp in bulk_result]
+
+
 def test_ctrl_c_does_not_produce_garbage_text():
     """The old bug: ESC[99;5u parsed as Escape + '[99;5u' literal text.
     After the fix, the result must be a single Keys.ControlC keypress —
@@ -128,6 +200,80 @@ def test_multiple_ctrl_keys_in_sequence():
     assert result[1].key == Keys.ControlD
 
 
+def test_ctrl_c_followed_by_plain_text():
+    """Ctrl+C followed by 'hello' must produce Ctrl+C then the text chars."""
+    result = _parse("\x1b[99;5uhello")
+    assert result[0].key == Keys.ControlC
+    assert [kp.key for kp in result[1:]] == ["h", "e", "l", "l", "o"]
+
+
+def test_escape_followed_by_plain_text():
+    """Escape followed by 'hello' must produce Escape then the text chars."""
+    result = _parse("\x1b[27uhello")
+    assert result[0].key == Keys.Escape
+    assert [kp.key for kp in result[1:]] == ["h", "e", "l", "l", "o"]
+
+
+def test_rapid_escape_and_ctrl_c():
+    """Escape then Ctrl+C in rapid succession."""
+    result = _parse("\x1b[27u\x1b[99;5u")
+    assert len(result) == 2
+    assert result[0].key == Keys.Escape
+    assert result[1].key == Keys.ControlC
+
+
+# ---- No-conflict tests ----------------------------------------------------
+
+
+def test_no_conflict_with_shift_enter():
+    """install_kitty_control_aliases must not overwrite Shift+Enter mappings
+    installed by install_shift_enter_alias."""
+    from hermes_cli.pt_input_extras import install_shift_enter_alias
+    install_shift_enter_alias()
+    install_kitty_control_aliases()
+    alt_enter = (Keys.Escape, Keys.ControlM)
+    assert ANSI_SEQUENCES.get("\x1b[13;2u") == alt_enter
+
+
+def test_no_conflict_with_ctrl_enter():
+    """install_kitty_control_aliases must not overwrite Ctrl+Enter mappings
+    installed by install_ctrl_enter_alias."""
+    from hermes_cli.pt_input_extras import install_ctrl_enter_alias
+    install_ctrl_enter_alias()
+    install_kitty_control_aliases()
+    alt_enter = (Keys.Escape, Keys.ControlM)
+    assert ANSI_SEQUENCES.get("\x1b[13;5u") == alt_enter
+
+
+def test_ctrl_m_does_not_conflict_with_ctrl_enter():
+    """Ctrl+M (codepoint 109) and Ctrl+Enter (codepoint 13) are different
+    sequences and must not interfere with each other."""
+    assert ANSI_SEQUENCES.get("\x1b[109;5u") == Keys.ControlM
+    # Ctrl+Enter is codepoint 13 — mapped by install_ctrl_enter_alias
+    from hermes_cli.pt_input_extras import install_ctrl_enter_alias
+    install_ctrl_enter_alias()
+    assert ANSI_SEQUENCES.get("\x1b[13;5u") == (Keys.Escape, Keys.ControlM)
+
+
+def test_escape_csi_u_does_not_conflict_with_xterm_shift_enter():
+    """ESC[27u (plain Escape) must not interfere with ESC[27;2;13~ (xterm
+    Shift+Enter). The parser must correctly disambiguate them by prefix."""
+    from hermes_cli.pt_input_extras import install_shift_enter_alias
+    install_shift_enter_alias()
+    install_kitty_control_aliases()
+
+    # Both must parse correctly
+    esc_result = _parse("\x1b[27u")
+    shift_enter_result = _parse("\x1b[27;2;13~")
+
+    assert len(esc_result) == 1
+    assert esc_result[0].key == Keys.Escape
+
+    assert len(shift_enter_result) == 2
+    assert shift_enter_result[0].key == Keys.Escape
+    assert shift_enter_result[1].key == Keys.ControlM
+
+
 # ---- Idempotency / cache tests -------------------------------------------
 
 
@@ -142,8 +288,6 @@ def test_prefix_cache_cleared_after_install():
     like '\\x1b[99' (previously cached as is_prefix_of_longer=False because
     no longer match existed) are recomputed and now return True."""
     install_kitty_control_aliases()
-    # After install, \x1b[99 should be a prefix of \x1b[99;5u
-    # The cache should have been cleared, so this will recompute
     assert _IS_PREFIX_OF_LONGER_MATCH_CACHE["\x1b[99"] is True
 
 

--- a/tests/cli/test_kitty_control_aliases.py
+++ b/tests/cli/test_kitty_control_aliases.py
@@ -1,0 +1,162 @@
+"""Regression tests for Kitty keyboard protocol CSI-u control key sequences.
+
+When ``enable_kitty_keyboard_protocol()`` pushes the terminal into CSI-u
+mode, *every* modified key is sent as a CSI-u sequence — not just
+Shift+Enter and Ctrl+Enter.  prompt_toolkit's stock ``ANSI_SEQUENCES``
+table contains only four CSI-u entries (codepoint 1, modifier 5–8).
+
+Without ``install_kitty_control_aliases()``, sequences like ``\\x1b[99;5u``
+(Ctrl+C) are unmapped.  The VT100 parser fires ``Keys.Escape`` on the
+leading ESC byte, then inserts ``[99;5u`` as literal text — making
+Ctrl+C, Ctrl+D, Escape, etc. unusable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.input.vt100_parser import (
+    Vt100Parser,
+    _IS_PREFIX_OF_LONGER_MATCH_CACHE,
+)
+from prompt_toolkit.keys import Keys
+
+from hermes_cli.pt_input_extras import install_kitty_control_aliases
+
+
+def _parse(byte_seq: str):
+    """Feed *byte_seq* through a fresh VT100 parser and return KeyPress list."""
+    out: list = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return out
+
+
+# ---- Mapping tests --------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _ensure_aliases_installed():
+    """Make every test idempotent — install the aliases once per test run."""
+    install_kitty_control_aliases()
+
+
+@pytest.mark.parametrize(
+    "codepoint,expected_key",
+    [
+        (97, Keys.ControlA),
+        (98, Keys.ControlB),
+        (99, Keys.ControlC),
+        (100, Keys.ControlD),
+        (101, Keys.ControlE),
+        (102, Keys.ControlF),
+        (103, Keys.ControlG),
+        (104, Keys.ControlH),
+        (105, Keys.ControlI),
+        (106, Keys.ControlJ),
+        (107, Keys.ControlK),
+        (108, Keys.ControlL),
+        (109, Keys.ControlM),
+        (110, Keys.ControlN),
+        (111, Keys.ControlO),
+        (112, Keys.ControlP),
+        (113, Keys.ControlQ),
+        (114, Keys.ControlR),
+        (115, Keys.ControlS),
+        (116, Keys.ControlT),
+        (117, Keys.ControlU),
+        (118, Keys.ControlV),
+        (119, Keys.ControlW),
+        (120, Keys.ControlX),
+        (121, Keys.ControlY),
+        (122, Keys.ControlZ),
+    ],
+)
+def test_csi_u_ctrl_letter_mapped(codepoint, expected_key):
+    """Each Ctrl+letter CSI-u sequence must map to the correct Keys.ControlX."""
+    seq = f"\x1b[{codepoint};5u"
+    assert ANSI_SEQUENCES.get(seq) == expected_key, (
+        f"CSI-u sequence {seq!r} should map to {expected_key}, "
+        f"got {ANSI_SEQUENCES.get(seq)!r}"
+    )
+
+
+def test_escape_csi_u_mapped():
+    """Plain Escape in kitty protocol is ESC[27u — must map to Keys.Escape."""
+    assert ANSI_SEQUENCES.get("\x1b[27u") == Keys.Escape
+
+
+# ---- Parser-level tests ---------------------------------------------------
+
+
+def test_ctrl_c_parses_as_single_keypress():
+    """Ctrl+C via CSI-u must produce exactly one KeyPress (Keys.ControlC),
+    not Escape followed by literal '[99;5u' text."""
+    result = _parse("\x1b[99;5u")
+    assert len(result) == 1, f"Expected 1 key, got {len(result)}: {result!r}"
+    assert result[0].key == Keys.ControlC
+
+
+def test_escape_parses_as_single_keypress():
+    """Escape via CSI-u must produce exactly one KeyPress (Keys.Escape),
+    not Escape followed by literal '[27u' text."""
+    result = _parse("\x1b[27u")
+    assert len(result) == 1, f"Expected 1 key, got {len(result)}: {result!r}"
+    assert result[0].key == Keys.Escape
+
+
+def test_ctrl_c_does_not_produce_garbage_text():
+    """The old bug: ESC[99;5u parsed as Escape + '[99;5u' literal text.
+    After the fix, the result must be a single Keys.ControlC keypress —
+    no extra literal-text keypresses."""
+    result = _parse("\x1b[99;5u")
+    assert len(result) == 1, f"Expected 1 key, got {len(result)}: {result!r}"
+    assert result[0].key == Keys.ControlC
+    # No literal '[', '9', '9', ';', '5', 'u' keypresses should appear
+    literal_chars = [kp for kp in result if kp.key in ("[", "9", ";", "5", "u")]
+    assert not literal_chars, f"Literal text leaked: {literal_chars!r}"
+
+
+def test_multiple_ctrl_keys_in_sequence():
+    """Rapidly typed Ctrl+C then Ctrl+D must each parse independently."""
+    result = _parse("\x1b[99;5u\x1b[100;5u")
+    assert len(result) == 2
+    assert result[0].key == Keys.ControlC
+    assert result[1].key == Keys.ControlD
+
+
+# ---- Idempotency / cache tests -------------------------------------------
+
+
+def test_install_is_idempotent():
+    """Running install twice should report 0 changes on the second call."""
+    install_kitty_control_aliases()
+    assert install_kitty_control_aliases() == 0
+
+
+def test_prefix_cache_cleared_after_install():
+    """The _IS_PREFIX_OF_LONGER_MATCH_CACHE must be cleared so that prefixes
+    like '\\x1b[99' (previously cached as is_prefix_of_longer=False because
+    no longer match existed) are recomputed and now return True."""
+    install_kitty_control_aliases()
+    # After install, \x1b[99 should be a prefix of \x1b[99;5u
+    # The cache should have been cleared, so this will recompute
+    assert _IS_PREFIX_OF_LONGER_MATCH_CACHE["\x1b[99"] is True
+
+
+def test_prefix_cache_recomputes_correctly_after_clear():
+    """After clearing the cache and installing aliases, the parser can
+    correctly wait for the full CSI-u sequence instead of falling through
+    to literal text on the first unmatched character."""
+    # Simulate the old state: cache has stale entries
+    _IS_PREFIX_OF_LONGER_MATCH_CACHE["\x1b[99"] = False
+    _IS_PREFIX_OF_LONGER_MATCH_CACHE["\x1b[99;5"] = False
+
+    # Install aliases — this should clear the cache
+    install_kitty_control_aliases()
+
+    # Now the parser should see \x1b[99 as a prefix of a longer match
+    assert _IS_PREFIX_OF_LONGER_MATCH_CACHE["\x1b[99"] is True


### PR DESCRIPTION
## Problem

PR #56645 added `enable_kitty_keyboard_protocol()` which sends `CSI > 1 u` at CLI startup, making the terminal send distinct CSI-u byte sequences for modified keys. This works great for Shift+Enter and Ctrl+Enter (covered by existing aliases).

**But it breaks every other Ctrl+key combination.**

When the terminal is in Kitty protocol mode, `Ctrl+C` is sent as `ESC[99;5u`, `Ctrl+D` as `ESC[100;5u`, plain `Escape` as `ESC[27u`, etc. prompt_toolkit's stock `ANSI_SEQUENCES` table only has 4 CSI-u entries. The existing aliases only cover Enter (codepoint 13).

Unmapped CSI-u sequences fall through the VT100 parser to literal text insertion: the leading ESC fires as `Keys.Escape`, then `[99;5u` appears as garbage text in the prompt buffer.

**User-visible symptom:** pressing Ctrl+C, Ctrl+D, Escape, etc. inserts garbage like `[99;5u` into the prompt instead of performing the expected action. In vi mode this is especially disruptive because Escape is the mode-switch key.

## Root Cause

```
Terminal (kitty mode)          prompt_toolkit parser
─────────────────────          ─────────────────────
Ctrl+C → ESC[99;5u  ──────►    ESC → Keys.Escape (fires immediately)
                                [99;5u → literal text inserted into buffer
```

The VT100 parser builds a prefix character by character. When it reaches `ESC[99;5u`:
1. No exact match in `ANSI_SEQUENCES`
2. Not a prefix of any longer match
3. Falls through: ESC fires as `Keys.Escape`, then `[99;5u` is inserted character by character

## Solution

Add `install_kitty_control_aliases()` which registers CSI-u sequences for:

- **Ctrl+A–Z** (codepoints 97–122, modifier 5 = Ctrl) → `Keys.ControlA`–`Keys.ControlZ`
- **Ctrl+0–9** (codepoints 48–57, modifier 5 = Ctrl) → `Keys.Control0`–`Keys.Control9`
- **Ctrl+special chars**: `@` (64), `[` (91), `\` (92), `]` (93), `^` (94), `_` (95), `Space` (32) — all modifier 5 = Ctrl
- **Plain Escape** (codepoint 27, no modifier) → `Keys.Escape`

Also clears the VT100 parser's `_IS_PREFIX_OF_LONGER_MATCH_CACHE` so the new entries are immediately effective.

### Known limitation

Sequences for which prompt_toolkit has no corresponding `Keys` entry cannot be mapped:
- Alt+letter (modifier 3)
- Ctrl+Shift+letter (modifier 6)
- Ctrl+Alt+letter (modifier 7)
- Ctrl+Shift+Alt+letter (modifier 8)
- Ctrl+Tab (codepoint 9, modifier 5)
- Ctrl+Backspace (codepoint 127, modifier 5)

These will still fall through to literal text — a limitation of prompt_toolkit's key model, documented in the docstring.

## Testing

**59 tests** in `tests/cli/test_kitty_control_aliases.py`:
- 26 parametrized Ctrl+letter mapping tests (A–Z)
- 10 parametrized Ctrl+number mapping tests (0–9)
- 7 parametrized Ctrl+special char mapping tests (@ [ \ ] ^ _ Space)
- Escape mapping test
- Parser-level tests: Ctrl+C and Escape each produce a single KeyPress
- Bulk feed vs char feed equivalence test
- Garbage text prevention test
- Multiple keys in sequence, mixed with plain text
- No-conflict tests with existing Shift+Enter and Ctrl+Enter aliases
- Prefix collision test: ESC[27u vs ESC[27;2;13~ (xterm Shift+Enter)
- Idempotency and prefix cache invalidation tests

All 78 tests pass (59 new + 19 existing shift-enter / ctrl-enter / focus-event tests).

## Relationship to #56645

This PR is based on top of #56645 (which adds `enable_kitty_keyboard_protocol()`). If #56645 is merged first, this PR can be rebased onto main. If this PR is merged first, #56645 becomes unnecessary as it's included in this branch.

```bash
git checkout fix/kitty-csi-u-control-keys
git log --oneline -3
# b77ea221 test: expand coverage to Ctrl+numbers, specials, Space; add conflict tests
# 326cee757 fix: map all Kitty CSI-u control key sequences
# 3cc3b906d feat: enable Kitty keyboard protocol at CLI startup  ← from #56645
```