### PR TITLE
fix(kanban): deliver auto-subscriptions from dispatcher-spawned workers

### DIFF
--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -657,3 +657,50 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     # Only the real file was uploaded.
     assert len(documents_uploaded) == 1
     assert "real.pdf" in documents_uploaded[0]
+
+
+# ---------------------------------------------------------------------------
+# Session-key subscription decoding (dispatcher-spawned worker path)
+# ---------------------------------------------------------------------------
+
+def test_parse_gateway_session_key():
+    from tools.kanban_tools import _parse_gateway_session_key as parse
+
+    # thread session: 6th part is the thread id
+    assert parse("agent:main:discord:thread:123:456") == ("discord", "123", "456")
+    # dm without thread suffix
+    assert parse("agent:main:telegram:dm:999") == ("telegram", "999", None)
+    # group: 6th part may be a per-user suffix, NOT a thread id
+    assert parse("agent:main:discord:group:123:u42") == ("discord", "123", None)
+    # profile-namespaced key (multiplexing)
+    assert parse("agent:coder:slack:dm:C1:T1") == ("slack", "C1", "T1")
+    # non-gateway keys
+    assert parse("") is None
+    assert parse("desktop-session-abc") is None
+    assert parse("agent:main:discord") is None
+
+
+def test_auto_subscribe_decodes_gateway_session_key(kanban_home, monkeypatch):
+    """A worker subprocess that only inherits HERMES_SESSION_KEY gets a
+    REAL platform/chat subscription, not an undeliverable 'tui' row."""
+    import hermes_cli.kanban_db as kb
+    from tools.kanban_tools import _maybe_auto_subscribe
+
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_KEY", "agent:main:discord:thread:123:456")
+    monkeypatch.setenv("HERMES_PROFILE", "dirk")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="sub-decode task", assignee="worker1")
+        assert _maybe_auto_subscribe(conn, tid) is True
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "123"
+    assert subs[0]["thread_id"] == "456"
+

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -950,6 +950,30 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(f"kanban_create: {e}")
 
 
+def _parse_gateway_session_key(session_key: str) -> "tuple[str, str, str | None] | None":
+    """Decode a gateway session key into ``(platform, chat_id, thread_id)``.
+
+    Mirrors ``gateway/run.py:_parse_session_key`` for the historical key
+    format ``agent:<ns>:<platform>:<chat_type>:<chat_id>[:<extra>]`` (the
+    namespace slot is ``main`` for the default profile or a profile name
+    under multi-profile multiplexing — see
+    ``gateway/session.py:_session_key_namespace``).
+
+    ``<extra>`` is only treated as a thread_id for ``dm`` / ``thread`` chat
+    types, where it is unambiguous; for group/channel sessions it may be a
+    per-user isolation suffix instead. Returns None when the key is not a
+    gateway session key (e.g. a genuine TUI/desktop session key).
+    """
+    parts = (session_key or "").split(":")
+    if len(parts) < 5 or parts[0] != "agent" or not parts[2] or not parts[4]:
+        return None
+    platform, chat_type, chat_id = parts[2], parts[3], parts[4]
+    thread_id = None
+    if len(parts) >= 6 and chat_type in ("dm", "thread") and parts[5]:
+        thread_id = parts[5]
+    return platform, chat_id, thread_id
+
+
 def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     """Auto-subscribe the calling session to task completion / block events.
 
@@ -971,14 +995,15 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
       messaging gateway before agent dispatch. The notification poller
       already keys off these, so we just register a row.
 
-    - **TUI** (herm desktop / herm TUI): the platform/chat_id ContextVars
-      are intentionally cleared (TUI is a single-channel local UI, not
-      a multi-tenant chat surface), but the agent subprocess inherits
-      ``HERMES_SESSION_KEY`` from the parent session. We subscribe with
-      ``platform="tui"`` and ``chat_id=<key>``; the TUI notification
-      poller (``tui_gateway/server.py``) reads ``kanban_notify_subs``
-      for these rows and posts the completion message into the running
-      session.
+    - **Session-key fallback**: when the platform/chat_id ContextVars are
+      unset (TUI sessions clear them; dispatcher-spawned workers never
+      had them), the agent subprocess inherits ``HERMES_SESSION_KEY``
+      from the parent session. If the key is a *gateway* session key
+      (``agent:<ns>:<platform>:...``) we decode it and subscribe to the
+      real platform/chat/thread so the gateway notifier can deliver.
+      Otherwise we record ``platform="tui"`` / ``chat_id=<key>`` —
+      note no poller currently consumes these rows, so they are
+      best-effort bookkeeping only.
 
     - **CLI / cron / test / unattached**: no persistent delivery channel,
       no-op.
@@ -1003,29 +1028,37 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         from gateway.session_context import get_session_env
         platform = get_session_env("HERMES_SESSION_PLATFORM", "")
         chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+        thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
         if not platform or not chat_id:
-            # TUI / desktop fallback: platform/chat_id ContextVars are
-            # cleared for TUI sessions, but the parent process exports
-            # HERMES_SESSION_KEY into the subprocess env. Treat that
-            # as a "tui" subscription so the TUI notification poller
-            # (tui_gateway/server.py) can pick it up.
+            # Fallback: platform/chat_id ContextVars are cleared for TUI
+            # sessions and not propagated into dispatcher-spawned worker
+            # subprocesses, but the parent exports HERMES_SESSION_KEY.
             #
             # HERMES_SESSION_ID is intentionally NOT a fallback here:
             # it is set by ACP / the agent subprocess for telemetry
             # regardless of whether the parent is a TUI or a CLI, so
             # treating it as a notification target would auto-subscribe
             # every CLI invocation, which is exactly the over-eager
-            # behaviour that got #19718 reverted upstream. The TUI
-            # poller keys on HERMES_SESSION_KEY.
+            # behaviour that got #19718 reverted upstream.
             session_key = (
                 get_session_env("HERMES_SESSION_KEY", "")
                 or os.environ.get("HERMES_SESSION_KEY", "")
             )
             if not session_key:
                 return False  # CLI / cron / test — no persistent channel
-            platform = "tui"
-            chat_id = session_key
-        thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
+            parsed = _parse_gateway_session_key(session_key)
+            if parsed:
+                # Gateway session key (agent:<ns>:<platform>:<chat_type>:...):
+                # subscribe to the REAL platform/chat so the gateway notifier
+                # can deliver. Recording these as platform="tui" produced
+                # permanently undeliverable rows — the notifier only sends
+                # via connected platform adapters, and no TUI poller consumes
+                # kanban_notify_subs.
+                platform, chat_id, key_thread_id = parsed
+                thread_id = thread_id or key_thread_id
+            else:
+                platform = "tui"
+                chat_id = session_key
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
         notifier_profile = (
             get_session_env("HERMES_SESSION_PROFILE", "")


### PR DESCRIPTION
## What does this PR do?

Kanban auto-subscriptions created by **dispatcher-spawned workers** are written with `platform="tui"` and a raw session key as the address. Nothing consumes `tui` subscription rows for delivery, so every such subscription is dead on arrival — the user is never notified when the task completes, blocks, or crashes. This is the primary path for the async kanban orchestration/swarm subsystem.

`_maybe_auto_subscribe` (`tools/kanban_tools.py`) resolves the delivery target from the `HERMES_SESSION_PLATFORM` / `HERMES_SESSION_CHAT_ID` session ContextVars and falls back to `platform="tui"` / `chat_id=session_key` when they are unset, citing a "TUI poller." That poller does not exist:

- `git grep -nE "list_notify_subs|claim_unseen_events_for_sub|kanban_notify_subs" -- 'tui_gateway/*' 'desktop/*' 'apps/*'` → **no matches**.
- There is **no `Platform.TUI`** enum, so a `tui` row can't survive the notifier's `Platform(platform_str)` decode in the delivery phase.
- The only *delivery* consumer, `gateway/kanban_watchers.py`, routes solely through connected platform adapters. The two other readers are read-only display (`plugins/kanban/dashboard/plugin_api.py`, `notify-list`).

Dispatcher workers spawn with `env = dict(os.environ)` (`hermes_cli/kanban_db.py::_default_spawn`); the platform/chat ContextVars are per-message and don't cross into the subprocess, so gateway-origin workers hit the `tui` fallback even though their session key encodes the real route (`agent:<ns>:<platform>:<chat_type>:<chat_id>[:<thread>]`). Inline creation (an agent handling a live chat message) is unaffected.

**Fix:** decode the gateway session key back into `(platform, chat_id, thread_id)` (mirroring `gateway/run.py::_parse_session_key`) and subscribe to that. Genuine TUI/desktop keys don't match the gateway shape, so they fall through to the existing `tui` behavior unchanged — the change only rescues gateway-origin subscriptions that are currently undeliverable. Also corrects the stale docstring referencing the nonexistent TUI poller.

## Related work

- Complements the merged profile-routing salvage (#54872 and siblings): that fixed the *delivery-side* profile→adapter routing; this fixes the *address* (`tui` vs real platform/chat), which is a separate layer.
- Alternative approach to the same symptom as **#45940**, which propagates the session ContextVars into the worker subprocess env via a new `build_session_subprocess_env()` helper so the `tui` fallback never fires. This PR is a smaller, more targeted fix (decode at the point of use, no spawn-path change) and does not conflict — happy to defer/rebase if the env-propagation approach is preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/kanban_tools.py`: add `_parse_gateway_session_key()`; decode the session key in `_maybe_auto_subscribe` instead of recording `platform="tui"`; fix the docstring.
- `tests/hermes_cli/test_kanban_notify.py`: `test_parse_gateway_session_key` (dm/thread/group/profile-namespaced/non-gateway keys) and `test_auto_subscribe_decodes_gateway_session_key` (worker with only `HERMES_SESSION_KEY` → real discord/chat/thread sub, not a `tui` row).

## How to Test

Repro (single-gateway host running kanban orchestration): every auto-subscription lands as `platform='tui'` with a gateway session key as `chat_id` and `last_event_id=0` (never delivered). With this change, a dispatcher-spawned worker's `kanban_create` produces a real `discord`/`telegram` subscription and terminal events deliver.

```
python -m pytest tests/hermes_cli/test_kanban_notify.py -q
```

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs for duplicates (this is a distinct approach from #45940 / #50972)
- [x] PR contains only changes related to this fix
- [x] `pytest tests/hermes_cli/test_kanban_notify.py -q` passes
- [x] Added tests for the change
- [x] Tested on: Raspberry Pi OS (aarch64), Python 3.13

## Behavior change worth flagging

Users running gateway-orchestrated kanban who currently get *no* terminal notifications will start getting them. That is the intended fix, but it is a visible change from "silently nothing."