### PR TITLE
feat(gateway): webhook synthetic source platform + media payload support

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -52,11 +52,14 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.session import SessionSource
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     SendResult,
+    cache_audio_from_bytes,
+    cache_image_from_bytes,
 )
 from gateway.platforms.webhook_filters import (
     DEFAULT_SCRIPT_TIMEOUT_SECONDS,
@@ -91,6 +94,40 @@ _LOOPBACK_HOSTS = frozenset({
     "ip6-localhost",
     "ip6-loopback",
 })
+
+# Webhook media is untrusted JSON, even after the route HMAC succeeds. Keep
+# the MIME vocabulary small and require bytes consistent with the claimed MIME
+# before choosing the cache extension. The shared cache helpers remain the
+# authority for cache location and inbound-media byte limits.
+_IMAGE_MEDIA_SIGNATURES = {
+    "image/png": (".png", lambda data: data.startswith(b"\x89PNG\r\n\x1a\n")),
+    "image/jpeg": (".jpg", lambda data: data.startswith(b"\xff\xd8\xff")),
+    "image/gif": (".gif", lambda data: data.startswith((b"GIF87a", b"GIF89a"))),
+    "image/bmp": (".bmp", lambda data: data.startswith(b"BM")),
+    "image/webp": (
+        ".webp",
+        lambda data: data.startswith(b"RIFF") and len(data) >= 12 and data[8:12] == b"WEBP",
+    ),
+}
+_AUDIO_MEDIA_SIGNATURES = {
+    "audio/ogg": (".ogg", lambda data: data.startswith(b"OggS")),
+    "audio/opus": (".opus", lambda data: data.startswith(b"OggS")),
+    "audio/mpeg": (
+        ".mp3",
+        lambda data: data.startswith(b"ID3") or data[:2] in {b"\xff\xfb", b"\xff\xf3", b"\xff\xf2"},
+    ),
+    "audio/wav": (
+        ".wav",
+        lambda data: data.startswith(b"RIFF") and len(data) >= 12 and data[8:12] == b"WAVE",
+    ),
+    "audio/flac": (".flac", lambda data: data.startswith(b"fLaC")),
+    "audio/mp4": (".m4a", lambda data: len(data) >= 8 and data[4:8] == b"ftyp"),
+    "audio/aac": (
+        ".m4a",
+        lambda data: (len(data) >= 2 and data[0] == 0xFF and data[1] & 0xF6 == 0xF0)
+        or (len(data) >= 8 and data[4:8] == b"ftyp"),
+    ),
+}
 
 
 def _is_loopback_host(host: str) -> bool:
@@ -562,6 +599,10 @@ class WebhookAdapter(BasePlatformAdapter):
                 return web.json_response(
                     {"error": "Cannot parse body"}, status=400
                 )
+        if not isinstance(payload, dict):
+            return web.json_response(
+                {"error": "Webhook payload must be a JSON object"}, status=400
+            )
 
         # Check event type filter
         event_type = (
@@ -656,6 +697,72 @@ class WebhookAdapter(BasePlatformAdapter):
                         )
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
+
+        # A synthetic source is an explicit trusted-route contract: identity
+        # fields come only from route config, never from the untrusted payload.
+        source_platform: Platform | None = None
+        target_adapter = None
+        source_platform_name = route_config.get("source_platform")
+        if source_platform_name is not None:
+            try:
+                source_platform = Platform(str(source_platform_name))
+            except ValueError:
+                return web.json_response({"error": "Invalid configured source platform"}, status=500)
+            if source_platform in {Platform.WEBHOOK, Platform.API_SERVER}:
+                return web.json_response({"error": "Invalid configured source platform"}, status=500)
+            for required in ("source_chat_id", "source_user_id"):
+                value = route_config.get(required)
+                if not isinstance(value, (str, int)) or not str(value):
+                    return web.json_response(
+                        {"error": f"Synthetic source requires {required}"}, status=500
+                    )
+            target_adapter = getattr(self.gateway_runner, "adapters", {}).get(source_platform)
+            if (
+                target_adapter is None
+                or not bool(getattr(getattr(target_adapter, "config", None), "enabled", False))
+                or not bool(getattr(target_adapter, "_running", False))
+                or not callable(getattr(target_adapter, "_message_handler", None))
+                or not callable(getattr(target_adapter, "handle_message", None))
+            ):
+                return web.json_response(
+                    {"error": "Configured source platform is unavailable"}, status=503
+                )
+
+        # Decode before idempotency/cache writes. Malformed attachments must not
+        # silently become text-only agent turns.
+        def decode_media(field_names: tuple[str, ...], kind: str) -> bytes | None:
+            value = next((payload[name] for name in field_names if name in payload), None)
+            if value is None:
+                return None
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"Invalid {kind} base64 payload")
+            try:
+                decoded = base64.b64decode(value, validate=True)
+            except (binascii.Error, ValueError) as exc:
+                raise ValueError(f"Invalid {kind} base64 payload") from exc
+            if not decoded:
+                raise ValueError(f"Invalid {kind} base64 payload")
+            return decoded
+
+        try:
+            audio_bytes = decode_media(("audio_base64", "voice_base64"), "audio")
+            image_bytes = decode_media(("screenshot_base64", "image_base64"), "image")
+        except ValueError:
+            return web.json_response({"error": "Invalid media payload"}, status=400)
+        if audio_bytes is not None and image_bytes is not None:
+            return web.json_response(
+                {"error": "Only one media payload is supported per webhook"}, status=400
+            )
+        audio_mime = str(payload.get("audio_mime_type") or payload.get("voice_mime_type") or "audio/ogg").lower()
+        image_mime = str(payload.get("screenshot_mime_type") or payload.get("image_mime_type") or "image/jpeg").lower()
+        audio_spec = _AUDIO_MEDIA_SIGNATURES.get(audio_mime)
+        image_spec = _IMAGE_MEDIA_SIGNATURES.get(image_mime)
+        if audio_bytes is not None and (audio_spec is None or not audio_spec[1](audio_bytes)):
+            return web.json_response({"error": "Invalid media payload"}, status=400)
+        if image_bytes is not None and (image_spec is None or not image_spec[1](image_bytes)):
+            return web.json_response({"error": "Invalid media payload"}, status=400)
+        audio_ext = audio_spec[0] if audio_spec is not None else ".ogg"
+        image_ext = image_spec[0] if image_spec is not None else ".jpg"
 
         # Build a unique delivery ID
         delivery_id = request.headers.get(
@@ -754,39 +861,91 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_order.append((now, session_chat_id))
         self._prune_delivery_info(now)
 
-        # Build source and event
-        source = self.build_source(
-            chat_id=session_chat_id,
-            chat_name=f"webhook/{route_name}",
-            chat_type="webhook",
-            user_id=f"webhook:{route_name}",
-            user_name=route_name,
-        )
+        # Cache validated media through the shared inbound-media funnel. If a
+        # cache operation fails after creating a file, remove it immediately;
+        # successful files follow the existing gateway cache TTL cleanup.
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        message_type = MessageType.TEXT
+        try:
+            if audio_bytes is not None:
+                media_urls.append(cache_audio_from_bytes(audio_bytes, ext=audio_ext))
+                media_types.append(audio_mime)
+                message_type = MessageType.VOICE
+            if image_bytes is not None:
+                media_urls.append(cache_image_from_bytes(image_bytes, ext=image_ext))
+                media_types.append(image_mime)
+                message_type = MessageType.PHOTO
+        except (OSError, ValueError) as exc:
+            for path in media_urls:
+                try:
+                    import os
+                    os.unlink(path)
+                except OSError:
+                    pass
+            # A delivery is not accepted until its attachment cache succeeds;
+            # otherwise a transient disk/cache failure would consume the ID and
+            # permanently block a valid provider retry. Remove the matching
+            # ordering record too so repeated failures cannot grow stale deque
+            # entries until the normal TTL prune runs.
+            if self._seen_deliveries.get(delivery_id) == now:
+                self._seen_deliveries.pop(delivery_id, None)
+            self._delivery_info.pop(session_chat_id, None)
+            self._delivery_info_created.pop(session_chat_id, None)
+            try:
+                self._delivery_info_order.remove((now, session_chat_id))
+            except ValueError:
+                pass
+            if isinstance(exc, OSError):
+                return web.json_response({"error": "Media cache unavailable"}, status=503)
+            return web.json_response({"error": "Invalid media payload"}, status=400)
+
+        if source_platform is not None:
+            source = SessionSource(
+                platform=source_platform,
+                chat_id=str(route_config["source_chat_id"]),
+                chat_name=route_config.get("source_chat_name") or f"webhook/{route_name}",
+                chat_type=str(route_config.get("source_chat_type") or "dm"),
+                user_id=str(route_config["source_user_id"]),
+                user_name=str(route_config.get("source_user_name") or route_name),
+                thread_id=str(route_config.get("source_thread_id")) if route_config.get("source_thread_id") else None,
+            )
+            event_message_id = None
+        else:
+            source = self.build_source(
+                chat_id=session_chat_id,
+                chat_name=f"webhook/{route_name}",
+                chat_type="webhook",
+                user_id=f"webhook:{route_name}",
+                user_name=route_name,
+            )
+            event_message_id = delivery_id
         if profile and isinstance(profile, str):
             source.profile = profile
         event = MessageEvent(
             text=prompt,
-            message_type=MessageType.TEXT,
+            message_type=message_type,
             source=source,
             raw_message=payload,
-            message_id=delivery_id,
+            message_id=event_message_id,
+            media_urls=media_urls,
+            media_types=media_types,
         )
 
         logger.info(
             "[webhook] %s event=%s route=%s prompt_len=%d delivery=%s",
-            request.method,
+            getattr(request, "method", "POST"),
             event_type,
             route_name,
             len(prompt),
             delivery_id,
         )
 
-        # Non-blocking — return 202 Accepted immediately.  The per-delivery
-        # session is closed by the ``on_processing_complete`` override below
-        # once the agent run actually finishes (``handle_message`` itself is
-        # fire-and-forget: it spawns ``_process_message_background`` and
-        # returns before the run starts, so nothing can be closed here).
-        task = asyncio.create_task(self.handle_message(event))
+        # Non-blocking — return 202 Accepted immediately. The default webhook
+        # handler closes its one-shot delivery session on completion; a native
+        # synthetic source deliberately uses that platform adapter instead.
+        handler = target_adapter.handle_message if target_adapter is not None else self.handle_message
+        task = asyncio.create_task(handler(event))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1145,6 +1145,25 @@ class TestRateLimiting:
 class TestBodySize:
 
     @pytest.mark.asyncio
+    async def test_configured_large_payload_reaches_handler(self):
+        """aiohttp must honor max_body_bytes before Hermes reads JSON bodies."""
+        routes = {"screen": {"secret": _INSECURE_NO_AUTH, "prompt": "{message}"}}
+        adapter = _make_adapter(routes=routes, max_body_bytes=2_000_000)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            payload = {
+                "event_type": "siri_screen_phone",
+                "message": "x" * 1_200_000,
+            }
+            resp = await cli.post("/webhooks/screen", json=payload)
+            assert resp.status == 202
+
+        await asyncio.sleep(0.05)
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_oversized_payload_rejected(self):
         """Content-Length > max_body_bytes returns 413."""
         routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}

