### PR TITLE
fix(update): detect profile dashboard processes in stale-dashboard sweep

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5863,8 +5863,16 @@ def _find_stale_dashboard_pids(
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
+                    # Normalise away ``--profile <name>`` / ``-p <name>``
+                    # — same rationale as the POSIX branch below.
+                    import re as _re
+                    _cmd_norm = _re.sub(
+                        r"\s{2,}",
+                        " ",
+                        _re.sub(r"(?:--profile|-p)\s+\S+", "", current_cmd),
+                    )
                     if (
-                        any(p in current_cmd for p in patterns)
+                        any(p in _cmd_norm for p in patterns)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5897,7 +5905,18 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    # Normalise away ``--profile <name>`` / ``-p <name>``
+                    # so that ``hermes --profile bruce dashboard`` still
+                    # matches the ``"hermes dashboard"`` pattern.  Without
+                    # this, non-default-profile dashboard processes are
+                    # invisible to the stale-dashboard sweep (issue #56717).
+                    import re as _re
+                    _cmd_norm = _re.sub(
+                        r"\s{2,}",
+                        " ",
+                        _re.sub(r"(?:--profile|-p)\s+\S+", "", command),
+                    )
+                    if any(p in _cmd_norm for p in patterns) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/tests/hermes_cli/test_stale_dashboard_profile_detection.py
+++ b/tests/hermes_cli/test_stale_dashboard_profile_detection.py
@@ -1,0 +1,87 @@
+"""Regression tests for profile-aware stale dashboard detection.
+
+Verifies that ``_find_stale_dashboard_pids`` correctly identifies dashboard
+processes launched with ``--profile <name>`` or ``-p <name>`` flags between
+the binary name and the subcommand (issue #56717).
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_ps_output(lines: list[tuple[int, str]]) -> str:
+    """Build a fake ``ps -A -o pid=,command=`` output string."""
+    return "\n".join(f"{pid} {cmd}" for pid, cmd in lines)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestProfileAwareDashboardDetection:
+    """Non-default profile dashboards should be found even when
+    ``--profile <name>`` sits between the binary and the subcommand."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only ps test")
+    def test_profile_flag_between_binary_and_subcommand(self):
+        """``hermes --profile bruce dashboard --isolated`` should match."""
+        from hermes_cli.main import _find_stale_dashboard_pids
+
+        fake_ps = _fake_ps_output([
+            (9001, "/venv/bin/hermes --profile bruce dashboard --isolated"),
+            (9002, "/venv/bin/python -m hermes_cli.main --profile bruce dashboard --isolated"),
+            (9003, "/venv/bin/python -m hermes_cli.main -p coder serve --port 9119"),
+            (9999, "/usr/bin/vim somefile.py"),  # unrelated — must NOT match
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=fake_ps,
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert 9001 in pids, "hermes --profile bruce dashboard should be detected"
+        assert 9002 in pids, "hermes_cli.main --profile bruce dashboard should be detected"
+        assert 9003 in pids, "hermes_cli.main -p coder serve should be detected"
+        assert 9999 not in pids, "unrelated process must not match"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only ps test")
+    def test_default_profile_still_detected(self):
+        """Existing non-profile dashboards must continue to match."""
+        from hermes_cli.main import _find_stale_dashboard_pids
+
+        fake_ps = _fake_ps_output([
+            (8001, "/venv/bin/hermes dashboard --isolated"),
+            (8002, "/venv/bin/python -m hermes_cli.main dashboard --isolated"),
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=fake_ps,
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert 8001 in pids
+        assert 8002 in pids
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only ps test")
+    def test_short_profile_flag_p(self):
+        """``-p bruce`` should also be normalised away."""
+        from hermes_cli.main import _find_stale_dashboard_pids
+
+        fake_ps = _fake_ps_output([
+            (7001, "/venv/bin/hermes -p bruce dashboard --isolated"),
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=fake_ps,
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert 7001 in pids


### PR DESCRIPTION
## What does this PR do?

Fixes the stale-dashboard sweep after `hermes update` so that dashboard processes launched with `--profile <name>` (non-default profiles) are correctly detected and killed.

**Root cause**: `_find_stale_dashboard_pids()` uses substring matching against the process command line (e.g. `"hermes dashboard"`). When a non-default profile launches a dashboard with `--profile <name>` between the binary and the subcommand — `hermes --profile bruce dashboard --isolated` — the contiguous pattern never matches. The process is invisible to the sweep and continues running stale Python code after the update, causing `ImportError` when new symbols (like `is_output_cap_error`) are added.

**Fix**: Strip `--profile <name>` / `-p <name>` tokens from the command line (and collapse resulting double-spaces) before pattern matching. Applied to both the POSIX (`ps`) and Windows (`wmic`) code paths.

## Related Issue

Fixes #56717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Normalise process command lines in `_find_stale_dashboard_pids()` by stripping `--profile`/`-p` flags before pattern matching (both POSIX and Windows code paths). +21/-2 lines.
- `tests/hermes_cli/test_stale_dashboard_profile_detection.py`: 3 regression tests covering `--profile`, `-p`, and default (no profile) cases.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_stale_dashboard_profile_detection.py -v` — all 3 tests should pass.
2. Run `python -m pytest tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_dashboard_lifecycle_flags.py -v` — all 22+10 existing tests should pass (no regressions).
3. Manual verification: start a profile dashboard (`hermes --profile test dashboard`), then run `hermes update` — the profile dashboard should be detected and killed (previously it was invisible).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
