### PR TITLE
fix(mcp): fail fast on headless expired OAuth tokens

### DIFF
--- a/tests/tools/test_mcp_oauth_cold_load_expiry.py
+++ b/tests/tools/test_mcp_oauth_cold_load_expiry.py
@@ -352,6 +352,81 @@ async def test_initialize_flags_expired_token_as_invalid(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.asyncio
+async def test_initialize_headless_expired_token_without_refresh_fails_fast(
+    tmp_path, monkeypatch
+):
+    """Headless startup must not fall into a browser OAuth flow it cannot finish.
+
+    If the cached access token is expired and the token file has no
+    ``refresh_token``, the SDK's default path sends an unauthenticated request,
+    receives 401, then starts an authorization-code browser flow. In a gateway
+    or cron context that blocks until the callback timeout and gets reported as
+    a generic transport failure. Hermes should fail fast with an auth-specific
+    error so callers can surface ``needs_reauth`` instead.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import (
+        HermesTokenStorage,
+        OAuthNonInteractiveError,
+        _get_token_dir,
+        suppress_interactive_oauth,
+    )
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+    reset_manager_for_tests()
+
+    token_dir = _get_token_dir()
+    token_dir.mkdir(parents=True, exist_ok=True)
+    (token_dir / "srv.json").write_text(
+        json.dumps(
+            {
+                "access_token": "stale",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "expires_at": time.time() - 60,
+                # No refresh_token: this credential cannot recover headlessly.
+            }
+        )
+    )
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    with suppress_interactive_oauth():
+        with pytest.raises(OAuthNonInteractiveError) as exc_info:
+            await provider._initialize()
+
+    message = str(exc_info.value)
+    assert "requires re-authentication" in message
+    assert "no refresh_token" in message
+    assert "hermes mcp login srv" in message
+
+
 async def _noop_redirect(_url: str) -> None:
     return None
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -181,6 +181,30 @@ def _make_hermes_provider_class() -> Optional[type]:
             if tokens is not None and tokens.expires_in is not None:
                 self.context.update_token_expiry(tokens)
 
+            # Headless reconnects must not fall through to the SDK's full
+            # authorization-code browser flow when the cached credential is
+            # expired and cannot be refreshed.  In gateways/cron/startup
+            # discovery there is no user to complete that flow; letting it run
+            # blocks until the callback timeout and then looks like a generic
+            # transport failure.  Fail fast with the same auth-specific
+            # exception the tool handler already maps to ``needs_reauth``.
+            if tokens is not None:
+                from tools.mcp_oauth import OAuthNonInteractiveError, _is_interactive
+
+                if (
+                    not _is_interactive()
+                    and not self.context.is_token_valid()
+                    and not self.context.can_refresh_token()
+                ):
+                    raise OAuthNonInteractiveError(
+                        f"MCP OAuth for '{self._hermes_server_name}' requires "
+                        "re-authentication: the cached access token is expired "
+                        "and no refresh_token is available. Run `hermes mcp "
+                        f"login {self._hermes_server_name}` interactively to "
+                        "refresh the credential before using this server from "
+                        "a headless gateway or cron job."
+                    )
+
             # Cold-load: restore OAuth server metadata from disk before any
             # refresh attempt. Without this, a restarted process with cached
             # tokens but no in-memory metadata would fall back to the SDK's


### PR DESCRIPTION
Fixes #56673.\n\nWhen an HTTP MCP OAuth credential is loaded in a headless context with an expired access token and no refresh_token, Hermes now raises OAuthNonInteractiveError during provider initialization instead of falling through to the SDK authorization-code browser flow and waiting for the callback timeout. This gives startup/reconnect/tool-call handling an auth-specific failure that can surface as re-authentication-needed rather than a generic transport timeout.\n\nTests:\n- scripts/run_tests.sh tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_tool_401_handling.py -v