### PR TITLE
fix(desktop): align context usage and compaction status

### DIFF
--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -40,6 +40,43 @@ def _json_tokens(value: Any) -> int:
     return _chars_to_tokens(json.dumps(value, ensure_ascii=False))
 
 
+def _scale_categories_to_total(
+    categories: Sequence[Tuple[str, str, int]],
+    target_total: int,
+) -> List[Tuple[str, str, int]]:
+    """Scale rough category estimates so their sum matches measured usage.
+
+    ``last_prompt_tokens`` is provider-reported current prompt occupancy, while
+    the category rows are necessarily heuristic buckets. The desktop presents
+    both in one breakdown, so keep the rows as proportional estimates but make
+    the invariant visible to users true: the rows add up to the header total.
+    """
+    rough_total = sum(tokens for _, _, tokens in categories)
+    if target_total <= 0 or rough_total <= 0 or rough_total == target_total:
+        return list(categories)
+
+    scaled: List[Tuple[str, str, int]] = []
+    remainders: List[Tuple[float, int]] = []
+    assigned = 0
+
+    for index, (category_id, label, tokens) in enumerate(categories):
+        if tokens <= 0:
+            scaled.append((category_id, label, 0))
+            continue
+        exact = tokens * target_total / rough_total
+        whole = int(exact)
+        assigned += whole
+        scaled.append((category_id, label, whole))
+        remainders.append((exact - whole, index))
+
+    remainder = target_total - assigned
+    for _, index in sorted(remainders, reverse=True)[:remainder]:
+        category_id, label, tokens = scaled[index]
+        scaled[index] = (category_id, label, tokens + 1)
+
+    return scaled
+
+
 def _tool_name(tool: dict) -> str:
     fn = tool.get("function") if isinstance(tool, dict) else None
     if isinstance(fn, dict):
