### PR TITLE
fix: use manual PKCE generation for Google OAuth to avoid code challenge encoding error

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -327,6 +327,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 | `HttpError 403: Access Not Configured` | API not enabled — user needs to enable it in Google Cloud Console |
 | `ModuleNotFoundError` | Run `$GSETUP --install-deps` |
 | Advanced Protection blocks auth | Workspace admin must allowlist the OAuth client ID |
+| `Error 400: invalid_request` — "Code Challenge must be base64 encoded" | The `google_auth_oauthlib` library (≤1.3.1) generates code verifiers that Google's stricter parser rejects. Fixed in the setup script as of this patch — the OAuth URL is now constructed manually with a clean `secrets.token_urlsafe()` verifier. If you still hit this, update the skill. |
 
 ## Revoking Access
 

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -332,20 +332,42 @@ def get_auth_url():
         print("ERROR: No client secret stored. Run --client-secret first.")
         sys.exit(1)
 
-    _ensure_deps()
-    from google_auth_oauthlib.flow import Flow
+    import hashlib
+    import secrets
+    from urllib.parse import urlencode
 
-    flow = Flow.from_client_secrets_file(
-        str(CLIENT_SECRET_PATH),
-        scopes=SCOPES,
-        redirect_uri=REDIRECT_URI,
-        autogenerate_code_verifier=True,
-    )
-    auth_url, state = flow.authorization_url(
-        access_type="offline",
-        prompt="consent",
-    )
-    _save_pending_auth(state=state, code_verifier=flow.code_verifier)
+    client_data = json.loads(CLIENT_SECRET_PATH.read_text())
+    installed = client_data.get("installed", {})
+    client_id = installed.get("client_id", "")
+
+    if not client_id:
+        print("ERROR: No client_id found in client_secret.json.")
+        sys.exit(1)
+
+    # Generate PKCE values manually — google_auth_oauthlib's
+    # autogenerate_code_verifier can produce verifiers with characters
+    # that Google's stricter parser rejects (e.g. periods), causing
+    # "Code Challenge must be base64 encoded" errors.
+    code_verifier = secrets.token_urlsafe(64)  # ~86 chars, [A-Za-z0-9_-] only
+    code_challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode("ascii")).digest()
+    ).rstrip(b"=").decode("ascii")
+    state = secrets.token_urlsafe(16)
+
+    _save_pending_auth(state=state, code_verifier=code_verifier)
+
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": REDIRECT_URI,
+        "scope": " ".join(SCOPES),
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    auth_url = f"https://accounts.google.com/o/oauth2/auth?{urlencode(params)}"
     # Print just the URL so the agent can extract it cleanly
     print(auth_url)
 


### PR DESCRIPTION
## Summary

Fixes an issue where the Google Workspace OAuth setup fails with:

```
Error 400: invalid_request — "Code Challenge must be base64 encoded"
```

## Root Cause

`google_auth_oauthlib` (≤1.3.1) `autogenerate_code_verifier` can produce PKCE code verifiers containing characters that Google's stricter OAuth parser rejects — specifically periods (`.`) mixed into the base64url string. While technically valid per RFC 7636, Google's endpoint returns a 400 error.

## Fix

Replace the library-managed PKCE flow in `get_auth_url()` with a manual implementation:

- Uses `secrets.token_urlsafe(64)` which produces clean `[A-Za-z0-9_-]` characters only
- Computes the SHA256 challenge manually with `base64.urlsafe_b64encode`
- Constructs the authorization URL with `urllib.parse.urlencode`

Also adds the error to the troubleshooting table in `SKILL.md`.

## Changes

- `skills/productivity/google-workspace/scripts/setup.py` — Replace `google_auth_oauthlib.flow.Flow`-based PKCE generation with manual implementation
- `skills/productivity/google-workspace/SKILL.md` — Add troubleshooting entry for the error

## Testing

Tested end-to-end during a real Google Workspace setup for a Hermes Agent user on Telegram. The old code produced the error; the new code succeeded on the first attempt.