### PR TITLE
feat(kanban): add safe Discord projection loop

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,23 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _config_bool(value: Any, default: bool = False) -> bool:
+    """Parse a config boolean without treating string "false" as truthy."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on", "enabled"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off", "disabled", ""}:
+            return False
+    return default
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -56,6 +73,81 @@ def _resolve_auto_decompose_settings(
         per_tick = 1
     return enabled, per_tick
 
+
+
+def _resolve_discord_projection_outbox_drain_settings(
+    load_config: Callable[[], Any],
+) -> "tuple[bool, int]":
+    """Resolve the explicitly mocked Discord projection outbox drain gate.
+
+    This is intentionally disabled by default and only supports a test/mocked
+    sender path.  It never constructs a Discord adapter and never performs
+    archive actions; it just lets the gateway layer exercise the durable
+    outbox projector with a caller-provided send callable.
+    """
+    try:
+        cfg = load_config()
+    except Exception:
+        return False, 1
+    kcfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    enabled = _config_bool(kcfg.get("discord_projection_outbox_drain_mock"), False)
+    try:
+        max_events = int(kcfg.get("discord_projection_outbox_drain_per_tick", 1) or 1)
+    except (TypeError, ValueError):
+        max_events = 1
+    return enabled, max(1, max_events)
+
+
+def _drain_discord_projection_outbox_once(
+    *,
+    kb_module: Any,
+    kdp_module: Any,
+    send: Callable[[str, str, str], str],
+    max_events: int = 1,
+) -> list[Any]:
+    """Drain up to ``max_events`` Discord projection rows across kanban boards.
+
+    The supplied ``send`` is the only delivery path.  Passing a fake sender in
+    tests records outbox delivery; production code must opt in explicitly and
+    still cannot accidentally use a live Discord adapter through this helper.
+    """
+    if not callable(send):
+        return []
+    remaining = max(1, int(max_events or 1))
+    try:
+        boards = kb_module.list_boards(include_archived=False)
+    except Exception:
+        boards = [kb_module.read_board_metadata(kb_module.DEFAULT_BOARD)]
+
+    results: list[Any] = []
+    seen_db_paths: set[str] = set()
+    for board_meta in boards:
+        if remaining <= 0:
+            break
+        slug = board_meta.get("slug") or kb_module.DEFAULT_BOARD
+        db_path = board_meta.get("db_path")
+        try:
+            resolved_db_path = str(Path(db_path).expanduser().resolve()) if db_path else str(kb_module.kanban_db_path(slug).resolve())
+        except Exception:
+            resolved_db_path = f"slug:{slug}"
+        if resolved_db_path in seen_db_paths:
+            continue
+        seen_db_paths.add(resolved_db_path)
+        conn = None
+        try:
+            conn = kb_module.connect(board=slug)
+            while remaining > 0:
+                result = kdp_module.project_next_outbox_event(conn, send)
+                if getattr(result, "event_id", None) is None:
+                    break
+                results.append(result)
+                remaining -= 1
+                if not getattr(result, "delivered", False):
+                    break
+        finally:
+            if conn is not None:
+                conn.close()
+    return results
 
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
@@ -740,6 +832,58 @@ class GatewayKanbanWatchersMixin:
                     "kanban notifier: artifact upload (%s) failed: %s",
                     path, exc,
                 )
+
+
+    def _kanban_discord_projection_drain_tick(self) -> list[Any]:
+        """One dry-run/mocked Discord projection outbox drain tick.
+
+        Gated by ``kanban.discord_projection_outbox_drain_mock`` (default
+        false).  The sender must be injected as
+        ``self._kanban_discord_projection_send`` by a test harness or another
+        explicitly mocked caller.  No live Discord adapter is discovered here.
+        """
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            logger.warning("kanban discord projection: config loader unavailable; disabled")
+            return []
+        enabled, max_events = _resolve_discord_projection_outbox_drain_settings(_load_config)
+        if not enabled:
+            logger.debug("kanban discord projection: mocked outbox drain disabled")
+            return []
+        send = getattr(self, "_kanban_discord_projection_send", None)
+        if not callable(send):
+            logger.warning(
+                "kanban discord projection: mocked outbox drain enabled but no injected sender; disabled"
+            )
+            return []
+        try:
+            from hermes_cli import kanban_db as _kb
+            from hermes_cli import kanban_discord_projection as _kdp
+        except Exception as exc:
+            logger.warning("kanban discord projection: imports unavailable; disabled (%s)", exc)
+            return []
+        return _drain_discord_projection_outbox_once(
+            kb_module=_kb,
+            kdp_module=_kdp,
+            send=send,
+            max_events=max_events,
+        )
+
+    async def _kanban_discord_projection_watcher(self, interval: float = 5.0) -> None:
+        """Disabled-by-default dry-run/mocked Discord projection drain loop."""
+        while self._running:
+            try:
+                await asyncio.to_thread(self._kanban_discord_projection_drain_tick)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("kanban discord projection: watcher tick failed")
+            slept = 0.0
+            interval = max(float(interval or 1.0), 1.0)
+            while slept < interval and self._running:
+                await asyncio.sleep(min(1.0, interval - slept))
+                slept += 1.0
 
     async def _kanban_dispatcher_watcher(self) -> None:
         """Embedded kanban dispatcher — one tick every `dispatch_interval_seconds`.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6906,6 +6906,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # so human-in-the-loop workflows hear back without polling.
         asyncio.create_task(self._kanban_notifier_watcher())
 
+        # Start background kanban Discord projection drain. This watcher is
+        # inert unless its own default-off mocked/dry-run config gate is true
+        # and an explicit test/mock sender has been injected; it never creates
+        # a live Discord adapter.
+        asyncio.create_task(self._kanban_discord_projection_watcher())
+
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -99,7 +99,10 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+VALID_STATUSES = {
+    "triage", "todo", "scheduled", "ready", "running", "blocked",
+    "review", "done", "archive_candidate", "closed", "archived",
+}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
@@ -914,6 +917,11 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    parent_discord_thread_id: Optional[str] = None
+    parent_discord_channel_id: Optional[str] = None
+    parent_discord_guild_id: Optional[str] = None
+    discord_thread_link_state: Optional[str] = None
+    discord_thread_link_idempotency_key: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -997,6 +1005,22 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            parent_discord_thread_id=(
+                row["parent_discord_thread_id"] if "parent_discord_thread_id" in keys else None
+            ),
+            parent_discord_channel_id=(
+                row["parent_discord_channel_id"] if "parent_discord_channel_id" in keys else None
+            ),
+            parent_discord_guild_id=(
+                row["parent_discord_guild_id"] if "parent_discord_guild_id" in keys else None
+            ),
+            discord_thread_link_state=(
+                row["discord_thread_link_state"] if "discord_thread_link_state" in keys else None
+            ),
+            discord_thread_link_idempotency_key=(
+                row["discord_thread_link_idempotency_key"]
+                if "discord_thread_link_idempotency_key" in keys else None
             ),
         )
 
