### PR TITLE
feat(plugins): turn_failed hook — observe non-clean turn exits

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1130,6 +1130,12 @@ def build_turn_context(
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
 
+    # Per-turn ``turn_failed`` emission latch. Reset here so the hook fires at
+    # most once per turn regardless of which exit path the turn takes:
+    # ``finalize_turn`` for normal teardown, or the bypass-exit sweep for the
+    # paths that ``return`` straight out of ``run_conversation``.
+    agent._turn_failed_emitted = False
+
     # Record the execution thread so interrupt()/clear_interrupt() can scope
     # the tool-level interrupt signal to THIS agent's thread only.
     agent._execution_thread_id = threading.current_thread().ident

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -66,6 +66,23 @@ def _drop_verification_continuation_scaffolding(messages) -> None:
     ]
 
 
+def _should_emit_turn_failed(reason, last_msg_role) -> bool:
+    """Return True when the ``turn_failed`` hook should fire for this exit.
+
+    Fire for every NON-clean turn exit:
+      * the agent stopped mid-work — ``last_msg_role == "tool"`` (the
+        protocol_violation / "breads-pc" premature-stop class), OR
+      * the reason is anything other than a healthy ``text_response(...)``
+        completion (errors, exhaustion, interrupt, guardrail, etc.).
+
+    Do NOT fire on a healthy completion: a ``text_response(...)`` exit whose
+    last message is not a pending tool result. Mirrors the
+    ``normal_text_response`` classification used for the diagnostic log.
+    """
+    normal_text_response = str(reason).startswith("text_response(")
+    return last_msg_role == "tool" or not normal_text_response
+
+
 def finalize_turn(
     agent,
     *,
@@ -397,6 +414,29 @@ def finalize_turn(
         )
     else:
         logger.info(_diag_msg, *_diag_args)
+
+    # Plugin hook: turn_failed
+    # Fired once per turn at the same point the turn-exit diagnostic is
+    # logged, reusing the exact diag fields (no new computation). Observers
+    # only — for Phase-0 agent-failure observability capture. Gated to
+    # non-clean exits via the shared classification so healthy turns stay
+    # quiet, and wrapped so a failing handler never breaks finalization.
+    if _should_emit_turn_failed(_turn_exit_reason, _last_msg_role):
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "turn_failed",
+                reason=str(_turn_exit_reason),
+                model=agent.model,
+                session_id=agent.session_id,
+                turn_id=turn_id,
+                last_msg_role=_last_msg_role,
+                api_calls=api_call_count,
+                tool_turns=_turn_tool_count,
+                response_len=_resp_len,
+            )
+        except Exception as exc:
+            logger.warning("turn_failed hook failed: %s", exc)
 
     # File-mutation verifier footer.
     # If one or more ``write_file`` / ``patch`` calls failed during this

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -66,19 +66,27 @@ def _drop_verification_continuation_scaffolding(messages) -> None:
     ]
 
 
-def _should_emit_turn_failed(reason, last_msg_role) -> bool:
+def _should_emit_turn_failed(reason, last_msg_role, interrupted) -> bool:
     """Return True when the ``turn_failed`` hook should fire for this exit.
 
     Fire for every NON-clean turn exit:
       * the agent stopped mid-work — ``last_msg_role == "tool"`` (the
         protocol_violation / "breads-pc" premature-stop class), OR
       * the reason is anything other than a healthy ``text_response(...)``
-        completion (errors, exhaustion, interrupt, guardrail, etc.).
+        completion (errors, exhaustion, guardrail, etc.).
+
+    Never fire when ``interrupted`` is True: a user ``/stop`` is a deliberate,
+    clean exit, not a failure. Its exit reason (``interrupted_by_user``) is not
+    a ``text_response(...)``, so without this gate the reason-arm below would
+    raise a false-positive failure signal. Mirrors the existing
+    ``and not interrupted`` gate on the pending-tool diagnostic warning.
 
     Do NOT fire on a healthy completion: a ``text_response(...)`` exit whose
     last message is not a pending tool result. Mirrors the
     ``normal_text_response`` classification used for the diagnostic log.
     """
+    if interrupted:
+        return False
     normal_text_response = str(reason).startswith("text_response(")
     return last_msg_role == "tool" or not normal_text_response
 