@@ -114,7 +151,7 @@ def compute_session_context_breakdown(
 
     conversation_tokens = estimate_messages_tokens_rough(messages or [])
 
-    categories = [
+    rough_categories = [
         ("system_prompt", "System prompt", _chars_to_tokens(system_prompt_text)),
         ("tool_definitions", "Tool definitions", _json_tokens(builtin_tools)),
         ("rules", "Rules", _chars_to_tokens(context)),
@@ -125,12 +162,17 @@ def compute_session_context_breakdown(
         ("conversation", "Conversation", conversation_tokens),
     ]
 
-    estimated_total = sum(tokens for _, _, tokens in categories)
+    estimated_total = sum(tokens for _, _, tokens in rough_categories)
 
     comp = getattr(agent, "context_compressor", None)
     context_max = int(getattr(comp, "context_length", 0) or 0) if comp else 0
     measured_used = int(getattr(comp, "last_prompt_tokens", 0) or 0) if comp else 0
     context_used = measured_used if measured_used > 0 else estimated_total
+    categories = (
+        _scale_categories_to_total(rough_categories, context_used)
+        if measured_used > 0
+        else rough_categories
+    )
     context_percent = (
         max(0, min(100, round(context_used / context_max * 100)))
         if context_max

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -50,6 +50,21 @@ COMPACTION_STATUS_MARKER = "Compacting context"
 COMPACTION_STATUS = (
     f"🗜️ {COMPACTION_STATUS_MARKER} — summarizing earlier conversation so I can continue..."
 )
+COMPACTION_DONE_STATUS = "✓ Context compaction complete — continuing turn..."
+
+
+def _emit_compaction_done(agent: Any) -> None:
+    """Emit a structured compaction-complete status for UI drivers.
+
+    ``_emit_status`` intentionally maps everything to the generic lifecycle
+    channel. Desktop needs a distinct edge so its "Summarizing thread" indicator
+    means active work, not "compaction happened sometime during this turn".
+    """
+    if getattr(agent, "status_callback", None):
+        try:
+            agent.status_callback("compacted", COMPACTION_DONE_STATUS)
+        except Exception:
+            logger.debug("status_callback error in _emit_compaction_done", exc_info=True)
 
 
 def _compression_lock_holder(agent: Any) -> str:
@@ -458,6 +473,7 @@ def compress_context(
         focus_topic,
     )
     agent._emit_status(COMPACTION_STATUS)
+    _compaction_done_emitted = False
 
     # ── Compression lock ────────────────────────────────────────────────
     # Atomic, state.db-backed lock per session_id.  Without this, two
@@ -552,6 +568,8 @@ def compress_context(
             _existing_sp = getattr(agent, "_cached_system_prompt", None)
             if not _existing_sp:
                 _existing_sp = agent._build_system_prompt(system_message)
+            _emit_compaction_done(agent)
+            _compaction_done_emitted = True
             return messages, _existing_sp
         if _lock_holder is not None:
             _lock_refresher = _CompressionLockLeaseRefresher(
@@ -564,6 +582,10 @@ def compress_context(
 
     def _release_lock() -> None:
         """Release the lock keyed on the OLD session_id (before rotation)."""
+        nonlocal _compaction_done_emitted
+        if not _compaction_done_emitted:
+            _emit_compaction_done(agent)
+            _compaction_done_emitted = True
         if _lock_refresher is not None:
             _lock_refresher.stop()
         if _lock_db is not None and _lock_sid and _lock_holder:
@@ -613,6 +635,8 @@ def compress_context(
             _existing_sp = getattr(agent, "_cached_system_prompt", None)
             if not _existing_sp:
                 _existing_sp = agent._build_system_prompt(system_message)
+            _emit_compaction_done(agent)
+            _compaction_done_emitted = True
             return messages, _existing_sp
         finally:
             _release_lock()
@@ -1185,6 +1209,7 @@ def try_shrink_image_parts_in_messages(
 
 
 __all__ = [
+    "COMPACTION_DONE_STATUS",
     "COMPACTION_STATUS",
     "COMPACTION_STATUS_MARKER",
     "check_compression_model_feasibility",

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -547,6 +547,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         if (sessionId && payload?.kind === 'compacting') {
           setSessionCompacting(sessionId, true)
           compactedTurnRef.current.add(sessionId)
+        } else if (sessionId && payload?.kind === 'compacted') {
+          setSessionCompacting(sessionId, false)
         } else if (sessionId && payload?.kind === 'process') {
           // The gateway's notification poller announces background process
           // completions / watch matches here — re-sync the status stack.

--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ContextBreakdown, UsageStats } from '@/types/hermes'
+
+import { ContextUsagePanel } from './context-usage-panel'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('ContextUsagePanel', () => {
+  it('publishes the live breakdown usage snapshot so the status bar can re-baseline', async () => {
+    const currentUsage: UsageStats = {
+      calls: 1,
+      input: 0,
+      output: 0,
+      total: 0,
+      context_max: 272_000,
+      context_used: 128_200,
+      context_percent: 47
+    }
+
+    const breakdown: ContextBreakdown = {
+      categories: [{ id: 'conversation', label: 'Conversation', color: 'teal', tokens: 241_400 }],
+      context_max: 272_000,
+      context_percent: 89,
+      context_used: 241_400,
+      estimated_total: 286_600,
+      model: 'test-model'
+    }
+
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
+    const onUsageSnapshot = vi.fn()
+
+    render(
+      <ContextUsagePanel
+        currentUsage={currentUsage}
+        onUsageSnapshot={onUsageSnapshot}
+        requestGateway={requestGateway}
+        sessionId="runtime-1"
+      />
+    )
+
+    await waitFor(() => {
+      expect(onUsageSnapshot).toHaveBeenCalledWith({
+        context_max: 272_000,
+        context_percent: 89,
+        context_used: 241_400
+      })
+    })
+  })
+})

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -7,11 +7,17 @@ import type { ContextBreakdown, ContextUsageCategory, UsageStats } from '@/types
 
 interface ContextUsagePanelProps {
   currentUsage: UsageStats
+  onUsageSnapshot?: (usage: Partial<UsageStats>) => void
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
   sessionId: string | null
 }
 
-export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: ContextUsagePanelProps) {
+export function ContextUsagePanel({
+  currentUsage,
+  onUsageSnapshot,
+  requestGateway,
+  sessionId
+}: ContextUsagePanelProps) {
   const { t } = useI18n()
   const copy = t.shell.statusbar.contextUsagePanel
   const [breakdown, setBreakdown] = useState<ContextBreakdown | null>(null)
@@ -21,6 +27,7 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
     if (!sessionId) {
       setBreakdown(null)
       setLoading(false)
+
       return
     }
 
@@ -31,6 +38,12 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
       .then(data => {
         if (!cancelled) {
           setBreakdown(data)
+
+          onUsageSnapshot?.({
+            context_max: data.context_max,
+            context_percent: data.context_percent,
+            context_used: data.context_used
+          })
         }
       })
       .catch(() => {
@@ -47,10 +60,11 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
     return () => {
       cancelled = true
     }
-  }, [requestGateway, sessionId])
+  }, [onUsageSnapshot, requestGateway, sessionId])
 
   const contextMax = breakdown?.context_max ?? currentUsage.context_max ?? 0
   const contextUsed = breakdown?.context_used ?? currentUsage.context_used ?? 0
+
   const contextPercent = Math.max(
     0,
     Math.min(100, Math.round(breakdown?.context_percent ?? currentUsage.context_percent ?? 0))
@@ -62,7 +76,7 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
         ...category,
         label: copy.categories[category.id as keyof typeof copy.categories] ?? category.label
       })),
-    [breakdown?.categories, copy.categories]
+    [breakdown?.categories, copy]
   )
 
   const segmentTotal = categories.reduce((sum, category) => sum + category.tokens, 0) || contextUsed || 1
@@ -85,10 +99,7 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
         {categories.map(category => (
           <li className="flex items-center justify-between gap-2" key={category.id}>
             <span className="flex min-w-0 items-center gap-2">
-              <span
-                className="size-2 shrink-0 rounded-[2px]"
-                style={{ background: category.color }}
-              />
+              <span className="size-2 shrink-0 rounded-[2px]" style={{ background: category.color }} />
 
               <span className="truncate text-muted-foreground">{category.label}</span>
             </span>

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -21,6 +21,7 @@ import {
   $sessionStartedAt,
   $turnStartedAt,
   $yoloActive,
+  setCurrentUsage,
   setYoloActive
 } from '@/store/session'
 import { $subagentsBySession, activeSubagentCount, failedSubagentCount } from '@/store/subagents'
@@ -369,7 +370,12 @@ export function useStatusbarItems({
         menuAlign: 'end',
         menuClassName: 'w-auto border-(--ui-stroke-secondary) p-0',
         menuContent: (
-          <ContextUsagePanel currentUsage={currentUsage} requestGateway={requestGateway} sessionId={activeSessionId} />
+          <ContextUsagePanel
+            currentUsage={currentUsage}
+            onUsageSnapshot={usage => setCurrentUsage(current => ({ ...current, ...usage }))}
+            requestGateway={requestGateway}
+            sessionId={activeSessionId}
+          />
         ),
         title: copy.openContextUsage,
         variant: 'menu'

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -58,3 +58,22 @@ def test_breakdown_uses_measured_context_when_available():
 
     assert data["context_used"] == 42_000
     assert data["context_percent"] == 21
+
+
+def test_breakdown_scales_category_rows_to_measured_total():
+    agent, parts = _make_agent(
+        stable="system prompt " * 100,
+        context="rules " * 100,
+        volatile="volatile " * 100,
+        tools=[{"type": "function", "function": {"name": "terminal", "description": "run " * 100}}],
+        last_prompt_tokens=42_000,
+    )
+    history = [{"role": "user", "content": "conversation " * 1000}]
+
+    with patch("agent.system_prompt.build_system_prompt_parts", return_value=parts):
+        data = compute_session_context_breakdown(agent, history)
+
+    assert data["context_used"] == 42_000
+    assert data["estimated_total"] != 42_000
+    assert sum(item["tokens"] for item in data["categories"]) == data["context_used"]
+    assert all(item["tokens"] <= data["context_used"] for item in data["categories"])

--- a/tests/tui_gateway/test_compaction_status.py
+++ b/tests/tui_gateway/test_compaction_status.py
@@ -71,3 +71,12 @@ def test_compaction_status_contains_marker():
     )
 
     assert COMPACTION_STATUS_MARKER in COMPACTION_STATUS
+
+
+def test_compaction_done_kind_is_preserved(server, monkeypatch):
+    from agent.conversation_compression import COMPACTION_DONE_STATUS
+
+    events = _capture(server, monkeypatch)
+    server._status_update("sid", "compacted", COMPACTION_DONE_STATUS)
+
+    assert events == [{"kind": "compacted", "text": COMPACTION_DONE_STATUS}]


### PR DESCRIPTION
## Summary
- keep desktop context usage popup internals consistent by scaling rough category buckets to the provider-measured prompt total when real usage is available
- re-baseline the status bar from the live `session.context_breakdown` snapshot when the popup opens, so the footer and popup stop showing stale/different context totals
- add an explicit compaction-complete status edge and clear the desktop "Summarizing thread" indicator as soon as compaction finishes instead of leaving it latched for the rest of the turn

## Issue
The desktop app could show multiple incompatible context numbers at the same time. For example, the footer might show `128.2k/272.0k (47%)`, while the context popup showed `~241.4k/272.0k (89%)`, and the popup's category rows could sum to a third value or even show `Conversation` larger than the header total.

Root causes:
1. the popup header used provider-measured `last_prompt_tokens`, but its category rows were independent rough estimates;
2. the footer used the last pushed usage event while the popup fetched a fresh live breakdown;
3. auto-compaction only emitted a start event, so the desktop treated "Summarizing thread" as a turn-long latch rather than active summarization work.

## Test Plan
- `uv run --with pytest python -m pytest tests/agent/test_context_breakdown.py tests/tui_gateway/test_compaction_status.py tests/test_tui_gateway_server.py::test_get_usage_reports_real_current_occupancy tests/test_tui_gateway_server.py::test_get_usage_clamps_post_compression_sentinel -q -o 'addopts='`
- `npm run test:ui -- src/app/shell/context-usage-panel.test.tsx src/store/compaction.test.ts`
- `npm run typecheck`
- `npx eslint src/app/shell/context-usage-panel.test.tsx src/app/shell/context-usage-panel.tsx src/app/shell/hooks/use-statusbar-items.tsx src/app/session/hooks/use-message-stream/gateway-event.ts`
- `git diff --check`
