### PR TITLE
fix(streaming): handle completed responses with empty/None choices (#55933)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2017,13 +2017,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         request_client_holder["diag"] = _diag
         stream = request_client.chat.completions.create(**stream_kwargs)
 
-        # Some OpenAI-compatible adapters (for example copilot-acp) accept
-        # stream=True but still return a completed response object rather than
-        # an iterator of chunks.  Treat that as "streaming unsupported" for the
-        # rest of this session instead of crashing on ``for chunk in stream``
-        # with ``'types.SimpleNamespace' object is not iterable`` (#11732).
-        response_choices = getattr(stream, "choices", None)
-        if isinstance(response_choices, list) and response_choices:
+        # Some OpenAI-compatible adapters (for example copilot-acp, and the MoA
+        # openai-codex aggregator) accept stream=True but still return a
+        # completed response object rather than an iterator of chunks.  Treat
+        # that as "streaming unsupported" for the rest of this session instead
+        # of crashing on ``for chunk in stream`` with ``'types.SimpleNamespace'
+        # object is not iterable`` (#11732, #55933).
+        #
+        # Discriminate on the mere PRESENCE of a ``choices`` attribute, not on
+        # it being a non-empty list: an adapter may hand back a completed
+        # response whose ``choices`` is ``None`` or empty (an error /
+        # content-filter / terminal frame), and every such shape is still a
+        # whole response — not a token stream — that would crash iteration just
+        # the same.  A genuine provider stream (SDK ``Stream`` object,
+        # generator) exposes no ``choices`` attribute, so it is left untouched.
+        if hasattr(stream, "choices"):
             logger.info(
                 "Streaming request returned a final response object instead of "
                 "an iterator; switching %s/%s to non-streaming for this session.",
@@ -2031,7 +2039,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 agent.model or "unknown",
             )
             agent._disable_streaming = True
-            message = getattr(response_choices[0], "message", None)
+            response_choices = stream.choices
+            # An empty/None ``choices`` carries no message to surface; return the
+            # completed object as-is so the outer loop's normal invalid-response
+            # validation (conversation_loop.py) handles it via the retry path,
+            # never ``for chunk in stream``.
+            first_choice = (
+                response_choices[0]
+                if isinstance(response_choices, (list, tuple)) and response_choices
+                else None
+            )
+            message = getattr(first_choice, "message", None) if first_choice is not None else None
             if message is not None:
                 reasoning_text = (
                     getattr(message, "reasoning_content", None)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2039,17 +2039,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 agent.model or "unknown",
             )
             agent._disable_streaming = True
-            response_choices = stream.choices
             # An empty/None ``choices`` carries no message to surface; return the
             # completed object as-is so the outer loop's normal invalid-response
             # validation (conversation_loop.py) handles it via the retry path,
             # never ``for chunk in stream``.
-            first_choice = (
-                response_choices[0]
-                if isinstance(response_choices, (list, tuple)) and response_choices
-                else None
-            )
-            message = getattr(first_choice, "message", None) if first_choice is not None else None
+            choices = stream.choices
+            first_choice = choices[0] if isinstance(choices, (list, tuple)) and choices else None
+            message = getattr(first_choice, "message", None)
             if message is not None:
                 reasoning_text = (
                     getattr(message, "reasoning_content", None)

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -671,28 +671,26 @@ class TestStreamingFallback:
         assert agent._disable_streaming is True
         assert deltas == ["Hello from ACP"]
 
+    @pytest.mark.parametrize("choices", [[], None], ids=["empty", "none"])
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_completed_response_empty_choices_returned_not_iterated(
-        self, mock_close, mock_create
+    def test_completed_response_no_usable_choices_returned_not_iterated(
+        self, mock_close, mock_create, choices
     ):
-        """A completed response whose ``choices`` is an EMPTY list is still a
-        whole (non-iterable) response, not a token stream.
+        """A completed response whose ``choices`` is empty ``[]`` or ``None`` is
+        still a whole (non-iterable) response, not a token stream.
 
-        The pre-existing guard only recognized a *non-empty* choices list, so an
-        empty/terminal frame fell through to ``for chunk in stream`` and crashed
-        with ``'types.SimpleNamespace' object is not iterable`` (#55933, hit by
-        the MoA openai-codex aggregator). It must now disable streaming and
-        return the object for the outer loop's invalid-response retry path
+        The pre-existing guard (#55932) recognized a completed response only
+        when ``choices`` was a *non-empty* list, so an empty/terminal or
+        error/content-filter frame fell through to ``for chunk in stream`` and
+        crashed with ``'types.SimpleNamespace' object is not iterable`` (#55933,
+        hit by the MoA openai-codex aggregator). It must now disable streaming
+        and return the object for the outer loop's invalid-response retry path
         instead of iterating it.
         """
         from run_agent import AIAgent
 
-        final_response = SimpleNamespace(
-            model="gpt-5.5",
-            choices=[],
-            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=0, total_tokens=1),
-        )
+        final_response = SimpleNamespace(model="gpt-5.5", choices=choices, usage=None)
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.return_value = final_response
@@ -714,47 +712,6 @@ class TestStreamingFallback:
         agent._stream_callback = lambda text: deltas.append(text)
 
         # Must NOT raise "'types.SimpleNamespace' object is not iterable".
-        response = agent._interruptible_streaming_api_call({})
-
-        assert response is final_response
-        assert agent._disable_streaming is True
-        assert deltas == []
-
-    @patch("run_agent.AIAgent._create_request_openai_client")
-    @patch("run_agent.AIAgent._close_request_openai_client")
-    def test_completed_response_none_choices_returned_not_iterated(
-        self, mock_close, mock_create
-    ):
-        """A completed response whose ``choices`` is ``None`` (error /
-        content-filter frame) is recognized as a whole response and returned,
-        not handed to ``for chunk in stream``."""
-        from run_agent import AIAgent
-
-        final_response = SimpleNamespace(
-            model="gpt-5.5",
-            choices=None,
-            usage=None,
-        )
-
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = final_response
-        mock_create.return_value = mock_client
-
-        agent = AIAgent(
-            model="default",
-            provider="moa",
-            api_key="test-key",
-            base_url="moa://local",
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-        )
-        agent.api_mode = "chat_completions"
-        agent._interrupt_requested = False
-
-        deltas = []
-        agent._stream_callback = lambda text: deltas.append(text)
-
         response = agent._interruptible_streaming_api_call({})
 
         assert response is final_response

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -673,6 +673,96 @@ class TestStreamingFallback:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_completed_response_empty_choices_returned_not_iterated(
+        self, mock_close, mock_create
+    ):
+        """A completed response whose ``choices`` is an EMPTY list is still a
+        whole (non-iterable) response, not a token stream.
+
+        The pre-existing guard only recognized a *non-empty* choices list, so an
+        empty/terminal frame fell through to ``for chunk in stream`` and crashed
+        with ``'types.SimpleNamespace' object is not iterable`` (#55933, hit by
+        the MoA openai-codex aggregator). It must now disable streaming and
+        return the object for the outer loop's invalid-response retry path
+        instead of iterating it.
+        """
+        from run_agent import AIAgent
+
+        final_response = SimpleNamespace(
+            model="gpt-5.5",
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=0, total_tokens=1),
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = final_response
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            model="default",
+            provider="moa",
+            api_key="test-key",
+            base_url="moa://local",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        deltas = []
+        agent._stream_callback = lambda text: deltas.append(text)
+
+        # Must NOT raise "'types.SimpleNamespace' object is not iterable".
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response is final_response
+        assert agent._disable_streaming is True
+        assert deltas == []
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_completed_response_none_choices_returned_not_iterated(
+        self, mock_close, mock_create
+    ):
+        """A completed response whose ``choices`` is ``None`` (error /
+        content-filter frame) is recognized as a whole response and returned,
+        not handed to ``for chunk in stream``."""
+        from run_agent import AIAgent
+
+        final_response = SimpleNamespace(
+            model="gpt-5.5",
+            choices=None,
+            usage=None,
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = final_response
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            model="default",
+            provider="moa",
+            api_key="test-key",
+            base_url="moa://local",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        deltas = []
+        agent._stream_callback = lambda text: deltas.append(text)
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response is final_response
+        assert agent._disable_streaming is True
+        assert deltas == []
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_stream_error_propagates_original(self, mock_close, mock_create):
         """The original streaming error propagates (not a fallback error)."""
         from run_agent import AIAgent


### PR DESCRIPTION
## What does this PR do?

Fixes a crash where a MoA turn using an `openai-codex` aggregator dies under streaming with `'types.SimpleNamespace' object is not iterable` on TUI/Desktop (issue #55933).

## Why this is a small, targeted follow-up (not a re-fix)

The general bug class — "an adapter accepts `stream=True` but returns a **completed** response object instead of a chunk iterator" — was already fixed at the streaming-consumer seam by **#55932** (merged 2026-06-30), which detects the completed object, disables streaming for the session, fires content/reasoning deltas, and returns the object instead of iterating it. That guard already prevents the common MoA/Codex crash (text and tool-call responses, whose `choices` is a non-empty list).

The remaining gap: #55932's guard only recognized a completed response when its `choices` was a **non-empty list**:

```python
response_choices = getattr(stream, "choices", None)
if isinstance(response_choices, list) and response_choices:   # misses [] and None
```

A completed response whose `choices` is `None` or an empty list (an error / content-filter / terminal frame — a shape the Codex auxiliary adapter can produce) is still a whole, non-iterable response, but it **fell through** to `for chunk in stream` and crashed with the same `'types.SimpleNamespace' object is not iterable`.

## The fix

Broaden the guard to discriminate on the **presence** of a `choices` attribute rather than a truthy non-empty list. A genuine provider `Stream` object exposes no `choices` attribute (verified: the OpenAI SDK `Stream` container has no `.choices` — only its per-chunk `ChatCompletionChunk` items do), so real streams still pass through untouched. Empty/`None` choices now disable streaming and return the completed object, letting the outer loop's existing invalid-response validation (`conversation_loop.py`) route it through the normal retry path instead of iterating it.

## Changes Made

- `agent/chat_completion_helpers.py` — broaden the completed-response guard in `interruptible_streaming_api_call` from `isinstance(list) and non-empty` to `hasattr(stream, "choices")`; guard `choices[0]` access for the empty/None case.
- `tests/run_agent/test_streaming.py` — two regression tests: empty-list `choices` and `None` `choices` both disable streaming and return the object without raising (mutation-verified: reverting the guard to the old condition makes both fail with the historical `TypeError`).

## How to Test

`scripts/run_tests.sh tests/run_agent/test_streaming.py` — 44 passed (2 new).

## Credit / relation to #56525

Based on the diagnosis in **#56525** by @spiky02plateau. That PR proposed normalizing the MoA aggregator return into a one-shot chunk iterator inside `agent/moa_loop.py` (205 lines). Since the common text/tool-call crash was already fixed at the shared consumer seam by #55932, this follow-up instead extends that **existing** guard to cover only the remaining empty/None-choices gap — a smaller, provider-agnostic change at the same layer. Authorship of this commit is attributed to @spiky02plateau via `git commit --author`.

Fixes #55933
