### PR TITLE
fix(gateway): drop empty inbound events before dispatch

### DIFF
--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -13,6 +13,14 @@ from typing import Any
 # Canonical model-emitted control token for intentional silence.
 SILENT_REPLY_TOKEN = "NO_REPLY"
 
+# Discord can surface attachment/unsupported/deleted-message shells through the
+# gateway as a literal placeholder string instead of an empty body.  Treat this
+# as empty at the dispatch boundary; otherwise it starts a full agent turn and
+# can keep shutdown/restart drains alive with meaningless work.
+EMPTY_INBOUND_TEXT_SENTINELS = frozenset({
+    "(The user sent a message with no text content)",
+})
+
 # Exact whole-response markers that mean "the agent intentionally chose not to
 # reply".  Keep this list small and explicit; arbitrary empty output remains an
 # error/empty-response path, not silence.
@@ -51,6 +59,48 @@ def _canonical_silence_candidates(text: str) -> tuple[str, ...]:
         return (exact,)
     fallback = _canonical_silence_candidate(stripped)
     return (exact, fallback)
+
+
+def should_drop_empty_inbound_event(event: Any) -> bool:
+    """Return True for user-originated empty events that should not start a turn.
+
+    Some platforms can emit text updates with no body (for example topic/router
+    artifacts or deleted/unsupported payload shells). Letting those through to
+    the agent creates useless "blank message" replies and can loop across
+    mirrored chats. Keep the predicate conservative: internal synthetic events,
+    media/file payloads, and reply-context events still flow.  A blank trigger
+    with ``channel_context`` also flows: the Discord adapter deliberately lets
+    a bare mention through when history backfill produced context — the context
+    IS the message ("catch me up"), and run.py prepends it ahead of the trigger.
+    """
+    if bool(getattr(event, "internal", False)):
+        return False
+    text = getattr(event, "text", "")
+    if not isinstance(text, str):
+        return False
+    stripped = text.strip()
+    if stripped and stripped not in EMPTY_INBOUND_TEXT_SENTINELS:
+        return False
+
+    if getattr(event, "media_urls", None):
+        return False
+    if getattr(event, "media_types", None):
+        return False
+    if any(
+        getattr(event, field, None)
+        for field in (
+            "reply_to_message_id",
+            "reply_to_text",
+            "reply_to_author_id",
+            "reply_to_author_name",
+            "reply_to_is_own_message",
+        )
+    ):
+        return False
+    if getattr(event, "channel_context", None):
+        return False
+
+    return True
 
 
 def is_intentional_silence_response(response: Any) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10529,6 +10529,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return None
 
