### PR TITLE
[codex] hide empty untitled sessions from pickers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13264,7 +13264,10 @@ def main():
 
         if action == "list":
             sessions = db.list_sessions_rich(
-                source=args.source, exclude_sources=_exclude, limit=args.limit
+                source=args.source,
+                exclude_sources=_exclude,
+                exclude_empty_untitled=True,
+                limit=args.limit,
             )
             if not sessions:
                 print("No sessions found.")
@@ -13372,7 +13375,10 @@ def main():
             source = getattr(args, "source", None)
             _browse_exclude = None if source else ["tool"]
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                exclude_empty_untitled=True,
+                limit=limit,
             )
             db.close()
             if not sessions:

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -54,6 +54,7 @@ def query_session_listing(
     rows = session_db.list_sessions_rich(
         source=query_source,
         exclude_sources=exclude_sources,
+        exclude_empty_untitled=True,
         limit=fetch_limit,
     )
     result: list[dict[str, Any]] = []

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2707,6 +2707,7 @@ class SessionDB:
         offset: int = 0,
         include_children: bool = False,
         min_message_count: int = 0,
+        exclude_empty_untitled: bool = False,
         project_compression_tips: bool = True,
         order_by_last_active: bool = False,
         include_archived: bool = False,
@@ -2739,6 +2740,10 @@ class SessionDB:
         surfaces in the correct slot. Ordering is computed at SQL level via
         a recursive CTE that walks compression-continuation edges, so LIMIT
         and OFFSET still apply efficiently.
+
+        Pass ``exclude_empty_untitled=True`` for user-facing resume/list
+        surfaces that should hide non-conversational placeholder rows while
+        preserving named draft sessions with zero messages.
         """
         where_clauses = []
         params = []
@@ -2775,6 +2780,11 @@ class SessionDB:
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
+        if exclude_empty_untitled:
+            where_clauses.append(
+                "(COALESCE(s.message_count, 0) > 0 "
+                "OR LENGTH(TRIM(COALESCE(s.title, ''))) > 0)"
+            )
         if archived_only:
             where_clauses.append("s.archived = 1")
         elif not include_archived:

--- a/tests/hermes_cli/test_session_listing.py
+++ b/tests/hermes_cli/test_session_listing.py
@@ -1,0 +1,43 @@
+from hermes_cli.session_listing import query_session_listing
+
+
+def test_query_session_listing_skips_empty_untitled_placeholders():
+    captured = {}
+
+    class _DB:
+        def list_sessions_rich(self, **kwargs):
+            captured.update(kwargs)
+            rows = [
+                {
+                    "id": "ghost",
+                    "source": "cli",
+                    "title": "",
+                    "preview": "",
+                    "message_count": 0,
+                },
+                {
+                    "id": "real",
+                    "source": "cli",
+                    "title": "",
+                    "preview": "hello",
+                    "message_count": 1,
+                },
+            ]
+            if kwargs.get("exclude_empty_untitled"):
+                rows = [
+                    row
+                    for row in rows
+                    if (row.get("message_count") or 0) > 0
+                    or str(row.get("title") or "").strip()
+                ]
+            return rows
+
+    rows = query_session_listing(
+        _DB(),
+        source="cli",
+        include_unnamed=True,
+        limit=10,
+    )
+
+    assert captured["exclude_empty_untitled"] is True
+    assert [row["id"] for row in rows] == ["real"]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3153,6 +3153,24 @@ class TestListSessionsRich:
         sessions = db.list_sessions_rich()
         assert sessions[0]["preview"] == ""
 
+    def test_exclude_empty_untitled_placeholders_keeps_resumable_rows(self, db):
+        db.create_session("real", "tui")
+        db.append_message("real", "user", "resume me")
+        db.create_session("titled-zero", "tui")
+        db.set_session_title("titled-zero", "Named draft")
+        db.create_session("ghost", "tui")
+        db.end_session("ghost", "tui_shutdown")
+
+        sessions = db.list_sessions_rich(
+            source="tui",
+            exclude_empty_untitled=True,
+        )
+
+        ids = {s["id"] for s in sessions}
+        assert "real" in ids
+        assert "titled-zero" in ids
+        assert "ghost" not in ids
+
     def test_last_active_from_latest_message(self, db):
         import time
         db.create_session("s1", "cli")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5640,6 +5640,55 @@ def test_session_list_returns_clean_error_when_state_db_is_unavailable(monkeypat
     assert "state.db unavailable: locking protocol" in resp["error"]["message"]
 
 
+def test_session_list_skips_empty_untitled_placeholders(monkeypatch):
+    captured = {}
+
+    class _DB:
+        def list_sessions_rich(self, **kwargs):
+            captured.update(kwargs)
+            rows = [
+                {
+                    "id": "ghost",
+                    "source": "tui",
+                    "title": "",
+                    "preview": "",
+                    "message_count": 0,
+                    "started_at": 101,
+                },
+                {
+                    "id": "titled-zero",
+                    "source": "tui",
+                    "title": "Named draft",
+                    "preview": "",
+                    "message_count": 0,
+                    "started_at": 100,
+                },
+                {
+                    "id": "real",
+                    "source": "tui",
+                    "title": "",
+                    "preview": "hello",
+                    "message_count": 1,
+                    "started_at": 99,
+                },
+            ]
+            if kwargs.get("exclude_empty_untitled"):
+                rows = [
+                    row
+                    for row in rows
+                    if (row.get("message_count") or 0) > 0
+                    or str(row.get("title") or "").strip()
+                ]
+            return rows
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request({"id": "1", "method": "session.list", "params": {}})
+
+    assert captured["exclude_empty_untitled"] is True
+    assert [s["id"] for s in resp["result"]["sessions"]] == ["titled-zero", "real"]
+
+
 # --------------------------------------------------------------------------
 # session.delete — TUI resume picker `d` key
 # --------------------------------------------------------------------------
@@ -6317,7 +6366,14 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            exclude_empty_untitled=False,
+        ):
             return [
                 {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
@@ -6334,9 +6390,57 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     assert resp["result"]["source"] == "tui"
 
 
+def test_session_most_recent_skips_empty_untitled_placeholders(monkeypatch):
+    captured = {}
+
+    class _DB:
+        def list_sessions_rich(self, **kwargs):
+            captured.update(kwargs)
+            rows = [
+                {
+                    "id": "ghost",
+                    "source": "tui",
+                    "title": "",
+                    "started_at": 100,
+                    "message_count": 0,
+                },
+                {
+                    "id": "real",
+                    "source": "tui",
+                    "title": "Real",
+                    "started_at": 99,
+                    "message_count": 1,
+                },
+            ]
+            if kwargs.get("exclude_empty_untitled"):
+                rows = [
+                    row
+                    for row in rows
+                    if (row.get("message_count") or 0) > 0
+                    or str(row.get("title") or "").strip()
+                ]
+            return rows
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+
+    assert captured["exclude_empty_untitled"] is True
+    assert resp["result"]["session_id"] == "real"
+
+
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            exclude_empty_untitled=False,
+        ):
             return [{"id": "tool-1", "source": "tool", "started_at": 1}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -6354,7 +6458,14 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     'no answer' (Copilot review on #17130)."""
 
     class _BrokenDB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            exclude_empty_untitled=False,
+        ):
             raise RuntimeError("db locked")
 
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5050,7 +5050,12 @@ def _(rid, params: dict) -> dict:
         fetch_limit = max(limit * 2, 200)
         rows = [
             s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit, order_by_last_active=True)
