### PR TITLE
fix(config): distinguish disabled-plugin toolsets from typos in validation

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6162,8 +6162,11 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         from toolsets import validate_toolset
         from hermes_cli.toolset_validation import validate_platform_toolsets
 
+        _raw_cfg_for_validation = read_raw_config()
         ts_warnings = validate_platform_toolsets(
-            read_raw_config().get("platform_toolsets"), validate_toolset
+            _raw_cfg_for_validation.get("platform_toolsets"),
+            validate_toolset,
+            _raw_cfg_for_validation.get("known_plugin_toolsets"),
         )
         for w in ts_warnings:
             results["warnings"].append(w)

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -10,23 +10,36 @@ returns an empty list, so every tool silently disappeared with no error, warning
 or log entry — the agent degraded to text-only replies and the cause took
 significant debugging to find. Surfacing invalid toolset names (and the
 zero-tools end state) loudly turns that silent failure into an actionable one.
+
+Also cross-references ``known_plugin_toolsets`` (see
+``hermes_cli/tools_config.py``): a name that ``is_valid_toolset`` rejects
+today but was recorded there for the same platform is almost always a
+disabled/uninstalled plugin, not a typo — the two cases warrant different
+"did you mean" advice.
 """
 
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 
 def validate_platform_toolsets(
     platform_toolsets: object,
     is_valid_toolset: Callable[[str], bool],
+    known_plugin_toolsets: Optional[object] = None,
 ) -> List[str]:
     """Return human-readable warnings for a ``platform_toolsets`` mapping.
 
     Two failure modes are reported:
 
     1. A toolset name that ``is_valid_toolset`` rejects — usually a corrupted or
