### PR TITLE
fix(desktop): detect scoop-installed git bash in findGitBash()

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -21,6 +21,7 @@ const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
+const os = require('node:os')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -1590,6 +1591,14 @@ function findGitBash() {
     return findOnPath('bash')
   }
 
+  // HERMES_GIT_BASH_PATH — set by install.ps1 or manually by users who
+  // installed Git via scoop/choco/package-manager. Checked first so a
+  // known-good bash is picked up regardless of where it lives on disk.
+  const bashEnvPath = process.env.HERMES_GIT_BASH_PATH
+  if (bashEnvPath && fileExists(bashEnvPath)) {
+    return bashEnvPath
+  }
+
   // install.ps1 drops PortableGit at %LOCALAPPDATA%\hermes\git\... — checked
   // first so users who installed via install.ps1 are detected before we
   // start probing system-wide locations.
@@ -1606,6 +1615,14 @@ function findGitBash() {
   if (localAppData) {
     candidates.push(path.join(localAppData, 'Programs', 'Git', 'bin', 'bash.exe'))
   }
+
+  // Scoop git — installs git-for-windows at apps/git/current/ but only shims
+  // git.exe, NOT bash.exe. Without explicit paths here the agent's terminal
+  // tool won't find bash even though `git` works fine on the command line.
+  const scoopRoot = process.env.SCOOP || path.join(os.homedir(), 'scoop')
+  const scoopGitRoot = path.join(scoopRoot, 'apps', 'git', 'current')
+  candidates.push(path.join(scoopGitRoot, 'usr', 'bin', 'bash.exe'))
+  candidates.push(path.join(scoopGitRoot, 'mingw64', 'bin', 'bash.exe'))
 
   for (const candidate of candidates) {
     if (fileExists(candidate)) return candidate
@@ -3173,7 +3190,9 @@ async function ensureRuntime(backend) {
     throw new Error(
       'Git for Windows is required for Hermes on Windows (provides Git Bash, ' +
         "which the agent's terminal tool uses). Install it from " +
-        'https://git-scm.com/download/win or run `winget install -e --id Git.Git`, ' +
+        'https://git-scm.com/download/win, run `winget install -e --id Git.Git`, ' +
+        'or `scoop install git`. If Git Bash is already installed, set the ' +
+        'HERMES_GIT_BASH_PATH environment variable to the full path of bash.exe, ' +
         'then relaunch Hermes.'
     )
   }


### PR DESCRIPTION
## What does this PR do?

Adds `HERMES_GIT_BASH_PATH` env var support and Scoop's Git-for-Windows install paths to `findGitBash()` in `apps/desktop/electron/main.cjs`. Lets the desktop boot succeed when Git for Windows is installed to a non-default location (Scoop, custom dir, etc.) and gives users an explicit override when auto-detection fails.

## Related Issue

Fixes #45435.

The reporter's root cause analysis is exactly right: `install.ps1` correctly sets `HERMES_GIT_BASH_PATH` to wherever Git is installed, but the desktop boot path (`ensureRuntime` → `findGitBash`) only probes 5 hardcoded locations under `%ProgramFiles%` and `%LOCALAPPDATA%\Programs`. When Git is anywhere else, the env var the bootstrap just set is ignored.

This PR addresses the first item in the reporter's "Expected Behavior" list ("Read the `HERMES_GIT_BASH_PATH` environment variable (set by bootstrap)") and adds the two common package-manager cases the report calls out by analogy:

- **Scoop** — installs `git-for-windows` at `%SCOOP%\apps\git\current\` (or `~/scoop/apps/git/current/` when `%SCOOP%` is unset) but only shims `git.exe`, never `bash.exe`. The agent's terminal tool fails to spawn bash even though `git` works on the command line. This case isn't in #45435 directly but follows the same root cause (non-default install path not probed) and was reported independently on Discord.

The other cases in the reporter's "Expected Behavior" (PATH detection, broader install-location search) are out of scope here — `findGitBash()` already falls through to a `findOnPath('bash')` last-resort, and adding a PATH-based probe would mask the deeper problem that the explicit `HERMES_GIT_BASH_PATH` contract between `install.ps1` and `main.cjs` was being silently dropped.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.cjs`:
  - Add `const os = require('node:os')` to the top-level requires (one line, alphabetized with the other `node:*` imports).
  - In `findGitBash()`: check `process.env.HERMES_GIT_BASH_PATH` first. If set and the file exists, return it. This makes the env var the bootstrap sets the actual source of truth, instead of a value `main.cjs` ignores.
  - In `findGitBash()`: append two Scoop candidates — `%SCOOP%\apps\git\current\usr\bin\bash.exe` and `%SCOOP%\apps\git\current\mingw64\bin\bash.exe`. The `usr/bin` path is the primary one; `mingw64/bin` is the fallback Scoop's Git sometimes leaves around after a manual upgrade.
  - In the boot-time error in `ensureRuntime`: add `scoop install git` to the install options and tell the user about `HERMES_GIT_BASH_PATH` as an escape hatch when Git is already installed somewhere the auto-detection can't find.

The change is Windows-only at runtime (everything is gated on `IS_WINDOWS`) and a no-op on macOS/Linux.

## How to Test

**Case 1 — `HERMES_GIT_BASH_PATH` override (the #45435 case):**

1. Install Git for Windows to a non-default path, e.g. `D:\software\Git`.
2. Verify the env var isn't set: `Get-ChildItem Env:HERMES_GIT_BASH_PATH` returns nothing.
3. Set it manually: ``$Env:HERMES_GIT_BASH_PATH = "D:\software\Git\bin\bash.exe"``.
4. Launch the Hermes desktop app.
5. **Before this PR:** boot fails with "Git for Windows is required for Hermes on Windows...".
6. **After this PR:** boot succeeds; `findGitBash()` returns the override before probing the hardcoded list.

**Case 2 — Scoop install:**

1. `scoop install git`.
2. Confirm `git.exe` is on PATH (the Scoop shim works) but `bash.exe` is NOT (Scoop doesn't shim it).
3. Launch Hermes desktop.
4. **Before this PR:** boot fails for the same reason.
5. **After this PR:** boot succeeds; `findGitBash()` returns `%SCOOP%\apps\git\current\usr\bin\bash.exe`.

**Case 3 — Sanity (default install still works):**

1. Install Git for Windows to the default `C:\Program Files\Git`.
2. Launch Hermes desktop.
3. **Before and after this PR:** boot succeeds via the existing `ProgramFiles\Git\bin\bash.exe` candidate. The new `HERMES_GIT_BASH_PATH` check is skipped (env var unset) and the new Scoop candidates are skipped (no `scoop/` directory).

**Verified on:** Windows 11 ARM64 (Snapdragon X Plus, Lenovo Slim 7x), Node.js 22, Hermes desktop v0.17.0. The change is platform-agnostic in code (no Windows-only APIs added); Windows-only at runtime by `IS_WINDOWS` gate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):` format)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — N/A (no Python changes)
- [x] I've added tests for my changes — N/A (no existing `findGitBash` test infrastructure; manual e2e on Windows ARM64 above)
- [x] I've tested on my platform: Windows 11 ARM64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing config / docs change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-only at runtime; no-op on macOS/Linux
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal Electron bootstrap path, not a model tool)
