### PR TITLE
fix(tui): register shell hooks and discover plugins at TUI gateway startup

### DIFF
--- a/tests/tui_gateway/test_entry_shell_hook_registration.py
+++ b/tests/tui_gateway/test_entry_shell_hook_registration.py
@@ -1,0 +1,51 @@
+"""Regression test: shell hooks and plugins must be registered when the TUI
+gateway is spawned directly (``python -m tui_gateway.entry``).
+
+``ui-tui``'s ``gatewayClient.ts`` spawns this module as a raw subprocess
+(``spawn(python, ['-m', 'tui_gateway.entry'], ...)``), bypassing
+``hermes_cli/main.py``'s ``_prepare_agent_startup`` entirely. That function is
+the only place ``discover_plugins()`` and ``register_from_config()`` normally
+run for CLI-driven agent turns; the gateway process (``gateway/run.py``) has
+its own equivalent calls, but ``tui_gateway/entry.py`` had neither, so shell
+hooks configured under ``hooks:`` in ``cli-config.yaml`` silently never
+registered for anyone using the TUI (desktop app or ``hermes --tui``).
+"""
+
+from unittest.mock import patch
+
+import tui_gateway.entry as entry
+
+
+def test_main_discovers_plugins_and_registers_shell_hooks():
+    """entry.main() must call discover_plugins() and register_from_config()
+    at startup, mirroring gateway/run.py's equivalent startup calls."""
+    with patch.object(entry, "_install_sidecar_publisher"), \
+         patch("hermes_cli.config.read_raw_config", return_value={}), \
+         patch("hermes_cli.config.load_config", return_value={}) as mock_load_config, \
+         patch("hermes_cli.plugins.discover_plugins") as mock_discover_plugins, \
+         patch("agent.shell_hooks.register_from_config") as mock_register_hooks, \
+         patch.object(entry, "write_json", return_value=True), \
+         patch("sys.stdin", iter([])):
+        entry.main()
+
+    mock_discover_plugins.assert_called_once()
+    mock_register_hooks.assert_called_once()
+    (cfg_arg,), kwargs = mock_register_hooks.call_args
+    assert cfg_arg == mock_load_config.return_value
+    assert kwargs.get("accept_hooks") is False
+
+
+def test_shell_hook_registration_failure_does_not_block_startup():
+    """A registration failure must be swallowed, not crash the TUI gateway
+    (mirrors the try/except around the equivalent gateway/run.py call)."""
+    with patch.object(entry, "_install_sidecar_publisher"), \
+         patch("hermes_cli.config.read_raw_config", return_value={}), \
+         patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.plugins.discover_plugins"), \
+         patch(
+             "agent.shell_hooks.register_from_config",
+             side_effect=RuntimeError("boom"),
+         ), \
+         patch.object(entry, "write_json", return_value=True), \
+         patch("sys.stdin", iter([])):
+        entry.main()  # must not raise

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -293,6 +293,35 @@ def join_mcp_discovery(timeout: float | None = None) -> bool:
 def main():
     _install_sidecar_publisher()
 
+    # Discover Python plugins and register declarative shell hooks from
+    # cli-config.yaml.  This process is spawned directly by ui-tui's
+    # gatewayClient (``python -m tui_gateway.entry``, see
+    # ``ui-tui/src/gatewayClient.ts``) rather than going through
+    # ``hermes_cli/main.py``'s ``_prepare_agent_startup``, so neither of
+    # these normally-implicit startup steps has run yet in this process —
+    # mirrors the equivalent calls in ``gateway/run.py``.  ``accept_hooks``
+    # is left ``False`` and resolved from env/config inside
+    # ``register_from_config``; ``_prompt_and_record`` there already no-ops
+    # safely (returns ``False`` without prompting) when stdin isn't a TTY,
+    # which is always true here since stdin is the JSON-RPC pipe to the TUI.
+    # Failures are logged but must never block TUI startup.
+    try:
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
+    except Exception:
+        logger.warning(
+            "plugin discovery failed at TUI gateway startup", exc_info=True,
+        )
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at TUI gateway startup",
+            exc_info=True,
+        )
+
     # MCP tool discovery — runs in a background daemon thread so a slow or
     # unreachable MCP server can't freeze TUI startup.  Previously this ran
     # inline before ``gateway.ready``, which meant any configured-but-down


### PR DESCRIPTION
## What changed

`tui_gateway/entry.py::main()` now calls `discover_plugins()` and `agent.shell_hooks.register_from_config()` at startup, mirroring the equivalent calls already present in `gateway/run.py`.

## Why

`ui-tui`'s `gatewayClient.ts` spawns this module directly as a subprocess (`spawn(python, ['-m', 'tui_gateway.entry'], ...)`), bypassing `hermes_cli/main.py`'s `_prepare_agent_startup` entirely. That function is the only place `discover_plugins()` and `register_from_config()` normally run for CLI-driven agent turns (`hermes chat`, `hermes --tui` launched via the CLI arg parser). The gateway process (`gateway/run.py`) has its own equivalent startup calls for the same reason (it also doesn't go through `_prepare_agent_startup`), but `tui_gateway/entry.py` had neither — confirmed via grep, zero hits for either call in the file before this change.

Net effect: shell hooks configured under `hooks:` in `cli-config.yaml` silently never registered for anyone using the TUI surface (desktop app or `hermes --tui`), even though the exact same config works fine for plain CLI chat and the gateway.

## Approach

Mirrors `gateway/run.py`'s pattern exactly:
- `discover_plugins()` runs first (plugin-defined hooks need discovery to have happened before registration).
- `register_from_config(load_config(), accept_hooks=False)` — `accept_hooks` stays `False` here just like the gateway path; the three opt-in channels (`--accept-hooks` doesn't apply to this surface, but `HERMES_ACCEPT_HOOKS` env var and `hooks_auto_accept: true` in config) are still resolved inside `register_from_config` itself.
- Unlike the gateway (which has no TTY), this process nominally *could* have one, but its stdin is always the JSON-RPC pipe to the TUI frontend, not a real TTY — `_prompt_and_record`'s `sys.stdin.isatty()` check already handles this safely (returns `False`, no prompt, just a logged warning), so no interactive-prompt-corrupting-the-protocol risk.
- Both calls are wrapped in their own try/except (logged, non-fatal), consistent with every other startup call in this file and with `gateway/run.py`'s handling of the same two calls.

## Test plan

- Added `tests/tui_gateway/test_entry_shell_hook_registration.py`:
  - Asserts `main()` calls `discover_plugins()` once and `register_from_config()` once with the loaded config and `accept_hooks=False`.
  - Asserts a `register_from_config` exception doesn't propagate out of `main()` (startup must not be blocked by a hook-registration failure).
- Ran the full `tests/tui_gateway/` suite locally (261 tests, 23 files) — all green, no regressions.
- Ran `scripts/run_tests.sh` against the new file plus the two other `entry.py`-adjacent test files — all passing.

Fixes the TUI shell-hooks gap noted in passing during an internal audit of Hermes's three startup paths (CLI / gateway / TUI) for this exact call.