### PR TITLE
fix(ops): bound messaging and computer-use token bloat

### DIFF
--- a/agent/install_success_stop.py
+++ b/agent/install_success_stop.py
@@ -1,0 +1,146 @@
+"""Success-stop helpers for low-token install tasks."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Iterable
+
+
+_INSTALL_INTENT_RE = re.compile(
+    r"(?:安装|帮我装|装一下|\binstall\b|\bsetup\b)",
+    re.IGNORECASE,
+)
+_INSTALL_SOURCE_RE = re.compile(
+    r"(?:github\.com|gitlab\.com|bitbucket\.org|\.dmg\b|\.pkg\b|"
+    r"\bbrew\b|\bnpm\b|\bpip\b|\bgo install\b)",
+    re.IGNORECASE,
+)
+
+_ACQUIRE_RE = re.compile(
+    r"(?:github\.com|git clone|curl\b|wget\b|download(?:ed|ing)?|"
+    r"release|\.dmg\b|\.pkg\b|\bbrew install\b|\bnpm install\b|"
+    r"\bpip install\b|\bgo install\b|获取|下载)",
+    re.IGNORECASE,
+)
+_INSTALL_RE = re.compile(
+    r"(?:successfully installed|already installed|\binstalled\b|"
+    r"\bnpm install\b|\bpip install\b|\bbrew install\b|\bgo install\b|"
+    r"copied|/applications|安装完成|已安装|已复制)",
+    re.IGNORECASE,
+)
+_VERIFY_RE = re.compile(
+    r"(?:\b--version\b|\bversion\b|\bwhich\b|\btest -[ef]\b|"
+    r"\bls\b|verified|verification|校验|验证|存在|found)",
+    re.IGNORECASE,
+)
+_FAIL_RE = re.compile(
+    r"(?:exit_code[\"']?\s*:\s*[1-9]|failed|failure|"
+    r"permission denied|not found|no such file|失败|错误|未找到)",
+    re.IGNORECASE,
+)
+
+
+def is_install_task_message(platform: str, budget_key: str, message: str) -> bool:
+    """Return True for ordinary Feishu install requests.
+
+    Deep diagnostic turns are intentionally excluded so users keep the larger
+    investigation path when they opt into it.
+    """
+    if (platform or "").strip().lower() != "feishu":
+        return False
+    if (budget_key or "").strip().lower() == "feishu_deep":
+        return False
+    text = message or ""
+    return bool(_INSTALL_INTENT_RE.search(text) and _INSTALL_SOURCE_RE.search(text))
+
+
+def install_success_stop_response(messages: list[dict[str, Any]], current_turn_user_idx: int) -> str | None:
+    """Build a concise final response once an install task is verified.
+
+    The detector is deliberately conservative: it needs acquisition, install,
+    and verification evidence, and it refuses to fire if the recent evidence
+    contains a clear failure marker.
+    """
+    evidence = _current_turn_tool_evidence(messages, current_turn_user_idx)
+    if not evidence:
+        return None
+
+    combined = "\n".join(evidence)
+    if _FAIL_RE.search(combined):
+        return None
+
+    has_acquire = bool(_ACQUIRE_RE.search(combined))
+    has_install = bool(_INSTALL_RE.search(combined))
+    has_verify = _has_verification_evidence(evidence)
+    if not (has_acquire and has_install and has_verify):
+        return None
+
+    detail = _extract_install_detail(combined)
+    if detail:
+        return (
+            f"已完成安装并通过验证：{detail}\n\n"
+            "我已在验证通过后停止继续探测，避免继续消耗 token。"
+        )
+    return (
+        "已完成安装并通过验证。\n\n"
+        "我已在验证通过后停止继续探测，避免继续消耗 token。"
+    )
+
+
+def _current_turn_tool_evidence(messages: list[dict[str, Any]], current_turn_user_idx: int) -> list[str]:
+    start = max(0, current_turn_user_idx + 1)
+    chunks: list[str] = []
+    for msg in messages[start:]:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                if isinstance(tc, dict):
+                    fn = tc.get("function") or {}
+                    chunks.append(str(fn.get("name") or ""))
+                    chunks.append(str(fn.get("arguments") or ""))
+        elif msg.get("role") == "tool":
+            chunks.append(_stringify_tool_content(msg.get("content")))
+    return [chunk for chunk in chunks if chunk]
+
+
+def _stringify_tool_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(str(item.get("text") or item.get("content") or ""))
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    try:
+        return json.dumps(content, ensure_ascii=False)
+    except Exception:
+        return str(content)
+
+
+def _has_verification_evidence(chunks: Iterable[str]) -> bool:
+    for chunk in chunks:
+        text = chunk or ""
+        lower = text.lower()
+        if _VERIFY_RE.search(text) and not re.search(r"exit_code[\"']?\s*:\s*[1-9]", lower):
+            return True
+        if re.search(r"exit_code[\"']?\s*:\s*0", lower) and _VERIFY_RE.search(text):
+            return True
+    return False
+
+
+def _extract_install_detail(text: str) -> str:
+    candidates = []
+    for pattern in (
+        r"(/Applications/[^\s\"']+)",
+        r"(v?\d+(?:\.\d+){1,3}[^\s,;)]*)",
+        r"(https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)",
+    ):
+        match = re.search(pattern, text)
+        if match:
+            candidates.append(match.group(1).strip())
+    return " · ".join(list(dict.fromkeys(candidates))[:2])

--- a/agent/phase_checkpoint.py
+++ b/agent/phase_checkpoint.py
@@ -1,0 +1,59 @@
+"""Compact phase handoff records for budget-sensitive agent workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import re
+from typing import Any, Iterable
+
+
+_DATA_IMAGE_RE = re.compile(r"data:image/[A-Za-z0-9.+-]+;base64,[A-Za-z0-9+/=_-]+")
+_MAX_FIELD_CHARS = 1500
+
+
+def _clean_text(value: Any, *, max_chars: int = _MAX_FIELD_CHARS) -> str:
+    text = str(value or "")
+    text = _DATA_IMAGE_RE.sub("[image data omitted; use artifact path]", text)
+    if len(text) > max_chars:
+        return text[:max_chars] + "\n... [checkpoint field truncated]"
+    return text
+
+
+def _clean_list(values: Iterable[Any], *, max_item_chars: int = _MAX_FIELD_CHARS) -> list[str]:
+    return [_clean_text(value, max_chars=max_item_chars) for value in values or []]
+
+
+@dataclass(frozen=True)
+class PhaseCheckpoint:
+    """Small, explicit handoff between repair, verification, and UI phases.
+
+    It intentionally stores conclusions and artifact paths, not raw logs,
+    screenshots, or tool dumps. The JSON output is safe to feed into a fresh
+    short verification phase without dragging earlier context along.
+    """
+
+    objective: str
+    changes: list[str] = field(default_factory=list)
+    verification_passed: list[str] = field(default_factory=list)
+    next_phase_inputs: list[str] = field(default_factory=list)
+    artifact_paths: list[str] = field(default_factory=list)
+    stop_reason: str = ""
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "objective": _clean_text(self.objective),
+            "changes": _clean_list(self.changes),
+            "verification_passed": _clean_list(self.verification_passed),
+            "next_phase_inputs": _clean_list(self.next_phase_inputs),
+            "artifact_paths": _clean_list(self.artifact_paths, max_item_chars=500),
+            "stop_reason": _clean_text(self.stop_reason, max_chars=500),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_payload(), ensure_ascii=False, indent=2)
+
+
+def build_phase_checkpoint(**kwargs: Any) -> PhaseCheckpoint:
+    return PhaseCheckpoint(**kwargs)
+

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -46,25 +46,62 @@ from tools.tool_result_storage import (
     maybe_persist_tool_result,
     enforce_turn_budget,
 )
