### PR TITLE
fix(agent): pass MoA context overrides to aggregator

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1834,7 +1834,9 @@ def get_model_context_length(
                     agg_model,
                     base_url=rt.get("base_url", "") or "",
                     api_key=rt.get("api_key", "") or "",
+                    config_context_length=config_context_length,
                     provider=agg_provider,
+                    custom_providers=custom_providers,
                 )
         except Exception:
             logger.debug("MoA aggregator context-length resolution failed", exc_info=True)

--- a/tests/agent/test_moa_context_length.py
+++ b/tests/agent/test_moa_context_length.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def test_moa_context_length_uses_aggregator_custom_provider_override():
+    """MoA should resolve its acting aggregator's configured context length.
+
+    The virtual ``moa`` provider's model is just a preset name.  The acting
+    context window belongs to the preset's aggregator, including per-model
+    custom-provider overrides threaded in by the caller.
+    """
+    from agent.model_metadata import get_model_context_length
+
+    custom_providers = [
+        {
+            "name": "private-router",
+            "base_url": "https://private.example/v1",
+            "models": {
+                "private-32k": {
+                    "context_length": 32_768,
+                },
+            },
+        }
+    ]
+
+    with patch("hermes_cli.config.load_config", return_value={"moa": {}}), patch(
+        "hermes_cli.moa_config.resolve_moa_preset",
+        return_value={
+            "aggregator": {"provider": "private-router", "model": "private-32k"},
+            "reference_models": [],
+        },
+    ), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={
+            "provider": "private-router",
+            "model": "private-32k",
+            "base_url": "https://private.example/v1",
+            "api_key": "test-key",
+            "api_mode": "chat_completions",
+        },
+    ):
+        assert (
+            get_model_context_length(
+                "default",
+                provider="moa",
+                custom_providers=custom_providers,
+            )
+            == 32_768
+        )


### PR DESCRIPTION
Fixes #56749.\n\nMoA context-length resolution now forwards the caller's configured context override and custom provider table into the recursive aggregator lookup, so the virtual MoA provider reports the acting aggregator's configured window instead of falling through to the 256k default.\n\nTests: scripts/run_tests.sh tests/agent/test_moa_context_length.py