### PR TITLE
fix(journey): Windows strftime crash on %-d format directive

### DIFF
--- a/agent/learning_graph_render.py
+++ b/agent/learning_graph_render.py
@@ -73,7 +73,9 @@ def format_date(ts: Optional[float]) -> str:
     if not ts:
         return "unknown"
     try:
-        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%-d %b %Y")
+        dt = datetime.fromtimestamp(float(ts), tz=timezone.utc)
+        # Cross-platform: avoid %-d (POSIX) / %#d (Windows) — use dt.day directly.
+        return f"{dt.day} {dt.strftime('%b %Y')}"
     except (ValueError, OSError, OverflowError):
         return "unknown"
 
@@ -255,7 +257,8 @@ def _period_key(ts: float, granularity: str) -> tuple[int, ...]:
 def _period_label(ts: float, granularity: str) -> str:
     dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     if granularity == "day":
-        return dt.strftime("%-d %b")
+        # Cross-platform: avoid %-d (POSIX) / %#d (Windows) — use dt.day directly.
+        return f"{dt.day} {dt.strftime('%b')}"
     if granularity == "month":
         return dt.strftime("%b %Y")
     return dt.strftime("%Y")


### PR DESCRIPTION
Hi maintainers 👋 first-time contributor here.

## What does this PR do?

Fixes a `ValueError: Invalid format string` crash on Windows when running `hermes journey` (or any code path that renders a day label via `_period_label` / `format_date`).

Python's `strftime` on Windows does not support the POSIX `%-d` directive (no-padding day-of-month). Windows uses `%#d`, but rather than adding platform detection, this PR removes the platform-specific directive entirely — using `dt.day` + `strftime("%b")` yields identical output on both POSIX and Windows.

## Related Issue

No existing issue — this is a fresh Windows-only regression introduced by the new `/journey` feature in v0.18.0 (2026.7.1).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**File:** `agent/learning_graph_render.py`

- `format_date()` (line 76): replaced `strftime("%-d %b %Y")` with `f"{dt.day} {dt.strftime('%b %Y')}"`
- `_period_label()` (line 258, `granularity == "day"` branch): replaced `strftime("%-d %b")` with `f"{dt.day} {dt.strftime('%b')}"`

Added a short inline comment at both sites explaining why the platform-specific directive is avoided.

## How to Test

On Windows 11 with a populated `~/.hermes/skills` + memory store:

1. Before the fix — run `hermes journey`, observe crash:File "agent/learning_graph_render.py", line 258, in _period_label return dt.strftime("%-d %b") ValueError: Invalid format string
2. Apply this PR.
3. Run `hermes journey` again — the timeline renders correctly. Day labels appear as `1 Jul`, `30 Jun`, etc. (identical to POSIX output).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior unchanged, only Windows compatibility)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A