### PR TITLE
perf: replace COUNT(*) with LIMIT-based existence checks

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1274,7 +1274,7 @@ class SessionStore:
         """
         if self._db:
             try:
-                return self._db.session_count() > 1
+                return self._db.session_count_ge(2)
             except Exception:
                 pass  # fall through to heuristic
         # Fallback: check if sessions.json was loaded with existing data.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4612,6 +4612,17 @@ class SessionDB:
             cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions s{where_sql}", params)
             return cursor.fetchone()[0]
 
+    def session_count_ge(self, n: int = 1) -> bool:
+        """Check if at least N sessions exist.
+
+        Short-circuits via LIMIT — much cheaper than COUNT(*) when
+        you only need an existence check.  Use this instead of
+        ``session_count() >= n`` when the exact count is irrelevant.
+        """
+        cursor = self._conn.execute("SELECT 1 FROM sessions LIMIT ?", (n,))
+        rows = cursor.fetchall()
+        return len(rows) >= n
+
     def message_count(self, session_id: str = None) -> int:
         """Count messages, optionally for a specific session."""
         with self._lock:
@@ -4723,9 +4734,9 @@ class SessionDB:
 
         def _do(conn):
             cursor = conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE id = ?", (session_id,)
+                "SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (session_id,)
             )
-            if cursor.fetchone()[0] == 0:
+            if cursor.fetchone() is None:
                 return False
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
             # Orphan remaining child sessions (branches, etc.) so FK is satisfied.

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1254,22 +1254,22 @@ class TestHasAnySessions:
         return s
 
     def test_uses_database_count_when_available(self, store_with_mock_db):
-        """has_any_sessions should use database session_count, not len(_entries)."""
+        """has_any_sessions should use database session_count_ge, not len(_entries)."""
         store = store_with_mock_db
         # Simulate single-platform user with only 1 entry in memory
         store._entries = {"telegram:12345": MagicMock()}
         # But database has 3 sessions (current + 2 previous resets)
-        store._db.session_count.return_value = 3
+        store._db.session_count_ge.return_value = True
 
         assert store.has_any_sessions() is True
-        store._db.session_count.assert_called_once()
+        store._db.session_count_ge.assert_called_once_with(2)
 
     def test_first_session_ever_returns_false(self, store_with_mock_db):
         """First session ever should return False (only current session in DB)."""
         store = store_with_mock_db
         store._entries = {"telegram:12345": MagicMock()}
         # Database has exactly 1 session (the current one just created)
-        store._db.session_count.return_value = 1
+        store._db.session_count_ge.return_value = False
 
         assert store.has_any_sessions() is False
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1742,6 +1742,22 @@ class TestCounts:
 
         assert db.session_count(cwd_prefix="/repo") == 2
 
+    def test_session_count_ge_empty(self, db):
+        """session_count_ge should return False for 0 sessions."""
+        assert db.session_count_ge(1) is False
+        assert db.session_count_ge(2) is False
+
+    def test_session_count_ge_at_threshold(self, db):
+        """session_count_ge should True when count >= n."""
+        db.create_session("s1", "cli")
+        assert db.session_count_ge(1) is True
+        assert db.session_count_ge(2) is False
+
+        db.create_session("s2", "telegram")
+        assert db.session_count_ge(1) is True
+        assert db.session_count_ge(2) is True
+        assert db.session_count_ge(3) is False
+
     def test_message_count_total(self, db):
         assert db.message_count() == 0
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## Summary

Two places in the codebase were using `SELECT COUNT(*)` when they only needed a boolean existence check — performing full table scans unnecessarily.

### Changes

**1. `session_count_ge(n)` — new method on SessionDB** (`hermes_state.py`)
Short-circuits via `SELECT 1 FROM sessions LIMIT n`. Returns `True` when at least `n` sessions exist, without counting the whole table.

**2. `has_any_sessions()`** (`gateway/session.py:1277`)
Was calling `session_count() > 1` — a full `SELECT COUNT(*)` just to ask "are there at least 2 sessions?". Now uses `session_count_ge(2)`.

**3. `delete_session()`** (`hermes_state.py:4725-4728`)
Was using `SELECT COUNT(*) FROM sessions WHERE id = ?` to check if a session exists. Changed to `SELECT 1 ... LIMIT 1` and checking `fetchone() is None`.

**4. Tests updated/added**
- `test_session.py`: mocks now target `session_count_ge` instead of `session_count`
- `test_hermes_state.py`: added `test_session_count_ge_empty` + `test_session_count_ge_at_threshold`

> This PR was authored by an AI assistant under the direction of @skywind5487.