### PR TITLE
fix(gateway): transcribe voice messages during pending clarify

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8617,6 +8617,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+            # Voice/audio messages arrive with empty text and audio cached
+            # in media_urls.  Transcribe via STT and resolve the clarify
+            # with the transcript so the user can respond by voice.
+            if not _raw_clarify_reply:
+                _audio_urls = getattr(event, "media_urls", None) or []
+                _audio_types = getattr(event, "media_types", None) or []
+                _msg_type = getattr(event, "message_type", None)
+                from gateway.platforms.base import MessageType as _MT
+                _is_voice_media = _msg_type in (_MT.VOICE, _MT.AUDIO) or any(
+                    (t or "").startswith("audio/") for t in _audio_types
+                )
+                if _is_voice_media and _audio_urls:
+                    try:
+                        from tools.transcription_tools import transcribe_audio
+                        _transcript = await asyncio.to_thread(
+                            transcribe_audio, _audio_urls[0],
+                        )
+                        if _transcript.get("success") and _transcript.get("transcript"):
+                            _voice_text = _transcript["transcript"].strip()
+                            if _voice_text:
+                                _resolved = _clarify_mod.resolve_text_response_for_session(
+                                    _quick_key, _voice_text,
+                                )
+                                if _resolved:
+                                    logger.info(
+                                        "Gateway intercepted clarify voice response (session=%s, id=%s, transcript=%s)",
+                                        _quick_key, _pending_clarify.clarify_id,
+                                        _voice_text[:80],
+                                    )
+                                    return ""
+                    except Exception as _stt_err:
+                        logger.warning(
+                            "Failed to transcribe voice for clarify response (session=%s): %s",
+                            _quick_key, _stt_err,
+                        )
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/tests/gateway/test_voice_clarify_intercept.py
+++ b/tests/gateway/test_voice_clarify_intercept.py
@@ -1,0 +1,253 @@
+"""Tests for voice/audio clarify intercept in GatewayRunner._handle_message.
+
+Regression test for #56739: voice messages sent while the clarify tool is
+waiting for a user response should be transcribed via STT and used to resolve
+the pending clarify, rather than being silently ignored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_runner() -> "GatewayRunner":  # type: ignore[name-defined]
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    runner.pairing_store = MagicMock()
+    runner._update_prompt_pending = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._slash_confirm_pending = {}
+    runner._startup_restore_in_progress = False
+    runner.session_store = MagicMock()
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner._inbound_last_ts = {}
+    return runner
+
+
+def _voice_event(text: str = "") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.VOICE,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="private",
+            user_id="user1",
+        ),
+        message_id="msg1",
+        media_urls=["/tmp/voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+
+def _text_event(text: str = "hello") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="private",
+            user_id="user1",
+        ),
+        message_id="msg2",
+    )
+
+
+def _clear_clarify_state():
+    from tools import clarify_gateway as cm
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+        cm._notify_cbs.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestVoiceClarifyIntercept:
+    """Voice messages arriving during a pending clarify should resolve it."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_voice_message_resolves_pending_clarify(self):
+        """A voice message with empty text transcribes and resolves the clarify."""
+        runner = _make_runner()
+        event = _voice_event()
+        session_key = build_session_key(event.source)
+
+        from tools import clarify_gateway as cm
+        cm.register("cid1", session_key, "What do you want?", None)
+
+        with (
+            patch.object(runner, "_is_user_authorized", return_value=True),
+            patch.object(runner, "_session_key_for_source", return_value=session_key),
+            patch(
+                "tools.transcription_tools.transcribe_audio",
+                return_value={"success": True, "transcript": "I want pizza", "provider": "whisper"},
+            ) as mock_stt,
+        ):
+            result = await runner._handle_message(event)
+
+        # The clarify should be resolved with the transcript
+        mock_stt.assert_called_once_with("/tmp/voice.ogg")
+        # _handle_message returns "" when clarify is intercepted
+        assert result == ""
+        # The clarify entry should have the response set
+        entry = cm.get_pending_for_session(session_key)
+        assert entry is not None
+        assert entry.response == "I want pizza"
+
+    @pytest.mark.asyncio
+    async def test_text_message_still_resolves_clarify_normally(self):
+        """Text messages still resolve clarifies via the existing text path."""
+        runner = _make_runner()
+        event = _text_event("I want sushi")
+        session_key = build_session_key(event.source)
+
+        from tools import clarify_gateway as cm
+        cm.register("cid2", session_key, "What food?", None)
+
+        with (
+            patch.object(runner, "_is_user_authorized", return_value=True),
+            patch.object(runner, "_session_key_for_source", return_value=session_key),
+        ):
+            result = await runner._handle_message(event)
+
+        assert result == ""
+        entry = cm.get_pending_for_session(session_key)
+        assert entry is not None
+        assert entry.response == "I want sushi"
+
+    @pytest.mark.asyncio
+    async def test_voice_stt_failure_does_not_resolve_clarify(self):
+        """If STT fails, the clarify stays pending and message falls through."""
+        runner = _make_runner()
+        event = _voice_event()
+        session_key = build_session_key(event.source)
+
+        from tools import clarify_gateway as cm
+        cm.register("cid3", session_key, "Pick one", ["A", "B"])
+
+        with (
+            patch.object(runner, "_is_user_authorized", return_value=True),
+            patch.object(runner, "_session_key_for_source", return_value=session_key),
+            patch(
+                "tools.transcription_tools.transcribe_audio",
+                return_value={"success": False, "error": "no STT provider"},
+            ),
+        ):
+            result = await runner._handle_message(event)
+
+        # Clarify should still be pending (not resolved by failed STT)
+        pending = cm.get_pending_for_session(session_key, include_choice_prompts=True)
+        assert pending is not None
+        assert pending.clarify_id == "cid3"
+
+    @pytest.mark.asyncio
+    async def test_voice_empty_transcript_does_not_resolve_clarify(self):
+        """If STT returns an empty transcript, clarify stays pending."""
+        runner = _make_runner()
+        event = _voice_event()
+        session_key = build_session_key(event.source)
+
+        from tools import clarify_gateway as cm
+        cm.register("cid4", session_key, "What?", None)
+
+        with (
+            patch.object(runner, "_is_user_authorized", return_value=True),
+            patch.object(runner, "_session_key_for_source", return_value=session_key),
+            patch(
+                "tools.transcription_tools.transcribe_audio",
+                return_value={"success": True, "transcript": "", "provider": "whisper"},
+            ),
+        ):
+            result = await runner._handle_message(event)
+
+        # Empty transcript should not resolve
+        pending = cm.get_pending_for_session(session_key)
+        assert pending is not None
+
+    @pytest.mark.asyncio
+    async def test_audio_file_type_also_resolves_clarify(self):
+        """MessageType.AUDIO (file attachment) also resolves clarify via STT."""
+        runner = _make_runner()
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.AUDIO,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="private",
+                user_id="user1",
+            ),
+            message_id="msg5",
+            media_urls=["/tmp/song.mp3"],
+            media_types=["audio/mpeg"],
+        )
+        session_key = build_session_key(event.source)
+
+        from tools import clarify_gateway as cm
+        cm.register("cid5", session_key, "Which one?", ["X", "Y"])
+
+        with (
+            patch.object(runner, "_is_user_authorized", return_value=True),
+            patch.object(runner, "_session_key_for_source", return_value=session_key),
+            patch(
+                "tools.transcription_tools.transcribe_audio",
+                return_value={"success": True, "transcript": "option X please", "provider": "whisper"},
+            ) as mock_stt,
+        ):
+            result = await runner._handle_message(event)
+
+        mock_stt.assert_called_once_with("/tmp/song.mp3")
+        assert result == ""
+        entry = cm.get_pending_for_session(session_key, include_choice_prompts=True)
+        assert entry is not None
+        assert entry.response == "option X please"
+
+    @pytest.mark.asyncio
+    async def test_stt_exception_does_not_crash(self):
+        """If STT raises an exception, the clarify stays pending (no crash)."""
+        runner = _make_runner()
+        event = _voice_event()
+        session_key = build_session_key(event.source)
+
+        from tools import clarify_gateway as cm
+        cm.register("cid6", session_key, "What?", None)
+
+        with (
+            patch.object(runner, "_is_user_authorized", return_value=True),
+            patch.object(runner, "_session_key_for_source", return_value=session_key),
+            patch(
+                "tools.transcription_tools.transcribe_audio",
+                side_effect=RuntimeError("STT service down"),
+            ),
+        ):
+            result = await runner._handle_message(event)
+
+        # Should not crash; clarify stays pending
+        pending = cm.get_pending_for_session(session_key)
+        assert pending is not None


