### PR TITLE
feat(gateway): session key aliases + API session fanout

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -558,6 +558,8 @@ class GatewayConfig:
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
     thread_sessions_per_user: bool = False  # When False (default), threads are shared across all participants
+    session_key_aliases: Dict[str, str] = field(default_factory=dict)  # Map platform-derived keys onto shared logical keys
+    session_id_overrides: Dict[str, str] = field(default_factory=dict)  # Force selected session keys to stable SessionDB IDs
     max_concurrent_sessions: Optional[int] = None  # Positive int caps simultaneous active chat sessions
 
     # Multi-profile multiplexing (opt-in; default off preserves one-gateway-per-profile).
@@ -679,6 +681,8 @@ class GatewayConfig:
             "stt_enabled": self.stt_enabled,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
+            "session_key_aliases": self.session_key_aliases,
+            "session_id_overrides": self.session_id_overrides,
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -742,6 +746,23 @@ class GatewayConfig:
             max_concurrent_raw,
             max_concurrent_key,
         )
+        session_key_aliases_raw = data.get("session_key_aliases")
+        if session_key_aliases_raw is None:
+            session_key_aliases_raw = nested_gateway.get("session_key_aliases")
+        session_key_aliases = (
+            {str(k): str(v) for k, v in session_key_aliases_raw.items()}
+            if isinstance(session_key_aliases_raw, dict)
+            else {}
+        )
+
+        session_id_overrides_raw = data.get("session_id_overrides")
+        if session_id_overrides_raw is None:
+            session_id_overrides_raw = nested_gateway.get("session_id_overrides")
+        session_id_overrides = (
+            {str(k): str(v) for k, v in session_id_overrides_raw.items()}
+            if isinstance(session_id_overrides_raw, dict)
+            else {}
+        )
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
             data.get("unauthorized_dm_behavior"),
             "pair",
