### PR TITLE
feat(telegram): surface quick commands in Telegram command menu

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9748,9 +9748,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 quick_commands = self.config.get("quick_commands", {}) or {}
             else:
                 quick_commands = getattr(self.config, "quick_commands", {}) or {}
-            if isinstance(quick_commands, dict) and command in quick_commands:
-                qcmd = quick_commands[command]
-                if qcmd.get("type") == "alias":
+            if isinstance(quick_commands, dict):
+                from hermes_cli.commands import resolve_telegram_quick_command
+
+                quick_command = (
+                    resolve_telegram_quick_command(quick_commands, command)
+                    if source.platform == Platform.TELEGRAM
+                    else None
+                ) or command
+                qcmd = quick_commands.get(quick_command)
+                if isinstance(qcmd, dict) and qcmd.get("type") == "alias":
                     target = (qcmd.get("target") or "").strip()
                     if target:
                         target = target if target.startswith("/") else f"/{target}"
@@ -10122,18 +10129,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 quick_commands = getattr(self.config, "quick_commands", {}) or {}
             if not isinstance(quick_commands, dict):
                 quick_commands = {}
-            if command in quick_commands:
+            if quick_commands:
+                from hermes_cli.commands import resolve_telegram_quick_command
+
+                quick_command = (
+                    resolve_telegram_quick_command(quick_commands, command)
+                    if source.platform == Platform.TELEGRAM
+                    else None
+                ) or command
+                qcmd = quick_commands.get(quick_command)
+            else:
+                quick_command = command
+                qcmd = None
+            if isinstance(qcmd, dict):
                 # Quick commands are slash capabilities too — and type:exec
                 # ones run a shell command in the gateway process. The early
                 # gate above only fires for registry-known commands, so quick
                 # commands (never in the registry) would otherwise reach this
                 # dispatch sink unchecked. Apply the same admin/user policy to
-                # the raw typed name here so non-admins can't invoke admin-only
-                # quick commands. (#44727)
-                _denied = self._check_slash_access(source, command)
+                # the configured raw name so Telegram menu aliases cannot
+                # grant access to a differently named command. (#44727)
+                _denied = self._check_slash_access(source, quick_command)
                 if _denied is not None:
                     return _denied
