### PR TITLE
[codex] Harden profile stale runtime sweep after update

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -52,6 +52,8 @@ from hermes_cli.colors import Colors, color
 
 logger = logging.getLogger(__name__)
 
+GATEWAY_SYSTEMD_UNIT_GLOB = "hermes*gateway*"
+
 # =============================================================================
 # Process Management (for manual gateway runs)
 # =============================================================================
@@ -99,7 +101,7 @@ def _get_service_pids() -> set:
                     scope_args
                     + [
                         "list-units",
-                        "hermes-gateway*",
+                        GATEWAY_SYSTEMD_UNIT_GLOB,
                         "--plain",
                         "--no-legend",
                         "--no-pager",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5817,6 +5817,28 @@ def _find_stale_dashboard_pids(
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
+
+    def _strip_profile_selector_tokens(command: str) -> str:
+        try:
+            raw_tokens = shlex.split(command, posix=False)
+        except ValueError:
+            raw_tokens = command.split()
+
+        filtered: list[str] = []
+        skip_next = False
+        for token in raw_tokens:
+            normalized = token.strip("\"'")
+            if skip_next:
+                skip_next = False
+                continue
+            if normalized in {"--profile", "-p"}:
+                skip_next = True
+                continue
+            if normalized.startswith("--profile=") or normalized.startswith("-p="):
+                continue
+            filtered.append(normalized)
+        return " ".join(filtered)
+
     patterns = [
         "hermes dashboard",
         "hermes_cli.main dashboard",
@@ -5863,14 +5885,9 @@ def _find_stale_dashboard_pids(
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
-                    # Normalise away ``--profile <name>`` / ``-p <name>``
-                    # — same rationale as the POSIX branch below.
-                    import re as _re
-                    _cmd_norm = _re.sub(
-                        r"\s{2,}",
-                        " ",
-                        _re.sub(r"(?:--profile|-p)\s+\S+", "", current_cmd),
-                    )
+                    # Hermes accepts profile selectors before the subcommand;
+                    # strip them so profile dashboards still match.
+                    _cmd_norm = _strip_profile_selector_tokens(current_cmd)
                     if (
                         any(p in _cmd_norm for p in patterns)
                         and int(pid_str) != self_pid
@@ -5905,17 +5922,9 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    # Normalise away ``--profile <name>`` / ``-p <name>``
-                    # so that ``hermes --profile bruce dashboard`` still
-                    # matches the ``"hermes dashboard"`` pattern.  Without
-                    # this, non-default-profile dashboard processes are
-                    # invisible to the stale-dashboard sweep (issue #56717).
-                    import re as _re
-                    _cmd_norm = _re.sub(
-                        r"\s{2,}",
-                        " ",
-                        _re.sub(r"(?:--profile|-p)\s+\S+", "", command),
-                    )
+                    # Hermes accepts profile selectors before the subcommand;
+                    # strip them so profile dashboards still match.
+                    _cmd_norm = _strip_profile_selector_tokens(command)
                     if any(p in _cmd_norm for p in patterns) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
@@ -10049,6 +10058,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _ensure_user_systemd_env,
                 find_gateway_pids,
                 find_profile_gateway_processes,
+                GATEWAY_SYSTEMD_UNIT_GLOB,
                 launch_detached_profile_gateway_restart,
                 _get_service_pids,
                 _graceful_restart_via_sigusr1,
@@ -10155,7 +10165,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 non-interactive sudo (``sudo -n``) — first a blanket probe,
                 then a targeted ``systemctl reset-failed`` probe so a
                 least-privilege sudoers entry scoped to
-                ``systemctl ... hermes-gateway*`` also qualifies
+                ``systemctl ... hermes*gateway*`` also qualifies
                 (``reset-failed`` is an idempotent no-op we run before every
                 privileged restart anyway).  If neither works, return None —
                 the caller must SKIP the restart (without draining the
@@ -10182,7 +10192,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         sudo_ok = _probe.returncode == 0
                         if not sudo_ok:
                             # Blanket sudo refused — a targeted sudoers entry
-                            # (NOPASSWD for systemctl ... hermes-gateway*)
+                            # (NOPASSWD for systemctl ... hermes*gateway*)
                             # may still allow the exact commands we need.
                             _probe = subprocess.run(
                                 sudo_cmd + ["reset-failed", svc_name_],
@@ -10233,7 +10243,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             relaunched_profiles = []
 
             # --- Systemd services (Linux) ---
-            # Discover all hermes-gateway* units (default + profiles)
+            # Discover default and profile gateway units.
             if supports_systemd_services():
                 try:
                     _ensure_user_systemd_env()
@@ -10249,7 +10259,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             scope_cmd
                             + [
                                 "list-units",
-                                "hermes-gateway*",
+                                GATEWAY_SYSTEMD_UNIT_GLOB,
                                 "--plain",
                                 "--no-legend",
                                 "--no-pager",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5863,8 +5863,16 @@ def _find_stale_dashboard_pids(
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
+                    # Normalise away ``--profile <name>`` / ``-p <name>``
+                    # — same rationale as the POSIX branch below.
+                    import re as _re
+                    _cmd_norm = _re.sub(
+                        r"\s{2,}",
+                        " ",
+                        _re.sub(r"(?:--profile|-p)\s+\S+", "", current_cmd),
+                    )
                     if (
-                        any(p in current_cmd for p in patterns)
+                        any(p in _cmd_norm for p in patterns)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5897,7 +5905,18 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    # Normalise away ``--profile <name>`` / ``-p <name>``
+                    # so that ``hermes --profile bruce dashboard`` still
+                    # matches the ``"hermes dashboard"`` pattern.  Without
+                    # this, non-default-profile dashboard processes are
+                    # invisible to the stale-dashboard sweep (issue #56717).
+                    import re as _re
+                    _cmd_norm = _re.sub(
+                        r"\s{2,}",
+                        " ",
+                        _re.sub(r"(?:--profile|-p)\s+\S+", "", command),
+                    )
+                    if any(p in _cmd_norm for p in patterns) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1046,6 +1046,39 @@ def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch)
     assert gateway._scan_gateway_pids(set(), all_profiles=True) == [2468]
 
 
+def test_get_service_pids_discovers_profile_named_systemd_units(monkeypatch):
+    """Service PID discovery must catch default and profile gateway units."""
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["systemctl", "--user", "list-units"]:
+            glob = cmd[3]
+            if glob == "hermes-gateway*":
+                stdout = "hermes-gateway.service loaded active running Hermes Gateway\n"
+            elif glob == "hermes*gateway*":
+                stdout = (
+                    "hermes-gateway.service loaded active running Hermes Gateway\n"
+                    "hermes-secondbrain-gateway.service loaded active running Hermes Gateway\n"
+                )
+            else:
+                stdout = ""
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+        if cmd[:2] == ["systemctl", "list-units"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["systemctl", "--user", "show"]:
+            pid = {
+                "hermes-gateway.service": "111\n",
+                "hermes-secondbrain-gateway.service": "222\n",
+            }[cmd[3]]
+            return SimpleNamespace(returncode=0, stdout=pid, stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._get_service_pids() == {111, 222}
+
+
 # ---------------------------------------------------------------------------
 # _wait_for_gateway_exit
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_stale_dashboard_profile_detection.py
+++ b/tests/hermes_cli/test_stale_dashboard_profile_detection.py
@@ -85,3 +85,38 @@ class TestProfileAwareDashboardDetection:
             pids = _find_stale_dashboard_pids()
 
         assert 7001 in pids
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only ps test")
+    def test_equals_profile_flags(self):
+        """``--profile=bruce`` and ``-p=bruce`` should also be normalised."""
+        from hermes_cli.main import _find_stale_dashboard_pids
+
+        fake_ps = _fake_ps_output([
+            (6001, "/venv/bin/hermes --profile=bruce dashboard --isolated"),
+            (6002, "/venv/bin/hermes -p=bruce serve --port 9119"),
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=fake_ps,
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert 6001 in pids
+        assert 6002 in pids
+
+    def test_windows_profile_equals_flags(self, monkeypatch):
+        """Windows WMIC output should get the same profile normalisation."""
+        from hermes_cli import main
+
+        fake_wmic = (
+            "CommandLine=hermes --profile=bruce dashboard --isolated\n"
+            "ProcessId=5001\n\n"
+            "CommandLine=python -m hermes_cli.main -p=bruce serve --port 9119\n"
+            "ProcessId=5002\n"
+        )
+        monkeypatch.setattr(main.sys, "platform", "win32")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=fake_wmic)
+            pids = main._find_stale_dashboard_pids()
+
+        assert pids == [5001, 5002]

--- a/tests/hermes_cli/test_stale_dashboard_profile_detection.py
+++ b/tests/hermes_cli/test_stale_dashboard_profile_detection.py
@@ -1,0 +1,87 @@
+"""Regression tests for profile-aware stale dashboard detection.
+
+Verifies that ``_find_stale_dashboard_pids`` correctly identifies dashboard
+processes launched with ``--profile <name>`` or ``-p <name>`` flags between
+the binary name and the subcommand (issue #56717).
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_ps_output(lines: list[tuple[int, str]]) -> str:
+    """Build a fake ``ps -A -o pid=,command=`` output string."""
+    return "\n".join(f"{pid} {cmd}" for pid, cmd in lines)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestProfileAwareDashboardDetection:
+    """Non-default profile dashboards should be found even when
+    ``--profile <name>`` sits between the binary and the subcommand."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only ps test")
+    def test_profile_flag_between_binary_and_subcommand(self):
+        """``hermes --profile bruce dashboard --isolated`` should match."""
+        from hermes_cli.main import _find_stale_dashboard_pids
+
+        fake_ps = _fake_ps_output([
+            (9001, "/venv/bin/hermes --profile bruce dashboard --isolated"),
+            (9002, "/venv/bin/python -m hermes_cli.main --profile bruce dashboard --isolated"),
+            (9003, "/venv/bin/python -m hermes_cli.main -p coder serve --port 9119"),
+            (9999, "/usr/bin/vim somefile.py"),  # unrelated — must NOT match
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=fake_ps,
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert 9001 in pids, "hermes --profile bruce dashboard should be detected"
+        assert 9002 in pids, "hermes_cli.main --profile bruce dashboard should be detected"
+        assert 9003 in pids, "hermes_cli.main -p coder serve should be detected"
+        assert 9999 not in pids, "unrelated process must not match"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only ps test")
+    def test_default_profile_still_detected(self):
+        """Existing non-profile dashboards must continue to match."""
+        from hermes_cli.main import _find_stale_dashboard_pids
+
+        fake_ps = _fake_ps_output([
+            (8001, "/venv/bin/hermes dashboard --isolated"),
+            (8002, "/venv/bin/python -m hermes_cli.main dashboard --isolated"),
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=fake_ps,
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert 8001 in pids
+        assert 8002 in pids
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only ps test")
+    def test_short_profile_flag_p(self):
+        """``-p bruce`` should also be normalised away."""
+        from hermes_cli.main import _find_stale_dashboard_pids
+
+        fake_ps = _fake_ps_output([
+            (7001, "/venv/bin/hermes -p bruce dashboard --isolated"),
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=fake_ps,
+            )
+            pids = _find_stale_dashboard_pids()
+
+        assert 7001 in pids


### PR DESCRIPTION
## Summary

This draft PR builds on the direction in #56723 for #56717 and tightens the stale-runtime cleanup paths for non-default profiles after `hermes update`.

It keeps the original dashboard-process fix and adds two follow-up hardening pieces:

- make stale dashboard/serve process detection token-aware for Hermes profile selectors, covering both `--profile name` / `-p name` and `--profile=name` / `-p=name` forms on POSIX and Windows WMIC scans
- use one shared systemd gateway unit glob, `hermes*gateway*`, so both `hermes-gateway.service` and profile-shaped units like `hermes-secondbrain-gateway.service` are discovered consistently by the update restart path and service-PID exclusion path

## Why

#56717 reports a mixed/stale runtime state for a non-default profile after update. #56723 correctly identifies that `hermes --profile bruce dashboard ...` can evade the stale-dashboard sweep when matching relies on contiguous substrings such as `"hermes dashboard"`.

While checking that path, I found two nearby edge cases worth covering in the same bug class:

- Hermes also accepts equals-form profile selectors (`--profile=bruce`, `-p=bruce`), which the regex-based normalization did not strip.
- The systemd gateway service discovery still used `hermes-gateway*` in some update-related paths, which catches the default unit but not profile-shaped gateway units such as `hermes-secondbrain-gateway.service`.

## Validation

```text
scripts/run_tests.sh tests/hermes_cli/test_stale_dashboard_profile_detection.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_dashboard_lifecycle_flags.py tests/test_windows_subprocess_no_window_flags.py -q
# 106 tests passed, 0 failed

uv run --frozen --extra dev ruff check hermes_cli/main.py hermes_cli/gateway.py tests/hermes_cli/test_stale_dashboard_profile_detection.py tests/hermes_cli/test_gateway.py tests/test_windows_subprocess_no_window_flags.py
# All checks passed

git diff --check
# clean
```

Fixes #56717
Builds on #56723