### PR TITLE
fix(toolsets): restore terminal toolset on api_server and acp composites (#56732)

### DIFF
--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -23,7 +23,7 @@ class TestHermesApiServerToolset:
     def test_toolset_includes_core_tools(self):
         tools = resolve_toolset("hermes-api-server")
         expected = [
-            "terminal", "process",
+            "terminal", "process", "read_terminal", "close_terminal",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze", "image_generate",
             "execute_code", "delegate_task",
@@ -31,6 +31,25 @@ class TestHermesApiServerToolset:
         ]
         for tool in expected:
             assert tool in tools, f"Missing expected tool: {tool}"
+
+    def test_terminal_toolset_is_subset_of_composite(self):
+        """Regression #56732: registry-merged terminal tools must appear in the
+        composite list or _get_platform_tools drops the whole terminal toolset."""
+        from model_tools import get_tool_definitions  # noqa: F401 — register tools
+
+        terminal_tools = set(resolve_toolset("terminal"))
+        api_server_tools = set(resolve_toolset("hermes-api-server"))
+        assert terminal_tools.issubset(api_server_tools), (
+            f"hermes-api-server missing terminal members: {terminal_tools - api_server_tools}"
+        )
+
+    def test_api_server_platform_enables_terminal_toolset(self):
+        """Default api_server platform config must enable the terminal toolset."""
+        from hermes_cli.tools_config import _get_platform_tools
+        from hermes_cli.config import load_config
+
+        enabled = _get_platform_tools(load_config(), "api_server")
+        assert "terminal" in enabled
 
     def test_toolset_includes_browser_tools(self):
         tools = resolve_toolset("hermes-api-server")

--- a/tests/toolsets/test_composite_terminal_parity.py
+++ b/tests/toolsets/test_composite_terminal_parity.py
@@ -1,0 +1,21 @@
+"""Regression: composite hermes-* toolsets must stay in sync with terminal toolset."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _register_tools():
+    import model_tools  # noqa: F401 — force tool discovery
+
+
+@pytest.mark.parametrize("composite", ["hermes-acp", "hermes-api-server"])
+def test_composite_includes_full_terminal_toolset(composite: str) -> None:
+    from toolsets import resolve_toolset
+
+    terminal_tools = set(resolve_toolset("terminal"))
+    composite_tools = set(resolve_toolset(composite))
+    assert terminal_tools.issubset(composite_tools), (
+        f"{composite} missing terminal members: {sorted(terminal_tools - composite_tools)}"
+    )

--- a/toolsets.py
+++ b/toolsets.py
@@ -379,7 +379,7 @@ TOOLSETS = {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
         "tools": [
             "web_search", "web_extract",
-            "terminal", "process",
+            "terminal", "process", "read_terminal", "close_terminal",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
@@ -400,7 +400,7 @@ TOOLSETS = {
             # Web
             "web_search", "web_extract",
             # Terminal + process management
-            "terminal", "process",
+            "terminal", "process", "read_terminal", "close_terminal",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
             # Vision + image generation


### PR DESCRIPTION
## Summary
- Add `read_terminal` and `close_terminal` to `hermes-acp` and `hermes-api-server` composite tool lists in `toolsets.py`
- Fixes silent loss of the entire `terminal` toolset on `api_server` when `_get_platform_tools()` subset-inference compares against registry-merged `terminal` tools (#56732)
- Add regression tests for composite/terminal parity and api_server platform resolution

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_api_server_toolset.py tests/toolsets/test_composite_terminal_parity.py -q`

Fixes #56732 