### PR TITLE
fix(cli): add google/ publisher prefix normalization for Vertex AI

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -382,6 +382,12 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
         >>> normalize_model_for_provider("MiMo-V2.5-Pro", "xiaomi")
         'mimo-v2.5-pro'
+
+        >>> normalize_model_for_provider("gemini-3.1-flash-lite", "vertex")
+        'google/gemini-3.1-flash-lite'
+
+        >>> normalize_model_for_provider("google/gemini-3-pro-preview", "vertex")
+        'google/gemini-3-pro-preview'
     """
     name = (model_input or "").strip()
     if not name:
@@ -458,6 +464,17 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         if provider in _LOWERCASE_MODEL_PROVIDERS:
             result = result.lower()
         return result
+
+    # --- Vertex AI: requires 'google/' publisher prefix ---
+    # Bare names like "gemini-3.1-flash-lite" must become
+    # "google/gemini-3.1-flash-lite".  A "vertex/" prefix (e.g. copied from
+    # an old config) is stripped first.  Names already carrying "google/"
+    # are returned unchanged.
+    if provider == "vertex":
+        bare = _strip_matching_provider_prefix(name, provider)
+        if bare.startswith("google/"):
+            return bare
+        return f"google/{bare}"
 
     # --- Authoritative native providers: preserve user-facing slugs as-is ---
     if provider in _AUTHORITATIVE_NATIVE_PROVIDERS:

--- a/tests/hermes_cli/test_vertex_provider.py
+++ b/tests/hermes_cli/test_vertex_provider.py
@@ -98,3 +98,52 @@ def test_vertex_extra_body_empty_without_reasoning():
 
     p = get_provider_profile("vertex")
     assert p.build_extra_body(model="google/gemini-3-flash-preview") == {}
+
+
+# ---------------------------------------------------------------------------
+# Model name normalization for Vertex AI
+# ---------------------------------------------------------------------------
+
+
+class TestVertexModelNormalization:
+    """Vertex AI requires the 'google/' publisher prefix on all model IDs."""
+
+    @pytest.mark.parametrize(
+        "model_input, expected",
+        [
+            ("gemini-3.1-flash-lite", "google/gemini-3.1-flash-lite"),
+            ("gemini-2.5-pro", "google/gemini-2.5-pro"),
+            ("gemini-3-flash-preview", "google/gemini-3-flash-preview"),
+        ],
+        ids=["flash-lite", "pro", "flash-preview"],
+    )
+    def test_bare_name_gets_google_prefix(self, model_input, expected):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        assert normalize_model_for_provider(model_input, "vertex") == expected
+
+    @pytest.mark.parametrize(
+        "model_input",
+        [
+            "google/gemini-3.1-flash-lite",
+            "google/gemini-2.5-pro",
+            "google/gemini-3-pro-preview",
+        ],
+        ids=["flash-lite", "pro", "pro-preview"],
+    )
+    def test_already_prefixed_unchanged(self, model_input):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        assert normalize_model_for_provider(model_input, "vertex") == model_input
+
+    def test_vertex_prefix_stripped_then_google_added(self):
+        """'vertex/gemini-2.5-flash' → strip 'vertex/' → add 'google/'."""
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        assert normalize_model_for_provider("vertex/gemini-2.5-flash", "vertex") == "google/gemini-2.5-flash"
+
+    def test_empty_input_returns_empty(self):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        assert normalize_model_for_provider("", "vertex") == ""
+        assert normalize_model_for_provider(None, "vertex") == ""


### PR DESCRIPTION
## What does this PR do?

Adds a dedicated normalization handler for the `vertex` provider in `normalize_model_for_provider()`. Vertex AI endpoints require model IDs in the `google/MODEL_NAME` format (e.g. `google/gemini-3.1-flash-lite`), but bare names like `gemini-3.1-flash-lite` were passed through unchanged, causing HTTP 400 `INVALID_ARGUMENT` errors from the Vertex API.

## Related Issue

Fixes #56778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_normalize.py`: Added a `vertex` provider block that prepends `google/` to bare model names, preserves names already carrying the `google/` prefix, and strips a matching `vertex/` prefix before adding `google/`. Added two docstring examples.
- `tests/hermes_cli/test_vertex_provider.py`: Added `TestVertexModelNormalization` class with 4 test methods covering bare names, already-prefixed names, `vertex/` prefix stripping, and empty input.

## How to Test

1. Run the new normalization tests:
   ```bash
   python -m pytest tests/hermes_cli/test_vertex_provider.py -q -k "TestVertexModelNormalization"
   ```
   All 7 parametrized cases should pass.

2. Run the full vertex provider test suite to check for regressions:
   ```bash
   python -m pytest tests/hermes_cli/test_vertex_provider.py -q
   ```
   All 29 tests should pass.

3. Verify normalization behavior interactively:
   ```python
   from hermes_cli.model_normalize import normalize_model_for_provider
   assert normalize_model_for_provider("gemini-3.1-flash-lite", "vertex") == "google/gemini-3.1-flash-lite"
   assert normalize_model_for_provider("google/gemini-2.5-pro", "vertex") == "google/gemini-2.5-pro"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Python 3.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring examples added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string normalization, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
