### PR TITLE
feat(kanban): add list --all cross-board query (closes #54464)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -462,6 +462,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     # --- list ---
     p_list = sub.add_parser("list", aliases=["ls"], help="List tasks")
+    p_list.add_argument("--all", action="store_true",
+                        help="List tasks across ALL boards (cross-board query). "
+                             "Each result is prefixed with its board slug.")
     p_list.add_argument("--mine", action="store_true",
                         help="Filter by $HERMES_PROFILE as assignee")
     p_list.add_argument("--assignee", default=None)
@@ -1742,6 +1745,8 @@ def _cmd_list(args: argparse.Namespace) -> int:
     assignee = args.assignee
     if args.mine and not assignee:
         assignee = _profile_author()
+    if getattr(args, "all", False):
+        return _cmd_list_all_boards(args, assignee=assignee)
     with kb.connect_closing() as conn:
         # Cheap "mini-dispatch": recompute ready so list output reflects
         # dependencies that may have cleared since the last dispatcher tick.
@@ -1780,6 +1785,60 @@ def _cmd_list(args: argparse.Namespace) -> int:
         return 0
     for t in tasks:
         print(_fmt_task_line(t))
+    return 0
+
+
+def _cmd_list_all_boards(args: argparse.Namespace, *, assignee: Optional[str]) -> int:
+    """Cross-board ``kanban list --all``.
+
+    Iterates every board on disk, lists tasks from each under the shared
+    filters, tags each result with its board slug, and aggregates.
+    """
+    boards = []
+    try:
+        boards = kb.list_boards(include_archived=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"kanban list --all: failed to enumerate boards: {exc}", file=sys.stderr)
+        return 1
+
+    results: list[tuple[str, kb.Task]] = []
+    for meta in boards:
+        slug = meta.get("slug")
+        if not slug:
+            continue
+        try:
+            with kb.connect_closing(board=slug) as conn:
+                kb.recompute_ready(conn)
+                tasks = kb.list_tasks(
+                    conn,
+                    assignee=assignee,
+                    status=args.status,
+                    tenant=args.tenant,
+                    session_id=args.session,
+                    include_archived=args.archived,
+                    order_by=getattr(args, "sort", None),
+                    workflow_template_id=args.workflow_template_id,
+                    current_step_key=args.current_step_key,
+                )
+        except Exception as exc:  # pragma: no cover - one bad board shouldn't abort the rest
+            print(f"kanban list --all: board {slug!r} failed: {exc}", file=sys.stderr)
+            continue
+        for t in tasks:
+            results.append((slug, t))
+
+    if getattr(args, "json", False):
+        payload = [
+            {**_task_to_dict(t), "board": slug}
+            for slug, t in results
+        ]
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    if not results:
+        print("(no matching tasks across boards)")
+        return 0
+    for slug, t in results:
+        print(f"[{slug}] {_fmt_task_line(t)}")
     return 0
 
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -70,6 +70,44 @@ def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     assert "Cannot operate on a closed database" not in output
 
 
+def test_kanban_list_all_cross_board_json(kanban_home):
+    """`kanban list --all --json` aggregates tasks across all boards and
+    tags each row with its board slug (issue #54464)."""
+    kb.create_board("alpha")
+    kb.create_board("beta")
+
+    with kb.connect_closing(board="default") as conn:
+        kb.create_task(conn, title="default task", assignee="alice")
+    with kb.connect_closing(board="alpha") as conn:
+        kb.create_task(conn, title="alpha task", assignee="alice")
+    with kb.connect_closing(board="beta") as conn:
+        kb.create_task(conn, title="beta task", assignee="bob")
+
+    raw = kc.run_slash("list --all --json")
+    payload = json.loads(raw)
+
+    titles = {(row.get("board"), row.get("title")) for row in payload}
+    assert ("default", "default task") in titles
+    assert ("alpha", "alpha task") in titles
+    assert ("beta", "beta task") in titles
+
+
+def test_kanban_list_all_cross_board_text(kanban_home):
+    """Text output prefixes each row with its board slug."""
+    kb.create_board("alpha")
+    with kb.connect_closing(board="alpha") as conn:
+        kb.create_task(conn, title="alpha task", assignee="alice")
+
+    out = kc.run_slash("list --all")
+    assert "[alpha]" in out and "alpha task" in out
+
+
+def test_kanban_list_all_no_matches(kanban_home):
+    kb.create_board("alpha")
+    out = kc.run_slash("list --all --status running")
+    assert "no matching tasks across boards" in out
+
+
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):
     kb.create_board("alpha")
     kb.create_board("beta")


### PR DESCRIPTION
## Summary

Adds `hermes kanban list --all`, a cross-board task query that iterates every
board on disk, aggregates tasks under the shared filters, and tags each result
with its board slug (both text and `--json` output; each JSON row gains a
`board` field). Closes #54464.

**Scope slimming (2026-08-23):** this PR previously also added `--board` to
`kanban create` and `kanban list` subcommands. Those halves are now redundant:
current `main` routes the global `--board <slug>` to every subcommand via
`board_override` → `scoped_current_board`, so `hermes kanban --board <slug>
create` / `list` already work. This PR now ships only the genuinely
unimplemented cross-board `--all` aggregation.

## Changes

- `hermes_cli/kanban.py`: add `--all` to the `list` subparser; dispatch to a
  new `_cmd_list_all_boards()` when set. Each board's tasks are listed under
  the same filters (`--assignee`, `--status`, `--tenant`, `--session`,
  `--archived`, `--sort`), tagged with their slug, and aggregated. One board
  failing to open logs a warning and does not abort the rest.
- `tests/hermes_cli/test_kanban_cli.py`: cross-board JSON aggregation
  (rows carry `board` slug), text prefixing (`[alpha] task`), and the
  no-match case.

## Verification

- `tests/hermes_cli/test_kanban_cli.py`: 7/7 pass locally, including the 3 new
  `--all` tests.
- `git merge-tree --write-tree main HEAD` → clean, no conflicts.
- Diff is exactly 2 files (+97/-0): `hermes_cli/kanban.py` +
  `tests/hermes_cli/test_kanban_cli.py`.