--- a/tests/gateway/test_webhook_synthetic_source.py
+++ b/tests/gateway/test_webhook_synthetic_source.py
@@ -1,0 +1,367 @@
+import asyncio
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import _reply_anchor_for_event, _thread_metadata_for_source
+from gateway.platforms.webhook import WebhookAdapter
+
+
+class _FakeRequest:
+    def __init__(self, route_name: str, body: dict, headers: dict | None = None):
+        self.match_info = {"route_name": route_name}
+        self._body = json.dumps(body).encode("utf-8")
+        self.headers = headers or {}
+        self.content_length = len(self._body)
+
+    async def read(self):
+        return self._body
+
+
+class _CapturingAdapter:
+    def __init__(self):
+        self.events = []
+        self.config = SimpleNamespace(enabled=True)
+        self._running = True
+        self._message_handler = AsyncMock()
+
+    async def handle_message(self, event):
+        self.events.append(event)
+        await self._message_handler(event)
+
+
+def _app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application(client_max_size=adapter._max_body_bytes)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_synthetic_telegram_webhook_source_does_not_use_delivery_id_as_reply_anchor():
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "host": "127.0.0.1",
+            "routes": {
+                "siri": {
+                    "secret": "INSECURE_NO_AUTH",
+                    "prompt": "{text}",
+                    "source_platform": "telegram",
+                    "source_chat_id": "1000000001",
+                    "source_chat_type": "dm",
+                    "source_user_id": "1000000001",
+                    "source_user_name": "User",
+                }
+            },
+        },
+    )
+    adapter = WebhookAdapter(config)
+    telegram_adapter = _CapturingAdapter()
+    setattr(adapter, "gateway_runner", SimpleNamespace(adapters={Platform.TELEGRAM: telegram_adapter}))
+
+    response = await adapter._handle_webhook(
+        _FakeRequest(
+            "siri",
+            {"text": "Give me the Burning Man itinerary"},
+            headers={"X-Request-ID": "1781840547354"},
+        )
+    )
+    assert response.status == 202
+
+    # Let the task created by _handle_webhook run.
+    await asyncio.sleep(0)
+
+    assert len(telegram_adapter.events) == 1
+    event = telegram_adapter.events[0]
+    assert event.source.platform == Platform.TELEGRAM
+    assert event.source.chat_id == "1000000001"
+    assert event.source.message_id is None
+    assert event.message_id is None
+    assert _reply_anchor_for_event(event) is None
+
+    metadata = _thread_metadata_for_source(event.source)
+    assert metadata is None
+
+
+@pytest.mark.asyncio
+async def test_synthetic_telegram_webhook_audio_payload_routes_as_voice(monkeypatch, tmp_path):
+    cached_audio = tmp_path / "shortcut_audio.m4a"
+    m4a_bytes = b"\x00\x00\x00\x18ftypM4A fake-m4a-bytes"
+
+    def fake_cache_audio_from_bytes(data: bytes, ext: str = ".ogg") -> str:
+        assert data == m4a_bytes
+        assert ext == ".m4a"
+        cached_audio.write_bytes(data)
+        return str(cached_audio)
+
+    monkeypatch.setattr(
+        "gateway.platforms.webhook.cache_audio_from_bytes",
+        fake_cache_audio_from_bytes,
+    )
+
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "host": "127.0.0.1",
+            "routes": {
+                "siri": {
+                    "secret": "INSECURE_NO_AUTH",
+                    "prompt": "[Siri relay / {route}]\n\n{message}",
+                    "source_platform": "telegram",
+                    "source_chat_id": "1000000001",
+                    "source_chat_type": "dm",
+                    "source_user_id": "1000000001",
+                    "source_user_name": "User",
+                }
+            },
+        },
+    )
+    adapter = WebhookAdapter(config)
+    telegram_adapter = _CapturingAdapter()
+    setattr(adapter, "gateway_runner", SimpleNamespace(adapters={Platform.TELEGRAM: telegram_adapter}))
+
+    response = await adapter._handle_webhook(
+        _FakeRequest(
+            "siri",
+            {
+                "event_type": "siri",
+                "message": "",
+                "audio_base64": base64.b64encode(m4a_bytes).decode("ascii"),
+                "audio_mime_type": "audio/mp4",
+                "audio_filename": "Shortcut Recording.m4a",
+            },
+            headers={"X-Request-ID": "shortcut-audio-1"},
+        )
+    )
+    assert response.status == 202
+
+    await asyncio.sleep(0)
+
+    assert len(telegram_adapter.events) == 1
+    event = telegram_adapter.events[0]
+    assert event.source.platform == Platform.TELEGRAM
+    assert event.source.chat_id == "1000000001"
+    assert event.source.message_id is None
+    assert event.message_id is None
+    assert _reply_anchor_for_event(event) is None
+    assert event.message_type.value == "voice"
+    assert event.media_urls == [str(cached_audio)]
+    assert event.media_types == ["audio/mp4"]
+
+
+@pytest.mark.asyncio
+async def test_synthetic_telegram_webhook_image_payload_routes_as_photo(monkeypatch, tmp_path):
+    cached_image = tmp_path / "shortcut_screenshot.png"
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"fake-png-body"
+
+    def fake_cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
+        assert data == png_bytes
+        assert ext == ".png"
+        cached_image.write_bytes(data)
+        return str(cached_image)
+
+    monkeypatch.setattr(
+        "gateway.platforms.webhook.cache_image_from_bytes",
+        fake_cache_image_from_bytes,
+    )
+
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "host": "127.0.0.1",
+            "routes": {
+                "siri-screen-phone": {
+                    "secret": "INSECURE_NO_AUTH",
+                    "prompt": "[Siri screen relay / phone]\n\n{message}",
+                    "source_platform": "telegram",
+                    "source_chat_id": "1000000001",
+                    "source_chat_type": "dm",
+                    "source_user_id": "1000000001",
+                    "source_user_name": "User",
+                }
+            },
+        },
+    )
+    adapter = WebhookAdapter(config)
+    telegram_adapter = _CapturingAdapter()
+    setattr(adapter, "gateway_runner", SimpleNamespace(adapters={Platform.TELEGRAM: telegram_adapter}))
+
+    response = await adapter._handle_webhook(
+        _FakeRequest(
+            "siri-screen-phone",
+            {
+                "event_type": "siri_screen_phone",
+                "message": "Act on this screenshot as Todd should.",
+                "screenshot_base64": base64.b64encode(png_bytes).decode("ascii"),
+                "screenshot_mime_type": "image/png",
+                "screenshot_filename": "Screenshot Todd.png",
+            },
+            headers={"X-Request-ID": "shortcut-screen-1"},
+        )
+    )
+    assert response.status == 202
+
+    await asyncio.sleep(0)
+
+    assert len(telegram_adapter.events) == 1
+    event = telegram_adapter.events[0]
+    assert event.source.platform == Platform.TELEGRAM
+    assert event.source.chat_id == "1000000001"
+    assert event.source.message_id is None
+    assert event.message_id is None
+    assert _reply_anchor_for_event(event) is None
+    assert event.message_type.value == "photo"
+    assert event.media_urls == [str(cached_image)]
+    assert event.media_types == ["image/png"]
+
+
+@pytest.mark.asyncio
+async def test_real_aiohttp_image_payload_is_cached_and_malformed_base64_is_rejected(
+    monkeypatch, tmp_path
+):
+    """The HTTP boundary dispatches valid image media and never caches bad base64."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "host": "127.0.0.1",
+            "routes": {
+                "siri": {
+                    "secret": "INSECURE_NO_AUTH",
+                    "prompt": "{message}",
+                    "source_platform": "telegram",
+                    "source_chat_id": "1000000001",
+                    "source_user_id": "1000000001",
+                }
+            },
+        },
+    )
+    adapter = WebhookAdapter(config)
+    telegram_adapter = _CapturingAdapter()
+    adapter.gateway_runner = SimpleNamespace(adapters={Platform.TELEGRAM: telegram_adapter})
+    png_bytes = b"\x89PNG\r\n\x1a\nvalid-test-image"
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        bad = await client.post(
+            "/webhooks/siri",
+            json={"message": "bad", "image_base64": "not valid base64!"},
+        )
+        assert bad.status == 400
+        assert not telegram_adapter.events
+
+        accepted = await client.post(
+            "/webhooks/siri",
+            json={
+                "message": "inspect this",
+                "image_base64": base64.b64encode(png_bytes).decode(),
+                "image_mime_type": "image/png",
+            },
+            headers={"X-Request-ID": "valid-image-1"},
+        )
+        assert accepted.status == 202
+
+    await asyncio.sleep(0)
+    assert len(telegram_adapter.events) == 1
+    cached_path = telegram_adapter.events[0].media_urls[0]
+    try:
+        with open(cached_path, "rb") as cached:
+            assert cached.read() == png_bytes
+    finally:
+        # The production cache uses gateway TTL cleanup; remove this test file
+        # explicitly so the integration fixture leaves no temp artifact behind.
+        import os
+        os.unlink(cached_path)
+
+
+@pytest.mark.asyncio
+async def test_synthetic_source_uses_only_route_identity_and_native_handler():
+    """Authenticated payload identity cannot impersonate a different native chat."""
+    config = PlatformConfig(
+        enabled=True,
+        extra={"host": "127.0.0.1", "routes": {"relay": {
+            "secret": "INSECURE_NO_AUTH", "prompt": "{message}",
+            "source_platform": "telegram", "source_chat_id": "configured-chat",
+            "source_user_id": "configured-user", "source_thread_id": "configured-thread",
+        }}},
+    )
+    adapter = WebhookAdapter(config)
+    target = _CapturingAdapter()
+    adapter.gateway_runner = SimpleNamespace(adapters={Platform.TELEGRAM: target})
+
+    response = await adapter._handle_webhook(_FakeRequest("relay", {
+        "message": "hello", "source_chat_id": "spoofed-chat", "source_user_id": "spoofed-user",
+        "source_thread_id": "spoofed-thread", "source_platform": "discord",
+    }, headers={"X-Request-ID": "identity-1"}))
+    assert response.status == 202
+    await asyncio.sleep(0)
+    target._message_handler.assert_awaited_once()
+    event = target.events[0]
+    assert (event.source.platform, event.source.chat_id, event.source.user_id, event.source.thread_id) == (
+        Platform.TELEGRAM, "configured-chat", "configured-user", "configured-thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_synthetic_source_rejects_unavailable_and_recursive_targets():
+    base_route = {"secret": "INSECURE_NO_AUTH", "prompt": "x", "source_chat_id": "c", "source_user_id": "u"}
+    for platform in ("telegram", "webhook", "api_server"):
+        adapter = WebhookAdapter(PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "routes": {
+            "relay": {**base_route, "source_platform": platform},
+        }}))
+        adapter.gateway_runner = SimpleNamespace(adapters={})
+        response = await adapter._handle_webhook(_FakeRequest("relay", {"message": "x"}))
+        assert response.status in {500, 503}
+
+
+@pytest.mark.asyncio
+async def test_media_signature_mismatch_is_rejected_before_idempotency_or_cache(monkeypatch):
+    adapter = WebhookAdapter(PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "routes": {
+        "relay": {"secret": "INSECURE_NO_AUTH", "prompt": "x"},
+    }}))
+    cache = AsyncMock()
+    monkeypatch.setattr("gateway.platforms.webhook.cache_image_from_bytes", cache)
+    response = await adapter._handle_webhook(_FakeRequest("relay", {
+        "image_base64": base64.b64encode(b"OggS not an image").decode(), "image_mime_type": "image/png",
+    }, headers={"X-Request-ID": "bad-signature"}))
+    assert response.status == 400
+    assert "bad-signature" not in adapter._seen_deliveries
+    cache.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_media_delivery_caches_once_and_cache_failure_can_retry(monkeypatch, tmp_path):
+    adapter = WebhookAdapter(PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "routes": {
+        "relay": {"secret": "INSECURE_NO_AUTH", "prompt": "x"},
+    }}))
+    calls = 0
+    cache_path = tmp_path / "image.png"
+
+    def cache_image(data, ext):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("temporary disk failure")
+        cache_path.write_bytes(data)
+        return str(cache_path)
+
+    monkeypatch.setattr("gateway.platforms.webhook.cache_image_from_bytes", cache_image)
+    adapter.handle_message = AsyncMock()
+    payload = {"image_base64": base64.b64encode(b"\x89PNG\r\n\x1a\nimage").decode(), "image_mime_type": "image/png"}
+    first = await adapter._handle_webhook(_FakeRequest("relay", payload, {"X-Request-ID": "retry-cache"}))
+    second = await adapter._handle_webhook(_FakeRequest("relay", payload, {"X-Request-ID": "retry-cache"}))
+    duplicate = await adapter._handle_webhook(_FakeRequest("relay", payload, {"X-Request-ID": "retry-cache"}))
+    assert (first.status, second.status, duplicate.status) == (503, 202, 200)
+    assert calls == 2
+    assert sum(
+        chat_id == "webhook:relay:retry-cache"
+        for _created_at, chat_id in adapter._delivery_info_order
+    ) == 1
+    await asyncio.sleep(0)
+    adapter.handle_message.assert_awaited_once()
+    assert cache_path.exists()

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -87,6 +87,9 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
+| `source_platform` | No | Deliver the inbound event through a connected native adapter (for example `telegram` or `discord`) rather than the webhook adapter. `webhook` and `api_server` are rejected to prevent recursion. |
+| `source_chat_id`, `source_user_id` | With `source_platform` | Configured native destination and sender identity. These are route configuration, never read from the request payload. |
+| `source_chat_name`, `source_user_name`, `source_chat_type`, `source_thread_id` | No | Optional configured native routing metadata. `source_thread_id` selects the native topic/thread session and response lane. |
 
 ### Full example
 
@@ -206,6 +209,29 @@ prompt: "PR #{pull_request.number} by {pull_request.user.login}: {__raw__}"
 If no `prompt` template is configured for a route, the entire payload is dumped as indented JSON (truncated at 4000 characters).
 
 The same dot-notation templates work in `deliver_extra` values.
+
+### Synthetic Native Sources and Media Payloads
+
+Set `source_platform` when an authenticated integration should behave as a message from a configured native chat, including that platform's authorization, session, thread, media, and reply-routing path. The target adapter must be enabled and connected; otherwise Hermes rejects the request rather than silently falling back to webhook routing. The configured `source_*` values are authoritative: payload fields with those names are ignored.
+
+```yaml
+platforms:
+  webhook:
+    extra:
+      routes:
+        phone-relay:
+          secret: "relay-shared-secret"
+          prompt: "{message}"
+          source_platform: telegram
+          source_chat_id: "1000000001"
+          source_user_id: "1000000001"
+          source_chat_type: dm
+          source_thread_id: "42" # optional Telegram topic / native thread
+```
+
+The payload may contain exactly one base64 attachment. Audio aliases are `audio_base64` and `voice_base64`; their MIME aliases are `audio_mime_type` and `voice_mime_type`. Image aliases are `image_base64` and `screenshot_base64`; their MIME aliases are `image_mime_type` and `screenshot_mime_type`.
+
+Hermes accepts only supported audio (`audio/ogg`, `audio/opus`, `audio/mpeg`, `audio/wav`, `audio/flac`, `audio/mp4`, `audio/aac`) and image (`image/png`, `image/jpeg`, `image/gif`, `image/bmp`, `image/webp`) MIME values whose file signatures match the declared type. It rejects malformed base64, MIME/signature mismatches, oversized media, and requests containing both an audio and image. Media bytes use the normal gateway cache and its configured inbound-media limit.
 
 ### Forum Topic Delivery
 


### PR DESCRIPTION
## Summary

Allow an authenticated webhook route to synthesize a configured native platform source so the event follows that adapter's normal authorization, session, thread, media, and response-routing path. Add validated inline audio/image payload support without allowing request data to choose the native identity.

## Configuration

Synthetic source settings live on an individual route:

```yaml
platforms:
  webhook:
    enabled: true
    extra:
      routes:
        phone-relay:
          secret: "relay-shared-secret"
          prompt: "{message}"
          source_platform: telegram
          source_chat_id: "1000000001"
          source_user_id: "1000000001"
          source_chat_type: dm
          source_thread_id: "42" # optional
```

`source_chat_id` and `source_user_id` are required when `source_platform` is set. Optional route fields include `source_chat_name`, `source_user_name`, `source_chat_type`, and `source_thread_id`.

## Behavior and safety

- source identity comes only from trusted route configuration, never request payload fields
- `webhook` and `api_server` synthetic targets are rejected to prevent recursion
- the target adapter must be enabled, running, and connected through its normal message handler
- malformed base64, unsupported MIME values, signature mismatches, oversized media, and simultaneous audio plus image payloads are rejected
- accepted media uses the shared inbound cache and size limits
- transient cache failures return `503`, roll back idempotency and delivery metadata, and allow a clean provider retry
- duplicate deliveries do not create duplicate cache files

Supported payload aliases:

- audio: `audio_base64` or `voice_base64`, with `audio_mime_type` or `voice_mime_type`
- image: `image_base64` or `screenshot_base64`, with `image_mime_type` or `screenshot_mime_type`

The canonical webhook documentation lists the accepted MIME/signature combinations. Existing aiohttp request-size enforcement on current `main` is retained and covered by regression tests.

## Verification

```text
311 tests passed, 2 skipped
Ruff passed
git diff --check passed
git show --check passed
```
