### PR TITLE
fix: hashlib.md5 FIPS crash in context_compressor.py

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1226,7 +1226,7 @@ class ContextCompressor(ContextEngine):
                 continue
             if len(content) < 200:
                 continue
-            h = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]
+            h = hashlib.md5(content.encode("utf-8", errors="replace"), usedforsecurity=False).hexdigest()[:12]
             if h in content_hashes:
                 # This is an older duplicate — replace with back-reference
                 result[i] = {**msg, "content": "[Duplicate tool output — same content as a more recent call]"}


### PR DESCRIPTION
## Summary

`hashlib.md5()` in `context_compressor.py` is used for content deduplication (hashing tool outputs to detect duplicates). On FIPS-enabled systems (RHEL 8/9, CentOS with FIPS mode), this raises:

```
ValueError: EVP_DigestInit_ex disabled for FIPS
```

## Root Cause

Line 1229 calls `hashlib.md5()` without `usedforsecurity=False`. OpenSSL in FIPS mode rejects MD5 for any use unless explicitly marked as non-security.

## Fix

Added `usedforsecurity=False` parameter to the `hashlib.md5()` call. This hash is used solely for content deduplication — no security implications.

## Changes

- `agent/context_compressor.py`: `hashlib.md5(...)` → `hashlib.md5(..., usedforsecurity=False)`

## Test Plan

- [x] Lint passes
- [ ] Verify on FIPS-enabled system (RHEL 8/9)
