### PR TITLE
fix: honor configured connect_timeout on MCP OAuth login path

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -694,8 +694,19 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
     _info(f"Starting OAuth flow for '{name}'...")
 
     # Probe triggers the OAuth flow (browser redirect + callback capture).
+    # Honor the server's configured connect_timeout so a human has enough
+    # time to complete the browser sign-in; the 30s default is too tight for
+    # an interactive OAuth round-trip. Give at least 180s for the login path.
     try:
-        tools = _probe_single_server(name, server_config)
+        _login_connect_timeout = server_config.get("connect_timeout")
+        try:
+            _login_connect_timeout = float(_login_connect_timeout)
+        except (TypeError, ValueError):
+            _login_connect_timeout = 0.0
+        _login_connect_timeout = max(_login_connect_timeout, 180.0)
+        tools = _probe_single_server(
+            name, server_config, connect_timeout=_login_connect_timeout
+        )
         # A clean probe is NOT proof of authentication. Some MCP servers
         # (notably Google's official Drive server) serve initialize +
         # tools/list WITHOUT auth, so the probe lists tools even when the

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -716,7 +716,9 @@ class TestMcpLogin:
         # Probe returns tools even though auth never completed.
         monkeypatch.setattr(
             "hermes_cli.mcp_config._probe_single_server",
-            lambda name, cfg: [("search_files", "d"), ("read_file_content", "d")],
+            lambda name, cfg, connect_timeout=30: [
+                ("search_files", "d"), ("read_file_content", "d"),
+            ],
         )
         # No token file is created → _oauth_tokens_present() returns False.
         from hermes_cli.mcp_config import cmd_mcp_login
@@ -738,7 +740,10 @@ class TestMcpLogin:
         # cmd_mcp_login wipes tokens before probing, then the real OAuth flow
         # writes a fresh token during the probe. Simulate that: the mocked
         # probe drops a token file, mirroring a successful authorization.
-        def mock_probe(name, cfg):
+        seen = {}
+
+        def mock_probe(name, cfg, connect_timeout=30):
+            seen["connect_timeout"] = connect_timeout
             token_dir.mkdir(exist_ok=True)
             (token_dir / "realserver.json").write_text('{"access_token": "x"}')
             return [("a", "d"), ("b", "d"), ("c", "d")]
@@ -754,6 +759,9 @@ class TestMcpLogin:
 
         assert "Authenticated — 3 tool(s) available" in out
         assert "no OAuth token" not in out
+        # The login path must grant a human enough time to finish the browser
+        # OAuth round-trip — far longer than the 30s probe default.
+        assert seen["connect_timeout"] >= 180
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Running `hermes mcp login <oauth-server>` (and `hermes mcp reauth`) opens the browser OAuth flow but aborts with `Authentication failed: MCP call timed out after ~40s` before a human can realistically complete a first-time browser sign-in (provider DCR → login → consent → loopback redirect capture). Setting `connect_timeout` / `timeout` on the server in `config.yaml` does **not** help.

## Root cause

`_reauth_oauth_server` in `hermes_cli/mcp_config.py` calls the probe without passing a timeout:

```python
tools = _probe_single_server(name, server_config)
```

`_probe_single_server(name, config, connect_timeout: float = 30)` therefore always uses the **30s default** on the interactive login path. That's fine for a machine-to-machine reconnect probe but far too short for a human OAuth round-trip, and the server-level `connect_timeout` from config is silently ignored on this path.

## Fix

Honor the server's configured `connect_timeout` on the login path, with a 180s floor so a human always has enough time to finish the browser flow, and pass it through to the probe.

## Tests

Updated the two `TestMcpLogin` probe mocks for the new kwarg and added a regression assertion that the login path propagates a `>= 180s` timeout.

```
scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py
=> 48 passed
```