### PR TITLE
docs: add eval done marker

### DIFF
--- a/docs/EVAL_DONE.md
+++ b/docs/EVAL_DONE.md
@@ -1,0 +1,3 @@
+# Evaluation Done
+
+This marker file indicates the evaluation is complete.


### PR DESCRIPTION
Adds `docs/EVAL_DONE.md` as a marker indicating the evaluation is complete.

This is a docs-only change: a single file with a short marker note. No code paths are affected.