### PR TITLE
fix(gateway): fall back to HERMES_HOME for gateway-locks state dir (#56402)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -13,6 +13,7 @@ concurrently under distinct configurations).
 
 import hashlib
 import json
+import logging
 import os
 import shlex
 import signal
@@ -36,6 +37,8 @@ _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
+_logger = logging.getLogger(__name__)
+_state_home_fallback_warned = False
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
@@ -61,12 +64,60 @@ def _get_runtime_status_path() -> Path:
     return _get_pid_path().with_name(_RUNTIME_STATUS_FILE)
 
 
+def _state_dir_is_writable(state_home: Path) -> bool:
+    """Return True when *state_home* can be created and written by this process."""
+    try:
+        state_home.mkdir(parents=True, exist_ok=True)
+        probe = state_home / f".hermes-write-probe-{os.getpid()}"
+        probe.write_text("", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+        return True
+    except OSError:
+        return False
+
+
+def _home_derived_state_dir() -> Path:
+    """Default XDG state dir derived from ``HOME`` / ``Path.home()``."""
+    override = os.getenv("XDG_STATE_HOME", "").strip()
+    if override:
+        return Path(override)
+    return Path.home() / ".local" / "state"
+
+
+def _resolve_state_home_for_locks() -> Path:
+    """Pick a writable XDG-style state directory for machine-local gateway locks.
+
+    Container/reconciler launches can inherit ``HOME=/root`` from the init
+    context while the gateway process runs as a non-root UID. In that case
+    ``$HOME/.local/state`` is not writable and scoped platform locks (e.g.
+    Telegram bot tokens) fail silently (#56402). Fall back to
+    ``$HERMES_HOME/.local/state`` when the HOME-derived path is unusable.
+    """
+    global _state_home_fallback_warned
+
+    home_state = _home_derived_state_dir()
+    if _state_dir_is_writable(home_state):
+        return home_state
+
+    hermes_state = get_hermes_home() / ".local" / "state"
+    if not _state_home_fallback_warned:
+        _logger.warning(
+            "HOME-derived state dir %s is not writable; falling back to %s "
+            "for gateway-locks (issue #56402). Set HERMES_GATEWAY_LOCK_DIR "
+            "or XDG_STATE_HOME to override.",
+            home_state,
+            hermes_state,
+        )
+        _state_home_fallback_warned = True
+    return hermes_state
+
+
 def _get_lock_dir() -> Path:
     """Return the machine-local directory for token-scoped gateway locks."""
     override = os.getenv("HERMES_GATEWAY_LOCK_DIR")
     if override:
         return Path(override)
-    state_home = Path(os.getenv("XDG_STATE_HOME", Path.home() / ".local" / "state"))
+    state_home = _resolve_state_home_for_locks()
     return state_home / "hermes" / _LOCKS_DIRNAME
 
 

--- a/tests/gateway/test_gateway_locks_writable_state_home_56402.py
+++ b/tests/gateway/test_gateway_locks_writable_state_home_56402.py
@@ -1,0 +1,79 @@
+"""Regression tests for #56402: gateway-locks must use a writable state dir."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway import status
+
+
+class TestResolveStateHomeForLocks:
+    def test_uses_home_derived_state_when_writable(self, tmp_path, monkeypatch):
+        home_state = tmp_path / "home" / ".local" / "state"
+        with patch.object(status, "_home_derived_state_dir", return_value=home_state), patch.object(
+            status, "_state_dir_is_writable", return_value=True
+        ):
+            resolved = status._resolve_state_home_for_locks()
+        assert resolved == home_state
+
+    def test_falls_back_to_hermes_home_when_home_state_not_writable(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / "hermes_data"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+
+        unwritable = tmp_path / "root_home"
+        unwritable.mkdir()
+        monkeypatch.setenv("HOME", str(unwritable))
+
+        with patch.object(status, "_state_dir_is_writable", side_effect=[False, True]):
+            resolved = status._resolve_state_home_for_locks()
+
+        assert resolved == hermes_home / ".local" / "state"
+
+    def test_get_lock_dir_uses_hermes_home_fallback(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_data"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+
+        with patch.object(
+            status,
+            "_resolve_state_home_for_locks",
+            return_value=hermes_home / ".local" / "state",
+        ):
+            lock_dir = status._get_lock_dir()
+
+        assert lock_dir == hermes_home / ".local" / "state" / "hermes" / "gateway-locks"
+
+
+class TestAcquireScopedLockWritableFallback:
+    def test_acquire_lock_under_hermes_home_fallback(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_data"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+
+        with patch.object(
+            status,
+            "_resolve_state_home_for_locks",
+            return_value=hermes_home / ".local" / "state",
+        ):
+            acquired, existing = status.acquire_scoped_lock(
+                "telegram-bot-token",
+                "secret-token",
+                metadata={"platform": "telegram"},
+            )
+
+        assert acquired is True
+        assert existing is None
+        lock_files = list((hermes_home / ".local" / "state" / "hermes" / "gateway-locks").glob("*.lock"))
+        assert len(lock_files) == 1
+        payload = json.loads(lock_files[0].read_text(encoding="utf-8"))
+        assert payload["scope"] == "telegram-bot-token"
+        assert payload["pid"] == os.getpid()


### PR DESCRIPTION
## Summary

When the gateway inherits `HOME=/root` from a container init context but runs as a non-root UID, scoped platform locks resolve under `/root/.local/state/hermes/gateway-locks/` and fail with `PermissionError`. Telegram (and other token-scoped platforms) then pause with no actionable error.

- Probe whether the HOME/XDG-derived state directory is writable.
- Fall back to `$HERMES_HOME/.local/state` when it is not.
- Log a one-time warning naming both paths.

Fixes #56402

## Real behavior proof

Issue reproduction: non-root container with `HOME=/root` → `PermissionError` on `gateway-locks/*.lock` → Telegram silently paused. Workaround from reporter: `HOME=/opt/data gateway run` writes locks under the writable data volume.

This PR makes the HERMES_HOME fallback automatic without requiring operators to override HOME manually.

## Test plan

- [x] `pytest tests/gateway/test_gateway_locks_writable_state_home_56402.py` (4/4)
- [x] `pytest tests/gateway/test_status.py -k lock` (scoped-lock regressions)
