### PR TITLE
feat(xai-tts): wire text_normalization parameter

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -528,3 +528,77 @@ def test_generate_xai_tts_provider_speed_overrides_global(tmp_path, monkeypatch)
     )
 
     assert captured["json"]["speed"] == 0.7
+
+
+def test_generate_xai_tts_omits_text_normalization_by_default(tmp_path, monkeypatch):
+    """text_normalization is not sent when unset (API default is False)."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello world.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "ara", "language": "en"}},
+    )
+
+    assert "text_normalization" not in captured["json"]
+
+
+def test_generate_xai_tts_sends_text_normalization_when_enabled(tmp_path, monkeypatch):
+    """tts.xai.text_normalization: true flows into the POST body."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello world.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "ara", "language": "en", "text_normalization": True}},
+    )
+
+    assert captured["json"]["text_normalization"] is True
+
+
+def test_generate_xai_tts_omits_text_normalization_when_explicit_false(
+    tmp_path, monkeypatch
+):
+    """text_normalization: false is the API default; field is not sent."""
+    captured = {}
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    _generate_xai_tts(
+        "Hello world.",
+        str(tmp_path / "out.mp3"),
+        {"xai": {"voice_id": "ara", "language": "en", "text_normalization": False}},
+    )
+
+    assert "text_normalization" not in captured["json"]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -195,6 +195,10 @@ DEFAULT_XAI_SPEED_DEFAULT = 1.0
 # xAI TTS `optimize_streaming_latency` accepts 0, 1, or 2; 0 (best quality) is
 # the API default (omitted => default). Values >0 trade quality for time-to-first-audio.
 DEFAULT_XAI_OPTIMIZE_STREAMING_LATENCY_DEFAULT = 0
+# xAI TTS `text_normalization` is a boolean (default False). When enabled,
+# the model normalizes written-form text (numbers, abbreviations, symbols)
+# into spoken-form before generating audio.
+DEFAULT_XAI_TEXT_NORMALIZATION_DEFAULT = False
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
@@ -1218,6 +1222,12 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
             optimize_streaming_latency = None
     if optimize_streaming_latency is not None:
         optimize_streaming_latency = max(0, min(2, optimize_streaming_latency))
+    # ``tts.xai.text_normalization`` enables spoken-form normalization
+    # (numbers, abbreviations, symbols → words). Defaults to False.
+    text_normalization = _xai_bool_config(
+        xai_config.get("text_normalization"),
+        DEFAULT_XAI_TEXT_NORMALIZATION_DEFAULT,
+    )
     if auto_speech_tags:
         text = _apply_xai_auto_speech_tags(text)
     base_url = str(
@@ -1258,6 +1268,9 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         and optimize_streaming_latency != DEFAULT_XAI_OPTIMIZE_STREAMING_LATENCY_DEFAULT
     ):
         payload["optimize_streaming_latency"] = optimize_streaming_latency
+    # Only attach `text_normalization` when explicitly enabled (default is False).
+    if text_normalization:
+        payload["text_normalization"] = True
 
     response = requests.post(
         f"{base_url}/tts",


### PR DESCRIPTION
## What does this PR do?
The [xAI TTS API](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech#request-body) supports a `text_normalization` boolean that normalizes written-form text (numbers, abbreviations, symbols) into spoken-form before synthesis, improving synthesis quality. This parameter was not being sent.

This PR adds config wiring for `tts.xai.text_normalization`.

## Related Issue

No related issues

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`tools/tts_tool.py` — 3 changes:

1. Constant (line 198–201): `DEFAULT_XAI_TEXT_NORMALIZATION_DEFAULT = False` with docstring
2. Config reading (line 1225–1227): reads `tts.xai.text_normalization` via `_xai_bool_config` — same pattern as `auto_speech_tags`
3. Payload wiring (line 1271–1273): only attaches `text_normalization: true` when enabled, omits when false/default

`tests/tools/test_tts_xai_speech_tags.py` — 3 new tests at EOF:

- Default omission: field absent when config unset
- Enabled passthrough: `True` flows to POST body
- Explicit false: `False` also omitted (matches API default)

No side effects, no unrelated changes. All tests pass.

Documentation updates in separate PR (includes other missing docs for xAI TTS): https://github.com/NousResearch/hermes-agent/pull/56703

Config
```yaml
tts:
  xai:
    text_normalization: true
```

## How to Test

1. Run the new tests: `pytest tests/tools/test_tts_xai_speech_tags.py -k text_normalization -v`
2. All 3 tests should pass:
    - Default omission: field absent when config unset
    - Enabled passthrough: true flows to POST body
    - Explicit false: field also omitted
3. No regressions: full test file (`pytest tests/tools/test_tts_xai_speech_tags.py -v`) should pass all 29 tests
4. Full tts-related tests run: 245 passed, 1 skipped, 0 failed

Platforms tested: Windows (Python 3.11.11, pytest 9.1.1)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

