### PR TITLE
fix(moa): lift hidden Anthropic aux output cap

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1190,7 +1190,7 @@ class _AnthropicCompletionsAdapter:
         if _skip_mt:
             max_tokens = None
         else:
-            max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens") or 2000
+            max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
         temperature = kwargs.get("temperature")
 
         normalized_tool_choice = None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1141,6 +1141,40 @@ class TestVisionClientFallback:
         assert response.usage.prompt_tokens == 3
         assert response.usage.completion_tokens == 4
 
+    def test_anthropic_auxiliary_client_uses_model_output_limit_by_default(self):
+        from agent.auxiliary_client import AnthropicAuxiliaryClient
+
+        final_message = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="aux response")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=3, output_tokens=4),
+        )
+        messages_api = SimpleNamespace(create=MagicMock())
+        real_client = SimpleNamespace(messages=messages_api)
+        captured_kwargs = {}
+
+        def fake_create_anthropic_message(_client, kwargs):
+            captured_kwargs.update(kwargs)
+            return final_message
+
+        client = AnthropicAuxiliaryClient(
+            real_client,
+            "claude-opus-4-8",
+            "sk-test",
+            "https://api.anthropic.com",
+        )
+
+        with patch(
+            "agent.anthropic_adapter.create_anthropic_message",
+            side_effect=fake_create_anthropic_message,
+        ):
+            response = client.chat.completions.create(
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert response.choices[0].message.content == "aux response"
+        assert captured_kwargs["max_tokens"] == 128_000
+
 
 class TestAuxiliaryPoolAwareness:
     def test_try_nous_uses_pool_entry(self):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1173,7 +1173,16 @@ class TestVisionClientFallback:
             )
 
         assert response.choices[0].message.content == "aux response"
-        assert captured_kwargs["max_tokens"] == 128_000
+        # Behavior contract, not a frozen literal: a capless native-Anthropic
+        # aux call must default to the model's native output ceiling (resolved
+        # via _get_anthropic_max_output) rather than the old hidden 2000 cap.
+        # Asserting against the resolver keeps this test alive across
+        # model-table churn while still catching a regression to `or 2000`.
+        from agent.anthropic_adapter import _get_anthropic_max_output
+
+        expected_ceiling = _get_anthropic_max_output("claude-opus-4-8")
+        assert expected_ceiling > 2000
+        assert captured_kwargs["max_tokens"] == expected_ceiling
 
 
 class TestAuxiliaryPoolAwareness:


### PR DESCRIPTION
## Summary

Native-Anthropic auxiliary calls now default to the model's native output ceiling when the caller omits `max_tokens`, instead of a hidden 2000-token cap.

Root cause: `_AnthropicCompletionsAdapter.create()` inserted `or 2000` before `build_anthropic_kwargs()` could resolve the model-specific output limit, so MoA aggregators that intentionally omit output caps hit `finish_reason="length"` / "Response truncated due to output length limit" even after users removed explicit MoA `max_tokens` config.

Salvage of #56604 by @helix4u — his fix commit is preserved via rebase-merge. A follow-up commit hardens the accompanying test.

## Changes

- `agent/auxiliary_client.py` (@helix4u): drop the `or 2000` fallback so `None` flows into `build_anthropic_kwargs()`, which resolves the model's native ceiling via `_resolve_anthropic_messages_max_tokens`. This removes a hardcoded magic number in favor of the existing single source of truth.
- `tests/agent/test_auxiliary_client.py`: regression test (@helix4u) + follow-up hardening — assert against `_get_anthropic_max_output("claude-opus-4-8")` and `> 2000` rather than a frozen `128_000` literal, so the test survives model-table churn while still catching a regression to `or 2000`.

## Validation

| | capless call | explicit `max_tokens=500` |
|---|---|---|
| Before (main) | 2000 (bug) | 500 |
| After | 128000 (Opus-4-8 native ceiling) | 500 |

- Two-env subprocess probe (main vs this branch) confirms the delta above; explicit-cap path unchanged.
- 281/281 `tests/agent/test_auxiliary_client.py` pass; retry test files unaffected.

Closes #56604
