### PR TITLE
feat(web): delegate backend availability check to plugin registry for unknown backends

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -235,6 +235,17 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    # Plugin-registered backends: when the name isn't in the hardcoded
+    # whitelist above, ask the provider registry — any plugin-backed
+    # provider (crawl4ai, etc.) supplies its own is_available() check
+    # and doesn't need a per-backend entry here.
+    try:
+        from agent.web_search_registry import get_provider
+        provider = get_provider(backend)
+        if provider is not None:
+            return bool(provider.is_available())
+    except Exception:
+        pass
     return False
 
 


### PR DESCRIPTION
## Problem

`_is_backend_available()` in `web_tools.py` is a hardcoded whitelist of backend names. Any plugin-registered backend (e.g., crawl4ai, future extract-only providers) is silently rejected because the function doesn't recognize its name — even though the plugin has already registered via `PluginContext.register_web_search_provider()` with its own `is_available()` check.

This means setting `web.extract_backend: crawl4ai` in config has **no effect** unless someone first patches `_is_backend_available()` to add a per-backend block. Every new extract-only plugin would need its own hardcoded entry.

## Fix

Add a fallthrough at the bottom of `_is_backend_available()`: when the backend name doesn't match any hardcoded entry, ask the provider registry whether a plugin has registered a provider for that name, and delegate to `provider.is_available()`.

## Why this approach

- **One change, all plugins**: No per-backend special cases in core. Any plugin that registers via `register_web_search_provider()` works automatically.
- **Plugin owns its check**: The plugin's own `is_available()` (which it implements via the `WebSearchProvider` ABC) is the authority — core doesn't need to know about specific packages or env vars.
- **Matches existing pattern**: `ddgs` already checks package importability. This is the same idea, generalized to the plugin registry.
- **Minimal surface**: 11 lines, no new imports at module level, lazy import prevents circular dependency.

## Tested

Verified end-to-end on a host with the crawl4ai plugin registered. Backward-compatible: the hardcoded checks run first and are unchanged. The fallthrough only fires for names not already recognized.