### PR TITLE
fix(execute-code): honor session cwd overrides

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -220,6 +220,17 @@ class TestResolveChildCwd(unittest.TestCase):
         with patch.dict(os.environ, {"TERMINAL_CWD": "~"}):
             self.assertEqual(_resolve_child_cwd("project", "/tmp/staging"), home)
 
+    def test_project_prefers_registered_task_cwd_override(self):
+        import tempfile
+        import tools.terminal_tool as terminal_tool
+
+        with tempfile.TemporaryDirectory() as td:
+            task_id = "session-cwd-test"
+            with patch.dict(os.environ, {"TERMINAL_CWD": "/does/not/exist"}):
+                with patch.object(terminal_tool, "_task_env_overrides", {}, create=False):
+                    terminal_tool.register_task_env_overrides(task_id, {"cwd": td})
+                    self.assertEqual(_resolve_child_cwd("project", "/tmp/staging", task_id=task_id), td)
+
 
 # ---------------------------------------------------------------------------
 # Schema description
@@ -315,6 +326,28 @@ class TestExecuteCodeModeIntegration(unittest.TestCase):
                 os.path.realpath(result["output"].strip()),
                 os.path.realpath(td),
             )
+
+    def test_project_mode_uses_registered_session_cwd_override(self):
+        """Project mode must honor session.cwd.set-style overrides even when
+        TERMINAL_CWD is absent or points elsewhere."""
+        import tempfile
+        import tools.terminal_tool as terminal_tool
+
+        with tempfile.TemporaryDirectory() as td:
+            task_id = "session-cwd-test"
+            with patch.dict(os.environ, {"TERMINAL_CWD": "/does/not/exist"}):
+                with patch.object(terminal_tool, "_task_env_overrides", {}, create=False):
+                    terminal_tool.register_task_env_overrides(task_id, {"cwd": td})
+                    with _mock_mode("project"):
+                        with patch("model_tools.handle_function_call", side_effect=_mock_handle_function_call):
+                            raw = execute_code(
+                                code="import os; print(os.getcwd())",
+                                task_id=task_id,
+                                enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+                            )
+            result = json.loads(raw)
+            self.assertEqual(result["status"], "success")
+            self.assertEqual(os.path.realpath(result["output"].strip()), os.path.realpath(td))
 
     def test_project_mode_interpreter_is_venv_python(self):
         """Project mode: sys.executable inside the child is the venv's python

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1328,7 +1328,7 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir)
+        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1734,17 +1734,28 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's TERMINAL_CWD (same as the terminal tool), or
-      ``os.getcwd()`` if TERMINAL_CWD is unset or doesn't point at a real dir.
-      Falls back to the staging tmpdir as a last resort so we never invoke
-      Popen with a nonexistent cwd.
+    - ``project``: the raw per-session cwd override registered via
+      ``session.cwd.set`` / ``register_task_env_overrides`` when available,
+      then the session's TERMINAL_CWD (same as the terminal tool), or
+      ``os.getcwd()`` if neither points at a real dir. Falls back to the
+      staging tmpdir as a last resort so we never invoke Popen with a
+      nonexistent cwd.
     """
     if mode != "project":
         return staging_dir
+    if task_id:
+        try:
+            from tools.file_tools import _registered_task_cwd_override
+
+            session_cwd = _registered_task_cwd_override(task_id)
+        except Exception:
+            session_cwd = None
+        if session_cwd and os.path.isdir(session_cwd):
+            return session_cwd
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)


### PR DESCRIPTION
## Summary
- resolve execute_code project-mode cwd from the registered per-session override before TERMINAL_CWD/process cwd
- thread the task id into the child cwd resolver so session.cwd.set and gateway session workspaces stay consistent with write_file/terminal
- add resolver + integration regression tests covering registered session cwd overrides

## Test Plan
- pytest tests/tools/test_code_execution_modes.py -q

Closes #56047