@@ -1175,7 +1199,16 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Mandatory human-audit projection seam. Discord is a projection/log
+    -- surface only; Kanban remains lifecycle source of truth.
+    parent_discord_thread_id TEXT,
+    parent_discord_channel_id TEXT,
+    parent_discord_guild_id TEXT,
+    discord_thread_link_state TEXT,
+    discord_thread_link_idempotency_key TEXT,
+    discord_thread_linked_at INTEGER,
+    discord_thread_link_failed_at INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1263,6 +1296,38 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+CREATE TABLE IF NOT EXISTS discord_projection_outbox (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type         TEXT NOT NULL,
+    issue_id           TEXT NOT NULL,
+    from_status        TEXT,
+    to_status          TEXT,
+    actor              TEXT,
+    reason             TEXT,
+    summary            TEXT,
+    sequence           INTEGER,
+    parent_thread_id   TEXT NOT NULL,
+    idempotency_key    TEXT NOT NULL UNIQUE,
+    delivery_status    TEXT NOT NULL DEFAULT 'pending',
+    attempts           INTEGER NOT NULL DEFAULT 0,
+    last_error         TEXT,
+    discord_message_id TEXT,
+    payload            TEXT,
+    created_at         INTEGER NOT NULL,
+    delivered_at       INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS discord_close_audit (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id           TEXT NOT NULL,
+    parent_thread_id   TEXT,
+    observed_status    TEXT,
+    dry_run            INTEGER NOT NULL DEFAULT 1,
+    allowed            INTEGER NOT NULL DEFAULT 0,
+    reasons            TEXT,
+    created_at         INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1273,6 +1338,12 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_outbox_delivery
+    ON discord_projection_outbox(delivery_status, id);
+CREATE INDEX IF NOT EXISTS idx_outbox_issue
+    ON discord_projection_outbox(issue_id, event_type, sequence);
+CREATE INDEX IF NOT EXISTS idx_close_audit_issue
+    ON discord_close_audit(issue_id, created_at);
 """
 
 
@@ -1986,6 +2057,20 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    discord_projection_columns = {
+        "parent_discord_thread_id": "parent_discord_thread_id TEXT",
+        "parent_discord_channel_id": "parent_discord_channel_id TEXT",
+        "parent_discord_guild_id": "parent_discord_guild_id TEXT",
+        "discord_thread_link_state": "discord_thread_link_state TEXT",
+        "discord_thread_link_idempotency_key": "discord_thread_link_idempotency_key TEXT",
+        "discord_thread_linked_at": "discord_thread_linked_at INTEGER",
+        "discord_thread_link_failed_at": "discord_thread_link_failed_at INTEGER",
+    }
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    for column, ddl in discord_projection_columns.items():
+        if column not in cols:
+            _add_column_if_missing(conn, "tasks", column, ddl)
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2000,6 +2085,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    if {"parent_discord_thread_id", "status"} <= cols:
+        existing_parent_idx = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_tasks_parent_discord_thread'"
+        ).fetchone()
+        if existing_parent_idx and "status NOT IN" in (existing_parent_idx["sql"] or ""):
+            conn.execute("DROP INDEX idx_tasks_parent_discord_thread")
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_parent_discord_thread "
+            "ON tasks(parent_discord_thread_id) "
+            "WHERE parent_discord_thread_id IS NOT NULL"
+        )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -3385,6 +3482,23 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        projection = conn.execute(
+            """
+            SELECT parent_discord_thread_id, discord_thread_link_state
+              FROM tasks
+             WHERE id = ? AND status = 'ready'
+            """,
+            (task_id,),
+        ).fetchone()
+        if projection and (
+            not projection["parent_discord_thread_id"]
+            or projection["discord_thread_link_state"] != "linked"
+        ):
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {"reason": "discord_parent_thread_not_linked"},
+            )
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -3514,6 +3628,23 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        projection = conn.execute(
+            """
+            SELECT parent_discord_thread_id, discord_thread_link_state
+              FROM tasks
+             WHERE id = ? AND status = 'review'
+            """,
+            (task_id,),
+        ).fetchone()
+        if projection and (
+            not projection["parent_discord_thread_id"]
+            or projection["discord_thread_link_state"] != "linked"
+        ):
+            _append_event(
+                conn, task_id, "claim_rejected",
+                {"reason": "discord_parent_thread_not_linked", "source_status": "review"},
+            )
+            return None
         cur = conn.execute(
             """
             UPDATE tasks

--- a/hermes_cli/kanban_discord_projection.py
+++ b/hermes_cli/kanban_discord_projection.py
@@ -1,0 +1,597 @@
+"""Kanban issue -> Discord parent-thread projection seams.
+
+This module keeps Discord as an append-only projection/log surface.  It never
+uses Discord delivery, archive state, reactions, or typing to decide Kanban
+lifecycle.  Callers persist Kanban lifecycle first, then enqueue/retry durable
+projection events here.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from hermes_cli import kanban_db as kb
+
+LINK_STATES = {"pending", "linked", "failed", "projection_blocked"}
+TERMINAL_ARCHIVE_STATUSES = {"archive_candidate", "closed"}
+CHECKPOINT_TYPES = {
+    "accepted",
+    "claimed",
+    "progress",
+    "blocker",
+    "waiting_for_approval",
+    "handoff",
+    "test",
+    "review",
+    "done",
+    "failed",
+}
+
+
+class ProjectionBlocked(RuntimeError):
+    """Raised when an issue cannot project to its required parent thread."""
+
+
+class ParentThreadConflict(RuntimeError):
+    """Raised when linking would violate the 1 issue <-> 1 parent thread rule."""
+
+
+@dataclass(frozen=True)
+class ParentThread:
+    issue_id: str
+    guild_id: str
+    channel_id: str
+    thread_id: str
+    link_state: str
+
+
+@dataclass(frozen=True)
+class LinkResult:
+    issue_id: str
+    thread_id: str
+    created: bool
+    link_state: str = "linked"
+
+
+@dataclass(frozen=True)
+class OutboxEvent:
+    id: int
+    event_type: str
+    issue_id: str
+    parent_thread_id: str
+    idempotency_key: str
+    delivery_status: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ProjectionResult:
+    delivered: bool
+    event_id: Optional[int] = None
+    idempotency_key: Optional[str] = None
+    message_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class TypingIndicatorState:
+    last_sent_by_thread: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ArchiveDryRunPlan:
+    issue_id: str
+    status: Optional[str]
+    allowed: bool
+    live_mode: bool
+    reasons: list[str]
+    parent_thread_id: Optional[str]
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+
+def mark_projection_required(conn: sqlite3.Connection, issue_id: str) -> None:
+    """Enroll an issue in the mandatory Discord-parent projection gate."""
+    with kb.write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET discord_thread_link_state = COALESCE(discord_thread_link_state, 'pending')
+             WHERE id = ?
+            """,
+            (issue_id,),
+        )
+        if cur.rowcount != 1:
+            raise ValueError(f"unknown issue_id: {issue_id}")
+
+
+def get_parent_thread(conn: sqlite3.Connection, issue_id: str) -> Optional[ParentThread]:
+    row = conn.execute(
+        """
+        SELECT id, parent_discord_guild_id, parent_discord_channel_id,
+               parent_discord_thread_id, discord_thread_link_state
+          FROM tasks
+         WHERE id = ?
+        """,
+        (issue_id,),
+    ).fetchone()
+    if not row or not row["parent_discord_thread_id"]:
+        return None
+    return ParentThread(
+        issue_id=row["id"],
+        guild_id=row["parent_discord_guild_id"],
+        channel_id=row["parent_discord_channel_id"],
+        thread_id=row["parent_discord_thread_id"],
+        link_state=row["discord_thread_link_state"] or "pending",
+    )
+
+
+def is_dispatchable(conn: sqlite3.Connection, issue_id: str) -> bool:
+    row = conn.execute(
+        """
+        SELECT status, parent_discord_thread_id, discord_thread_link_state
+          FROM tasks
+         WHERE id = ?
+        """,
+        (issue_id,),
+    ).fetchone()
+    if not row:
+        return False
+    if row["status"] not in {"ready", "review"}:
+        return False
+    return bool(row["parent_discord_thread_id"] and row["discord_thread_link_state"] == "linked")
+
+
+def _ensure_thread_not_owned_by_other_active_issue(
+    conn: sqlite3.Connection, issue_id: str, thread_id: str
+) -> None:
+    row = conn.execute(
+        """
+        SELECT id FROM tasks
+         WHERE parent_discord_thread_id = ?
+           AND id != ?
+         LIMIT 1
+        """,
+        (thread_id, issue_id),
+    ).fetchone()
+    if row:
+        raise ParentThreadConflict(
+            f"discord thread {thread_id} is already parent for active issue {row['id']}"
+        )
+
+
+def link_parent_thread(
+    conn: sqlite3.Connection,
+    *,
+    issue_id: str,
+    guild_id: str,
+    channel_id: str,
+    thread_id: str,
+    idempotency_key: str,
+) -> LinkResult:
+    """Idempotently bind exactly one Discord parent thread to one issue."""
+    if not all([issue_id, guild_id, channel_id, thread_id, idempotency_key]):
+        raise ValueError("issue_id, guild_id, channel_id, thread_id, and idempotency_key are required")
+    with kb.write_txn(conn):
+        row = conn.execute(
+            """
+            SELECT parent_discord_thread_id, discord_thread_link_state,
+                   discord_thread_link_idempotency_key
+              FROM tasks
+             WHERE id = ?
+            """,
+            (issue_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"unknown issue_id: {issue_id}")
+        existing = row["parent_discord_thread_id"]
+        if existing:
+            if existing == thread_id:
+                return LinkResult(issue_id=issue_id, thread_id=thread_id, created=False)
+            raise ParentThreadConflict(
+                f"issue {issue_id} already has parent Discord thread {existing}"
+            )
+        _ensure_thread_not_owned_by_other_active_issue(conn, issue_id, thread_id)
+        conn.execute(
+            """
+            UPDATE tasks
+               SET parent_discord_guild_id = ?,
+                   parent_discord_channel_id = ?,
+                   parent_discord_thread_id = ?,
+                   discord_thread_link_state = 'linked',
+                   discord_thread_link_idempotency_key = ?,
+                   discord_thread_linked_at = ?
+             WHERE id = ?
+            """,
+            (guild_id, channel_id, thread_id, idempotency_key, _now(), issue_id),
+        )
+        kb._append_event(
+            conn,
+            issue_id,
+            "discord_parent_thread_linked",
+            {
+                "guild_id": guild_id,
+                "channel_id": channel_id,
+                "thread_id": thread_id,
+                "idempotency_key": idempotency_key,
+            },
+        )
+    return LinkResult(issue_id=issue_id, thread_id=thread_id, created=True)
+
+
+def _parent_thread_or_raise(conn: sqlite3.Connection, issue_id: str) -> ParentThread:
+    parent = get_parent_thread(conn, issue_id)
+    if not parent or parent.link_state != "linked":
+        raise ProjectionBlocked(f"issue {issue_id} has no linked parent Discord thread")
+    return parent
+
+
+def _status_message(
+    *, from_status: str, to_status: str, actor: str, reason: Optional[str], next_step: Optional[str]
+) -> str:
+    lines = [
+        f"Kanban status changed: {from_status} -> {to_status}",
+        f"Actor: {actor}",
+    ]
+    if reason:
+        lines.append(f"Reason: {reason}")
+    if next_step:
+        lines.append(f"Next: {next_step}")
+    return "\n".join(lines)
+
+
+def record_status_change(
+    conn: sqlite3.Connection,
+    *,
+    issue_id: str,
+    from_status: str,
+    to_status: str,
+    actor: str,
+    reason: Optional[str] = None,
+    summary: Optional[str] = None,
+    next_step: Optional[str] = None,
+    sequence: int,
+) -> int:
+    """Create a durable Discord projection event for a Kanban state change."""
+    parent = _parent_thread_or_raise(conn, issue_id)
+    idempotency_key = f"kanban-status:{issue_id}:{sequence}:{from_status}->{to_status}"
+    content = _status_message(
+        from_status=from_status,
+        to_status=to_status,
+        actor=actor,
+        reason=reason or summary,
+        next_step=next_step,
+    )
+    payload = {
+        "content": content,
+        "from_status": from_status,
+        "to_status": to_status,
+        "actor": actor,
+        "reason": reason,
+        "summary": summary,
+        "next_step": next_step,
+        "sequence": sequence,
+    }
+    with kb.write_txn(conn):
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO discord_projection_outbox (
+                event_type, issue_id, from_status, to_status, actor, reason,
+                summary, sequence, parent_thread_id, idempotency_key,
+                delivery_status, payload, created_at
+            ) VALUES ('status_changed', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+            """,
+            (
+                issue_id,
+                from_status,
+                to_status,
+                actor,
+                reason,
+                summary,
+                int(sequence),
+                parent.thread_id,
+                idempotency_key,
+                _json(payload),
+                _now(),
+            ),
+        )
+        row = conn.execute(
+            "SELECT id FROM discord_projection_outbox WHERE idempotency_key = ?",
+            (idempotency_key,),
+        ).fetchone()
+        return int(row["id"])
+
+
+def _row_to_outbox(row: sqlite3.Row) -> OutboxEvent:
+    payload = json.loads(row["payload"] or "{}")
+    return OutboxEvent(
+        id=int(row["id"]),
+        event_type=row["event_type"],
+        issue_id=row["issue_id"],
+        parent_thread_id=row["parent_thread_id"],
+        idempotency_key=row["idempotency_key"],
+        delivery_status=row["delivery_status"],
+        payload=payload,
+    )
+
+
+def list_outbox(conn: sqlite3.Connection) -> list[OutboxEvent]:
+    rows = conn.execute(
+        "SELECT * FROM discord_projection_outbox ORDER BY id"
+    ).fetchall()
+    return [_row_to_outbox(row) for row in rows]
+
+
+def mark_outbox_delivered(
+    conn: sqlite3.Connection, idempotency_key: str, discord_message_id: str
+) -> bool:
+    with kb.write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE discord_projection_outbox
+               SET delivery_status = 'delivered', discord_message_id = ?, delivered_at = ?
+             WHERE idempotency_key = ?
+            """,
+            (discord_message_id, _now(), idempotency_key),
+        )
+        return cur.rowcount == 1
+
+
+def project_next_outbox_event(
+    conn: sqlite3.Connection,
+    send: Callable[[str, str, str], str],
+) -> ProjectionResult:
+    """Deliver one pending/failed projection event.
+
+    ``send`` receives ``(thread_id, content, idempotency_key)``.  Delivery
+    failure only marks the outbox row retryable; it never changes Kanban task
+    status.
+    """
+    row = conn.execute(
+        """
+        SELECT * FROM discord_projection_outbox
+         WHERE delivery_status IN ('pending', 'failed')
+         ORDER BY id
+         LIMIT 1
+        """
+    ).fetchone()
+    if not row:
+        return ProjectionResult(delivered=False)
+    event = _row_to_outbox(row)
+    try:
+        message_id = send(
+            event.parent_thread_id,
+            str(event.payload.get("content") or ""),
+            event.idempotency_key,
+        )
+    except Exception as exc:
+        with kb.write_txn(conn):
+            conn.execute(
+                """
+                UPDATE discord_projection_outbox
+                   SET delivery_status = 'failed', attempts = attempts + 1,
+                       last_error = ?
+                 WHERE id = ?
+                """,
+                (str(exc), event.id),
+            )
+        return ProjectionResult(
+            delivered=False,
+            event_id=event.id,
+            idempotency_key=event.idempotency_key,
+            error=str(exc),
+        )
+    mark_outbox_delivered(conn, event.idempotency_key, str(message_id))
+    return ProjectionResult(
+        delivered=True,
+        event_id=event.id,
+        idempotency_key=event.idempotency_key,
+        message_id=str(message_id),
+    )
+
+
+def _checkpoint_content(
+    *,
+    checkpoint_type: str,
+    agent_profile: str,
+    session_id: str,
+    run_id: str,
+    summary: str,
+    next_step: Optional[str],
+    blocker: Optional[str],
+    evidence: Optional[str],
+) -> str:
+    lines = [
+        f"Agent checkpoint: {checkpoint_type}",
+        f"Agent: {agent_profile}",
+        f"Session/run: {session_id} / {run_id}",
+        f"Summary: {summary}",
+    ]
+    if next_step:
+        lines.append(f"Next: {next_step}")
+    if blocker:
+        lines.append(f"Blocker: {blocker}")
+    if evidence:
+        lines.append(f"Evidence: {evidence}")
+    return "\n".join(lines)
+
+
+def emit_agent_checkpoint(
+    conn: sqlite3.Connection,
+    *,
+    issue_id: str,
+    checkpoint_type: str,
+    agent_profile: str,
+    session_id: str,
+    run_id: str,
+    summary: str,
+    next_step: Optional[str] = None,
+    blocker: Optional[str] = None,
+    evidence: Optional[str] = None,
+    now: Optional[int] = None,
+) -> LinkResult:
+    if checkpoint_type not in CHECKPOINT_TYPES:
+        raise ValueError(f"unknown checkpoint_type: {checkpoint_type}")
+    parent = _parent_thread_or_raise(conn, issue_id)
+    semantic = _json(
+        {
+            "issue_id": issue_id,
+            "checkpoint_type": checkpoint_type,
+            "agent_profile": agent_profile,
+            "session_id": session_id,
+            "run_id": run_id,
+            "summary": summary,
+            "next_step": next_step,
+            "blocker": blocker,
+            "evidence": evidence,
+        }
+    )
+    digest = hashlib.sha256(semantic.encode("utf-8")).hexdigest()[:24]
+    idempotency_key = f"kanban-checkpoint:{issue_id}:{digest}"
+    content = _checkpoint_content(
+        checkpoint_type=checkpoint_type,
+        agent_profile=agent_profile,
+        session_id=session_id,
+        run_id=run_id,
+        summary=summary,
+        next_step=next_step,
+        blocker=blocker,
+        evidence=evidence,
+    )
+    payload = {
+        "content": content,
+        "checkpoint_type": checkpoint_type,
+        "agent_profile": agent_profile,
+        "session_id": session_id,
+        "run_id": run_id,
+        "summary": summary,
+        "next_step": next_step,
+        "blocker": blocker,
+        "evidence": evidence,
+    }
+    with kb.write_txn(conn):
+        before = conn.execute(
+            "SELECT id FROM discord_projection_outbox WHERE idempotency_key = ?",
+            (idempotency_key,),
+        ).fetchone()
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO discord_projection_outbox (
+                event_type, issue_id, actor, summary, parent_thread_id,
+                idempotency_key, delivery_status, payload, created_at
+            ) VALUES ('agent_checkpoint', ?, ?, ?, ?, ?, 'pending', ?, ?)
+            """,
+            (
+                issue_id,
+                agent_profile,
+                summary,
+                parent.thread_id,
+                idempotency_key,
+                _json(payload),
+                int(now if now is not None else _now()),
+            ),
+        )
+    return LinkResult(issue_id=issue_id, thread_id=parent.thread_id, created=before is None)
+
+
+def send_typing_best_effort(
+    thread_id: str,
+    send_typing: Callable[[str], None],
+    *,
+    state: TypingIndicatorState,
+    now: Optional[float] = None,
+    min_interval_seconds: float = 5.0,
+) -> bool:
+    if not thread_id:
+        return False
+    current = float(now if now is not None else time.monotonic())
+    previous = state.last_sent_by_thread.get(thread_id)
+    if previous is not None and (current - previous) < min_interval_seconds:
+        return False
+    state.last_sent_by_thread[thread_id] = current
+    try:
+        send_typing(thread_id)
+        return True
+    except Exception:
+        return False
+
+
+def _latest_required_projection_delivered(
+    conn: sqlite3.Connection, issue_id: str, status: str
+) -> bool:
+    row = conn.execute(
+        """
+        SELECT delivery_status
+          FROM discord_projection_outbox
+         WHERE issue_id = ?
+           AND event_type = 'status_changed'
+           AND to_status = ?
+         ORDER BY sequence DESC, id DESC
+         LIMIT 1
+        """,
+        (issue_id, status),
+    ).fetchone()
+    return bool(row and row["delivery_status"] == "delivered")
+
+
+def plan_archive_dry_run(conn: sqlite3.Connection, issue_id: str) -> ArchiveDryRunPlan:
+    """Evaluate archive safety gates without Discord side effects.
+
+    MVP deliberately keeps live_mode False.  ``done`` posts status but does not
+    auto-archive; only ``archive_candidate`` and ``closed`` are archive-eligible.
+    """
+    row = conn.execute(
+        """
+        SELECT status, parent_discord_thread_id, discord_thread_link_state,
+               current_run_id, claim_lock
+          FROM tasks
+         WHERE id = ?
+        """,
+        (issue_id,),
+    ).fetchone()
+    if row is None:
+        return ArchiveDryRunPlan(issue_id, None, False, False, ["issue not found"], None)
+
+    status = row["status"]
+    parent_thread_id = row["parent_discord_thread_id"]
+    reasons: list[str] = []
+    if status == "done":
+        reasons.append("status done is not archive-eligible in MVP")
+    elif status not in TERMINAL_ARCHIVE_STATUSES:
+        reasons.append(f"status {status} is not archive-eligible in MVP")
+    if not parent_thread_id or row["discord_thread_link_state"] != "linked":
+        reasons.append("parent Discord thread is not linked")
+    if row["current_run_id"] or row["claim_lock"]:
+        reasons.append("active worker/session present")
+    if status in TERMINAL_ARCHIVE_STATUSES and not _latest_required_projection_delivered(conn, issue_id, status):
+        reasons.append("required terminal status projection is not delivered")
+
+    allowed = not reasons
+    with kb.write_txn(conn):
+        conn.execute(
+            """
+            INSERT INTO discord_close_audit (
+                issue_id, parent_thread_id, observed_status, dry_run,
+                allowed, reasons, created_at
+            ) VALUES (?, ?, ?, 1, ?, ?, ?)
+            """,
+            (issue_id, parent_thread_id, status, 1 if allowed else 0, _json({"reasons": reasons}), _now()),
+        )
+    return ArchiveDryRunPlan(
+        issue_id=issue_id,
+        status=status,
+        allowed=allowed,
+        live_mode=False,
+        reasons=reasons,
+        parent_thread_id=parent_thread_id,
+    )

--- a/tests/gateway/test_kanban_discord_projection_watcher.py
+++ b/tests/gateway/test_kanban_discord_projection_watcher.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_discord_projection as kdp
+
+
+def _runner(send=None):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    if send is not None:
+        runner._kanban_discord_projection_send = send
+    return runner
+
+
+def _cfg(enabled=True, per_tick=1):
+    return {
+        "kanban": {
+            "discord_projection_outbox_drain_mock": enabled,
+            "discord_projection_outbox_drain_per_tick": per_tick,
+        }
+    }
+
+
+def _linked_status_event():
+    conn = kb.connect()
+    try:
+        issue_id = kb.create_task(conn, title="gateway projection", assignee="worker")
+        kdp.link_parent_thread(
+            conn,
+            issue_id=issue_id,
+            guild_id="guild-1",
+            channel_id="channel-1",
+            thread_id="thread-parent-1",
+            idempotency_key="link:gateway-projection",
+        )
+        kdp.record_status_change(
+            conn,
+            issue_id=issue_id,
+            from_status="ready",
+            to_status="running",
+            actor="developer",
+            reason="mock drain",
+            sequence=42,
+        )
+        return issue_id
+    finally:
+        conn.close()
+
+
+def _outbox_rows():
+    conn = kb.connect()
+    try:
+        return kdp.list_outbox(conn)
+    finally:
+        conn.close()
+
+
+def test_discord_projection_drain_is_disabled_by_default():
+    runner = _runner(send=lambda *_: "msg-never")
+    with patch("hermes_cli.config.load_config", return_value={"kanban": {}}):
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            assert runner._kanban_discord_projection_drain_tick() == []
+    mock_connect.assert_not_called()
+
+
+def test_discord_projection_drain_requires_injected_mock_sender():
+    runner = _runner()
+    with patch("hermes_cli.config.load_config", return_value=_cfg(True)):
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            assert runner._kanban_discord_projection_drain_tick() == []
+    mock_connect.assert_not_called()
+
+
+def test_mocked_discord_projection_drain_delivers_one_outbox_event_with_parent_thread_metadata():
+    issue_id = _linked_status_event()
+    sent = []
+
+    def fake_send(thread_id: str, content: str, idempotency_key: str) -> str:
+        sent.append((thread_id, content, idempotency_key))
+        return "discord-message-1"
+
+    runner = _runner(send=fake_send)
+    with patch("hermes_cli.config.load_config", return_value=_cfg(True, per_tick=1)):
+        results = runner._kanban_discord_projection_drain_tick()
+
+    assert len(results) == 1
+    assert results[0].delivered is True
+    assert sent == [
+        (
+            "thread-parent-1",
+            "Kanban status changed: ready -> running\nActor: developer\nReason: mock drain",
+            f"kanban-status:{issue_id}:42:ready->running",
+        )
+    ]
+    rows = _outbox_rows()
+    assert len(rows) == 1
+    assert rows[0].delivery_status == "delivered"
+    assert rows[0].parent_thread_id == "thread-parent-1"
+
+    # Idempotency: a second tick sees no pending event and performs no send.
+    with patch("hermes_cli.config.load_config", return_value=_cfg(True, per_tick=1)):
+        again = runner._kanban_discord_projection_drain_tick()
+    assert again == []
+    assert len(sent) == 1
+
+
+def test_mocked_discord_projection_failure_is_retryable_and_does_not_mutate_task_or_archive():
+    issue_id = _linked_status_event()
+    attempts = []
+
+    def failing_send(thread_id: str, content: str, idempotency_key: str) -> str:
+        attempts.append((thread_id, idempotency_key))
+        raise RuntimeError("mock discord down")
+
+    runner = _runner(send=failing_send)
+    with patch("hermes_cli.config.load_config", return_value=_cfg(True, per_tick=1)):
+        results = runner._kanban_discord_projection_drain_tick()
+
+    assert len(results) == 1
+    assert results[0].delivered is False
+    assert results[0].error == "mock discord down"
+    assert attempts == [("thread-parent-1", f"kanban-status:{issue_id}:42:ready->running")]
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, issue_id)
+        assert task is not None
+        assert task.status == "ready"
+        row = conn.execute(
+            "SELECT delivery_status, attempts, last_error FROM discord_projection_outbox WHERE issue_id = ?",
+            (issue_id,),
+        ).fetchone()
+        assert row["delivery_status"] == "failed"
+        assert row["attempts"] == 1
+        assert row["last_error"] == "mock discord down"
+        audits = conn.execute("SELECT COUNT(*) AS n FROM discord_close_audit").fetchone()["n"]
+        assert audits == 0
+    finally:
+        conn.close()
+
+
+def test_mocked_discord_projection_drain_dedupes_board_aliases_to_same_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "shared-projection.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    kb.write_board_metadata("alias-a", name="Alias A")
+    kb.write_board_metadata("alias-b", name="Alias B")
+    _linked_status_event()
+
+    sent = []
+
+    def fake_send(thread_id: str, content: str, idempotency_key: str) -> str:
+        sent.append(idempotency_key)
+        return "discord-message-1"
+
+    runner = _runner(send=fake_send)
+    with patch("hermes_cli.config.load_config", return_value=_cfg(True, per_tick=3)):
+        results = runner._kanban_discord_projection_drain_tick()
+
+    assert len(results) == 1
+    assert len(sent) == 1
+
+def test_discord_projection_drain_string_false_is_disabled():
+    runner = _runner(send=lambda *_: "msg-never")
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value=_cfg("false", per_tick=1),
+    ):
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            assert runner._kanban_discord_projection_drain_tick() == []
+    mock_connect.assert_not_called()
+
+
+def test_gateway_startup_wires_discord_projection_watcher_into_lifecycle():
+    source = GatewayRunner.start.__code__.co_names
+    assert "_kanban_discord_projection_watcher" in source
+

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -18,6 +18,8 @@ KANBAN_METHODS = [
     "_kanban_unsub",
     "_kanban_rewind",
     "_deliver_kanban_artifacts",
+    "_kanban_discord_projection_drain_tick",
+    "_kanban_discord_projection_watcher",
 ]
 
 
@@ -43,6 +45,7 @@ def test_watcher_loops_are_coroutines():
     # The two long-running watchers are async loops.
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_notifier_watcher)
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_dispatcher_watcher)
+    assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_discord_projection_watcher)
 
 
 def test_singleton_dispatcher_lock_is_exclusive(tmp_path):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -51,6 +51,31 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture(autouse=True)
+def _auto_link_parent_threads_for_legacy_core_tests(monkeypatch):
+    """Seed synthetic parent-thread links for pre-projection lifecycle tests."""
+    original_create_task = kb.create_task
+
+    def create_task_with_parent_thread(conn, *args, **kwargs):
+        task_id = original_create_task(conn, *args, **kwargs)
+        conn.execute(
+            """
+            UPDATE tasks
+               SET parent_discord_thread_id = ?,
+                   parent_discord_channel_id = 'test-channel',
+                   parent_discord_guild_id = 'test-guild',
+                   discord_thread_link_state = 'linked',
+                   discord_thread_link_idempotency_key = ?
+             WHERE id = ?
+            """,
+            (f"test-parent:{task_id}", f"test-link:{task_id}", task_id),
+        )
+        conn.commit()
+        return task_id
+
+    monkeypatch.setattr(kb, "create_task", create_task_with_parent_thread)
+
+
 # ---------------------------------------------------------------------------
 # Idempotency key
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -28,6 +28,36 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture(autouse=True)
+def _auto_link_parent_threads_for_legacy_db_tests(monkeypatch):
+    """Keep DB-layer lifecycle tests focused on lifecycle mechanics.
+
+    The Discord projection tests cover the no-parent claim gate explicitly. The
+    older DB tests predate that invariant and exercise claim/retry/dispatch
+    behavior, so seed a unique synthetic parent link for tasks they create.
+    """
+    original_create_task = kb.create_task
+
+    def create_task_with_parent_thread(conn, *args, **kwargs):
+        task_id = original_create_task(conn, *args, **kwargs)
+        conn.execute(
+            """
+            UPDATE tasks
+               SET parent_discord_thread_id = ?,
+                   parent_discord_channel_id = 'test-channel',
+                   parent_discord_guild_id = 'test-guild',
+                   discord_thread_link_state = 'linked',
+                   discord_thread_link_idempotency_key = ?
+             WHERE id = ?
+            """,
+            (f"test-parent:{task_id}", f"test-link:{task_id}", task_id),
+        )
+        conn.commit()
+        return task_id
+
+    monkeypatch.setattr(kb, "create_task", create_task_with_parent_thread)
+
+
 def _init_git_repo(repo: Path) -> None:
     repo.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, text=True)

--- a/tests/hermes_cli/test_kanban_discord_projection.py
+++ b/tests/hermes_cli/test_kanban_discord_projection.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_discord_projection as kdp
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_issue_without_parent_thread_is_not_dispatchable(kanban_home):
+    with kb.connect() as conn:
+        issue_id = kb.create_task(conn, title="needs parent thread")
+        kdp.mark_projection_required(conn, issue_id)
+
+        assert kdp.is_dispatchable(conn, issue_id) is False
+        assert kb.claim_task(conn, issue_id, claimer="worker") is None
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (issue_id,))
+        conn.commit()
+        assert kb.claim_review_task(conn, issue_id, claimer="reviewer") is None
+
+
+def test_unmarked_ready_issue_without_parent_thread_cannot_be_claimed(kanban_home):
+    with kb.connect() as conn:
+        issue_id = kb.create_task(conn, title="unmarked ready needs parent thread")
+
+        assert kdp.is_dispatchable(conn, issue_id) is False
+        claimed = kb.claim_task(conn, issue_id, claimer="worker")
+        task = kb.get_task(conn, issue_id)
+        assert claimed is None
+        assert task is not None
+        assert task.status == "ready"
+
+
+def test_unmarked_review_issue_without_parent_thread_cannot_be_claimed(kanban_home):
+    with kb.connect() as conn:
+        issue_id = kb.create_task(conn, title="unmarked review needs parent thread")
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (issue_id,))
+        conn.commit()
+
+        assert kdp.is_dispatchable(conn, issue_id) is False
+        claimed = kb.claim_review_task(conn, issue_id, claimer="reviewer")
+        task = kb.get_task(conn, issue_id)
+        assert claimed is None
+        assert task is not None
+        assert task.status == "review"
+
+
+def test_link_parent_thread_is_idempotent_and_rejects_duplicates(kanban_home):
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="first")
+        second = kb.create_task(conn, title="second")
+
+        linked = kdp.link_parent_thread(
+            conn,
+            issue_id=first,
+            guild_id="guild-1",
+            channel_id="channel-1",
+            thread_id="thread-1",
+            idempotency_key="link:first",
+        )
+        again = kdp.link_parent_thread(
+            conn,
+            issue_id=first,
+            guild_id="guild-1",
+            channel_id="channel-1",
+            thread_id="thread-1",
+            idempotency_key="link:first",
+        )
+
+        assert linked.created is True
+        assert again.created is False
+        assert kdp.get_parent_thread(conn, first).thread_id == "thread-1"
+
+        with pytest.raises(kdp.ParentThreadConflict):
+            kdp.link_parent_thread(
+                conn,
+                issue_id=first,
+                guild_id="guild-1",
+                channel_id="channel-1",
+                thread_id="thread-2",
+                idempotency_key="link:first:other",
+            )
+
+        with pytest.raises(kdp.ParentThreadConflict):
+            kdp.link_parent_thread(
+                conn,
+                issue_id=second,
+                guild_id="guild-1",
+                channel_id="channel-1",
+                thread_id="thread-1",
+                idempotency_key="link:second",
+            )
+
+
+@pytest.mark.parametrize("terminal_status", ["closed", "archived"])
+def test_parent_thread_reuse_after_terminal_status_is_rejected(kanban_home, terminal_status):
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title=f"first {terminal_status}")
+        second = kb.create_task(conn, title=f"second {terminal_status}")
+        kdp.link_parent_thread(
+            conn,
+            issue_id=first,
+            guild_id="guild-1",
+            channel_id="channel-1",
+            thread_id="thread-1",
+            idempotency_key=f"link:first:{terminal_status}",
+        )
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (terminal_status, first))
+        conn.commit()
+
+        with pytest.raises(kdp.ParentThreadConflict):
+            kdp.link_parent_thread(
+                conn,
+                issue_id=second,
+                guild_id="guild-1",
+                channel_id="channel-1",
+                thread_id="thread-1",
+                idempotency_key=f"link:second:{terminal_status}",
+            )
+
+
+def test_status_change_outbox_projector_is_idempotent(kanban_home):
+    sent: list[tuple[str, str, str]] = []
+
+    def send(thread_id: str, content: str, idempotency_key: str) -> str:
+        sent.append((thread_id, content, idempotency_key))
+        return f"msg-{len(sent)}"
+
+    with kb.connect() as conn:
+        issue_id = kb.create_task(conn, title="status projection")
+        kdp.link_parent_thread(
+            conn,
+            issue_id=issue_id,
+            guild_id="guild-1",
+            channel_id="channel-1",
+            thread_id="thread-1",
+            idempotency_key="link:status",
+        )
+
+        event_id = kdp.record_status_change(
+            conn,
+            issue_id=issue_id,
+            from_status="ready",
+            to_status="running",
+            actor="developer",
+            reason="claimed for implementation",
+            next_step="post progress checkpoint",
+            sequence=7,
+        )
+        assert event_id == kdp.record_status_change(
+            conn,
+            issue_id=issue_id,
+            from_status="ready",
+            to_status="running",
+            actor="developer",
+            reason="claimed for implementation",
+            next_step="post progress checkpoint",
+            sequence=7,
+        )
+
+        result = kdp.project_next_outbox_event(conn, send)
+        assert result.delivered is True
+        assert sent == [
+            (
+                "thread-1",
+                "Kanban status changed: ready -> running\nActor: developer\nReason: claimed for implementation\nNext: post progress checkpoint",
+                f"kanban-status:{issue_id}:7:ready->running",
+            )
+        ]
+        assert kdp.project_next_outbox_event(conn, send).delivered is False
+
+
+def test_failed_projection_does_not_mutate_lifecycle_and_retry_dedupes(kanban_home):
+    attempts = 0
+
+    def flaky_send(thread_id: str, content: str, idempotency_key: str) -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("discord unavailable")
+        return "discord-msg-1"
+
+    with kb.connect() as conn:
+        issue_id = kb.create_task(conn, title="retry projection")
+        kdp.link_parent_thread(
+            conn,
+            issue_id=issue_id,
+            guild_id="guild-1",
+            channel_id="channel-1",
+            thread_id="thread-1",
+            idempotency_key="link:retry",
+        )
+        kdp.record_status_change(
+            conn,
+            issue_id=issue_id,
+            from_status="ready",
+            to_status="done",
+            actor="developer",
+            reason="finished",
+            sequence=1,
+        )
+
+        failed = kdp.project_next_outbox_event(conn, flaky_send)
+        assert failed.delivered is False
+        assert kb.get_task(conn, issue_id).status == "ready"
+
+        delivered = kdp.project_next_outbox_event(conn, flaky_send)
+        assert delivered.delivered is True
+        assert attempts == 2
+        assert kdp.project_next_outbox_event(conn, flaky_send).delivered is False
+
+
+def test_agent_checkpoint_targets_parent_thread_and_dedupes(kanban_home):
+    with kb.connect() as conn:
+        issue_id = kb.create_task(conn, title="checkpoint")
+        kdp.link_parent_thread(
+            conn,
+            issue_id=issue_id,
+            guild_id="guild-1",
+            channel_id="channel-1",
+            thread_id="thread-1",
+            idempotency_key="link:checkpoint",
+        )
+
+        first = kdp.emit_agent_checkpoint(
+            conn,
+            issue_id=issue_id,
+            checkpoint_type="progress",
+            agent_profile="developer",
+            session_id="session-1",
+            run_id="run-1",
+            summary="implemented helper",
+            next_step="run tests",
+            evidence="unit test added",
+            now=1000,
+        )
+        duplicate = kdp.emit_agent_checkpoint(
+            conn,
+            issue_id=issue_id,
+            checkpoint_type="progress",
+            agent_profile="developer",
+            session_id="session-1",
+            run_id="run-1",
+            summary="implemented helper",
+            next_step="run tests",
+            evidence="unit test added",
+            now=1010,
+        )
+
+        assert first.created is True
+        assert duplicate.created is False
+        pending = kdp.list_outbox(conn)
+        assert len(pending) == 1
+        assert pending[0].parent_thread_id == "thread-1"
+        assert "Agent checkpoint: progress" in pending[0].payload["content"]
+
+
+def test_typing_indicator_is_best_effort_and_rate_limited():
+    calls: list[str] = []
+
+    def typing(thread_id: str) -> None:
+        calls.append(thread_id)
+        raise RuntimeError("rate limited")
+
+    state = kdp.TypingIndicatorState()
+
+    assert kdp.send_typing_best_effort("thread-1", typing, state=state, now=1000) is False
+    assert kdp.send_typing_best_effort("thread-1", typing, state=state, now=1001) is False
+    assert calls == ["thread-1"]
+
+
+def test_archive_dry_run_gates_status_projection_and_active_work(kanban_home):
+    with kb.connect() as conn:
+        done_issue = kb.create_task(conn, title="done must not auto archive")
+        archive_issue = kb.create_task(conn, title="archive candidate")
+        blocked_issue = kb.create_task(conn, title="active blocker")
+
+        for issue_id in (done_issue, archive_issue, blocked_issue):
+            kdp.link_parent_thread(
+                conn,
+                issue_id=issue_id,
+                guild_id="guild-1",
+                channel_id="channel-1",
+                thread_id=f"thread-{issue_id}",
+                idempotency_key=f"link:{issue_id}",
+            )
+
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (done_issue,))
+        conn.execute("UPDATE tasks SET status = 'archive_candidate' WHERE id = ?", (archive_issue,))
+        conn.execute("UPDATE tasks SET status = 'closed', current_run_id = 123 WHERE id = ?", (blocked_issue,))
+        conn.commit()
+        kdp.record_status_change(
+            conn,
+            issue_id=archive_issue,
+            from_status="done",
+            to_status="archive_candidate",
+            actor="pm",
+            reason="review passed",
+            sequence=1,
+        )
+        kdp.mark_outbox_delivered(conn, f"kanban-status:{archive_issue}:1:done->archive_candidate", "msg-1")
+
+        done_plan = kdp.plan_archive_dry_run(conn, done_issue)
+        archive_plan = kdp.plan_archive_dry_run(conn, archive_issue)
+        blocked_plan = kdp.plan_archive_dry_run(conn, blocked_issue)
+
+        assert done_plan.allowed is False
+        assert "status done is not archive-eligible in MVP" in done_plan.reasons
+        assert archive_plan.allowed is True
+        assert archive_plan.live_mode is False
+        assert blocked_plan.allowed is False
+        assert "active worker/session present" in blocked_plan.reasons
+        assert kb.get_task(conn, archive_issue).status == "archive_candidate"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -146,6 +146,33 @@ def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
 # Handler happy paths
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def _auto_link_parent_threads_for_legacy_tool_tests(monkeypatch):
+    """Seed synthetic parent-thread links for pre-projection tool tests."""
+    from hermes_cli import kanban_db as kb
+
+    original_create_task = kb.create_task
+
+    def create_task_with_parent_thread(conn, *args, **kwargs):
+        task_id = original_create_task(conn, *args, **kwargs)
+        conn.execute(
+            """
+            UPDATE tasks
+               SET parent_discord_thread_id = ?,
+                   parent_discord_channel_id = 'test-channel',
+                   parent_discord_guild_id = 'test-guild',
+                   discord_thread_link_state = 'linked',
+                   discord_thread_link_idempotency_key = ?
+             WHERE id = ?
+            """,
+            (f"test-parent:{task_id}", f"test-link:{task_id}", task_id),
+        )
+        conn.commit()
+        return task_id
+
+    monkeypatch.setattr(kb, "create_task", create_task_with_parent_thread)
+
+
 @pytest.fixture
 def worker_env(monkeypatch, tmp_path):
     """Simulate being a worker: HERMES_HOME isolated, HERMES_KANBAN_TASK set


### PR DESCRIPTION
## Summary
- add Kanban Discord parent-thread projection seam and report-only outbox flow
- add default-off gateway watcher wiring with injected sender only
- enforce linked parent-thread invariant for ready/review claim paths and permanent no-reuse of parent thread ids

## Safety
- default-off config gate
- no live Discord API adapter in this change
- no archive/close side effects
- Kanban remains lifecycle source of truth

## Tests
- python3 -m py_compile gateway/run.py gateway/kanban_watchers.py hermes_cli/kanban_db.py hermes_cli/kanban_discord_projection.py
- pytest tests/gateway/test_kanban_discord_projection_watcher.py tests/gateway/test_kanban_watchers_mixin.py tests/hermes_cli/test_kanban_discord_projection.py -q => 22 passed
- pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_watchers_mixin.py tests/hermes_cli/test_kanban_discord_projection.py tests/gateway/test_kanban_discord_projection_watcher.py -q => 517 passed, 1 skipped

## Local deploy note
- also cherry-picked into local active runtime for Rosta's Hermes gateway testing
