### PR TITLE
fix: patch Windows strftime %-d crash in journey renderer

### DIFF
--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -16,8 +16,12 @@ stdlib-only.
 from __future__ import annotations
 
 import math
+import sys
 from datetime import datetime, timezone
 from typing import Any, Iterable, Optional
+
+# strftime day-of-month without leading zero: Linux/macOS use %-d, Windows %#d.
+_DAY_FMT = "%#d" if sys.platform == "win32" else "%-d"
 
 # time-axis.ts LEAD_IN: the oldest node sits just off recency 0.
 LEAD_IN = 0.06
@@ -73,7 +77,9 @@ def format_date(ts: Optional[float]) -> str:
     if not ts:
         return "unknown"
     try:
-        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%-d %b %Y")
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime(
+            f"{_DAY_FMT} %b %Y"
+        )
     except (ValueError, OSError, OverflowError):
         return "unknown"
 
@@ -255,7 +261,7 @@ def _period_key(ts: float, granularity: str) -> tuple[int, ...]:
 def _period_label(ts: float, granularity: str) -> str:
     dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     if granularity == "day":
-        return dt.strftime("%-d %b")
+        return dt.strftime(f"{_DAY_FMT} %b")
     if granularity == "month":
         return dt.strftime("%b %Y")
     return dt.strftime("%Y")


### PR DESCRIPTION
## Problem

`hermes journey` crashes on Windows with:

```
ValueError: Invalid format string
```

Stack trace points to `agent/learning_graph_render.py` in `_period_label()` and `format_date()`, both calling `strftime("%-d ...")`. The `%-d` format (strip leading zero from day) is Linux-only and raises `ValueError` on Windows.

## Fix

Add `import sys` and a module-level constant `_DAY_FMT = "%#d" if sys.platform == "win32" else "%-d"`, then use it at both call sites. This keeps the fix clean, readable, and ruff-compliant (no new line-length violations).

Two call sites patched:
- `format_date()` (~line 79)
- `_period_label()` (~line 264)

## Verification

- `hermes journey` now renders correctly on Windows 10
- ruff clean on touched file (no new violations introduced)
- 18/18 relevant tests green (`tests/agent/test_learning_graph_render.py`, `tests/hermes_cli/test_journey_render.py`)