### PR TITLE
fix(whatsapp): read WHATSAPP_GROUP_ALLOW_FROM env var as group allowlist fallback

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -408,7 +408,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        self._group_allow_from = self._coerce_allow_list(
+            config.extra.get("group_allow_from")
+            or config.extra.get("groupAllowFrom")
+            or os.getenv("WHATSAPP_GROUP_ALLOW_FROM")
+            or os.getenv("WHATSAPP_GROUP_ALLOWED_USERS")
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None

--- a/tests/gateway/test_whatsapp_group_env_fallback.py
+++ b/tests/gateway/test_whatsapp_group_env_fallback.py
@@ -1,0 +1,100 @@
+"""Verify that the WhatsApp group allowlist reads env vars as fallback.
+
+Regression test for #56767: after the built-in → plugin migration,
+``WHATSAPP_GROUP_ALLOW_FROM`` / ``WHATSAPP_GROUP_ALLOWED_USERS`` were no
+longer read, causing group messages to be silently dropped when the user
+configured the allowlist via ``.env`` instead of ``config.yaml``.
+"""
+
+from gateway.config import Platform, PlatformConfig
+
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+def _init_group_allow_from(extra, monkeypatch, env_overrides=None):
+    """Reproduce the ``__init__`` lines that set ``_group_allow_from``."""
+    if env_overrides:
+        for key, value in env_overrides.items():
+            monkeypatch.setenv(key, value)
+    config = PlatformConfig(enabled=True, extra=extra)
+    return WhatsAppAdapter._coerce_allow_list(
+        config.extra.get("group_allow_from")
+        or config.extra.get("groupAllowFrom")
+        or __import__("os").getenv("WHATSAPP_GROUP_ALLOW_FROM")
+        or __import__("os").getenv("WHATSAPP_GROUP_ALLOWED_USERS")
+    )
+
+
+# --- Env-only fallback (the core regression) ---
+
+
+def test_group_allowlist_reads_whatsapp_group_allow_from_env(monkeypatch):
+    """Env-only setup: ``WHATSAPP_GROUP_ALLOW_FROM`` must populate the
+    group allowlist when ``config.yaml`` has no ``group_allow_from``."""
+    result = _init_group_allow_from(
+        extra={},
+        monkeypatch=monkeypatch,
+        env_overrides={"WHATSAPP_GROUP_ALLOW_FROM": "12036300111@g.us, 12036300222@g.us"},
+    )
+    assert result == {"12036300111@g.us", "12036300222@g.us"}
+
+
+def test_group_allowlist_reads_whatsapp_group_allowed_users_env(monkeypatch):
+    """Env-only setup: ``WHATSAPP_GROUP_ALLOWED_USERS`` (setup-wizard name)
+    must also populate the group allowlist."""
+    result = _init_group_allow_from(
+        extra={},
+        monkeypatch=monkeypatch,
+        env_overrides={"WHATSAPP_GROUP_ALLOWED_USERS": "12036300333@g.us"},
+    )
+    assert result == {"12036300333@g.us"}
+
+
+# --- Config takes precedence over env ---
+
+
+def test_group_allowlist_config_extra_wins_over_env(monkeypatch):
+    """Explicit ``group_allow_from`` in config must not be widened by a
+    stale env var."""
+    result = _init_group_allow_from(
+        extra={"group_allow_from": ["12036300444@g.us"]},
+        monkeypatch=monkeypatch,
+        env_overrides={"WHATSAPP_GROUP_ALLOW_FROM": "12036300999@g.us"},
+    )
+    assert result == {"12036300444@g.us"}
+
+
+def test_group_allowlist_camelcase_config_wins_over_env(monkeypatch):
+    """CamelCase ``groupAllowFrom`` in config extra also takes precedence."""
+    result = _init_group_allow_from(
+        extra={"groupAllowFrom": ["12036300555@g.us"]},
+        monkeypatch=monkeypatch,
+        env_overrides={"WHATSAPP_GROUP_ALLOWED_USERS": "12036300999@g.us"},
+    )
+    assert result == {"12036300555@g.us"}
+
+
+# --- Env var priority: GROUP_ALLOW_FROM checked first ---
+
+
+def test_group_allow_from_checked_before_group_allowed_users(monkeypatch):
+    """When both env vars are set, ``WHATSAPP_GROUP_ALLOW_FROM`` wins
+    (checked first in the ``or`` chain)."""
+    result = _init_group_allow_from(
+        extra={},
+        monkeypatch=monkeypatch,
+        env_overrides={
+            "WHATSAPP_GROUP_ALLOW_FROM": "12036300666@g.us",
+            "WHATSAPP_GROUP_ALLOWED_USERS": "12036300777@g.us",
+        },
+    )
+    assert result == {"12036300666@g.us"}
+
+
+# --- Empty / missing env var ---
+
+
+def test_group_allowlist_empty_when_no_config_no_env(monkeypatch):
+    """No config and no env → empty allowlist (default)."""
+    result = _init_group_allow_from(extra={}, monkeypatch=monkeypatch)
+    assert result == set()

--- a/tests/gateway/test_whatsapp_group_env_fallback.py
+++ b/tests/gateway/test_whatsapp_group_env_fallback.py
@@ -11,43 +11,23 @@ from gateway.config import Platform, PlatformConfig
 from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
 
-def _init_group_allow_from(extra, monkeypatch, env_overrides=None):
-    """Reproduce the ``__init__`` lines that set ``_group_allow_from``."""
-    if env_overrides:
-        for key, value in env_overrides.items():
-            monkeypatch.setenv(key, value)
-    config = PlatformConfig(enabled=True, extra=extra)
-    return WhatsAppAdapter._coerce_allow_list(
-        config.extra.get("group_allow_from")
-        or config.extra.get("groupAllowFrom")
-        or __import__("os").getenv("WHATSAPP_GROUP_ALLOW_FROM")
-        or __import__("os").getenv("WHATSAPP_GROUP_ALLOWED_USERS")
-    )
-
-
 # --- Env-only fallback (the core regression) ---
 
 
 def test_group_allowlist_reads_whatsapp_group_allow_from_env(monkeypatch):
     """Env-only setup: ``WHATSAPP_GROUP_ALLOW_FROM`` must populate the
     group allowlist when ``config.yaml`` has no ``group_allow_from``."""
-    result = _init_group_allow_from(
-        extra={},
-        monkeypatch=monkeypatch,
-        env_overrides={"WHATSAPP_GROUP_ALLOW_FROM": "12036300111@g.us, 12036300222@g.us"},
-    )
-    assert result == {"12036300111@g.us", "12036300222@g.us"}
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOW_FROM", "12036300111@g.us, 12036300222@g.us")
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter._group_allow_from == {"12036300111@g.us", "12036300222@g.us"}
 
 
 def test_group_allowlist_reads_whatsapp_group_allowed_users_env(monkeypatch):
     """Env-only setup: ``WHATSAPP_GROUP_ALLOWED_USERS`` (setup-wizard name)
     must also populate the group allowlist."""
-    result = _init_group_allow_from(
-        extra={},
-        monkeypatch=monkeypatch,
-        env_overrides={"WHATSAPP_GROUP_ALLOWED_USERS": "12036300333@g.us"},
-    )
-    assert result == {"12036300333@g.us"}
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "12036300333@g.us")
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter._group_allow_from == {"12036300333@g.us"}
 
 
 # --- Config takes precedence over env ---
