### PR TITLE
fix(oneshot): honor configured auxiliary.<task>.timeout in run_oneshot (residual of #56322)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6283,18 +6283,27 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
-def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
+def _effective_aux_timeout(
+    task: str,
+    timeout: Optional[float],
+    default: float = _DEFAULT_AUX_TIMEOUT,
+) -> float:
     """Resolve the effective timeout for an auxiliary LLM call.
 
     Uses the caller-provided ``timeout`` when given; otherwise reads
-    ``auxiliary.{task}.timeout`` from config via :func:`_get_task_timeout`.
+    ``auxiliary.{task}.timeout`` from config via :func:`_get_task_timeout`,
+    falling back to ``default``.  Callers with a historical task-specific
+    fallback can supply it without resolving the timeout before this helper
+    applies task-level policy.
     For the ``compression`` task only, applies a bounded floor so a reasoning
     model summarising a large context is not cut off by the default timeout
     (#54915).  The floor is intentionally skipped when the caller passes an
     explicit ``timeout=`` — explicit per-call deadlines are always honoured —
     and it is a minimum (``max``), so a config value already above it is kept.
     """
-    effective = timeout if timeout is not None else _get_task_timeout(task)
+    effective = (
+        timeout if timeout is not None else _get_task_timeout(task, default=default)
+    )
     if timeout is None and task == "compression":
         effective = max(effective, _COMPRESSION_TIMEOUT_FLOOR_SECONDS)
     return effective

--- a/agent/oneshot.py
+++ b/agent/oneshot.py
@@ -24,7 +24,11 @@ the live session's provider/model, otherwise the configured ``task`` (default
 import logging
 from typing import Any, Callable, Dict, Optional, Tuple
 
-from agent.auxiliary_client import call_llm, extract_content_or_reasoning, _get_task_timeout
+from agent.auxiliary_client import (
+    _effective_aux_timeout,
+    call_llm,
+    extract_content_or_reasoning,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -135,15 +139,11 @@ def run_oneshot(
         messages.append({"role": "system", "content": instructions})
     messages.append({"role": "user", "content": user_input or ""})
 
-    # Resolve the per-task timeout the same way call_llm does, but keep this
-    # helper's historical 60s default for callers that neither pass a timeout nor
-    # configure ``auxiliary.<task>.timeout``. Previously the hard-coded 60.0 default
-    # was always forwarded, so call_llm never saw ``None`` and silently ignored a
-    # configured ``auxiliary.<task>.timeout`` on the live llm.oneshot path (the exact
-    # class of #32729 that #56322 fixed for generate_title).
-    effective_timeout = (
-        timeout if timeout is not None else _get_task_timeout(task, default=60.0)
-    )
+    # Preserve the absent-timeout signal through the shared resolver so task
+    # policy (notably the compression floor) still applies.  The caller-specific
+    # fallback keeps the historical 60s oneshot deadline only when the selected
+    # task has no configured timeout.
+    effective_timeout = _effective_aux_timeout(task, timeout, default=60.0)
 
     response = call_llm(
         task=task,

--- a/agent/oneshot.py
+++ b/agent/oneshot.py
@@ -24,7 +24,7 @@ the live session's provider/model, otherwise the configured ``task`` (default
 import logging
 from typing import Any, Callable, Dict, Optional, Tuple
 
-from agent.auxiliary_client import call_llm, extract_content_or_reasoning
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning, _get_task_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ def run_oneshot(
     task: str = "title_generation",
     max_tokens: int = 1024,
     temperature: Optional[float] = 0.3,
-    timeout: float = 60.0,
+    timeout: Optional[float] = None,
     main_runtime: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Run a single stateless LLM request and return its text.
@@ -135,12 +135,22 @@ def run_oneshot(
         messages.append({"role": "system", "content": instructions})
     messages.append({"role": "user", "content": user_input or ""})
 
+    # Resolve the per-task timeout the same way call_llm does, but keep this
+    # helper's historical 60s default for callers that neither pass a timeout nor
+    # configure ``auxiliary.<task>.timeout``. Previously the hard-coded 60.0 default
+    # was always forwarded, so call_llm never saw ``None`` and silently ignored a
+    # configured ``auxiliary.<task>.timeout`` on the live llm.oneshot path (the exact
+    # class of #32729 that #56322 fixed for generate_title).
+    effective_timeout = (
+        timeout if timeout is not None else _get_task_timeout(task, default=60.0)
+    )
+
     response = call_llm(
         task=task,
         messages=messages,
         max_tokens=max_tokens,
         temperature=temperature,
-        timeout=timeout,
+        timeout=effective_timeout,
         main_runtime=main_runtime,
     )
 

--- a/tests/agent/test_oneshot.py
+++ b/tests/agent/test_oneshot.py
@@ -96,6 +96,46 @@ class TestRunOneshot:
         ):
             assert run_oneshot(instructions="x", user_input="y") == "fix: bug"
 
+    def test_no_timeout_honors_configured_task_timeout(self):
+        # Regression for the residual of #32729/#56322 on the oneshot path: when the
+        # caller (e.g. the llm.oneshot RPC) passes no timeout, the configured
+        # auxiliary.<task>.timeout must reach call_llm instead of a hard-coded default.
+        with patch(
+            "agent.oneshot.call_llm",
+            return_value=self._mock_response("ok"),
+        ) as llm, patch(
+            "agent.oneshot._get_task_timeout", return_value=90.0
+        ) as get_timeout:
+            run_oneshot(instructions="x", user_input="y", task="my_task")
+
+        get_timeout.assert_called_once_with("my_task", default=60.0)
+        assert llm.call_args.kwargs["timeout"] == 90.0
+
+    def test_no_timeout_falls_back_to_60_when_unconfigured(self):
+        # With no explicit timeout and no auxiliary.<task>.timeout configured, the
+        # historical 60s oneshot default is preserved (no behavior change for
+        # unconfigured callers) -- _get_task_timeout returns its supplied default.
+        with patch(
+            "agent.oneshot.call_llm",
+            return_value=self._mock_response("ok"),
+        ) as llm, patch(
+            "agent.oneshot._get_task_timeout",
+            side_effect=lambda task, default: default,
+        ):
+            run_oneshot(instructions="x", user_input="y")
+
+        assert llm.call_args.kwargs["timeout"] == 60.0
+
+    def test_explicit_timeout_is_forwarded_and_skips_resolution(self):
+        with patch(
+            "agent.oneshot.call_llm",
+            return_value=self._mock_response("ok"),
+        ) as llm, patch("agent.oneshot._get_task_timeout") as get_timeout:
+            run_oneshot(instructions="x", user_input="y", timeout=5.0)
+
+        get_timeout.assert_not_called()
+        assert llm.call_args.kwargs["timeout"] == 5.0
+
 
 class TestHelpers:
     def test_truncate_under_limit_unchanged(self):

--- a/tests/agent/test_oneshot.py
+++ b/tests/agent/test_oneshot.py
@@ -100,41 +100,81 @@ class TestRunOneshot:
         # Regression for the residual of #32729/#56322 on the oneshot path: when the
         # caller (e.g. the llm.oneshot RPC) passes no timeout, the configured
         # auxiliary.<task>.timeout must reach call_llm instead of a hard-coded default.
-        with patch(
-            "agent.oneshot.call_llm",
-            return_value=self._mock_response("ok"),
-        ) as llm, patch(
-            "agent.oneshot._get_task_timeout", return_value=90.0
-        ) as get_timeout:
+        with (
+            patch(
+                "agent.oneshot.call_llm",
+                return_value=self._mock_response("ok"),
+            ) as llm,
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"timeout": 90},
+            ),
+        ):
             run_oneshot(instructions="x", user_input="y", task="my_task")
 
-        get_timeout.assert_called_once_with("my_task", default=60.0)
         assert llm.call_args.kwargs["timeout"] == 90.0
 
-    def test_no_timeout_falls_back_to_60_when_unconfigured(self):
-        # With no explicit timeout and no auxiliary.<task>.timeout configured, the
-        # historical 60s oneshot default is preserved (no behavior change for
-        # unconfigured callers) -- _get_task_timeout returns its supplied default.
+    def test_default_task_uses_merged_config_timeout(self):
+        # Exercise load_config's real default merge against the per-test empty
+        # HERMES_HOME, rather than restating the title_generation default here.
         with patch(
             "agent.oneshot.call_llm",
             return_value=self._mock_response("ok"),
-        ) as llm, patch(
-            "agent.oneshot._get_task_timeout",
-            side_effect=lambda task, default: default,
-        ):
+        ) as llm:
             run_oneshot(instructions="x", user_input="y")
+
+        assert llm.call_args.kwargs["timeout"] == 30.0
+
+    def test_no_timeout_falls_back_to_60_when_task_is_unconfigured(self):
+        # No built-in or registered plugin supplies this task in the hermetic
+        # test environment, so this covers the resolver's genuine miss path.
+        with patch(
+            "agent.oneshot.call_llm",
+            return_value=self._mock_response("ok"),
+        ) as llm:
+            run_oneshot(
+                instructions="x",
+                user_input="y",
+                task="oneshot_unregistered_test_task",
+            )
 
         assert llm.call_args.kwargs["timeout"] == 60.0
 
-    def test_explicit_timeout_is_forwarded_and_skips_resolution(self):
-        with patch(
-            "agent.oneshot.call_llm",
-            return_value=self._mock_response("ok"),
-        ) as llm, patch("agent.oneshot._get_task_timeout") as get_timeout:
-            run_oneshot(instructions="x", user_input="y", timeout=5.0)
+    def test_no_timeout_preserves_compression_floor(self):
+        with (
+            patch(
+                "agent.oneshot.call_llm",
+                return_value=self._mock_response("ok"),
+            ) as llm,
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"timeout": 120},
+            ),
+        ):
+            run_oneshot(instructions="x", user_input="y", task="compression")
 