+        # Drop genuinely empty user-originated events before they can be
+        # queued, authorized, or dispatched — a blank turn only produces a
+        # useless "you sent nothing" reply (and can loop across mirrored
+        # chats). Internal events, media-only payloads, reply-context and
+        # channel-context ("catch me up") events all still flow.
+        try:
+            from gateway.response_filters import should_drop_empty_inbound_event
+            _drop_empty_inbound = should_drop_empty_inbound_event(event)
+        except Exception:
+            _drop_empty_inbound = False
+        if _drop_empty_inbound:
+            logger.info(
+                "Dropping empty inbound message before agent dispatch: platform=%s chat=%s message_id=%s",
+                source.platform.value if source and source.platform else "unknown",
+                source.chat_id if source else "unknown",
+                getattr(event, "message_id", None),
+            )
+            return None
+
         if (
             getattr(self, "_startup_restore_in_progress", False)
             and not is_internal

--- a/tests/gateway/test_empty_inbound_event_drop.py
+++ b/tests/gateway/test_empty_inbound_event_drop.py
@@ -1,0 +1,210 @@
+"""GatewayRunner._handle_message must drop genuinely empty inbound events.
+
+Regression tests for the empty-inbound protection (salvaged from PR #56793):
+a user-originated event with no text (or only the Discord no-text sentinel),
+no media, no reply context, and no channel context must return before
+authorization, pairing, or agent dispatch.  Media-only events, reply-context
+events, channel-context ("catch me up") events, and internal synthetic events
+must continue to flow.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+DISCORD_NO_TEXT_SENTINEL = "(The user sent a message with no text content)"
+
+
+def _build_runner(monkeypatch, tmp_path) -> GatewayRunner:
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+
+    runner = GatewayRunner(GatewayConfig())
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner.adapters[Platform.DISCORD] = adapter
+    return runner
+
+
+def _instrument(monkeypatch, runner):
+    """Track authorization and agent dispatch on ``runner``.
+
+    Authorization is stubbed to False with chat_type='group' events so an
+    event that gets PAST the empty-event guard is silently ignored (no
+    pairing DM) — reaching the auth check at all is the signal we assert on.
+    """
+    calls = {"auth": 0, "agent": 0}
+
+    def _tracking_auth(self, src):
+        calls["auth"] += 1
+        return False
+
+    async def _tracking_agent(self, *a, **kw):
+        calls["agent"] += 1
+        raise RuntimeError("sentinel — stop before the agent runner")
+
+    monkeypatch.setattr(GatewayRunner, "_is_user_authorized", _tracking_auth)
+    monkeypatch.setattr(GatewayRunner, "_handle_message_with_agent", _tracking_agent)
+    return calls
+
+
+def _source(chat_type="group", user_id="user-1"):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name="alice",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("text", ["", "   \n\t", DISCORD_NO_TEXT_SENTINEL])
+async def test_blank_and_sentinel_events_return_before_authorization(
+    monkeypatch, tmp_path, text
+):
+    runner = _build_runner(monkeypatch, tmp_path)
+    calls = _instrument(monkeypatch, runner)
+
+    event = MessageEvent(text=text, source=_source())
+    result = await runner._handle_message(event)
+
+    assert result is None
+    assert calls["auth"] == 0, "empty event must be dropped before authorization"
+    assert calls["agent"] == 0, "empty event must never reach agent dispatch"
+
+
+@pytest.mark.asyncio
+async def test_blank_dm_event_does_not_trigger_pairing(monkeypatch, tmp_path):
+    """A blank DM from an unknown user is dropped before the pairing flow."""
+    runner = _build_runner(monkeypatch, tmp_path)
+    adapter = runner.adapters[Platform.DISCORD]
+
+    generate_called = False
+    original_generate = runner.pairing_store.generate_code
+
+    def tracking_generate(*args, **kwargs):
+        nonlocal generate_called
+        generate_called = True
+        return original_generate(*args, **kwargs)
+
+    runner.pairing_store.generate_code = tracking_generate
+
+    event = MessageEvent(
+        text="",
+        source=_source(chat_type="dm", user_id="unknown_user_999"),
+    )
+    result = await runner._handle_message(event)
+
+    assert result is None
+    assert not generate_called
+    assert adapter.send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_media_only_event_continues_past_the_empty_guard(monkeypatch, tmp_path):
+    runner = _build_runner(monkeypatch, tmp_path)
+    calls = _instrument(monkeypatch, runner)
+
+    event = MessageEvent(
+        text="",
+        source=_source(),
+        media_urls=["/tmp/voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+    await runner._handle_message(event)
+
+    assert calls["auth"] == 1, "media-only event must reach authorization"
+
+
+@pytest.mark.asyncio
+async def test_sentinel_text_with_media_continues(monkeypatch, tmp_path):
+    runner = _build_runner(monkeypatch, tmp_path)
+    calls = _instrument(monkeypatch, runner)
+
+    event = MessageEvent(
+        text=DISCORD_NO_TEXT_SENTINEL,
+        source=_source(),
+        media_urls=["/tmp/photo.png"],
+    )
+    await runner._handle_message(event)
+
+    assert calls["auth"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reply_context_event_continues_past_the_empty_guard(monkeypatch, tmp_path):
+    runner = _build_runner(monkeypatch, tmp_path)
+    calls = _instrument(monkeypatch, runner)
+
+    event = MessageEvent(
+        text="",
+        source=_source(),
+        reply_to_message_id="m-1",
+        reply_to_text="the assistant reply being pointed at",
+    )
+    await runner._handle_message(event)
+
+    assert calls["auth"] == 1, "reply-context event must reach authorization"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reply_metadata",
+    [
+        {"reply_to_message_id": "m-1"},
+        {"reply_to_author_id": "user-2"},
+        {"reply_to_author_name": "bob"},
+        {"reply_to_is_own_message": True},
+    ],
+)
+async def test_reply_metadata_without_quoted_text_continues_past_empty_guard(
+    monkeypatch, tmp_path, reply_metadata
+):
+    """Platforms can supply reply identity even when quoted-text lookup misses."""
+    runner = _build_runner(monkeypatch, tmp_path)
+    calls = _instrument(monkeypatch, runner)
+
+    event = MessageEvent(text="", source=_source(), **reply_metadata)
+    await runner._handle_message(event)
+
+    assert calls["auth"] == 1, "reply metadata must reach authorization"
+
+
+@pytest.mark.asyncio
+async def test_channel_context_catch_me_up_event_continues(monkeypatch, tmp_path):
+    """A bare-mention trigger with backfill context is a 'catch me up' turn."""
+    runner = _build_runner(monkeypatch, tmp_path)
+    calls = _instrument(monkeypatch, runner)
+
+    event = MessageEvent(
+        text="",
+        source=_source(),
+        channel_context="[Recent channel messages]\nbob: anyone seen the deploy?",
+    )
+    await runner._handle_message(event)
+
+    assert calls["auth"] == 1, "channel-context event must reach authorization"
+
+
+@pytest.mark.asyncio
+async def test_blank_internal_event_reaches_agent_dispatch(monkeypatch, tmp_path):
+    """Internal synthetic events must continue even with blank visible text."""
+    runner = _build_runner(monkeypatch, tmp_path)
+    calls = _instrument(monkeypatch, runner)
+
+    event = MessageEvent(text="", source=_source(), internal=True)
+
+    with pytest.raises(RuntimeError, match="sentinel"):
+        await runner._handle_message(event)
+
+    assert calls["auth"] == 0, "internal events bypass authorization"
+    assert calls["agent"] == 1, "internal event must reach agent dispatch"


### PR DESCRIPTION
## Summary

Drop truly empty inbound events before authorization, pairing, plugin hooks, or agent dispatch while preserving valid media-only, reply-context, internal, and Discord bare-mention catch-up turns.

## Problem

Some connectors can surface blank event shells or the literal placeholder `(The user sent a message with no text content)`. Those events can start meaningless agent turns, trigger pairing prompts, or keep a draining gateway alive.

Relay events with neither text nor media can create the same failure mode before they reach the gateway runner.

## Changes

- add a shared empty-inbound predicate for blank text and known empty-text sentinels
- drop empty relay events before dispatch and acknowledge them as deliberately consumed
- enforce the same guard at the real `GatewayRunner._handle_message()` entry point before authorization and agent dispatch
- preserve media-only events, sentinel-plus-media events, reply-context events, internal events, and Discord bare-mention catch-up turns
- avoid injecting the empty-text placeholder into Discord voice and attachment events
- add entry-point, relay, response-filter, and Discord attachment regression coverage

This revision intentionally does not use prose/content heuristics to suppress verifier-like assistant responses. Legitimate verification summaries remain valid output.

## Verification

```text
59 focused tests passed
Ruff passed
git diff --check passed
```