-       renamed entry. When ``hermes-<platform>`` would have been valid (the exact
+       renamed entry, or a plugin toolset whose plugin is currently disabled or
+       missing. When ``hermes-<platform>`` would have been valid (the exact
        #38798 shape, where ``cli`` held ``hermes`` instead of ``hermes-cli``),
-       the warning includes that as a suggestion.
+       the warning includes that as a suggestion. When the name instead matches
+       an entry previously recorded for this platform in
+       ``known_plugin_toolsets`` (populated by ``hermes tools`` — see
+       ``_save_platform_tools`` in ``hermes_cli/tools_config.py``), the warning
+       points at the plugin being disabled/uninstalled instead, since a stale
+       ``hermes-<platform>`` guess would be misleading there.
     2. The mapping is non-empty but resolves to *zero* valid toolsets, so the
        agent would start with no tools at all.
 
@@ -38,6 +51,11 @@ def validate_platform_toolsets(
             ``dict`` values carry toolset entries; anything else yields no
             warnings (nothing to validate).
         is_valid_toolset: Predicate returning ``True`` for a known toolset name.
+        known_plugin_toolsets: The raw ``known_plugin_toolsets`` value from
+            config — a ``{platform: [toolset_key, ...]}`` mapping of plugin
+            toolset keys seen the last time ``hermes tools`` saved that
+            platform. Optional; a missing/malformed value just skips the
+            cross-list check (falls back to the generic warning).
 
     Returns:
         A list of warning strings (empty when everything is valid).
@@ -46,14 +64,29 @@ def validate_platform_toolsets(
     if not isinstance(platform_toolsets, dict) or not platform_toolsets:
         return warnings
 
+    if not isinstance(known_plugin_toolsets, dict):
+        known_plugin_toolsets = {}
+
     valid_count = 0
     for platform, raw in platform_toolsets.items():
         names = raw if isinstance(raw, list) else [raw]
+        known_for_platform = known_plugin_toolsets.get(platform)
+        known_for_platform = (
+            set(known_for_platform) if isinstance(known_for_platform, list) else set()
+        )
         for name in names:
             if not isinstance(name, str) or not name:
                 continue
             if is_valid_toolset(name):
                 valid_count += 1
+                continue
+            if name in known_for_platform:
+                warnings.append(
+                    f"platform '{platform}' references toolset '{name}', "
+                    "which was previously provided by a plugin but is not "
+                    "currently available — check that the plugin is still "
+                    "enabled (plugins.enabled) and installed"
+                )
                 continue
             suggestion = f"hermes-{platform}"
             hint = (

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -2036,3 +2036,59 @@ class TestCodexAppServerAutoConfig:
             assert raw["compression"]["codex_app_server_auto"] == "hermes"
 
 
+
+
+class TestPlatformToolsetValidationWiring:
+    """migrate_config() must forward known_plugin_toolsets into
+    validate_platform_toolsets(), so a disabled plugin is reported as such
+    instead of falling back to the generic unknown-toolset warning.
+
+    The helper's own branches are covered in test_toolset_validation.py; this
+    guards the production wiring in hermes_cli/config.py, where dropping the
+    third argument would silently restore the generic warning.
+    """
+
+    def test_migrate_config_reports_disabled_plugin_toolset(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": DEFAULT_CONFIG["_config_version"],
+                    "platform_toolsets": {"cli": ["hermes-cli", "weather-tools"]},
+                    "known_plugin_toolsets": {"cli": ["weather-tools"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            results = migrate_config(interactive=False, quiet=True)
+
+        plugin_warnings = [
+            w
+            for w in results["warnings"]
+            if "weather-tools" in w and "plugin" in w
+        ]
+        assert len(plugin_warnings) == 1
+        # The typo guess is wrong advice for a disabled plugin.
+        assert "did you mean" not in plugin_warnings[0]
+
+    def test_migrate_config_still_reports_unknown_toolset_as_typo(self, tmp_path):
+        """Without a known_plugin_toolsets entry, the same bogus name keeps the
+        generic unknown-toolset warning — the cross-list check is what
+        distinguishes them, not the name itself."""
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": DEFAULT_CONFIG["_config_version"],
+                    "platform_toolsets": {"cli": ["hermes-cli", "weather-tools"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            results = migrate_config(interactive=False, quiet=True)
+
+        assert any(
+            "unknown toolset 'weather-tools'" in w for w in results["warnings"]
+        )

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -89,3 +89,51 @@ def test_real_validate_toolset_treats_hermes_cli_valid_and_hermes_invalid():
     assert validate_toolset("hermes") is False
     warnings = validate_platform_toolsets({"cli": ["hermes"]}, validate_toolset)
     assert any("did you mean 'hermes-cli'?" in w for w in warnings)
+
+
+# --- known_plugin_toolsets cross-list checks ---------------------------------
+#
+# A name that is_valid_toolset() rejects but that known_plugin_toolsets
+# recorded for the same platform is (almost certainly) a plugin that used to
+# provide that toolset and is now disabled or uninstalled — not a typo, so the
+# `hermes-<platform>` guess is the wrong advice for it.
+
+
+def test_disabled_plugin_toolset_gets_plugin_specific_warning():
+    cfg = {"cli": ["hermes-cli", "weather-tools"]}
+    known = {"cli": ["weather-tools"]}
+    warnings = validate_platform_toolsets(cfg, _is_valid, known)
+    assert not any("zero valid toolsets" in w for w in warnings)
+    assert len(warnings) == 1
+    assert "platform 'cli'" in warnings[0]
+    assert "toolset 'weather-tools'" in warnings[0]
+    assert "plugin" in warnings[0]
+    # Must not also carry (or be conflated with) the typo-guess wording.
+    assert "did you mean" not in warnings[0]
+    assert "unknown toolset" not in warnings[0]
+
+
+def test_known_plugin_toolset_scoped_to_its_own_platform():
+    # 'weather-tools' is only recorded as known for 'telegram', not 'cli' — a
+    # bogus 'cli' entry with the same name is still a plain unknown-toolset,
+    # not a disabled-plugin case, since it was never known there.
+    cfg = {"cli": ["weather-tools"]}
+    known = {"telegram": ["weather-tools"]}
+    warnings = validate_platform_toolsets(cfg, _is_valid, known)
+    unknown = [w for w in warnings if "unknown toolset 'weather-tools'" in w]
+    assert len(unknown) == 1
+
+
+def test_missing_known_plugin_toolsets_falls_back_to_generic_warning():
+    # known_plugin_toolsets omitted entirely (None) — existing behavior for
+    # callers that don't pass it (e.g. before this field existed in config).
+    cfg = {"cli": ["bogus"]}
+    warnings = validate_platform_toolsets(cfg, _is_valid)
+    assert any("unknown toolset 'bogus'" in w for w in warnings)
+
+
+@pytest.mark.parametrize("value", [None, [], "cli", 42, {"cli": "not-a-list"}])
+def test_malformed_known_plugin_toolsets_is_tolerated(value):
+    cfg = {"cli": ["bogus"]}
+    warnings = validate_platform_toolsets(cfg, _is_valid, value)
+    assert any("unknown toolset 'bogus'" in w for w in warnings)


### PR DESCRIPTION
## What changed

`validate_platform_toolsets()` (`hermes_cli/toolset_validation.py`, added for #38798) now accepts an optional third argument, `known_plugin_toolsets`, and cross-references it against unknown toolset names to produce a more accurate warning when the real cause is a disabled/uninstalled plugin rather than a typo.

## Why

Hermes tracks toolset names across three separate places:
- `plugins.enabled` — which plugins are turned on
- `known_plugin_toolsets` — per-platform snapshot of plugin toolset keys seen the last time `hermes tools` saved that platform (`hermes_cli/tools_config.py::_save_platform_tools`)
- `platform_toolsets` — the actual per-platform toolset selection

`validate_platform_toolsets` already does excellent work catching corrupted/renamed entries (the #38798 incident: `hermes-cli` silently rewritten to the nonexistent `hermes`), including a `hermes-<platform>` "did you mean" guess. But that guess is actively misleading for a very common real-world case: a `platform_toolsets` entry that names a real plugin toolset whose plugin is now disabled (or its package uninstalled). Since `is_valid_toolset` (backed by the live toolset registry) only knows about currently-loaded plugins, a disabled plugin's toolset name looks identical to a typo to the existing check — same generic "unknown toolset '<name>'" warning, with no `hermes-<platform>` hint either (since that guess doesn't happen to match), leaving the real cause unstated.

`known_plugin_toolsets` already has exactly the information needed to tell these apart: if a name is in `known_plugin_toolsets[platform]`, it was a real, valid plugin toolset the last time `hermes tools` ran for that platform — so its current invalidity almost certainly means the plugin got disabled or uninstalled, not that the name was ever wrong.

## Approach

- New optional `known_plugin_toolsets` param, default `None` (or any non-dict) → identical behavior to before this change, so existing callers/tests aren't broken.
- When a name fails `is_valid_toolset` AND is found in `known_plugin_toolsets[platform]`, emit a distinct, more actionable warning pointing at `plugins.enabled` and plugin installation, instead of the generic unknown-toolset message with its (here, irrelevant) `hermes-<platform>` guess.
- Threaded through the one existing call site in `hermes_cli/config.py` (`read_raw_config().get("known_plugin_toolsets")`), reusing the same try/except-wrapped, best-effort validation pass that already runs after every config migration.
- No new call sites, no new validation pass — purely widening the existing one.

## Test plan

- Extended `tests/hermes_cli/test_toolset_validation.py` with:
  - a disabled-plugin case producing the new plugin-specific warning (and confirming it does *not* also carry the typo-guess wording)
  - a case where the name is known for a *different* platform, confirming it still falls back to the generic unknown-toolset warning (the cross-check is platform-scoped)
  - omitted/malformed `known_plugin_toolsets` (`None`, `[]`, a string, `{}` with a non-list value) all falling back to the pre-existing generic behavior
- Ran `scripts/run_tests.sh tests/hermes_cli/test_toolset_validation.py tests/hermes_cli/test_config.py` — 153 tests, all passing, no regressions in the config-migration suite that exercises this call site.