### PR TITLE
fix(terminal): disable MSYS path conversion on Windows

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -24,8 +24,10 @@ from unittest.mock import patch
 from tools.environments import local as local_mod
 from tools.environments.local import (
     LocalEnvironment,
+    _make_run_env,
     _msys_to_windows_path,
     _resolve_safe_cwd,
+    _sanitize_subprocess_env,
     _windows_to_msys_path,
 )
 
@@ -267,3 +269,41 @@ class TestWrapCommandWindowsNativeCwd:
 
         assert "builtin cd -- /c/Users/liush 2>/dev/null || true" in captured["script"]
         assert r"C:\Users\liush" not in captured["script"]
+
+
+# ---------------------------------------------------------------------------
+# Windows terminal subprocess env — disable MSYS argv path conversion
+# ---------------------------------------------------------------------------
+
+class TestWindowsMsysPathConversionEnv:
+    def test_make_run_env_disables_msys_arg_path_conversion(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_resolve_hermes_bin_dir", lambda: None)
+
+        with patch.dict(local_mod.os.environ, {"PATH": r"C:\Windows\System32"}, clear=True):
+            env = _make_run_env({})
+
+        assert env["MSYS_NO_PATHCONV"] == "1"
+
+    def test_make_run_env_respects_explicit_msys_pathconv_override(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_resolve_hermes_bin_dir", lambda: None)
+
+        with patch.dict(local_mod.os.environ, {"PATH": r"C:\Windows\System32"}, clear=True):
+            env = _make_run_env({"MSYS_NO_PATHCONV": "0"})
+
+        assert env["MSYS_NO_PATHCONV"] == "0"
+
+    def test_sanitize_subprocess_env_disables_msys_arg_path_conversion(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        env = _sanitize_subprocess_env({"PATH": r"C:\Windows\System32"})
+
+        assert env["MSYS_NO_PATHCONV"] == "1"
+
+    def test_non_windows_env_does_not_inject_msys_pathconv(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+
+        env = _sanitize_subprocess_env({"PATH": "/usr/bin"})
+
+        assert "MSYS_NO_PATHCONV" not in env

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -334,6 +334,22 @@ def _inject_session_context_env(env: dict) -> None:
             env.pop(var_name, None)
 
 
+def _inject_windows_msys_env(env: dict) -> None:
+    """Disable MSYS argv path conversion for Windows terminal subprocesses.
+
+    Hermes runs local Windows terminal commands through Git Bash so the same
+    bash-wrapped command machinery works cross-platform. Git Bash/MSYS applies
+    automatic argv path conversion to child native Windows executables, which
+    turns flags like ``/FO`` and ``/TN`` (``tasklist /FO CSV``,
+    ``schtasks /Create /TN ...``) into bogus filesystem paths. Setting
+    ``MSYS_NO_PATHCONV=1`` preserves native Windows command arguments while
+    still letting bash itself run Hermes' wrapper script. Respect an explicit
+    caller value so advanced users can opt back into MSYS conversion.
+    """
+    if _IS_WINDOWS:
+        env.setdefault("MSYS_NO_PATHCONV", "1")
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -373,6 +389,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
 
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         sanitized.pop(_marker, None)
+
+    _inject_windows_msys_env(sanitized)
 
     return sanitized
 
@@ -794,6 +812,8 @@ def _make_run_env(env: dict) -> dict:
 
     for _marker in _ACTIVE_VENV_MARKER_VARS:
         run_env.pop(_marker, None)
+
+    _inject_windows_msys_env(run_env)
 
     return run_env
 


### PR DESCRIPTION
Fixes #56700.\n\n## Summary\n- set MSYS_NO_PATHCONV=1 for Windows local terminal foreground and background/PTY subprocess environments\n- preserve explicit user overrides of MSYS_NO_PATHCONV\n- add Windows-simulated regression coverage for terminal env construction\n\n## Tests\n- scripts/run_tests.sh tests/tools/test_local_env_windows_msys.py