### PR TITLE
fix: kitty keyboard protocol corruption after TUI /quit

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -90,6 +90,7 @@ import {
   DISABLE_MODIFY_OTHER_KEYS,
   ENABLE_KITTY_KEYBOARD,
   ENABLE_MODIFY_OTHER_KEYS,
+  RESET_KITTY_KEYBOARD,
   ERASE_SCREEN,
   ERASE_SCROLLBACK
 } from './termio/csi.js'
@@ -2443,7 +2444,11 @@ export default class Ink {
       this.drainStdin()
       // Disable extended key reporting (both kitty and modifyOtherKeys)
       writeSync(1, DISABLE_MODIFY_OTHER_KEYS)
+      // Pop the kitty keyboard stack (handles normal depth-1 case)
       writeSync(1, DISABLE_KITTY_KEYBOARD)
+      // Reset to flags=0 to handle stack depth > 1 from terminal resets
+      // or race conditions — CSI < u only pops one entry at a time
+      writeSync(1, RESET_KITTY_KEYBOARD)
       // Disable focus events (DECSET 1004)
       writeSync(1, DFE)
       // Disable bracketed paste mode

--- a/ui-tui/packages/hermes-ink/src/ink/termio/csi.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/csi.ts
@@ -322,6 +322,14 @@ export const ENABLE_KITTY_KEYBOARD = csi('>1u')
 export const DISABLE_KITTY_KEYBOARD = csi('<u')
 
 /**
+ * Reset Kitty keyboard protocol to disabled (flags=0).
+ * CSI = 0 u - sets the mode to 0 without relying on the stack.
+ * More robust than popping: works even when the stack has
+ * multiple entries from terminal resets or race conditions.
+ */
+export const RESET_KITTY_KEYBOARD = csi('=0u')
+
+/**
  * Enable xterm modifyOtherKeys level 2.
  * tmux accepts this (not the kitty stack) to enable extended keys — when
  * extended-keys-format is csi-u, tmux then emits keys in kitty format.


### PR DESCRIPTION
## Summary

After exiting the Hermes TUI via `/quit`, the terminal is left in a corrupted state where subsequent ncurses programs (nano, vim) receive raw CSI-u escape sequences instead of normal key codes. This survives `stty sane` and manual escape sequence resets — only `reset` fixes it.

Fixes #56759

## Root Cause

The unmount cleanup (`ink.tsx:2446`) sends `CSI < u` (pop keyboard mode stack) to disable the kitty keyboard protocol. However, `CSI < u` only pops **one entry** at a time. If the stack has multiple entries (from terminal resets, SSH reconnects, or race conditions in `reassertTerminalModes`), the protocol remains active with residual flags.

The `reassertTerminalModes` function (line 1383) pops before pushing to keep depth at 1, but this doesn't account for terminals that clear the stack independently (e.g., `reset` command, SSH session restart).

## Fix

Add `CSI = 0 u` (set keyboard mode flags to 0) after the pop. This explicitly disables the protocol regardless of stack depth:

```typescript
// Pop the kitty keyboard stack (handles normal depth-1 case)
writeSync(1, DISABLE_KITTY_KEYBOARD)  // CSI < u
// Reset to flags=0 to handle stack depth > 1
writeSync(1, RESET_KITTY_KEYBOARD)    // CSI = 0 u
```

`CSI = 0 u` sets the mode directly (not via the stack), making it robust against any stack state.

## Changes

- `ui-tui/packages/hermes-ink/src/ink/termio/csi.ts`: Add `RESET_KITTY_KEYBOARD = csi('=0u')` constant
- `ui-tui/packages/hermes-ink/src/ink/ink.tsx`: Import and use `RESET_KITTY_KEYBOARD` in unmount cleanup

## Test Plan

- [ ] Launch `hermes --tui` in Kitty terminal via SSH
- [ ] Exit with `/quit`
- [ ] Verify `nano` works normally (Ctrl+X exits, no raw sequences)
- [ ] Verify in tmux, iTerm2, Ghostty
