### PR TITLE
fix(browser): guard Camofox eval private pages

### DIFF
--- a/tests/tools/test_browser_eval_ssrf.py
+++ b/tests/tools/test_browser_eval_ssrf.py
@@ -141,6 +141,55 @@ class TestExpressionPreScan:
 # ---------------------------------------------------------------------------
 
 
+class TestCamofoxEvalGuard:
+    def _guard_on(self, monkeypatch):
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: True)
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_local_sidecar_key", lambda key: False)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+
+    def test_camofox_blocks_private_fetch_literal_before_request(self, monkeypatch):
+        self._guard_on(monkeypatch)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
+        monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda url: False)
+
+        import tools.browser_camofox as camofox
+
+        def fail_session(*_args, **_kwargs):
+            raise AssertionError("Camofox request should not run for a private URL literal")
+
+        monkeypatch.setattr(camofox, "_ensure_tab", fail_session)
+
+        result = _eval(f"fetch('{PRIVATE_URL}').then(r => r.text())")
+
+        assert result["success"] is False
+        assert "private or internal address" in result["error"]
+        assert PRIVATE_URL in result["error"]
+
+    def test_camofox_blocks_when_current_page_is_private(self, monkeypatch):
+        self._guard_on(monkeypatch)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
+        monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda url: False)
+
+        import tools.browser_camofox as camofox
+
+        monkeypatch.setattr(camofox, "_ensure_tab", lambda task_id: {"tab_id": "tab-1", "user_id": "user-1"})
+
+        def fake_post(path, body=None, **_kwargs):
+            if body and body.get("expression") == "window.location.href":
+                return {"result": PRIVATE_URL}
+            return {"result": "secret DOM text"}
+
+        monkeypatch.setattr(camofox, "_post", fake_post)
+
+        result = _eval("document.body.innerText")
+
+        assert result["success"] is False
+        assert "private or internal address" in result["error"]
+        assert PRIVATE_URL in result["error"]
+        assert "secret DOM text" not in json.dumps(result)
+
+
 class TestPostEvalPageRecheck:
     def _guard_on(self, monkeypatch):
         monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3536,19 +3536,8 @@ def _enforce_browser_eval_policy(expression: str) -> Optional[str]:
 
 def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     """Evaluate a JavaScript expression in the page context and return the result."""
-    if _is_camofox_mode():
-        return _camofox_eval(expression, task_id)
-
     effective_task_id = _last_session_key(task_id or "default")
 
-    # ── Private-network guard (eval return-value path) ──────────────────────
-    # browser_snapshot / browser_vision re-check the page URL before returning
-    # content, but eval returns arbitrary JS results directly — an attacker can
-    # read a private page via `fetch('http://127.0.0.1/secret')` or by reading
-    # the DOM after `location.href = 'http://127.0.0.1/'`, never touching
-    # snapshot/vision.  Close both sub-paths on the same gating condition:
-    #   1. Pre-scan the expression for private-host URL literals (direct fetch).
-    #   2. After eval, re-check the page URL (navigate-then-read).
     if _eval_ssrf_guard_active(effective_task_id):
         blocked_literal = _expression_targets_private_url(expression)
         if blocked_literal:
@@ -3561,6 +3550,18 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
                     "browser mode."
                 ),
             }, ensure_ascii=False)
+
+    if _is_camofox_mode():
+        return _camofox_eval(expression, effective_task_id)
+
+    # ── Private-network guard (eval return-value path) ──────────────────────
+    # browser_snapshot / browser_vision re-check the page URL before returning
+    # content, but eval returns arbitrary JS results directly — an attacker can
+    # read a private page via `fetch('http://127.0.0.1/secret')` or by reading
+    # the DOM after `location.href = 'http://127.0.0.1/'`, never touching
+    # snapshot/vision.  Close both sub-paths on the same gating condition:
+    #   1. Pre-scan the expression for private-host URL literals (direct fetch).
+    #   2. After eval, re-check the page URL (navigate-then-read).
 
     # --- Fast path: route through the supervisor's persistent CDP WS ---------
     # When a CDPSupervisor is alive for this task_id, ``Runtime.evaluate`` runs
