### PR TITLE
fix(desktop): surface all xAI TTS params in desktop GUI config

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -361,12 +361,12 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     xai: {
       voiceId: 'xAI (Grok) Voice',
       language: 'xAI Language',
-      speed: 'Playback Speed',
-      autoSpeechTags: 'Auto Speech Tags',
-      textNormalization: 'Text Normalization',
-      optimizeStreamingLatency: 'Streaming Latency Optimization',
-      sampleRate: 'Sample Rate',
-      bitRate: 'Bit Rate'
+      speed: 'xAI Playback Speed',
+      autoSpeechTags: 'xAI Auto Speech Tags',
+      textNormalization: 'xAI Text Normalization',
+      optimizeStreamingLatency: 'xAI Streaming Latency Optimization',
+      sampleRate: 'xAI Sample Rate',
+      bitRate: 'xAI Bit Rate'
     },
     minimax: {
       model: 'MiniMax TTS Model',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -360,7 +360,13 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     },
     xai: {
       voiceId: 'xAI (Grok) Voice',
-      language: 'xAI Language'
+      language: 'xAI Language',
+      speed: 'Playback Speed',
+      autoSpeechTags: 'Auto Speech Tags',
+      textNormalization: 'Text Normalization',
+      optimizeStreamingLatency: 'Streaming Latency Optimization',
+      sampleRate: 'Sample Rate',
+      bitRate: 'Bit Rate'
     },
     minimax: {
       model: 'MiniMax TTS Model',
@@ -467,7 +473,13 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   tts: {
     xai: {
       voiceId: 'xAI voice ID (e.g. eve) or a custom voice ID.',
-      language: 'Spoken language code, e.g. en.'
+      language: 'Spoken language code (e.g. en, pt-BR) or "auto" for auto-detection.',
+      speed: 'Playback speed. 0.7 = slower, 1.0 = normal, 1.5 = faster.',
+      autoSpeechTags: 'Let an LLM insert expressive audio tags ([laughing], [sighs]) into the script before synthesis.',
+      textNormalization: 'Convert numbers, abbreviations, and symbols to spoken form before synthesis.',
+      optimizeStreamingLatency: 'Latency vs. quality trade-off. 0 = best quality, 2 = lowest latency.',
+      sampleRate: 'Audio sample rate in Hz. Higher = better quality, larger files.',
+      bitRate: 'MP3 bitrate in bps. Only applies when codec is mp3.'
     },
     neutts: {
       device: 'Local inference device for NeuTTS.'
@@ -566,6 +578,12 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.elevenlabs.model_id',
       'tts.xai.voice_id',
       'tts.xai.language',
+      'tts.xai.speed',
+      'tts.xai.auto_speech_tags',
+      'tts.xai.text_normalization',
+      'tts.xai.optimize_streaming_latency',
+      'tts.xai.sample_rate',
+      'tts.xai.bit_rate',
       'tts.minimax.model',
       'tts.minimax.voice_id',
       'tts.mistral.model',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -450,7 +450,13 @@ export const ja = defineLocale({
         },
         xai: {
           voiceId: 'xAI (Grok) 音声',
-          language: 'xAI 言語'
+          language: 'xAI 言語',
+          speed: '再生速度',
+          autoSpeechTags: '自動音声タグ',
+          textNormalization: 'テキスト正規化',
+          optimizeStreamingLatency: 'ストリーミング遅延最適化',
+          sampleRate: 'サンプルレート',
+          bitRate: 'ビットレート'
         },
         minimax: {
           model: 'MiniMax TTS モデル',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -439,7 +439,13 @@ export const zhHant = defineLocale({
         },
         xai: {
           voiceId: 'xAI (Grok) 語音',
-          language: 'xAI 語言'
+          language: 'xAI 語言',
+          speed: '播放速度',
+          autoSpeechTags: '自動語音標籤',
+          textNormalization: '文字正規化',
+          optimizeStreamingLatency: '串流延遲最佳化',
+          sampleRate: '取樣率',
+          bitRate: '位元率'
         },
         minimax: {
           model: 'MiniMax TTS 模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -530,7 +530,13 @@ export const zh: Translations = {
         },
         xai: {
           voiceId: 'xAI (Grok) 语音',
-          language: 'xAI 语言'
+          language: 'xAI 语言',
+          speed: '播放速度',
+          autoSpeechTags: '自动语音标签',
+          textNormalization: '文本规范化',
+          optimizeStreamingLatency: '流式延迟优化',
+          sampleRate: '采样率',
+          bitRate: '比特率'
         },
         minimax: {
           model: 'MiniMax TTS 模型',

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1966,9 +1966,13 @@ DEFAULT_CONFIG = {
         },
         "xai": {
             "voice_id": "eve",  # or custom voice ID — see https://docs.x.ai/developers/model-capabilities/audio/custom-voices
-            "language": "en",
-            "sample_rate": 24000,
-            "bit_rate": 128000,
+            "language": "en",  # BCP-47 code ("en", "pt-BR") or "auto"
+            "speed": 1.0,  # 0.7–1.5, playback speed
+            "auto_speech_tags": False,  # insert expressive audio tags via LLM rewrite
+            "text_normalization": False,  # normalize numbers/abbreviations/symbols to spoken form
+            "optimize_streaming_latency": 0,  # 0–2, trades quality for lower latency
+            "sample_rate": 24000,  # 22050 / 24000 / 44100 / 48000
+            "bit_rate": 128000,  # MP3 bitrate; only applies when codec=mp3
         },
         "mistral": {
             "model": "voxtral-mini-tts-2603",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -625,7 +625,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "neutts"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
     },
     "stt.provider": {
         "type": "select",


### PR DESCRIPTION
## What does this PR do?

On the desktop apps' voice menu when xAI TTS is set up, the UI shows only voice and language options, ignoring all other supported options. This PR adds the necessary changes to surface all the supported params in the desktop UI.

## Related Issue

No related issues

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Root Cause
Two layers of missing configuration:

1. Backend `DEFAULT_CONFIG` (`hermes_cli/config.py:1967`) — the xAI TTS section only had voice_id, language, sample_rate, and bit_rate. The schema generator (`_build_schema_from_config`) walks this dict to produce the `/api/config/schema` endpoint that feeds the UI. Missing keys = missing UI fields.

2. Frontend `constants.ts` — `FIELD_LABELS`, `FIELD_DESCRIPTIONS`, and the voice section's `keys` array only listed `voice_id` and `language` for xAI. Even if the backend sent the right schema, the frontend wouldn't know how to label or describe them.

### Solution
- Add speed, auto_speech_tags, [text_normalization](https://github.com/NousResearch/hermes-agent/pull/56686), optimize_streaming_latency, sample_rate, bit_rate to DEFAULT_CONFIG tts.xai block (backend schema source)
- Add field labels, descriptions, and section keys in frontend constants.ts for all 7 xAI TTS fields
- Update i18n translations (ja, zh, zh-hant)
- Fix stale tts.provider options in web_server.py schema overrides (was missing xai, minimax, mistral, gemini, kittentts, piper)

### What Wasn't Changed
The schema builder (`_build_schema_from_config` + `_infer_type`) already handles the new types correctly — booleans become Switch toggles, numbers become number inputs. The `voiceFieldVisible` filter logic already works by matching provider prefixes, so no changes needed there.

## How to Test

Backend test_get_config_schema — ✅ (verifies /api/config/schema builds correctly with the new fields)
Frontend voice-field-visible.test — ✅ (5/5, verifies provider-based field filtering)
Schema spot-check — ✅ All 8 tts.xai.* keys present with correct types (boolean, number, string)

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

<img width="944" height="548" alt="image" src="https://github.com/user-attachments/assets/a51cd2f9-98b4-4d7c-afff-aa8797ec6c95" />

