### PR TITLE
fix(acp): support embedded_context, parse line ranges, fix resource-only prompt has_content check

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -182,6 +182,70 @@ def _path_from_file_uri(uri: str) -> Path | None:
     return Path(path_text)
 
 
+def _parse_line_range_from_uri(uri: str) -> tuple[int | None, int | None]:
+    """Parse line range from a URI fragment like ``#L100:200`` or ``#L100-L200``.
+
+    Returns ``(start_line, end_line)`` both 0-based (or ``None`` when absent).
+    Understands these fragment formats:
+    - ``#L100:200`` — range from line 100 to 200
+    - ``#L100-L200`` — range with hyphen separator
+    - ``#100:200`` — without the L prefix
+    - ``#L1872`` — single line
+    """
+    try:
+        parsed = urlparse(uri)
+    except Exception:
+        return (None, None)
+    fragment = (parsed.fragment or "").strip()
+    if not fragment:
+        return (None, None)
+    # Strip leading 'L' for the whole fragment, then split
+    raw = fragment.lstrip("L")
+    if ":" in raw:
+        parts = raw.split(":", 1)
+    elif "-" in raw:
+        parts = raw.split("-", 1)
+    else:
+        # single line number like L1872
+        try:
+            val = int(raw)
+            return (max(0, val - 1), max(0, val - 1))
+        except ValueError:
+            return (None, None)
+    if len(parts) != 2:
+        return (None, None)
+    try:
+        # Each part may still carry a stray 'L' (e.g. L100-L200)
+        start = int(parts[0].lstrip("L"))
+        end = int(parts[1].lstrip("L"))
+        # ACP line numbers are 1-based; convert to 0-based
+        return (max(0, start - 1), max(0, end - 1))
+    except ValueError:
+        return (None, None)
+
+
+def _apply_line_range(text: str, uri: str) -> tuple[str, list[str]]:
+    """Clip *text* to the line range specified in *uri*'s fragment (e.g. ``#L14:21``).
+
+    Returns ``(clipped_text, notes)`` where *notes* is a list of annotation
+    strings (empty when no range was specified or the range covers the whole
+    content).
+    """
+    notes: list[str] = []
+    start_line, end_line = _parse_line_range_from_uri(uri)
+    if start_line is not None and end_line is not None:
+        lines = text.splitlines(keepends=True)
+        if not lines:
+            return (text, notes)
+        start_line = max(0, min(start_line, len(lines) - 1))
+        end_line = max(start_line, min(end_line, len(lines) - 1))
+        clipped = "".join(lines[start_line:end_line + 1])
+        if clipped != text:
+            notes.append(f"lines {start_line + 1}-{end_line + 1} of {len(lines)}")
+            text = clipped
+    return (text, notes)
+
+
 def _decode_text_bytes(data: bytes, mime_type: str | None) -> str | None:
     """Decode resource bytes if they are probably text; return None for binary."""
     if b"\x00" in data and not _is_text_resource(mime_type):
@@ -288,9 +352,16 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
                     body=f"[Binary file omitted: {size} bytes, mime={mime_type or 'unknown'}]",
                 ),
             }]
-        note = None
+        notes = []
         if size > _MAX_ACP_RESOURCE_BYTES:
