### PR TITLE
feat(plugins): register_slack_view_handler — plugin-registered modal submissions

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -991,6 +991,40 @@ class PluginContext:
             action_id,
         )
 
+    def register_slack_view_handler(
+        self,
+        callback_id: str,
+        callback: Callable,
+    ) -> None:
+        """Register a Slack view-submission (modal) handler from a plugin.
+
+        Mirrors :meth:`register_slack_action_handler` but for
+        ``slack_bolt.App.view()`` - invoked when a modal whose ``callback_id``
+        matches is submitted. Callback signature follows slack_bolt::
+
+            async def handler(ack, body, view) -> None:
+                await ack()
+                ...
+        """
+        if not callable(callback):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Slack "
+                f"view handler with a non-callable callback."
+            )
+        if not (isinstance(callback_id, str) and callback_id.strip()):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Slack "
+                f"view handler with an empty callback_id."
+            )
+        self._manager._slack_view_handlers.append(
+            (callback_id, callback, self.manifest.name)
+        )
+        logger.debug(
+            "Plugin %s registered Slack view handler: %s",
+            self.manifest.name,
+            callback_id,
+        )
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------
@@ -1222,6 +1256,7 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        self._slack_view_handlers: List[tuple] = []
 
     # -----------------------------------------------------------------------
     # Public
@@ -1255,6 +1290,7 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
+            self._slack_view_handlers.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
@@ -1927,6 +1963,15 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    def get_slack_view_handlers(self) -> List[tuple]:
+        """Return the list of plugin-registered Slack view-submission handlers.
+
+        Each entry is a ``(callback_id, callback, plugin_name)`` tuple,
+        consumed by the Slack adapter at connect time (mirrors
+        :meth:`get_slack_action_handlers`).
+        """
+        return list(self._slack_view_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1238,6 +1238,41 @@ class SlackAdapter(BasePlatformAdapter):
                     len(_plugin_handlers),
                 )
 
+            # Register plugin-provided Slack view-submission (modal) handlers,
+            # mirroring the action-handler wiring above.
+            try:
+                _plugin_view_handlers = list(get_plugin_manager().get_slack_view_handlers())
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("[Slack] Could not load plugin view handlers: %s", e)
+                _plugin_view_handlers = []
+
+            def _make_view_wrapper(cb, plugin_name):
+                async def _wrapped(ack, body, view):
+                    try:
+                        await cb(ack, body, view)
+                    except Exception as exc:  # pragma: no cover - defensive
+                        logger.error(
+                            "[Slack] Plugin '%s' view handler raised: %s",
+                            plugin_name, exc, exc_info=True,
+                        )
+                        try:
+                            await ack()
+                        except Exception:
+                            pass
+                return _wrapped
+
+            for _callback_id, _vcb, _vplugin_name in _plugin_view_handlers:
+                self._app.view(_callback_id)(_make_view_wrapper(_vcb, _vplugin_name))
+                logger.debug(
+                    "[Slack] Registered plugin view handler %s (from %s)",
+                    _callback_id, _vplugin_name,
+                )
+            if _plugin_view_handlers:
+                logger.info(
+                    "[Slack] Wired %d plugin view handler(s)",
+                    len(_plugin_view_handlers),
+                )
+
             # Bring up the handler and watchdog atomically. ``_running`` only
             # flips to True after the handler is alive so the watchdog loop
             # observes the live task immediately; on any failure here we tear

