### PR TITLE
fix(tui): check prebuilt bundle before requiring ui-tui/ workspace

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1749,10 +1749,12 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         )
         sys.exit(1)
 
-    if not ext_dir:
-        _ensure_tui_workspace(tui_dir)
-
     # 1. Prebuilt bundle (nix / packaged release): just run it.
+    #    These paths need no ``ui-tui/`` source workspace, so check them BEFORE
+    #    requiring one — a pip/uv wheel ships the prebuilt bundle but has no
+    #    ``ui-tui/`` dir and isn't a git checkout, so calling
+    #    _ensure_tui_workspace() first would abort with a bogus "git restore"
+    #    message and never reach the bundle it actually shipped.
     if not tui_dev:
         if ext_dir:
             p = Path(ext_dir)
@@ -1771,6 +1773,11 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     #    Existing desktop behaviour runs npm from the workspace root.  Termux
     #    scopes the install to ui-tui so launch does not pull desktop/web
     #    dependencies into the hot path.
+    #    This is the only path that builds from the ``ui-tui/`` source tree, so
+    #    the workspace guard belongs here (skipped when HERMES_TUI_DIR points at
+    #    an external checkout, matching the prior behaviour).
+    if not ext_dir:
+        _ensure_tui_workspace(tui_dir)
     did_install = False
     termux_startup = _is_termux_startup_environment()
     termux_need_rebuild = False

--- a/tests/hermes_cli/test_tui_bundled.py
+++ b/tests/hermes_cli/test_tui_bundled.py
@@ -1,3 +1,6 @@
+import sys
+
+import pytest
 
 
 def test_tui_finds_bundled_entry_js(tmp_path):
@@ -18,3 +21,66 @@ def test_tui_returns_none_when_no_bundle(tmp_path):
     from hermes_cli.main import _find_bundled_tui
     result = _find_bundled_tui(hermes_cli_dir=tmp_path / "hermes_cli")
     assert result is None