@@ -3688,13 +3689,31 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False, default=str)
 
 
+def _camofox_current_page_private_url(tab_id: str, user_id: str) -> Optional[str]:
+    try:
+        from tools.browser_camofox import _post
+
+        data = _post(
+            f"/tabs/{tab_id}/evaluate",
+            body={"expression": "window.location.href", "userId": user_id},
+        )
+        current_url = str(data.get("result") if isinstance(data, dict) else data or "")
+        current_url = current_url.strip().strip('"').strip("'")
+        if current_url and (_is_always_blocked_url(current_url) or not _is_safe_url(current_url)):
+            return current_url
+    except Exception as exc:
+        logger.debug("_camofox_current_page_private_url: probe failed (%s)", exc)
+    return None
+
+
 def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
     """Evaluate JS via Camofox's /tabs/{tab_id}/eval endpoint (if available)."""
     from tools.browser_camofox import _ensure_tab, _post
     try:
         tab_info = _ensure_tab(task_id or "default")
         tab_id = tab_info.get("tab_id") or tab_info.get("id")
-        resp = _post(f"/tabs/{tab_id}/evaluate", body={"expression": expression, "userId": tab_info["user_id"]})
+        user_id = tab_info["user_id"]
+        resp = _post(f"/tabs/{tab_id}/evaluate", body={"expression": expression, "userId": user_id})
 
         # Camofox returns the result in a JSON envelope
         raw_result = resp.get("result") if isinstance(resp, dict) else resp
@@ -3704,6 +3723,18 @@ def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
                 parsed = json.loads(raw_result)
             except (json.JSONDecodeError, ValueError):
                 pass
+
+        if _eval_ssrf_guard_active(task_id or "default"):
+            _blocked_url = _camofox_current_page_private_url(tab_id, user_id)
+            if _blocked_url:
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        "Blocked: page URL targets a private or internal address "
+                        f"({_blocked_url}). This may have been caused by a "
+                        "JavaScript navigation via browser_console."
+                    ),
+                }, ensure_ascii=False)
 
         return json.dumps({
             "success": True,


### PR DESCRIPTION
## What does this PR do?

Extends the browser private-network eval guard to the Camofox backend.

Recent browser hardening closed the eval/private-page leak for the normal browser paths, but `_browser_eval()` returned early in Camofox mode before running the shared private URL literal pre-scan and before re-checking the current page URL after eval. That left Camofox as a sibling backend that could still execute `browser_console(expression=...)` against private/internal targets.

This PR routes Camofox eval through the same guard shape:

- block private/internal URL literals before sending an eval request to Camofox
- after Camofox eval, re-check `window.location.href`
- withhold the eval result if the page is now private/internal

## Related Issue

Follow-up to the browser private-network hardening in #56173, #56526, and #56664.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_tool.py`
  - move the eval private URL literal pre-scan before the Camofox early return
  - add a Camofox-specific current-page private URL probe using the Camofox evaluate endpoint
  - block Camofox eval responses when the page is private/internal after eval
- `tests/tools/test_browser_eval_ssrf.py`
  - add regression coverage for Camofox private URL literal blocking
  - add regression coverage for Camofox private current-page blocking without leaking eval results

## How to Test

1. Reproduce the bug on the old code:
   - `python -m pytest tests/tools/test_browser_eval_ssrf.py::TestCamofoxEvalGuard -q`
   - both new tests fail because Camofox eval bypasses the private-network guard
2. Verify the targeted fix:
   - `python -m pytest tests/tools/test_browser_eval_ssrf.py::TestCamofoxEvalGuard tests/tools/test_browser_eval_ssrf.py::TestExpressionPreScan tests/tools/test_browser_eval_ssrf.py::TestPostEvalPageRecheck -q`
3. Verify related browser guard coverage:
   - `python -m pytest tests/tools/test_browser_eval_ssrf.py tests/tools/test_browser_snapshot_ssrf.py tests/tools/test_browser_private_page_action_guard.py tests/tools/test_browser_cdp_tool.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
python -m pytest tests/tools/test_browser_eval_ssrf.py::TestCamofoxEvalGuard tests/tools/test_browser_eval_ssrf.py::TestExpressionPreScan tests/tools/test_browser_eval_ssrf.py::TestPostEvalPageRecheck -q
...........                                                              [100%]
11 passed in 0.45s
```

```text
python -m pytest tests/tools/test_browser_eval_ssrf.py tests/tools/test_browser_snapshot_ssrf.py tests/tools/test_browser_private_page_action_guard.py tests/tools/test_browser_cdp_tool.py -q
.................................................................        [100%]
65 passed in 10.14s
```

```text
python -m ruff check tools/browser_tool.py tests/tools/test_browser_eval_ssrf.py
All checks passed!
```
