### PR TITLE
fix(cua): skip list_windows rows with null pid/window_id on Linux/WSL

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1542,6 +1542,45 @@ class TestCaptureAppFilterNoMatch:
         assert backend._active_pid == 100
 
 
+class TestListWindowsNullIds56704:
+    """Linux/WSL list_windows can return null pid/window_id for panel windows."""
+
+    def test_capture_skips_null_ids_and_targets_real_window(self):
+        windows = [
+            {"app_name": "wl-panel", "pid": None, "window_id": 99,
+             "is_on_screen": True, "title": "panel", "z_index": 10},
+            {"app_name": "Terminal", "pid": 100, "window_id": 7,
+             "is_on_screen": True, "title": "bash", "z_index": 1},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+        backend._session.call_tool.side_effect = [
+            {"data": "", "images": [], "isError": False,
+             "structuredContent": {"windows": windows}},
+            {"data": '✅ Terminal — 0 elements\n', "images": [], "isError": False,
+             "structuredContent": None},
+        ]
+
+        backend.capture(mode="ax", app=None)
+
+        assert backend._active_pid == 100
+        assert backend._active_window_id == 7
+
+    def test_focus_app_skips_null_ids(self):
+        windows = [
+            {"app_name": "wl-panel", "pid": None, "window_id": 99,
+             "is_on_screen": True, "title": "panel", "z_index": 10},
+            {"app_name": "Terminal", "pid": 100, "window_id": 7,
+             "is_on_screen": True, "title": "bash", "z_index": 1},
+        ]
+        backend = _make_cua_backend_with_windows(windows)
+
+        res = backend.focus_app("Terminal")
+
+        assert res.ok is True
+        assert backend._active_pid == 100
+        assert backend._active_window_id == 7
+
+
 class TestFocusAppFilterNoMatch:
     """focus_app(app=X) must return ok=False when X matches nothing —
     not silently target the frontmost window and report ok=True with a

--- a/tests/tools/test_cua_list_windows_parse.py
+++ b/tests/tools/test_cua_list_windows_parse.py
@@ -1,0 +1,38 @@
+"""Tests for list_windows normalization (issue #56704)."""
+
+from tools.computer_use.cua_backend import _parse_list_windows_entries
+
+
+def test_parse_list_windows_skips_null_pid_or_window_id():
+    raw = [
+        {"app_name": "panel", "pid": None, "window_id": 99, "is_on_screen": True},
+        {"app_name": "dock", "pid": 42, "window_id": None, "is_on_screen": True},
+        {
+            "app_name": "Terminal",
+            "pid": 100,
+            "window_id": 7,
+            "is_on_screen": True,
+            "title": "bash",
+            "z_index": 3,
+        },
+    ]
+    parsed = _parse_list_windows_entries(raw)
+    assert len(parsed) == 1
+    assert parsed[0]["app_name"] == "Terminal"
+    assert parsed[0]["pid"] == 100
+    assert parsed[0]["window_id"] == 7
+    assert parsed[0]["title"] == "bash"
+    assert parsed[0]["z_index"] == 3
+    assert parsed[0]["off_screen"] is False
+
+
+def test_parse_list_windows_skips_non_numeric_ids():
+    raw = [
+        {"app_name": "bad", "pid": "nope", "window_id": 1, "is_on_screen": True},
+        {"app_name": "ok", "pid": "200", "window_id": "2", "is_on_screen": False},
+    ]
+    parsed = _parse_list_windows_entries(raw)
+    assert len(parsed) == 1
+    assert parsed[0]["pid"] == 200
+    assert parsed[0]["window_id"] == 2
+    assert parsed[0]["off_screen"] is True

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1059,17 +1059,7 @@ class CuaDriverBackend(ComputerUseBackend):
             {"on_screen_only": True, "session": self._session_id},
         )
         raw_windows = (lw_out.get("structuredContent") or {}).get("windows") or []
-        windows = [
-            {
-                "app_name": w.get("app_name", ""),
-                "pid": int(w["pid"]),
-                "window_id": int(w["window_id"]),
-                "off_screen": not w.get("is_on_screen", True),
-                "title": w.get("title", ""),
-                "z_index": w.get("z_index", 0),
-            }
-            for w in raw_windows
-        ]
+        windows = _parse_list_windows_entries(raw_windows)
         # Sort by z_index descending (lowest z_index = frontmost on macOS).
         windows.sort(key=lambda w: w["z_index"])
 
@@ -1464,15 +1454,7 @@ class CuaDriverBackend(ComputerUseBackend):
             {"on_screen_only": True, "session": self._session_id},
         )
         raw_windows = (lw_out.get("structuredContent") or {}).get("windows") or []
-        windows = [
-            {
-                "app_name": w.get("app_name", ""),
-                "pid": int(w["pid"]),
-                "window_id": int(w["window_id"]),
-                "z_index": w.get("z_index", 0),
-            }
-            for w in raw_windows
-        ]
+        windows = _parse_list_windows_entries(raw_windows)
         windows.sort(key=lambda w: w["z_index"])
 
         app_lower = app.lower()

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -909,6 +909,37 @@ def _image_from_tool_result(out: Dict[str, Any]) -> tuple[Optional[str], Optiona
     return None, None
 
 
+def _parse_list_windows_entries(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Normalize ``list_windows`` structuredContent rows for capture/focus.
+
+    cua-driver on Linux/WSL can return panel/dock windows with ``pid`` or
+    ``window_id`` set to ``null`` (NousResearch/hermes-agent#56704). Skip
+    those entries instead of crashing on ``int(None)``.
+    """
+    parsed: List[Dict[str, Any]] = []
+    for w in raw_windows:
+        pid_raw = w.get("pid")
+        wid_raw = w.get("window_id")
+        if pid_raw is None or wid_raw is None:
+            continue
+        try:
+            pid = int(pid_raw)
+            window_id = int(wid_raw)
+        except (TypeError, ValueError):
+            continue
+        parsed.append(
+            {
+                "app_name": w.get("app_name", ""),
+                "pid": pid,
+                "window_id": window_id,
+                "off_screen": not w.get("is_on_screen", True),
+                "title": w.get("title", ""),
+                "z_index": w.get("z_index", 0),
+            }
+        )
+    return parsed
+
+
 # ---------------------------------------------------------------------------
 # The backend itself
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`computer_use` capture crashed on WSL/Linux when `cua-driver`'s `list_windows` returned panel/dock rows with `pid: null` or `window_id: null`.

- Add `_parse_list_windows_entries()` to skip unusable rows instead of `int(None)`
- Wire into `capture()` and `focus_app()`

## Test plan

- [x] `scripts/run_tests.sh tests/tools/test_cua_list_windows_parse.py`
- [x] `scripts/run_tests.sh tests/tools/test_computer_use.py` (169 passed)


Made with [Cursor](https://cursor.com)