--- a/tests/gateway/test_slack_plugin_view_handlers.py
+++ b/tests/gateway/test_slack_plugin_view_handlers.py
@@ -1,0 +1,307 @@
+"""Tests for plugin-registered Slack view-submission (modal) handlers.
+
+Covers:
+* ``PluginContext.register_slack_view_handler`` validation + queuing
+* ``PluginManager.get_slack_view_handlers`` accessor
+* ``SlackAdapter.connect`` wiring those handlers into the AsyncApp via
+  ``app.view(callback_id)``
+* Defensive wrapping: a plugin view handler that raises does NOT take
+  down the gateway and Slack still gets an ack.
+
+Mirrors ``test_slack_plugin_action_handlers.py`` (the Block Kit action
+sibling of this API).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable when this test runs directly
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Mock slack-bolt so SlackAdapter can be imported even without the package
+# ---------------------------------------------------------------------------
+
+def _ensure_slack_mock() -> None:
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        ("slack_bolt.adapter.socket_mode.async_handler",
+         slack_bolt.adapter.socket_mode.async_handler),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+import plugins.platforms.slack.adapter as _slack_mod  # noqa: E402
+
+_slack_mod.SLACK_AVAILABLE = True
+
+from gateway.config import PlatformConfig  # noqa: E402
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+from hermes_cli.plugins import (  # noqa: E402
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# PluginContext.register_slack_view_handler — input validation + queuing
+# ---------------------------------------------------------------------------
+
+def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
+    """Build a fresh PluginManager + PluginContext bound to it."""
+    mgr = PluginManager()
+    manifest = PluginManifest(
+        name=name,
+        version="0.1.0",
+        description="test",
+    )
+    ctx = PluginContext(manifest=manifest, manager=mgr)
+    return mgr, ctx
+
+
+class TestRegisterSlackViewHandlerAPI:
+    """Behaviour of ctx.register_slack_view_handler()."""
+
+    def test_callback_id_is_queued(self):
+        mgr, ctx = _make_ctx()
+
+        async def cb(ack, body, view):  # pragma: no cover - never called here
+            await ack()
+
+        ctx.register_slack_view_handler("edit_modal", cb)
+
+        handlers = mgr.get_slack_view_handlers()
+        assert len(handlers) == 1
+        callback_id, callback, plugin_name = handlers[0]
+        assert callback_id == "edit_modal"
+        assert callback is cb
+        assert plugin_name == "test_plugin"
+
+    def test_non_callable_callback_rejected(self):
+        _mgr, ctx = _make_ctx()
+        with pytest.raises(ValueError, match="non-callable"):
+            ctx.register_slack_view_handler("edit_modal", "not a function")
+
+    def test_empty_callback_id_rejected(self):
+        _mgr, ctx = _make_ctx()
+
+        async def cb(ack, body, view):  # pragma: no cover
+            await ack()
+
+        with pytest.raises(ValueError, match="empty callback_id"):
+            ctx.register_slack_view_handler("   ", cb)
+
+    def test_accessor_returns_copy(self):
+        mgr, ctx = _make_ctx()
+
+        async def cb(ack, body, view):  # pragma: no cover
+            await ack()
+
+        ctx.register_slack_view_handler("edit_modal", cb)
+        handlers = mgr.get_slack_view_handlers()
+        handlers.clear()
+        assert len(mgr.get_slack_view_handlers()) == 1
+
+    def test_multiple_plugins_tracked_by_name(self):
+        mgr = PluginManager()
+        ctx_a = PluginContext(
+            manifest=PluginManifest(name="plug_a", version="0.1", description="a"),
+            manager=mgr,
+        )
+        ctx_b = PluginContext(
+            manifest=PluginManifest(name="plug_b", version="0.1", description="b"),
+            manager=mgr,
+        )
+
+        async def cb_a(ack, body, view):  # pragma: no cover
+            await ack()
+
+        async def cb_b(ack, body, view):  # pragma: no cover
+            await ack()
+
+        ctx_a.register_slack_view_handler("modal_a", cb_a)
+        ctx_b.register_slack_view_handler("modal_b", cb_b)
+
+        handlers = mgr.get_slack_view_handlers()
+        assert {h[2] for h in handlers} == {"plug_a", "plug_b"}
+
+
+# ---------------------------------------------------------------------------
+# SlackAdapter.connect wires plugin-registered view handlers into AsyncApp
+# ---------------------------------------------------------------------------
+
+
+def _connect_with_recording_app(
+    adapter: SlackAdapter,
+    *,
+    view_handlers: list,
+) -> tuple[bool, list]:
+    """Run adapter.connect() with mocks and return (result, registered_views).
+
+    Captures every callback_id passed to ``app.view()`` so tests can
+    assert plugin-supplied view handlers were wired up.
+    """
+    registered_views: list = []  # list of (callback_id, callback)
+
+    def mock_view(callback_id):
+        def decorator(fn):
+            registered_views.append((callback_id, fn))
+            return fn
+        return decorator
+
+    def mock_action(_action_id):
+        def decorator(fn):
+            return fn
+        return decorator
+
+    def mock_event(_event_type):
+        def decorator(fn):
+            return fn
+        return decorator
+
+    def mock_command(_cmd):
+        def decorator(fn):
+            return fn
+        return decorator
+
+    mock_app = MagicMock()
+    mock_app.event = mock_event
+    mock_app.command = mock_command
+    mock_app.action = mock_action
+    mock_app.view = mock_view
+    mock_app.client = AsyncMock()
+
+    mock_web_client = AsyncMock()
+    mock_web_client.auth_test = AsyncMock(return_value={
+        "user_id": "U_BOT",
+        "user": "testbot",
+        "team_id": "T_FAKE",
+        "team": "FakeTeam",
+    })
+
+    fake_mgr = MagicMock()
+    fake_mgr.get_slack_action_handlers.return_value = []
+    fake_mgr.get_slack_view_handlers.return_value = view_handlers
+
+    with patch.object(_slack_mod, "AsyncApp", return_value=mock_app), \
+         patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client), \
+         patch.object(_slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()), \
+         patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}), \
+         patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
+         patch("gateway.status.release_scoped_lock"), \
+         patch("hermes_cli.plugins.get_plugin_manager", return_value=fake_mgr), \
+         patch("asyncio.create_task"):
+        result = asyncio.run(adapter.connect())
+
+    return result, registered_views
+
+
+class TestSlackAdapterPluginViewWiring:
+    """connect() must register plugin-supplied view handlers on AsyncApp."""
+
+    def test_plugin_view_handler_wired_into_app(self):
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        async def my_handler(ack, body, view):  # pragma: no cover - not invoked
+            await ack()
+
+        result, registered = _connect_with_recording_app(
+            adapter, view_handlers=[("edit_modal", my_handler, "jarvis")],
+        )
+
+        assert result is True
+        assert "edit_modal" in [cid for cid, _cb in registered]
+
+    def test_no_view_handlers_does_not_break_connect(self):
+        """An empty view handler list is the common case — must be a no-op."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        result, registered = _connect_with_recording_app(
+            adapter, view_handlers=[],
+        )
+        assert result is True
+        assert registered == []
+
+    def test_plugin_exception_does_not_propagate_to_slack(self):
+        """A misbehaving view handler must NOT crash slack_bolt's dispatch.
+
+        The wrapper installed by connect() catches exceptions, logs them,
+        and best-effort-acks so Slack stops retrying the submission.
+        """
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        async def boom(ack, body, view):
+            raise RuntimeError("plugin bug")
+
+        _result, registered = _connect_with_recording_app(
+            adapter, view_handlers=[("explode_modal", boom, "buggy_plugin")],
+        )
+
+        wrapped = next(cb for cid, cb in registered if cid == "explode_modal")
+        ack = AsyncMock()
+
+        # Wrapper must swallow the RuntimeError.
+        asyncio.run(wrapped(ack, {"foo": "bar"}, {"callback_id": "explode_modal"}))
+
+        # Slack still got an ack — best-effort fallback after exception.
+        ack.assert_awaited()
+
+    def test_plugin_view_handler_invoked_with_slack_args(self):
+        """Happy path: the plugin's callback receives (ack, body, view)."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        seen: dict = {}
+
+        async def cb(ack, body, view):
+            seen["body"] = body
+            seen["view"] = view
+            await ack()
+
+        _result, registered = _connect_with_recording_app(
+            adapter, view_handlers=[("modal_x", cb, "plug_x")],
+        )
+
+        wrapped = next(c for cid, c in registered if cid == "modal_x")
+        ack = AsyncMock()
+        asyncio.run(wrapped(ack, {"b": 1}, {"callback_id": "modal_x"}))
+
+        assert seen["body"] == {"b": 1}
+        assert seen["view"] == {"callback_id": "modal_x"}
+        ack.assert_awaited()


### PR DESCRIPTION
## What

Adds `PluginContext.register_slack_view_handler(callback_id, callback)` — the view-submission (modal) sibling of `register_slack_action_handler` (#20589). `SlackAdapter.connect` wires registered handlers via `app.view(callback_id)` with the same defensive wrapper as actions: a raising plugin handler is logged and best-effort-acked, never crashing slack_bolt dispatch.

## Why

Plugins can already open modals (via `client.views_open` from an action handler) but have no supported way to receive the submission — the `view()` registration is adapter-private. This closes the loop for plugin-driven human-in-the-loop flows (approve/edit modals). Running in production on a fork for a month driving an edit-before-send review modal.

## Testing

`tests/gateway/test_slack_plugin_view_handlers.py` (mirrors the action-handler test file): registration validation + queuing, accessor isolation, connect-time wiring, exception containment with best-effort ack, happy-path args. Existing action-handler + plugin suites still green (123 passed across the three files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)