@@ -768,6 +789,8 @@ class GatewayConfig:
             stt_enabled=_coerce_bool(stt_enabled, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
+            session_key_aliases=session_key_aliases,
+            session_id_overrides=session_id_overrides,
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -800,6 +800,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        self._session_fanout_handler = None
+        self._session_run_handler = None
+        self._session_control_handler = None
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         # Concurrency cap shared across all agent-serving endpoints
         # (/v1/chat/completions, /v1/responses, /v1/runs). Read from
@@ -810,6 +813,75 @@ class APIServerAdapter(BasePlatformAdapter):
         # Number of in-flight runs on the non-streaming chat/responses paths
         # (the /v1/runs path tracks its own in-flight set via _run_streams).
         self._inflight_agent_runs: int = 0
+
+    def set_session_fanout_handler(self, handler) -> None:
+        self._session_fanout_handler = handler
+
+    def set_session_run_handler(self, handler) -> None:
+        self._session_run_handler = handler
+
+    def set_session_control_handler(self, handler) -> None:
+        self._session_control_handler = handler
+
+    @staticmethod
+    def _stringify_user_message_for_fanout(user_message: Any) -> str:
+        if isinstance(user_message, str):
+            return user_message
+        if isinstance(user_message, list):
+            parts = []
+            for item in user_message:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    parts.append(str(item.get("text") or ""))
+                elif isinstance(item, str):
+                    parts.append(item)
+            return "\n".join(p for p in parts if p)
+        return str(user_message or "")
+
+    async def _notify_session_fanout(
+        self,
+        *,
+        gateway_session_key: Optional[str],
+        session_id: Optional[str],
+        user_message: Any,
+        assistant_response: str = "",
+        run_id: Optional[str] = None,
+        message_kind: str = "turn",
+    ) -> None:
+        handler = self._session_fanout_handler
+        if handler is None:
+            return
+        result = handler(
+            origin_platform="api_server",
+            session_key=gateway_session_key or "",
+            session_id=session_id or "",
+            user_message=self._stringify_user_message_for_fanout(user_message),
+            assistant_response=assistant_response,
+            run_id=run_id,
+            message_kind=message_kind,
+        )
+        if asyncio.iscoroutine(result):
+            await result
+
+    def _notify_session_run_lifecycle(
+        self,
+        event: str,
+        *,
+        gateway_session_key: Optional[str],
+        session_id: Optional[str],
+        run_id: Optional[str],
+        agent: Any = None,
+    ) -> None:
+        handler = self._session_run_handler
+        if handler is None:
+            return
+        handler(
+            event=event,
+            origin_platform="api_server",
+            session_key=gateway_session_key or "",
+            session_id=session_id or "",
+            run_id=run_id or "",
+            agent=agent,
+        )
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -1069,6 +1141,37 @@ class APIServerAdapter(BasePlatformAdapter):
     # Agent creation helper
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _surface_context_from_session_key(session_key: Optional[str], user_config: Optional[dict] = None) -> dict:
+        """Map a stable gateway session key to the platform context it represents.
+
+        API-server mobile clients use X-Hermes-Session-Key to select a real
+        Telegram/Discord surface. Treating those turns as plain api_server
+        scoped memory correctly but lost platform toolsets and channel prompts.
+        This resolver keeps delivery stateless while letting agent construction
+        inherit the selected surface's tools and prompt.
+        """
+        raw = str(session_key or "").strip()
+        parts = raw.split(":")
+        out = {"platform_key": "api_server", "platform": "api_server", "chat_id": "", "thread_id": "", "channel_prompt": None}
+        if len(parts) < 5 or parts[0] != "agent":
+            return out
+        platform = parts[2]
+        chat_type = parts[3]
+        chat_id = parts[4] if len(parts) > 4 else ""
+        thread_id = parts[5] if chat_type == "thread" and len(parts) > 5 else ""
+        if platform not in {"discord", "telegram"}:
+            return out
+        out.update({"platform_key": platform, "platform": platform, "chat_id": chat_id, "thread_id": thread_id})
+        cfg = user_config if isinstance(user_config, dict) else {}
+        platform_cfg = cfg.get(platform) if isinstance(cfg.get(platform), dict) else {}
+        prompts = platform_cfg.get("channel_prompts") if isinstance(platform_cfg, dict) else {}
+        if isinstance(prompts, dict):
+            prompt = prompts.get(str(chat_id))
+            if isinstance(prompt, str) and prompt.strip():
+                out["channel_prompt"] = prompt.strip()
+        return out
+
     def _create_agent(
         self,
         ephemeral_system_prompt: Optional[str] = None,
@@ -1121,7 +1224,16 @@ class APIServerAdapter(BasePlatformAdapter):
             model = runtime_model
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        surface_context = self._surface_context_from_session_key(gateway_session_key, user_config)
+        platform_key = surface_context["platform_key"]
+        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        surface_prompt = surface_context.get("channel_prompt")
+        if surface_prompt:
+            ephemeral_system_prompt = (
+                (surface_prompt + "\n\n" + ephemeral_system_prompt)
+                if ephemeral_system_prompt
+                else surface_prompt
+            )
 
         max_iterations = _current_max_iterations()
 
@@ -1138,7 +1250,10 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=ephemeral_system_prompt or None,
             enabled_toolsets=enabled_toolsets,
             session_id=session_id,
-            platform="api_server",
+            platform=surface_context.get("platform") or "api_server",
+            chat_id=surface_context.get("chat_id") or None,
+            chat_type="group" if surface_context.get("platform") == "discord" else ("dm" if surface_context.get("platform") == "telegram" else None),
+            thread_id=surface_context.get("thread_id") or None,
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
@@ -1645,6 +1760,42 @@ class APIServerAdapter(BasePlatformAdapter):
         fork = db.get_session(fork_id) or {"id": fork_id, "parent_session_id": source_id}
         return web.json_response({"object": "hermes.session", "session": self._session_response(fork)}, status=201)
 
+    async def _handle_session_key_current(self, request: "web.Request") -> "web.Response":
+        """GET /api/session-key/current — return the active session_id for X-Hermes-Session-Key."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        gateway_session_key, key_err = self._parse_session_key_header(request)
+        if key_err is not None:
+            return key_err
+        if not gateway_session_key:
+            return web.json_response(_openai_error("X-Hermes-Session-Key is required", code="missing_session_key"), status=400)
+        handler = self._session_control_handler
+        if handler is None:
+            return web.json_response(_openai_error("Session key control is unavailable", code="session_control_unavailable"), status=503)
+        result = handler(action="current", session_key=gateway_session_key)
+        if result is None:
+            return web.json_response(_openai_error("Session key not found", code="session_key_not_found"), status=404)
+        return web.json_response({"object": "hermes.session_key", **result})
+
+    async def _handle_session_key_reset(self, request: "web.Request") -> "web.Response":
+        """POST /api/session-key/reset — rotate the session_id for X-Hermes-Session-Key."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        gateway_session_key, key_err = self._parse_session_key_header(request)
+        if key_err is not None:
+            return key_err
+        if not gateway_session_key:
+            return web.json_response(_openai_error("X-Hermes-Session-Key is required", code="missing_session_key"), status=400)
+        handler = self._session_control_handler
+        if handler is None:
+            return web.json_response(_openai_error("Session key control is unavailable", code="session_control_unavailable"), status=503)
+        result = handler(action="reset", session_key=gateway_session_key)
+        if result is None:
+            return web.json_response(_openai_error("Session key not found", code="session_key_not_found"), status=404)
+        return web.json_response({"object": "hermes.session_key", **result})
+
     async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/chat — one synchronous agent turn."""
         auth_err = self._check_auth(request)
@@ -1676,6 +1827,13 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+        await self._notify_session_fanout(
+            gateway_session_key=gateway_session_key,
+            session_id=effective_session_id or session_id,
+            user_message=user_message,
+            assistant_response=final_response,
+            message_kind="turn",
+        )
         headers = {"X-Hermes-Session-Id": effective_session_id or session_id}
         if gateway_session_key:
             headers["X-Hermes-Session-Key"] = gateway_session_key
@@ -1768,6 +1926,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
                 turn_messages = self._turn_transcript_messages(history, user_message, result) if isinstance(result, dict) else []
+                await self._notify_session_fanout(
+                    gateway_session_key=gateway_session_key,
+                    session_id=effective_session_id or session_id,
+                    user_message=user_message,
+                    assistant_response=final_response,
+                    run_id=run_id,
+                    message_kind="turn",
+                )
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
@@ -3942,11 +4108,11 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
         raw_input = body.get("input")
-        if not raw_input:
+        if raw_input is None:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
-        if not user_message:
+        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) and raw_input and isinstance(raw_input[-1], dict) else "")
+        if not _content_has_visible_payload(user_message):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
         instructions = body.get("instructions")
@@ -4531,6 +4697,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_delete("/api/sessions/{session_id}", self._handle_delete_session)
             self._app.router.add_get("/api/sessions/{session_id}/messages", self._handle_session_messages)
             self._app.router.add_post("/api/sessions/{session_id}/fork", self._handle_fork_session)
+            self._app.router.add_get("/api/session-key/current", self._handle_session_key_current)
+            self._app.router.add_post("/api/session-key/reset", self._handle_session_key_reset)
             self._app.router.add_post("/api/sessions/{session_id}/chat", self._handle_session_chat)
             self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -43,7 +43,9 @@ import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+import traceback
+import uuid
+from datetime import datetime, timezone
 from typing import Callable, Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
@@ -3288,7 +3290,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 session_key = self.session_store._generate_session_key(source)
                 if isinstance(session_key, str) and session_key:
-                    return session_key
+                    aliases = getattr(getattr(self, "config", None), "session_key_aliases", {}) or {}
+                    return str(aliases.get(session_key, session_key))
             except Exception:
                 pass
         config = getattr(self, "config", None)
@@ -3305,12 +3308,234 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
-        return build_session_key(
+        session_key = build_session_key(
             source,
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
             profile=_profile,
         )
+        aliases = getattr(config, "session_key_aliases", {}) or {}
+        return str(aliases.get(session_key, session_key))
+
+    def _canonical_api_session_key(self, session_key: str = "", session_id: str = "") -> str:
+        """Resolve an API session key/session_id onto the shared gateway key."""
+        config = getattr(self, "config", None)
+        aliases = getattr(config, "session_key_aliases", {}) or {}
+        overrides = getattr(config, "session_id_overrides", {}) or {}
+        if session_key:
+            return str(aliases.get(session_key, session_key))
+        if session_id:
+            for key, value in overrides.items():
+                if str(value) == str(session_id):
+                    return str(aliases.get(key, key))
+            store = getattr(self, "session_store", None)
+            if store is not None:
+                try:
+                    with store._lock:
+                        store._ensure_loaded_locked()
+                        for entry_key, entry in store._entries.items():
+                            if str(getattr(entry, "session_id", "")) == str(session_id):
+                                return str(aliases.get(entry_key, entry_key))
+                except Exception:
+                    logger.debug(
+                        "API session fanout could not resolve session_id %s via SessionStore",
+                        session_id,
+                        exc_info=True,
+                    )
+        return str(session_key or "")
+
+    def _fanout_targets_for_session_key(self, session_key: str, session_id: str = "") -> list[tuple[Platform, str, str]]:
+        """Return chat targets whose configured session alias maps to this canonical key."""
+        canonical = self._canonical_api_session_key(session_key, session_id)
+        if not canonical and session_id:
+            canonical = self._canonical_api_session_key("", session_id)
+        aliases = getattr(getattr(self, "config", None), "session_key_aliases", {}) or {}
+        seen: set[tuple[Platform, str, str]] = set()
+        targets: list[tuple[Platform, str, str]] = []
+        candidate_keys = []
+        for raw_key, target_key in aliases.items():
+            if str(target_key) != canonical and str(raw_key) != canonical:
+                continue
+            candidate_keys.append(str(raw_key))
+        # If the canonical key is already a concrete platform session key
+        # (agent:main:discord:group:<channel>:<user>, etc.), route it
+        # directly even when config has no alias entry for it. Mobile/API
+        # clients can resume existing SessionDB lanes by session_id/header and
+        # still need live fanout to the selected surface.
+        candidate_keys.append(canonical)
+
+        for raw_key in candidate_keys:
+            parts = raw_key.split(":")
+            if len(parts) < 5:
+                continue
+            platform_name = parts[2]
+            chat_type = parts[3]
+            chat_id = parts[4]
+            # Only real thread/topic session keys carry fanout thread metadata.
+            # For Discord group/channel sessions, the suffix is usually the
+            # per-user isolation segment, not a Discord thread.
+            # Passing that user id as metadata.thread_id makes Discord reject
+            # the send with Unknown Channel.
+            thread_id = parts[5] if chat_type == "thread" and len(parts) > 5 else ""
+            try:
+                platform = Platform(platform_name)
+            except ValueError:
+                continue
+            item = (platform, chat_id, thread_id)
+            if item not in seen:
+                seen.add(item)
+                targets.append(item)
+        return targets
+
+    async def _fanout_api_session_turn(
+        self,
+        *,
+        origin_platform: str,
+        session_key: str,
+        session_id: str,
+        user_message: Any,
+        assistant_response: str,
+        run_id: str | None = None,
+        message_kind: str = "turn",
+    ) -> None:
+        if origin_platform != "api_server":
+            return
+        canonical = self._canonical_api_session_key(session_key, session_id)
+        if not canonical:
+            logger.info(
+                "API session fanout skipped: unresolved session key session_id=%s kind=%s has_header=%s",
+                session_id,
+                message_kind,
+                bool(session_key),
+            )
+            return
+        user_text = self._stringify_api_user_message(user_message).strip()
+        assistant_text = str(assistant_response or "").strip()
+        kind = str(message_kind or "turn")
+        if kind == "user":
+            # Do not mirror pre-run mobile/API user turns into Discord/Telegram.
+            # That local experiment created extra platform events while an agent
+            # was active and made control-plane/verifier payloads visible as chat
+            # traffic. Fan out only completed turns or final assistant messages.
+            return
+        if kind == "assistant":
+            if not assistant_text:
+                return
+            content = assistant_text
+        else:
+            if not user_text and not assistant_text:
+                return
+            content = f"📱 Mobile: {user_text}\n\n{assistant_text}" if user_text and assistant_text else (user_text or assistant_text)
+        targets = self._fanout_targets_for_session_key(canonical, session_id)
+        if not targets:
+            logger.info(
+                "API session fanout skipped: no targets canonical=%s session_id=%s kind=%s",
+                canonical,
+                session_id,
+                kind,
+            )
+            return
+        for platform, chat_id, thread_id in targets:
+            adapter = getattr(self, "adapters", {}).get(platform)
+            if adapter is None:
+                logger.info(
+                    "API session fanout skipped: no adapter platform=%s chat=%s thread=%s canonical=%s kind=%s",
+                    platform.value if hasattr(platform, "value") else platform,
+                    chat_id,
+                    thread_id,
+                    canonical,
+                    kind,
+                )
+                continue
+            metadata = {"thread_id": thread_id} if thread_id else None
+            result = await adapter.send(chat_id, content, reply_to=None, metadata=metadata)
+            logger.info(
+                "API session fanout sent: platform=%s chat=%s thread=%s canonical=%s kind=%s success=%s error=%s message_id=%s",
+                platform.value if hasattr(platform, "value") else platform,
+                chat_id,
+                thread_id,
+                canonical,
+                kind,
+                getattr(result, "success", None),
+                getattr(result, "error", None),
+                getattr(result, "message_id", None),
+            )
+
+    @staticmethod
+    def _stringify_api_user_message(user_message: Any) -> str:
+        if isinstance(user_message, str):
+            return user_message
+        if isinstance(user_message, list):
+            parts = []
+            for item in user_message:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    parts.append(str(item.get("text") or ""))
+                elif isinstance(item, str):
+                    parts.append(item)
+            return "\n".join(p for p in parts if p)
+        return str(user_message or "")
+
+    def _handle_api_session_run_lifecycle(
+        self,
+        *,
+        event: str,
+        origin_platform: str,
+        session_key: str,
+        session_id: str,
+        run_id: str,
+        agent: Any = None,
+    ) -> None:
+        if origin_platform != "api_server":
+            return
+        canonical = self._canonical_api_session_key(session_key, session_id)
+        if not canonical:
+            return
+        if event == "started" and agent is not None:
+            self._running_agents[canonical] = agent
+            self._running_agents_ts[canonical] = time.time()
+            return
+        if event in {"completed", "failed", "cancelled", "stopped"}:
+            current = self._running_agents.get(canonical)
+            if agent is None or current is agent:
+                self._running_agents.pop(canonical, None)
+                self._running_agents_ts.pop(canonical, None)
+            # Drain one pending platform follow-up now that the API-owned run is done.
+            for platform, _chat_id, _thread_id in self._fanout_targets_for_session_key(canonical, session_id):
+                adapter = getattr(self, "adapters", {}).get(platform)
+                if adapter is None:
+                    continue
+                if hasattr(adapter, "get_pending_message"):
+                    pending = _dequeue_pending_event(adapter, canonical)
+                else:
+                    pending = getattr(adapter, "_pending_messages", {}).pop(canonical, None)
+                if pending is not None and hasattr(adapter, "_start_session_processing"):
+                    adapter._start_session_processing(pending, canonical)
+                    break
+
+    def _api_session_key_control(self, *, action: str, session_key: str) -> Optional[dict]:
+        if not session_key:
+            return None
+        canonical = self._canonical_api_session_key(session_key, "")
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return None
+        from gateway.session import SessionEntry
+        now = datetime.now()
+        with store._lock:
+            store._ensure_loaded_locked()
+            entry = store._entries.get(canonical)
+            if entry is None:
+                session_id = (getattr(getattr(self, "config", None), "session_id_overrides", {}) or {}).get(canonical)
+                if not session_id:
+                    session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+                entry = SessionEntry(session_key=canonical, session_id=str(session_id), created_at=now, updated_at=now)
+                store._entries[canonical] = entry
+                store._save()
+            if action == "reset":
+                entry.session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+                entry.updated_at = now
+                store._save()
+            return {"session_key": canonical, "session_id": entry.session_id}
 
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
@@ -6626,6 +6851,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
+            if hasattr(adapter, "set_session_fanout_handler"):
+                adapter.set_session_fanout_handler(self._fanout_api_session_turn)
+            if hasattr(adapter, "set_session_run_handler"):
+                adapter.set_session_run_handler(self._handle_api_session_run_lifecycle)
+            if hasattr(adapter, "set_session_control_handler"):
+                adapter.set_session_control_handler(self._api_session_key_control)
             adapter._busy_text_mode = self._busy_text_mode
             
             # Try to connect
@@ -8126,6 +8357,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
+            if hasattr(adapter, "set_session_fanout_handler"):
+                adapter.set_session_fanout_handler(self._fanout_api_session_turn)
+            if hasattr(adapter, "set_session_run_handler"):
+                adapter.set_session_run_handler(self._handle_api_session_run_lifecycle)
+            if hasattr(adapter, "set_session_control_handler"):
+                adapter.set_session_control_handler(self._api_session_key_control)
             adapter._busy_text_mode = self._busy_text_mode
 
             try:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1051,12 +1051,14 @@ class SessionStore:
 
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
-        return build_session_key(
+        session_key = build_session_key(
             source,
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
             profile=self._resolve_profile_for_key(source),
         )
+        aliases = getattr(self.config, "session_key_aliases", {}) or {}
+        return str(aliases.get(session_key, session_key))
 
     def _create_entry_from_recovered_row(
         self,
@@ -1408,7 +1410,8 @@ class SessionStore:
                     return recovered_entry
 
             # Create new session
-            session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            overrides = getattr(self.config, "session_id_overrides", {}) or {}
+            session_id = str(overrides.get(session_key) or f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}")
 
             entry = SessionEntry(
                 session_key=session_key,

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -153,6 +153,23 @@ class TestStartRun:
         assert resp.status == 400
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"input": "   \n\t  "},
+            {"input": [{"role": "user", "content": "   "}]},
+            {"input": [{"role": "user", "content": []}]},
+        ],
+    )
+    async def test_start_blank_visible_payload_returns_400(self, adapter, payload):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs", json=payload)
+        assert resp.status == 400
+        assert adapter._run_statuses == {}
+        assert adapter._run_streams == {}
+
+    @pytest.mark.asyncio
     async def test_start_invalid_history_does_not_allocate_run(self, adapter):
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/gateway/test_api_session_fanout.py
+++ b/tests/gateway/test_api_session_fanout.py
@@ -1,0 +1,594 @@
+import pytest
+from collections import OrderedDict
+from typing import Any, cast
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, SessionStore
+from gateway.run import GatewayRunner
+
+
+CANONICAL_KEY = "agent:main:shared:mobile-main"
+DISCORD_KEY = "agent:main:discord:group:200000000000000001:900000000000000001"
+MOBILE_SURFACE_KEYS = {
+    "telegram-main": ("agent:main:telegram:dm:1000000001", Platform.TELEGRAM, "1000000001"),
+    "discord-main": ("agent:main:discord:group:200000000000000002:900000000000000001", Platform.DISCORD, "200000000000000002"),
+    "discord-life": ("agent:main:discord:group:200000000000000003:900000000000000001", Platform.DISCORD, "200000000000000003"),
+    "discord-culture": ("agent:main:discord:group:200000000000000004:900000000000000001", Platform.DISCORD, "200000000000000004"),
+}
+
+
+class FakeAdapter:
+    def __init__(self):
+        self.sent = []
+        self._pending_messages = {}
+        self.started = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return object()
+
+    async def _send_with_retry(self, chat_id, content, reply_to=None, metadata=None):
+        return await self.send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+    def _start_session_processing(self, event, session_key):
+        self.started.append((session_key, event.text))
+        return True
+
+
+def _runner(config):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = cast(Any, {})
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    runner._busy_ack_ts = {}
+    runner._queued_events = {}
+    runner._agent_cache = OrderedDict()
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_native_image_paths_by_session = {}
+    runner._session_run_generation = {}
+    runner._session_sources = OrderedDict()
+    runner._session_sources_max = 512
+    runner._is_user_authorized = lambda source: True
+    return runner
+
+
+class FakeAgent:
+    def __init__(self):
+        self.interrupts = []
+
+    def interrupt(self, reason):
+        self.interrupts.append(reason)
+
+
+def _discord_event(text="new Discord instruction", chat_id="200000000000000001"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id=chat_id,
+            chat_type="group",
+            user_id="900000000000000001",
+            user_name="User",
+        ),
+        message_id="m1",
+    )
+
+
+def _telegram_event(text="new Telegram instruction"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="1000000001",
+            chat_type="dm",
+            user_id="1000000001",
+            user_name="User",
+        ),
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_api_originated_shared_session_fans_out_to_discord_alias():
+    config = GatewayConfig(
+        session_key_aliases={DISCORD_KEY: CANONICAL_KEY},
+        session_id_overrides={CANONICAL_KEY: "mobile-main"},
+    )
+    runner = _runner(config)
+    discord = FakeAdapter()
+    runner.adapters[Platform.DISCORD] = cast(Any, discord)
+
+    await runner._fanout_api_session_turn(
+        origin_platform="api_server",
+        session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        user_message="hello from the phone",
+        assistant_response="hello back",
+        run_id="run_test",
+    )
+
+    assert discord.sent == [
+        {
+            "chat_id": "200000000000000001",
+            "content": "📱 Mobile: hello from the phone\n\nhello back",
+            "reply_to": None,
+            "metadata": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_api_originated_daylight_user_only_fanout_is_dropped():
+    config = GatewayConfig(
+        session_key_aliases={DISCORD_KEY: CANONICAL_KEY},
+        session_id_overrides={CANONICAL_KEY: "mobile-main"},
+    )
+    runner = _runner(config)
+    discord = FakeAdapter()
+    runner.adapters[Platform.DISCORD] = cast(Any, discord)
+
+    await runner._fanout_api_session_turn(
+        origin_platform="api_server",
+        session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        user_message="hello from Mobile",
+        assistant_response="",
+        run_id="run_test",
+        message_kind="user",
+    )
+    await runner._fanout_api_session_turn(
+        origin_platform="api_server",
+        session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        user_message="hello from Mobile",
+        assistant_response="hello back",
+        run_id="run_test",
+        message_kind="turn",
+    )
+
+    assert discord.sent == [
+        {
+            "chat_id": "200000000000000001",
+            "content": "📱 Mobile: hello from Mobile\n\nhello back",
+            "reply_to": None,
+            "metadata": None,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_api_fanout_can_resolve_canonical_key_from_session_id_override():
+    config = GatewayConfig(
+        session_key_aliases={DISCORD_KEY: CANONICAL_KEY},
+        session_id_overrides={CANONICAL_KEY: "mobile-main"},
+    )
+    runner = _runner(config)
+    discord = FakeAdapter()
+    runner.adapters[Platform.DISCORD] = cast(Any, discord)
+
+    await runner._fanout_api_session_turn(
+        origin_platform="api_server",
+        session_key="",
+        session_id="mobile-main",
+        user_message="session id only",
+        assistant_response="still mapped",
+    )
+
+    assert len(discord.sent) == 1
+    assert discord.sent[0]["chat_id"] == "200000000000000001"
+    assert discord.sent[0]["content"] == "📱 Mobile: session id only\n\nstill mapped"
+    assert discord.sent[0]["metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_api_fanout_can_resolve_session_key_from_session_store_when_header_missing(tmp_path):
+    config = GatewayConfig(session_key_aliases={DISCORD_KEY: DISCORD_KEY})
+    runner = _runner(config)
+    runner.session_store = SessionStore(tmp_path, config)
+    runner.session_store._db = None
+    with runner.session_store._lock:
+        runner.session_store._ensure_loaded_locked()
+        from datetime import datetime
+        from gateway.session import SessionEntry
+
+        now = datetime.now()
+        runner.session_store._entries[DISCORD_KEY] = SessionEntry(
+            session_key=DISCORD_KEY,
+            session_id="mobile-session-id",
+            created_at=now,
+            updated_at=now,
+        )
+    discord = FakeAdapter()
+    runner.adapters[Platform.DISCORD] = cast(Any, discord)
+
+    await runner._fanout_api_session_turn(
+        origin_platform="api_server",
+        session_key="",
+        session_id="mobile-session-id",
+        user_message="missing header still resolves",
+        assistant_response="resolved reply",
+        message_kind="turn",
+    )
+
+    assert discord.sent == [
+        {
+            "chat_id": "200000000000000001",
+            "content": "📱 Mobile: missing header still resolves\n\nresolved reply",
+            "reply_to": None,
+            "metadata": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_api_origin_does_not_fan_out_back_to_discord():
+    config = GatewayConfig(session_key_aliases={DISCORD_KEY: CANONICAL_KEY})
+    runner = _runner(config)
+    discord = FakeAdapter()
+    runner.adapters[Platform.DISCORD] = cast(Any, discord)
+
+    await runner._fanout_api_session_turn(
+        origin_platform="discord",
+        session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        user_message="from discord",
+        assistant_response="do not loop",
+    )
+
+    assert discord.sent == []
+
+
+@pytest.mark.asyncio
+async def test_api_fanout_is_gated_by_alias_mapping_and_connected_adapter():
+    runner = _runner(GatewayConfig())
+    discord = FakeAdapter()
+    runner.adapters[Platform.DISCORD] = cast(Any, discord)
+
+    await runner._fanout_api_session_turn(
+        origin_platform="api_server",
+        session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        user_message="unmapped",
+        assistant_response="not visible",
+    )
+    assert discord.sent == []
+
+    mapped_without_adapter = _runner(GatewayConfig(session_key_aliases={DISCORD_KEY: CANONICAL_KEY}))
+    await mapped_without_adapter._fanout_api_session_turn(
+        origin_platform="api_server",
+        session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        user_message="mapped",
+        assistant_response="but no adapter",
+    )
+    # No exception and no implicit adapter creation.
+    assert mapped_without_adapter.adapters == {}
+
+
+def test_api_fanout_target_resolution_dedupes_config_aliases():
+    duplicate_key = "agent:main:discord:group:200000000000000001:900000000000000001"
+    runner = _runner(
+        GatewayConfig(
+            session_key_aliases={
+                DISCORD_KEY: CANONICAL_KEY,
+                duplicate_key: CANONICAL_KEY,
+            }
+        )
+    )
+
+    assert runner._fanout_targets_for_session_key(CANONICAL_KEY) == [
+        (Platform.DISCORD, "200000000000000001", "")
+    ]
+
+
+def test_api_fanout_target_resolution_routes_direct_concrete_session_key_without_alias():
+    runner = _runner(GatewayConfig())
+
+    assert runner._fanout_targets_for_session_key(DISCORD_KEY) == [
+        (Platform.DISCORD, "200000000000000001", "")
+    ]
+
+
+
+def test_api_fanout_target_resolution_preserves_real_discord_thread_keys():
+    thread_key = "agent:main:discord:thread:200000000000000005:200000000000000005"
+    runner = _runner(GatewayConfig(session_key_aliases={thread_key: thread_key}))
+
+    assert runner._fanout_targets_for_session_key(thread_key) == [
+        (Platform.DISCORD, "200000000000000005", "200000000000000005")
+    ]
+
+def test_pinned_mobile_surface_targets_resolve_from_session_id_overrides():
+    """mobile surface switcher targets must survive Hermes updates/refactors."""
+    aliases = {key: key for key, _, _ in MOBILE_SURFACE_KEYS.values()}
+    overrides = {key: session_id for session_id, (key, _, _) in MOBILE_SURFACE_KEYS.items()}
+    runner = _runner(
+        GatewayConfig(
+            session_key_aliases=aliases,
+            session_id_overrides=overrides,
+        )
+    )
+
+    for session_id, (key, platform, chat_id) in MOBILE_SURFACE_KEYS.items():
+        expected_thread_id = ""
+        assert runner._fanout_targets_for_session_key("", session_id) == [
+            (platform, chat_id, expected_thread_id)
+        ]
+        assert runner._fanout_targets_for_session_key(key, session_id) == [
+            (platform, chat_id, expected_thread_id)
+        ]
+
+
+def test_pinned_surface_platform_turns_use_same_session_ids_as_mobile_fetches(tmp_path):
+    """Platform-origin turns and mobile app history fetch must address one SessionDB lane."""
+    aliases = {key: key for key, _, _ in MOBILE_SURFACE_KEYS.values()}
+    overrides = {key: session_id for session_id, (key, _, _) in MOBILE_SURFACE_KEYS.items()}
+    config = GatewayConfig(
+        session_key_aliases=aliases,
+        session_id_overrides=overrides,
+    )
+    store = SessionStore(tmp_path, config)
+
+    telegram_entry = store.get_or_create_session(_telegram_event().source)
+    assert telegram_entry.session_key == MOBILE_SURFACE_KEYS["telegram-main"][0]
+    assert telegram_entry.session_id == "telegram-main"
+
+    for session_id, (key, platform, chat_id) in MOBILE_SURFACE_KEYS.items():
+        if platform != Platform.DISCORD:
+            continue
+        entry = store.get_or_create_session(_discord_event(chat_id=chat_id).source)
+        assert entry.session_key == key
+        assert entry.session_id == session_id
+
+
+def test_api_session_key_control_rotates_session_id_not_channel_key(tmp_path):
+    key, _, _ = MOBILE_SURFACE_KEYS["discord-life"]
+    config = GatewayConfig(
+        session_key_aliases={key: key},
+        session_id_overrides={key: "discord-life"},
+    )
+    runner = _runner(config)
+    runner.session_store = SessionStore(tmp_path, config)
+
+    current = runner._api_session_key_control(action="current", session_key=key)
+    assert current is not None
+    assert current["session_key"] == key
+    assert current["session_id"] == "discord-life"
+
+    reset = runner._api_session_key_control(action="reset", session_key=key)
+    assert reset is not None
+    assert reset["session_key"] == key
+    assert reset["session_id"] != "discord-life"
+
+    current_again = runner._api_session_key_control(action="current", session_key=key)
+    assert current_again is not None
+    assert current_again["session_key"] == key
+    assert current_again["session_id"] == reset["session_id"]
+
+
+@pytest.mark.asyncio
+async def test_pinned_surface_platform_followups_interrupt_api_owned_runs():
+    aliases = {key: key for key, _, _ in MOBILE_SURFACE_KEYS.values()}
+    overrides = {key: session_id for session_id, (key, _, _) in MOBILE_SURFACE_KEYS.items()}
+
+    for session_id, (key, platform, chat_id) in MOBILE_SURFACE_KEYS.items():
+        runner = _runner(
+            GatewayConfig(
+                session_key_aliases=aliases,
+                session_id_overrides=overrides,
+            )
+        )
+        adapter = FakeAdapter()
+        runner.adapters[platform] = cast(Any, adapter)
+        agent = FakeAgent()
+        event = (
+            _telegram_event(f"interrupt {session_id}")
+            if platform == Platform.TELEGRAM
+            else _discord_event(f"interrupt {session_id}", chat_id=chat_id)
+        )
+
+        runner._handle_api_session_run_lifecycle(
+            event="started",
+            origin_platform="api_server",
+            session_key=key,
+            session_id=session_id,
+            run_id=f"run_{session_id}",
+            agent=agent,
+        )
+
+        handled = await runner._handle_active_session_busy_message(event, key)
+
+        assert handled is True
+        assert agent.interrupts == [f"interrupt {session_id}"]
+        assert adapter._pending_messages[key].text == f"interrupt {session_id}"
+
+        runner._handle_api_session_run_lifecycle(
+            event="completed",
+            origin_platform="api_server",
+            session_key=key,
+            session_id=session_id,
+            run_id=f"run_{session_id}",
+            agent=agent,
+        )
+
+        assert key not in runner._running_agents
+        assert adapter._pending_messages == {}
+        assert adapter.started == [(key, f"interrupt {session_id}")]
+
+
+def test_api_session_run_lifecycle_registers_and_clears_canonical_agent():
+    runner = _runner(
+        GatewayConfig(
+            session_key_aliases={DISCORD_KEY: CANONICAL_KEY},
+            session_id_overrides={CANONICAL_KEY: "mobile-main"},
+        )
+    )
+    agent = FakeAgent()
+
+    runner._handle_api_session_run_lifecycle(
+        event="started",
+        origin_platform="api_server",
+        session_key="",
+        session_id="mobile-main",
+        run_id="run_api",
+        agent=agent,
+    )
+
+    assert runner._running_agents[CANONICAL_KEY] is agent
+
+    runner._handle_api_session_run_lifecycle(
+        event="completed",
+        origin_platform="api_server",
+        session_key="",
+        session_id="mobile-main",
+        run_id="run_api",
+        agent=agent,
+    )
+
+    assert CANONICAL_KEY not in runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_discord_followup_interrupts_api_owned_shared_session_and_drains_after_completion():
+    runner = _runner(
+        GatewayConfig(
+            session_key_aliases={DISCORD_KEY: CANONICAL_KEY},
+            session_id_overrides={CANONICAL_KEY: "mobile-main"},
+        )
+    )
+    discord = FakeAdapter()
+    runner.adapters[Platform.DISCORD] = cast(Any, discord)
+    agent = FakeAgent()
+    event = _discord_event("interrupt from discord")
+
+    runner._handle_api_session_run_lifecycle(
+        event="started",
+        origin_platform="api_server",
+        session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        run_id="run_api",
+        agent=agent,
+    )
+
+    handled = await runner._handle_active_session_busy_message(event, CANONICAL_KEY)
+
+    assert handled is True
+    assert agent.interrupts == ["interrupt from discord"]
+    assert discord._pending_messages[CANONICAL_KEY].text == "interrupt from discord"
+
+    runner._handle_api_session_run_lifecycle(
+        event="completed",
+        origin_platform="api_server",
+        session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        run_id="run_api",
+        agent=agent,
+    )
+
+    assert CANONICAL_KEY not in runner._running_agents
+    assert discord._pending_messages == {}
+    assert discord.started == [(CANONICAL_KEY, "interrupt from discord")]
+
+
+@pytest.mark.asyncio
+async def test_api_server_adapter_invokes_session_fanout_hook():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    calls = []
+
+    async def handler(**kwargs):
+        calls.append(kwargs)
+
+    adapter.set_session_fanout_handler(handler)
+    await adapter._notify_session_fanout(
+        gateway_session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        user_message=[{"type": "text", "text": "phone text"}],
+        assistant_response="assistant text",
+        run_id="run_1",
+    )
+
+    assert calls == [
+        {
+            "origin_platform": "api_server",
+            "session_key": CANONICAL_KEY,
+            "session_id": "mobile-main",
+            "user_message": "phone text",
+            "assistant_response": "assistant text",
+            "run_id": "run_1",
+            "message_kind": "turn",
+        }
+    ]
+
+
+def test_api_server_adapter_invokes_session_run_lifecycle_hook():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    calls = []
+    agent = object()
+
+    def handler(**kwargs):
+        calls.append(kwargs)
+
+    adapter.set_session_run_handler(handler)
+    adapter._notify_session_run_lifecycle(
+        "started",
+        gateway_session_key=CANONICAL_KEY,
+        session_id="mobile-main",
+        run_id="run_1",
+        agent=agent,
+    )
+
+    assert calls == [
+        {
+            "event": "started",
+            "origin_platform": "api_server",
+            "session_key": CANONICAL_KEY,
+            "session_id": "mobile-main",
+            "run_id": "run_1",
+            "agent": agent,
+        }
+    ]
+
+
+def test_api_server_session_key_resolves_platform_context_for_mobile_surfaces():
+    user_config = {
+        "discord": {
+            "channel_prompts": {
+                "200000000000000003": "Life workspace prompt",
+            }
+        }
+    }
+    ctx = APIServerAdapter._surface_context_from_session_key(
+        "agent:main:discord:group:200000000000000003:900000000000000001",
+        user_config,
+    )
+    assert ctx["platform_key"] == "discord"
+    assert ctx["platform"] == "discord"
+    assert ctx["chat_id"] == "200000000000000003"
+    assert ctx["channel_prompt"] == "Life workspace prompt"
+
+    tg = APIServerAdapter._surface_context_from_session_key(
+        "agent:main:telegram:dm:1000000001",
+        {"telegram": {}},
+    )
+    assert tg["platform_key"] == "telegram"
+    assert tg["platform"] == "telegram"
+    assert tg["chat_id"] == "1000000001"
+
+    plain = APIServerAdapter._surface_context_from_session_key("mobile-main", user_config)
+    assert plain["platform_key"] == "api_server"

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -438,3 +438,154 @@ async def test_session_header_rejected_without_api_key(adapter, session_db):
         assert resp.status == 403
         data = await resp.json()
         assert "X-Hermes-Session-Key requires API key" in data["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_session_chat_invokes_session_fanout_hook(auth_adapter, session_db):
+    session_id = session_db.create_session("fanout-chat-session", "api_server")
+
+    async def fake_run(**kwargs):
+        return {"final_response": "reply from api", "session_id": "effective-session"}, {"total_tokens": 3}
+
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", side_effect=fake_run), \
+        patch.object(auth_adapter, "_notify_session_fanout", new_callable=AsyncMock) as fanout:
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                headers={
+                    "Authorization": "Bearer sk-test",
+                    "X-Hermes-Session-Key": "agent:main:discord:group:channel:user",
+                },
+                json={"message": "from phone"},
+            )
+            assert resp.status == 200, await resp.text()
+
+    assert fanout.await_count == 1
+    only = fanout.await_args_list[0].kwargs
+    assert only == {
+        "gateway_session_key": "agent:main:discord:group:channel:user",
+        "session_id": "effective-session",
+        "user_message": "from phone",
+        "assistant_response": "reply from api",
+        "message_kind": "turn",
+    }
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_invokes_session_fanout_hook(auth_adapter, session_db):
+    session_id = session_db.create_session("fanout-stream-session", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("reply")
+        return {"final_response": "stream reply", "session_id": "effective-stream-session"}, {"total_tokens": 4}
+
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", side_effect=fake_run), \
+        patch.object(auth_adapter, "_notify_session_fanout", new_callable=AsyncMock) as fanout:
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                headers={
+                    "Authorization": "Bearer sk-test",
+                    "X-Hermes-Session-Key": "agent:main:discord:group:channel:user",
+                },
+                json={"message": "stream from phone"},
+            )
+            assert resp.status == 200, await resp.text()
+            body = await resp.text()
+
+    assert "event: assistant.completed" in body
+    assert fanout.await_count == 1
+    only = fanout.await_args_list[0].kwargs
+    assert only["gateway_session_key"] == "agent:main:discord:group:channel:user"
+    assert only["session_id"] == "effective-stream-session"
+    assert only["user_message"] == "stream from phone"
+    assert only["assistant_response"] == "stream reply"
+    assert only["message_kind"] == "turn"
+    assert isinstance(only["run_id"], str) and only["run_id"].startswith("run_")
+
+
+@pytest.mark.asyncio
+async def test_session_chat_invokes_registered_fanout_handler(auth_adapter, session_db):
+    """End-to-end: POST /api/sessions/{id}/chat must deliver the turn to a
+    handler registered via set_session_fanout_handler with the gateway session
+    key from X-Hermes-Session-Key, the effective session_id, the user message,
+    and the assistant response."""
+    session_id = session_db.create_session("reg-fanout-chat", "api_server")
+
+    async def fake_run(**kwargs):
+        return {"final_response": "registered reply", "session_id": "eff-reg-session"}, {"total_tokens": 2}
+
+    handler_calls = []
+
+    async def fanout_handler(**kwargs):
+        handler_calls.append(kwargs)
+
+    auth_adapter.set_session_fanout_handler(fanout_handler)
+
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                headers={
+                    "Authorization": "Bearer sk-test",
+                    "X-Hermes-Session-Key": "agent:main:discord:group:ch:user",
+                },
+                json={"message": "from tablet"},
+            )
+            assert resp.status == 200, await resp.text()
+
+    assert len(handler_calls) == 1
+    assert handler_calls[0]["origin_platform"] == "api_server"
+    assert handler_calls[0]["session_key"] == "agent:main:discord:group:ch:user"
+    assert handler_calls[0]["session_id"] == "eff-reg-session"
+    assert handler_calls[0]["user_message"] == "from tablet"
+    assert handler_calls[0]["assistant_response"] == "registered reply"
+    assert handler_calls[0]["message_kind"] == "turn"
+    assert handler_calls[0]["run_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_invokes_registered_fanout_handler_with_run_id(auth_adapter, session_db):
+    """End-to-end: POST /api/sessions/{id}/chat/stream must deliver the turn to
+    a handler registered via set_session_fanout_handler after the final response,
+    including a run_id."""
+    session_id = session_db.create_session("reg-fanout-stream", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("registered stream")
+        return {"final_response": "registered stream reply", "session_id": "eff-reg-stream"}, {"total_tokens": 5}
+
+    handler_calls = []
+
+    async def fanout_handler(**kwargs):
+        handler_calls.append(kwargs)
+
+    auth_adapter.set_session_fanout_handler(fanout_handler)
+
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                headers={
+                    "Authorization": "Bearer sk-test",
+                    "X-Hermes-Session-Key": "agent:main:telegram:dm:123",
+                },
+                json={"message": "stream from tablet"},
+            )
+            assert resp.status == 200, await resp.text()
+            body = await resp.text()
+
+    assert "event: assistant.completed" in body
+    assert len(handler_calls) == 1
+    only = handler_calls[0]
+    assert only["origin_platform"] == "api_server"
+    assert only["session_key"] == "agent:main:telegram:dm:123"
+    assert only["session_id"] == "eff-reg-stream"
+    assert only["user_message"] == "stream from tablet"
+    assert only["assistant_response"] == "registered stream reply"
+    assert only["message_kind"] == "turn"
+    assert isinstance(only["run_id"], str) and only["run_id"].startswith("run_")


### PR DESCRIPTION
## Summary

Allow config-driven session key aliasing and stable session ID overrides,
enabling API/mobile clients to target and fanout turns to real platform
surfaces (Telegram, Discord) via a shared logical session key.

## Problem

When a mobile or API client sends a message through the API server, the
turn is processed in the API session lane — it does not propagate to the
user's other platform surfaces (Telegram, Discord). If a user starts a
conversation on Discord and later continues via the API, the two lanes
have no shared session identity, so the agent has no continuity and the
Discord channel never sees the follow-up.

## Changes

- **`gateway/config.py`**: Add `session_key_aliases: Dict[str, str]` and
  `session_id_overrides: Dict[str, str]` to `GatewayConfig` with
  `from_dict()` parsing and `to_dict()` serialization.
- **`gateway/session.py`**: `_generate_session_key()` applies aliases;
  session creation honors `session_id_overrides` for stable IDs.
- **`gateway/run.py`**: Add `_canonical_api_session_key()`,
  `_fanout_targets_for_session_key()`, `_fanout_api_session_turn()`,
  `_handle_api_session_run_lifecycle()`, `_api_session_key_control()`.
  Wire aliases into `_resolve_session_key` / `_generate_session_key`.
  Register fanout/run/control handlers on adapter setup.
- **`gateway/platforms/api_server.py`**: Add `set_session_fanout_handler`,
  `set_session_run_handler`, `set_session_control_handler` injection
  points. `_notify_session_fanout()` dispatches turns to platform targets.
  Session response exposes `session_key`, `chat_id`, `chat_type`,
  `thread_id` for mobile client routing. Blank/whitespace input
  validation tightened via `_content_has_visible_payload`.
- **`tests/gateway/test_api_session_fanout.py`**: New 594-line test suite.
- **`tests/gateway/test_session_api.py`**: Session-key control tests.
- **`tests/gateway/test_api_server_runs.py`**: Blank-payload rejection
  tests.

## Configuration

```yaml
gateway:
  session_key_aliases:
    "agent:main:api_server:dm:mobile:geo": "agent:main:discord:group:123:geo"
  session_id_overrides:
    "agent:main:api_server:dm:mobile:geo": "stable-uuid-here"
```

## Test plan

```bash
python -m pytest tests/gateway/test_api_session_fanout.py \
  tests/gateway/test_session_api.py \
  tests/gateway/test_api_server_runs.py -o 'addopts=' -q
```

60 passed, 0 failed.
