### PR TITLE
fix(gateway): handle voice clarify replies on telegram

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8600,17 +8600,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _pending_clarify = None
         if _pending_clarify is not None and _clarify_mod is not None:
             _raw_clarify_reply = (event.text or "").strip()
+            _clarify_reply = _raw_clarify_reply
             # Skip slash commands — the user clearly wanted to issue a
             # command, not answer the clarify.  Leave the clarify pending
             # so the user can retry; if it times out, the agent unblocks
             # with an empty response.
-            if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
+            if not _clarify_reply:
+                _audio_paths = [
+                    _path
+                    for _i, _path in enumerate(getattr(event, "media_urls", None) or [])
+                    if _event_media_is_audio(event, _i)
+                ]
+                if _audio_paths:
+                    _enriched_reply, _successful_transcripts = await self._enrich_message_with_transcription(
+                        "",
+                        _audio_paths,
+                    )
+                    if _successful_transcripts:
+                        _clarify_reply = "\n\n".join(
+                            _tx.strip() for _tx in _successful_transcripts if str(_tx).strip()
+                        ).strip()
+                        _echo_adapter = self.adapters.get(source.platform)
+                        _echo_meta = self._thread_metadata_for_source(
+                            source,
+                            self._reply_anchor_for_event(event),
+                        )
+                        if _echo_adapter:
+                            for _tx in _successful_transcripts:
+                                try:
+                                    await _echo_adapter.send(
+                                        source.chat_id,
+                                        f'🎙️ "{_tx}"',
+                                        metadata=_echo_meta,
+                                    )
+                                except Exception as _echo_exc:
+                                    logger.debug(
+                                        "Clarify transcript echo failed (non-fatal): %s",
+                                        _echo_exc,
+                                    )
+                    else:
+                        _clarify_reply = (_enriched_reply or _build_media_placeholder(event)).strip()
+            if _clarify_reply and not _clarify_reply.startswith("/"):
                 _resolved = _clarify_mod.resolve_text_response_for_session(
-                    _quick_key, _raw_clarify_reply,
+                    _quick_key, _clarify_reply,
                 )
                 if _resolved:
                     logger.info(
-                        "Gateway intercepted clarify text response (session=%s, id=%s)",
+                        "Gateway intercepted clarify response (session=%s, id=%s)",
                         _quick_key, _pending_clarify.clarify_id,
                     )
                     # Acknowledge with empty string so adapters that emit

--- a/tests/gateway/test_telegram_clarify_voice_reply.py
+++ b/tests/gateway/test_telegram_clarify_voice_reply.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _clear_clarify_state():
+    from tools import clarify_gateway as cm
+
+    cm._entries.clear()
+    cm._session_index.clear()
+    cm._notify_cbs.clear()
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+        user_name="tester",
+    )
+
+
+def _make_runner(adapter) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        stt_enabled=True,
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._is_user_authorized = lambda _source: True
+    runner._session_key_for_source = lambda _source: "telegram:dm:12345"
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    runner._reply_anchor_for_event = lambda _event: None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_pending_telegram_clarify_accepts_voice_reply():
+    from tools import clarify_gateway as cm
+
+    _clear_clarify_state()
+    cm.register("cid-voice", "telegram:dm:12345", "How should I proceed?", None)
+
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner = _make_runner(adapter)
+    runner._enrich_message_with_transcription = AsyncMock(
+        return_value=('"spoken answer"', ["spoken answer"])
+    )
+
+    event = MessageEvent(
+        text="",
+        source=_make_source(),
+        message_type=MessageType.VOICE,
+        media_urls=["/tmp/reply.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == ""
+    assert cm.wait_for_response("cid-voice", timeout=0.1) == "spoken answer"
+    runner._enrich_message_with_transcription.assert_awaited_once_with(
+        "", ["/tmp/reply.ogg"]
+    )
+    adapter.send.assert_awaited_once_with("12345", '🎙️ "spoken answer"', metadata={})


### PR DESCRIPTION
Fix Telegram clarify waits so a voice reply is transcribed and delivered back to the pending clarify instead of being dropped. This keeps clarify behavior aligned with normal Telegram voice turns.

## What changed and why
- Updated `gateway/run.py` so the pending-clarify intercept no longer only accepts `event.text`; when the reply is a voice/audio message, it now extracts audio attachments, runs the existing STT enrichment path, and resolves the clarify from the transcript.
- Reused the existing transcript-echo behavior for successful STT results so Telegram users still see the raw `🎙️` transcript before the agent continues.
- Added `tests/gateway/test_telegram_clarify_voice_reply.py` to cover the regression where a pending Telegram clarify was answered by voice and stayed stuck waiting.

## How to test
- Run `/opt/homebrew/bin/timeout -k 30 480 pytest tests/gateway/test_telegram_clarify_voice_reply.py tests/tools/test_clarify_gateway.py tests/gateway/test_stt_config.py -q --timeout=60`
- Run `ruff check gateway/run.py tests/gateway/test_telegram_clarify_voice_reply.py`
- Run `ruff format --check tests/gateway/test_telegram_clarify_voice_reply.py`
- Run `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_telegram_clarify_voice_reply.py`
- Optional manual check: in a Telegram DM, trigger a `clarify` prompt and answer with a voice note; Hermes should echo the transcript and continue the clarify flow without requiring a typed reply.
- Broad-suite note: `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` aborts during collection in this local environment because `tests/hermes_cli/test_cron_fire_dashboard.py` imports `hermes_cli.web_server`, which exits when `fastapi` is unavailable.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #56739

<!-- autocontrib:worker-id=issue-new-3b353341 kind=pr-open -->