@@ -421,7 +429,7 @@ def finalize_turn(
     # only — for Phase-0 agent-failure observability capture. Gated to
     # non-clean exits via the shared classification so healthy turns stay
     # quiet, and wrapped so a failing handler never breaks finalization.
-    if _should_emit_turn_failed(_turn_exit_reason, _last_msg_role):
+    if _should_emit_turn_failed(_turn_exit_reason, _last_msg_role, interrupted):
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _invoke_hook(
@@ -431,6 +439,7 @@ def finalize_turn(
                 session_id=agent.session_id,
                 turn_id=turn_id,
                 last_msg_role=_last_msg_role,
+                interrupted=interrupted,
                 api_calls=api_call_count,
                 tool_turns=_turn_tool_count,
                 response_len=_resp_len,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -91,6 +91,88 @@ def _should_emit_turn_failed(reason, last_msg_role, interrupted) -> bool:
     return last_msg_role == "tool" or not normal_text_response
 
 
+def emit_turn_failed(agent, **fields) -> bool:
+    """Fire the ``turn_failed`` hook, at most once per turn.
+
+    Idempotent via ``agent._turn_failed_emitted``, which turn setup resets per
+    turn (``agent/turn_context.py``). The flag is what lets the bypass-exit
+    sweep in :func:`emit_turn_failed_for_unfinalized_exit` run unconditionally
+    without double-firing for turns that did reach :func:`finalize_turn`.
+
+    Returns True if this call emitted. Never raises: a failing observer must
+    not break turn teardown.
+    """
+    if getattr(agent, "_turn_failed_emitted", False):
+        return False
+    agent._turn_failed_emitted = True
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook("turn_failed", **fields)
+    except Exception as exc:
+        # ``logger`` is imported lazily here for the same reason the rest of
+        # this module does it: importing agent.conversation_loop at module
+        # scope would create a cycle. Kept inside its own guard so a failing
+        # observer cannot be turned into a NameError by a broken import.
+        try:
+            from agent.conversation_loop import logger as _logger
+        except Exception:  # pragma: no cover - defensive
+            import logging
+            _logger = logging.getLogger("agent.conversation_loop")
+        _logger.warning("turn_failed hook failed: %s", exc)
+    return True
+
+
+def emit_turn_failed_for_unfinalized_exit(agent, result, *, turn_id=None) -> bool:
+    """Emit ``turn_failed`` for a turn that never reached :func:`finalize_turn`.
+
+    ``run_conversation`` has ~24 terminal paths that build a result dict and
+    ``return`` it directly — invalid-response exhaustion, context overflow with
+    compaction disabled, payload-too-large, truncated tool arguments, and so
+    on. None of them reach ``finalize_turn``, so the hook fired there cannot
+    see them and the most interesting failures were the ones going unobserved.
+
+    Rather than instrument each site (and require every future site to
+    remember), this reads the terminal contract those paths already satisfy:
+    every one of them sets ``completed: False``. A future 25th path is covered
+    the moment it honours the same contract.
+
+    Deliberately silent when:
+      * ``completed`` is not exactly False — a healthy turn, or a
+        non-dict/None return from a stubbed or partial path;
+      * ``interrupted`` is True — a user ``/stop`` is a clean exit, matching
+        the gate in :func:`_should_emit_turn_failed`;
+      * the turn already emitted via :func:`finalize_turn`.
+
+    Note ``completed`` is used rather than ``failed``: only 13 of those paths
+    set ``failed``, while all of them set ``completed: False``.
+    """
+    if not isinstance(result, dict):
+        return False
+    if result.get("completed") is not False:
+        return False
+    if result.get("interrupted") is True:
+        return False
+
+    _reason = result.get("error") or result.get("final_response") or "unknown"
+    _messages = result.get("messages") or []
+    _last_role = None
+    if _messages and isinstance(_messages[-1], dict):
+        _last_role = _messages[-1].get("role")
+
+    return emit_turn_failed(
+        agent,
+        reason=f"direct_return({_reason})",
+        model=getattr(agent, "model", None),
+        session_id=getattr(agent, "session_id", None),
+        turn_id=turn_id,
+        last_msg_role=_last_role,
+        interrupted=False,
+        api_calls=result.get("api_calls"),
+        tool_turns=None,
+        response_len=len(str(result.get("final_response") or "")),
+    )
+
+
 def finalize_turn(
     agent,
     *,
@@ -443,22 +525,24 @@ def finalize_turn(
     # non-clean exits via the shared classification so healthy turns stay
     # quiet, and wrapped so a failing handler never breaks finalization.
     if _should_emit_turn_failed(_turn_exit_reason, _last_msg_role, interrupted):
-        try:
-            from hermes_cli.plugins import invoke_hook as _invoke_hook
-            _invoke_hook(
-                "turn_failed",
-                reason=str(_turn_exit_reason),
-                model=agent.model,
-                session_id=agent.session_id,
-                turn_id=turn_id,
-                last_msg_role=_last_msg_role,
-                interrupted=interrupted,
-                api_calls=api_call_count,
-                tool_turns=_turn_tool_count,
-                response_len=_resp_len,
-            )
-        except Exception as exc:
-            logger.warning("turn_failed hook failed: %s", exc)
+        emit_turn_failed(
+            agent,
+            reason=str(_turn_exit_reason),
+            model=agent.model,
+            session_id=agent.session_id,
+            turn_id=turn_id,
+            last_msg_role=_last_msg_role,
+            interrupted=interrupted,
+            api_calls=api_call_count,
+            tool_turns=_turn_tool_count,
+            response_len=_resp_len,
+        )
+    else:
+        # A healthy turn still marks itself emitted-or-decided, so the
+        # bypass-exit sweep in the forwarder cannot second-guess a
+        # deliberate silence (e.g. a clean interrupt whose result dict
+        # happens to carry completed: False).
+        agent._turn_failed_emitted = True
 
     # File-mutation verifier footer.
     # If one or more ``write_file`` / ``patch`` calls failed during this

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -284,6 +284,14 @@ def finalize_turn(
         _cleanup_errors.append(f"cleanup_task_resources: {_cleanup_err}")
         logger.error("finalize_turn: _cleanup_task_resources failed: %s", _cleanup_err, exc_info=True)
 
+    # Capture the turn's TRUE tail role before persist-time mutations below
+    # (scaffolding drop, interrupt-close, and the #43849/#44100 assistant-row
+    # append) rewrite the tail. The "ended with a pending tool result" signal
+    # feeds both the turn-exit diagnostic and the ``turn_failed`` hook; reading
+    # ``messages[-1]`` after the append would classify every premature stop
+    # that delivered *any* final_response as a clean assistant exit.
+    _pre_persist_last_role = messages[-1].get("role") if messages else None
+
     # Persist session to both JSON log and SQLite only after private retry
     # scaffolding has been removed. Otherwise a later user "continue" turn
     # can replay assistant("(empty)") / recovery nudges and fall into the
@@ -383,7 +391,12 @@ def finalize_turn(
     # Always logged at INFO so agent.log captures WHY every turn ended.
     # When the last message is a tool result (agent was mid-work), log
     # at WARNING — this is the "just stops" scenario users report.
-    _last_msg_role = messages[-1].get("role") if messages else None
+    # Uses the tail role captured BEFORE persist-time mutations: the
+    # #43849/#44100 assistant-row append above makes ``messages[-1]`` always
+    # "assistant" whenever a final_response was delivered, which would hide
+    # every pending-tool premature stop from this diagnostic and the
+    # ``turn_failed`` hook.
+    _last_msg_role = _pre_persist_last_role
     _last_tool_name = None
     if _last_msg_role == "tool":
         # Walk back to find the assistant message with the tool call

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -212,6 +212,19 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Turn-exit observability hook. Fired once per turn by
+    # ``agent.turn_finalizer.finalize_turn`` ONLY for non-clean exits — i.e.
+    # any error / exhaustion / interrupt / guardrail ``_turn_exit_reason``, OR
+    # whenever the last message is a tool result (``last_msg_role == "tool"``,
+    # the agent stopped mid-work: the protocol_violation / "breads-pc"
+    # premature-stop class). A healthy ``text_response(finish_reason=stop)``
+    # exit with ``last_msg_role != "tool"`` never fires it. Observers only:
+    # return values are ignored; a failing handler never breaks finalization.
+    #
+    # Kwargs: reason: str, model: str, session_id: str | None,
+    #   turn_id: str | None, last_msg_role: str | None, api_calls: int,
+    #   tool_turns: int, response_len: int.
+    "turn_failed",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -214,16 +214,18 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_blocked",
     # Turn-exit observability hook. Fired once per turn by
     # ``agent.turn_finalizer.finalize_turn`` ONLY for non-clean exits — i.e.
-    # any error / exhaustion / interrupt / guardrail ``_turn_exit_reason``, OR
-    # whenever the last message is a tool result (``last_msg_role == "tool"``,
-    # the agent stopped mid-work: the protocol_violation / "breads-pc"
-    # premature-stop class). A healthy ``text_response(finish_reason=stop)``
-    # exit with ``last_msg_role != "tool"`` never fires it. Observers only:
-    # return values are ignored; a failing handler never breaks finalization.
+    # any error / exhaustion / guardrail ``_turn_exit_reason``, OR whenever the
+    # last message is a tool result (``last_msg_role == "tool"``, the agent
+    # stopped mid-work: the protocol_violation / "breads-pc" premature-stop
+    # class). A healthy ``text_response(finish_reason=stop)`` exit with
+    # ``last_msg_role != "tool"`` never fires it; neither does a deliberate user
+    # ``/stop`` (``interrupted`` True), which is a clean exit, not a failure.
+    # Observers only: return values are ignored; a failing handler never breaks
+    # finalization.
     #
     # Kwargs: reason: str, model: str, session_id: str | None,
-    #   turn_id: str | None, last_msg_role: str | None, api_calls: int,
-    #   tool_turns: int, response_len: int.
+    #   turn_id: str | None, last_msg_role: str | None, interrupted: bool,
+    #   api_calls: int, tool_turns: int, response_len: int.
     "turn_failed",
 }
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7112,6 +7112,20 @@ class AIAgent:
                 relay_turn,
                 outcome=relay_outcome,
             )
+            # Cover the terminal paths that return straight out of
+            # run_conversation without reaching finalize_turn, so the
+            # turn_failed hook observes them too. No-ops when the turn already
+            # emitted, when the exit was clean, or on a user interrupt.
+            try:
+                from agent.turn_finalizer import (
+                    emit_turn_failed_for_unfinalized_exit,
+                )
+                emit_turn_failed_for_unfinalized_exit(
+                    self, result, turn_id=effective_task_id
+                )
+            except Exception:
+                logger.debug("turn_failed bypass sweep failed", exc_info=True)
+
             task_finished = True
             finish_task_run(**task_context, result=result)
             return result

--- a/tests/run_agent/test_turn_failed_hook.py
+++ b/tests/run_agent/test_turn_failed_hook.py
@@ -5,12 +5,13 @@ Phase-0 agent-observability (T1): the turn finalizer resolves a 13-value
 was no programmatic hook for downstream observability. This adds ``turn_failed``,
 fired ONLY for non-clean turn exits:
 
-  * any error / exhaustion / interrupt / guardrail reason, OR
+  * any error / exhaustion / guardrail reason, OR
   * ``last_msg_role == "tool"`` (the agent stopped mid-work — the
     ``protocol_violation`` / ``breads-pc`` premature-stop class).
 
 A healthy ``text_response(finish_reason=stop)`` exit with
-``last_msg_role != "tool"`` must NOT fire it.
+``last_msg_role != "tool"`` must NOT fire it, and neither must a deliberate
+user ``/stop`` (``interrupted`` True) — that is a clean exit, not a failure.
 
 The classification lives in the pure guard ``_should_emit_turn_failed`` so it is
 deterministic and testable without a full agent. A small integration-style test
@@ -42,19 +43,24 @@ def test_turn_failed_in_valid_hooks():
 
 
 # --------------------------------------------------------------------------- #
-# Pure guard: _should_emit_turn_failed(reason, last_msg_role)
+# Pure guard: _should_emit_turn_failed(reason, last_msg_role, interrupted)
 # --------------------------------------------------------------------------- #
 def test_guard_fires_on_protocol_violation_shaped_premature_stop():
     # Worker stopped mid-work: last message is a tool result. This is the
     # protocol_violation class — fire regardless of reason text.
-    assert _should_emit_turn_failed("text_response(finish_reason=stop)", "tool") is True
+    assert (
+        _should_emit_turn_failed("text_response(finish_reason=stop)", "tool", False)
+        is True
+    )
 
 
 def test_guard_fires_on_breads_pc_premature_text_response_with_pending_tool():
     # breads-pc: premature text_response while a tool call is still pending,
     # i.e. last_msg_role == "tool".
     assert (
-        _should_emit_turn_failed("text_response(finish_reason=tool_calls)", "tool")
+        _should_emit_turn_failed(
+            "text_response(finish_reason=tool_calls)", "tool", False
+        )
         is True
     )
 
@@ -64,21 +70,39 @@ def test_guard_fires_on_error_and_exhaustion_reasons():
         "max_iterations_reached(50/50)",
         "empty_response_exhausted",
         "api_request_error",
-        "interrupted",
         "guardrail_triggered",
     ):
-        assert _should_emit_turn_failed(reason, "assistant") is True, reason
+        assert _should_emit_turn_failed(reason, "assistant", False) is True, reason
 
 
 def test_guard_does_not_fire_on_healthy_completion():
     # Healthy: text_response(...) AND last message is NOT a tool result.
     assert (
-        _should_emit_turn_failed("text_response(finish_reason=stop)", "assistant")
+        _should_emit_turn_failed(
+            "text_response(finish_reason=stop)", "assistant", False
+        )
         is False
     )
     assert (
-        _should_emit_turn_failed("text_response(finish_reason=stop)", None) is False
+        _should_emit_turn_failed("text_response(finish_reason=stop)", None, False)
+        is False
     )
+
+
+def test_guard_does_not_fire_on_user_interrupt():
+    # A deliberate user /stop is a clean exit, not a failure. The interrupt
+    # flag suppresses the hook regardless of reason text or last_msg_role —
+    # including the interrupted_by_user reason (not a text_response(...)) and a
+    # mid-tool stop, both of which would otherwise trip the reason/tool arms.
+    for reason, role in (
+        ("interrupted_by_user", "assistant"),
+        ("interrupted_by_user", "tool"),
+        ("text_response(finish_reason=stop)", "tool"),
+        ("api_request_error", "assistant"),
+    ):
+        assert (
+            _should_emit_turn_failed(reason, role, True) is False
+        ), (reason, role)
 
 
 # --------------------------------------------------------------------------- #
@@ -181,7 +205,43 @@ def test_finalize_fires_turn_failed_on_pending_tool_premature_stop():
     assert kw["api_calls"] == 5
     assert kw["response_len"] == len("partial")
     assert kw["turn_id"] == "turn-1"
+    assert kw["interrupted"] is False
     assert "tool_turns" in kw
+
+
+def test_finalize_does_not_fire_turn_failed_on_user_interrupt_mid_tool():
+    # A user /stop while a tool result is pending: finalize appends a synthetic
+    # assistant close (so last_msg_role flips to "assistant"), and the interrupt
+    # flag suppresses the hook regardless. This is the clean-stop path that must
+    # NOT surface as a failure signal.
+    agent = _make_agent()
+    messages = [
+        {"role": "user", "content": "do the thing"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"function": {"name": "kanban_complete"}}],
+        },
+        {"role": "tool", "content": "ok"},
+    ]
+    calls, fake = _capture_turn_failed_calls(None)
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=fake):
+        finalize_turn(
+            agent,
+            final_response="partial",
+            api_call_count=5,
+            interrupted=True,
+            failed=False,
+            messages=messages,
+            conversation_history=[],
+            effective_task_id="task-9",
+            turn_id="turn-3",
+            user_message="do the thing",
+            original_user_message="do the thing",
+            _should_review_memory=False,
+            _turn_exit_reason="interrupted_by_user",
+        )
+    assert calls == [], "turn_failed must NOT fire on a deliberate user interrupt"
 
 
 def test_finalize_does_not_fire_turn_failed_on_healthy_completion():

--- a/tests/run_agent/test_turn_failed_hook.py
+++ b/tests/run_agent/test_turn_failed_hook.py
@@ -1,0 +1,210 @@
+"""Tests for the ``turn_failed`` plugin hook emitted by ``finalize_turn``.
+
+Phase-0 agent-observability (T1): the turn finalizer resolves a 13-value
+``_turn_exit_reason`` and logs a "Turn ended: reason=..." diagnostic, but there
+was no programmatic hook for downstream observability. This adds ``turn_failed``,
+fired ONLY for non-clean turn exits:
+
+  * any error / exhaustion / interrupt / guardrail reason, OR
+  * ``last_msg_role == "tool"`` (the agent stopped mid-work — the
+    ``protocol_violation`` / ``breads-pc`` premature-stop class).
+
+A healthy ``text_response(finish_reason=stop)`` exit with
+``last_msg_role != "tool"`` must NOT fire it.
+
+The classification lives in the pure guard ``_should_emit_turn_failed`` so it is
+deterministic and testable without a full agent. A small integration-style test
+drives the real ``finalize_turn`` path with a mocked ``invoke_hook`` to confirm
+the emit wiring + kwargs.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from hermes_cli.plugins import VALID_HOOKS
+from agent.turn_finalizer import _should_emit_turn_failed, finalize_turn
+
+
+# --------------------------------------------------------------------------- #
+# Hook registration
+# --------------------------------------------------------------------------- #
+def test_turn_failed_in_valid_hooks():
+    assert "turn_failed" in VALID_HOOKS
+
+
+# --------------------------------------------------------------------------- #
+# Pure guard: _should_emit_turn_failed(reason, last_msg_role)
+# --------------------------------------------------------------------------- #
+def test_guard_fires_on_protocol_violation_shaped_premature_stop():
+    # Worker stopped mid-work: last message is a tool result. This is the
+    # protocol_violation class — fire regardless of reason text.
+    assert _should_emit_turn_failed("text_response(finish_reason=stop)", "tool") is True
+
+
+def test_guard_fires_on_breads_pc_premature_text_response_with_pending_tool():
+    # breads-pc: premature text_response while a tool call is still pending,
+    # i.e. last_msg_role == "tool".
+    assert (
+        _should_emit_turn_failed("text_response(finish_reason=tool_calls)", "tool")
+        is True
+    )
+
+
+def test_guard_fires_on_error_and_exhaustion_reasons():
+    for reason in (
+        "max_iterations_reached(50/50)",
+        "empty_response_exhausted",
+        "api_request_error",
+        "interrupted",
+        "guardrail_triggered",
+    ):
+        assert _should_emit_turn_failed(reason, "assistant") is True, reason
+
+
+def test_guard_does_not_fire_on_healthy_completion():
+    # Healthy: text_response(...) AND last message is NOT a tool result.
+    assert (
+        _should_emit_turn_failed("text_response(finish_reason=stop)", "assistant")
+        is False
+    )
+    assert (
+        _should_emit_turn_failed("text_response(finish_reason=stop)", None) is False
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Integration: real finalize_turn path with a mocked invoke_hook
+# --------------------------------------------------------------------------- #
+def _make_agent():
+    budget = SimpleNamespace(remaining=10, used=3, max_total=50)
+    return SimpleNamespace(
+        model="anthropic/claude-x",
+        provider="anthropic",
+        base_url="https://example.test",
+        session_id="sess-123",
+        max_iterations=50,
+        iteration_budget=budget,
+        quiet_mode=True,
+        platform="cli",
+        # Token / cost accounting referenced when assembling the result dict.
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_estimated_cost_usd=0.0,
+        session_cost_status="ok",
+        session_cost_source="estimate",
+        context_compressor=SimpleNamespace(last_prompt_tokens=0),
+        _tool_guardrail_halt_decision=None,
+        _response_was_previewed=False,
+        _interrupt_message=None,
+        _stream_callback=None,
+        _skill_nudge_interval=0,
+        _iters_since_skill=0,
+        valid_tool_names=set(),
+        # finalize_turn calls these — stub them as no-ops.
+        _emit_status=lambda *a, **k: None,
+        _safe_print=lambda *a, **k: None,
+        _save_trajectory=lambda *a, **k: None,
+        _cleanup_task_resources=lambda *a, **k: None,
+        _drop_trailing_empty_response_scaffolding=lambda *a, **k: None,
+        _persist_session=lambda *a, **k: None,
+        _file_mutation_verifier_enabled=lambda: False,
+        _turn_completion_explainer_enabled=lambda: False,
+        _turn_failed_file_mutations={},
+        _drain_pending_steer=lambda *a, **k: None,
+        clear_interrupt=lambda *a, **k: None,
+        _sync_external_memory_for_turn=lambda *a, **k: None,
+        _spawn_background_review=lambda *a, **k: None,
+    )
+
+
+def _capture_turn_failed_calls(monkeypatch_hook):
+    """Patch invoke_hook so we record turn_failed kwargs; other hooks no-op."""
+    calls = []
+
+    def _fake_invoke_hook(name, **kwargs):
+        if name == "turn_failed":
+            calls.append(kwargs)
+        return []
+
+    return calls, _fake_invoke_hook
+
+
+def test_finalize_fires_turn_failed_on_pending_tool_premature_stop():
+    agent = _make_agent()
+    messages = [
+        {"role": "user", "content": "do the thing"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"function": {"name": "kanban_complete"}}],
+        },
+        {"role": "tool", "content": "ok"},
+    ]
+    calls, fake = _capture_turn_failed_calls(None)
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=fake):
+        finalize_turn(
+            agent,
+            final_response="partial",
+            api_call_count=5,
+            interrupted=False,
+            failed=False,
+            messages=messages,
+            conversation_history=[],
+            effective_task_id="task-9",
+            turn_id="turn-1",
+            user_message="do the thing",
+            original_user_message="do the thing",
+            _should_review_memory=False,
+            _turn_exit_reason="text_response(finish_reason=stop)",
+        )
+    assert len(calls) == 1, "turn_failed should fire exactly once on pending-tool stop"
+    kw = calls[0]
+    assert kw["reason"] == "text_response(finish_reason=stop)"
+    assert kw["last_msg_role"] == "tool"
+    assert kw["model"] == "anthropic/claude-x"
+    assert kw["session_id"] == "sess-123"
+    assert kw["api_calls"] == 5
+    assert kw["response_len"] == len("partial")
+    assert kw["turn_id"] == "turn-1"
+    assert "tool_turns" in kw
+
+
+def test_finalize_does_not_fire_turn_failed_on_healthy_completion():
+    agent = _make_agent()
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "Done."},
+    ]
+    calls, fake = _capture_turn_failed_calls(None)
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=fake):
+        finalize_turn(
+            agent,
+            final_response="Done.",
+            api_call_count=2,
+            interrupted=False,
+            failed=False,
+            messages=messages,
+            conversation_history=[],
+            effective_task_id="task-9",
+            turn_id="turn-2",
+            user_message="hi",
+            original_user_message="hi",
+            _should_review_memory=False,
+            _turn_exit_reason="text_response(finish_reason=stop)",
+        )
+    assert calls == [], "turn_failed must NOT fire on a healthy completed turn"

--- a/tests/run_agent/test_turn_failed_hook.py
+++ b/tests/run_agent/test_turn_failed_hook.py
@@ -268,3 +268,184 @@ def test_finalize_does_not_fire_turn_failed_on_healthy_completion():
             _turn_exit_reason="text_response(finish_reason=stop)",
         )
     assert calls == [], "turn_failed must NOT fire on a healthy completed turn"
+
+
+# --------------------------------------------------------------------------- #
+# Bypass exits: paths that return straight out of run_conversation and never
+# reach finalize_turn (the gap the finalizer-only hook could not observe).
+# --------------------------------------------------------------------------- #
+def _unfinalized(result, agent=None, **kw):
+    """Run the sweep with invoke_hook captured; return the recorded calls."""
+    from agent import turn_finalizer
+
+    calls, fake = _capture_turn_failed_calls(None)
+    agent = agent if agent is not None else _make_agent()
+    agent._turn_failed_emitted = False
+    with patch("hermes_cli.plugins.invoke_hook", fake):
+        turn_finalizer.emit_turn_failed_for_unfinalized_exit(agent, result, **kw)
+    return calls
+
+
+def test_bypass_sweep_fires_on_invalid_response_exhaustion():
+    """The reviewer's named path: invalid-response terminal return.
+
+    Dict shape mirrors the real terminal return in
+    ``agent/conversation_loop.py`` for "Invalid API response after N retries",
+    which persists the session and returns directly — never reaching
+    ``finalize_turn``.
+    """
+    msg = "Invalid API response after 5 retries: empty content"
+    calls = _unfinalized(
+        {
+            "final_response": msg,
+            "messages": [{"role": "assistant", "content": ""}],
+            "completed": False,
+            "api_calls": 5,
+            "error": msg,
+            "failed": True,
+        },
+        turn_id="task-abc",
+    )
+    assert len(calls) == 1, "invalid-response exhaustion must emit turn_failed"
+    assert msg in calls[0]["reason"]
+    assert calls[0]["interrupted"] is False
+    assert calls[0]["api_calls"] == 5
+    assert calls[0]["turn_id"] == "task-abc"
+
+
+def test_bypass_sweep_fires_on_context_overflow_without_failed_key():
+    """Second named path, and the reason ``completed`` is the predicate.
+
+    Context-overflow / compaction-disabled returns set ``completed: False`` but
+    NOT ``failed``. Keying on ``failed`` would silently miss them — 11 of the
+    terminal returns have no ``failed`` key at all.
+    """
+    calls = _unfinalized(
+        {
+            "final_response": "Context length exceeded: max compression reached",
+            "messages": [{"role": "tool", "content": "..."}],
+            "completed": False,
+            "api_calls": 2,
+        }
+    )
+    assert len(calls) == 1
+    assert "Context length exceeded" in calls[0]["reason"]
+    assert calls[0]["last_msg_role"] == "tool"
+
+
+def test_bypass_sweep_silent_on_user_interrupt():
+    """A user /stop is a clean exit — matches the _should_emit_turn_failed gate."""
+    assert (
+        _unfinalized(
+            {
+                "final_response": "Interrupted by user",
+                "messages": [],
+                "completed": False,
+                "interrupted": True,
+            }
+        )
+        == []
+    )
+
+
+def test_bypass_sweep_silent_on_healthy_completion():
+    assert (
+        _unfinalized(
+            {
+                "final_response": "here you go",
+                "messages": [{"role": "assistant", "content": "here you go"}],
+                "completed": True,
+                "api_calls": 1,
+            }
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize("result", [None, "not-a-dict", {}, {"completed": None}])
+def test_bypass_sweep_silent_on_non_terminal_shapes(result):
+    """Never emit on a shape the sweep cannot positively identify as failed."""
+    assert _unfinalized(result) == []
+
+
+def test_bypass_sweep_does_not_double_fire_after_finalize_turn():
+    """The per-turn latch is what makes the sweep safe to run unconditionally."""
+    from agent import turn_finalizer
+
+    agent = _make_agent()
+    agent._turn_failed_emitted = False
+    calls, fake = _capture_turn_failed_calls(None)
+    with patch("hermes_cli.plugins.invoke_hook", fake):
+        # Stand in for finalize_turn having already emitted this turn.
+        assert turn_finalizer.emit_turn_failed(agent, reason="api_error") is True
+        # The sweep then sees an already-emitted turn and stays quiet.
+        assert (
+            turn_finalizer.emit_turn_failed_for_unfinalized_exit(
+                agent, {"completed": False, "final_response": "x", "messages": []}
+            )
+            is False
+        )
+    assert len(calls) == 1, "hook must fire at most once per turn"
+
+
+def test_emit_turn_failed_survives_a_raising_observer():
+    """A broken plugin must not break turn teardown."""
+    from agent import turn_finalizer
+
+    agent = _make_agent()
+    agent._turn_failed_emitted = False
+
+    def _boom(name, **kwargs):
+        raise RuntimeError("observer exploded")
+
+    with patch("hermes_cli.plugins.invoke_hook", _boom):
+        assert turn_finalizer.emit_turn_failed(agent, reason="api_error") is True
+    # Latch still set, so a later sweep does not retry a broken observer.
+    assert agent._turn_failed_emitted is True
+
+
+def test_every_terminal_return_in_run_conversation_sets_completed():
+    """Source invariant the sweep depends on.
+
+    The sweep identifies a bypass exit by ``completed: False`` rather than by
+    instrumenting each site, so a future terminal return that omits
+    ``completed`` would be invisible. Assert the contract at the source: any
+    ``return {...}`` carrying ``final_response`` also carries ``completed``.
+    """
+    import ast
+    from pathlib import Path
+
+    src = Path("agent/conversation_loop.py")
+    if not src.exists():  # pragma: no cover - layout guard
+        pytest.skip("conversation_loop.py not at the expected path")
+
+    tree = ast.parse(src.read_text(encoding="utf-8"))
+    fn = next(
+        (
+            n
+            for n in tree.body
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name == "run_conversation"
+        ),
+        None,
+    )
+    assert fn is not None, "run_conversation not found"
+
+    offenders = []
+    checked = 0
+    for node in ast.walk(fn):
+        if not (isinstance(node, ast.Return) and isinstance(node.value, ast.Dict)):
+            continue
+        keys = {k.value for k in node.value.keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+        if "final_response" not in keys:
+            continue
+        checked += 1
+        if "completed" not in keys:
+            offenders.append(node.lineno)
+
+    assert checked > 0, "expected to find terminal result returns"
+    assert not offenders, (
+        "terminal return(s) carry final_response without completed, so the "
+        f"turn_failed bypass sweep cannot see them: lines {offenders}"
+    )


### PR DESCRIPTION
## What

Adds a `turn_failed` plugin hook (registered in `VALID_HOOKS`, emitted from `finalize_turn` at the same point the turn-exit diagnostic is logged) so observability plugins can capture non-clean turn exits: pending-tool premature stops, non-`text_response` exit reasons, guardrail/exhaustion exits. Observers only — a failing handler can never break finalization, and deliberate user interrupts (`/stop`) never fire it.

## Why

Failure-capture pipelines (e.g. feeding an agent-failure sink or a kanban triage queue) currently have no supported way to observe "the turn ended badly" — the closest hooks (`api_request_error`, `on_session_end`) fire at the wrong granularity. This has been running in production on a fork for a week feeding an automated failure-ingest pipeline.

## Bonus fix included

While rebasing onto current main we found the #43849/#44100 persist-invariant (append an assistant row whenever a `final_response` was delivered) lands **before** the turn-exit diagnostic, so `messages[-1]` can no longer be `"tool"` there — which silently degraded the existing **`Turn ended with pending tool result` WARNING** for any premature stop that delivered partial text. The third commit captures the tail role before persist-time mutations and uses it for both the diagnostic and the new hook.

## Testing

`tests/run_agent/test_turn_failed_hook.py` — 9 tests covering: fires on pending-tool stop, fires on non-text exit reasons, never fires on healthy completion, never fires on user interrupt, kwargs payload shape, handler-exception isolation, and the pre-persist tail classification. `pytest tests/run_agent/ -k 'final or persist or turn'` — 221 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)