+            for s in db.list_sessions_rich(
+                source=None,
+                limit=fetch_limit,
+                order_by_last_active=True,
+                exclude_empty_untitled=True,
+            )
             if (s.get("source") or "").strip().lower() not in deny
         ][:limit]
         return _ok(
@@ -5097,7 +5102,12 @@ def _(rid, params: dict) -> dict:
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a
         # similar over-fetch strategy.
-        rows = db.list_sessions_rich(source=None, limit=200, order_by_last_active=True)
+        rows = db.list_sessions_rich(
+            source=None,
+            limit=200,
+            order_by_last_active=True,
+            exclude_empty_untitled=True,
+        )
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:


### PR DESCRIPTION
## Summary

Fixes #56733.

- add an opt-in `exclude_empty_untitled` filter to `SessionDB.list_sessions_rich()` that hides placeholder rows with `message_count = 0` and no title
- use that filter for user-facing session pickers/lists: `hermes sessions list`, `hermes sessions browse`, shared `/sessions` listing, TUI `session.list`, and TUI `session.most_recent`
- preserve named zero-message sessions so user-titled drafts remain resumable
- add regression coverage for the DB filter, shared listing helper, and TUI gateway surfaces

## Testing

- `scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_cli/test_session_listing.py tests/test_tui_gateway_server.py -q -k 'exclude_empty_untitled or skips_empty_untitled_placeholders'`
- `scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_cli/test_session_listing.py tests/test_tui_gateway_server.py tests/cli/test_cli_init.py tests/hermes_cli/test_session_browse.py tests/gateway/test_resume_command.py -q -k 'not test_browser_manage_connect_default_local_reports_launch_hint'`

Note: `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` still has one unrelated browser-management expectation failure in `test_browser_manage_connect_default_local_reports_launch_hint`; it reproduces standalone and is outside the session-listing paths touched here.
