### PR TITLE
fix(tts): transcode OpenAI-compatible speech to Opus for .ogg targets (#54589)

### DIFF
--- a/tests/tools/test_openai_tts_opus_transcode_54589.py
+++ b/tests/tools/test_openai_tts_opus_transcode_54589.py
@@ -1,0 +1,99 @@
+"""Regression tests for #54589: OpenAI-compatible TTS mp3 + local Opus transcode."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools import tts_tool
+
+
+@pytest.fixture(autouse=True)
+def _openai_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+
+def _run_openai_tts(output_path: str, tts_config=None):
+    mock_response = MagicMock()
+    mock_client = MagicMock()
+    mock_client.audio.speech.create.return_value = mock_response
+    mock_cls = MagicMock(return_value=mock_client)
+
+    with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), patch(
+        "tools.tts_tool._resolve_openai_audio_client_config",
+        return_value=("test-key", None),
+    ):
+        result = tts_tool._generate_openai_tts(
+            "Hello",
+            output_path,
+            tts_config or {"openai": {}},
+        )
+    return result, mock_client, mock_response
+
+
+def test_openai_tts_mp3_target_requests_mp3(tmp_path):
+    out = tmp_path / "speech.mp3"
+    result, mock_client, mock_response = _run_openai_tts(str(out))
+
+    create_kwargs = mock_client.audio.speech.create.call_args[1]
+    assert create_kwargs["response_format"] == "mp3"
+    mock_response.stream_to_file.assert_called_once_with(str(out))
+    assert result == str(out)
+
+
+def test_openai_tts_ogg_target_synthesizes_mp3_then_transcodes(tmp_path, monkeypatch):
+    ogg = tmp_path / "speech.ogg"
+    mp3 = tmp_path / "speech.mp3"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(mp3)
+        ogg.write_bytes(b"ogg")
+        return str(ogg)
+
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", fake_convert)
+
+    result, mock_client, mock_response = _run_openai_tts(str(ogg))
+
+    create_kwargs = mock_client.audio.speech.create.call_args[1]
+    assert create_kwargs["response_format"] == "mp3"
+    mock_response.stream_to_file.assert_called_once_with(str(mp3))
+    assert result == str(ogg)
+
+
+def test_openai_tts_ogg_target_falls_back_to_mp3_when_transcode_unavailable(
+    tmp_path, monkeypatch
+):
+    ogg = tmp_path / "speech.ogg"
+    mp3 = tmp_path / "speech.mp3"
+
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", lambda _path: None)
+
+    result, mock_client, mock_response = _run_openai_tts(str(ogg))
+
+    create_kwargs = mock_client.audio.speech.create.call_args[1]
+    assert create_kwargs["response_format"] == "mp3"
+    mock_response.stream_to_file.assert_called_once_with(str(mp3))
+    assert result == str(mp3)
+
+
+def test_openai_telegram_integration_uses_transcoded_opus(tmp_path, monkeypatch):
+    """End-to-end through text_to_speech_tool on Telegram session."""
+    ogg = tmp_path / "speech.ogg"
+
+    def fake_openai(_text, output_path, _tts_config):
+        assert output_path == str(ogg)
+        ogg.write_bytes(b"ogg")
+        return str(ogg)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "openai"})
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_openai_tts", fake_openai)
+
+    import json
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(ogg)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(ogg)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{ogg}"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1027,11 +1027,14 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     base_url = oai_config.get("base_url", base_url)
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
 
-    # Determine response format from extension
-    if output_path.endswith(".ogg"):
-        response_format = "opus"
-    else:
-        response_format = "mp3"
+    # OpenAI-compatible backends vary in supported formats (e.g. Speaches/Kokoro
+    # only accept mp3/flac/wav/pcm). Always synthesize mp3, then transcode to
+    # OGG/Opus locally when the caller requested a .ogg target (#54589).
+    wants_opus_output = output_path.endswith(".ogg")
+    response_format = "mp3"
+    synth_path = output_path
+    if wants_opus_output:
+        synth_path = output_path.rsplit(".", 1)[0] + ".mp3"
 
     OpenAIClient = _import_openai_client()
     client = OpenAIClient(api_key=api_key, base_url=base_url)
@@ -1047,8 +1050,11 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         response = client.audio.speech.create(**create_kwargs)
 
-        response.stream_to_file(output_path)
-        return output_path
+        response.stream_to_file(synth_path)
+        if wants_opus_output:
+            converted = _convert_to_opus(synth_path)
+            return converted or synth_path
+        return synth_path
     finally:
         close = getattr(client, "close", None)
         if callable(close):
@@ -2174,9 +2180,9 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram voice bubbles require Opus (.ogg). ElevenLabs can produce Opus
+    # natively; OpenAI-compatible backends synthesize mp3 and transcode via
+    # ffmpeg. Edge TTS always outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
     want_opus = (platform == "telegram")
@@ -2216,8 +2222,8 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
-        # Use .ogg for Telegram with providers that support native Opus output,
-        # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
+        # Use .ogg for Telegram with providers that natively or locally produce
+        # Opus voice bubbles; otherwise fall back to .mp3 (Edge TTS converts later).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:


### PR DESCRIPTION
## Summary

- Always synthesize **mp3** from OpenAI-compatible TTS backends (Speaches/Kokoro, etc.) instead of hardcoding `response_format=opus` for `.ogg` targets.
- When Telegram requests a `.ogg` voice bubble, locally transcode via existing `_convert_to_opus()` (same pattern as Edge TTS).
- Falls back to the intermediate `.mp3` if ffmpeg is unavailable.

Fixes #54589

## Why

Non-OpenAI backends reject `response_format=opus` with errors like *Unsupported response_format opus*. Real OpenAI still works; mp3 + transcode is compatible with both.

## Test plan

- [x] `pytest tests/tools/test_openai_tts_opus_transcode_54589.py` (4/4)
- [x] `pytest tests/tools/test_tts_opus_routing.py tests/tools/test_tts_speed.py::TestOpenaiTtsSpeed tests/tools/test_managed_media_gateways.py -k openai_tts` (related regressions)