### PR TITLE
fix: resolve configured personality prompt

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -52,6 +52,7 @@ os.environ["HERMES_QUIET"] = "1"  # Our own modules
 import yaml
 
 from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.config import resolve_ephemeral_system_prompt_from_config
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 
@@ -3811,10 +3812,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # AGENTS.md/SOUL.md/.cursorrules and persistent memory are not loaded.
         self.ignore_rules = ignore_rules or os.environ.get("HERMES_IGNORE_RULES") == "1"
         
-        # Ephemeral system prompt: env var takes precedence, then config
+        # Ephemeral system prompt: env var takes precedence, then explicit
+        # agent.system_prompt, then display.personality resolved through
+        # agent.personalities.
         self.system_prompt = (
             os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
-            or CLI_CONFIG["agent"].get("system_prompt", "")
+            or resolve_ephemeral_system_prompt_from_config(CLI_CONFIG)
         )
         self.personalities = CLI_CONFIG["agent"].get("personalities", {})
         

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -55,7 +55,7 @@ from typing import Callable, Dict, Optional, Any, List, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
-from hermes_cli.config import cfg_get
+from hermes_cli.config import cfg_get, resolve_ephemeral_system_prompt_from_config
 from hermes_cli.fallback_config import get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -4465,13 +4465,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Load ephemeral system prompt from config or env var.
         
         Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
-        agent.system_prompt in ~/.hermes/config.yaml.
+        agent.system_prompt and finally display.personality in ~/.hermes/config.yaml.
         """
         prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
         if prompt:
             return prompt
         cfg = _load_gateway_runtime_config()
-        return str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+        return resolve_ephemeral_system_prompt_from_config(cfg)
 
     @staticmethod
     def _load_reasoning_config() -> dict | None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -38,7 +38,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
-from hermes_cli.config import cfg_get, clear_model_endpoint_credentials
+from hermes_cli.config import cfg_get, clear_model_endpoint_credentials, render_personality_prompt
 from utils import (
     atomic_json_write,
     atomic_yaml_write,
@@ -2044,34 +2044,30 @@ class GatewaySlashCommandsMixin:
             lines.append(t("gateway.personality.usage"))
             return "\n".join(lines)
 
-        def _resolve_prompt(value):
-            if isinstance(value, dict):
-                parts = [value.get("system_prompt", "")]
-                if value.get("tone"):
-                    parts.append(f'Tone: {value["tone"]}')
-                if value.get("style"):
-                    parts.append(f'Style: {value["style"]}')
-                return "\n".join(p for p in parts if p)
-            return str(value)
-
         if args in {"none", "default", "neutral"}:
             try:
                 if "agent" not in config or not isinstance(config.get("agent"), dict):
                     config["agent"] = {}
+                if "display" not in config or not isinstance(config.get("display"), dict):
+                    config["display"] = {}
                 config["agent"]["system_prompt"] = ""
+                config["display"]["personality"] = ""
                 atomic_yaml_write(config_path, config)
             except Exception as e:
                 return t("gateway.personality.save_failed", error=str(e))
             self._ephemeral_system_prompt = ""
             return t("gateway.personality.cleared")
         elif args in personalities:
-            new_prompt = _resolve_prompt(personalities[args])
+            new_prompt = render_personality_prompt(personalities[args])
 
             # Write to config.yaml, same pattern as CLI save_config_value.
             try:
                 if "agent" not in config or not isinstance(config.get("agent"), dict):
                     config["agent"] = {}
+                if "display" not in config or not isinstance(config.get("display"), dict):
+                    config["display"] = {}
                 config["agent"]["system_prompt"] = new_prompt
+                config["display"]["personality"] = args
                 atomic_yaml_write(config_path, config)
             except Exception as e:
                 return t("gateway.personality.save_failed", error=str(e))

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1013,7 +1013,11 @@ class CLICommandsMixin:
             if personality_name in {"none", "default", "neutral"}:
                 self.system_prompt = ""
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", ""):
+                saved = (
+                    save_config_value("agent.system_prompt", "")
+                    and save_config_value("display.personality", "")
+                )
+                if saved:
                     print("(^_^)b Personality cleared (saved to config)")
                 else:
                     print("(^_^) Personality cleared (session only)")
@@ -1021,7 +1025,11 @@ class CLICommandsMixin:
             elif personality_name in self.personalities:
                 self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", self.system_prompt):
+                saved = (
+                    save_config_value("agent.system_prompt", self.system_prompt)
+                    and save_config_value("display.personality", personality_name)
+                )
+                if saved:
                     print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
                 else:
                     print(f"(^_^) Personality set to '{personality_name}' (session only)")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6255,6 +6255,62 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
     return node
 
 
+_NEUTRAL_PERSONALITIES = {"", "none", "default", "neutral"}
+
+
+def _prompt_text(value: Any) -> str:
+    """Normalize config prompt values from YAML before handing them to AIAgent."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        return "\n".join(str(item).strip() for item in value if str(item).strip())
+    return str(value).strip()
+
+
+def render_personality_prompt(value: Any) -> str:
+    """Render a string or structured personality definition to a prompt."""
+    if isinstance(value, dict):
+        parts = [value.get("system_prompt", "")]
+        if value.get("tone"):
+            parts.append(f'Tone: {value["tone"]}')
+        if value.get("style"):
+            parts.append(f'Style: {value["style"]}')
+        return "\n".join(str(part).strip() for part in parts if str(part).strip())
+    return _prompt_text(value)
+
+
+def resolve_ephemeral_system_prompt_from_config(cfg: Optional[Dict[str, Any]]) -> str:
+    """Resolve the agent prompt overlay from config.yaml.
+
+    ``display.personality`` is the selected named personality.  A non-empty
+    ``agent.system_prompt`` still wins when it is a custom prompt, but if it
+    equals one of the known personality prompts it is treated as legacy cached
+    state and the selected ``display.personality`` is authoritative.
+    """
+    explicit = _prompt_text(cfg_get(cfg, "agent", "system_prompt", default=""))
+
+    name = str(cfg_get(cfg, "display", "personality", default="") or "").strip().lower()
+    personalities = cfg_get(cfg, "agent", "personalities", default={}) or {}
+    if (
+        name not in _NEUTRAL_PERSONALITIES
+        and isinstance(personalities, dict)
+        and name in personalities
+    ):
+        selected_prompt = render_personality_prompt(personalities[name])
+        known_prompts = {
+            render_personality_prompt(value)
+            for value in personalities.values()
+        }
+        # If agent.system_prompt is empty or just a stale copy of another named
+        # personality, honor the explicit display.personality selection.  If it
+        # is a custom prompt, preserve the user's custom overlay instead.
+        if not explicit or explicit in known_prompts:
+            return selected_prompt
+
+    return explicit
+
 
 def read_raw_config() -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.

