### PR TITLE
fix(approval): ignore leaked HERMES_CRON_SESSION in interactive sessions (#56771)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2076,9 +2076,8 @@ class TestApprovalTimeoutIsNotConsent:
         }
         os.environ.pop("HERMES_YOLO_MODE", None)
         os.environ.pop("HERMES_INTERACTIVE", None)
-        # HERMES_CRON_SESSION takes priority over HERMES_GATEWAY_SESSION in
-        # _is_gateway_approval_context(); a leaked value from a parent cron
-        # process would force the cron path and break these gateway tests.
+        # Leaked HERMES_CRON_SESSION from a parent cron process must not force
+        # the cron approval path when this test exercises gateway behavior.
         os.environ.pop("HERMES_CRON_SESSION", None)
         os.environ["HERMES_GATEWAY_SESSION"] = "1"
         os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY

--- a/tests/tools/test_cron_session_env_leak_56771.py
+++ b/tests/tools/test_cron_session_env_leak_56771.py
@@ -1,0 +1,73 @@
+"""Regression tests for #56771 — leaked HERMES_CRON_SESSION env blocking interactive sessions."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools import approval as A
+
+
+@pytest.fixture
+def manual_approval(monkeypatch):
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_get_cron_approval_mode", lambda: "deny")
+
+
+def test_leaked_cron_env_does_not_block_gateway_execute_code(manual_approval, monkeypatch):
+    """Interactive gateway with leaked HERMES_CRON_SESSION must use gateway path."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    session_key = "leak-test-gateway"
+    token = A.set_current_session_key(session_key)
+    try:
+        assert A._is_cron_approval_context() is False
+        assert A._is_gateway_approval_context() is True
+        res = A.check_execute_code_guard("print('hello')", "local")
+        assert res["approved"] is False
+        assert res.get("outcome") != "blocked"
+        assert res.get("status") in ("approval_required", "pending_approval")
+    finally:
+        A.reset_current_session_key(token)
+
+
+def test_leaked_cron_env_does_not_block_contextvar_gateway_execute_code(
+    manual_approval, monkeypatch
+):
+    """Modern gateway paths bind session_key/platform without HERMES_GATEWAY_SESSION."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    tokens = set_session_vars(platform="telegram", chat_id="123", session_key="tg-session")
+    try:
+        assert A._is_cron_approval_context() is False
+        assert A._is_gateway_approval_context() is True
+        res = A.check_execute_code_guard("print('hello')", "local")
+        assert res["approved"] is False
+        assert res.get("outcome") != "blocked"
+        assert res.get("status") in ("approval_required", "pending_approval")
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_real_cron_still_blocks_execute_code(manual_approval, monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    tokens = set_session_vars(platform="telegram", chat_id="123")
+    try:
+        assert A._is_cron_approval_context() is True
+        assert A._is_gateway_approval_context() is False
+        res = A.check_execute_code_guard("print('hello')", "local")
+        assert res["approved"] is False
+        assert res["outcome"] == "blocked"
+        assert "Cron jobs run without a user present" in res["message"]
+    finally:
+        clear_session_vars(tokens)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -175,6 +175,42 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _has_bound_session_key() -> bool:
+    """True when the current task has a non-empty session key bound."""
+    session_key = _approval_session_key.get()
+    if session_key:
+        return True
+    try:
+        from gateway.session_context import _UNSET, _VAR_MAP
+
+        var = _VAR_MAP.get("HERMES_SESSION_KEY")
+        if var is not None:
+            value = var.get()
+            if value is not _UNSET and value:
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _is_cron_approval_context() -> bool:
+    """True when this tool call is executing inside a cron job.
+
+    ``HERMES_CRON_SESSION`` is set process-wide by the cron scheduler and can
+    leak into interactive gateway/CLI sessions via env inheritance (#56771).
+    Live interactive contexts override the leaked flag.
+    """
+    if not env_var_enabled("HERMES_CRON_SESSION"):
+        return False
+    if env_var_enabled("HERMES_GATEWAY_SESSION"):
+        return False
+    if _is_interactive_cli():
+        return False
+    if _has_bound_session_key():
+        return False
+    return True
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -189,7 +225,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_approval_context():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -2002,7 +2038,7 @@ def check_dangerous_command(command: str, env_type: str,
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -2265,7 +2301,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -2652,7 +2688,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_approval_context():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,


### PR DESCRIPTION
## Summary

- Add `_is_cron_approval_context()` so `HERMES_CRON_SESSION` alone does not classify a call as cron when a live interactive session is active.
- Interactive overrides: `HERMES_GATEWAY_SESSION`, interactive CLI flag, or a bound `HERMES_SESSION_KEY` contextvar.
- Real cron jobs (including delivery-metadata `platform` bindings without a session key) still honor `approvals.cron_mode`.

Fixes #56771

## Why

The cron scheduler sets `HERMES_CRON_SESSION` process-wide. When that env leaks into a Telegram/gateway session, `execute_code` was blocked with the cron-deny message even though a user was present to approve.

## Test plan

- [x] `pytest tests/tools/test_cron_session_env_leak_56771.py` (3/3)
- [x] `pytest tests/tools/test_cron_approval_mode.py tests/tools/test_execute_code_approval_cluster.py` (48/48)
