### PR TITLE
fix: hashlib FIPS crash in gateway and tools modules

### DIFF
--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -366,7 +366,7 @@ class ChunkedUploader:
         data = await asyncio.get_running_loop().run_in_executor(
             None, _read_file_chunk, file_path, offset, length
         )
-        md5_hex = hashlib.md5(data).hexdigest()
+        md5_hex = hashlib.md5(data, usedforsecurity=False).hexdigest()
 
         logger.debug(
             "[%s] Part %d/%d: uploading %s (offset=%d md5=%s)",
@@ -558,9 +558,9 @@ def _read_file_chunk(file_path: str, offset: int, length: int) -> bytes:
 
 def _compute_file_hashes(file_path: str, file_size: int) -> Dict[str, str]:
     """Compute md5, sha1, and md5_10m in a single pass."""
-    md5 = hashlib.md5()
-    sha1 = hashlib.sha1()
-    md5_10m = hashlib.md5()
+    md5 = hashlib.md5(usedforsecurity=False)
+    sha1 = hashlib.sha1(usedforsecurity=False)
+    md5_10m = hashlib.md5(usedforsecurity=False)
 
     need_10m = file_size > _MD5_10M_SIZE
     bytes_read = 0

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1416,7 +1416,7 @@ class WeixinAdapter(BasePlatformAdapter):
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
         if text:
-            content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
+            content_key = f"content:{sender_id}:{hashlib.md5(text.encode(), usedforsecurity=False).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
                 return
@@ -2114,7 +2114,7 @@ class WeixinAdapter(BasePlatformAdapter):
         filekey = secrets.token_hex(16)
         aes_key = secrets.token_bytes(16)
         rawsize = len(plaintext)
-        rawfilemd5 = hashlib.md5(plaintext).hexdigest()
+        rawfilemd5 = hashlib.md5(plaintext, usedforsecurity=False).hexdigest()
         upload_response = await _get_upload_url(
             self._send_session,
             base_url=self._base_url,

--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -107,7 +107,7 @@ def get_image_format(mime_type: str) -> int:
 
 def md5_hex(data: bytes) -> str:
     """计算 MD5 十六进制摘要。"""
-    return hashlib.md5(data).hexdigest()
+    return hashlib.md5(data, usedforsecurity=False).hexdigest()
 
 
 def generate_file_id() -> str:
@@ -328,7 +328,7 @@ def _cos_sign(
     ])
 
     # Step 3: StringToSign = sha1 hash of HttpString
-    sha1_of_http = hashlib.sha1(http_string.encode("utf-8")).hexdigest()
+    sha1_of_http = hashlib.sha1(http_string.encode("utf-8"), usedforsecurity=False).hexdigest()
     string_to_sign = "\n".join([
         "sha1",
         q_sign_time,

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1266,7 +1266,7 @@ class WellKnownSkillSource(SkillSource):
         }
 
     def _parse_index(self, index_url: str) -> Optional[dict]:
-        cache_key = f"well_known_index_{hashlib.md5(index_url.encode()).hexdigest()}"
+        cache_key = f"well_known_index_{hashlib.md5(index_url.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict) and isinstance(cached.get("skills"), list):
             return cached
@@ -1531,7 +1531,7 @@ class SkillsShSource(SkillSource):
             # entries; the sitemap walks the full ~20k+ catalog.
             return self._sitemap_catalog(limit)
 
-        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**item) for item in cached][:limit]
@@ -1758,7 +1758,7 @@ class SkillsShSource(SkillSource):
         )
 
     def _fetch_detail_page(self, identifier: str) -> Optional[dict]:
-        cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode()).hexdigest()}"
+        cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict):
             return cached
@@ -2252,7 +2252,7 @@ class ClawHubSource(SkillSource):
 
         # Non-empty query catalog miss, or catalog walker failure: fall back to
         # the lightweight listing API for a best-effort response.
-        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode()).hexdigest()}_{limit}"
+        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode(), usedforsecurity=False).hexdigest()}_{limit}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return self._finalize_search_results(
@@ -2358,7 +2358,7 @@ class ClawHubSource(SkillSource):
         )
 
     def _search_catalog(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**s) for s in cached][:limit]


### PR DESCRIPTION
## Summary

Multiple `hashlib.md5()` and `hashlib.sha1()` calls across gateway and tools modules lack `usedforsecurity=False`, causing `ValueError: EVP_DigestInit_ex disabled for FIPS` on FIPS-enabled systems (RHEL 8/9, CentOS with FIPS mode).

All affected calls are non-security uses (content dedup, file integrity, cache keys, API signing).

## Changes

| File | Function | Hash | Purpose |
|------|----------|------|---------|
| `gateway/platforms/qqbot/chunked_upload.py` | `_upload_part` | md5 | File chunk integrity |
| `gateway/platforms/qqbot/chunked_upload.py` | `_compute_file_hashes` | md5 x2, sha1 | File hash computation |
| `gateway/platforms/yuanbao_media.py` | `md5_hex` | md5 | File hash utility |
| `gateway/platforms/yuanbao_media.py` | Tencent Cloud signing | sha1 | API request signing |
| `gateway/platforms/weixin.py` | Content dedup | md5 | Message deduplication |
| `gateway/platforms/weixin.py` | File upload | md5 | Raw file hash |
| `tools/skills_hub.py` | Cache key generation | md5 x5 | Index/detail cache keys |

## Test Plan

- [x] Lint passes
- [ ] Verify on FIPS-enabled system (RHEL 8/9)