-from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
+from tools.budget_config import (
+    BudgetConfig,
+    DEFAULT_BUDGET,
+    FEISHU_BUDGET,
+    FEISHU_DEEP_BUDGET,
+    MESSAGING_BUDGET,
+    UI_VERIFICATION_BUDGET,
+    DEEP_DIAGNOSTIC_BUDGET,
+    budget_for_context_window,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _budget_for_agent(agent) -> BudgetConfig:
-    """Resolve a tool-result BudgetConfig scaled to the agent's context window.
+def _platform_budget_for_agent(agent) -> BudgetConfig:
+    platform = (
+        getattr(agent, "_platform_budget_key", None)
+        or getattr(agent, "platform", "")
+        or ""
+    ).strip().lower()
+    if platform == "feishu":
+        return FEISHU_BUDGET
+    if platform == "feishu_deep":
+        return FEISHU_DEEP_BUDGET
+    if platform in {"telegram", "telegram_ordinary", "feishu_ordinary"}:
+        return MESSAGING_BUDGET
+    if platform in {"telegram_ui", "feishu_ui", "ui_verification"}:
+        return UI_VERIFICATION_BUDGET
+    if platform in {"telegram_deep", "deep_diagnostic"}:
+        return DEEP_DIAGNOSTIC_BUDGET
+    return DEFAULT_BUDGET
 
-    Large-context models keep the historical 100K/200K char defaults; small
-    models (e.g. a 65K-token local model switched into mid-session) get a budget
-    proportional to their window so a single large tool result can't push the
-    request past the model's limit (#23767). Falls back to the default budget
-    when the context length isn't resolvable.
-    """
+
+def _combine_budget_caps(base: BudgetConfig, cap: BudgetConfig) -> BudgetConfig:
+    default_result_size = min(base.default_result_size, cap.default_result_size)
+    return BudgetConfig(
+        default_result_size=default_result_size,
+        turn_budget=min(base.turn_budget, cap.turn_budget),
+        preview_size=min(base.preview_size, cap.preview_size),
+        tool_overrides={
+            name: min(value, default_result_size)
+            for name, value in base.tool_overrides.items()
+        },
+    )
+
+
+def _budget_for_agent(agent) -> BudgetConfig:
+    """Resolve a tool-result budget from platform policy and context size."""
+    platform_budget = _platform_budget_for_agent(agent)
     try:
         ctx = getattr(getattr(agent, "context_compressor", None), "context_length", None)
-        return budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
+        context_budget = budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
     except Exception:
-        return DEFAULT_BUDGET
+        context_budget = DEFAULT_BUDGET
+    return _combine_budget_caps(platform_budget, context_budget)
+
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
@@ -1397,18 +1434,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 spinner.start()
             _spinner_result = None
             try:
+                _hfc_kwargs = {
+                    "tool_call_id": tool_call.id,
+                    "session_id": agent.session_id or "",
+                    "turn_id": getattr(agent, "_current_turn_id", "") or "",
+                    "api_request_id": getattr(agent, "_current_api_request_id", "") or "",
+                    "enabled_tools": list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                    "skip_pre_tool_call_hook": True,
+                    "skip_tool_request_middleware": True,
+                    "enabled_toolsets": getattr(agent, "enabled_toolsets", None),
+                    "disabled_toolsets": getattr(agent, "disabled_toolsets", None),
+                    "tool_request_middleware_trace": list(middleware_trace),
+                }
+                _platform_budget_key = getattr(agent, "_platform_budget_key", None)
+                if _platform_budget_key:
+                    _hfc_kwargs["platform"] = _platform_budget_key
                 function_result = _ra().handle_function_call(
                     function_name, function_args, effective_task_id,
-                    tool_call_id=tool_call.id,
-                    session_id=agent.session_id or "",
-                    turn_id=getattr(agent, "_current_turn_id", "") or "",
-                    api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-                    enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
-                    skip_pre_tool_call_hook=True,
-                    skip_tool_request_middleware=True,
-                    enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                    disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                    tool_request_middleware_trace=list(middleware_trace),
+                    **_hfc_kwargs,
                 )
                 _spinner_result = function_result
             except KeyboardInterrupt:
@@ -1439,18 +1482,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     agent._vprint(f"  {cute_msg}")
         else:
             try:
+                _hfc_kwargs = {
+                    "tool_call_id": tool_call.id,
+                    "session_id": agent.session_id or "",
+                    "turn_id": getattr(agent, "_current_turn_id", "") or "",
+                    "api_request_id": getattr(agent, "_current_api_request_id", "") or "",
+                    "enabled_tools": list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                    "skip_pre_tool_call_hook": True,
+                    "skip_tool_request_middleware": True,
+                    "enabled_toolsets": getattr(agent, "enabled_toolsets", None),
+                    "disabled_toolsets": getattr(agent, "disabled_toolsets", None),
+                    "tool_request_middleware_trace": list(middleware_trace),
+                }
+                _platform_budget_key = getattr(agent, "_platform_budget_key", None)
+                if _platform_budget_key:
+                    _hfc_kwargs["platform"] = _platform_budget_key
                 function_result = _ra().handle_function_call(
                     function_name, function_args, effective_task_id,
-                    tool_call_id=tool_call.id,
-                    session_id=agent.session_id or "",
-                    turn_id=getattr(agent, "_current_turn_id", "") or "",
-                    api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-                    enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
-                    skip_pre_tool_call_hook=True,
-                    skip_tool_request_middleware=True,
-                    enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                    disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                    tool_request_middleware_trace=list(middleware_trace),
+                    **_hfc_kwargs,
                 )
             except KeyboardInterrupt:
                 _emit_cancelled_terminal_post_tool_call(

--- a/gateway/known_ops_tasks.py
+++ b/gateway/known_ops_tasks.py
@@ -1,0 +1,803 @@
+"""Deterministic gateway fast paths for known Hermes ops tasks.
+
+Known ops tasks are small, repeatable, low-token workflows that should not
+spend an agent turn rediscovering their data source or repair path.  Add a new
+entry here when a repeated failure has a stable detector and executable handler.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import datetime as dt
+import logging
+import re
+import subprocess
+import sys
+from typing import Callable, Sequence
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+
+Detector = Callable[[str], bool]
+Handler = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class KnownOpsTask:
+    """Registered deterministic task available before agent dispatch."""
+
+    name: str
+    platforms: frozenset[str]
+    detector: Detector
+    handler: Handler
+    verification: tuple[str, ...]
+    promotion_hint: str
+    description: str = ""
+
+    def supports_platform(self, platform: str) -> bool:
+        normalized = (platform or "").strip().lower()
+        return "all" in self.platforms or normalized in self.platforms
+
+
+@dataclass(frozen=True)
+class KnownOpsTaskResult:
+    task: KnownOpsTask
+    text: str
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", "", text or "").lower()
+
+
+def _looks_like_token_usage_request(text: str) -> bool:
+    """Detect token-report requests before dispatching to the agent."""
+    normalized = _normalize_text(text)
+    if not normalized:
+        return False
+    has_token = "token" in normalized or "tokens" in normalized
+    has_usage = any(marker in normalized for marker in ("消耗", "统计", "输入", "输出", "用量", "使用"))
+    has_time_window = any(
+        marker in normalized
+        for marker in (
+            "今天",
+            "今日",
+            "当日",
+            "截止到现在",
+            "昨天",
+            "昨日",
+            "最近",
+            "之内",
+            "以内",
+            "一周",
+            "一月",
+            "一个月",
+            "本周",
+            "本月",
+        )
+    ) or bool(re.search(r"\d+\s*(?:天|周|个月|月)", text or "")) or bool(
+        re.search(r"\d{4}-\d{2}-\d{2}", text or "")
+    )
+    return bool(has_token and has_usage and has_time_window)
+
+
+def _looks_like_token_usage_clarification_request(text: str) -> bool:
+    """Catch vague token usage asks so they do not enter broad agent exploration."""
+    normalized = _normalize_text(text)
+    if not normalized or "token" not in normalized:
+        return False
+    if _looks_like_token_usage_request(text):
+        return False
+    if any(marker in normalized for marker in ("什么是token", "token是什么", "解释token")):
+        return False
+    return any(
+        marker in normalized
+        for marker in ("查", "看", "查询", "检查", "统计", "用量", "使用", "消耗")
+    )
+
+
+def _looks_like_agent_loop_diagnostic_request(text: str) -> bool:
+    """Detect repeated asks about Hermes/OpenClaw diagnosis loops themselves."""
+    normalized = _normalize_text(text)
+    if not normalized:
+        return False
+    has_agent = "hermes" in normalized or "openclaw" in normalized
+    has_loop = any(
+        marker in normalized
+        for marker in (
+            "死循环",
+            "循环",
+            "卡住",
+            "无法答复",
+            "不能答复",
+            "没有答复",
+            "预算",
+            "限额",
+            "进展",
+            "查故障",
+            "故障诊断",
+            "虚幻",
+        )
+    )
+    has_diagnosis = any(
+        marker in normalized
+        for marker in ("为什么", "原因", "分析", "查", "诊断", "不正常", "无法结束")
+    )
+    return bool(has_agent and has_loop and has_diagnosis)
+
+
+_GITHUB_REPO_URL_RE = re.compile(
+    r"https?://github\.com/(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)(?:[/?#][^\s]*)?",
+    re.IGNORECASE,
+)
+_GITHUB_OWNER_REPO_RE = re.compile(
+    r"(?<![\w.-])(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)(?![\w.-])"
+)
+_GITHUB_SKILL_IDENTIFIER_RE = re.compile(
+    r"(?<![\w.-])(?P<identifier>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+)(?![\w.-])"
+)
+
+
+def _looks_like_github_skill_install_request(text: str) -> bool:
+    """Detect clear Feishu requests to install a GitHub-hosted skill."""
+    normalized = _normalize_text(text)
+    if not normalized:
+        return False
+    has_install = _has_github_skill_install_intent(text)
+    has_skill = (
+        "skill" in normalized
+        or "技能" in normalized
+        or bool(_github_skill_identifiers_from_text(text))
+    )
+    has_github = "github.com" in normalized or bool(_GITHUB_OWNER_REPO_RE.search(text or ""))
+    return bool(has_install and has_skill and has_github)
+
+
+def _has_github_skill_install_intent(text: str) -> bool:
+    normalized = _normalize_text(text)
+    return any(marker in normalized for marker in ("安装", "帮我装", "装一下", "install", "setup"))
+
+
+def _looks_like_github_skill_reference_without_install_request(text: str) -> bool:
+    """Stop path-only GitHub skill mentions before they start a low-budget agent turn."""
+    if not text or _has_github_skill_install_intent(text):
+        return False
+    if _github_skill_identifiers_from_text(text):
+        return True
+    return bool(re.search(r"https?://github\.com/[^/\s]+/[^/\s]+/.*/SKILL\.md(?:[?#]\S*)?", text, re.IGNORECASE))
+
+
+def _github_skill_identifiers_from_text(text: str) -> list[str]:
+    raw = text or ""
+    identifiers: list[str] = []
+    for match in _GITHUB_SKILL_IDENTIFIER_RE.finditer(raw):
+        identifier = match.group("identifier").rstrip(".,，。)")
+        if identifier.lower().startswith("github.com/"):
+            continue
+        if "/blob/" in identifier or "/tree/" in identifier:
+            continue
+        identifiers.append(identifier.removesuffix(".git"))
+    return list(dict.fromkeys(identifiers))
+
+
+def _github_skill_identifier_from_text(text: str) -> tuple[str, str]:
+    """Return (mode, identifier) for a GitHub skill install request.
+
+    mode is "install" for direct SKILL.md URLs and "tap" for GitHub repos.
+    """
+    raw = text or ""
+    identifiers = _github_skill_identifiers_from_text(raw)
+    if identifiers:
+        return "install", identifiers[0]
+
+    match = _GITHUB_REPO_URL_RE.search(raw)
+    if match:
+        owner = match.group("owner")
+        repo = match.group("repo").removesuffix(".git")
+        url = match.group(0).rstrip(".,，。)")
+        if re.search(r"/SKILL\.md(?:[?#].*)?$", url, re.IGNORECASE):
+            blob_match = re.match(
+                r"https?://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.*/?SKILL\.md)(?:[?#].*)?$",
+                url,
+                re.IGNORECASE,
+            )
+            if blob_match:
+                raw_owner, raw_repo, branch, path = blob_match.groups()
+                url = f"https://raw.githubusercontent.com/{raw_owner}/{raw_repo}/{branch}/{path}"
+            return "install", url
+        return "tap", f"{owner}/{repo}"
+
+    match = _GITHUB_OWNER_REPO_RE.search(raw)
+    if not match:
+        raise ValueError("未找到可安装的 GitHub repo 或 SKILL.md URL")
+    owner = match.group("owner")
+    repo = match.group("repo").removesuffix(".git")
+    return "tap", f"{owner}/{repo}"
+
+
+def _github_skill_targets_from_text(text: str) -> list[tuple[str, str]]:
+    raw = text or ""
+    targets: list[tuple[str, str]] = []
+
+    for match in _GITHUB_REPO_URL_RE.finditer(raw):
+        owner = match.group("owner")
+        repo = match.group("repo").removesuffix(".git")
+        url = match.group(0).rstrip(".,，。)")
+        if re.search(r"/SKILL\.md(?:[?#].*)?$", url, re.IGNORECASE):
+            blob_match = re.match(
+                r"https?://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.*/?SKILL\.md)(?:[?#].*)?$",
+                url,
+                re.IGNORECASE,
+            )
+            if blob_match:
+                raw_owner, raw_repo, branch, path = blob_match.groups()
+                url = f"https://raw.githubusercontent.com/{raw_owner}/{raw_repo}/{branch}/{path}"
+            targets.append(("install", url))
+        else:
+            targets.append(("tap", f"{owner}/{repo}"))
+
+    for identifier in _github_skill_identifiers_from_text(raw):
+        targets.append(("install", identifier))
+
+    if not targets:
+        targets.append(_github_skill_identifier_from_text(raw))
+
+    deduped: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for target in targets:
+        if target in seen:
+            continue
+        seen.add(target)
+        deduped.append(target)
+    return deduped
+
+
+def _run_hermes_skills_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "skills", *args],
+        text=True,
+        capture_output=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def _discover_github_skill_dirs(repo: str) -> tuple[list[str], str]:
+    try:
+        from tools.skills_hub import GitHubAuth, GitHubSource
+    except Exception as exc:
+        return [], f"无法加载 GitHub skill 探测器: {exc}"
+
+    try:
+        source = GitHubSource(GitHubAuth())
+        tree = source._get_repo_tree(repo)
+    except Exception as exc:
+        return [], f"无法读取 GitHub repo tree: {exc}"
+    if tree is None:
+        rate_limited = bool(getattr(source, "is_rate_limited", False))
+        if rate_limited:
+            return [], "GitHub API rate limit 已耗尽，暂时无法列出仓库内 skills。"
+        return [], "未能读取 GitHub repo tree。"
+
+    _branch, entries = tree
+    dirs: list[str] = []
+    for entry in entries:
+        if entry.get("type") != "blob":
+            continue
+        path = str(entry.get("path") or "")
+        if not path.endswith("/SKILL.md") and path != "SKILL.md":
+            continue
+        skill_dir = path[: -len("/SKILL.md")] if path.endswith("/SKILL.md") else ""
+        if not skill_dir:
+            dirs.append(repo)
+        elif "/deprecated/" not in f"/{skill_dir}/":
+            dirs.append(f"{repo}/{skill_dir}")
+
+    return sorted(dict.fromkeys(dirs)), ""
+
+
+def _format_github_skill_candidates(candidates: Sequence[str], limit: int = 12) -> str:
+    if not candidates:
+        return ""
+    lines = [f"发现 {len(candidates)} 个可安装 skill。这个 repo 不是单个 skill，所以我没有盲装全部。"]
+    for item in candidates[:limit]:
+        lines.append(f"- {item}")
+    if len(candidates) > limit:
+        lines.append(f"- ... 另有 {len(candidates) - limit} 个未展开")
+    lines.append("")
+    lines.append("请回复要安装的具体条目，例如：")
+    lines.append(f"安装 {candidates[0]}")
+    return "\n".join(lines)
+
+
+def _clip_command_output(text: str, limit: int = 1200) -> str:
+    text = re.sub(r"\x1b\[[0-9;]*m", "", text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "\n...(output clipped)"
+
+
+def _render_github_skill_install(text: str) -> str:
+    targets = _github_skill_targets_from_text(text)
+    install_targets = [identifier for mode, identifier in targets if mode == "install"]
+    if install_targets:
+        lines = ["已通过确定性快路径安装指定 GitHub skill："]
+        ok = 0
+        failed = 0
+        for identifier in install_targets:
+            result = _run_hermes_skills_command(["install", identifier, "--yes"])
+            combined = "\n".join(part for part in (result.stdout, result.stderr) if part)
+            output = _clip_command_output(combined, limit=500) or "(no output)"
+            if result.returncode == 0:
+                ok += 1
+                lines.append(f"- 成功: {identifier}")
+            else:
+                failed += 1
+                lines.append(f"- 失败: {identifier} (exit {result.returncode})")
+                lines.append(f"  {output}")
+        lines.append("")
+        lines.append(f"结果: {ok} 成功, {failed} 失败。")
+        lines.append("这次没有启动通用 Agent 探索，也没有扫描本机目录。")
+        return "\n".join(lines)
+
+    mode, identifier = targets[0]
+    if mode == "install":
+        cmd_args = ["install", identifier, "--yes"]
+        action = "安装 GitHub SKILL.md"
+    else:
+        cmd_args = ["tap", "add", identifier]
+        action = "添加 GitHub skill tap"
+
+    result = _run_hermes_skills_command(cmd_args)
+    combined = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    output = _clip_command_output(combined) or "(no output)"
+    if result.returncode == 0:
+        if mode == "tap":
+            candidates, discovery_error = _discover_github_skill_dirs(identifier)
+            if len(candidates) == 1:
+                install_result = _run_hermes_skills_command(["install", candidates[0], "--yes"])
+                install_output = _clip_command_output(
+                    "\n".join(part for part in (install_result.stdout, install_result.stderr) if part)
+                ) or "(no output)"
+                if install_result.returncode == 0:
+                    return "\n".join(
+                        [
+                            "已通过确定性快路径完成：添加 GitHub skill tap 并安装唯一候选",
+                            f"目标: {candidates[0]}",
+                            "",
+                            install_output,
+                            "",
+                            "这次没有启动通用 Agent 探索，也没有扫描本机目录。",
+                        ]
+                    )
+                return "\n".join(
+                    [
+                        "已添加 GitHub skill tap，但安装唯一候选失败。",
+                        f"目标: {candidates[0]}",
+                        f"退出码: {install_result.returncode}",
+                        "",
+                        install_output,
+                    ]
+                )
+            candidate_text = _format_github_skill_candidates(candidates)
+            if candidate_text:
+                output = f"{output}\n\n{candidate_text}"
+            elif discovery_error:
+                output = f"{output}\n\n{discovery_error}"
+        return "\n".join(
+            [
+                f"已通过确定性快路径完成：{action}",
+                f"目标: {identifier}",
+                "",
+                output,
+                "",
+                "这次没有启动通用 Agent 探索，也没有扫描本机目录。新 skill/tap 会在下个会话或 reload 后进入可用范围。",
+            ]
+        )
+    return "\n".join(
+        [
+            f"GitHub skill 快路径执行失败：{action}",
+            f"目标: {identifier}",
+            f"退出码: {result.returncode}",
+            "",
+            output,
+            "",
+            "我已停止继续探索，避免再次消耗普通飞书轮次。请改用明确的 SKILL.md URL，或发送 `深诊断：继续安装这个 skill` 进入高预算路径。",
+        ]
+    )
+
+
+def _render_github_skill_reference_clarification(text: str) -> str:
+    identifiers = _github_skill_identifiers_from_text(text)
+    if not identifiers:
+        identifiers = [match.group(0).rstrip(".,，。)") for match in re.finditer(
+            r"https?://github\.com/[^/\s]+/[^/\s]+/.*/SKILL\.md(?:[?#]\S*)?",
+            text or "",
+            re.IGNORECASE,
+        )]
+    lines = [
+        "我识别到了 GitHub skill 路径，但没有看到明确的安装指令，所以这次没有执行安装。",
+        "",
+        "要安装请回复：",
+    ]
+    for identifier in identifiers[:5]:
+        lines.append(f"- 安装 {identifier}")
+    if len(identifiers) > 5:
+        lines.append(f"- ... 另有 {len(identifiers) - 5} 个未展开")
+    lines.extend(
+        [
+            "",
+            "这次没有启动通用 Agent 探索，也没有扫描本机目录。",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _cron_jobs_named_in_text(text: str) -> list[dict[str, object]]:
+    normalized = _normalize_text(text)
+    if not normalized:
+        return []
+    try:
+        from cron.jobs import load_jobs
+    except Exception:
+        return []
+    matches: list[dict[str, object]] = []
+    try:
+        jobs = load_jobs()
+    except Exception as exc:
+        logger.warning("Failed to load cron jobs for known ops fast path: %s", exc)
+        return []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        name = str(job.get("name") or "").strip()
+        if name and _normalize_text(name) in normalized:
+            matches.append(job)
+    return matches
+
+
+def _looks_like_cron_schedule_status_request(text: str) -> bool:
+    """Detect simple cron schedule questions that should not start an agent turn."""
+    normalized = _normalize_text(text)
+    if not normalized:
+        return False
+    has_cron_context = any(
+        marker in normalized
+        for marker in (
+            "定时",
+            "自动运行",
+            "计划任务",
+            "cron",
+            "scheduledjob",
+            "schedule",
+        )
+    )
+    has_schedule_question = any(
+        marker in normalized
+        for marker in (
+            "间隔",
+            "多久",
+            "多长时间",
+            "频率",
+            "几分钟",
+            "几小时",
+            "下次",
+            "什么时候",
+            "schedule",
+        )
+    )
+    return bool(has_cron_context and has_schedule_question and _cron_jobs_named_in_text(text))
+
+
+def _render_cron_schedule_status(text: str) -> str:
+    jobs = _cron_jobs_named_in_text(text)
+    if not jobs:
+        return "没有在当前 cron 配置里找到这个定时任务。"
+
+    lines = ["当前定时任务配置："]
+    for job in jobs[:3]:
+        name = str(job.get("name") or job.get("id") or "cron job")
+        schedule = str(job.get("schedule_display") or "")
+        if not schedule:
+            raw_schedule = job.get("schedule")
+            if isinstance(raw_schedule, dict):
+                schedule = str(
+                    raw_schedule.get("display")
+                    or raw_schedule.get("value")
+                    or raw_schedule.get("expr")
+                    or raw_schedule.get("run_at")
+                    or "?"
+                )
+            else:
+                schedule = str(raw_schedule or "?")
+        state = "active" if job.get("enabled", True) and job.get("state", "scheduled") != "paused" else "paused"
+        lines.append(f"- {name}: {schedule} ({state})")
+        next_run = str(job.get("next_run_at") or "").strip()
+        if next_run:
+            lines.append(f"  下次运行: {next_run}")
+        last_run = str(job.get("last_run_at") or "").strip()
+        last_status = str(job.get("last_status") or "").strip()
+        if last_run or last_status:
+            suffix = f" {last_status}" if last_status else ""
+            lines.append(f"  最近运行: {last_run}{suffix}".rstrip())
+    if len(jobs) > 3:
+        lines.append(f"另外还有 {len(jobs) - 3} 个同名/匹配任务未展开。")
+    return "\n".join(lines)
+
+
+def _render_agent_loop_diagnostic_report(text: str) -> str:
+    return "\n".join(
+        [
+            "Hermes/OpenClaw 故障诊断循环快照：",
+            "",
+            "- 已识别为诊断循环类问题，先走确定性报告，避免再次进入通用 Agent 探索循环。",
+            "- 当前已知风险点：普通 Feishu 诊断预算较低，深诊断只是扩大轮次；如果没有预算前收口，仍可能继续发散。",
+            "- 已知有效保护：Feishu 普通/深诊断预算分流、工具结果压缩、压缩低收益停止、工具循环 guardrail、known ops 快路径。",
+            "- 仍需看代码/日志时，请只查一个明确缺口：预算前收口、连续探索 guardrail、known ops 覆盖，避免重新大范围搜索历史归档。",
+            "",
+            "建议下一步：如果你是在排查“为什么上轮没答复”，先看最近一次 trajectory 的 finalStatus、toolMetas 数量、turn_exit_reason；如果只是要继续修复 Hermes，请直接指定一个缺口继续。",
+        ]
+    )
+
+
+def _parse_top_n(text: str, default: int = 3) -> int:
+    match = re.search(r"(?:前|top)\s*([0-9一二三四五六七八九十]+)", text or "", re.IGNORECASE)
+    if not match:
+        return default
+    raw = match.group(1)
+    chinese_digits = {
+        "一": 1,
+        "二": 2,
+        "三": 3,
+        "四": 4,
+        "五": 5,
+        "六": 6,
+        "七": 7,
+        "八": 8,
+        "九": 9,
+        "十": 10,
+    }
+    try:
+        value = int(raw)
+    except ValueError:
+        value = chinese_digits.get(raw, default)
+    return max(1, min(value, 10))
+
+
+def _today_token_usage_scope(text: str) -> str:
+    normalized = _normalize_text(text)
+    if "飞书" in normalized and not any(marker in normalized for marker in ("全部", "所有", "整体")):
+        return "feishu"
+    return "all"
+
+
+def _chinese_number_to_int(raw: str, default: int) -> int:
+    raw = (raw or "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    digits = {
+        "一": 1,
+        "二": 2,
+        "两": 2,
+        "三": 3,
+        "四": 4,
+        "五": 5,
+        "六": 6,
+        "七": 7,
+        "八": 8,
+        "九": 9,
+        "十": 10,
+    }
+    if raw == "十":
+        return 10
+    if raw.startswith("十"):
+        return 10 + digits.get(raw[1:], 0)
+    if "十" in raw:
+        left, _, right = raw.partition("十")
+        return digits.get(left, 1) * 10 + digits.get(right, 0)
+    return digits.get(raw, default)
+
+
+def _parse_token_usage_window(text: str) -> dict[str, object]:
+    normalized = _normalize_text(text)
+    now = dt.datetime.now(ZoneInfo("Asia/Shanghai"))
+    today = now.date()
+    dates = re.findall(r"\d{4}-\d{2}-\d{2}", text or "")
+
+    if len(dates) >= 2:
+        return {
+            "range_start": dates[0],
+            "range_end": (dt.date.fromisoformat(dates[1]) + dt.timedelta(days=1)).isoformat(),
+            "label": f"{dates[0]} 至 {dates[1]}",
+        }
+    if len(dates) == 1:
+        return {"target_date": dates[0], "label": dates[0]}
+
+    if any(marker in normalized for marker in ("昨天", "昨日")):
+        target = today - dt.timedelta(days=1)
+        return {"target_date": target.isoformat(), "label": "昨日"}
+
+    if any(marker in normalized for marker in ("本周", "这周")):
+        start = today - dt.timedelta(days=today.weekday())
+        return {"range_start": start.isoformat(), "range_end": (today + dt.timedelta(days=1)).isoformat(), "label": "本周"}
+
+    if any(marker in normalized for marker in ("本月", "这个月")):
+        start = today.replace(day=1)
+        return {"range_start": start.isoformat(), "range_end": (today + dt.timedelta(days=1)).isoformat(), "label": "本月"}
+
+    month_match = re.search(r"(?:最近)?([0-9一二两三四五六七八九十]+)?(?:个)?月(?:内|以内|之内)?", normalized)
+    if month_match and "本月" not in normalized:
+        months = _chinese_number_to_int(month_match.group(1) or "一", 1)
+        return {"days": max(1, min(months * 30, 366)), "label": f"最近 {months} 个月"}
+
+    week_match = re.search(r"(?:最近)?([0-9一二两三四五六七八九十]+)?周(?:内|以内|之内)?", normalized)
+    if week_match:
+        weeks = _chinese_number_to_int(week_match.group(1) or "一", 1)
+        return {"days": max(1, min(weeks * 7, 366)), "label": f"最近 {weeks} 周"}
+
+    day_match = re.search(r"(?:最近)?([0-9一二两三四五六七八九十]+)天(?:内|以内|之内)?", normalized)
+    if day_match:
+        days = _chinese_number_to_int(day_match.group(1), 1)
+        return {"days": max(1, min(days, 366)), "label": f"最近 {days} 天"}
+
+    return {"label": "今日"}
+
+
+def _render_token_usage_report(text: str) -> str:
+    from tools.local_repair_tool import render_token_usage_report
+
+    return render_token_usage_report(
+        scope=_today_token_usage_scope(text),
+        top_n=_parse_top_n(text),
+        **_parse_token_usage_window(text),
+    )
+
+
+def _render_token_usage_clarification(text: str) -> str:
+    return (
+        "请指定 token 统计时间范围，例如：\n"
+        "- 查今天 token 使用情况\n"
+        "- 查昨天 token 使用情况\n"
+        "- 统计最近 3 天 Token 消耗"
+    )
+
+
+KNOWN_OPS_TASKS: tuple[KnownOpsTask, ...] = (
+    KnownOpsTask(
+        name="cron_schedule_status",
+        platforms=frozenset({"feishu"}),
+        detector=_looks_like_cron_schedule_status_request,
+        handler=_render_cron_schedule_status,
+        verification=(
+            "unit: tests/gateway/test_known_ops_tasks.py",
+            "runtime: ask Feishu for a named cron job interval and verify no agent turn starts",
+        ),
+        promotion_hint=(
+            "Named cron schedule/status questions should read cron/jobs.json "
+            "deterministically instead of spending a low-budget Feishu agent turn."
+        ),
+        description="Answer simple schedule questions for named cron jobs without starting an agent turn.",
+    ),
+    KnownOpsTask(
+        name="agent_loop_diagnostic_report",
+        platforms=frozenset({"feishu"}),
+        detector=_looks_like_agent_loop_diagnostic_request,
+        handler=_render_agent_loop_diagnostic_report,
+        verification=(
+            "unit: tests/gateway/test_known_ops_tasks.py",
+            "runtime: send a Feishu diagnostic-loop question and verify no agent turn starts",
+        ),
+        promotion_hint=(
+            "Repeated questions about Hermes/OpenClaw diagnostic loops should get a "
+            "bounded deterministic status report first; only the named missing gap "
+            "should be handed to the general agent."
+        ),
+        description="Explain Hermes/OpenClaw diagnostic-loop state without starting another broad diagnostic turn.",
+    ),
+    KnownOpsTask(
+        name="github_skill_install",
+        platforms=frozenset({"feishu"}),
+        detector=_looks_like_github_skill_install_request,
+        handler=_render_github_skill_install,
+        verification=(
+            "unit: tests/gateway/test_known_ops_tasks.py",
+            "runtime: send a Feishu GitHub skill install request and verify no agent turn starts",
+        ),
+        promotion_hint=(
+            "Clear Feishu requests to install a GitHub-hosted skill should call "
+            "the Hermes skills CLI directly instead of letting the model scan "
+            "home directories or GitHub contents JSON."
+        ),
+        description="Install or add GitHub-hosted skills through the Hermes skills CLI before agent dispatch.",
+    ),
+    KnownOpsTask(
+        name="github_skill_reference_clarification",
+        platforms=frozenset({"feishu"}),
+        detector=_looks_like_github_skill_reference_without_install_request,
+        handler=_render_github_skill_reference_clarification,
+        verification=(
+            "unit: tests/gateway/test_known_ops_tasks.py",
+            "runtime: send a Feishu GitHub skill path without an install verb and verify no agent turn starts",
+        ),
+        promotion_hint=(
+            "Path-only GitHub skill mentions should ask for explicit install confirmation "
+            "instead of entering the low-budget Feishu general agent."
+        ),
+        description="Clarify path-only GitHub skill mentions without starting an agent turn.",
+    ),
+    KnownOpsTask(
+        name="token_usage_report",
+        platforms=frozenset({"feishu", "telegram"}),
+        detector=_looks_like_token_usage_request,
+        handler=_render_token_usage_report,
+        verification=(
+            "unit: tests/gateway/test_known_ops_tasks.py",
+            "unit: tests/tools/test_local_repair_tool.py",
+            "runtime: ask Feishu or Telegram for token usage and verify no agent turn starts",
+        ),
+        promotion_hint=(
+            "Repeated messaging-platform requests for token usage over common time windows should "
+            "stay on this deterministic state.db report path; extend the time-window "
+            "parser instead of adding one-off scripts."
+        ),
+        description="Render Hermes input/output token usage and top sessions for common time windows.",
+    ),
+    KnownOpsTask(
+        name="token_usage_clarification",
+        platforms=frozenset({"feishu", "telegram"}),
+        detector=_looks_like_token_usage_clarification_request,
+        handler=_render_token_usage_clarification,
+        verification=(
+            "unit: tests/gateway/test_known_ops_tasks.py",
+            "runtime: ask Telegram '查token' and verify no agent turn starts",
+        ),
+        promotion_hint=(
+            "Vague token usage asks should request a bounded time window instead of "
+            "starting an exploratory agent turn."
+        ),
+        description="Clarify vague token usage requests without starting an agent turn.",
+    ),
+)
+
+
+def iter_known_ops_tasks(platform: str) -> tuple[KnownOpsTask, ...]:
+    return tuple(task for task in KNOWN_OPS_TASKS if task.supports_platform(platform))
+
+
+def match_known_ops_task(platform: str, text: str) -> KnownOpsTask | None:
+    for task in iter_known_ops_tasks(platform):
+        try:
+            if task.detector(text):
+                return task
+        except Exception as exc:
+            logger.warning("Known ops detector failed for %s: %s", task.name, exc)
+    return None
+
+
+def render_known_ops_task(platform: str, text: str) -> KnownOpsTaskResult | None:
+    task = match_known_ops_task(platform, text)
+    if task is None:
+        return None
+    return KnownOpsTaskResult(task=task, text=task.handler(text))
+
+
+def known_ops_task_metadata(platform: str | None = None) -> list[dict[str, object]]:
+    tasks: Sequence[KnownOpsTask]
+    if platform:
+        tasks = iter_known_ops_tasks(platform)
+    else:
+        tasks = KNOWN_OPS_TASKS
+    return [
+        {
+            "name": task.name,
+            "platforms": sorted(task.platforms),
+            "description": task.description,
+            "verification": list(task.verification),
+            "promotion_hint": task.promotion_hint,
+        }
+        for task in tasks
+    ]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -55,6 +55,7 @@ from typing import Callable, Dict, Optional, Any, List, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
+from gateway.known_ops_tasks import render_known_ops_task
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -2176,6 +2177,88 @@ def _check_unavailable_skill(command_name: str) -> str | None:
 def _platform_config_key(platform: "Platform") -> str:
     """Map a Platform enum to its config.yaml key (LOCAL→"cli", rest→enum value)."""
     return "cli" if platform == Platform.LOCAL else platform.value
+
+
+def _deep_command_message(text: str) -> str:
+    """Rewrite /deep arguments into the plain-text diagnostic trigger."""
+    text = (text or "").strip()
+    return f"深诊断：{text or '继续上一轮问题'}"
+
+
+def _platform_budget_key_for_message(platform: str, message: str) -> str:
+    """Return the runtime budget key for a platform/message pair.
+
+    Messaging platforms get a narrow default budget for ordinary ops
+    diagnostics. Users must opt into the larger one with either the plain-text
+    trigger or /deep. UI verification is a separate compact mode because it is
+    allowed to touch desktop state but should not inherit earlier repair logs.
+    """
+    platform_key = (platform or "").strip().lower()
+    text = (message or "").lstrip()
+    is_deep = (
+        text == "深诊断"
+        or text.startswith("深诊断：")
+        or text.startswith("深诊断:")
+        or text.startswith("/deep")
+    )
+    is_ui = (
+        text == "UI验证"
+        or text.startswith("UI验证：")
+        or text.startswith("UI验证:")
+        or text.startswith("/ui")
+    )
+    if platform_key in {"feishu", "telegram"}:
+        if is_deep:
+            return f"{platform_key}_deep"
+        if is_ui:
+            return f"{platform_key}_ui"
+        return platform_key
+    if (
+        is_deep
+        and platform_key in {"discord", "slack", "matrix", "wechat", "qq"}
+    ):
+        return "deep_diagnostic"
+    if is_ui:
+        return "ui_verification"
+    return platform_key
+
+
+def _platform_task_mode_for_message(platform: str, budget_key: str, message: str) -> str:
+    try:
+        from agent.install_success_stop import is_install_task_message
+        if is_install_task_message(platform, budget_key, message):
+            return "install"
+    except Exception:
+        pass
+    return ""
+
+
+def _max_iterations_for_platform_budget(default_max: int, platform_budget_key: str) -> int:
+    if platform_budget_key in {"feishu", "telegram"}:
+        return min(default_max, 6)
+    if platform_budget_key in {"feishu_ui", "telegram_ui", "ui_verification"}:
+        return min(default_max, 6)
+    if platform_budget_key in {"feishu_deep", "telegram_deep", "deep_diagnostic"}:
+        return min(max(default_max, 12), 12)
+    return default_max
+
+
+def _safe_first_response_before_queued_followup(text: str) -> str:
+    """Return a bounded response for delivery before a queued follow-up."""
+    text = text or ""
+    if "[OUT-OF-BAND USER MESSAGE" in text:
+        return (
+            "本轮已结束，但生成的收口内容包含内部中途消息标记，已停止直接投递以避免刷屏。"
+            "\n\n"
+            "我会继续处理你刚发来的新消息；如果要延续原任务，请发送 `深诊断：继续`。"
+        )
+    if len(text) > 12000:
+        return (
+            "本轮已结束，但生成的收口内容过长，已停止整段投递以避免刷屏。"
+            "\n\n"
+            "我会继续处理你刚发来的新消息；如果要延续原任务，请发送 `深诊断：继续`。"
+        )
+    return text
 
 
 def _teams_pipeline_plugin_enabled() -> bool:
@@ -8668,6 +8751,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # clearly moved on.
             _slash_confirm_mod.clear_if_stale(_quick_key)
 
+        if not event.get_command():
+            try:
+                platform_name = source.platform.value if source.platform else ""
+                known_ops_result = render_known_ops_task(platform_name, event.text or "")
+            except Exception as exc:
+                logger.warning("Known ops fast path failed: %s", exc)
+                return f"已知运维快路径执行失败：{exc}"
+            if known_ops_result is not None:
+                logger.info("Known ops fast path matched: %s", known_ops_result.task.name)
+                return known_ops_result.text
+
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
         # are handled with minimal latency.
@@ -9425,6 +9519,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "background":
             return await self._handle_background_command(event)
+
+        if canonical == "deep":
+            try:
+                event.text = _deep_command_message(event.get_command_args())
+            except Exception:
+                pass
+            # Do NOT return — fall through to normal message processing with
+            # the plain-text deep diagnostic trigger.
 
         if canonical == "steer":
             # No active agent — /steer has no tool call to inject into.
@@ -12588,6 +12690,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
 
             platform_key = _platform_config_key(source.platform)
+            platform_budget_key = _platform_budget_key_for_message(platform_key, prompt)
+            platform_task_mode = _platform_task_mode_for_message(
+                platform_key,
+                platform_budget_key,
+                prompt,
+            )
 
             from hermes_cli.tools_config import _get_platform_tools
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -12595,7 +12703,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
             pr = self._provider_routing
-            max_iterations = _current_max_iterations()
+            max_iterations = _max_iterations_for_platform_budget(
+                int(os.getenv("HERMES_MAX_ITERATIONS", "90")),
+                platform_budget_key,
+            )
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -12648,6 +12759,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     fallback_model=self._fallback_model,
                 )
+                agent._platform_budget_key = platform_budget_key
+                agent._platform_task_mode = platform_task_mode
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,
@@ -16771,7 +16884,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
-            
+            platform_budget_key = _platform_budget_key_for_message(platform_key, message)
+            platform_task_mode = _platform_task_mode_for_message(
+                platform_key,
+                platform_budget_key,
+                message,
+            )
+
+            # Read from env var or use default (same as CLI). Messaging
+            # platforms can narrow or widen this per explicit diagnostic mode.
+            max_iterations = _max_iterations_for_platform_budget(
+                int(os.getenv("HERMES_MAX_ITERATIONS", "90")),
+                platform_budget_key,
+            )
+
             # Combine platform context, per-channel context, and the user-configured
             # ephemeral system prompt.
             combined_ephemeral = context_prompt or ""
@@ -16780,8 +16906,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
             if self._ephemeral_system_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
-
-            max_iterations = _current_max_iterations()
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(
@@ -17113,6 +17237,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
+            agent.platform = platform_key
+            agent._platform_budget_key = platform_budget_key
+            agent._platform_task_mode = platform_task_mode
+            agent.max_iterations = max_iterations
             # Credits / out-of-band notices (usage bands, depletion, restored).
             # Messaging has no persistent status bar, so each notice is a
             # standalone push: render to a single plaintext line and deliver via
@@ -18543,6 +18671,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         previewed=_previewed,
                     )
                     if first_response and not _already_streamed:
+                        first_response = _safe_first_response_before_queued_followup(
+                            first_response
+                        )
                         try:
                             logger.info(
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -115,6 +115,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[text | draft <text> | show | pause | resume | clear | status | wait <pid> | unwait]"),
     CommandDef("moa", "Run one prompt through the default Mixture of Agents preset, then restore your model", "Session",
                args_hint="<prompt>"),
+    CommandDef("deep", "Run one expanded diagnostic turn from messaging platforms", "Session",
+               gateway_only=True, args_hint="[prompt]"),
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",
                args_hint="[text | remove N | clear]"),
     CommandDef("status", "Show session, model, token, and context info", "Session"),

--- a/tests/agent/test_install_success_stop.py
+++ b/tests/agent/test_install_success_stop.py
@@ -1,0 +1,129 @@
+from agent.install_success_stop import install_success_stop_response
+
+
+def test_install_success_stop_requires_acquire_install_and_verify():
+    messages = [
+        {"role": "user", "content": "请帮我安装 https://github.com/BigPizzaV3/CodexPlusPlus"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"curl -L https://github.com/BigPizzaV3/CodexPlusPlus/releases/latest -o app.dmg"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "call_1",
+            "content": '{"output":"downloaded CodexPlusPlus v1.1.7 dmg from github.com","exit_code":0}',
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_2",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"cp -R CodexPlusPlus.app /Applications && ls /Applications/CodexPlusPlus.app"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "call_2",
+            "content": '{"output":"/Applications/CodexPlusPlus.app installed and verified","exit_code":0}',
+        },
+    ]
+
+    response = install_success_stop_response(messages, 0)
+
+    assert response is not None
+    assert "已完成安装并通过验证" in response
+    assert "v1.1.7" in response
+
+
+def test_install_success_stop_does_not_fire_without_verification():
+    messages = [
+        {"role": "user", "content": "install https://github.com/acme/tool"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"git clone https://github.com/acme/tool && npm install"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "call_1",
+            "content": '{"output":"downloaded and installed packages","exit_code":0}',
+        },
+    ]
+
+    assert install_success_stop_response(messages, 0) is None
+
+
+def test_install_success_stop_does_not_fire_on_failure():
+    messages = [
+        {"role": "user", "content": "install https://github.com/acme/tool"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"curl https://github.com/acme/tool && tool --version"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "call_1",
+            "content": '{"output":"download failed: not found","exit_code":1}',
+        },
+    ]
+
+    assert install_success_stop_response(messages, 0) is None
+
+
+def test_install_success_stop_supports_package_manager_installs():
+    messages = [
+        {"role": "user", "content": "install ffmpeg with brew"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"brew install ffmpeg && ffmpeg -version"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "terminal",
+            "tool_call_id": "call_1",
+            "content": '{"output":"ffmpeg 7.1 successfully installed\\nffmpeg version 7.1","exit_code":0}',
+        },
+    ]
+
+    assert install_success_stop_response(messages, 0) is not None

--- a/tests/agent/test_phase_checkpoint.py
+++ b/tests/agent/test_phase_checkpoint.py
@@ -1,0 +1,21 @@
+from agent.phase_checkpoint import PhaseCheckpoint
+
+
+def test_phase_checkpoint_omits_raw_base64_and_truncates():
+    raw = "data:image/png;base64," + ("A" * 5000)
+    checkpoint = PhaseCheckpoint(
+        objective="verify UI",
+        changes=[f"stored screenshot {raw}"],
+        verification_passed=["pytest ok"],
+        next_phase_inputs=["x" * 3000],
+        artifact_paths=["/tmp/capture.png"],
+        stop_reason="fast path verified",
+    )
+
+    text = checkpoint.to_json()
+
+    assert "data:image" not in text
+    assert "base64,AAAA" not in text
+    assert "/tmp/capture.png" in text
+    assert "checkpoint field truncated" in text
+

--- a/tests/gateway/test_feishu_deep_budget.py
+++ b/tests/gateway/test_feishu_deep_budget.py
@@ -1,0 +1,76 @@
+"""Feishu low-budget routing and deterministic diagnostic shortcuts."""
+
+from gateway.run import (
+    _deep_command_message,
+    _platform_budget_key_for_message,
+    _platform_task_mode_for_message,
+)
+from gateway.known_ops_tasks import match_known_ops_task
+from hermes_cli.commands import is_gateway_known_command, resolve_command
+
+
+def test_feishu_plain_message_keeps_low_token_budget_key():
+    assert _platform_budget_key_for_message("feishu", "继续上一轮") == "feishu"
+
+
+def test_feishu_deep_prefix_selects_deep_budget_key():
+    assert _platform_budget_key_for_message("feishu", "深诊断") == "feishu_deep"
+    assert _platform_budget_key_for_message("feishu", "深诊断：继续查路由配置") == "feishu_deep"
+    assert _platform_budget_key_for_message("feishu", "/deep 继续查路由配置") == "feishu_deep"
+
+
+def test_deep_prefix_selects_telegram_deep_budget_key():
+    assert _platform_budget_key_for_message("telegram", "继续上一轮") == "telegram"
+    assert _platform_budget_key_for_message("telegram", "/deep 继续查") == "telegram_deep"
+    assert _platform_budget_key_for_message("telegram", "深诊断：继续查") == "telegram_deep"
+
+
+def test_feishu_github_install_request_uses_install_task_mode():
+    message = "请帮我安装这个 : https://github.com/BigPizzaV3/CodexPlusPlus"
+    budget_key = _platform_budget_key_for_message("feishu", message)
+
+    assert budget_key == "feishu"
+    assert _platform_task_mode_for_message("feishu", budget_key, message) == "install"
+
+
+def test_feishu_deep_install_request_does_not_use_install_task_mode():
+    message = "深诊断：请帮我安装这个 : https://github.com/BigPizzaV3/CodexPlusPlus"
+    budget_key = _platform_budget_key_for_message("feishu", message)
+
+    assert budget_key == "feishu_deep"
+    assert _platform_task_mode_for_message("feishu", budget_key, message) == ""
+
+
+def test_non_feishu_install_request_does_not_use_install_task_mode():
+    message = "install https://github.com/BigPizzaV3/CodexPlusPlus"
+
+    assert _platform_task_mode_for_message("telegram", "telegram", message) == ""
+
+
+def test_deep_slash_command_is_registered_for_gateway():
+    cmd = resolve_command("deep")
+
+    assert cmd is not None
+    assert cmd.name == "deep"
+    assert is_gateway_known_command("deep")
+
+
+def test_deep_slash_command_rewrites_to_text_trigger():
+    assert _deep_command_message("") == "深诊断：继续上一轮问题"
+    assert _deep_command_message("继续查路由") == "深诊断：继续查路由"
+    assert _platform_budget_key_for_message("feishu", _deep_command_message("")) == "feishu_deep"
+
+
+def test_today_token_usage_request_uses_fast_report_intent():
+    task = match_known_ops_task(
+        "feishu",
+        "请查一下 今天截止到现在，输入输出Token的整体消耗情况，消耗Token最多的前三项任务是哪几个"
+    )
+    assert task is not None
+    assert task.name == "token_usage_report"
+    assert match_known_ops_task("feishu", "今日 token 用量统计") is not None
+
+
+def test_unrelated_token_text_does_not_use_fast_report_intent():
+    assert match_known_ops_task("feishu", "解释一下 token 是什么") is None
+    assert match_known_ops_task("feishu", "今天帮我检查 OpenClaw 状态") is None

--- a/tests/gateway/test_known_ops_tasks.py
+++ b/tests/gateway/test_known_ops_tasks.py
@@ -1,0 +1,393 @@
+"""Known ops task registry behavior."""
+
+from types import SimpleNamespace
+
+from gateway.known_ops_tasks import (
+    known_ops_task_metadata,
+    match_known_ops_task,
+    render_known_ops_task,
+)
+
+
+def test_known_ops_task_metadata_exposes_promotion_contract():
+    metadata = known_ops_task_metadata("feishu")
+
+    cron_task = next(item for item in metadata if item["name"] == "cron_schedule_status")
+    assert "verification" in cron_task
+    assert "cron/jobs.json" in cron_task["promotion_hint"]
+
+    token_task = next(item for item in metadata if item["name"] == "token_usage_report")
+    assert "verification" in token_task
+    assert "promotion_hint" in token_task
+    assert token_task["platforms"] == ["feishu", "telegram"]
+
+    loop_task = next(item for item in metadata if item["name"] == "agent_loop_diagnostic_report")
+    assert "diagnostic-loop" in " ".join(loop_task["verification"])
+
+    github_skill_task = next(item for item in metadata if item["name"] == "github_skill_install")
+    assert "Hermes skills CLI" in github_skill_task["promotion_hint"]
+
+    github_skill_clarification = next(
+        item for item in metadata if item["name"] == "github_skill_reference_clarification"
+    )
+    assert "Path-only" in github_skill_clarification["promotion_hint"]
+
+
+def test_known_ops_task_is_platform_scoped():
+    text = "请检查今天的token使用情况"
+
+    assert match_known_ops_task("feishu", text) is not None
+    assert match_known_ops_task("telegram", text) is not None
+    assert match_known_ops_task("discord", text) is None
+
+
+def test_github_skill_repo_install_uses_tap_fast_path(monkeypatch):
+    captured = {}
+
+    def fake_run(args):
+        captured.setdefault("args", []).append(args)
+        return SimpleNamespace(returncode=0, stdout="Added tap: mattpocock/skills\n", stderr="")
+
+    monkeypatch.setattr("gateway.known_ops_tasks._run_hermes_skills_command", fake_run)
+    monkeypatch.setattr(
+        "gateway.known_ops_tasks._discover_github_skill_dirs",
+        lambda repo: (
+            [
+                "mattpocock/skills/skills/engineering/tdd",
+                "mattpocock/skills/skills/engineering/diagnosing-bugs",
+            ],
+            "",
+        ),
+    )
+
+    result = render_known_ops_task(
+        "feishu",
+        "请帮我安装这个skill: https://github.com/mattpocock/skills",
+    )
+
+    assert result is not None
+    assert result.task.name == "github_skill_install"
+    assert captured["args"] == [["tap", "add", "mattpocock/skills"]]
+    assert "没有启动通用 Agent 探索" in result.text
+    assert "mattpocock/skills" in result.text
+    assert "发现 2 个可安装 skill" in result.text
+    assert "没有盲装全部" in result.text
+    assert "mattpocock/skills/skills/engineering/tdd" in result.text
+
+
+def test_github_skill_repo_install_continues_for_single_candidate(monkeypatch):
+    captured = {}
+
+    def fake_run(args):
+        captured.setdefault("args", []).append(args)
+        if args[0] == "tap":
+            return SimpleNamespace(returncode=0, stdout="Added tap: owner/repo\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="Installed skill: only-skill\n", stderr="")
+
+    monkeypatch.setattr("gateway.known_ops_tasks._run_hermes_skills_command", fake_run)
+    monkeypatch.setattr(
+        "gateway.known_ops_tasks._discover_github_skill_dirs",
+        lambda repo: (["owner/repo/skills/only-skill"], ""),
+    )
+
+    result = render_known_ops_task("feishu", "安装这个 skill https://github.com/owner/repo")
+
+    assert result is not None
+    assert result.task.name == "github_skill_install"
+    assert captured["args"] == [
+        ["tap", "add", "owner/repo"],
+        ["install", "owner/repo/skills/only-skill", "--yes"],
+    ]
+    assert "安装唯一候选" in result.text
+
+
+def test_github_skill_identifier_installs_specific_skill(monkeypatch):
+    captured = {}
+
+    def fake_run(args):
+        captured.setdefault("args", []).append(args)
+        return SimpleNamespace(returncode=0, stdout="Installed skill: tdd\n", stderr="")
+
+    monkeypatch.setattr("gateway.known_ops_tasks._run_hermes_skills_command", fake_run)
+
+    result = render_known_ops_task(
+        "feishu",
+        "安装 mattpocock/skills/skills/engineering/tdd",
+    )
+
+    assert result is not None
+    assert result.task.name == "github_skill_install"
+    assert captured["args"] == [
+        ["install", "mattpocock/skills/skills/engineering/tdd", "--yes"],
+    ]
+    assert "成功: mattpocock/skills/skills/engineering/tdd" in result.text
+    assert "没有启动通用 Agent 探索" in result.text
+
+
+def test_github_skill_identifier_installs_multiple_specific_skills(monkeypatch):
+    captured = {}
+
+    def fake_run(args):
+        captured.setdefault("args", []).append(args)
+        return SimpleNamespace(returncode=0, stdout=f"Installed skill: {args[1]}\n", stderr="")
+
+    monkeypatch.setattr("gateway.known_ops_tasks._run_hermes_skills_command", fake_run)
+
+    result = render_known_ops_task(
+        "feishu",
+        "\n".join(
+            [
+                "请先帮我安装这几个:",
+                "mattpocock/skills/skills/engineering/tdd",
+                "mattpocock/skills/skills/engineering/diagnosing-bugs",
+                "mattpocock/skills/skills/engineering/codebase-design",
+            ]
+        ),
+    )
+
+    assert result is not None
+    assert result.task.name == "github_skill_install"
+    assert captured["args"] == [
+        ["install", "mattpocock/skills/skills/engineering/tdd", "--yes"],
+        ["install", "mattpocock/skills/skills/engineering/diagnosing-bugs", "--yes"],
+        ["install", "mattpocock/skills/skills/engineering/codebase-design", "--yes"],
+    ]
+    assert "结果: 3 成功, 0 失败。" in result.text
+
+
+def test_github_skill_identifier_without_install_asks_for_confirmation(monkeypatch):
+    def fail_if_called(args):
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr("gateway.known_ops_tasks._run_hermes_skills_command", fail_if_called)
+
+    result = render_known_ops_task(
+        "feishu",
+        "\n".join(
+            [
+                "帮 skill",
+                "mattpocock/skills/skills/engineering/tdd",
+                "mattpocock/skills/skills/engineering/diagnosing-bugs",
+            ]
+        ),
+    )
+
+    assert result is not None
+    assert result.task.name == "github_skill_reference_clarification"
+    assert "没有看到明确的安装指令" in result.text
+    assert "安装 mattpocock/skills/skills/engineering/tdd" in result.text
+    assert "没有启动通用 Agent 探索" in result.text
+
+
+def test_github_skill_identifier_without_install_clarification_is_platform_scoped(monkeypatch):
+    def fail_if_called(args):
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr("gateway.known_ops_tasks._run_hermes_skills_command", fail_if_called)
+
+    result = render_known_ops_task(
+        "telegram",
+        "mattpocock/skills/skills/engineering/tdd",
+    )
+
+    assert result is None
+
+
+def test_github_skill_direct_skill_md_uses_install_fast_path(monkeypatch):
+    captured = {}
+
+    def fake_run(args):
+        captured["args"] = args
+        return SimpleNamespace(returncode=0, stdout="Installed skill: demo\n", stderr="")
+
+    monkeypatch.setattr("gateway.known_ops_tasks._run_hermes_skills_command", fake_run)
+
+    result = render_known_ops_task(
+        "feishu",
+        "安装这个 skill https://github.com/example/repo/blob/main/SKILL.md",
+    )
+
+    assert result is not None
+    assert result.task.name == "github_skill_install"
+    assert captured["args"] == [
+        "install",
+        "https://raw.githubusercontent.com/example/repo/main/SKILL.md",
+        "--yes",
+    ]
+
+
+def test_github_skill_install_fast_path_is_platform_scoped(monkeypatch):
+    def fail_if_called(args):
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr("gateway.known_ops_tasks._run_hermes_skills_command", fail_if_called)
+
+    result = render_known_ops_task(
+        "telegram",
+        "请帮我安装这个skill: https://github.com/mattpocock/skills",
+    )
+
+    assert result is None
+
+
+def test_cron_schedule_question_uses_fast_path(monkeypatch):
+    monkeypatch.setattr(
+        "cron.jobs.load_jobs",
+        lambda: [
+            {
+                "id": "61fc0eed3cbe",
+                "name": "模型限频监控",
+                "schedule": {"kind": "interval", "minutes": 10, "display": "every 10m"},
+                "schedule_display": "every 10m",
+                "enabled": True,
+                "state": "scheduled",
+                "next_run_at": "2026-06-23T23:03:57+08:00",
+                "last_run_at": "2026-06-23T22:53:57+08:00",
+                "last_status": "ok",
+            }
+        ],
+    )
+
+    result = render_known_ops_task(
+        "feishu",
+        "请问 定时自动运行的 模型限频监控 目前的间隔是多长时间?",
+    )
+
+    assert result is not None
+    assert result.task.name == "cron_schedule_status"
+    assert "模型限频监控: every 10m" in result.text
+    assert "下次运行: 2026-06-23T23:03:57+08:00" in result.text
+    assert "最近运行: 2026-06-23T22:53:57+08:00 ok" in result.text
+
+
+def test_cron_schedule_question_is_platform_scoped(monkeypatch):
+    monkeypatch.setattr(
+        "cron.jobs.load_jobs",
+        lambda: [{"name": "模型限频监控", "schedule_display": "every 10m"}],
+    )
+
+    assert (
+        render_known_ops_task(
+            "telegram",
+            "请问 定时自动运行的 模型限频监控 目前的间隔是多长时间?",
+        )
+        is None
+    )
+
+
+def test_unrelated_cron_text_does_not_use_fast_path(monkeypatch):
+    monkeypatch.setattr(
+        "cron.jobs.load_jobs",
+        lambda: [{"name": "模型限频监控", "schedule_display": "every 10m"}],
+    )
+
+    assert render_known_ops_task("feishu", "请解释一下什么是 cron") is None
+    assert render_known_ops_task("feishu", "今天帮我检查 OpenClaw 状态") is None
+
+
+def test_vague_token_usage_request_asks_for_time_window():
+    result = render_known_ops_task("telegram", "查token")
+
+    assert result is not None
+    assert result.task.name == "token_usage_clarification"
+    assert "请指定 token 统计时间范围" in result.text
+    assert "查昨天 token 使用情况" in result.text
+
+
+def test_known_ops_task_render_uses_registered_handler(monkeypatch):
+    captured = {}
+
+    def fake_render_token_usage_report(**kwargs):
+        captured.update(kwargs)
+        return "fake token report"
+
+    monkeypatch.setattr(
+        "tools.local_repair_tool.render_token_usage_report",
+        fake_render_token_usage_report,
+    )
+
+    result = render_known_ops_task("feishu", "查一下飞书今日 Token 消耗 Top 5")
+
+    assert result is not None
+    assert result.task.name == "token_usage_report"
+    assert result.text == "fake token report"
+    assert captured["scope"] == "feishu"
+    assert captured["top_n"] == 5
+    assert captured["label"] == "今日"
+
+
+def test_known_ops_task_render_parses_yesterday(monkeypatch):
+    captured = {}
+
+    def fake_render_token_usage_report(**kwargs):
+        captured.update(kwargs)
+        return "fake token report"
+
+    monkeypatch.setattr(
+        "tools.local_repair_tool.render_token_usage_report",
+        fake_render_token_usage_report,
+    )
+
+    result = render_known_ops_task("feishu", "请查一下昨天一整天的token消耗情况")
+
+    assert result is not None
+    assert result.task.name == "token_usage_report"
+    assert result.text == "fake token report"
+    assert "target_date" in captured
+    assert captured["label"] == "昨日"
+
+
+def test_known_ops_task_render_parses_rolling_days(monkeypatch):
+    captured = {}
+
+    def fake_render_token_usage_report(**kwargs):
+        captured.update(kwargs)
+        return "fake token report"
+
+    monkeypatch.setattr(
+        "tools.local_repair_tool.render_token_usage_report",
+        fake_render_token_usage_report,
+    )
+
+    result = render_known_ops_task("feishu", "统计最近3天 Token 消耗 Top 8")
+
+    assert result is not None
+    assert result.task.name == "token_usage_report"
+    assert result.text == "fake token report"
+    assert captured["days"] == 3
+    assert captured["top_n"] == 8
+    assert captured["label"] == "最近 3 天"
+
+
+def test_known_ops_task_render_parses_explicit_date_range(monkeypatch):
+    captured = {}
+
+    def fake_render_token_usage_report(**kwargs):
+        captured.update(kwargs)
+        return "fake token report"
+
+    monkeypatch.setattr(
+        "tools.local_repair_tool.render_token_usage_report",
+        fake_render_token_usage_report,
+    )
+
+    result = render_known_ops_task("feishu", "统计 2026-06-10 到 2026-06-17 的 Token 用量")
+
+    assert result is not None
+    assert result.task.name == "token_usage_report"
+    assert result.text == "fake token report"
+    assert captured["range_start"] == "2026-06-10"
+    assert captured["range_end"] == "2026-06-18"
+    assert captured["label"] == "2026-06-10 至 2026-06-17"
+
+
+def test_agent_loop_diagnostic_request_uses_bounded_report():
+    result = render_known_ops_task(
+        "feishu",
+        "请分析为什么 Hermes 查 OpenClaw 故障一直卡住，无法答复，陷入死循环",
+    )
+
+    assert result is not None
+    assert result.task.name == "agent_loop_diagnostic_report"
+    assert "确定性报告" in result.text
+    assert "避免再次进入通用 Agent 探索循环" in result.text

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -15,7 +15,12 @@ import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, merge_pending_message_event
-from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+from gateway.run import (
+    GatewayRunner,
+    _AGENT_PENDING_SENTINEL,
+    _max_iterations_for_platform_budget,
+    _platform_budget_key_for_message,
+)
 from gateway.session import SessionSource, build_session_key
 
 
@@ -73,6 +78,17 @@ def _make_event(text="hello", chat_id="12345"):
         user_id="u1",
     )
     return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
+
+
+def test_messaging_budget_modes_are_explicit():
+    assert _platform_budget_key_for_message("telegram", "查token") == "telegram"
+    assert _platform_budget_key_for_message("telegram", "UI验证：查token") == "telegram_ui"
+    assert _platform_budget_key_for_message("telegram", "深诊断：查token") == "telegram_deep"
+    assert _platform_budget_key_for_message("feishu", "/deep 查token") == "feishu_deep"
+
+    assert _max_iterations_for_platform_budget(90, "telegram") == 6
+    assert _max_iterations_for_platform_budget(90, "telegram_ui") == 6
+    assert _max_iterations_for_platform_budget(90, "telegram_deep") == 12
 
 
 # ------------------------------------------------------------------

--- a/tests/tools/test_codex_context_bloat_monitor.py
+++ b/tests/tools/test_codex_context_bloat_monitor.py
@@ -1,0 +1,49 @@
+import json
+import sqlite3
+
+from tools.codex_context_bloat_monitor import collect_metrics
+
+
+def test_collect_metrics_flags_context_bloat(tmp_path):
+    rollout = tmp_path / "rollout.jsonl"
+    rollout.write_text(
+        json.dumps({"event": "usage", "last_input": 70000}) + "\n"
+        + json.dumps(
+            {
+                "tool": "get_app_state",
+                "output": "data:image/png;base64," + ("A" * 2000),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    db = tmp_path / "state_5.sqlite"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """
+        CREATE TABLE threads (
+            id TEXT,
+            title TEXT,
+            tokens_used INTEGER,
+            rollout_path TEXT,
+            archived INTEGER,
+            updated_at_ms INTEGER
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO threads VALUES (?, ?, ?, ?, 0, 1)",
+        ("t1", "token incident", 900000, str(rollout)),
+    )
+    conn.commit()
+    conn.close()
+
+    metrics = collect_metrics(tmp_path, limit=10)
+
+    assert len(metrics) == 1
+    reasons = metrics[0].incidents()
+    assert "tokens_used" in reasons
+    assert "last_input" in reasons
+    assert "image_base64_chars" in reasons
+

--- a/tests/tools/test_computer_use_budgeting.py
+++ b/tests/tools/test_computer_use_budgeting.py
@@ -1,0 +1,47 @@
+import base64
+import json
+
+from tools.computer_use.backend import CaptureResult, UIElement
+from tools.computer_use import tool as cu_tool
+
+
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAADUlEQVR4nG"
+    "NgGAUgAAABCAABgukLHQAAAABJRU5ErkJggg=="
+)
+
+
+def test_compact_capture_omits_inline_image_and_writes_artifact(monkeypatch, tmp_path):
+    monkeypatch.setattr("hermes_constants.get_hermes_dir", lambda: tmp_path)
+    cap = CaptureResult(
+        mode="som",
+        width=800,
+        height=600,
+        png_b64=_PNG_B64,
+        elements=[UIElement(index=0, role="AXButton", label="Send", bounds=(1, 2, 3, 4))],
+        app="Telegram",
+        window_title="Telegram",
+        png_bytes_len=len(base64.b64decode(_PNG_B64)),
+    )
+
+    resp = cu_tool._capture_response(cap, inspect_full=False, max_inline_chars=8000)
+    payload = json.loads(resp)
+
+    assert "data:image" not in resp
+    assert payload["image_inline_omitted"] is True
+    assert payload["screenshot_path"].startswith(str(tmp_path))
+    assert (tmp_path / "cache" / "computer-use").exists()
+
+
+def test_action_text_response_is_capped():
+    result = cu_tool.ActionResult(
+        ok=True,
+        action="type",
+        meta={"visible_text": "x" * 5000},
+    )
+
+    resp = cu_tool._text_response(result, max_inline_chars=1000)
+
+    assert len(resp) <= 1100
+    assert "inline_truncated" in resp
+

--- a/tests/tools/test_feishu_file_tool_budget.py
+++ b/tests/tools/test_feishu_file_tool_budget.py
@@ -1,0 +1,224 @@
+"""Feishu low-token behavior for file tools."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.file_tools import (
+    notify_other_tool_call,
+    read_file_tool,
+    search_tool,
+    _read_tracker,
+    _read_tracker_lock,
+)
+
+
+class FakeReadResult:
+    def __init__(self, content="1|hello\n"):
+        self.content = content
+
+    def to_dict(self):
+        return {
+            "content": self.content,
+            "file_size": len(self.content),
+            "total_lines": len(self.content.splitlines()),
+            "truncated": False,
+        }
+
+
+class FakeSearchResult:
+    def __init__(self):
+        self.matches = []
+
+    def to_dict(self, **_kwargs):
+        return {
+            "total_count": 30,
+            "files": [f"/tmp/file_{i}.py" for i in range(30)],
+            "truncated": True,
+        }
+
+
+class FakeFileOps:
+    def __init__(self):
+        self.read_calls = []
+        self.search_calls = []
+
+    def read_file(self, path, offset, limit):
+        self.read_calls.append((path, offset, limit))
+        return FakeReadResult()
+
+    def search(self, **kwargs):
+        self.search_calls.append(kwargs)
+        return FakeSearchResult()
+
+
+def _clear_task(task_id):
+    with _read_tracker_lock:
+        _read_tracker.pop(task_id, None)
+
+
+def test_feishu_read_file_default_and_explicit_limit_are_narrowed(tmp_path):
+    task_id = "feishu-read-limit"
+    _clear_task(task_id)
+    target = tmp_path / "sample.txt"
+    target.write_text("hello\n" * 300)
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        read_file_tool(str(target), task_id=task_id, platform="feishu")
+        read_file_tool(str(target), limit=999, task_id=task_id, platform="feishu")
+
+    assert fake.read_calls[0][2] == 120
+    assert fake.read_calls[1][2] == 200
+
+
+def test_cli_read_file_keeps_existing_default_limit(tmp_path):
+    task_id = "cli-read-limit"
+    _clear_task(task_id)
+    target = tmp_path / "sample.txt"
+    target.write_text("hello\n")
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        read_file_tool(str(target), task_id=task_id, platform="cli")
+
+    assert fake.read_calls[0][2] == 500
+
+
+def test_feishu_read_file_blocks_raw_cron_jobs_json(tmp_path):
+    task_id = "feishu-read-cron-jobs-json"
+    _clear_task(task_id)
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir()
+    jobs_path = cron_dir / "jobs.json"
+    jobs_path.write_text('{"jobs": []}\n')
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        result = json.loads(read_file_tool(str(jobs_path), task_id=task_id, platform="feishu"))
+
+    assert result["error"].startswith("BLOCKED: Feishu should not read raw cron/jobs.json")
+    assert result["recommendation"] == "Use cronjob(action='list') or execute_code with a targeted jobs filter."
+    assert fake.read_calls == []
+
+
+def test_feishu_deep_read_file_blocks_raw_cron_jobs_json(tmp_path):
+    task_id = "feishu-deep-read-cron-jobs-json"
+    _clear_task(task_id)
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir()
+    jobs_path = cron_dir / "jobs.json"
+    jobs_path.write_text('{"jobs": []}\n')
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        result = json.loads(read_file_tool(str(jobs_path), task_id=task_id, platform="feishu_deep"))
+
+    assert result["error"].startswith("BLOCKED: Feishu should not read raw cron/jobs.json")
+    assert fake.read_calls == []
+
+
+def test_cli_read_file_allows_raw_cron_jobs_json(tmp_path):
+    task_id = "cli-read-cron-jobs-json"
+    _clear_task(task_id)
+    cron_dir = tmp_path / "cron"
+    cron_dir.mkdir()
+    jobs_path = cron_dir / "jobs.json"
+    jobs_path.write_text('{"jobs": []}\n')
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        result = json.loads(read_file_tool(str(jobs_path), task_id=task_id, platform="cli"))
+
+    assert "error" not in result
+    assert fake.read_calls[0][0] == str(jobs_path)
+
+
+def test_feishu_search_files_defaults_to_files_only_and_limit_twenty(tmp_path):
+    task_id = "feishu-search-limit"
+    _clear_task(task_id)
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        search_tool("needle", path=str(tmp_path), task_id=task_id, platform="feishu")
+
+    call = fake.search_calls[0]
+    assert call["limit"] == 20
+    assert call["output_mode"] == "files_only"
+
+
+def test_feishu_search_files_blocks_default_home_root(monkeypatch):
+    task_id = "feishu-search-home-root"
+    _clear_task(task_id)
+    monkeypatch.setattr("tools.file_tools._resolve_base_dir", lambda _task_id="default": Path.home())
+
+    result = json.loads(search_tool("needle", task_id=task_id, platform="feishu"))
+
+    assert result["error"].startswith("BLOCKED: Feishu low-token search_files refused")
+    assert str(Path.home().resolve()) in result["error"]
+    assert "narrow path" in result["recommendation"]
+
+
+def test_feishu_search_files_blocks_explicit_home_root():
+    task_id = "feishu-search-explicit-home-root"
+    _clear_task(task_id)
+
+    result = json.loads(search_tool("needle", path=str(Path.home()), task_id=task_id, platform="feishu"))
+
+    assert result["error"].startswith("BLOCKED: Feishu low-token search_files refused")
+
+
+def test_feishu_deep_search_files_also_blocks_explicit_home_root():
+    task_id = "feishu-deep-search-explicit-home-root"
+    _clear_task(task_id)
+
+    result = json.loads(search_tool("needle", path=str(Path.home()), task_id=task_id, platform="feishu_deep"))
+
+    assert result["error"].startswith("BLOCKED: Feishu low-token search_files refused")
+
+
+def test_feishu_search_files_allows_explicit_narrow_path(tmp_path):
+    task_id = "feishu-search-narrow-path"
+    _clear_task(task_id)
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        raw = search_tool("needle", path=str(tmp_path), task_id=task_id, platform="feishu")
+        result = json.loads(raw.split("\n\n[Hint:", 1)[0])
+
+    assert "error" not in result
+    assert fake.search_calls[0]["path"] == str(tmp_path)
+
+
+def test_feishu_file_tool_budget_blocks_fifth_read_or_search(tmp_path):
+    task_id = "feishu-budget"
+    _clear_task(task_id)
+    target = tmp_path / "sample.txt"
+    target.write_text("hello\n")
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        read_file_tool(str(target), offset=1, task_id=task_id, platform="feishu")
+        read_file_tool(str(target), offset=2, task_id=task_id, platform="feishu")
+        search_tool("a", path=str(tmp_path), task_id=task_id, platform="feishu")
+        search_tool("b", path=str(tmp_path), task_id=task_id, platform="feishu")
+        result = json.loads(search_tool("c", path=str(tmp_path), task_id=task_id, platform="feishu"))
+
+    assert result["error"].startswith("BLOCKED: Feishu low-token file budget")
+    assert result["recommendation"] == "Switch to execute_code for batched local diagnosis."
+
+
+def test_non_read_tool_resets_feishu_file_tool_budget(tmp_path):
+    task_id = "feishu-budget-reset"
+    _clear_task(task_id)
+    target = tmp_path / "sample.txt"
+    target.write_text("hello\n")
+    fake = FakeFileOps()
+
+    with patch("tools.file_tools._get_file_ops", return_value=fake):
+        for i in range(4):
+            read_file_tool(str(target), offset=i + 1, task_id=task_id, platform="feishu")
+        notify_other_tool_call(task_id)
+        result = json.loads(read_file_tool(str(target), offset=10, task_id=task_id, platform="feishu"))
+
+    assert "error" not in result

--- a/tests/tools/test_local_repair_tool.py
+++ b/tests/tools/test_local_repair_tool.py
@@ -1,0 +1,251 @@
+"""Deterministic low-token local repair helpers."""
+
+import datetime as dt
+import sqlite3
+from zoneinfo import ZoneInfo
+
+from tools.local_repair_tool import (
+    collect_token_usage_report,
+    collect_today_token_usage_report,
+    format_token_usage_report,
+    format_today_token_usage_report,
+    repair_morning_briefing_operation_summary,
+)
+
+
+OLD_SCRIPT = '''import datetime as dt
+import re
+from pathlib import Path
+
+OPS_DIR = Path(__file__).resolve().parent / "docs" / "operation summary"
+
+
+def op_titles_for(day: dt.date) -> list[str]:
+    prefix = day.strftime("%Y%m%d")
+    titles: list[str] = []
+    if not OPS_DIR.exists():
+        return titles
+    for path in sorted(OPS_DIR.glob(f"{prefix}_*.html")):
+        stem = path.stem
+        title = re.sub(r"^\\d{12}_", "", stem).replace("_", " ")
+        titles.append(title)
+    return titles[:10]
+
+
+def summarize_cron(jobs):
+    return [], []
+'''
+
+
+def _write_fixture(tmp_path):
+    script = tmp_path / "morning-briefing-report.py"
+    docs = tmp_path / "docs"
+    ops = docs / "operation summary"
+    ops.mkdir(parents=True)
+    script.write_text(OLD_SCRIPT, encoding="utf-8")
+    (ops / "202606041044_Antigravity反代故障诊断与开机自启设置.html").write_text(
+        "<html></html>",
+        encoding="utf-8",
+    )
+    return script, docs
+
+
+def test_local_repair_dry_run_reports_fix_without_writing(tmp_path):
+    script, docs = _write_fixture(tmp_path)
+
+    result = repair_morning_briefing_operation_summary(
+        script_path=script,
+        docs_dir=docs,
+        target_date=dt.date(2026, 6, 4),
+        title_hint="Antigravity",
+        dry_run=True,
+    )
+
+    assert result["success"] is True
+    assert result["would_change"] is True
+    assert result["changed"] is False
+    assert 'OPS_DIR.glob(f"{prefix}_*.html")' in script.read_text(encoding="utf-8")
+
+
+def test_local_repair_updates_script_and_verifies_wide_match(tmp_path):
+    script, docs = _write_fixture(tmp_path)
+
+    result = repair_morning_briefing_operation_summary(
+        script_path=script,
+        docs_dir=docs,
+        target_date="2026-06-04",
+        title_hint="Antigravity",
+    )
+
+    source = script.read_text(encoding="utf-8")
+    assert result["success"] is True
+    assert result["changed"] is True
+    assert result["verify_titles"] == ["Antigravity反代故障诊断与开机自启设置"]
+    assert 'OPS_DIR.glob(f"{prefix}*.html")' in source
+    assert "prefix_dash" in source
+
+
+def _write_state_db(tmp_path):
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            user_id TEXT,
+            model TEXT,
+            model_config TEXT,
+            system_prompt TEXT,
+            parent_session_id TEXT,
+            started_at REAL,
+            ended_at REAL,
+            end_reason TEXT,
+            message_count INTEGER DEFAULT 0,
+            tool_call_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            billing_provider TEXT,
+            billing_base_url TEXT,
+            billing_mode TEXT,
+            estimated_cost_usd REAL,
+            actual_cost_usd REAL,
+            cost_status TEXT,
+            cost_source TEXT,
+            pricing_version TEXT,
+            title TEXT,
+            api_call_count INTEGER DEFAULT 0,
+            handoff_state TEXT,
+            handoff_platform TEXT,
+            handoff_error TEXT,
+            cwd TEXT,
+            rewind_count INTEGER DEFAULT 0,
+            archived INTEGER DEFAULT 0
+        )
+        """
+    )
+    tz = ZoneInfo("Asia/Shanghai")
+    today_a = dt.datetime(2026, 6, 16, 8, 0, tzinfo=tz).timestamp()
+    today_b = dt.datetime(2026, 6, 16, 9, 0, tzinfo=tz).timestamp()
+    yesterday = dt.datetime(2026, 6, 15, 23, 59, tzinfo=tz).timestamp()
+    old = dt.datetime(2026, 6, 14, 11, 59, tzinfo=tz).timestamp()
+    conn.executemany(
+        """
+        INSERT INTO sessions (
+            id, source, model, started_at, end_reason, message_count,
+            tool_call_count, input_tokens, output_tokens, cache_read_tokens,
+            estimated_cost_usd, cost_status, title, api_call_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("s-small", "feishu", "m", today_a, "done", 3, 1, 100, 10, 5, 0.01, "estimated", "Small", 2),
+            ("s-large", "cron", "m", today_b, "done", 4, 2, 900, 30, 10, 0.02, "estimated", "Large", 3),
+            ("s-old", "feishu", "m", yesterday, "done", 4, 2, 5000, 50, 0, 1.0, "estimated", "Old", 3),
+            ("s-too-old", "feishu", "m", old, "done", 4, 2, 7000, 70, 0, 1.0, "estimated", "Too Old", 3),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_today_token_usage_report_sums_today_and_sorts_top_sessions(tmp_path):
+    db_path = _write_state_db(tmp_path)
+    now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+    result = collect_today_token_usage_report(db_path=db_path, top_n=2, now=now)
+
+    assert result["success"] is True
+    assert result["session_count"] == 2
+    assert result["input_tokens"] == 1000
+    assert result["output_tokens"] == 40
+    assert [item["session_id"] for item in result["top_sessions"]] == ["s-large", "s-small"]
+
+
+def test_today_token_usage_report_can_filter_feishu_scope(tmp_path):
+    db_path = _write_state_db(tmp_path)
+    now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+    result = collect_today_token_usage_report(
+        db_path=db_path,
+        scope="feishu",
+        top_n=3,
+        now=now,
+    )
+    text = format_today_token_usage_report(result)
+
+    assert result["session_count"] == 1
+    assert result["input_tokens"] == 100
+    assert "飞书会话" in text
+    assert "Small" in text
+    assert "Old" not in text
+
+
+def test_token_usage_report_can_target_yesterday_natural_day(tmp_path):
+    db_path = _write_state_db(tmp_path)
+    now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+    result = collect_token_usage_report(
+        db_path=db_path,
+        target_date=dt.date(2026, 6, 15),
+        top_n=5,
+        now=now,
+    )
+    text = format_token_usage_report(result)
+
+    assert result["session_count"] == 1
+    assert result["input_tokens"] == 5000
+    assert [item["session_id"] for item in result["top_sessions"]] == ["s-old"]
+    assert "2026-06-15 00:00:00 至 2026-06-16 00:00:00" in text
+
+
+def test_token_usage_report_accepts_string_target_date(tmp_path):
+    db_path = _write_state_db(tmp_path)
+    now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+    result = collect_token_usage_report(
+        db_path=db_path,
+        target_date="2026-06-15",
+        top_n=5,
+        now=now,
+    )
+
+    assert result["session_count"] == 1
+    assert result["input_tokens"] == 5000
+
+
+def test_token_usage_report_supports_rolling_days(tmp_path):
+    db_path = _write_state_db(tmp_path)
+    now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+    result = collect_token_usage_report(
+        db_path=db_path,
+        days=2,
+        top_n=5,
+        now=now,
+        label="最近 2 天",
+    )
+
+    assert result["session_count"] == 3
+    assert result["input_tokens"] == 6000
+    assert [item["session_id"] for item in result["top_sessions"]] == ["s-old", "s-large", "s-small"]
+
+
+def test_token_usage_report_supports_explicit_date_range(tmp_path):
+    db_path = _write_state_db(tmp_path)
+    now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+    result = collect_token_usage_report(
+        db_path=db_path,
+        range_start="2026-06-15",
+        range_end="2026-06-17",
+        top_n=5,
+        now=now,
+    )
+
+    assert result["session_count"] == 3
+    assert result["input_tokens"] == 6000
+    assert "s-too-old" not in [item["session_id"] for item in result["top_sessions"]]

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -112,3 +112,72 @@ def budget_for_context_window(context_length: int | None) -> BudgetConfig:
         turn_budget=per_turn,
         preview_size=DEFAULT_PREVIEW_SIZE_CHARS,
     )
+
+
+# Messaging diagnostics need much tighter inline results than CLI/desktop.
+# A single 50K-char terminal/execute_code result can dominate every following
+# Feishu model call, so persist or inline-truncate far earlier there.
+FEISHU_BUDGET = BudgetConfig(
+    default_result_size=8_000,
+    turn_budget=24_000,
+    preview_size=1_200,
+    tool_overrides={
+        "execute_code": 8_000,
+        "terminal": 8_000,
+        "search_files": 8_000,
+    },
+)
+
+FEISHU_DEEP_BUDGET = BudgetConfig(
+    default_result_size=16_000,
+    turn_budget=48_000,
+    preview_size=1_500,
+    tool_overrides={
+        "execute_code": 16_000,
+        "terminal": 16_000,
+        "search_files": 16_000,
+    },
+)
+
+
+# Messaging operations should default to a compact "summary + artifact path"
+# shape regardless of platform. Telegram was previously allowed to inherit the
+# large desktop/CLI defaults, so a routine ops request could carry tens of
+# thousands of chars into every later model request.
+MESSAGING_BUDGET = BudgetConfig(
+    default_result_size=8_000,
+    turn_budget=24_000,
+    preview_size=1_200,
+    tool_overrides={
+        "execute_code": 8_000,
+        "terminal": 8_000,
+        "search_files": 8_000,
+        "computer_use": 8_000,
+    },
+)
+
+
+UI_VERIFICATION_BUDGET = BudgetConfig(
+    default_result_size=8_000,
+    turn_budget=24_000,
+    preview_size=1_200,
+    tool_overrides={
+        "computer_use": 8_000,
+        "execute_code": 8_000,
+        "terminal": 8_000,
+        "search_files": 8_000,
+    },
+)
+
+
+DEEP_DIAGNOSTIC_BUDGET = BudgetConfig(
+    default_result_size=16_000,
+    turn_budget=48_000,
+    preview_size=1_500,
+    tool_overrides={
+        "computer_use": 16_000,
+        "execute_code": 16_000,
+        "terminal": 16_000,
+        "search_files": 16_000,
+    },
+)

--- a/tools/codex_context_bloat_monitor.py
+++ b/tools/codex_context_bloat_monitor.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Scan local Codex threads for context-bloat incidents.
+
+The monitor is intentionally read-only. It combines the Codex thread index
+(``state_5.sqlite``) with rollout JSONL files and reports threads that exceed
+the guardrails used for Hermes/Codex UI verification work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Iterable
+
+
+DEFAULT_CODEX_HOME = Path.home() / ".codex"
+DEFAULT_THRESHOLDS = {
+    "tokens_used": 800_000,
+    "last_input": 60_000,
+    "computer_use_inline_chars": 8_000,
+    "image_base64_chars": 1_500,
+}
+
+_DATA_IMAGE_RE = re.compile(r"data:image/[A-Za-z0-9.+-]+;base64,([A-Za-z0-9+/=_-]+)")
+_COMPUTER_USE_RE = re.compile(r"\b(get_app_state|computer_use|click|type_text)\b", re.I)
+_MAX_TITLE_CHARS = 160
+
+
+def _short_text(text: Any, max_chars: int = _MAX_TITLE_CHARS) -> str:
+    value = re.sub(r"\s+", " ", str(text or "")).strip()
+    if len(value) <= max_chars:
+        return value
+    return value[:max_chars] + "..."
+
+
+@dataclass
+class ThreadBloatMetrics:
+    thread_id: str
+    title: str
+    tokens_used: int
+    rollout_path: str
+    last_input_max: int = 0
+    computer_use_output_max_chars: int = 0
+    image_base64_chars: int = 0
+
+    def incidents(self, thresholds: dict[str, int] | None = None) -> list[str]:
+        t = thresholds or DEFAULT_THRESHOLDS
+        out: list[str] = []
+        if self.tokens_used > t["tokens_used"]:
+            out.append("tokens_used")
+        if self.last_input_max > t["last_input"]:
+            out.append("last_input")
+        if self.computer_use_output_max_chars > t["computer_use_inline_chars"]:
+            out.append("computer_use_inline_chars")
+        if self.image_base64_chars > t["image_base64_chars"]:
+            out.append("image_base64_chars")
+        return out
+
+
+def _iter_thread_rows(db_path: Path, *, limit: int) -> Iterable[dict[str, Any]]:
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, title, tokens_used, rollout_path
+            FROM threads
+            WHERE archived = 0
+            ORDER BY updated_at_ms DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def _json_text(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except Exception:
+        return str(value)
+
+
+def _extract_last_input(event: dict[str, Any], raw_line: str) -> int:
+    text = _json_text(event)
+    candidates = []
+    for pattern in (
+        r'"last_input"\s*:\s*(\d+)',
+        r'last_input[=: ]+(\d+)',
+        r'"input_tokens"\s*:\s*(\d+)',
+    ):
+        candidates.extend(int(m.group(1)) for m in re.finditer(pattern, text))
+    if not candidates:
+        candidates.extend(int(m.group(1)) for m in re.finditer(r"last_input[=: ]+(\d+)", raw_line))
+    return max(candidates or [0])
+
+
+def _scan_rollout(path: Path) -> tuple[int, int, int]:
+    last_input_max = 0
+    computer_use_output_max = 0
+    image_base64_chars = 0
+    if not path.exists():
+        return (0, 0, 0)
+
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            image_base64_chars += sum(len(m.group(1)) for m in _DATA_IMAGE_RE.finditer(line))
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                event = {}
+            last_input_max = max(last_input_max, _extract_last_input(event, line))
+            if _COMPUTER_USE_RE.search(line):
+                computer_use_output_max = max(computer_use_output_max, len(line))
+    return (last_input_max, computer_use_output_max, image_base64_chars)
+
+
+def collect_metrics(codex_home: Path = DEFAULT_CODEX_HOME, *, limit: int = 50) -> list[ThreadBloatMetrics]:
+    db_path = codex_home / "state_5.sqlite"
+    metrics: list[ThreadBloatMetrics] = []
+    for row in _iter_thread_rows(db_path, limit=limit):
+        rollout = Path(row.get("rollout_path") or "")
+        last_input, computer_use_chars, image_chars = _scan_rollout(rollout)
+        metrics.append(
+            ThreadBloatMetrics(
+                thread_id=str(row.get("id") or ""),
+                title=_short_text(row.get("title") or ""),
+                tokens_used=int(row.get("tokens_used") or 0),
+                rollout_path=str(rollout),
+                last_input_max=last_input,
+                computer_use_output_max_chars=computer_use_chars,
+                image_base64_chars=image_chars,
+            )
+        )
+    return metrics
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--codex-home", type=Path, default=DEFAULT_CODEX_HOME)
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    metrics = collect_metrics(args.codex_home, limit=args.limit)
+    incidents = [
+        {**asdict(item), "incident_reasons": item.incidents()}
+        for item in metrics
+        if item.incidents()
+    ]
+    if args.json:
+        print(json.dumps({"incidents": incidents}, ensure_ascii=False, indent=2))
+    else:
+        for item in incidents:
+            print(
+                f"context-bloat incident thread={item['thread_id']} "
+                f"tokens={item['tokens_used']} reasons={','.join(item['incident_reasons'])} "
+                f"rollout={item['rollout_path']}"
+            )
+    return 1 if incidents else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -211,6 +211,27 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "when you need to verify an action's effect."
                 ),
             },
+            "inspect_full": {
+                "type": "boolean",
+                "description": (
+                    "Default false. When false, captures and action follow-up "
+                    "captures return a compact text result plus any artifact "
+                    "path instead of inline screenshot/base64 or a full UI "
+                    "tree. Set true only for an explicit deep UI inspection."
+                ),
+                "default": False,
+            },
+            "max_inline_chars": {
+                "type": "integer",
+                "description": (
+                    "Maximum inline text characters returned by this tool. "
+                    "Default 8000; action-only results are internally capped "
+                    "much lower. Full artifacts are saved to disk when needed."
+                ),
+                "default": 8000,
+                "minimum": 500,
+                "maximum": 16000,
+            },
         },
         "required": ["action"],
     },

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -46,6 +46,7 @@ import re
 import struct
 import sys
 import threading
+import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
 from tools.computer_use.backend import (
@@ -342,18 +343,25 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
 
 def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
     capture_after = bool(args.get("capture_after"))
+    inspect_full = bool(args.get("inspect_full", False))
+    max_inline_chars = _coerce_max_inline_chars(args.get("max_inline_chars"))
 
     if action == "capture":
         mode = str(args.get("mode", "som"))
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
         cap = backend.capture(mode=mode, app=args.get("app"))
-        return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
+        return _capture_response(
+            cap,
+            max_elements=_coerce_max_elements(args.get("max_elements")),
+            inspect_full=inspect_full,
+            max_inline_chars=max_inline_chars,
+        )
 
     if action == "wait":
         seconds = float(args.get("seconds", 1.0))
         res = backend.wait(seconds)
-        return _text_response(res)
+        return _text_response(res, max_inline_chars=1000)
 
     if action == "list_apps":
         apps = backend.list_apps()
@@ -364,7 +372,13 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(
+            backend,
+            res,
+            capture_after,
+            inspect_full=inspect_full,
+            max_inline_chars=max_inline_chars,
+        )
 
     if action in {"click", "double_click", "right_click", "middle_click"}:
         button = args.get("button")
@@ -385,7 +399,13 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(
+            backend,
+            res,
+            capture_after,
+            inspect_full=inspect_full,
+            max_inline_chars=max_inline_chars,
+        )
 
     if action == "drag":
         has_elements = args.get("from_element") is not None and args.get("to_element") is not None
@@ -402,7 +422,13 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(
+            backend,
+            res,
+            capture_after,
+            inspect_full=inspect_full,
+            max_inline_chars=max_inline_chars,
+        )
 
     if action == "scroll":
         coord = args.get("coordinate") or (None, None)
@@ -414,22 +440,46 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(
+            backend,
+            res,
+            capture_after,
+            inspect_full=inspect_full,
+            max_inline_chars=max_inline_chars,
+        )
 
     if action == "type":
         res = backend.type_text(args.get("text", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(
+            backend,
+            res,
+            capture_after,
+            inspect_full=inspect_full,
+            max_inline_chars=max_inline_chars,
+        )
 
     if action == "key":
         res = backend.key(args.get("keys", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(
+            backend,
+            res,
+            capture_after,
+            inspect_full=inspect_full,
+            max_inline_chars=max_inline_chars,
+        )
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
         res = backend.set_value(value=str(value), element=args.get("element"))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(
+            backend,
+            res,
+            capture_after,
+            inspect_full=inspect_full,
+            max_inline_chars=max_inline_chars,
+        )
 
     return json.dumps({"error": f"unknown action {action!r}"})
 
@@ -438,13 +488,13 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
 # Response shaping
 # ---------------------------------------------------------------------------
 
-def _text_response(res: ActionResult) -> str:
+def _text_response(res: ActionResult, max_inline_chars: int = 1000) -> str:
     payload: Dict[str, Any] = {"ok": res.ok, "action": res.action}
     if res.message:
         payload["message"] = res.message
     if res.meta:
         payload["meta"] = res.meta
-    return json.dumps(payload)
+    return _json_limited(payload, max_inline_chars=max_inline_chars)
 
 
 # Default cap for the AX `elements` array returned by capture. Dense UIs
@@ -457,6 +507,9 @@ _DEFAULT_MAX_ELEMENTS = 100
 # reintroduce the original unbounded behavior.
 _MAX_ALLOWED_MAX_ELEMENTS = 1000
 _MIN_PROVIDER_IMAGE_DIMENSION = 8
+_DEFAULT_MAX_INLINE_CHARS = 8000
+_MAX_ALLOWED_INLINE_CHARS = 16000
+_MIN_ALLOWED_INLINE_CHARS = 500
 
 
 def _image_dimensions_from_b64(image_b64: str) -> Optional[Tuple[int, int]]:
@@ -535,7 +588,75 @@ def _coerce_max_elements(value: Any) -> int:
     return n
 
 
-def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEMENTS) -> Any:
+def _coerce_max_inline_chars(value: Any) -> int:
+    if value is None:
+        return _DEFAULT_MAX_INLINE_CHARS
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_INLINE_CHARS
+    if n < _MIN_ALLOWED_INLINE_CHARS:
+        return _MIN_ALLOWED_INLINE_CHARS
+    if n > _MAX_ALLOWED_INLINE_CHARS:
+        return _MAX_ALLOWED_INLINE_CHARS
+    return n
+
+
+def _json_limited(payload: Dict[str, Any], *, max_inline_chars: int) -> str:
+    text = json.dumps(payload, ensure_ascii=False)
+    if len(text) <= max_inline_chars:
+        return text
+
+    compact = dict(payload)
+    if "elements" in compact:
+        compact["elements"] = []
+        compact["elements_omitted_for_inline_budget"] = True
+    if isinstance(compact.get("summary"), str):
+        compact["summary"] = compact["summary"][: max(120, max_inline_chars // 2)] + "\n..."
+    compact["inline_truncated"] = True
+    compact["max_inline_chars"] = max_inline_chars
+    text = json.dumps(compact, ensure_ascii=False)
+    if len(text) <= max_inline_chars:
+        return text
+    minimal = {
+        "ok": payload.get("ok"),
+        "action": payload.get("action"),
+        "inline_truncated": True,
+        "max_inline_chars": max_inline_chars,
+    }
+    if "screenshot_path" in payload:
+        minimal["screenshot_path"] = payload["screenshot_path"]
+    text = json.dumps(minimal, ensure_ascii=False)
+    if len(text) <= max_inline_chars:
+        return text
+    return text[:max_inline_chars] + "\n... [computer_use inline result truncated]"
+
+
+def _store_capture_artifact(cap: CaptureResult) -> Optional[str]:
+    if not cap.png_b64:
+        return None
+    try:
+        from hermes_constants import get_hermes_dir
+
+        cache_dir = os.path.join(str(get_hermes_dir()), "cache", "computer-use")
+        os.makedirs(cache_dir, exist_ok=True)
+        suffix = ".jpg" if (cap.image_mime_type == "image/jpeg" or cap.png_b64.startswith("/9j/")) else ".png"
+        path = os.path.join(cache_dir, f"capture-{uuid.uuid4().hex[:12]}{suffix}")
+        with open(path, "wb") as fh:
+            fh.write(base64.b64decode(cap.png_b64, validate=False))
+        return path
+    except Exception as exc:
+        logger.debug("computer_use: failed to persist capture artifact: %s", exc)
+        return None
+
+
+def _capture_response(
+    cap: CaptureResult,
+    max_elements: int = _DEFAULT_MAX_ELEMENTS,
+    *,
+    inspect_full: bool = True,
+    max_inline_chars: int = _DEFAULT_MAX_INLINE_CHARS,
+) -> Any:
     total_elements = len(cap.elements)
     visible_elements = cap.elements[:max_elements]
     truncated_elements = max(0, total_elements - len(visible_elements))
@@ -575,6 +696,33 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
             "provider minimum)"
         )
     summary = "\n".join(summary_lines)
+
+    if not inspect_full:
+        if truncated_elements:
+            summary_lines.append(
+                f"  (response truncated to {len(visible_elements)} of {total_elements} elements; "
+                "set inspect_full=true only for a bounded deep UI inspection)"
+            )
+        artifact_path = _store_capture_artifact(cap)
+        payload: Dict[str, Any] = {
+            "mode": cap.mode,
+            "width": response_width,
+            "height": response_height,
+            "app": cap.app,
+            "window_title": cap.window_title,
+            "elements": [_element_to_dict(e) for e in visible_elements],
+            "total_elements": total_elements,
+            "summary": "\n".join(summary_lines),
+            "inspect_full": False,
+        }
+        if artifact_path:
+            payload["screenshot_path"] = artifact_path
+            payload["screenshot_bytes"] = cap.png_bytes_len
+        if truncated_elements:
+            payload["truncated_elements"] = truncated_elements
+        if cap.png_b64:
+            payload["image_inline_omitted"] = True
+        return _json_limited(payload, max_inline_chars=max_inline_chars)
 
     if cap.png_b64 and cap.mode != "ax" and not image_too_small:
         # Decide whether to hand the screenshot to the auxiliary.vision
@@ -834,15 +982,20 @@ def _route_capture_through_aux_vision(
 
 
 def _maybe_follow_capture(
-    backend: ComputerUseBackend, res: ActionResult, do_capture: bool,
+    backend: ComputerUseBackend,
+    res: ActionResult,
+    do_capture: bool,
+    *,
+    inspect_full: bool = False,
+    max_inline_chars: int = _DEFAULT_MAX_INLINE_CHARS,
 ) -> Any:
     if not do_capture:
-        return _text_response(res)
+        return _text_response(res, max_inline_chars=1000)
     # Skip the follow-up capture when the action itself failed: showing a
     # normal-looking screenshot after a failure misleads the model into thinking
     # the action succeeded. Return the error text instead.
     if not res.ok:
-        return _text_response(res)
+        return _text_response(res, max_inline_chars=1000)
     try:
         # Preserve the app context established by the preceding capture/focus_app so
         # that capture_after=True re-captures the same app rather than the frontmost
@@ -851,9 +1004,13 @@ def _maybe_follow_capture(
         cap = backend.capture(mode="som", app=last_app)
     except Exception as e:
         logger.warning("follow-up capture failed: %s", e)
-        return _text_response(res)
+        return _text_response(res, max_inline_chars=1000)
     # Combine action summary with the capture.
-    resp = _capture_response(cap)
+    resp = _capture_response(
+        cap,
+        inspect_full=inspect_full,
+        max_inline_chars=max_inline_chars,
+    )
     if isinstance(resp, dict) and resp.get("_multimodal"):
         prefix = f"[{res.action}] ok={res.ok}" + (f" — {res.message}" if res.message else "")
         resp["content"][0]["text"] = prefix + "\n\n" + resp["content"][0]["text"]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -750,6 +750,99 @@ _READ_DEDUP_STATUS_MESSAGE = (
     "the earlier read_file result in this conversation is "
     "still current — refer to that instead of re-reading."
 )
+_FEISHU_FILE_TOOL_BUDGET = 4
+
+
+def _is_feishu_low_token_platform(platform: str | None) -> bool:
+    return (platform or "").strip().lower() == "feishu"
+
+
+def _is_feishu_messaging_platform(platform: str | None) -> bool:
+    return (platform or "").strip().lower() in {"feishu", "feishu_deep"}
+
+
+def _feishu_broad_search_block(path: str, task_id: str) -> str | None:
+    """Block ordinary Feishu searches whose root is too broad for low budget."""
+    raw = str(path or ".").strip() or "."
+    try:
+        resolved = _resolve_path_for_task(raw, task_id)
+    except Exception:
+        return None
+
+    broad_roots = {Path("/").resolve()}
+    try:
+        broad_roots.add(Path.home().resolve())
+    except Exception:
+        pass
+    try:
+        broad_roots.add(Path(_expand_tilde("~")).resolve())
+    except Exception:
+        pass
+
+    if resolved not in broad_roots:
+        return None
+
+    return json.dumps({
+        "error": (
+            "BLOCKED: Feishu low-token search_files refused to search a broad "
+            f"root ({resolved}). Provide a narrow absolute path such as "
+            "`/Users/minim4/.hermes/cron`, `/Users/minim4/.hermes/logs`, or a "
+            "specific project directory; for structured state like cron jobs, "
+            "use execute_code to load the JSON and filter the named item."
+        ),
+        "recommendation": "Retry search_files with a narrow path, or use execute_code for a targeted local query.",
+    }, ensure_ascii=False)
+
+
+def _feishu_structured_state_read_block(resolved_path: Path) -> str | None:
+    """Block noisy raw reads of state files that have compact tool APIs."""
+    try:
+        path = resolved_path.resolve()
+    except Exception:
+        path = resolved_path
+    if path.name == "jobs.json" and path.parent.name == "cron":
+        return json.dumps({
+            "error": (
+                "BLOCKED: Feishu should not read raw cron/jobs.json. It can "
+                "contain large embedded prompts and wastes context. Use "
+                "cronjob(action='list') for a compact schedule/status summary, "
+                "or execute_code to load JSON and filter a specific named job."
+            ),
+            "recommendation": "Use cronjob(action='list') or execute_code with a targeted jobs filter.",
+        }, ensure_ascii=False)
+    return None
+
+
+def _file_glob_hint_for_regexish_pattern(pattern: str) -> str | None:
+    pattern = str(pattern or "")
+    if ".*" not in pattern:
+        return None
+    suggestion = pattern.replace(".*", "*")
+    if not suggestion.startswith("*") and "/" not in suggestion:
+        suggestion = f"*{suggestion}"
+    if not suggestion.endswith("*") and "/" not in suggestion:
+        suggestion = f"{suggestion}*"
+    return (
+        "File-name search uses glob patterns, not regex. "
+        f"Try target='files' with pattern='{suggestion}', or use "
+        "target='content' when you intend a regex content search."
+    )
+
+
+def _record_feishu_file_tool_call(task_data: dict, *, tool: str) -> str | None:
+    count = int(task_data.get("feishu_file_tool_count", 0) or 0) + 1
+    task_data["feishu_file_tool_count"] = count
+    if count > _FEISHU_FILE_TOOL_BUDGET:
+        return json.dumps({
+            "error": (
+                "BLOCKED: Feishu low-token file budget reached "
+                f"({_FEISHU_FILE_TOOL_BUDGET}/{_FEISHU_FILE_TOOL_BUDGET}) "
+                f"while calling {tool}. Summarize current findings or ask "
+                "the user to use `深诊断：<问题>` for one expanded turn."
+            ),
+            "recommendation": "Switch to execute_code for batched local diagnosis.",
+        }, ensure_ascii=False)
+    return None
 
 
 def _cap_read_tracker_data(task_data: dict) -> None:
@@ -1047,10 +1140,18 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 500,
+    task_id: str = "default",
+    platform: str | None = None,
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
+        if _is_feishu_low_token_platform(platform):
+            limit = 120 if limit == 500 else min(limit, 200)
 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
@@ -1065,6 +1166,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             })
 
         _resolved = _resolve_path_for_task(path, task_id)
+        if _is_feishu_messaging_platform(platform):
+            _structured_block = _feishu_structured_state_read_block(_resolved)
+            if _structured_block:
+                return _structured_block
 
         # ── Structured-document extraction ────────────────────────────
         # Try before the binary-extension guard so .docx/.xlsx can render as text.
@@ -1146,6 +1251,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "read_history": set(), "dedup": {},
                 "dedup_hits": {}, "read_timestamps": {},
             })
+            if _is_feishu_low_token_platform(platform):
+                _budget_block = _record_feishu_file_tool_call(task_data, tool="read_file")
+                if _budget_block:
+                    return _budget_block
             # Backward-compat for pre-existing tracker entries that predate
             # dedup_hits/read_timestamps (long-lived task or crossed an
             # upgrade boundary).
@@ -1358,6 +1467,7 @@ def notify_other_tool_call(task_id: str = "default"):
             # progress, so clear per-key dedup hit counters too.
             if "dedup_hits" in task_data:
                 task_data["dedup_hits"].clear()
+            task_data["feishu_file_tool_count"] = 0
 
 
 def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
@@ -1759,9 +1869,20 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
-                task_id: str = "default") -> str:
+                task_id: str = "default", platform: str | None = None) -> str:
     """Search for content or files."""
     try:
+        if _is_feishu_messaging_platform(platform):
+            _broad_search_block = _feishu_broad_search_block(path, task_id)
+            if _broad_search_block:
+                return _broad_search_block
+        if _is_feishu_low_token_platform(platform):
+            if limit == 50:
+                limit = 20
+            else:
+                limit = min(limit, 20)
+            if output_mode == "content":
+                output_mode = "files_only"
         offset, limit = normalize_search_pagination(offset, limit)
 
         # Track searches to detect *consecutive* repeated search loops.
@@ -1780,6 +1901,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0, "read_history": set(),
             })
+            if _is_feishu_low_token_platform(platform):
+                _budget_block = _record_feishu_file_tool_call(task_data, tool="search_files")
+                if _budget_block:
+                    return _budget_block
             if task_data["last_key"] == search_key:
                 task_data["consecutive"] += 1
             else:
@@ -1817,6 +1942,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content, file_read=True)
         result_dict = result.to_dict(densify=True)
+        if target == "files" and int(result_dict.get("total_count") or 0) == 0:
+            glob_hint = _file_glob_hint_for_regexish_pattern(pattern)
+            if glob_hint:
+                result_dict["hint"] = glob_hint
 
         if omitted:
             result_dict["_omitted"] = (
@@ -1959,7 +2088,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        task_id=tid,
+        platform=kw.get("platform"),
+    )
 
 
 def _handle_write_file(args, **kw):
@@ -2008,7 +2143,8 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"), context=args.get("context", 0),
+        task_id=tid, platform=kw.get("platform"))
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)

--- a/tools/local_repair_tool.py
+++ b/tools/local_repair_tool.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Small deterministic local repair helpers for known Hermes ops tasks."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from tools.registry import registry
+
+
+LOCAL_REPAIR_SCHEMA = {
+    "name": "local_repair",
+    "description": (
+        "Run a deterministic, low-token local repair for known Hermes Feishu ops "
+        "issues. For morning briefing / operation summary file matching issues, "
+        "and token usage reports, use this before broad execute_code/search_files "
+        "exploration."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_type": {
+                "type": "string",
+                "enum": ["morning_briefing_operation_summary", "today_token_usage_report", "token_usage_report"],
+                "description": "Known local repair flow to run.",
+            },
+            "target_date": {
+                "type": "string",
+                "description": "Optional operation summary or token report date, in YYYY-MM-DD form.",
+            },
+            "title_hint": {
+                "type": "string",
+                "description": "Optional expected operation summary title substring.",
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "When true, inspect and report the intended fix without writing files.",
+                "default": False,
+            },
+            "scope": {
+                "type": "string",
+                "enum": ["all", "feishu"],
+                "description": "For token_usage_report, include all Hermes sessions or only Feishu sessions.",
+                "default": "all",
+            },
+            "top_n": {
+                "type": "integer",
+                "description": "For token_usage_report, number of highest-input sessions to return.",
+                "default": 3,
+            },
+            "days": {
+                "type": "integer",
+                "description": "For token_usage_report, rolling lookback window in days.",
+            },
+            "range_start": {
+                "type": "string",
+                "description": "For token_usage_report, inclusive start date/time.",
+            },
+            "range_end": {
+                "type": "string",
+                "description": "For token_usage_report, exclusive end date/time.",
+            },
+            "label": {
+                "type": "string",
+                "description": "For token_usage_report, human-readable window label.",
+            },
+        },
+        "required": ["task_type"],
+        "additionalProperties": False,
+    },
+}
+
+
+FIXED_OP_TITLES_FOR = '''def op_titles_for(day: dt.date) -> list[str]:
+    prefix = day.strftime("%Y%m%d")
+    prefix_dash = day.strftime("%Y-%m-%d")
+    titles: list[str] = []
+    if not OPS_DIR.exists():
+        return titles
+    paths = list(OPS_DIR.glob(f"{prefix}*.html")) + list(OPS_DIR.glob(f"{prefix_dash}_*.html"))
+    for path in sorted(paths):
+        stem = path.stem
+        title = re.sub(r"^(\\d+|\\d{4}-\\d{2}-\\d{2})_", "", stem).replace("_", " ")
+        titles.append(title)
+    return titles[:10]
+'''
+
+
+def _default_script_path() -> Path:
+    return Path.home() / ".hermes" / "scripts" / "morning-briefing-report.py"
+
+
+def _default_docs_dir() -> Path:
+    return Path.home() / "Documents" / "Hermes"
+
+
+def _default_state_db_path() -> Path:
+    return Path.home() / ".hermes" / "state.db"
+
+
+def _parse_target_date(value: str | None) -> dt.date | None:
+    if not value:
+        return None
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _parse_local_datetime(value: str | None, tz: ZoneInfo) -> dt.datetime | None:
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw):
+            return dt.datetime.combine(dt.date.fromisoformat(raw), dt.time.min, tzinfo=tz)
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=tz)
+    return parsed.astimezone(tz)
+
+
+def _date_from_filename(path: Path) -> dt.date | None:
+    stem = path.stem
+    match = re.match(r"^(\d{8}|\d{4}-\d{2}-\d{2})", stem)
+    if not match:
+        return None
+    raw = match.group(1)
+    try:
+        if "-" in raw:
+            return dt.date.fromisoformat(raw)
+        return dt.datetime.strptime(raw, "%Y%m%d").date()
+    except ValueError:
+        return None
+
+
+def _wide_titles_for(ops_dir: Path, day: dt.date) -> list[str]:
+    prefix = day.strftime("%Y%m%d")
+    prefix_dash = day.strftime("%Y-%m-%d")
+    paths = list(ops_dir.glob(f"{prefix}*.html")) + list(ops_dir.glob(f"{prefix_dash}_*.html"))
+    titles: list[str] = []
+    for path in sorted(set(paths)):
+        stem = path.stem
+        title = re.sub(r"^(\d+|\d{4}-\d{2}-\d{2})_", "", stem).replace("_", " ")
+        titles.append(title)
+    return titles[:10]
+
+
+def _replace_op_titles_for(source: str) -> tuple[str, bool]:
+    lines = source.splitlines(keepends=True)
+    start: int | None = None
+    end = len(lines)
+    for idx, line in enumerate(lines):
+        if line.startswith("def op_titles_for("):
+            start = idx
+            break
+    if start is None:
+        return source, False
+    for idx in range(start + 1, len(lines)):
+        line = lines[idx]
+        if line.startswith("def ") or line.startswith("class "):
+            end = idx
+            break
+    replacement = FIXED_OP_TITLES_FOR
+    if end < len(lines) and not replacement.endswith("\n\n"):
+        replacement += "\n"
+    new_source = "".join(lines[:start]) + replacement + "".join(lines[end:])
+    return new_source, new_source != source
+
+
+def _load_script_module(script_path: Path):
+    name = f"_hermes_morning_briefing_report_{abs(hash(str(script_path)))}"
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load script module from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _script_titles_for(script_path: Path, day: dt.date) -> list[str]:
+    module = _load_script_module(script_path)
+    titles = module.op_titles_for(day)
+    return list(titles) if isinstance(titles, list) else []
+
+
+def _candidate_dates(ops_dir: Path) -> list[dt.date]:
+    dates = {
+        day
+        for path in ops_dir.glob("*.html")
+        for day in [_date_from_filename(path)]
+        if day is not None
+    }
+    return sorted(dates, reverse=True)
+
+
+def _select_target_date(
+    script_path: Path,
+    ops_dir: Path,
+    requested: dt.date | None,
+    title_hint: str,
+) -> tuple[dt.date | None, list[str], list[str]]:
+    if requested is not None:
+        wide = _wide_titles_for(ops_dir, requested)
+        try:
+            current = _script_titles_for(script_path, requested)
+        except Exception:
+            current = []
+        return requested, current, wide
+
+    for day in _candidate_dates(ops_dir):
+        wide = _wide_titles_for(ops_dir, day)
+        if not wide:
+            continue
+        try:
+            current = _script_titles_for(script_path, day)
+        except Exception:
+            current = []
+        missing_hint = bool(title_hint) and not any(title_hint in title for title in current)
+        if current != wide or missing_hint:
+            return day, current, wide
+
+    dates = _candidate_dates(ops_dir)
+    if not dates:
+        return None, [], []
+    day = dates[0]
+    try:
+        current = _script_titles_for(script_path, day)
+    except Exception:
+        current = []
+    return day, current, _wide_titles_for(ops_dir, day)
+
+
+def repair_morning_briefing_operation_summary(
+    *,
+    script_path: Path | None = None,
+    docs_dir: Path | None = None,
+    target_date: str | dt.date | None = None,
+    title_hint: str = "",
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Repair the known operation-summary glob mismatch in the briefing script."""
+    script_path = script_path or _default_script_path()
+    docs_dir = docs_dir or _default_docs_dir()
+    ops_dir = docs_dir / "operation summary"
+    if isinstance(target_date, dt.date):
+        requested_date = target_date
+    else:
+        requested_date = _parse_target_date(target_date)
+
+    result: dict[str, Any] = {
+        "task_type": "morning_briefing_operation_summary",
+        "script_path": str(script_path),
+        "ops_dir": str(ops_dir),
+        "dry_run": bool(dry_run),
+    }
+
+    if not script_path.exists():
+        return {**result, "success": False, "error": "morning briefing script not found"}
+    if not ops_dir.exists():
+        return {**result, "success": False, "error": "operation summary directory not found"}
+
+    before_source = script_path.read_text(encoding="utf-8")
+    selected_date, current_titles, wide_titles = _select_target_date(
+        script_path,
+        ops_dir,
+        requested_date,
+        title_hint.strip(),
+    )
+    result.update(
+        {
+            "target_date": selected_date.isoformat() if selected_date else None,
+            "before_titles": current_titles[:5],
+            "expected_titles": wide_titles[:5],
+        }
+    )
+    if selected_date is None:
+        return {**result, "success": False, "error": "no operation summary html candidates found"}
+
+    already_fixed = 'OPS_DIR.glob(f"{prefix}*.html")' in before_source and "prefix_dash" in before_source
+    new_source, replaced = _replace_op_titles_for(before_source)
+    if not replaced:
+        return {**result, "success": False, "error": "op_titles_for function not found"}
+
+    changed = new_source != before_source and not already_fixed
+    if changed and not dry_run:
+        script_path.write_text(new_source, encoding="utf-8")
+
+    verify_titles = _script_titles_for(script_path, selected_date) if not dry_run else wide_titles
+    expected_found = bool(wide_titles) and all(title in verify_titles for title in wide_titles[:1])
+    if title_hint:
+        expected_found = expected_found and any(title_hint in title for title in verify_titles)
+
+    return {
+        **result,
+        "success": bool(expected_found),
+        "changed": bool(changed and not dry_run),
+        "would_change": bool(changed),
+        "already_fixed": bool(already_fixed),
+        "root_cause": (
+            "op_titles_for used a narrow YYYYMMDD_*.html glob and missed "
+            "operation summary files named like YYYYMMDDHHMM_title.html."
+        ),
+        "fix": "Use YYYYMMDD*.html plus YYYY-MM-DD_*.html and strip either numeric or dashed date prefixes.",
+        "verify_titles": verify_titles[:5],
+    }
+
+
+def _clamp_top_n(value: int | str | None) -> int:
+    try:
+        top_n = int(value if value is not None else 3)
+    except (TypeError, ValueError):
+        top_n = 3
+    return max(1, min(top_n, 10))
+
+
+def _session_row_to_item(row: sqlite3.Row, tz: ZoneInfo) -> dict[str, Any]:
+    started_at = float(row["started_at"] or 0.0)
+    started_local = dt.datetime.fromtimestamp(started_at, tz).strftime("%Y-%m-%d %H:%M:%S")
+    return {
+        "session_id": row["id"],
+        "title": row["title"] or "(untitled)",
+        "source": row["source"] or "",
+        "model": row["model"] or "",
+        "started_at": started_at,
+        "started_local": started_local,
+        "end_reason": row["end_reason"] or "",
+        "api_call_count": row["api_call_count"] or 0,
+        "tool_call_count": row["tool_call_count"] or 0,
+        "message_count": row["message_count"] or 0,
+        "input_tokens": row["input_tokens"] or 0,
+        "output_tokens": row["output_tokens"] or 0,
+        "cache_read_tokens": row["cache_read_tokens"] or 0,
+        "estimated_cost_usd": row["estimated_cost_usd"],
+        "cost_status": row["cost_status"] or "",
+    }
+
+
+def collect_token_usage_report(
+    *,
+    db_path: Path | None = None,
+    scope: str = "all",
+    top_n: int = 3,
+    now: dt.datetime | None = None,
+    timezone: str = "Asia/Shanghai",
+    target_date: str | dt.date | None = None,
+    days: int | None = None,
+    range_start: str | dt.datetime | None = None,
+    range_end: str | dt.datetime | None = None,
+    label: str | None = None,
+) -> dict[str, Any]:
+    """Collect Hermes token usage for a bounded local-time window from state.db."""
+    db_path = db_path or _default_state_db_path()
+    tz = ZoneInfo(timezone)
+    now_local = now.astimezone(tz) if now is not None else dt.datetime.now(tz)
+    window_kind = "today"
+    if isinstance(range_start, dt.datetime):
+        start_local = range_start.astimezone(tz) if range_start.tzinfo else range_start.replace(tzinfo=tz)
+    else:
+        start_local = _parse_local_datetime(range_start, tz)
+    if isinstance(range_end, dt.datetime):
+        end_local = range_end.astimezone(tz) if range_end.tzinfo else range_end.replace(tzinfo=tz)
+    else:
+        end_local = _parse_local_datetime(range_end, tz)
+
+    requested_date: dt.date | None
+    if isinstance(target_date, dt.date):
+        requested_date = target_date
+    else:
+        requested_date = _parse_target_date(target_date)
+
+    if start_local is not None and end_local is not None:
+        window_kind = "custom"
+    elif requested_date is not None:
+        start_local = dt.datetime.combine(requested_date, dt.time.min, tzinfo=tz)
+        end_local = start_local + dt.timedelta(days=1)
+        window_kind = "date"
+    elif days is not None:
+        days = max(1, min(int(days), 366))
+        start_local = now_local - dt.timedelta(days=days)
+        end_local = now_local
+        window_kind = f"rolling_{days}_days"
+    else:
+        start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_local = now_local
+
+    if start_local is None:
+        start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    if end_local is None:
+        end_local = now_local
+    if end_local <= start_local:
+        end_local = start_local + dt.timedelta(days=1)
+
+    start_ts = start_local.timestamp()
+    end_ts = end_local.timestamp()
+    scope = "feishu" if str(scope or "").lower() == "feishu" else "all"
+    top_n = _clamp_top_n(top_n)
+    window_label = label or {
+        "today": "今日",
+        "date": start_local.strftime("%Y-%m-%d"),
+        "custom": "自定义时间范围",
+    }.get(window_kind, window_kind.replace("_", " "))
+
+    result: dict[str, Any] = {
+        "task_type": "token_usage_report",
+        "success": False,
+        "db_path": str(db_path),
+        "scope": scope,
+        "timezone": timezone,
+        "window_label": window_label,
+        "window_kind": window_kind,
+        "window_start": start_local.strftime("%Y-%m-%d %H:%M:%S"),
+        "window_end": end_local.strftime("%Y-%m-%d %H:%M:%S"),
+        "top_n": top_n,
+    }
+    if not db_path.exists():
+        return {**result, "error": "state.db not found"}
+
+    where = "started_at >= ? AND started_at < ?"
+    params: list[Any] = [start_ts, end_ts]
+    if scope == "feishu":
+        where += " AND source = ?"
+        params.append("feishu")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        totals = conn.execute(
+            f"""
+            SELECT COUNT(*) AS session_count,
+                   COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                   COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                   COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                   COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+                   COALESCE(SUM(api_call_count), 0) AS api_call_count,
+                   COALESCE(SUM(tool_call_count), 0) AS tool_call_count,
+                   COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd
+            FROM sessions
+            WHERE {where}
+            """,
+            params,
+        ).fetchone()
+        rows = conn.execute(
+            f"""
+            SELECT id, title, source, model, started_at, ended_at, end_reason,
+                   message_count, tool_call_count, api_call_count, input_tokens,
+                   output_tokens, cache_read_tokens, estimated_cost_usd, cost_status
+            FROM sessions
+            WHERE {where}
+            ORDER BY input_tokens DESC, started_at DESC
+            LIMIT ?
+            """,
+            [*params, top_n],
+        ).fetchall()
+    finally:
+        conn.close()
+
+    return {
+        **result,
+        "success": True,
+        "session_count": totals["session_count"] or 0,
+        "input_tokens": totals["input_tokens"] or 0,
+        "output_tokens": totals["output_tokens"] or 0,
+        "cache_read_tokens": totals["cache_read_tokens"] or 0,
+        "cache_write_tokens": totals["cache_write_tokens"] or 0,
+        "api_call_count": totals["api_call_count"] or 0,
+        "tool_call_count": totals["tool_call_count"] or 0,
+        "estimated_cost_usd": totals["estimated_cost_usd"] or 0.0,
+        "top_sessions": [_session_row_to_item(row, tz) for row in rows],
+    }
+
+
+def collect_today_token_usage_report(
+    *,
+    db_path: Path | None = None,
+    scope: str = "all",
+    top_n: int = 3,
+    now: dt.datetime | None = None,
+    timezone: str = "Asia/Shanghai",
+) -> dict[str, Any]:
+    """Backward-compatible wrapper for today's token report."""
+    return collect_token_usage_report(
+        db_path=db_path,
+        scope=scope,
+        top_n=top_n,
+        now=now,
+        timezone=timezone,
+        label="今日",
+    )
+
+
+def format_token_usage_report(report: dict[str, Any]) -> str:
+    """Render a compact Chinese report suitable for Feishu text delivery."""
+    if not report.get("success"):
+        return f"Token 统计失败：{report.get('error') or 'unknown error'}"
+
+    scope_label = "飞书会话" if report.get("scope") == "feishu" else "Hermes 全部会话"
+    lines = [
+        f"{report.get('window_label') or 'Token'} Token 消耗统计（{scope_label}）",
+        f"时间范围：{report['window_start']} 至 {report['window_end']}（{report['timezone']}）",
+        (
+            f"整体：{report['session_count']} 个 session，"
+            f"输入 {report['input_tokens']:,}，输出 {report['output_tokens']:,}，"
+            f"cache read {report['cache_read_tokens']:,}，"
+            f"API 调用 {report['api_call_count']:,}，工具调用 {report['tool_call_count']:,}"
+        ),
+        "",
+        f"输入 Token Top {report['top_n']}：",
+    ]
+    top_sessions = report.get("top_sessions") or []
+    if not top_sessions:
+        lines.append("无记录。")
+    for idx, item in enumerate(top_sessions, 1):
+        title = str(item.get("title") or "(untitled)")
+        if len(title) > 60:
+            title = title[:57] + "..."
+        lines.append(
+            f"{idx}. {title} [{item.get('source') or 'unknown'}] "
+            f"输入 {item['input_tokens']:,}，输出 {item['output_tokens']:,}，"
+            f"API {item['api_call_count']}，工具 {item['tool_call_count']}，"
+            f"开始 {item['started_local']}"
+        )
+    return "\n".join(lines)
+
+
+def format_today_token_usage_report(report: dict[str, Any]) -> str:
+    """Backward-compatible formatter for callers using the old name."""
+    return format_token_usage_report(report)
+
+
+def render_token_usage_report(
+    *,
+    db_path: Path | None = None,
+    scope: str = "all",
+    top_n: int = 3,
+    now: dt.datetime | None = None,
+    timezone: str = "Asia/Shanghai",
+    target_date: str | dt.date | None = None,
+    days: int | None = None,
+    range_start: str | dt.datetime | None = None,
+    range_end: str | dt.datetime | None = None,
+    label: str | None = None,
+) -> str:
+    return format_token_usage_report(
+        collect_token_usage_report(
+            db_path=db_path,
+            scope=scope,
+            top_n=top_n,
+            now=now,
+            timezone=timezone,
+            target_date=target_date,
+            days=days,
+            range_start=range_start,
+            range_end=range_end,
+            label=label,
+        )
+    )
+
+
+def render_today_token_usage_report(
+    *,
+    db_path: Path | None = None,
+    scope: str = "all",
+    top_n: int = 3,
+    now: dt.datetime | None = None,
+    timezone: str = "Asia/Shanghai",
+) -> str:
+    return render_token_usage_report(
+        db_path=db_path,
+        scope=scope,
+        top_n=top_n,
+        now=now,
+        timezone=timezone,
+        label="今日",
+    )
+
+
+def _handle_local_repair(args: dict, **kw) -> str:
+    task_type = args.get("task_type")
+    if task_type in {"today_token_usage_report", "token_usage_report"}:
+        result = collect_token_usage_report(
+            scope=args.get("scope") or "all",
+            top_n=_clamp_top_n(args.get("top_n")),
+            target_date=args.get("target_date"),
+            days=args.get("days"),
+            range_start=args.get("range_start"),
+            range_end=args.get("range_end"),
+            label=args.get("label"),
+        )
+        result["text"] = format_token_usage_report(result)
+        return json.dumps(result, ensure_ascii=False)
+
+    if task_type != "morning_briefing_operation_summary":
+        return json.dumps(
+            {
+                "success": False,
+                "error": f"Unsupported local_repair task_type: {task_type}",
+                "supported": [
+                    "morning_briefing_operation_summary",
+                    "today_token_usage_report",
+                    "token_usage_report",
+                ],
+            },
+            ensure_ascii=False,
+        )
+    result = repair_morning_briefing_operation_summary(
+        target_date=args.get("target_date"),
+        title_hint=args.get("title_hint") or "",
+        dry_run=bool(args.get("dry_run", False)),
+    )
+    return json.dumps(result, ensure_ascii=False)
+
+
+registry.register(
+    name="local_repair",
+    toolset="file",
+    schema=LOCAL_REPAIR_SCHEMA,
+    handler=_handle_local_repair,
+    emoji="🛠️",
+    max_result_size_chars=12_000,
+)


### PR DESCRIPTION
## Summary
- add deterministic known-ops fast paths for token usage / ops requests so Telegram and Feishu do not enter broad agent repair loops
- add ordinary, UI-verification, and deep-diagnostic tool-result budgets for messaging platforms
- compact computer_use outputs by default, writing screenshots to artifacts instead of returning inline base64 unless inspect_full=true
- add phase checkpoint and Codex context-bloat monitor helpers

## Validation
- .venv/bin/python -m py_compile gateway/known_ops_tasks.py tools/computer_use/tool.py tools/codex_context_bloat_monitor.py agent/phase_checkpoint.py agent/tool_executor.py tools/budget_config.py gateway/run.py
- .venv/bin/python -m pytest tests/gateway/test_feishu_deep_budget.py tests/gateway/test_known_ops_tasks.py tests/gateway/test_session_race_guard.py tests/agent/test_install_success_stop.py tests/tools/test_local_repair_tool.py tests/tools/test_feishu_file_tool_budget.py tests/tools/test_tool_result_storage.py tests/tools/test_computer_use_capture_routing.py tests/tools/test_computer_use_budgeting.py tests/agent/test_phase_checkpoint.py tests/tools/test_codex_context_bloat_monitor.py
