### PR TITLE
fix: hashlib.sha1 FIPS crash in codex_responses_adapter.py

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -233,7 +233,7 @@ def _derive_responses_function_call_id(
         return f"fc_{sanitized[:48]}"
 
     seed = source or str(response_item_id or "") or uuid.uuid4().hex
-    digest = hashlib.sha1(seed.encode("utf-8")).hexdigest()[:24]
+    digest = hashlib.sha1(seed.encode("utf-8"), usedforsecurity=False).hexdigest()[:24]
     return f"fc_{digest}"
 
 


### PR DESCRIPTION
## Summary

`hashlib.sha1()` in `codex_responses_adapter.py` is used for generating deterministic function-call IDs from source strings. On FIPS-enabled systems (RHEL 8/9, CentOS with FIPS mode), this raises:

```
ValueError: EVP_DigestInit_ex disabled for FIPS
```

## Root Cause

Line 236 calls `hashlib.sha1()` without `usedforsecurity=False`. OpenSSL in FIPS mode rejects SHA1 for any use unless explicitly marked as non-security.

## Fix

Added `usedforsecurity=False` parameter to the `hashlib.sha1()` call. This hash is used solely for generating deterministic function call IDs — no security implications.

## Changes

- `agent/codex_responses_adapter.py`: `hashlib.sha1(...)` → `hashlib.sha1(..., usedforsecurity=False)`

## Test Plan

- [x] Lint passes
- [ ] Verify on FIPS-enabled system (RHEL 8/9)