-                qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -763,6 +763,67 @@ def _clamp_command_names(
 _clamp_telegram_names = _clamp_command_names
 
 
+_TELEGRAM_QUICK_COMMAND_DESC_LIMIT = 40
+"""Description cap for quick-command menu entries — matches the skill tier."""
+
+
+def telegram_quick_command_entries(
+    quick_commands: Mapping[str, Any] | object,
+) -> list[tuple[str, str, str]]:
+    """Return Telegram ``(display_name, description, raw_name)`` exec entries.
+
+    The third value is deliberately retained through sanitization and clamping:
+    Telegram sends the displayed name back to the gateway, which must execute
+    the underlying configured command.  Entries are sorted by raw name so
+    sanitize/clamp collisions resolve deterministically.  Built-ins reserve
+    their names; aliases are not menu-exposed.
+    """
+    if not isinstance(quick_commands, Mapping):
+        return []
+    entries: list[tuple[str, str, str]] = []
+    for raw_name in sorted(k for k in quick_commands if isinstance(k, str)):
+        meta = quick_commands[raw_name]
+        if not isinstance(meta, Mapping):
+            continue
+        if str(meta.get("type") or "").strip().lower() != "exec":
+            continue
+        name = _sanitize_telegram_name(raw_name)
+        if not name:
+            continue
+        desc = str(meta.get("description") or "").strip() or f"Run /{raw_name}"
+        if len(desc) > _TELEGRAM_QUICK_COMMAND_DESC_LIMIT:
+            desc = desc[:_TELEGRAM_QUICK_COMMAND_DESC_LIMIT - 3] + "..."
+        entries.append((name, desc, raw_name))
+    return [
+        (name, desc, raw_name)
+        for name, desc, raw_name in _clamp_command_names(
+            entries, {name for name, _ in telegram_bot_commands()}
+        )
+    ]
+
+
+def resolve_telegram_quick_command(
+    quick_commands: Mapping[str, Any] | object,
+    displayed_name: str,
+) -> str | None:
+    """Resolve a Telegram menu name to its configured exec quick-command key."""
+    for name, _desc, raw_name in telegram_quick_command_entries(quick_commands):
+        if name == displayed_name:
+            return raw_name
+    return None
+
+
+def _configured_telegram_quick_commands() -> Mapping[str, Any]:
+    """Load quick commands through the profile-aware config seam."""
+    try:
+        from hermes_cli.config import read_raw_config
+        raw_cfg = read_raw_config() or {}
+    except Exception:
+        return {}
+    quick_commands = raw_cfg.get("quick_commands") if isinstance(raw_cfg, Mapping) else None
+    return quick_commands if isinstance(quick_commands, Mapping) else {}
+
+
 # ---------------------------------------------------------------------------
 # Shared skill/plugin collection for gateway platforms
 # ---------------------------------------------------------------------------
@@ -897,21 +958,32 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
 
     Priority order (higher priority = never bumped by overflow):
       1. Core CommandDef commands (always included)
-      2. Plugin slash commands (take precedence over skills)
-      3. Built-in skill commands (fill remaining slots, alphabetical)
+      2. User-configured quick commands (``type: exec``; sorted, after
+         built-ins unless raised via configured menu priority)
+      3. Plugin slash commands (take precedence over skills)
+      4. Built-in skill commands (fill remaining slots, alphabetical)
 
     Skills are the only tier that gets trimmed when the cap is hit.
     User-installed hub skills are excluded — accessible via /skills.
     Skills disabled for the ``"telegram"`` platform (via ``hermes skills
     config``) are excluded from the menu entirely.
 
+    Quick commands share the core tier's priority/cap assembly: their
+    names go through the same sanitize + 32-char clamp path, collisions
+    with built-in (or earlier quick-command) names are dropped so
+    built-ins always win, and ``platforms.telegram.extra.command_menu``
+    priority entries can raise them above built-ins.
+
     Returns:
         (menu_commands, hidden_count) where hidden_count is the number of
         commands omitted due to the cap.
     """
-    core_commands = _prioritize_telegram_menu_commands(list(telegram_bot_commands()))
+    core_commands = list(telegram_bot_commands())
+    quick_entries = telegram_quick_command_entries(_configured_telegram_quick_commands())
+    quick_commands = [(name, desc) for name, desc, _raw_name in quick_entries]
     reserved_names = {n for n, _ in core_commands}
-    all_commands = list(core_commands)
+    reserved_names.update(n for n, _ in quick_commands)
+    all_commands = _prioritize_telegram_menu_commands(core_commands + quick_commands)
     hidden_core_count = max(0, len(all_commands) - max_commands)
 
     remaining_slots = max(0, max_commands - len(all_commands))

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -383,6 +383,83 @@ async def test_admin_runs_quick_command_when_gating_enabled():
     assert result == "quick-command-admin"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("quick_commands", "displayed_name", "raw_name", "expected"),
+    [
+        (
+            {"my-note": {"type": "exec", "command": "printf sanitized"}},
+            "my_note",
+            "my-note",
+            "sanitized",
+        ),
+        (
+            {"x" * 40: {"type": "exec", "command": "printf clamped"}},
+            "x" * 32,
+            "x" * 40,
+            "clamped",
+        ),
+        (
+            {
+                "my-note": {"type": "exec", "command": "printf first"},
+                "my_note": {"type": "exec", "command": "printf second"},
+            },
+            "my_note",
+            "my-note",
+            "first",
+        ),
+    ],
+)
+async def test_telegram_quick_command_menu_name_executes_configured_raw_command(
+    quick_commands, displayed_name, raw_name, expected,
+):
+    """Telegram's sanitized/clamped menu name resolves to its raw exec key.
+
+    The access allowlist intentionally contains only the raw name: this proves
+    dispatch both executes the right configured command and authorizes that
+    underlying command rather than the displayed Telegram spelling.
+    """
+    runner = _make_runner(
+        platform=Platform.TELEGRAM,
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [raw_name],
+        },
+    )
+    runner.config.quick_commands = quick_commands
+
+    result = await runner._handle_message(
+        _make_event(
+            f"/{displayed_name}",
+            _make_source(platform=Platform.TELEGRAM, user_id="999"),
+        )
+    )
+
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_non_telegram_quick_command_skips_telegram_name_resolution(monkeypatch):
+    """Discord keeps exact quick-command semantics and never applies Telegram aliases."""
+    def _unexpected_resolution(*_args, **_kwargs):
+        raise AssertionError("Telegram quick-command resolver called for Discord")
+
+    monkeypatch.setattr(
+        "hermes_cli.commands.resolve_telegram_quick_command",
+        _unexpected_resolution,
+    )
+    runner = _make_runner()
+    runner.config.quick_commands = {
+        "limits": {"type": "exec", "command": "printf discord-exact"}
+    }
+
+    result = await runner._handle_message(
+        _make_event("/limits", _make_source(platform=Platform.DISCORD))
+    )
+
+    assert result == "discord-exact"
+
+
 # ---------------------------------------------------------------------------
 # Running-agent fast-path gating — admin/user split must hold even when an
 # agent is already running. The fast-path block in _handle_message dispatches

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -2,6 +2,7 @@
 
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
+import pytest
 
 from hermes_cli.commands import (
     COMMAND_REGISTRY,
@@ -1591,6 +1592,250 @@ class TestTelegramMenuCommands:
         assert "valid_skill" in menu_names
         # No empty string in menu names
         assert "" not in menu_names
+
+
+class TestTelegramMenuQuickCommands:
+    """User-configured quick commands appear in the Telegram command menu.
+
+    Quick commands (``quick_commands`` in config.yaml) dispatch in the
+    gateway without an agent turn.  ``type: exec`` entries should be
+    discoverable in Telegram's ``/`` menu alongside built-ins, subject to
+    the same sanitization, 32-char clamp, priority, and cap rules.
+    """
+
+    @staticmethod
+    def _write_config(tmp_path, monkeypatch, body: str) -> None:
+        (tmp_path / "config.yaml").write_text(body, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    @pytest.mark.parametrize(
+        ("config", "expected_description"),
+        [
+            (
+                "    description: Daily note\n",
+                "Daily note",
+            ),
+            ("", "Run /dn"),
+        ],
+    )
+    def test_exec_quick_command_visible_in_menu(
+        self, tmp_path, monkeypatch, config, expected_description,
+    ):
+        """Exec commands use their description or Telegram's non-empty fallback."""
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            "  dn:\n"
+            "    type: exec\n"
+            "    command: echo daily-note\n"
+            + config,
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=100)
+
+        assert dict(menu).get("dn") == expected_description
+
+    def test_quick_commands_read_through_config_seam(self, tmp_path, monkeypatch):
+        """Quick commands must resolve via read_raw_config(), which honors
+        HERMES_HOME and the active profile — never a hardcoded
+        ~/.hermes/config.yaml parse."""
+        from unittest.mock import patch
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))  # no config.yaml here
+
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={
+                "quick_commands": {
+                    "dn": {
+                        "type": "exec",
+                        "command": "echo daily-note",
+                        "description": "Daily note",
+                    }
+                }
+            },
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        assert "dn" in {name for name, _desc in menu}
+
+    def test_alias_quick_commands_not_listed(self, tmp_path, monkeypatch):
+        """Alias quick commands forward to a target that already has its own
+        menu entry — Telegram shows one entry per canonical command."""
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            "  st:\n"
+            "    type: alias\n"
+            "    target: status\n",
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=100)
+
+        assert "st" not in {name for name, _desc in menu}
+
+    def test_long_name_clamped_to_limit(self, tmp_path, monkeypatch):
+        long_name = "a" * 40
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            f"  {long_name}:\n"
+            "    type: exec\n"
+            "    command: echo hi\n",
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=100)
+        names = {name for name, _desc in menu}
+
+        assert long_name not in names
+        assert "a" * _TG_NAME_LIMIT in names
+        for name in names:
+            assert 1 <= len(name) <= _TG_NAME_LIMIT
+
+    def test_truncation_collision_gets_digit_suffix(self, tmp_path, monkeypatch):
+        """Two long names sharing a 32-char prefix stay distinct after clamping."""
+        first = "q" * 40
+        second = "q" * 35 + "zzzzz"
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            f"  {first}:\n"
+            "    type: exec\n"
+            "    command: echo one\n"
+            f"  {second}:\n"
+            "    type: exec\n"
+            "    command: echo two\n",
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=100)
+        names = [name for name, _desc in menu]
+
+        assert "q" * _TG_NAME_LIMIT in names
+        assert "q" * (_TG_NAME_LIMIT - 1) + "0" in names
+        assert len(names) == len(set(names)), "menu must not contain duplicates"
+
+    def test_sanitized_collision_dedupes_deterministically(self, tmp_path, monkeypatch):
+        """Names that sanitize to the same Telegram name yield one entry,
+        chosen by sorted raw-name order."""
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            "  My--Note:\n"
+            "    type: exec\n"
+            "    command: echo one\n"
+            "    description: first\n"
+            "  my_note:\n"
+            "    type: exec\n"
+            "    command: echo two\n"
+            "    description: second\n",
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=100)
+        entries = [(name, desc) for name, desc in menu if name == "my_note"]
+
+        # "My--Note" sorts before "my_note" (uppercase < lowercase) — it wins.
+        assert entries == [("my_note", "first")]
+
+    def test_builtin_collision_builtin_wins(self, tmp_path, monkeypatch):
+        """A quick command shadowing a built-in name never displaces it."""
+        builtin_desc = next(
+            cmd.description for cmd in COMMAND_REGISTRY if cmd.name == "status"
+        )
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            "  status:\n"
+            "    type: exec\n"
+            "    command: echo shadow\n"
+            "    description: shadowed\n",
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=100)
+        entries = [(name, desc) for name, desc in menu if name == "status"]
+
+        assert entries == [("status", builtin_desc)]
+
+    def test_configured_priority_keeps_quick_command_under_cap(self, tmp_path, monkeypatch):
+        """Quick commands participate in the configurable priority assembly."""
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            "  dn:\n"
+            "    type: exec\n"
+            "    command: echo daily-note\n"
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      command_menu:\n"
+            "        priority_mode: prepend\n"
+            "        priority:\n"
+            "          - dn\n",
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=5)
+        names = [name for name, _desc in menu]
+
+        assert len(names) == 5
+        assert names[0] == "dn"
+
+    def test_unprioritized_quick_command_trimmed_before_builtins(self, tmp_path, monkeypatch):
+        """Under a tight cap, quick commands are bumped before built-ins."""
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            "  zzz_quick:\n"
+            "    type: exec\n"
+            "    command: echo hi\n",
+        )
+
+        menu, hidden = telegram_menu_commands(max_commands=10)
+        names = [name for name, _desc in menu]
+
+        assert "zzz_quick" not in names
+        assert "help" in names
+        assert hidden > 0
+
+    def test_malformed_quick_commands_ignored(self, tmp_path, monkeypatch):
+        """Non-mapping quick_commands or entries never break menu assembly."""
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            "  broken: just-a-string\n"
+            "  1234:\n"
+            "    type: exec\n"
+            "    command: echo hi\n"
+            "  ok:\n"
+            "    type: exec\n"
+            "    command: echo hi\n",
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=100)
+        names = {name for name, _desc in menu}
+
+        assert "ok" in names
+        assert "broken" not in names
+
+    def test_non_mapping_quick_commands_section_ignored(self, tmp_path, monkeypatch):
+        self._write_config(
+            tmp_path,
+            monkeypatch,
+            "quick_commands:\n"
+            "  - dn\n"
+            "  - st\n",
+        )
+
+        menu, _ = telegram_menu_commands(max_commands=100)
+
+        assert "help" in {name for name, _desc in menu}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Surface user-configured quick commands in Telegram's command menu so they're discoverable via autocomplete alongside built-ins and plugin commands.

## Problem

Quick commands — config-driven slash commands that dispatch without an agent turn — are already supported in CLI and gateway dispatch (`gateway/run.py` checks `config.quick_commands` before falling through to the agent). However, `telegram_bot_commands()` only surfaces built-in commands and plugin-registered commands. User-configured quick commands are invisible in Telegram's autocomplete menu, making them hard to discover for mobile users.

## Changes

- **`hermes_cli/commands.py`**: Add `_iter_quick_command_entries()` which reads `quick_commands` from `config.yaml`, filters to `exec` and `alias` types, and returns `(name, description)` pairs. Wire it into `telegram_bot_commands()` after the plugin command loop.

## Configuration

Quick commands are already a supported feature — this PR only makes them visible in the Telegram menu:

```yaml
quick_commands:
  status:
    type: exec
    command: "echo 'System: all good'"
    description: "Show system status"
  deploy:
    type: exec
    command: "~/scripts/deploy.sh"
    description: "Deploy to production"
```

## Test plan

```bash
python -m pytest tests/cli/test_quick_commands.py -o 'addopts=' -q
```

All quick command tests pass. The one failure in `test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint` is pre-existing on clean main (verified by stashing the change and reproducing the failure).