@@ -56,22 +36,20 @@ def test_group_allowlist_reads_whatsapp_group_allowed_users_env(monkeypatch):
 def test_group_allowlist_config_extra_wins_over_env(monkeypatch):
     """Explicit ``group_allow_from`` in config must not be widened by a
     stale env var."""
-    result = _init_group_allow_from(
-        extra={"group_allow_from": ["12036300444@g.us"]},
-        monkeypatch=monkeypatch,
-        env_overrides={"WHATSAPP_GROUP_ALLOW_FROM": "12036300999@g.us"},
-    )
-    assert result == {"12036300444@g.us"}
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOW_FROM", "12036300999@g.us")
+    adapter = WhatsAppAdapter(PlatformConfig(
+        enabled=True, extra={"group_allow_from": ["12036300444@g.us"]},
+    ))
+    assert adapter._group_allow_from == {"12036300444@g.us"}
 
 
 def test_group_allowlist_camelcase_config_wins_over_env(monkeypatch):
     """CamelCase ``groupAllowFrom`` in config extra also takes precedence."""
-    result = _init_group_allow_from(
-        extra={"groupAllowFrom": ["12036300555@g.us"]},
-        monkeypatch=monkeypatch,
-        env_overrides={"WHATSAPP_GROUP_ALLOWED_USERS": "12036300999@g.us"},
-    )
-    assert result == {"12036300555@g.us"}
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "12036300999@g.us")
+    adapter = WhatsAppAdapter(PlatformConfig(
+        enabled=True, extra={"groupAllowFrom": ["12036300555@g.us"]},
+    ))
+    assert adapter._group_allow_from == {"12036300555@g.us"}
 
 
 # --- Env var priority: GROUP_ALLOW_FROM checked first ---
