### PR TITLE
fix(kanban): require durable artifact readback on completion

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3975,6 +3975,105 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+class CompletionArtifactError(ValueError):
+    """Raised when completion metadata declares artifacts that cannot be read back."""
+
+
+def _declared_completion_artifact_paths(metadata: Optional[dict]) -> list[str]:
+    if not isinstance(metadata, dict):
+        return []
+    paths: list[str] = []
+    for key in ("artifacts", "artifact_paths"):
+        raw = metadata.get(key)
+        if isinstance(raw, str):
+            candidates = [raw]
+        elif isinstance(raw, (list, tuple)):
+            candidates = list(raw)
+        else:
+            continue
+        for item in candidates:
+            if isinstance(item, str):
+                value = item.strip()
+            elif isinstance(item, dict):
+                value = str(item.get("path") or item.get("file") or item.get("artifact_path") or "").strip()
+            else:
+                value = ""
+            if value and value not in paths:
+                paths.append(value)
+    return paths
+
+
+def _readback_completion_artifacts(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: Optional[dict],
+) -> list[dict[str, Any]]:
+    declared = _declared_completion_artifact_paths(metadata)
+    if not declared:
+        return []
+    row = conn.execute(
+        "SELECT workspace_path FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    workspace = Path(row["workspace_path"]).expanduser() if row and row["workspace_path"] else Path.cwd()
+    checked: list[tuple[str, Path, os.stat_result, str]] = []
+    errors: list[str] = []
+    for raw_path in declared:
+        candidate = Path(raw_path).expanduser()
+        path = candidate if candidate.is_absolute() else workspace / candidate
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        try:
+            stat = resolved.stat()
+        except OSError:
+            errors.append(f"{raw_path}: missing")
+            continue
+        if not resolved.is_file():
+            errors.append(f"{raw_path}: not a file")
+            continue
+        if stat.st_size <= 0:
+            errors.append(f"{raw_path}: empty")
+            continue
+        digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
+        checked.append((raw_path, resolved, stat, digest))
+    if errors:
+        raise CompletionArtifactError(
+            "kanban completion refused because declared artifacts are not durable/readable: "
+            + "; ".join(errors)
+        )
+
+    attachment_dir = task_attachments_dir(task_id)
+    attachment_dir.mkdir(parents=True, exist_ok=True)
+    readback: list[dict[str, Any]] = []
+    for raw_path, resolved, stat, digest in checked:
+        leaf = Path(raw_path).name or resolved.name or "artifact"
+        safe_leaf = re.sub(r"[^A-Za-z0-9._-]+", "_", leaf).strip("._") or "artifact"
+        stored = attachment_dir / f"{digest[:12]}_{safe_leaf}"
+        if not stored.exists():
+            shutil.copy2(resolved, stored)
+        attachment_id = add_attachment(
+            conn,
+            task_id,
+            filename=safe_leaf,
+            stored_path=str(stored.resolve()),
+            size=int(stored.stat().st_size),
+            uploaded_by="kanban-complete-artifact-gate",
+        )
+        readback.append(
+            {
+                "path": raw_path,
+                "resolved_path": str(resolved),
+                "durable_path": str(stored.resolve()),
+                "attachment_id": attachment_id,
+                "size_bytes": int(stat.st_size),
+                "sha256": digest,
+            }
+        )
+    return readback
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4041,6 +4140,14 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    artifact_readback = _readback_completion_artifacts(conn, task_id, metadata)
+    if artifact_readback:
+        if metadata is None:
+            metadata = {}
+        else:
+            metadata = dict(metadata)
+        metadata["artifact_readback"] = artifact_readback
 
     with write_txn(conn):
         if expected_run_id is None:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -155,6 +155,58 @@ def test_successful_spawn_does_not_reset_failure_counter(kanban_home, all_assign
         conn.close()
 
 
+
+
+def test_complete_task_rejects_missing_declared_artifact(kanban_home, all_assignees_spawnable):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="artifact producer", assignee="worker")
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, tid, str(workspace))
+        kb.claim_task(conn, tid)
+
+        with pytest.raises(kb.CompletionArtifactError):
+            kb.complete_task(
+                conn,
+                tid,
+                summary="claims a missing artifact",
+                metadata={"artifact_paths": ["missing.json"]},
+            )
+
+        assert kb.get_task(conn, tid).status == "running"
+    finally:
+        conn.close()
+
+
+def test_complete_task_records_sha256_for_declared_artifacts(kanban_home, all_assignees_spawnable):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="artifact producer", assignee="worker")
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        workspace.mkdir(parents=True, exist_ok=True)
+        artifact = workspace / "packet.json"
+        artifact.write_text("{\"ok\": true}\n", encoding="utf-8")
+        kb.set_workspace_path(conn, tid, str(workspace))
+        kb.claim_task(conn, tid)
+
+        metadata = {"artifact_paths": ["packet.json"]}
+        expected_size = artifact.stat().st_size
+        assert kb.complete_task(conn, tid, summary="done", metadata=metadata) is True
+
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        readback = run.metadata["artifact_readback"]
+        assert readback[0]["path"] == "packet.json"
+        assert readback[0]["size_bytes"] == expected_size
+        assert len(readback[0]["sha256"]) == 64
+        durable_path = Path(readback[0]["durable_path"])
+        assert durable_path.exists()
+        assert durable_path.read_text(encoding="utf-8") == "{\"ok\": true}\n"
+    finally:
+        conn.close()
+
 def test_successful_completion_resets_failure_counter(kanban_home, all_assignees_spawnable):
     """A successful kb.complete_task wipes the counter — the task+profile
     combination proved it can succeed, so past failures are history."""

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -311,6 +311,25 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+
+
+def test_complete_rejects_missing_artifact_path(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_complete({
+        "summary": "claims missing artifact",
+        "artifacts": ["missing.json"],
+    })
+    payload = json.loads(out)
+    assert "declared artifacts are not durable/readable" in payload["error"]
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "running"
+    finally:
+        conn.close()
+
 def test_complete_metadata_round_trips_through_show(worker_env):
     """Structured completion metadata should be visible to downstream agents."""
     from tools import kanban_tools as kt
@@ -397,69 +416,75 @@ def test_complete_with_result_only(worker_env):
     assert d["ok"] is True
 
 
-def test_complete_with_artifacts_lands_in_event_payload(worker_env):
+def test_complete_with_artifacts_lands_in_event_payload(worker_env, tmp_path):
     """``artifacts=[...]`` rides into the completed event payload so the
     gateway notifier can upload them as native attachments. See the
     kanban notifier in gateway/run.py for the consumer side."""
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    chart = tmp_path / "q3-revenue.png"
+    report = tmp_path / "q3-report.pdf"
+    chart.write_bytes(b"chart")
+    report.write_bytes(b"report")
+    artifacts = [str(chart), str(report)]
+
     out = kt._handle_complete({
         "summary": "rendered the chart",
-        "artifacts": ["/tmp/q3-revenue.png", "/tmp/q3-report.pdf"],
+        "artifacts": artifacts,
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         events = kb.list_events(conn, worker_env)
-        # Find the completion event
         completed = [e for e in events if e.kind == "completed"]
         assert len(completed) == 1
         payload = completed[0].payload or {}
-        assert payload.get("artifacts") == [
-            "/tmp/q3-revenue.png",
-            "/tmp/q3-report.pdf",
-        ]
-        # And the artifacts also live on metadata for downstream workers
+        assert payload.get("artifacts") == artifacts
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata.get("artifacts") == [
-            "/tmp/q3-revenue.png",
-            "/tmp/q3-report.pdf",
-        ]
+        assert run.metadata.get("artifacts") == artifacts
+        assert len(run.metadata.get("artifact_readback", [])) == 2
     finally:
         conn.close()
 
 
-def test_complete_artifacts_accepts_single_string(worker_env):
+def test_complete_artifacts_accepts_single_string(worker_env, tmp_path):
     """A bare string is auto-promoted to a single-element list for convenience."""
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    chart = tmp_path / "chart.png"
+    chart.write_bytes(b"chart")
     out = kt._handle_complete({
         "summary": "one chart",
-        "artifacts": "/tmp/chart.png",
+        "artifacts": str(chart),
     })
     assert json.loads(out)["ok"] is True
 
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata.get("artifacts") == ["/tmp/chart.png"]
+        assert run.metadata.get("artifacts") == [str(chart)]
+        assert run.metadata["artifact_readback"][0]["durable_path"]
     finally:
         conn.close()
 
 
-def test_complete_artifacts_merges_with_explicit_metadata_field(worker_env):
+def test_complete_artifacts_merges_with_explicit_metadata_field(worker_env, tmp_path):
     """If the worker passes metadata.artifacts AND the top-level artifacts
     param, merge the two without duplicates."""
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
+    a = tmp_path / "a.png"
+    b = tmp_path / "b.pdf"
+    a.write_bytes(b"a")
+    b.write_bytes(b"b")
     out = kt._handle_complete({
         "summary": "merged",
-        "metadata": {"artifacts": ["/tmp/a.png"], "other": "fact"},
-        "artifacts": ["/tmp/b.pdf", "/tmp/a.png"],
+        "metadata": {"artifacts": [str(a)], "other": "fact"},
+        "artifacts": [str(b), str(a)],
     })
     assert json.loads(out)["ok"] is True
 
@@ -467,8 +492,9 @@ def test_complete_artifacts_merges_with_explicit_metadata_field(worker_env):
     try:
         run = kb.latest_run(conn, worker_env)
         # Order: existing entries first, then new ones, deduplicated.
-        assert run.metadata.get("artifacts") == ["/tmp/a.png", "/tmp/b.pdf"]
+        assert run.metadata.get("artifacts") == [str(a), str(b)]
         assert run.metadata.get("other") == "fact"
+        assert len(run.metadata.get("artifact_readback", [])) == 2
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
- refuses Kanban completion when `metadata.artifacts`, `metadata.artifact_paths`, or top-level `artifacts` declare files that are missing, empty, or not files
- copies each declared artifact into durable task attachments before scratch workspace cleanup
- records `artifact_readback` metadata with sha256, size, original path, durable path, and attachment id
- updates tool tests so artifact claims must be backed by real bytes

## Validation
- `/srv/hermes/home/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_complete_task_rejects_missing_declared_artifact tests/hermes_cli/test_kanban_core_functionality.py::test_complete_task_records_sha256_for_declared_artifacts tests/tools/test_kanban_tools.py::test_complete_rejects_missing_artifact_path tests/tools/test_kanban_tools.py::test_complete_with_artifacts_lands_in_event_payload tests/tools/test_kanban_tools.py::test_complete_artifacts_accepts_single_string tests/tools/test_kanban_tools.py::test_complete_artifacts_merges_with_explicit_metadata_field -q`
- `git diff --check`