-            note = f"truncated to {_MAX_ACP_RESOURCE_BYTES} of {size} bytes"
+            notes.append(f"truncated to {_MAX_ACP_RESOURCE_BYTES} of {size} bytes")
+
+        # Extract line range from URI fragment and clip content
+        clipped_text, range_notes = _apply_line_range(text, uri)
+        notes.extend(range_notes)
+        text = clipped_text
+
+        note = "; ".join(notes) if notes else None
         return [{
             "type": "text",
             "text": _format_resource_text(uri=uri, name=name, title=title, body=text, note=note),
@@ -317,7 +388,10 @@ def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dic
     mime_type = str(getattr(resource, "mime_type", "") or "").strip() or None
 
     if isinstance(resource, TextResourceContents):
-        return [{"type": "text", "text": _format_resource_text(uri=uri, body=resource.text)}]
+        body = resource.text
+        body, range_notes = _apply_line_range(body, uri)
+        note = "; ".join(range_notes) if range_notes else None
+        return [{"type": "text", "text": _format_resource_text(uri=uri, body=body, note=note)}]
 
     if isinstance(resource, BlobResourceContents):
         blob = resource.blob or ""
@@ -347,13 +421,22 @@ def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dic
             body = f"[Binary embedded file omitted: {len(data)} bytes, mime={mime_type or 'unknown'}]"
         else:
             body = text
+            notes = []
             if len(data) > _MAX_ACP_RESOURCE_BYTES:
-                body += f"\n\n[Truncated to {_MAX_ACP_RESOURCE_BYTES} of {len(data)} bytes]"
+                notes.append(f"truncated to {_MAX_ACP_RESOURCE_BYTES} of {len(data)} bytes")
+            clipped_body, range_notes = _apply_line_range(body, uri)
+            notes.extend(range_notes)
+            body = clipped_body
+            if notes:
+                body += f"\n\n[{' - '.join(notes)}]"
         return [{"type": "text", "text": _format_resource_text(uri=uri, body=body)}]
 
     text = getattr(resource, "text", None)
     if text:
-        return [{"type": "text", "text": _format_resource_text(uri=uri, body=str(text))}]
+        body = str(text)
+        body, range_notes = _apply_line_range(body, uri)
+        note = "; ".join(range_notes) if range_notes else None
+        return [{"type": "text", "text": _format_resource_text(uri=uri, body=body, note=note)}]
     return []
 
 
@@ -882,7 +965,7 @@ class HermesACPAgent(acp.Agent):
             agent_info=Implementation(name="hermes-agent", version=HERMES_VERSION),
             agent_capabilities=AgentCapabilities(
                 load_session=True,
-                prompt_capabilities=PromptCapabilities(image=True),
+                prompt_capabilities=PromptCapabilities(image=True, embedded_context=True),
                 session_capabilities=SessionCapabilities(
                     fork=SessionForkCapabilities(),
                     list=SessionListCapabilities(),
@@ -1310,9 +1393,7 @@ class HermesACPAgent(acp.Agent):
         user_text = _extract_text(prompt).strip()
         user_content = _content_blocks_to_openai_user_content(prompt)
         text_only_prompt = all(isinstance(block, TextContentBlock) for block in prompt)
-        has_content = bool(user_text) or (
-            isinstance(user_content, list) and bool(user_content)
-        )
+        has_content = bool(user_content) if isinstance(user_content, str) else bool(user_text) or bool(user_content)
         if not has_content:
             return PromptResponse(stop_reason="end_turn")
 
@@ -1506,7 +1587,7 @@ class HermesACPAgent(acp.Agent):
                     user_message=user_content,
                     conversation_history=state.history,
                     task_id=session_id,
-                    persist_user_message=user_text or "[Image attachment]",
+                    persist_user_message=user_text or str(user_content)[:200] if isinstance(user_content, str) else "[File reference]",
                 )
                 return result
             except Exception as e:


### PR DESCRIPTION
## What does this PR do?

Three fixes for ACP @-file references in Zed/VS Code:

1. **Advertise `embedded_context=True` in `PromptCapabilities`** — tells ACP clients (Zed) to send `EmbeddedResource` (file content) instead of `ResourceLink` (URI only). Without this the agent only gets a `file:///` URI and must read the file from disk itself, which fails in remote or container setups.

2. **Parse line ranges from URI fragments and clip file content** — new `_parse_line_range_from_uri()` and `_apply_line_range()` helpers extract ranges from `file:///path#L14:21`, `#L100-L200`, `#L1872` formats. Applied in both `_resource_link_to_parts()` and `_embedded_resource_to_parts()` so line range clipping works regardless of whether the client sends `ResourceLink` or `EmbeddedResource`. The clipped range is annotated in the resource display header (e.g. `(lines 14-21 of 674)`).

3. **Fix `has_content` check dropping resource-only prompts** — when a user sends ONLY an `EmbeddedResource` (no `TextContentBlock`), `_content_blocks_to_openai_user_content()` collapses all-text parts into a single `str`, not a `list`. The old `isinstance(user_content, list)` check returned `end_turn` without calling the agent, causing Hermes to silently do nothing when the user sends only a file reference.

Also fixes `persist_user_message` to use the actual resource content preview instead of `"[Image attachment]"` when no text is present.

## Related Issue

Fixes #51842

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py`:
  - `PromptCapabilities(image=True, embedded_context=True)` in initialize handshake
  - New `_parse_line_range_from_uri()` — parse `#L14:21`, `#L100-L200`, `#L1872` from URI fragments
  - New `_apply_line_range()` — clip text content to line range, return annotation notes
  - Line range clipping applied in `_resource_link_to_parts()` and `_embedded_resource_to_parts()`
  - `has_content` check: add `isinstance(user_content, str)` fallback
  - `persist_user_message`: use resource content preview when no text

## How to Test

1. Set up Hermes as ACP agent in Zed
2. Send `@file.go#L10:20` (file reference with line range, no text instruction)
3. **Before**: Hermes returns `stopReason: "end_turn"` immediately with no response
4. **After**: Agent responds, sees only lines 10-20, header shows `(lines 10-20 of N)`
5. Send a text message with `@file.go#L10:20` — both text and clipped file content arrive correctly

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(acp): ...`)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run `pytest tests/acp_adapter/ -q` and all 19 tests pass
- [x] I have tested on my platform: macOS 26.5.1
- [x] Documentation — N/A (behavioral fix, existing docs unaffected)

## Screenshots / Logs

ACP debug panel showing resource-only prompt being processed correctly after fix:
```
{
  "sessionId": "89b3afa1-...",
  "prompt": [{ "type": "resource", "resource": { "text": "...", "uri": "file:///path#L14:21" } }]
}
→ Agent responds instead of returning end_turn
```