--- a/tests/cli/test_personality_none.py
+++ b/tests/cli/test_personality_none.py
@@ -48,7 +48,17 @@ class TestCLIPersonalityNone:
         cli = self._make_cli()
         with patch("cli.save_config_value", return_value=True) as mock_save:
             cli._handle_personality_command("/personality none")
-        mock_save.assert_called_once_with("agent.system_prompt", "")
+        mock_save.assert_any_call("agent.system_prompt", "")
+        mock_save.assert_any_call("display.personality", "")
+        assert mock_save.call_count == 2
+
+    def test_known_personality_saves_display_personality(self):
+        cli = self._make_cli()
+        with patch("cli.save_config_value", return_value=True) as mock_save:
+            cli._handle_personality_command("/personality helpful")
+        mock_save.assert_any_call("agent.system_prompt", "You are helpful.")
+        mock_save.assert_any_call("display.personality", "helpful")
+        assert mock_save.call_count == 2
 
     def test_known_personality_still_works(self):
         cli = self._make_cli()

--- a/tests/gateway/test_runtime_config_env_expansion.py
+++ b/tests/gateway/test_runtime_config_env_expansion.py
@@ -56,6 +56,20 @@ def test_load_prefill_messages_prefers_top_level_over_legacy(monkeypatch, gatewa
     assert gateway_run.GatewayRunner._load_prefill_messages() == top_level
 
 
+def test_load_ephemeral_system_prompt_uses_display_personality(gateway_home):
+    _write_config(
+        gateway_home,
+        "agent:\n"
+        "  system_prompt: ''\n"
+        "  personalities:\n"
+        "    kawaii: sparkle system prompt\n"
+        "display:\n"
+        "  personality: kawaii\n",
+    )
+
+    assert gateway_run.GatewayRunner._load_ephemeral_system_prompt() == "sparkle system prompt"
+
+
 @pytest.mark.parametrize(
     ("config_body", "env_name", "env_value", "loader_name", "expected"),
     [

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -157,9 +157,9 @@ def test_make_agent_provider_routing_defaults_when_unset():
         assert kwargs["provider_data_collection"] is None
 
 
-def test_make_agent_ignores_display_personality_without_system_prompt():
-    """The TUI matches the classic CLI: personality only becomes active once
-    it has been saved to agent.system_prompt."""
+def test_make_agent_uses_display_personality_when_system_prompt_unset():
+    """A globally configured display.personality should activate its prompt
+    even before the user has run /personality in the current session."""
 
     fake_runtime = {
         "provider": "openrouter",
@@ -192,7 +192,86 @@ def test_make_agent_ignores_display_personality_without_system_prompt():
 
         _make_agent("sid-default-personality", "key-default-personality")
 
-        assert mock_agent.call_args.kwargs["ephemeral_system_prompt"] is None
+        assert mock_agent.call_args.kwargs["ephemeral_system_prompt"] == "sparkle system prompt"
+
+
+def test_make_agent_display_personality_wins_over_stale_known_system_prompt():
+    """display.personality is the selected global personality; a legacy
+    agent.system_prompt containing another built-in personality is stale state."""
+
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "agent": {
+            "system_prompt": "pirate system prompt",
+            "personalities": {
+                "kawaii": "sparkle system prompt",
+                "pirate": "pirate system prompt",
+            },
+        },
+        "display": {"personality": "kawaii"},
+        "model": {"default": "glm-5"},
+    }
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-stale-personality", "key-stale-personality")
+
+        assert mock_agent.call_args.kwargs["ephemeral_system_prompt"] == "sparkle system prompt"
+
+
+def test_make_agent_preserves_custom_system_prompt_over_display_personality():
+    """A hand-written agent.system_prompt is a custom overlay, not stale
+    personality cache, so display.personality must not replace it."""
+
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "agent": {
+            "system_prompt": "custom reviewer prompt",
+            "personalities": {"kawaii": "sparkle system prompt"},
+        },
+        "display": {"personality": "kawaii"},
+        "model": {"default": "glm-5"},
+    }
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-custom-prompt", "key-custom-prompt")
+
+        assert mock_agent.call_args.kwargs["ephemeral_system_prompt"] == "custom reviewer prompt"
 
 
 def test_make_agent_honors_tui_launch_env_flags():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4235,8 +4235,9 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
-    agent_cfg = cfg.get("agent") or {}
-    system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
+    from hermes_cli.config import resolve_ephemeral_system_prompt_from_config
+
+    system_prompt = resolve_ephemeral_system_prompt_from_config(cfg)
     startup_skills = _parse_tui_skills_env()
     if startup_skills:
         from agent.skill_commands import build_preloaded_skills_prompt


### PR DESCRIPTION
## Summary
- Resolve `display.personality` into the actual ephemeral system prompt for CLI, TUI/Desktop, and gateway startup paths.
- Keep `display.personality` and `agent.system_prompt` synchronized when `/personality` changes or clears the active personality.
- Preserve custom `agent.system_prompt` overlays while treating stale built-in personality prompt copies as legacy cache.

## Test Plan
- `python -m pytest tests/tui_gateway/test_make_agent_provider.py tests/cli/test_personality_none.py tests/gateway/test_runtime_config_env_expansion.py -q`
- `python -m compileall -q cli.py hermes_cli/config.py hermes_cli/cli_commands_mixin.py gateway/run.py gateway/slash_commands.py tui_gateway/server.py tests/tui_gateway/test_make_agent_provider.py tests/cli/test_personality_none.py tests/gateway/test_runtime_config_env_expansion.py`
