### PR TITLE
fix: replace assert with explicit check in codex app-server session

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -396,7 +396,10 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            result.error = "codex app-server started but client or thread_id is None"
+            result.should_retire = True
+            return result
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()


### PR DESCRIPTION
## Summary

`agent/transports/codex_app_server_session.py:399` uses `assert` to check that `_client` and `_thread_id` are not None after `ensure_started()`. In production, `assert` statements are stripped when Python runs with `-O` flag, silently removing the invariant check.

If `_client` or `_thread_id` is None after startup, the code would continue and crash later with an unhelpful `AttributeError` or `NoneType` error.

## Fix

Replace the bare `assert` with an explicit `if/return` that sets `result.error` and `result.should_retire = True`, matching the pattern already used for startup failures in the same function (lines 391-398).

## Changes

- `agent/transports/codex_app_server_session.py`: `assert self._client is not None and self._thread_id is not None` → explicit if/return with error message

## Test Plan

- [x] Lint passes
- [ ] Verify codex session startup still works
