### PR TITLE
fix(cwd): honor gateway session cwd in tool surfaces

### DIFF
--- a/tests/tools/test_gateway_cwd_contract.py
+++ b/tests/tools/test_gateway_cwd_contract.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from gateway.session_context import clear_session_vars, set_session_vars
 from tools import code_execution_tool, file_tools, terminal_tool
 
 
@@ -67,3 +68,26 @@ def test_execute_code_project_mode_falls_back_when_terminal_cwd_missing(monkeypa
 
     assert Path(resolved).is_dir()
     assert Path(resolved) != tmp_path / "missing"
+
+
+def test_tool_surfaces_use_gateway_session_cwd_without_terminal_cwd(monkeypatch, tmp_path):
+    """Webhook sessions pin cwd via contextvars, not process-wide TERMINAL_CWD."""
+    workspace = tmp_path / "workspace"
+    staging = tmp_path / "staging"
+    workspace.mkdir()
+    staging.mkdir()
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    tokens = set_session_vars(cwd=str(workspace))
+    try:
+        terminal_cwd = Path(terminal_tool._get_env_config()["cwd"])
+        file_cwd = file_tools._resolve_path_for_task("notes/today.md").parent.parent
+        execute_cwd = Path(code_execution_tool._resolve_child_cwd("project", str(staging)))
+    finally:
+        clear_session_vars(tokens)
+
+    assert terminal_cwd == workspace
+    assert file_cwd == workspace
+    assert execute_cwd == workspace

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1738,18 +1738,21 @@ def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's TERMINAL_CWD (same as the terminal tool), or
-      ``os.getcwd()`` if TERMINAL_CWD is unset or doesn't point at a real dir.
+    - ``project``: the session's resolved cwd (same as the terminal tool), or
+      ``os.getcwd()`` if no configured cwd points at a real dir.
       Falls back to the staging tmpdir as a last resort so we never invoke
       Popen with a nonexistent cwd.
     """
     if mode != "project":
         return staging_dir
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
-    if raw:
-        expanded = os.path.expanduser(raw)
-        if os.path.isdir(expanded):
-            return expanded
+    try:
+        from agent.runtime_cwd import resolve_agent_cwd
+
+        resolved = resolve_agent_cwd()
+        if resolved.is_dir():
+            return str(resolved)
+    except Exception:
+        pass
     here = os.getcwd()
     if os.path.isdir(here):
         return here

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -137,14 +137,25 @@ def _sentinel_free_abs_cwd(raw: str | None) -> str | None:
 
 
 def _configured_terminal_cwd() -> str | None:
-    """Return ``$TERMINAL_CWD`` only when it names a real directory anchor.
+    """Return the configured session cwd only when it is a stable anchor.
 
     Sentinel values (see ``_TERMINAL_CWD_SENTINELS``) and relative paths are
     rejected — a relative anchor is meaningless without knowing which cwd it is
     relative to, which is exactly the ambiguity that misroutes worktree edits.
     Only an absolute, sentinel-free value is honored.
     """
-    return _sentinel_free_abs_cwd(os.environ.get("TERMINAL_CWD"))
+    configured = _sentinel_free_abs_cwd(os.environ.get("TERMINAL_CWD"))
+    if configured:
+        return configured
+    try:
+        from agent.runtime_cwd import resolve_context_cwd
+
+        context_cwd = resolve_context_cwd()
+    except Exception:
+        return None
+    if context_cwd is None:
+        return None
+    return _sentinel_free_abs_cwd(str(context_cwd))
 
 
 def _registered_task_cwd_override(task_id: str = "default") -> str | None:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1275,7 +1275,12 @@ def _get_env_config() -> Dict[str, Any]:
     # remote home, and everything else starts in the backend's default
     # root-like cwd.
     if env_type == "local":
-        default_cwd = _safe_getcwd()
+        try:
+            from agent.runtime_cwd import resolve_agent_cwd
+
+            default_cwd = str(resolve_agent_cwd())
+        except Exception:
+            default_cwd = _safe_getcwd()
     elif env_type == "ssh":
         default_cwd = "~"
     else:
@@ -1285,7 +1290,7 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = default_cwd if env_type == "local" else os.getenv("TERMINAL_CWD", default_cwd)
     if cwd:
         cwd = os.path.expanduser(cwd)
     host_cwd = None


### PR DESCRIPTION
## Summary
- make local terminal env setup use the existing runtime cwd resolver
- let file tools and execute_code project mode consume gateway session cwd when TERMINAL_CWD is absent
- add a regression covering contextvar-only gateway cwd across terminal, file, and execute_code surfaces

## Test plan
- /Users/dimon/002Project/001Agent/venv/bin/python -m pytest tests/tools/test_gateway_cwd_contract.py -q
- /Users/dimon/002Project/001Agent/venv/bin/python -m pytest tests/tools/test_gateway_cwd_contract.py tests/tools/test_code_execution_modes.py::TestResolveChildCwd tests/tools/test_terminal_task_cwd.py tests/gateway/test_session_env.py -q
- /Users/dimon/002Project/001Agent/venv/bin/python -m py_compile tools/terminal_tool.py tools/file_tools.py tools/code_execution_tool.py
- git diff --cached --check

Issue closeout: none. This fixes an observed local Hermes gateway cwd drift, not a tracked upstream issue.