### PR TITLE
fix(hindsight): specify UTF-8 encoding for file I/O on Windows

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -746,7 +746,7 @@ class HindsightMemoryProvider(MemoryProvider):
         existing = {}
         if config_path.exists():
             try:
-                existing = json.loads(config_path.read_text())
+                existing = json.loads(config_path.read_text(encoding="utf-8"))
             except Exception:
                 pass
         existing.update(values)
@@ -895,7 +895,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 env_path = Path(hermes_home) / ".env"
                 existing_llm_key = ""
                 if env_path.exists():
-                    for line in env_path.read_text().splitlines():
+                    for line in env_path.read_text(encoding="utf-8").splitlines():
                         if line.startswith("HINDSIGHT_LLM_API_KEY="):
                             existing_llm_key = line.split("=", 1)[1]
                             break
@@ -925,7 +925,7 @@ class HindsightMemoryProvider(MemoryProvider):
             env_path.parent.mkdir(parents=True, exist_ok=True)
             existing_lines = []
             if env_path.exists():
-                existing_lines = env_path.read_text().splitlines()
+                existing_lines = env_path.read_text(encoding="utf-8").splitlines()
             updated_keys = set()
             new_lines = []
             for line in existing_lines:
@@ -938,7 +938,7 @@ class HindsightMemoryProvider(MemoryProvider):
             for k, v in env_writes.items():
                 if k not in updated_keys:
                     new_lines.append(f"{k}={v}")
-            env_path.write_text("\n".join(new_lines) + "\n")
+            env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
 
         if mode == "local_embedded":
             materialized_config = dict(provider_config)


### PR DESCRIPTION
## Problem

On Windows with CJK system locales (e.g. Chinese GBK), `pathlib.Path.read_text()` defaults to the system encoding instead of UTF-8. This causes a `UnicodeDecodeError` when the hindsight memory provider reads `.env` or JSON config files containing non-ASCII characters.

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 661: illegal multibyte sequence
```

## Fix

Explicitly pass `encoding="utf-8"` to all 3 `read_text()` and 1 `write_text()` calls in `plugins/memory/hindsight/__init__.py` that handle `.env` and JSON config files.

This is consistent with the existing `write_text(..., encoding="utf-8")` call already present at line 556 in the same file.

## Affected lines

| Line | Change |
|------|--------|
| 749 | `config_path.read_text()` → `read_text(encoding="utf-8")` |
| 898 | `env_path.read_text()` → `read_text(encoding="utf-8")` |
| 928 | `env_path.read_text()` → `read_text(encoding="utf-8")` |
| 941 | `env_path.write_text(...)` → `write_text(..., encoding="utf-8")` |

## Environment

- OS: Windows 10, Chinese (GBK) locale
- Python: 3.11.15
- Hermes: v2026.7.1