### PR TITLE
fix(cron): warn when agent response is truncated by output token budget

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2978,6 +2978,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     turn_exit_reason,
                 )
                 final_response = ""
+        # Detect truncated responses and warn the user (issue #56790).
+        # When the agent hits its token budget, finish_reason='length' and
+        # the conversation loop's continuation retries are exhausted.  The
+        # response is still delivered but the user has no signal it was cut
+        # off — potentially omitting critical data.  Append a visible warning.
+        if final_response.strip() and "finish_reason=length" in turn_exit_reason:
+            final_response += (
+                "\n\n> ⚠️ **Warning:** This response was truncated because the "
+                "model hit its output token limit. Content may be incomplete."
+            )
+            logger.warning(
+                "Job '%s': response truncated (finish_reason=length) — "
+                "appending truncation warning to delivery",
+                job_id,
+            )
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1086,6 +1086,84 @@ class TestRunJobSessionPersistence:
         assert final_response == "Daily report: 4 PRs merged."
         assert success is True
 
+    def test_run_job_warns_on_truncated_response(self, tmp_path):
+        """When the agent hits its token budget (finish_reason=length), a
+        warning must be appended to the delivered output (issue #56790)."""
+        from run_agent import AIAgent
+        job = {"id": "test-job", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "Here is the analysis of your data...",
+                "turn_exit_reason": "text_response(finish_reason=length)",
+            }
+            mock_agent_cls.return_value = mock_agent
+            mock_agent_cls._format_turn_completion_explanation = (
+                AIAgent._format_turn_completion_explanation
+            )
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert "truncated" in final_response.lower()
+        assert "⚠️" in final_response
+        # The original content must still be present.
+        assert "Here is the analysis of your data..." in final_response
+
+    def test_run_job_no_warning_when_finish_reason_stop(self, tmp_path):
+        """A normal response (finish_reason=stop) must NOT get a truncation
+        warning (issue #56790 — false-positive guard)."""
+        from run_agent import AIAgent
+        job = {"id": "test-job", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "All tasks completed successfully.",
+                "turn_exit_reason": "text_response(finish_reason=stop)",
+            }
+            mock_agent_cls.return_value = mock_agent
+            mock_agent_cls._format_turn_completion_explanation = (
+                AIAgent._format_turn_completion_explanation
+            )
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert "truncated" not in final_response.lower()
+        assert final_response == "All tasks completed successfully."
+
     def test_run_job_titles_cron_session_from_job_not_important_hint(self, tmp_path):
         # The cron session's first message is the injected "[IMPORTANT: …]"
         # hint, which used to surface as the sidebar/history row label. run_job


### PR DESCRIPTION
## What does this PR do?

When a cron job's agent response is truncated by the output token budget (`finish_reason=length`), the scheduler currently marks the run as `ok` and delivers the partial response without any warning. Users receive output that looks complete but is actually cut off — potentially missing critical data, ending mid-sentence, or with unbalanced markdown fences.

This PR adds a lightweight truncation detection guard in `run_job()`: when `turn_exit_reason` indicates the conversation loop exited with `finish_reason=length`, a visible warning is appended to the delivered output so the user knows the response may be incomplete.

## Related Issue

Fixes #56790

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — Added truncation detection after the explainer-suppression block in `run_job()`. Checks `turn_exit_reason` for `finish_reason=length` and appends a ⚠️ warning to `final_response` before delivery. Also logs a `WARNING` for observability.
- `tests/cron/test_scheduler.py` — Added two tests:
  - `test_run_job_warns_on_truncated_response` — verifies warning is appended when `finish_reason=length`
  - `test_run_job_no_warning_when_finish_reason_stop` — verifies no false-positive warning on normal completion

## How to Test

1. Run the new tests: `python -m pytest tests/cron/test_scheduler.py -k "truncated or finish_reason_stop" -xvs`
   Observed result: Both tests pass — the truncated response includes `⚠️ **Warning:** This response was truncated...` and the normal response has no warning.
2. Run all `run_job` tests: `python -m pytest tests/cron/test_scheduler.py -k "run_job" -x`
   Observed result: All 28 run_job tests pass (0 failures).
3. The fix is in `run_job()` which is the execution core for both the built-in cron ticker and external providers (Chronos). When `turn_exit_reason` is `text_response(finish_reason=length)`, the warning is appended to `final_response` before it reaches `_deliver_result()`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_scheduler.py -k "run_job" -q` and all 28 run_job tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