+
+
+def test_prebuilt_bundle_used_before_workspace_guard(tmp_path, monkeypatch):
+    """Regression: a wheel install (no ``ui-tui/`` source, not a git checkout) must
+    run the prebuilt bundle instead of aborting in ``_ensure_tui_workspace()``.
+
+    Previously ``_make_tui_argv`` ran the workspace guard *before* the
+    prebuilt-bundle checks, so pip/uv installs died with a bogus
+    "git restore -- ui-tui" message and never reached the bundle the wheel ships.
+    """
+    import hermes_cli.main as m
+
+    tui_dir = tmp_path / "ui-tui"  # deliberately absent, as on a wheel install
+    assert not tui_dir.exists()
+
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setenv("HERMES_NODE", sys.executable)  # a real executable file
+    monkeypatch.setattr(m, "_ensure_tui_node", lambda: None)
+
+    bundled = tmp_path / "hermes_cli" / "tui_dist" / "entry.js"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("// bundled TUI", encoding="utf-8")
+    monkeypatch.setattr(m, "_find_bundled_tui", lambda *a, **k: bundled)
+
+    def _guard_must_not_run(_td):
+        raise AssertionError(
+            "_ensure_tui_workspace ran before the prebuilt-bundle check"
+        )
+
+    monkeypatch.setattr(m, "_ensure_tui_workspace", _guard_must_not_run)
+
+    argv, cwd = m._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert argv[0] == sys.executable
+    assert argv[-1] == str(bundled)
+    assert cwd == bundled.parent
+
+
+def test_workspace_guard_runs_when_no_bundle(tmp_path, monkeypatch):
+    """The relocated guard still runs on the source-build path: when there is no
+    prebuilt bundle and no ``HERMES_TUI_DIR``, ``_make_tui_argv`` must fall through
+    to ``_ensure_tui_workspace()`` before attempting an npm/esbuild build.
+    """
+    import hermes_cli.main as m
+
+    tui_dir = tmp_path / "ui-tui"
+
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setenv("HERMES_NODE", sys.executable)
+    monkeypatch.setattr(m, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(m, "_find_bundled_tui", lambda *a, **k: None)
+
+    class _GuardReached(Exception):
+        pass
+
+    def _guard(td):
+        assert td == tui_dir
+        raise _GuardReached
+
+    monkeypatch.setattr(m, "_ensure_tui_workspace", _guard)
+
+    with pytest.raises(_GuardReached):
+        m._make_tui_argv(tui_dir, tui_dev=False)


### PR DESCRIPTION
## What does this PR do?

`hermes --tui` (and `hermes --yolo`, which defaults to the TUI) aborts on a
pip/uv wheel install with:

```
Error: the TUI workspace is missing from this Hermes checkout.
Expected directory: .../site-packages/ui-tui
This usually means `hermes update` left tracked ui-tui files deleted.
Recovery:
  1. From the Hermes checkout, run `git restore -- ui-tui`
  ...
```

The recovery advice is impossible to follow for these installs: a wheel has no
`ui-tui/` source tree and is not a git checkout, so `git restore` does nothing
and `hermes update --force` just reinstalls the same layout.

Root cause: `_make_tui_argv()` in `hermes_cli/main.py` called
`_ensure_tui_workspace()` — which hard-exits when `ui-tui/` is absent — **before**
the prebuilt-bundle checks. But the wheel *does* ship a runnable prebuilt TUI at
`hermes_cli/tui_dist/entry.js` (it's in the wheel RECORD), which
`_find_bundled_tui()` is meant to run. Because the workspace guard ran first, that
bundle was never reached.

Fix: check the prebuilt-bundle paths (`HERMES_TUI_DIR` and `_find_bundled_tui()`)
**before** the workspace guard, and move the guard to the top of the source-build
path (section 2), which is the only path that actually needs a `ui-tui/` tree. The
guard stays conditioned on `not HERMES_TUI_DIR`, so behavior for git-checkout, dev
(`--dev`), and `HERMES_TUI_DIR` users is unchanged.

## Related Issue

<!-- No existing issue linked. Search the tracker / create one if the project requires it. -->

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py` — in `_make_tui_argv()`, moved the prebuilt-bundle
  resolution (the `HERMES_TUI_DIR` dist check and `_find_bundled_tui()`) ahead of
  the `_ensure_tui_workspace()` call, and relocated `_ensure_tui_workspace()` to
  the start of the source-build path (section 2). No other logic changed.
- `tests/hermes_cli/test_tui_bundled.py` — added two regression tests:
  `test_prebuilt_bundle_used_before_workspace_guard` (a wheel install with no
  `ui-tui/` runs the bundle and never reaches the guard) and
  `test_workspace_guard_runs_when_no_bundle` (the relocated guard still runs on
  the source-build path when no bundle exists).

## How to Test

Reproduction (before this change), on any pip/uv wheel install with Node present
and no `ui-tui/` source dir:

1. `pip install hermes-agent` (or `uv tool install hermes-agent`).
2. `hermes --tui` → aborts with "the TUI workspace is missing from this Hermes
   checkout" and the unusable `git restore -- ui-tui` recovery text.

Proof the fix works:

3. With this change, `_make_tui_argv()` resolves to the shipped bundle instead of
   aborting — it returns `[node, "--expose-gc", ".../hermes_cli/tui_dist/entry.js"]`
   (cwd `.../hermes_cli/tui_dist`) and `hermes --tui` launches normally.

Control-flow verification (no `ui-tui/`, no `HERMES_TUI_DIR`) confirms the
prebuilt-bundle branch is taken and `_ensure_tui_workspace()` is never reached.
The `--dev`, git-checkout, and `HERMES_TUI_DIR` paths are unaffected because the
guard still runs for them at the top of the source-build path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected tests and they pass: `pytest tests/hermes_cli/test_tui_bundled.py tests/hermes_cli/test_tui_npm_install.py tests/hermes_cli/test_tui_resume_flow.py tests/docker/test_tui_prebuilt_bundle.py -q` → 81 passed, 2 skipped (the full `tests/` suite requires external services/API keys not available in my environment)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Alpine Linux edge (musl), kernel 6.18, x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (control-flow reorder only; no doc-facing change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is platform-agnostic control flow; it actually removes a spurious failure that hits every wheel install regardless of OS

## Screenshots / Logs

Before (wheel install, `hermes --tui`):

```
Error: the TUI workspace is missing from this Hermes checkout.
Expected directory: .../site-packages/ui-tui
This usually means `hermes update` left tracked ui-tui files deleted.
Recovery:
  1. From the Hermes checkout, run `git restore -- ui-tui`
  2. Run `npm install --silent --no-fund --no-audit --progress=false`
  3. Retry `hermes --tui`
If the checkout is still inconsistent, run `hermes update --force`.
```

After (same install): `hermes --tui` runs the bundled
`hermes_cli/tui_dist/entry.js` and the TUI starts normally.