### PR DESCRIPTION
## What does this PR do?

Fixes voice/audio messages being silently ignored when the `clarify` tool is waiting for a user response in the gateway.

When the agent asks a clarifying question via the `clarify` tool and the user responds with a Telegram voice message, the message was dropped because the gateway's clarify intercept only checked `event.text` — which is empty for voice messages (audio is cached in `event.media_urls`). The voice message would fall through to normal dispatch and be treated as a new conversation turn instead of answering the clarify prompt.

Now the clarify intercept detects voice/audio media in the event, transcribes it via the existing STT pipeline (`transcribe_audio`), and resolves the pending clarify with the transcript. Falls back gracefully if STT is disabled, fails, or returns empty text.

## Related Issue

Fixes #56739

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Added voice/audio transcription in the clarify intercept block (lines 8620–8655). When `event.text` is empty and the event carries audio media, transcribe via STT and resolve the pending clarify with the transcript.
- `tests/gateway/test_voice_clarify_intercept.py`: 6 regression tests covering voice resolve, text path unaffected, STT failure graceful fallback, empty transcript handling, audio file type, and STT exception safety.

## How to Test

1. Connect Hermes to Telegram via the gateway with STT enabled.
2. Send a message that triggers the `clarify` tool (e.g., an ambiguous request).
3. When the agent asks a clarifying question, reply with a **voice message**.
4. Observed result: the voice message is transcribed and used as the clarify response. The agent proceeds with the clarified intent.
5. Run `pytest tests/gateway/test_voice_clarify_intercept.py -v` — all 6 tests should pass.
6. Run `pytest tests/tools/test_clarify_gateway.py tests/gateway/test_clarify_active_session_bypass.py tests/gateway/test_telegram_clarify_buttons.py -v` — all 33 existing clarify tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
