### PR TITLE
fix(computer-use): guard against None pid/window_id from list_windows

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1391,6 +1391,64 @@ def _make_cua_backend_with_windows(windows: List[Dict[str, Any]]):
     return backend
 
 
+class TestCuaNonePidWindowIdGuard:
+    """Regression test for #56704 — list_windows returns entries with
+    pid: null and/or window_id: null for non-application X11 windows
+    (panel, dock, taskbar) on Linux/WSL.  These must be silently
+    skipped rather than crashing with TypeError: int(None).
+    """
+
+    def test_capture_skips_windows_with_none_pid(self):
+        """Windows whose pid is None must be filtered out; if all are
+        filtered the capture returns an empty result without crashing."""
+        raw = [
+            {"app_name": "Xwayland", "pid": None, "window_id": 2,
+             "is_on_screen": True, "title": "", "z_index": 0},
+            {"app_name": "Panel", "pid": 50, "window_id": None,
+             "is_on_screen": True, "title": "taskbar", "z_index": 1},
+        ]
+        backend = _make_cua_backend_with_windows(raw)
+        # Must not raise TypeError; all windows filtered → empty result.
+        result = backend.capture(mode="vision")
+        assert result.png_b64 is None
+        assert result.width == 0
+
+    def test_capture_mixed_none_and_valid_windows(self):
+        """Valid windows are kept; None-pid/None-window_id entries skipped."""
+        from unittest.mock import MagicMock
+        raw = [
+            {"app_name": "Xwayland", "pid": None, "window_id": 2,
+             "is_on_screen": True, "title": "", "z_index": 0},
+            {"app_name": "Firefox", "pid": 100, "window_id": 1,
+             "is_on_screen": True, "title": "Home", "z_index": 1},
+        ]
+        backend = _make_cua_backend_with_windows(raw)
+        # Override call_tool so the screenshot call returns a valid image.
+        _lw_result = backend._session.call_tool.return_value
+        _sc_result = {
+            "data": "", "images": [{"data": "iVBOR", "mimeType": "image/png"}],
+            "structuredContent": None, "isError": False,
+        }
+        backend._session.call_tool.side_effect = [_lw_result, _sc_result]
+        backend._session._has_tool.return_value = True
+        backend._session.capabilities_discovered = True
+        result = backend.capture(mode="vision", app="Firefox")
+        assert backend._active_pid == 100
+        assert backend._active_window_id == 1
+
+    def test_focus_app_skips_windows_with_none_pid(self):
+        """focus_app must also skip windows with None pid."""
+        raw = [
+            {"app_name": "Panel", "pid": None, "window_id": 5,
+             "z_index": 0},
+            {"app_name": "Firefox", "pid": 100, "window_id": 1,
+             "z_index": 1},
+        ]
+        backend = _make_cua_backend_with_windows(raw)
+        result = backend.focus_app("Firefox")
+        assert result.ok is True
+
+
 class TestCuaDriverSessionReconnect:
     """Verify reconnect-once on a closed-resource error. After the
     lifecycle-owner refactor (Sun Jun 21 2026) the session no longer goes

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1038,6 +1038,7 @@ class CuaDriverBackend(ComputerUseBackend):
                 "z_index": w.get("z_index", 0),
             }
             for w in raw_windows
+            if w.get("pid") is not None and w.get("window_id") is not None
         ]
         # Sort by z_index descending (lowest z_index = frontmost on macOS).
         windows.sort(key=lambda w: w["z_index"])
@@ -1441,6 +1442,7 @@ class CuaDriverBackend(ComputerUseBackend):
                 "z_index": w.get("z_index", 0),
             }
             for w in raw_windows
+            if w.get("pid") is not None and w.get("window_id") is not None
         ]
         windows.sort(key=lambda w: w["z_index"])
 


### PR DESCRIPTION
## What does this PR do?

Guards against `TypeError: int(None)` when `cua-driver`'s `list_windows` MCP tool returns entries with `pid: null` and/or `window_id: null` for non-application X11 windows (panel, dock, taskbar) on Linux/WSL. Both `capture()` and `focus_app()` now silently skip such entries instead of crashing.

## Related Issue

Fixes #56704

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py`: Added `if w.get("pid") is not None and w.get("window_id") is not None` filter to both `capture()` (line 1041) and `focus_app()` (line 1445) list comprehensions that process `list_windows` results.
- `tests/tools/test_computer_use.py`: Added `TestCuaNonePidWindowIdGuard` with 3 regression tests covering all-None, mixed-None-and-valid, and focus_app scenarios.

## How to Test

1. Run `python -m pytest tests/tools/test_computer_use.py::TestCuaNonePidWindowIdGuard -v` — all 3 tests should pass
2. Run `python -m pytest tests/tools/test_computer_use.py -v` — all 170 tests should pass (no regressions)
3. The fix is a 2-line guard in list comprehensions; the tests mock `list_windows` responses with None entries to verify they are filtered without crashing

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