-        get_timeout.assert_not_called()
-        assert llm.call_args.kwargs["timeout"] == 5.0
+        assert llm.call_args.kwargs["timeout"] == 300.0
+
+    @pytest.mark.parametrize("timeout", [0.0, 5.0])
+    def test_explicit_compression_timeout_is_forwarded_exactly(self, timeout):
+        with (
+            patch(
+                "agent.oneshot.call_llm",
+                return_value=self._mock_response("ok"),
+            ) as llm,
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config"
+            ) as get_task_config,
+        ):
+            run_oneshot(
+                instructions="x",
+                user_input="y",
+                task="compression",
+                timeout=timeout,
+            )
+
+        get_task_config.assert_not_called()
+        assert llm.call_args.kwargs["timeout"] == timeout
 
 
 class TestHelpers:


### PR DESCRIPTION
Follow-up to merged #56322, which fixed the same `auxiliary.<task>.timeout` bug class (#32729) for the `generate_title` sibling.

## The residual

`agent/oneshot.py::run_oneshot` defaulted `timeout` to `60.0` and forwarded that numeric value to `call_llm`. The live `llm.oneshot` JSON-RPC handler calls `run_oneshot(task=task, ...)` without a timeout, so the configured `auxiliary.<task>.timeout` could never be selected on that path.

## Fix

Default `run_oneshot`'s timeout to `None` and resolve it through the shared task-policy helper:

```python
effective_timeout = _effective_aux_timeout(task, timeout, default=60.0)
```

This preserves the omitted-timeout signal until task policy is applied:

- configured task timeouts are honored;
- the normal `title_generation` task uses its merged 30-second config default;
- an unregistered task retains the historical 60-second oneshot fallback;
- omitted `compression` timeouts retain the shared 300-second floor;
- explicit per-call timeouts, including `0.0`, are forwarded exactly and skip config/floor resolution.

The helper's new `default` argument is optional, so its existing callers retain the 30-second auxiliary fallback.

## Tests

Added focused coverage for configured, merged-default, unregistered-task, compression-floor, and explicit compression deadline paths.

```text
26 passed in 1.26s
ruff: All checks passed
```
