### PR TITLE
fix(auxiliary): unwrap explicit provider:moa to its aggregator, not the literal name

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5329,8 +5329,8 @@ def _resolve_task_provider_model(
     task: str = None,
     provider: str = None,
     model: str = None,
-    base_url: str = None,
-    api_key: str = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Determine provider + model for a call.
 
@@ -5371,6 +5371,51 @@ def _resolve_task_provider_model(
 
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
+
+    # MoA virtual provider: an *explicit* `provider: moa` override (either the
+    # caller-passed `provider` arg or `auxiliary.<task>.provider` in
+    # config.yaml) reaches this function directly — it never goes through
+    # _resolve_auto(), which only unwraps the *implicit* "main provider is
+    # moa" case (#53827). Left as-is, "moa" is returned verbatim and
+    # resolve_provider_client() looks it up in PROVIDER_REGISTRY (which has
+    # no "moa" entry — it's not a real HTTP provider), falls to the
+    # unknown-provider dead end, and call_llm surfaces a nonsensical
+    # "MOA_API_KEY environment variable" error for a provider that was never
+    # meant to be reached over the wire. Auxiliary tasks don't need the
+    # reference fan-out — resolve to the preset's aggregator slot instead,
+    # exactly like the implicit path does.
+    def _unwrap_moa_provider(prov: str, mdl: Optional[str]) -> Tuple[str, Optional[str]]:
+        if prov.strip().lower() != "moa":
+            return prov, mdl
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.moa_config import resolve_moa_preset
+
+            preset = resolve_moa_preset(load_config().get("moa") or {}, mdl)
+            agg = preset.get("aggregator") or {}
+            agg_provider = str(agg.get("provider") or "").strip()
+            agg_model = str(agg.get("model") or "").strip()
+            if agg_provider and agg_model and agg_provider.lower() != "moa":
+                return agg_provider, agg_model
+        except Exception:
+            logger.debug("MoA aux resolution (explicit provider override) to aggregator failed", exc_info=True)
+        return prov, mdl
+
+    if provider and str(provider).strip().lower() == "moa":
+        provider, resolved_model = _unwrap_moa_provider(provider, resolved_model)
+        # The moa:// virtual endpoint (if any explicit base_url/api_key was
+        # passed alongside provider="moa") belongs to the facade, not the
+        # aggregator's real provider — drop it so the aggregator resolves
+        # through its own provider credentials, mirroring _resolve_auto().
+        if provider and provider.lower() != "moa":
+            base_url = None
+            api_key = None
+    elif cfg_provider and str(cfg_provider).strip().lower() == "moa":
+        cfg_provider, cfg_model = _unwrap_moa_provider(cfg_provider, resolved_model)
+        if cfg_provider and cfg_provider.lower() != "moa":
+            resolved_model = cfg_model
+            cfg_base_url = None
+            cfg_api_key = None
 
     # Convenience aliases for direct API-key endpoints that aren't first-class
     # providers (e.g. ``provider: openai`` → custom + api.openai.com/v1).

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -168,6 +168,126 @@ class TestResolveTaskProviderModel:
         assert api_key == "sk-test"
         assert api_mode is None
 
+    def test_explicit_provider_moa_unwraps_to_aggregator(self, monkeypatch):
+        """An *explicit* `provider="moa"` arg (e.g. a per-task model override
+        naming a MoA preset) must resolve to the preset's aggregator, not the
+        literal "moa" string — mirrors #53827's fix for the implicit
+        "main provider is moa" case in _resolve_auto(), which this function
+        never went through."""
+        preset = {
+            "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+        }
+        monkeypatch.setattr("agent.auxiliary_client._get_auxiliary_task_config", lambda task: {})
+        monkeypatch.setattr(
+            "hermes_cli.moa_config.resolve_moa_preset",
+            lambda cfg, name: preset,
+        )
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"moa": {}})
+
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="title_generation",
+            provider="moa",
+            model="opus-gpt",
+            base_url="moa://local",
+            api_key="moa-virtual-provider",
+        )
+
+        assert resolved_provider == "openrouter"
+        assert model == "anthropic/claude-opus-4.8"
+        # The virtual moa:// endpoint must not be forwarded to the aggregator.
+        assert base_url is None
+        assert api_key is None
+
+    def test_config_provider_moa_unwraps_to_aggregator(self, monkeypatch):
+        """`auxiliary.<task>.provider: moa` in config.yaml — the same crash,
+        reached via the config path instead of an explicit call-time arg.
+        Before the fix this returned ("moa", ...) verbatim, and
+        resolve_provider_client() would then look up "moa" in
+        PROVIDER_REGISTRY (which has no such entry, it's not a real HTTP
+        provider), fail, and surface a "MOA_API_KEY environment variable"
+        error for a provider that was never meant to be reached over the wire."""
+        preset = {
+            "aggregator": {"provider": "anthropic", "model": "claude-opus-4.8"},
+        }
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"provider": "moa", "model": "opus-gpt"} if task == "title_generation" else {},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.moa_config.resolve_moa_preset",
+            lambda cfg, name: preset,
+        )
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"moa": {}})
+
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="title_generation",
+        )
+
+        assert resolved_provider == "anthropic"
+        assert model == "claude-opus-4.8"
+        assert base_url is None
+        assert api_key is None
+
+    def test_config_provider_moa_falls_back_to_default_preset(self, monkeypatch):
+        """`auxiliary.<task>.provider: moa` with no `model:` set must resolve
+        against the user's default MoA preset, not crash or leave "moa"
+        unresolved — resolve_moa_preset() already falls back to
+        default_preset when name is falsy; this just confirms the call site
+        doesn't force a preset name where none was configured."""
+        preset = {
+            "aggregator": {"provider": "nous", "model": "hermes-4-405b"},
+        }
+
+        def fake_resolve(cfg, name):
+            assert name is None  # no auxiliary.<task>.model configured
+            return preset
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"provider": "moa"} if task == "title_generation" else {},
+        )
+        monkeypatch.setattr("hermes_cli.moa_config.resolve_moa_preset", fake_resolve)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"moa": {}})
+
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="title_generation",
+        )
+
+        assert resolved_provider == "nous"
+        assert model == "hermes-4-405b"
+
+    def test_provider_moa_falls_back_to_literal_when_preset_resolution_fails(self, monkeypatch):
+        """If the MoA preset can't be resolved (e.g. renamed/deleted), the
+        function must not raise — it degrades to the pre-fix behavior
+        (literal "moa") rather than crash resolve_provider_client() harder."""
+        monkeypatch.setattr("agent.auxiliary_client._get_auxiliary_task_config", lambda task: {})
+        monkeypatch.setattr(
+            "hermes_cli.moa_config.resolve_moa_preset",
+            lambda cfg, name: (_ for _ in ()).throw(KeyError("gone-preset")),
+        )
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"moa": {}})
+
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="title_generation",
+            provider="moa",
+            model="gone-preset",
+        )
+
+        assert resolved_provider == "moa"
+        assert model == "gone-preset"
+
+    def test_non_moa_provider_unaffected_by_unwrap_logic(self):
+        """Regression guard: providers other than "moa" must not be touched
+        by the new unwrap branch."""
+        resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+            task="title_generation",
+            provider="anthropic",
+            model="claude-haiku-4-5-20251001",
+        )
+
+        assert resolved_provider == "anthropic"
+        assert model == "claude-haiku-4-5-20251001"
+
 
 class TestBuildCallKwargsMaxTokens:
     """_build_call_kwargs should not cap output by default (#34530).


### PR DESCRIPTION
## What does this PR do?

`_resolve_task_provider_model()` in `agent/auxiliary_client.py` returned an explicit `provider="moa"` override — either a caller-passed arg (e.g. a per-task model override naming a MoA preset) or `auxiliary.<task>.provider: moa` in config.yaml — verbatim, with no MoA-preset unwrap. Only the *implicit* "main provider is moa" path inside `_resolve_auto()` unwraps to the aggregator slot (#53827, already merged) — this function never goes through `_resolve_auto()` at all, so the explicit case was never covered.

MoA is a virtual provider with no real HTTP endpoint: `resolve_provider_client()` looks `"moa"` up in `PROVIDER_REGISTRY` (no such entry — it's not a real HTTP provider), falls to the unknown-provider dead end, and `call_llm` surfaces a nonsensical `"Provider 'moa' is set in config.yaml but no API key was found. Set the MOA_API_KEY environment variable..."` error.

Verified live before the fix: `_resolve_task_provider_model('title_generation')` with `auxiliary.title_generation.provider: moa` configured returned `('moa', None, None, None, None)` unresolved.

### Fix

Mirrors #53827's aggregator-resolution approach exactly: when either the explicit `provider` arg or the config-derived `cfg_provider` is `"moa"`, resolve the named (or default) MoA preset via `resolve_moa_preset()` and continue with its aggregator's real provider+model, dropping any explicit `base_url`/`api_key` (the `moa://` virtual endpoint and placeholder key belong to the facade, not the aggregator's real provider — same reasoning as #53827). If the preset can't be resolved (e.g. renamed/deleted), it degrades gracefully to the pre-fix behavior instead of raising harder.

- `_unwrap_moa_provider()` helper + call sites for both the explicit-arg and config-derived `provider="moa"` cases.
- Tightened `base_url`/`api_key` parameter types to `Optional[str]` (matching their actual None-accepting behavior) — incidentally resolved 5 pre-existing `ty` diagnostics at call sites (verified via before/after diagnostic diff).

### Testing

- 5 new regression tests in `tests/agent/test_auxiliary_client.py::TestResolveTaskProviderModel`: explicit-arg unwrap, config-derived unwrap, default-preset fallback when no model is configured, graceful degradation on preset-resolution failure, and a non-moa regression guard.
- Full existing suite: `tests/agent/test_auxiliary_client.py` (285 tests) + all MoA-specific suites (`test_moa_config.py`, `test_moa_trace_streamed_capture.py`, `test_moa_aggregator_cost_slot.py`, `test_moa_switch_api_mode.py`, `test_moa_slot_api_mode.py`, `test_auxiliary_main_first.py` — the #53827 reference test file) — 336 tests total, 0 failures.
- `ruff check` clean. `ty check` on `agent/auxiliary_client.py`: diffed diagnostics before/after — net 5 pre-existing diagnostics resolved, zero new ones introduced.

## Test plan

- [x] `uv run --frozen --extra dev python -m pytest tests/agent/test_auxiliary_client.py -q` — 285 passed
- [x] `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_moa_config.py tests/agent/test_moa_trace_streamed_capture.py tests/agent/test_moa_aggregator_cost_slot.py tests/agent/test_moa_switch_api_mode.py tests/agent/test_moa_slot_api_mode.py tests/agent/test_auxiliary_main_first.py -q` — 51 passed
- [x] `uv run --frozen --extra dev ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` — clean
- [x] `uv run --frozen --extra dev ty check agent/auxiliary_client.py` — no new diagnostics (verified via before/after diff), 5 pre-existing ones resolved