### PR TITLE
fix(approval): use per-job ContextVar for cron-session flag instead of leaking env var (#56771)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2439,9 +2439,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     agent = None
 
     # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
+    # Use a per-job ContextVar (NOT a process-global env var) so the flag is
+    # task-local: concurrent interactive gateway sessions in the same process
+    # never inherit it (#56771).
+    from gateway.session_context import set_cron_session as _set_cron_session
+    _set_cron_session(True)
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
@@ -3041,6 +3043,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
+        # Reset the per-job cron-session flag (#56771).
+        try:
+            from gateway.session_context import clear_cron_session
+            clear_cron_session()
+        except Exception:
+            pass
         if _session_db:
             # Title the cron session from the job (name → short prompt → id) so
             # sidebars/history show a meaningful label instead of the injected

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -113,6 +113,25 @@ _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_P
 _CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
 _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
 
+# Per-job cron-session flag (issue #56771).
+#
+# The scheduler used to set ``os.environ["HERMES_CRON_SESSION"] = "1"``
+# process-wide at job start and never clear it. When the gateway and scheduler
+# share a process (the normal architecture) the env var leaked into every
+# concurrent interactive session, causing the approval system to treat user
+# chats as cron and block ``execute_code`` / dangerous commands.
+#
+# This ContextVar replaces that process-global env var. It is task-local:
+# only the asyncio task / worker thread that runs the cron job sees it.
+# Concurrent interactive sessions never inherit it.
+#
+# Tri-state semantics (mirrors the _UNSET pattern of the session vars):
+#   _UNSET — never set in this context → fall back to os.environ for backward
+#            compat (tests, CLI cron that sets the env var directly).
+#   True   — this task is running a cron job → approval applies cron_mode.
+#   False  — explicitly not a cron job (overrides a stale env var leak).
+_CRON_SESSION: ContextVar = ContextVar("HERMES_CRON_SESSION", default=_UNSET)
+
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_SOURCE": _SESSION_SOURCE,
@@ -333,3 +352,47 @@ def async_delivery_supported() -> bool:
     if value is _UNSET:
         return True
     return bool(value)
+
+
+# ---------------------------------------------------------------------------
+# Cron-session flag (issue #56771)
+# ---------------------------------------------------------------------------
+
+def set_cron_session(value: bool = True) -> None:
+    """Mark the current task as running (or not running) a cron job.
+
+    Called by ``cron/scheduler.py::run_job()`` before the agent starts so the
+    approval system applies ``approvals.cron_mode``. Because this is a
+    ContextVar, the flag is visible only within the scheduler's task/thread —
+    concurrent interactive sessions in the same process never inherit it.
+    """
+    _CRON_SESSION.set(bool(value))
+
+
+def clear_cron_session() -> None:
+    """Reset the cron-session flag to the "never set" sentinel.
+
+    Called in the ``run_job()`` finally block so a re-entrant or reused context
+    does not retain the flag after the job completes.
+    """
+    _CRON_SESSION.set(_UNSET)
+
+
+def is_cron_session() -> bool:
+    """Whether the current task is running a cron job.
+
+    Resolution order:
+    1. ContextVar — if explicitly set (True/False), that value is authoritative.
+    2. ``HERMES_CRON_SESSION`` env var — fallback when the ContextVar was never
+       bound in this context (tests, CLI cron that sets the env var directly).
+       In production the scheduler no longer sets this env var, so interactive
+       sessions fall through to ``False``.
+    """
+    import os
+
+    value = _CRON_SESSION.get()
+    if value is not _UNSET:
+        return bool(value)
+    return os.getenv("HERMES_CRON_SESSION", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -1,4 +1,11 @@
-"""Tests for approvals.cron_mode — configurable approval behavior for cron jobs."""
+"""Tests for approvals.cron_mode — configurable approval behavior for cron jobs.
+
+Cron sessions are identified via the per-job ``_CRON_SESSION`` ContextVar
+(see ``gateway.session_context.py`` and #56771). Setting ``HERMES_CRON_SESSION``
+as an env var still works as a fallback for tests/CLI paths that set it
+directly, but these tests exercise the ContextVar path to match what
+``cron/scheduler.py::run_job()`` does in production.
+"""
 
 import pytest
 
@@ -9,6 +16,7 @@ from tools.approval import (
     check_dangerous_command,
     detect_dangerous_command,
 )
+from gateway.session_context import clear_cron_session, set_cron_session
 
 
 @pytest.fixture(autouse=True)
@@ -16,10 +24,15 @@ def _clear_approval_state():
     approval_module._permanent_approved.clear()
     approval_module.clear_session("default")
     approval_module.clear_session("test-session")
+    # Reset the cron ContextVar so a leak from a prior test never
+    # bleeds into another test (the ContextVar default is _UNSET, which
+    # falls back to the env var; we want a clean _UNSET here).
+    clear_cron_session()
     yield
     approval_module._permanent_approved.clear()
     approval_module.clear_session("default")
     approval_module.clear_session("test-session")
+    clear_cron_session()
 
 
 # ---------------------------------------------------------------------------
@@ -88,10 +101,10 @@ class TestCronApprovalModeParsing:
 # ---------------------------------------------------------------------------
 
 class TestCronDenyMode:
-    """When HERMES_CRON_SESSION is set and cron_mode=deny, dangerous commands are blocked."""
+    """When the cron ContextVar is set and cron_mode=deny, dangerous commands are blocked."""
 
     def test_dangerous_command_blocked_in_cron_deny_mode(self, monkeypatch):
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -105,7 +118,7 @@ class TestCronDenyMode:
 
     def test_safe_command_allowed_in_cron_deny_mode(self, monkeypatch):
         """Non-dangerous commands still work even with cron_mode=deny."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -117,7 +130,7 @@ class TestCronDenyMode:
 
     def test_multiple_dangerous_patterns_blocked(self, monkeypatch):
         """All dangerous patterns are blocked, not just rm."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -140,7 +153,7 @@ class TestCronDenyMode:
 
     def test_block_message_includes_description(self, monkeypatch):
         """The block message should mention what pattern was matched."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -154,10 +167,10 @@ class TestCronDenyMode:
 
 
 class TestCronApproveMode:
-    """When HERMES_CRON_SESSION is set and cron_mode=approve, dangerous commands pass through."""
+    """When the cron ContextVar is set and cron_mode=approve, dangerous commands pass through."""
 
     def test_dangerous_command_allowed_in_cron_approve_mode(self, monkeypatch):
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -176,7 +189,7 @@ class TestCronDenyModeAllGuards:
     """The combined guard function also respects cron_mode."""
 
     def test_dangerous_command_blocked_in_combined_guard(self, monkeypatch):
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
@@ -189,7 +202,7 @@ class TestCronDenyModeAllGuards:
             assert "BLOCKED" in result["message"]
 
     def test_safe_command_allowed_in_combined_guard(self, monkeypatch):
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
@@ -201,7 +214,7 @@ class TestCronDenyModeAllGuards:
             assert result["approved"]
 
     def test_combined_guard_approve_mode(self, monkeypatch):
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
@@ -217,7 +230,7 @@ class TestCronDenyModeAllGuards:
         are blocked in cron-deny mode. Regression for #22070: previously the
         cron-deny early return ran only detect_dangerous_command and returned
         before reaching the tirith check, so these were silently approved."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
@@ -247,7 +260,7 @@ class TestCronDenyModeAllGuards:
         """When tirith is unavailable and security.tirith_fail_open is false,
         cron-deny mode blocks rather than silently allowing (a cron session has
         no user to approve). Mirrors the fail-closed handling in the main flow."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
@@ -278,7 +291,7 @@ class TestCronDenyModeAllGuards:
     def test_tirith_import_error_fail_open_allows_in_cron_deny(self, monkeypatch):
         """When tirith is unavailable and tirith_fail_open is true (default),
         cron-deny mode allows safe commands — preserving pre-#22070 behavior."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
@@ -315,7 +328,7 @@ class TestCronModeInteractions:
 
     def test_container_env_still_auto_approves(self, monkeypatch):
         """Docker/sandbox environments bypass approvals regardless of cron_mode."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -327,7 +340,7 @@ class TestCronModeInteractions:
 
     def test_yolo_overrides_cron_deny(self, monkeypatch):
         """--yolo still bypasses cron_mode=deny for dangerous (non-hardline) commands."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.setenv("HERMES_YOLO_MODE", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
@@ -350,8 +363,11 @@ class TestCronModeInteractions:
             assert result["approved"]
 
     def test_non_cron_non_interactive_still_auto_approves(self, monkeypatch):
-        """Non-cron, non-interactive sessions (e.g. scripted usage) still auto-approve."""
-        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        """Non-cron, non-interactive sessions (e.g. scripted usage) still auto-approve.
+        Note: this exercises the negative case — the cron ContextVar is NOT set,
+        which mirrors a fresh interactive session in a process that never ran a
+        cron job (#56771)."""
+        clear_cron_session()
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -373,7 +389,7 @@ class TestCronWithGatewayOrigin:
 
     def test_cron_with_telegram_origin_uses_cron_mode_not_gateway(self, monkeypatch):
         """Cron + contextvar platform=telegram + cron_mode=deny → BLOCKED, not pending."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -395,7 +411,7 @@ class TestCronWithGatewayOrigin:
 
     def test_cron_with_telegram_origin_approve_mode_allows(self, monkeypatch):
         """Cron + contextvar platform=telegram + cron_mode=approve → allowed via cron path."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
@@ -415,7 +431,7 @@ class TestCronWithGatewayOrigin:
 
     def test_cron_with_telegram_origin_combined_guard_uses_cron_mode(self, monkeypatch):
         """check_all_command_guards must also honor cron_mode over gateway classification."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(True)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)

--- a/tests/tools/test_cron_session_leak.py
+++ b/tests/tools/test_cron_session_leak.py
@@ -1,0 +1,198 @@
+"""Regression tests for #56771: HERMES_CRON_SESSION env var leaks from the
+scheduler process into interactive gateway sessions, blocking execute_code
+and dangerous commands for users who never ran a cron job in their chat.
+
+The fix replaces the process-global ``os.environ["HERMES_CRON_SESSION"]``
+set with a per-job ``ContextVar`` so the cron flag is task-local and cannot
+leak into concurrent interactive sessions.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import pytest
+
+from tools import approval as A
+from tools.approval import check_execute_code_guard
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_cron_contextvar():
+    """Ensure the cron ContextVar is cleared between tests."""
+    try:
+        from gateway.session_context import clear_cron_session
+        clear_cron_session()
+    except ImportError:
+        pass
+    yield
+    try:
+        from gateway.session_context import clear_cron_session
+        clear_cron_session()
+    except ImportError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 1. is_cron_session() — contextvar-based cron detection
+# ---------------------------------------------------------------------------
+
+class TestCronSessionContextVar:
+    def test_false_by_default(self, monkeypatch):
+        """Without a cron contextvar or env var, is_cron_session() is False."""
+        from gateway.session_context import is_cron_session
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        assert is_cron_session() is False
+
+    def test_true_when_contextvar_set(self, monkeypatch):
+        """Setting the cron contextvar makes is_cron_session() True."""
+        from gateway.session_context import set_cron_session, is_cron_session
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        set_cron_session(True)
+        assert is_cron_session() is True
+
+    def test_contextvar_overrides_leaked_env(self, monkeypatch):
+        """Even if HERMES_CRON_SESSION leaked into env, an explicitly-cleared
+        contextvar means NOT cron (interactive session in same process)."""
+        from gateway.session_context import set_cron_session, is_cron_session
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        set_cron_session(False)
+        assert is_cron_session() is False
+
+    def test_env_fallback_when_contextvar_unset(self, monkeypatch):
+        """Backward compat: env var still works when contextvar was never set
+        (tests, CLI cron that sets the env var directly)."""
+        from gateway.session_context import is_cron_session
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        assert is_cron_session() is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Thread isolation — the core fix
+# ---------------------------------------------------------------------------
+
+class TestCronContextVarThreadIsolation:
+    def test_scheduler_thread_does_not_leak_to_gateway_thread(self, monkeypatch):
+        """The cron ContextVar set in the scheduler thread must NOT be visible
+        in a concurrent gateway/interactive thread. This is the core mechanism
+        that prevents #56771 — os.environ leaks across threads, ContextVars do
+        not."""
+        from gateway.session_context import set_cron_session, is_cron_session
+
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        set_cron_session(True)
+        assert is_cron_session() is True  # scheduler thread sees it
+
+        seen: dict = {}
+
+        def gateway_handler():
+            # Fresh thread → ContextVar at default (_UNSET) → env fallback
+            # → env not set (scheduler no longer sets it) → False
+            seen["is_cron"] = is_cron_session()
+
+        t = threading.Thread(target=gateway_handler)
+        t.start()
+        t.join(timeout=5)
+
+        assert seen["is_cron"] is False
+
+    def test_env_var_does_leak_across_threads(self, monkeypatch):
+        """Documents the pre-fix bug: os.environ IS visible across threads."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        seen: dict = {}
+
+        def handler():
+            seen["env"] = os.environ.get("HERMES_CRON_SESSION")
+
+        t = threading.Thread(target=handler)
+        t.start()
+        t.join(timeout=5)
+
+        assert seen["env"] == "1"  # process-global env leaks — this is the bug
+
+
+# ---------------------------------------------------------------------------
+# 3. check_execute_code_guard — cron blocks, interactive doesn't
+# ---------------------------------------------------------------------------
+
+class TestExecuteCodeGuardCronContextVar:
+    def _setup(self, monkeypatch):
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+        monkeypatch.setattr(A, "_get_cron_approval_mode", lambda: "deny")
+
+    def test_cron_contextvar_blocks_execute_code(self, monkeypatch):
+        """When cron ContextVar is set, execute_code is blocked (real cron job)."""
+        from gateway.session_context import set_cron_session
+        self._setup(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        set_cron_session(True)
+
+        result = check_execute_code_guard("print('hi')", "local")
+        assert result["approved"] is False
+        assert "BLOCKED" in result["message"]
+
+    def test_interactive_not_blocked_without_cron_contextvar(self, monkeypatch):
+        """Interactive session (no cron ContextVar, no leaked env) can run
+        execute_code."""
+        self._setup(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+        result = check_execute_code_guard("print('hi')", "local")
+        # Headless local non-gateway non-cron → approved (existing contract)
+        assert result["approved"] is True
+
+    def test_interactive_thread_not_blocked_after_scheduler_ran(self, monkeypatch):
+        """Regression for #56771: after the scheduler thread sets the cron
+        ContextVar, a concurrent interactive thread should still be able to
+        run execute_code."""
+        from gateway.session_context import set_cron_session
+        self._setup(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+        # Scheduler thread sets the cron flag
+        set_cron_session(True)
+
+        seen: dict = {}
+
+        def interactive_session():
+            # Fresh thread: ContextVar _UNSET, env not set → not cron
+            result = check_execute_code_guard("print('hi')", "local")
+            seen["approved"] = result["approved"]
+
+        t = threading.Thread(target=interactive_session)
+        t.start()
+        t.join(timeout=5)
+
+        assert seen["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# 4. _is_gateway_approval_context — cron contextvar short-circuits gateway
+# ---------------------------------------------------------------------------
+
+class TestGatewayContextCronShortCircuit:
+    def test_cron_contextvar_returns_false_for_gateway(self, monkeypatch):
+        """When cron ContextVar is set, _is_gateway_approval_context() is False
+        even if HERMES_GATEWAY_SESSION is also set (cron takes precedence)."""
+        from gateway.session_context import set_cron_session
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        set_cron_session(True)
+
+        assert A._is_gateway_approval_context() is False
+
+    def test_interactive_still_gateway_without_cron(self, monkeypatch):
+        """Interactive gateway session (no cron ContextVar) is recognized as
+        gateway context."""
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+
+        assert A._is_gateway_approval_context() is True

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -23,6 +23,18 @@ import pytest
 
 from tools import approval as A
 from tools.thread_context import propagate_context_to_thread
+from gateway.session_context import clear_cron_session, set_cron_session
+
+
+@pytest.fixture(autouse=True)
+def _reset_cron_session_contextvar():
+    """Ensure the per-job cron ContextVar is cleared between tests so a
+    leaked flag from a prior test never bleeds into a fresh one's decisions.
+    Mirrors the autouse pattern used in tests/tools/test_cron_session_leak.py
+    (#56771)."""
+    clear_cron_session()
+    yield
+    clear_cron_session()
 
 
 # ---------------------------------------------------------------------------
@@ -106,10 +118,12 @@ def test_both_rpc_threads_use_propagation_helper():
 @pytest.fixture
 def gw_session(monkeypatch):
     """A clean gateway session: HERMES_GATEWAY_SESSION set, a bound session
-    key, and isolated gateway queues/callbacks. Yields the session_key."""
+    key, and isolated gateway queues/callbacks. Yields the session_key.
+
+    The cron ContextVar is explicitly cleared so a stale flag from a previous
+    test cannot accidentally classify this gateway session as cron (#56771)."""
     monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
-    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
     monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
     # Force manual mode regardless of host config.
     monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
@@ -158,7 +172,10 @@ def test_guard_headless_local_approved(monkeypatch):
 
 
 def test_guard_cron_deny_blocks(monkeypatch):
-    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    """The cron ContextVar (not the legacy env var) drives cron-deny behavior
+    in check_execute_code_guard — this is the post-#56771 regression test for
+    the guard matrix."""
+    set_cron_session(True)
     monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
     monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
     monkeypatch.setattr(A, "_get_cron_approval_mode", lambda: "deny")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -175,6 +175,22 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _is_cron_session() -> bool:
+    """Whether the current task is running a cron job.
+
+    Uses a per-task ContextVar so the flag does not leak from the scheduler
+    process into concurrent interactive gateway sessions (#56771). Falls back
+    to the legacy ``HERMES_CRON_SESSION`` env var for backward compat (tests,
+    CLI cron that sets the env var directly).
+    """
+    try:
+        from gateway.session_context import is_cron_session
+
+        return is_cron_session()
+    except Exception:
+        return env_var_enabled("HERMES_CRON_SESSION")
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -189,7 +205,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -2002,7 +2018,7 @@ def check_dangerous_command(command: str, env_type: str,
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -2265,7 +2281,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_session():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -2652,7 +2668,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_session():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,


### PR DESCRIPTION
## What

`execute_code` (and dangerous-command guards) were blocked in **interactive** gateway/CLI/TUI sessions whenever `HERMES_CRON_SESSION=1` was present in the process environment — even though the user never ran a cron job in that session (#56771).

## Root cause

`cron/scheduler.py` set `os.environ["HERMES_CRON_SESSION"] = "1"` **process-wide** at job start and never cleared it. The approval system then gates on `env_var_enabled("HERMES_CRON_SESSION")` at 4 sites. When the gateway and scheduler share a process (the normal architecture), the env var leaks via inheritance into every concurrent interactive session, so the approval system treats user chats as cron and blocks `execute_code` / dangerous commands.

This was the **only** place in the codebase that set the var, and `approval.py` was the **only** consumer — so replacing the process-global set has no other side effects.

## Fix

Replace the process-global env var with a **task-local `ContextVar`** so the cron flag cannot leak into concurrent interactive sessions:

- **`gateway/session_context.py`** — add `_CRON_SESSION` ContextVar (mirroring the existing `_UNSET` sentinel pattern of the session vars) plus `set_cron_session()` / `clear_cron_session()` / `is_cron_session()` helpers. `is_cron_session()` checks the ContextVar first and falls back to the env var **only** for backward compat with tests / CLI cron paths that set it directly (in production the scheduler no longer sets it, so interactive sessions fall through to `False`).
- **`cron/scheduler.py`** — replace the `os.environ` set with `set_cron_session(True)`; add `clear_cron_session()` to the `run_job()` finally block. The flag is set *before* the scheduler's existing `copy_context()` (line 2861) that the agent thread runs inside (`_cron_context.run(agent.run_conversation)`), so **real cron jobs still see `True`** and `cron_mode: deny` keeps working.
- **`tools/approval.py`** — add `_is_cron_session()` (contextvar-aware, lazy-imported like the existing `get_session_env` calls) and replace all 4 `env_var_enabled("HERMES_CRON_SESSION")` checks with it.

### Why ContextVar and not env-var reordering

The scheduler sets the cron flag *before* spawning the agent in a worker thread via `copy_context().run(...)`. ContextVars propagate **downward** through `ctx.run`, so the agent thread sees `True`; concurrent interactive sessions run in their own tasks/contexts where the var is `_UNSET`, so they resolve to `False`. By contrast `os.environ` is shared across all threads/process-children, which is precisely the leak this fixes. Competing approaches that merely reorder the gateway/cron precedence checks (or gate on interactive indicators) leave the env var leaking into spawned subprocesses and reverse the original design invariant that cron takes absolute priority over gateway approval.

## How verified

- 11 new regression tests (`tests/tools/test_cron_session_leak.py`): contextvar resolution, the core **thread-isolation** mechanism (scheduler thread sets the flag, concurrent gateway thread does *not* see it), env-var fallback for backward compat, contextvar-overrides-leaked-env, and the full `check_execute_code_guard` + `_is_gateway_approval_context` matrix (cron blocks, interactive allowed, interactive-after-scheduler-ran still allowed).
- 325 existing approval/cron tests pass.
- 612 scheduler tests pass.
- Branch is exactly one focused commit ahead of `main` (`0 1`).

Closes #56771.

---
Auto-published by Moonsong via Path B automated pipeline.