@@ -80,15 +58,10 @@ def test_group_allowlist_camelcase_config_wins_over_env(monkeypatch):
 def test_group_allow_from_checked_before_group_allowed_users(monkeypatch):
     """When both env vars are set, ``WHATSAPP_GROUP_ALLOW_FROM`` wins
     (checked first in the ``or`` chain)."""
-    result = _init_group_allow_from(
-        extra={},
-        monkeypatch=monkeypatch,
-        env_overrides={
-            "WHATSAPP_GROUP_ALLOW_FROM": "12036300666@g.us",
-            "WHATSAPP_GROUP_ALLOWED_USERS": "12036300777@g.us",
-        },
-    )
-    assert result == {"12036300666@g.us"}
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOW_FROM", "12036300666@g.us")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "12036300777@g.us")
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter._group_allow_from == {"12036300666@g.us"}
 
 
 # --- Empty / missing env var ---
@@ -96,5 +69,19 @@ def test_group_allow_from_checked_before_group_allowed_users(monkeypatch):
 
 def test_group_allowlist_empty_when_no_config_no_env(monkeypatch):
     """No config and no env → empty allowlist (default)."""
-    result = _init_group_allow_from(extra={}, monkeypatch=monkeypatch)
-    assert result == set()
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter._group_allow_from == set()
+
+
+# --- End-to-end: env-only allowlist gates group messages ---
+
+
+def test_env_only_allowlist_accepts_listed_group(monkeypatch):
+    """Env-only ``group_policy=allowlist`` + ``group_allow_from`` lets a
+    listed group through via ``_is_group_allowed``."""
+    monkeypatch.setenv("WHATSAPP_GROUP_POLICY", "allowlist")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOW_FROM", "120363001234567890@g.us")
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter._group_allow_from == {"120363001234567890@g.us"}
+    assert adapter._is_group_allowed("120363001234567890@g.us") is True
+    assert adapter._is_group_allowed("999999999999@g.us") is False


### PR DESCRIPTION
## What does this PR do?

Restores the `WHATSAPP_GROUP_ALLOW_FROM` / `WHATSAPP_GROUP_ALLOWED_USERS` env-var fallback for the group allowlist that was lost when WhatsApp migrated from a built-in adapter (`gateway/platforms/whatsapp.py`) to a plugin (`plugins/platforms/whatsapp/adapter.py`).

Without this fix, users who configure the group allowlist via `.env` (the standard way) have their group messages silently dropped — `group_policy` reports "allowlist" but the allowlist is empty.

## Related Issue

Fixes #56767

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py`: Added `os.getenv("WHATSAPP_GROUP_ALLOW_FROM")` and `os.getenv("WHATSAPP_GROUP_ALLOWED_USERS")` as fallback sources for `_group_allow_from` (line 411), matching the pattern already used by `_group_policy` (line 410) and the setup wizard (line 1547).
- `tests/gateway/test_whatsapp_group_env_fallback.py`: 6 regression tests covering env-only fallback, config precedence over env, and dual-env-var priority.

## How to Test

1. Run the new regression tests: `pytest tests/gateway/test_whatsapp_group_env_fallback.py -v` — all 6 should pass.
2. Run existing group gating tests: `pytest tests/gateway/test_whatsapp_group_gating.py -v` — all 30 should pass.
3. To reproduce the original bug: set `WHATSAPP_GROUP_POLICY=allowlist` and `WHATSAPP_GROUP_ALLOW_FROM=120363001234567890@g.us` in `.env`, remove any `whatsapp:` section from `config.yaml`, and observe that group messages are now processed (previously silently dropped).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (env var reading is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
