### PR TITLE
fix(provider): handle reasoning deltas in model_extra

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2126,6 +2126,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate reasoning content
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
+            # Some OpenAI-compatible providers expose provider-specific
+            # reasoning fields via the SDK's model_extra dict instead of as
+            # direct attributes. Mirror the non-streaming transport fallback.
+            if reasoning_text is None and hasattr(delta, "model_extra"):
+                model_extra = getattr(delta, "model_extra", None)
+                if isinstance(model_extra, dict):
+                    reasoning_text = model_extra.get("reasoning_content") or model_extra.get("reasoning")
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
                 _fire_first_delta()
@@ -2270,6 +2277,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Zero-chunk guard: stream yielded nothing usable — a provider/upstream
         # error or malformed SSE, not a legitimate empty completion. Raise so the
         # retry machinery handles it instead of fabricating a successful turn.
+        # Reasoning-only streams are valid output even when no visible content
+        # arrives; providers may expose that reasoning via delta.model_extra.
         if (
             finish_reason is None
             and not content_parts

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6912,6 +6912,27 @@ class TestStreamingApiCall:
         assert resp.choices[0].message.content is None
         assert resp.choices[0].message.tool_calls is None
 
+    def test_reasoning_content_in_delta_model_extra_counts_as_stream_output(self, agent):
+        """OpenAI-compatible providers may expose reasoning deltas via model_extra."""
+        delta = SimpleNamespace(
+            content=None,
+            tool_calls=None,
+            model_extra={"reasoning_content": "thinking only"},
+        )
+        chunks = [
+            SimpleNamespace(
+                model="openai-compatible/reasoning",
+                choices=[SimpleNamespace(delta=delta, finish_reason=None)],
+            )
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert resp.choices[0].message.content is None
+        assert resp.choices[0].message.reasoning_content == "thinking only"
+        assert resp.choices[0].finish_reason == "stop"
+
     def test_callback_exception_swallowed(self, agent):
         chunks = [
             _make_chunk(content="Hello"),


### PR DESCRIPTION
## What does this PR do?

Fixes a false `Provider returned an empty stream with no finish_reason` error for OpenAI-compatible reasoning providers that stream reasoning deltas via `delta.model_extra` instead of direct `delta.reasoning_content` attributes.

Some providers expose provider-specific fields through the OpenAI SDK `model_extra` dict. The non-streaming transport already handles this shape, but the streaming path only checked direct delta attributes, so a reasoning-only stream could be misclassified as empty.

## Related Issue

Fixes #56516

## Changes Made

- Add streaming fallback from `delta.model_extra["reasoning_content"]` / `delta.model_extra["reasoning"]` when direct reasoning attributes are absent.
- Clarify the empty-stream guard comment: reasoning-only streams are valid output.
- Add a regression test covering a reasoning-only stream where reasoning arrives only through `delta.model_extra`.

## How to test

```bash
scripts/run_tests.sh tests/run_agent/test_run_agent.py -q -k "model_extra_counts_as_stream_output"
scripts/run_tests.sh tests/run_agent/test_run_agent.py -q -k "stream or reasoning or empty"
venv/bin/ruff check agent/chat_completion_helpers.py tests/run_agent/test_run_agent.py
git diff --check
```

## Platforms tested

- Linux (Python 3.12)
