### PR TITLE
feat(slack): route slash commands to the channel-owning profile (multi-app same-workspace)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -486,6 +486,12 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        # Cross-profile slash relay: consumer task + last-purge stamp (see
+        # slash_relay module — routes workspace-global slash commands to the
+        # profile that owns the invoking channel).
+        self._slash_relay_task: Optional[asyncio.Task] = None
+        self._slash_relay_poll_s = 1.5
+        self._last_slash_relay_purge = 0.0
 
     def _start_socket_mode_handler(self) -> None:
         """Start the Slack Socket Mode background task."""
@@ -816,7 +822,10 @@ class SlackAdapter(BasePlatformAdapter):
         text = chunks[0] if chunks else formatted
         payload = {
             "response_type": "ephemeral",
-            "replace_original": True,
+            # Relayed slash commands ack silently (there is no "Running…"
+            # placeholder to replace) — their contexts set replace_original
+            # False so this POST creates a fresh ephemeral message.
+            "replace_original": ctx.get("replace_original", True),
             "text": text,
         }
         try:
@@ -950,6 +959,44 @@ class SlackAdapter(BasePlatformAdapter):
                 )
         except Exception:  # pragma: no cover - diagnostics must never break connect
             pass
+
+    async def _send_slash_ephemeral_via_bot(
+        self,
+        chat_id: str,
+        ctx: Dict[str, Any],
+        content: str,
+    ) -> "SendResult":
+        """Ephemeral slash reply posted with THIS bot's token.
+
+        Used for relayed slash commands (see the slash relay): a
+        ``chat.postEphemeral`` from the owning profile's bot is attributed
+        to that profile's app in Slack, unlike a ``response_url`` POST,
+        which always shows the app that received the slash. Falls back to
+        the stashed ``response_url`` if the API call fails (e.g. the bot is
+        not a member of the channel).
+        """
+        user_id = str(ctx.get("user_id") or "")
+        if user_id:
+            formatted = self.format_message(content)
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            text = chunks[0] if chunks else formatted
+            try:
+                client = self._get_client(chat_id)
+                await client.chat_postEphemeral(
+                    channel=chat_id,
+                    user=user_id,
+                    text=text,
+                )
+                return SendResult(success=True, message_id=None)
+            except Exception as e:
+                logger.warning(
+                    "[Slack] chat_postEphemeral for relayed slash failed "
+                    "(%s) — falling back to response_url",
+                    e,
+                )
+        if ctx.get("response_url"):
+            return await self._send_slash_ephemeral(ctx, content)
+        return SendResult(success=False, error="No ephemeral route available")
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Slack via Socket Mode."""
@@ -1161,6 +1208,20 @@ class SlackAdapter(BasePlatformAdapter):
             @self._app.command(_slash_pattern)
             async def handle_hermes_command(ack, command):
                 slash = (command.get("command") or "").lstrip("/")
+                # Slash names are workspace-global: Slack delivers every
+                # colliding /command to ONE app, regardless of channel. When
+                # the invoking channel belongs to another profile, ack here
+                # (only the receiving app can, within Slack's 3 s window) and
+                # relay the payload to the owning profile's gateway.
+                owner = self._resolve_foreign_slash_owner(command)
+                if owner:
+                    # Silent ack: any text here (and any response_url POST)
+                    # would be attributed to THIS app, not the owning
+                    # profile's. The owner replies via its own bot token, so
+                    # the user only ever sees the right app's name.
+                    await ack()
+                    await self._forward_slash_to_profile(owner, command)
+                    return
                 await ack(
                     response_type="ephemeral",
                     text=f"Running `/{slash}`…",
@@ -1247,6 +1308,7 @@ class SlackAdapter(BasePlatformAdapter):
                 self._start_socket_mode_handler()
                 self._running = True
                 self._ensure_socket_watchdog()
+                self._ensure_slash_relay_task()
             except Exception:
                 self._running = False
                 try:
@@ -1317,6 +1379,20 @@ class SlackAdapter(BasePlatformAdapter):
         """Disconnect from Slack."""
         self._running = False
 
+        relay_task = self._slash_relay_task
+        self._slash_relay_task = None
+        if relay_task is not None and not relay_task.done():
+            relay_task.cancel()
+            try:
+                await relay_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # pragma: no cover - defensive logging
+                logger.debug(
+                    "[Slack] Slash relay task raised during disconnect",
+                    exc_info=True,
+                )
+
         watchdog_task = self._socket_watchdog_task
         self._socket_watchdog_task = None
         if watchdog_task is not None and not watchdog_task.done():
@@ -1368,6 +1444,16 @@ class SlackAdapter(BasePlatformAdapter):
             # the actual command reply ephemerally instead of posting publicly.
             slash_ctx = self._pop_slash_context(chat_id)
             if slash_ctx:
+                if slash_ctx.get("via_bot"):
+                    # Relayed slash command: reply through THIS bot's token so
+                    # Slack attributes the message to the owning profile's app
+                    # (a response_url reply would show the receiving app's
+                    # name). response_url stays available as fallback.
+                    return await self._send_slash_ephemeral_via_bot(
+                        chat_id,
+                        slash_ctx,
+                        content,
+                    )
                 return await self._send_slash_ephemeral(
                     slash_ctx,
                     content,
@@ -3886,7 +3972,159 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] Failed to fetch thread parent text: %s", exc)
             return ""
 
-    async def _handle_slash_command(self, command: dict) -> None:
+    # ── Cross-profile slash relay ────────────────────────────────────────
+    # Slack slash names are workspace-global; with multiple profile apps in
+    # one workspace, Slack delivers every colliding /command to a single app.
+    # The receiving adapter resolves the invoking channel's owning profile
+    # (slash_relay.resolve_channel_owner) and, when foreign, enqueues the
+    # payload on a shared SQLite queue; every adapter polls its own inbox
+    # and executes relayed payloads through its normal slash pipeline.
+
+    def _slash_relay_enabled(self) -> bool:
+        """Config kill switch: ``slack.slash_relay: false``. Default on."""
+        raw = self.config.extra.get("slash_relay") if self.config.extra else None
+        if raw is None:
+            return True
+        return str(raw).strip().lower() not in {"false", "0", "no", "off"}
+
+    def _slash_relay_profile(self) -> str:
+        """The profile name this gateway represents."""
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            return get_active_profile_name() or "default"
+        except Exception:
+            return "default"
+
+    def _resolve_foreign_slash_owner(self, command: dict) -> Optional[str]:
+        """Return the owning profile of the invoking channel when it is NOT
+        this gateway's profile; None means handle the command locally."""
+        if not self._slash_relay_enabled():
+            return None
+        channel_id = str(command.get("channel_id") or "")
+        if not channel_id:
+            return None
+        try:
+            from plugins.platforms.slack import slash_relay
+
+            owner = slash_relay.resolve_channel_owner(channel_id)
+        except Exception:
+            logger.debug(
+                "[Slack] Slash relay owner lookup failed", exc_info=True
+            )
+            return None
+        if owner is None or owner == self._slash_relay_profile():
+            return None
+        return owner
+
+    async def _forward_slash_to_profile(self, owner: str, command: dict) -> None:
+        """Enqueue a foreign-channel slash payload for *owner*'s gateway.
+
+        Falls back to local handling (pre-relay behavior) if the enqueue
+        fails — a wrong-profile answer beats no answer.
+        """
+        from plugins.platforms.slack import slash_relay
+
+        slash = (command.get("command") or "").lstrip("/")
+        try:
+            row_id = await asyncio.to_thread(
+                slash_relay.enqueue,
+                owner,
+                self._slash_relay_profile(),
+                command,
+            )
+        except Exception:
+            logger.warning(
+                "[Slack] Slash relay enqueue failed — handling /%s locally",
+                slash,
+                exc_info=True,
+            )
+            await self._handle_slash_command(command)
+            return
+        logger.info(
+            "[Slack] Relayed /%s in %s to profile %s (row %d)",
+            slash,
+            command.get("channel_id"),
+            owner,
+            row_id,
+        )
+        if command.get("response_url"):
+            asyncio.create_task(
+                self._warn_if_slash_unclaimed(owner, command, row_id)
+            )
+
+    async def _warn_if_slash_unclaimed(
+        self,
+        owner: str,
+        command: dict,
+        row_id: int,
+        delay_s: float = 20.0,
+    ) -> None:
+        """Replace the routed-ack with a warning if *owner* never picks the
+        relayed command up (its gateway is likely down)."""
+        await asyncio.sleep(delay_s)
+        try:
+            from plugins.platforms.slack import slash_relay
+
+            claimed = await asyncio.to_thread(slash_relay.is_claimed, row_id)
+        except Exception:
+            return
+        if claimed:
+            return
+        slash = (command.get("command") or "").lstrip("/")
+        await self._send_slash_ephemeral(
+            # The ack was silent, so create a new ephemeral rather than
+            # replacing a (nonexistent) original.
+            {"response_url": command["response_url"], "replace_original": False},
+            f"⚠️ *{owner}*'s gateway hasn't picked up `/{slash}` — "
+            "is it running?",
+        )
+
+    def _ensure_slash_relay_task(self) -> None:
+        if not self._slash_relay_enabled():
+            return
+        if self._slash_relay_task is None or self._slash_relay_task.done():
+            self._slash_relay_task = asyncio.create_task(
+                self._slash_relay_loop()
+            )
+
+    async def _slash_relay_loop(self) -> None:
+        """Poll the shared relay for slash payloads addressed to this
+        profile and run each through the normal slash pipeline."""
+        from plugins.platforms.slack import slash_relay
+
+        profile = self._slash_relay_profile()
+        logger.info("[Slack] Slash relay consumer started (profile %s)", profile)
+        while self._running:
+            try:
+                rows = await asyncio.to_thread(slash_relay.claim_pending, profile)
+                for row in rows:
+                    try:
+                        await self._handle_slash_command(
+                            row["payload"], relayed=True
+                        )
+                    except Exception:
+                        logger.warning(
+                            "[Slack] Relayed slash command failed",
+                            exc_info=True,
+                        )
+                    finally:
+                        await asyncio.to_thread(slash_relay.mark_done, row["id"])
+                now = time.monotonic()
+                if now - self._last_slash_relay_purge > 3600.0:
+                    self._last_slash_relay_purge = now
+                    await asyncio.to_thread(slash_relay.purge)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug(
+                    "[Slack] Slash relay loop error", exc_info=True
+                )
+            await asyncio.sleep(self._slash_relay_poll_s)
+
+    async def _handle_slash_command(
+        self, command: dict, *, relayed: bool = False
+    ) -> None:
         """Handle Slack slash commands.
 
         Every gateway command in COMMAND_REGISTRY is registered as a native
@@ -3966,10 +4204,20 @@ class SlackAdapter(BasePlatformAdapter):
         # the whole channel can see the agent's answer.
         response_url = command.get("response_url", "")
         if response_url and user_id and channel_id and text.startswith("/"):
-            self._slash_command_contexts[(channel_id, user_id)] = {
+            ctx: Dict[str, Any] = {
                 "response_url": response_url,
                 "ts": time.monotonic(),
             }
+            if relayed:
+                # Relayed from another profile's app: reply via THIS bot
+                # (chat.postEphemeral) so Slack shows the owning profile's
+                # app name, keeping response_url only as fallback. The
+                # receiving app acked silently, so a fallback POST must
+                # create a new message, not replace one.
+                ctx["via_bot"] = True
+                ctx["user_id"] = user_id
+                ctx["replace_original"] = False
+            self._slash_command_contexts[(channel_id, user_id)] = ctx
 
         # Set the ContextVar so send() can match the correct stashed
         # response_url even when multiple users slash concurrently.

--- a/plugins/platforms/slack/slash_relay.py
+++ b/plugins/platforms/slack/slash_relay.py
@@ -1,0 +1,322 @@
+"""Cross-profile relay for Slack slash commands.
+
+Slack slash-command names are workspace-global: when several Hermes
+profiles each install their own Slack app in ONE workspace and register
+the same command names, Slack delivers every ``/command`` to exactly one
+app (the most recently reinstalled), regardless of which channel it was
+typed in. The receiving gateway would then answer from the wrong profile.
+
+This module gives the receiving adapter what it needs to fix that:
+
+1. ``resolve_channel_owner(channel_id)`` — map a Slack channel (or bot-DM)
+   id to the profile that owns it, using only artifacts every profile
+   already writes: ``config.yaml``'s ``slack.free_response_channels`` /
+   ``allowed_channels`` (explicit intent, score 2) and
+   ``channel_directory.json``'s observed Slack channels (score 1). The
+   unique top scorer owns the channel; ties or no claimant resolve to
+   ``None`` (caller handles the command locally — the pre-relay behavior).
+
+2. A small SQLite queue (``slack-slash-relay.db`` in the hermes root,
+   next to ``kanban.db``) that the receiving adapter enqueues foreign
+   slash payloads into and every profile's adapter polls for its own
+   inbox. The payload travels verbatim, including ``response_url`` —
+   which Slack scopes to the invocation, not the receiving app, so the
+   owning profile's reply can still replace the ephemeral ack.
+
+Single-profile installs never observe a foreign channel, so the whole
+mechanism is a no-op there.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+import uuid
+from contextlib import closing
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+DB_FILENAME = "slack-slash-relay.db"
+
+# Rows older than this are never claimed: the payload's response_url dies
+# at ~30 minutes anyway, and a many-minutes-late slash answer helps nobody.
+DEFAULT_CLAIM_MAX_AGE_S = 600.0
+
+# Completed / expired rows are deleted past this age.
+DEFAULT_PURGE_KEEP_S = 86_400.0
+
+# How long a computed channel→profile map is trusted before rescanning the
+# profile homes (a rescan is a handful of small file reads).
+OWNER_CACHE_TTL_S = 60.0
+
+# root path str → (monotonic timestamp, {channel_id: profile})
+_owner_cache: Dict[str, tuple] = {}
+
+
+def _default_root() -> Path:
+    from hermes_constants import get_default_hermes_root
+
+    return get_default_hermes_root()
+
+
+def _resolve_root(root: Optional[Any]) -> Path:
+    return Path(root) if root is not None else _default_root()
+
+
+# ---------------------------------------------------------------------------
+# Channel → profile resolution
+# ---------------------------------------------------------------------------
+
+def _profile_homes(root: Path) -> Dict[str, Path]:
+    """Return {profile_name: home_dir} for the default + named profiles."""
+    homes: Dict[str, Path] = {}
+    if (root / "config.yaml").exists():
+        homes["default"] = root
+    profiles_root = root / "profiles"
+    if profiles_root.is_dir():
+        for entry in sorted(profiles_root.iterdir()):
+            if entry.name != "default" and (entry / "config.yaml").exists():
+                homes[entry.name] = entry
+    return homes
+
+
+def _split_channel_csv(raw: Any) -> Set[str]:
+    """Parse a channels value that may be a list, CSV string, or scalar."""
+    if isinstance(raw, list):
+        return {str(part).strip() for part in raw if str(part).strip()}
+    s = str(raw).strip() if raw is not None else ""
+    if not s:
+        return set()
+    return {part.strip() for part in s.split(",") if part.strip()}
+
+
+def _explicit_channel_claims(home: Path) -> Set[str]:
+    """Channels a profile claims in config.yaml (slack.free_response_channels
+    / slack.allowed_channels, under the top-level ``slack:`` block or a
+    ``platforms.slack`` block)."""
+    try:
+        import yaml
+
+        data = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    except Exception:
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    platforms = data.get("platforms")
+    blocks = [
+        data.get("slack"),
+        platforms.get("slack") if isinstance(platforms, dict) else None,
+    ]
+    claims: Set[str] = set()
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        for key in ("free_response_channels", "allowed_channels"):
+            claims |= _split_channel_csv(block.get(key))
+    return claims
+
+
+def _observed_channel_claims(home: Path) -> Set[str]:
+    """Slack channel ids a profile's gateway has actually seen traffic in
+    (channel_directory.json), including its own bot-DM channels. Thread
+    entries like ``C123:171...`` collapse to the base channel id."""
+    try:
+        data = json.loads(
+            (home / "channel_directory.json").read_text(encoding="utf-8")
+        )
+    except Exception:
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    platforms = data.get("platforms")
+    entries = platforms.get("slack") if isinstance(platforms, dict) else None
+    claims: Set[str] = set()
+    if isinstance(entries, list):
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            base = str(entry.get("id") or "").split(":", 1)[0].strip()
+            if base:
+                claims.add(base)
+    return claims
+
+
+def build_channel_owner_map(root: Optional[Any] = None) -> Dict[str, str]:
+    """Compute {channel_id: owning_profile} across all profile homes.
+
+    Explicit config claims score 2, observed directory claims score 1; a
+    channel maps to a profile only when that profile is the UNIQUE top
+    scorer. This settles template-config overlap: a profile that both
+    configures a channel and has actually seen it (score 3) beats profiles
+    that merely inherited the channel in a copied config (score 2).
+    """
+    root_path = _resolve_root(root)
+    scores: Dict[str, Dict[str, int]] = {}
+    for name, home in _profile_homes(root_path).items():
+        for cid in _explicit_channel_claims(home):
+            scores.setdefault(cid, {})[name] = scores.get(cid, {}).get(name, 0) + 2
+        for cid in _observed_channel_claims(home):
+            scores.setdefault(cid, {})[name] = scores.get(cid, {}).get(name, 0) + 1
+    owners: Dict[str, str] = {}
+    for cid, per_profile in scores.items():
+        best = max(per_profile.values())
+        winners = [p for p, s in per_profile.items() if s == best]
+        if len(winners) == 1:
+            owners[cid] = winners[0]
+        else:
+            logger.debug(
+                "slash-relay: channel %s claimed equally by %s — leaving unrouted",
+                cid,
+                winners,
+            )
+    return owners
+
+
+def resolve_channel_owner(
+    channel_id: str,
+    root: Optional[Any] = None,
+    *,
+    ttl_s: float = OWNER_CACHE_TTL_S,
+) -> Optional[str]:
+    """Return the profile that owns ``channel_id``, or None if unknown or
+    contested. Results are cached per hermes root for ``ttl_s`` seconds."""
+    base = str(channel_id or "").split(":", 1)[0].strip()
+    if not base:
+        return None
+    root_path = _resolve_root(root)
+    key = str(root_path)
+    now = time.monotonic()
+    cached = _owner_cache.get(key)
+    if cached is None or now - cached[0] > ttl_s:
+        try:
+            cached = (now, build_channel_owner_map(root_path))
+        except Exception:
+            logger.warning(
+                "slash-relay: channel owner scan failed", exc_info=True
+            )
+            cached = (now, {})
+        _owner_cache[key] = cached
+    return cached[1].get(base)
+
+
+def clear_owner_cache() -> None:
+    """Testing hook: drop all cached channel→profile maps."""
+    _owner_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Relay queue
+# ---------------------------------------------------------------------------
+
+def _connect(root: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(root / DB_FILENAME), timeout=5.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS slash_relay (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            target_profile TEXT NOT NULL,
+            source_profile TEXT NOT NULL,
+            payload        TEXT NOT NULL,
+            created_at     REAL NOT NULL,
+            claimed_at     REAL,
+            claimed_by     TEXT,
+            done_at        REAL
+        )
+        """
+    )
+    return conn
+
+
+def enqueue(
+    target_profile: str,
+    source_profile: str,
+    payload: Dict[str, Any],
+    *,
+    root: Optional[Any] = None,
+) -> int:
+    """Queue a slash payload for ``target_profile``. Returns the row id."""
+    root_path = _resolve_root(root)
+    with closing(_connect(root_path)) as conn, conn:
+        cur = conn.execute(
+            "INSERT INTO slash_relay"
+            " (target_profile, source_profile, payload, created_at)"
+            " VALUES (?, ?, ?, ?)",
+            (target_profile, source_profile, json.dumps(payload), time.time()),
+        )
+        return int(cur.lastrowid)
+
+
+def claim_pending(
+    profile: str,
+    *,
+    root: Optional[Any] = None,
+    max_age_s: float = DEFAULT_CLAIM_MAX_AGE_S,
+) -> List[Dict[str, Any]]:
+    """Atomically claim every unclaimed, unexpired row addressed to
+    ``profile``. Returns [{"id": int, "payload": dict}, ...]; a row is
+    handed out exactly once across all processes (single-UPDATE claim with
+    a unique token). Undecodable payloads are marked done and skipped."""
+    root_path = _resolve_root(root)
+    now = time.time()
+    token = f"{profile}:{uuid.uuid4().hex}"
+    with closing(_connect(root_path)) as conn, conn:
+        conn.execute(
+            "UPDATE slash_relay SET claimed_at = ?, claimed_by = ?"
+            " WHERE target_profile = ? AND claimed_at IS NULL"
+            "   AND created_at >= ?",
+            (now, token, profile, now - max_age_s),
+        )
+        rows = conn.execute(
+            "SELECT id, payload FROM slash_relay WHERE claimed_by = ?",
+            (token,),
+        ).fetchall()
+    claimed: List[Dict[str, Any]] = []
+    for row_id, payload_json in rows:
+        try:
+            claimed.append({"id": int(row_id), "payload": json.loads(payload_json)})
+        except Exception:
+            logger.warning("slash-relay: dropping undecodable row %s", row_id)
+            mark_done(int(row_id), root=root_path)
+    return claimed
+
+
+def mark_done(row_id: int, *, root: Optional[Any] = None) -> None:
+    root_path = _resolve_root(root)
+    with closing(_connect(root_path)) as conn, conn:
+        conn.execute(
+            "UPDATE slash_relay SET done_at = ? WHERE id = ?",
+            (time.time(), row_id),
+        )
+
+
+def is_claimed(row_id: int, *, root: Optional[Any] = None) -> bool:
+    """True when the row was picked up (or finished) by its target profile."""
+    root_path = _resolve_root(root)
+    with closing(_connect(root_path)) as conn:
+        row = conn.execute(
+            "SELECT claimed_at, done_at FROM slash_relay WHERE id = ?",
+            (row_id,),
+        ).fetchone()
+    if row is None:
+        return False
+    return row[0] is not None or row[1] is not None
+
+
+def purge(
+    *,
+    root: Optional[Any] = None,
+    keep_s: float = DEFAULT_PURGE_KEEP_S,
+) -> int:
+    """Delete rows older than ``keep_s``. Returns the number removed."""
+    root_path = _resolve_root(root)
+    with closing(_connect(root_path)) as conn, conn:
+        cur = conn.execute(
+            "DELETE FROM slash_relay WHERE created_at < ?",
+            (time.time() - keep_s,),
+        )
+        return int(cur.rowcount or 0)

--- a/tests/plugins/platforms/slack/test_slash_relay.py
+++ b/tests/plugins/platforms/slack/test_slash_relay.py
@@ -1,0 +1,504 @@
+"""Tests for the cross-profile Slack slash relay.
+
+Covers the channel→profile resolver (scored claims from config.yaml +
+channel_directory.json), the SQLite relay queue (exclusive claims, expiry,
+purge), and the adapter seam (forwarding decision, consumer execution,
+unclaimed-row warning).
+"""
+
+import asyncio
+import json
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from plugins.platforms.slack import slash_relay
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a fake hermes root with profile homes
+# ---------------------------------------------------------------------------
+
+def _write_profile(
+    home,
+    *,
+    free_response: str = "",
+    allowed: str = "",
+    directory_channels=(),
+):
+    home.mkdir(parents=True, exist_ok=True)
+    slack_cfg = {
+        "require_mention": True,
+        "free_response_channels": free_response,
+        "allowed_channels": allowed,
+    }
+    cfg = home / "config.yaml"
+    lines = ["slack:"]
+    for k, v in slack_cfg.items():
+        lines.append(f"  {k}: {json.dumps(v)}")
+    cfg.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    directory = {
+        "platforms": {
+            "slack": [{"id": cid, "name": cid, "type": "private"} for cid in directory_channels]
+        }
+    }
+    (home / "channel_directory.json").write_text(
+        json.dumps(directory), encoding="utf-8"
+    )
+
+
+@pytest.fixture()
+def fleet_root(tmp_path):
+    """Mimic Justin's fleet: default owns #olympus (explicit + observed),
+    media/orchestrator inherited #olympus in template configs (explicit
+    only, no observed traffic), crypto/strategist own their channels."""
+    root = tmp_path / "hermes"
+    _write_profile(
+        root,
+        free_response="C_OLY",
+        directory_channels=("C_OLY", "C_HEALTH", "D_DEF:171.1"),
+    )
+    _write_profile(
+        root / "profiles" / "crypto",
+        free_response="C_CRY",
+        directory_channels=("C_CRY", "D_CRY"),
+    )
+    _write_profile(
+        root / "profiles" / "strategist",
+        free_response="C_STR",
+        directory_channels=("C_STR", "C_STR:1781.2", "D_STR"),
+    )
+    _write_profile(root / "profiles" / "media", free_response="C_OLY")
+    _write_profile(root / "profiles" / "orchestrator", free_response="C_OLY")
+    slash_relay.clear_owner_cache()
+    yield root
+    slash_relay.clear_owner_cache()
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+class TestResolveChannelOwner:
+    def test_unique_explicit_plus_observed_claim(self, fleet_root):
+        assert slash_relay.resolve_channel_owner("C_CRY", fleet_root) == "crypto"
+        assert slash_relay.resolve_channel_owner("C_STR", fleet_root) == "strategist"
+
+    def test_explicit_plus_observed_beats_template_explicit_only(self, fleet_root):
+        # The #olympus case: default (score 3) vs media/orchestrator (2 each).
+        assert slash_relay.resolve_channel_owner("C_OLY", fleet_root) == "default"
+
+    def test_observed_only_claim_resolves(self, fleet_root):
+        assert slash_relay.resolve_channel_owner("C_HEALTH", fleet_root) == "default"
+
+    def test_dm_channels_resolve_to_their_bot_profile(self, fleet_root):
+        assert slash_relay.resolve_channel_owner("D_CRY", fleet_root) == "crypto"
+        assert slash_relay.resolve_channel_owner("D_STR", fleet_root) == "strategist"
+
+    def test_thread_suffixed_directory_entries_collapse(self, fleet_root):
+        # C_STR appears as "C_STR:1781.2" too; base id must still resolve
+        # (and the query side also strips a :thread suffix).
+        assert (
+            slash_relay.resolve_channel_owner("C_STR:999.9", fleet_root)
+            == "strategist"
+        )
+
+    def test_unknown_channel_is_unrouted(self, fleet_root):
+        assert slash_relay.resolve_channel_owner("C_NOPE", fleet_root) is None
+
+    def test_equal_claims_are_unrouted(self, tmp_path):
+        root = tmp_path / "hermes"
+        _write_profile(root, free_response="C_SHARED")
+        _write_profile(root / "profiles" / "crypto", free_response="C_SHARED")
+        slash_relay.clear_owner_cache()
+        assert slash_relay.resolve_channel_owner("C_SHARED", root) is None
+
+    def test_empty_channel_id_is_unrouted(self, fleet_root):
+        assert slash_relay.resolve_channel_owner("", fleet_root) is None
+        assert slash_relay.resolve_channel_owner(None, fleet_root) is None
+
+    def test_malformed_config_and_directory_fail_open(self, tmp_path):
+        root = tmp_path / "hermes"
+        _write_profile(root / "profiles" / "crypto", free_response="C_CRY")
+        (root / "config.yaml").write_text(": not yaml [", encoding="utf-8")
+        (root / "channel_directory.json").write_text("{broken", encoding="utf-8")
+        slash_relay.clear_owner_cache()
+        # Broken default home doesn't poison the scan; crypto still resolves.
+        assert slash_relay.resolve_channel_owner("C_CRY", root) == "crypto"
+
+    def test_list_valued_channels_config(self, tmp_path):
+        root = tmp_path / "hermes"
+        home = root / "profiles" / "crypto"
+        home.mkdir(parents=True)
+        (home / "config.yaml").write_text(
+            "slack:\n  free_response_channels:\n    - C_A\n    - C_B\n",
+            encoding="utf-8",
+        )
+        slash_relay.clear_owner_cache()
+        assert slash_relay.resolve_channel_owner("C_B", root) == "crypto"
+
+    def test_cache_ttl_respected(self, fleet_root):
+        assert slash_relay.resolve_channel_owner("C_CRY", fleet_root) == "crypto"
+        # Rewriting ownership is invisible until the TTL lapses…
+        _write_profile(
+            fleet_root / "profiles" / "crypto", directory_channels=()
+        )
+        assert slash_relay.resolve_channel_owner("C_CRY", fleet_root) == "crypto"
+        # …and visible with a zero TTL.
+        assert slash_relay.resolve_channel_owner("C_CRY", fleet_root, ttl_s=0.0) is None
+
+
+# ---------------------------------------------------------------------------
+# Relay queue
+# ---------------------------------------------------------------------------
+
+PAYLOAD = {
+    "command": "/cron",
+    "text": "list",
+    "user_id": "U1",
+    "channel_id": "C_STR",
+    "team_id": "T1",
+    "response_url": "https://hooks.slack.com/commands/T1/1/xyz",
+}
+
+
+class TestRelayQueue:
+    def test_enqueue_claim_done_roundtrip(self, tmp_path):
+        row_id = slash_relay.enqueue("strategist", "crypto", PAYLOAD, root=tmp_path)
+        assert not slash_relay.is_claimed(row_id, root=tmp_path)
+        rows = slash_relay.claim_pending("strategist", root=tmp_path)
+        assert [r["id"] for r in rows] == [row_id]
+        assert rows[0]["payload"] == PAYLOAD
+        assert slash_relay.is_claimed(row_id, root=tmp_path)
+        slash_relay.mark_done(row_id, root=tmp_path)
+        assert slash_relay.claim_pending("strategist", root=tmp_path) == []
+
+    def test_claims_are_exclusive(self, tmp_path):
+        slash_relay.enqueue("strategist", "crypto", PAYLOAD, root=tmp_path)
+        first = slash_relay.claim_pending("strategist", root=tmp_path)
+        second = slash_relay.claim_pending("strategist", root=tmp_path)
+        assert len(first) == 1
+        assert second == []
+
+    def test_claim_filters_by_target_profile(self, tmp_path):
+        slash_relay.enqueue("strategist", "crypto", PAYLOAD, root=tmp_path)
+        assert slash_relay.claim_pending("x-expert", root=tmp_path) == []
+        assert len(slash_relay.claim_pending("strategist", root=tmp_path)) == 1
+
+    def test_stale_rows_never_claimed(self, tmp_path):
+        row_id = slash_relay.enqueue("strategist", "crypto", PAYLOAD, root=tmp_path)
+        assert (
+            slash_relay.claim_pending("strategist", root=tmp_path, max_age_s=0.0)
+            == []
+        )
+        assert not slash_relay.is_claimed(row_id, root=tmp_path)
+
+    def test_purge_removes_old_rows(self, tmp_path):
+        slash_relay.enqueue("strategist", "crypto", PAYLOAD, root=tmp_path)
+        assert slash_relay.purge(root=tmp_path, keep_s=0.0) == 1
+        assert slash_relay.claim_pending("strategist", root=tmp_path) == []
+
+    def test_is_claimed_missing_row(self, tmp_path):
+        assert not slash_relay.is_claimed(12345, root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Adapter seam
+# ---------------------------------------------------------------------------
+
+def _adapter_stub(profile: str = "crypto", extra: Optional[Dict[str, Any]] = None):
+    """A bare object carrying just what the relay methods need."""
+    from plugins.platforms.slack.adapter import SlackAdapter
+
+    stub = MagicMock()
+    stub.config.extra = extra or {}
+    stub._slash_relay_profile = MagicMock(return_value=profile)
+    stub._slash_relay_enabled = lambda: SlackAdapter._slash_relay_enabled(stub)
+    stub._handle_slash_command = AsyncMock()
+    stub._send_slash_ephemeral = AsyncMock()
+    stub._warn_if_slash_unclaimed = AsyncMock()
+    return stub
+
+
+class _LoopStub:
+    """Minimal non-mock stand-in for the consumer-loop tests: real
+    ``_running`` property (True for exactly one iteration) without touching
+    MagicMock class attributes."""
+
+    def __init__(self):
+        self._slash_relay_poll_s = 0.0
+        self._last_slash_relay_purge = 0.0
+        self._runs = iter([True, False])
+        self._handle_slash_command = AsyncMock()
+
+    @property
+    def _running(self):
+        return next(self._runs)
+
+    def _slash_relay_profile(self):
+        return "crypto"
+
+
+class TestForwardingDecision:
+    def test_foreign_channel_resolves_to_owner(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="crypto")
+        with patch.object(
+            slash_relay, "resolve_channel_owner", return_value="strategist"
+        ):
+            owner = SlackAdapter._resolve_foreign_slash_owner(stub, PAYLOAD)
+        assert owner == "strategist"
+
+    def test_own_channel_is_not_foreign(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="strategist")
+        with patch.object(
+            slash_relay, "resolve_channel_owner", return_value="strategist"
+        ):
+            assert SlackAdapter._resolve_foreign_slash_owner(stub, PAYLOAD) is None
+
+    def test_unknown_channel_is_not_foreign(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="crypto")
+        with patch.object(slash_relay, "resolve_channel_owner", return_value=None):
+            assert SlackAdapter._resolve_foreign_slash_owner(stub, PAYLOAD) is None
+
+    def test_kill_switch_disables_forwarding(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="crypto", extra={"slash_relay": "false"})
+        with patch.object(
+            slash_relay, "resolve_channel_owner", return_value="strategist"
+        ):
+            assert SlackAdapter._resolve_foreign_slash_owner(stub, PAYLOAD) is None
+
+    def test_resolver_error_fails_open_to_local(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="crypto")
+        with patch.object(
+            slash_relay, "resolve_channel_owner", side_effect=RuntimeError("boom")
+        ):
+            assert SlackAdapter._resolve_foreign_slash_owner(stub, PAYLOAD) is None
+
+
+class TestForwardAndWarn:
+    def test_forward_enqueues_for_owner(self, tmp_path):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="crypto")
+        with patch.object(slash_relay, "enqueue", MagicMock(return_value=7)) as enq:
+            asyncio.run(
+                SlackAdapter._forward_slash_to_profile(stub, "strategist", PAYLOAD)
+            )
+        enq.assert_called_once_with("strategist", "crypto", PAYLOAD)
+        stub._handle_slash_command.assert_not_awaited()
+        stub._warn_if_slash_unclaimed.assert_called_once()
+
+    def test_forward_failure_falls_back_to_local(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="crypto")
+        with patch.object(
+            slash_relay, "enqueue", MagicMock(side_effect=RuntimeError("disk"))
+        ):
+            asyncio.run(
+                SlackAdapter._forward_slash_to_profile(stub, "strategist", PAYLOAD)
+            )
+        stub._handle_slash_command.assert_awaited_once_with(PAYLOAD)
+
+    def test_unclaimed_row_warns_via_response_url(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="crypto")
+        with patch.object(slash_relay, "is_claimed", MagicMock(return_value=False)):
+            asyncio.run(
+                SlackAdapter._warn_if_slash_unclaimed(
+                    stub, "strategist", PAYLOAD, 7, delay_s=0.0
+                )
+            )
+        stub._send_slash_ephemeral.assert_awaited_once()
+        ctx, text = stub._send_slash_ephemeral.await_args.args
+        assert ctx["response_url"] == PAYLOAD["response_url"]
+        assert "strategist" in text and "/cron" in text
+
+    def test_claimed_row_stays_silent(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = _adapter_stub(profile="crypto")
+        with patch.object(slash_relay, "is_claimed", MagicMock(return_value=True)):
+            asyncio.run(
+                SlackAdapter._warn_if_slash_unclaimed(
+                    stub, "strategist", PAYLOAD, 7, delay_s=0.0
+                )
+            )
+        stub._send_slash_ephemeral.assert_not_awaited()
+
+
+class TestConsumerLoop:
+    def test_consumer_executes_payload_and_marks_done(self, tmp_path):
+        """One full pass: enqueue → claim → _handle_slash_command → done."""
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        row_id = slash_relay.enqueue("crypto", "default", PAYLOAD, root=tmp_path)
+
+        stub = _LoopStub()
+
+        real_claim = slash_relay.claim_pending
+        real_done = slash_relay.mark_done
+        with patch.object(
+            slash_relay,
+            "claim_pending",
+            lambda profile, **kw: real_claim(profile, root=tmp_path),
+        ), patch.object(
+            slash_relay,
+            "mark_done",
+            lambda rid, **kw: real_done(rid, root=tmp_path),
+        ), patch.object(slash_relay, "purge", MagicMock(return_value=0)):
+            asyncio.run(SlackAdapter._slash_relay_loop(stub))
+
+        stub._handle_slash_command.assert_awaited_once_with(PAYLOAD, relayed=True)
+        assert slash_relay.is_claimed(row_id, root=tmp_path)
+        assert slash_relay.claim_pending("crypto", root=tmp_path) == []
+
+    def test_handler_error_still_marks_done(self, tmp_path):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        slash_relay.enqueue("crypto", "default", PAYLOAD, root=tmp_path)
+        stub = _LoopStub()
+        stub._handle_slash_command = AsyncMock(side_effect=RuntimeError("boom"))
+
+        real_claim = slash_relay.claim_pending
+        real_done = slash_relay.mark_done
+        with patch.object(
+            slash_relay,
+            "claim_pending",
+            lambda profile, **kw: real_claim(profile, root=tmp_path),
+        ), patch.object(
+            slash_relay,
+            "mark_done",
+            lambda rid, **kw: real_done(rid, root=tmp_path),
+        ), patch.object(slash_relay, "purge", MagicMock(return_value=0)):
+            asyncio.run(SlackAdapter._slash_relay_loop(stub))
+
+        # Errors are contained and the row is not re-delivered forever.
+        assert slash_relay.claim_pending("crypto", root=tmp_path) == []
+
+
+class TestRelayedReplyAttribution:
+    """Relayed slash replies must be attributed to the OWNING profile's app:
+    posted with its own bot token (chat.postEphemeral), with response_url
+    kept only as a delivery fallback."""
+
+    def _ctx(self, **extra):
+        return {
+            "response_url": PAYLOAD["response_url"],
+            "ts": 0.0,
+            "via_bot": True,
+            "user_id": "U1",
+            "replace_original": False,
+            **extra,
+        }
+
+    def _stub(self):
+        stub = MagicMock()
+        stub.format_message = lambda c: c
+        stub.truncate_message = lambda c, _n: [c]
+        stub.MAX_MESSAGE_LENGTH = 40000
+        stub._send_slash_ephemeral = AsyncMock(return_value="fallback-result")
+        return stub
+
+    def test_reply_posts_via_own_bot_token(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = self._stub()
+        client = MagicMock()
+        client.chat_postEphemeral = AsyncMock()
+        stub._get_client = MagicMock(return_value=client)
+
+        result = asyncio.run(
+            SlackAdapter._send_slash_ephemeral_via_bot(
+                stub, "C_STR", self._ctx(), "the jobs"
+            )
+        )
+        client.chat_postEphemeral.assert_awaited_once_with(
+            channel="C_STR", user="U1", text="the jobs"
+        )
+        assert result.success
+        stub._send_slash_ephemeral.assert_not_awaited()
+
+    def test_post_failure_falls_back_to_response_url(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = self._stub()
+        client = MagicMock()
+        client.chat_postEphemeral = AsyncMock(side_effect=RuntimeError("nope"))
+        stub._get_client = MagicMock(return_value=client)
+
+        result = asyncio.run(
+            SlackAdapter._send_slash_ephemeral_via_bot(
+                stub, "C_STR", self._ctx(), "the jobs"
+            )
+        )
+        stub._send_slash_ephemeral.assert_awaited_once()
+        assert result == "fallback-result"
+
+    def test_missing_user_id_goes_straight_to_fallback(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = self._stub()
+        result = asyncio.run(
+            SlackAdapter._send_slash_ephemeral_via_bot(
+                stub, "C_STR", self._ctx(user_id=""), "the jobs"
+            )
+        )
+        stub._send_slash_ephemeral.assert_awaited_once()
+        assert result == "fallback-result"
+
+    def test_no_route_at_all_reports_failure(self):
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        stub = self._stub()
+        result = asyncio.run(
+            SlackAdapter._send_slash_ephemeral_via_bot(
+                stub, "C_STR", {"via_bot": True, "user_id": ""}, "x"
+            )
+        )
+        assert not result.success
+
+
+class TestAdapterWiring:
+    """Guard the adapter integration points against accidental removal
+    (same pattern as test_run_py_dispatches_cron)."""
+
+    def _adapter_source(self) -> str:
+        import pathlib
+
+        import plugins.platforms.slack.adapter as slack_adapter
+
+        return pathlib.Path(slack_adapter.__file__).read_text(encoding="utf-8")
+
+    def test_command_closure_forwards_foreign_channels(self):
+        src = self._adapter_source()
+        assert "_resolve_foreign_slash_owner(command)" in src
+        assert "_forward_slash_to_profile(owner, command)" in src
+
+    def test_connect_starts_relay_consumer(self):
+        src = self._adapter_source()
+        assert "_ensure_slash_relay_task()" in src
+
+    def test_disconnect_cancels_relay_consumer(self):
+        src = self._adapter_source()
+        assert "relay_task.cancel()" in src
+
+    def test_relayed_replies_attributed_to_owning_bot(self):
+        # Guard the attribution chain: relayed contexts are flagged via_bot,
+        # and send() routes them through _send_slash_ephemeral_via_bot.
+        src = self._adapter_source()
+        assert 'ctx["via_bot"] = True' in src
+        assert "_send_slash_ephemeral_via_bot" in src
+        assert 'slash_ctx.get("via_bot")' in src


### PR DESCRIPTION
## What does this PR do?

Fixes cross-profile misrouting of Slack slash commands when several Hermes profiles each install their own Slack app in **one workspace**. Slash-command names are workspace-global: with N apps registering the same ~50 names, Slack delivers every `/command` — typed in ANY channel or DM — to a single app (the most recently reinstalled), whose gateway then answers from the wrong profile (`/cron list` in profile B's channel returns profile A's jobs; `/model` changes profile A's model; etc.). Telegram is unaffected (one bot = one namespace).

The receiving Slack adapter now routes by channel ownership:

- **Channel→profile resolution** from artifacts every profile already writes: `config.yaml` `slack.free_response_channels`/`allowed_channels` (explicit claim, score 2) + `channel_directory.json` observed Slack channels incl. bot-DM ids (score 1). A channel belongs to the unique top scorer; ties/unknown → handle locally (exact pre-PR behavior).
- **Cross-profile relay**: foreign payloads are enqueued on a small WAL SQLite queue in the hermes root (`slack-slash-relay.db`); every profile's adapter polls its own inbox (1.5 s) and executes relayed payloads through its normal `_handle_slash_command` pipeline. Atomic single-`UPDATE` claims; rows expire unclaimed after 10 min.
- **Correct attribution**: relayed replies post via the owning bot's **own token** (`chat.postEphemeral`, still "Only visible to you") so Slack shows the owning profile's app name — a `response_url` POST is always attributed to the app that received the slash, so it is kept only as a delivery fallback. The receiving app acks silently; if the owner's gateway doesn't claim the row within 20 s, the receiver posts a "gateway down?" warning via `response_url`.
- **Strictly a no-op for single-profile installs** (a foreign owner is never resolved) and fail-open everywhere: resolver/enqueue errors fall back to local handling.
- Kill switch: `slack.slash_relay: false`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/slack/slash_relay.py` (new): channel→profile resolver (scored claims, 60 s cache) + SQLite relay queue (`enqueue`/`claim_pending`/`mark_done`/`is_claimed`/`purge`)
- `plugins/platforms/slack/adapter.py`: foreign-owner check + silent ack + enqueue in the slash closure; relay consumer task (started in `connect()`, cancelled in `disconnect()`, mirroring the socket watchdog); `via_bot` slash contexts routed through new `_send_slash_ephemeral_via_bot()` (`chat.postEphemeral`, `response_url` fallback); `_send_slash_ephemeral` honors `replace_original`; 20 s unclaimed-row warning
- `tests/plugins/platforms/slack/test_slash_relay.py` (new): 36 tests — resolver scoring/tie/DM/thread-suffix/malformed-file/cache-TTL cases, queue claim exclusivity + expiry + purge, forwarding decision + fallbacks, consumer execution, attribution routing, wiring guards

## How to Test

1. Install two (or more) Hermes profiles' Slack apps in one workspace, each registering the same slash commands (`hermes slack manifest`), one gateway per profile.
2. Type `/cron list` in a channel belonging to a profile whose app does NOT currently own the `/cron` name — the reply arrives from that channel's profile, attributed to its app.
3. Repeat in a bot DM of a non-owning profile; repeat after reinstalling any app (ownership reshuffles; routing is unaffected).
4. Stop one profile's gateway and slash in its channel — an ephemeral "⚠️ …gateway hasn't picked up `/cron` — is it running?" appears after ~20 s.
5. `pytest tests/plugins/platforms/slack/test_slash_relay.py -q` — 36 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (`tests/plugins/platforms/ tests/gateway/`: 8639 passed; the 9 failures are order-dependent Telegram markdown-escape flakes that fail identically on pristine `main`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module + method docstrings; N/A otherwise
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: the `slack:` settings block (`require_mention`, `free_response_channels`, `allowed_channels`) is itself undocumented in the example; following that precedent for `slack.slash_relay`
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python `sqlite3`/`pathlib`, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Running on a 4-profile production deployment (apps: default/crypto/strategist/x-expert, one workspace) since 2026-07-01. With crypto's app owning every colliding name after a reinstall, `/cron list` in each profile's channel is answered by that profile under its own app name. Representative log lines:

```
[Slack] Relayed /cron in C0B9FEWQ9L2 to profile strategist (row 3)
[Slack] Slash relay consumer started (profile strategist)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
