### PR TITLE
feat(approval): generic config-driven tool-call approval gate

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2480,6 +2480,26 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             pass
         return result
 
+    # --- Generic tool-approval gate (config-driven; default OFF) ----------
+    # Single choke point for the concurrent dispatch path. Runs before any
+    # tool-specific branch so every gated tool (incl. registry/MCP via the
+    # ``else`` → handle_function_call branch) is covered. A staged result is
+    # a non-error "defer-success"; a blocked result is a hard error.
+    try:
+        from tools.approval import check_tool_approval
+        _gate = check_tool_approval(function_name, function_args)
+    except Exception as _gate_err:  # never let the gate crash a tool call
+        logger.debug("tool approval gate error: %s", _gate_err)
+        _gate = {"approved": True}
+    if _gate.get("approved") is False:
+        _gate_status = _gate.get("status", "blocked")
+        _gate_key = "error" if _gate_status == "blocked" else "message"
+        _gate_result = json.dumps(
+            {"status": _gate_status, _gate_key: _gate.get("message")},
+            ensure_ascii=False,
+        )
+        return _gate_result
+
     tool_start_time = time.monotonic()
 
     def _finish_agent_tool(result: Any, observed_args: Optional[dict] = None) -> Any:
@@ -2602,6 +2622,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
+                skip_tool_approval_gate=True,
             )
 
     from hermes_cli.middleware import run_tool_execution_middleware

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1158,10 +1158,35 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             if not guardrail_decision.allows_execution:
                 _guardrail_block_decision = guardrail_decision
 
-        _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
+        # Generic tool-approval gate (config-driven; default OFF). Single
+        # choke point for the sequential dispatch path — mirrors the
+        # concurrent path in agent_runtime_helpers.invoke_tool. A staged
+        # result is a non-error defer; a blocked result is a hard error.
+        _tool_gate_json: Optional[str] = None
+        _tool_gate_status: str = ""
+        if _block_msg is None and _guardrail_block_decision is None:
+            try:
+                from tools.approval import check_tool_approval
+                _gate = check_tool_approval(function_name, function_args)
+            except Exception as _gate_err:
+                logger.debug("tool approval gate error: %s", _gate_err)
+                _gate = {"approved": True}
+            if _gate.get("approved") is False:
+                _tool_gate_status = _gate.get("status", "blocked")
+                _gate_key = "error" if _tool_gate_status == "blocked" else "message"
+                _tool_gate_json = json.dumps(
+                    {"status": _tool_gate_status, _gate_key: _gate.get("message")},
+                    ensure_ascii=False,
+                )
+
+        _execution_blocked = (
+            _block_msg is not None
+            or _guardrail_block_decision is not None
+            or _tool_gate_json is not None
+        )
 
         if _execution_blocked:
-            # Tool blocked by plugin or guardrail policy — skip counters,
+            # Tool blocked by plugin, guardrail, or approval gate — skip counters,
             # callbacks, checkpointing, activity mutation, and real execution.
             pass
         # Reset nudge counters when the relevant tool is actually used
@@ -1266,6 +1291,25 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 status="blocked",
                 error_type="guardrail_block",
                 error_message=getattr(_guardrail_block_decision, "message", None) or "Tool blocked by guardrail policy",
+                middleware_trace=list(middleware_trace),
+            )
+        elif _tool_gate_json is not None:
+            # Tool staged or blocked by the approval gate — return the gate's
+            # result directly. A "staged" status is informational (not an
+            # error): the agent can continue; the action will run after human
+            # approval. A "blocked" status is a hard refusal.
+            function_result = _tool_gate_json
+            tool_duration = 0.0
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status=_tool_gate_status,
+                error_type="tool_gate",
+                error_message=None,
                 middleware_trace=list(middleware_trace),
             )
         elif function_name == "todo":
@@ -1519,6 +1563,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                     tool_request_middleware_trace=list(middleware_trace),
+                    skip_tool_approval_gate=True,
                 )
                 _spinner_result = function_result
             except KeyboardInterrupt:
@@ -1561,6 +1606,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                     disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                     tool_request_middleware_trace=list(middleware_trace),
+                    skip_tool_approval_gate=True,
                 )
             except KeyboardInterrupt:
                 _emit_cancelled_terminal_post_tool_call(

--- a/cli.py
+++ b/cli.py
@@ -16401,6 +16401,32 @@ def main(
             single_query_image_urls: list[str] = []
             _kanban_task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
             if _kanban_task_id:
+                # An exec card minted by tools.tool_gate.approve_action carries a
+                # replay marker in its body instead of ordinary task
+                # instructions. Those must run deterministically via
+                # replay_pending_action (the approved tool call, replayed
+                # exactly, exactly once) rather than being handed to the model
+                # as a prose instruction to "replay the staged tool call" —
+                # which would neither be deterministic nor guaranteed to
+                # actually invoke the tool. Short-circuit before touching the
+                # agent loop at all.
+                try:
+                    from tools.tool_gate import maybe_replay_kanban_task
+                    _replay_outcome = maybe_replay_kanban_task(_kanban_task_id)
+                except Exception as _replay_exc:
+                    logger.debug("kanban replay short-circuit failed: %s", _replay_exc)
+                    _replay_outcome = None
+                if _replay_outcome is not None:
+                    if not quiet:
+                        print(_replay_outcome.get("message") or "")
+                    # Always a clean exit: the task's board state (done vs
+                    # blocked, set above by maybe_replay_kanban_task) is what
+                    # tells the dispatcher whether the approved action
+                    # actually succeeded — a denied/failed tool call still
+                    # leaves this worker process completing normally, exactly
+                    # like an LLM-driven turn that calls kanban_block itself
+                    # and then exits 0.
+                    sys.exit(0)
                 try:
                     from hermes_cli import kanban_db as _kb
                     from agent.image_routing import extract_image_refs as _extract_refs

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -450,10 +450,12 @@ def _format_exec_approval_fallback(
     allow_permanent: bool = True,
     allow_session: bool = True,
     smart_denied: bool = False,
+    heading: Optional[str] = None,
 ) -> str:
     """Render the text fallback from approval capabilities, not platform names."""
     cmd_preview = command[:200] + "..." if len(command) > 200 else command
-    heading = "⚠️ **Dangerous command requires approval:**"
+    if heading is None:
+        heading = "⚠️ **Dangerous command requires approval:**"
     if smart_denied:
         heading = "⚠️ **Smart DENY — owner override for one operation:**"
 
@@ -21779,6 +21781,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # can actually type (`!approve`) — typed "/" is blocked in
                 # Slack threads and reserved by Matrix clients.
                 _p = getattr(_status_adapter, "typed_command_prefix", "/")
+                # Tool-gate approvals carry kind="tool" + tool_name; render a
+                # tool-flavoured header instead of "Dangerous command" so the
+                # prompt matches what's actually being approved.
+                _tool_heading = None
+                if approval_data.get("kind") == "tool":
+                    _tool_name = approval_data.get("tool_name", "this tool")
+                    _tool_heading = f"⚠️ **Approval required to run `{_tool_name}`:**"
                 msg = _format_exec_approval_fallback(
                     cmd,
                     desc,
@@ -21786,6 +21795,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     allow_permanent=approval_data.get("allow_permanent", True),
                     allow_session=approval_data.get("allow_session", True),
                     smart_denied=approval_data.get("smart_denied", False),
+                    heading=_tool_heading,
                 )
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(

--- a/model_tools.py
+++ b/model_tools.py
@@ -1081,6 +1081,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    skip_tool_approval_gate: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1253,6 +1254,45 @@ def handle_function_call(
                     status="blocked",
                     error_type="plugin_block",
                     error_message=block_message,
+                    middleware_trace=list(_tool_middleware_trace),
+                )
+                return result
+
+        # Generic tool-approval gate (config-driven; default OFF). This is
+        # the single choke point every dispatch path funnels through —
+        # sequential/concurrent agent-loop dispatch, the execute_code sandbox
+        # IPC handler, and the MCP tool server all call handle_function_call
+        # to actually run a tool. Callers that already ran the gate at their
+        # own choke point (agent_runtime_helpers.invoke_tool,
+        # tool_executor.execute_tool_calls_sequential) pass
+        # skip_tool_approval_gate=True so a staged/consumed replay token
+        # isn't evaluated twice.
+        if not skip_tool_approval_gate:
+            try:
+                from tools.approval import check_tool_approval
+                _gate = check_tool_approval(function_name, function_args)
+            except Exception as _gate_err:
+                logger.debug("tool approval gate error: %s", _gate_err)
+                _gate = {"approved": True}
+            if _gate.get("approved") is False:
+                _gate_status = _gate.get("status", "blocked")
+                _gate_key = "error" if _gate_status == "blocked" else "message"
+                result = json.dumps(
+                    {"status": _gate_status, _gate_key: _gate.get("message")},
+                    ensure_ascii=False,
+                )
+                _emit_post_tool_call_hook(
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=result,
+                    task_id=task_id,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                    turn_id=turn_id,
+                    api_request_id=api_request_id,
+                    status=_gate_status,
+                    error_type="tool_gate",
+                    error_message=None,
                     middleware_trace=list(_tool_middleware_trace),
                 )
                 return result

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3084,6 +3084,7 @@ class TestConcurrentToolExecution:
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
                 tool_request_middleware_trace=[],
+                skip_tool_approval_gate=True,
             )
             assert result == "result"
 

--- a/tests/run_agent/test_tool_gate_dispatch.py
+++ b/tests/run_agent/test_tool_gate_dispatch.py
@@ -1,0 +1,151 @@
+"""Integration: the tool-approval gate fires at the real dispatch choke point.
+
+Verifies that ``execute_tool_calls_sequential`` consults ``check_tool_approval``
+before executing, and that a deferred ("staged") decision short-circuits the
+tool — the underlying ``handle_function_call`` must never run, and the agent
+sees a non-error staged result.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names):
+    return [
+        {"type": "function",
+         "function": {"name": n, "description": f"{n} tool",
+                      "parameters": {"type": "object", "properties": {}}}}
+        for n in names
+    ]
+
+
+def _tool_call(name, arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _make_agent(*tool_names):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=5,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def test_staged_decision_blocks_execution_sequential():
+    agent = _make_agent("echo_tool")
+    assistant_message = SimpleNamespace(
+        content="", tool_calls=[_tool_call("echo_tool", '{"msg": "hi"}')])
+    messages: list = []
+
+    staged = {"approved": False, "status": "staged",
+              "message": "Queued for approval; continuing.",
+              "pending_id": "pX", "card_id": "tY"}
+
+    hfc = MagicMock(return_value='{"ok": true}')
+    with (
+        patch("tools.approval.check_tool_approval", return_value=staged) as gate,
+        patch("run_agent.handle_function_call", hfc),
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task1")
+
+    gate.assert_called_once()
+    # The gated tool must NOT have executed.
+    hfc.assert_not_called()
+    # The agent sees exactly one tool result carrying the staged decision.
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    payload = json.loads(tool_msgs[0]["content"])
+    assert payload["status"] == "staged"
+    assert "approval" in payload["message"].lower()
+
+
+def test_blocked_decision_is_error_sequential():
+    agent = _make_agent("echo_tool")
+    assistant_message = SimpleNamespace(
+        content="", tool_calls=[_tool_call("echo_tool", "{}")])
+    messages: list = []
+
+    blocked = {"approved": False, "status": "blocked",
+               "message": "BLOCKED: user denied. Do NOT retry."}
+
+    hfc = MagicMock(return_value='{"ok": true}')
+    with (
+        patch("tools.approval.check_tool_approval", return_value=blocked),
+        patch("run_agent.handle_function_call", hfc),
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task1")
+
+    hfc.assert_not_called()
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    payload = json.loads(tool_msgs[0]["content"])
+    assert payload["status"] == "blocked"
+    assert "error" in payload  # blocked → error key (hard failure)
+
+
+def test_staged_decision_blocks_execution_concurrent():
+    agent = _make_agent("echo_tool")
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[_tool_call("echo_tool", '{"i": 1}', "c1"),
+                    _tool_call("echo_tool", '{"i": 2}', "c2")])
+    messages: list = []
+
+    staged = {"approved": False, "status": "staged",
+              "message": "Queued for approval; continuing.",
+              "pending_id": "pX", "card_id": "tY"}
+
+    hfc = MagicMock(return_value='{"ok": true}')
+    with (
+        patch("tools.approval.check_tool_approval", return_value=staged),
+        patch("run_agent.handle_function_call", hfc),
+    ):
+        agent._execute_tool_calls_concurrent(assistant_message, messages, "task1")
+
+    # Gate ran in invoke_tool for both calls → neither executed.
+    hfc.assert_not_called()
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert len(tool_msgs) == 2
+    for tm in tool_msgs:
+        assert json.loads(tm["content"])["status"] == "staged"
+
+
+def test_allowed_decision_executes_sequential():
+    agent = _make_agent("echo_tool")
+    assistant_message = SimpleNamespace(
+        content="", tool_calls=[_tool_call("echo_tool", "{}")])
+    messages: list = []
+
+    hfc = MagicMock(return_value='{"ok": true}')
+    with (
+        patch("tools.approval.check_tool_approval",
+              return_value={"approved": True, "message": None}),
+        patch("run_agent.handle_function_call", hfc),
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task1")
+
+    hfc.assert_called_once()

--- a/tests/tools/test_tool_gate.py
+++ b/tests/tools/test_tool_gate.py
@@ -1,0 +1,522 @@
+"""Tests for the generic, config-driven tool-approval gate.
+
+Covers:
+  * detection / default-off / bypass ladder (check_tool_approval)
+  * mode selection across unattended / force_deferred / allow_inline / default
+  * deferred staging: pending record + Kanban card + non-error "staged" result
+  * inline (blocking) approval reuse of the dangerous-command engine
+  * one-shot replay token, TTL refusal, double-execution guard
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+import tools.approval as approval_module
+from tools import tool_gate
+from tools import write_approval as wa
+
+
+@pytest.fixture
+def hermes_home(monkeypatch):
+    d = tempfile.mkdtemp(prefix="hermes_tg_test_")
+    home = os.path.join(d, ".hermes")
+    os.makedirs(home)
+    monkeypatch.setenv("HERMES_HOME", home)
+    yield home
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    approval_module._session_approved.clear()
+    approval_module._permanent_approved.clear()
+    approval_module._gateway_notify_cbs.clear()
+    approval_module._gateway_queues.clear()
+    saved = {}
+    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+              "HERMES_EXEC_ASK", "HERMES_YOLO_MODE", "HERMES_SESSION_KEY"):
+        if k in os.environ:
+            saved[k] = os.environ.pop(k)
+    yield
+    approval_module._session_approved.clear()
+    approval_module._permanent_approved.clear()
+    approval_module._gateway_notify_cbs.clear()
+    approval_module._gateway_queues.clear()
+    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_CRON_SESSION",
+              "HERMES_EXEC_ASK", "HERMES_YOLO_MODE", "HERMES_SESSION_KEY"):
+        os.environ.pop(k, None)
+    for k, v in saved.items():
+        os.environ[k] = v
+
+
+def _set_gate(home, **gate):
+    import hermes_cli.config as cfg
+    c = cfg.load_config()
+    c.setdefault("approvals", {})["tool_gate"] = gate
+    cfg.save_config(c)
+
+
+# ---------------------------------------------------------------------------
+# Detection / bypass ladder
+# ---------------------------------------------------------------------------
+
+class TestDetectionLadder:
+    def test_no_config_allows(self, hermes_home):
+        assert tool_gate.get_tool_gate_config() == {}
+        assert approval_module.check_tool_approval("send_mail", {}) == {
+            "approved": True, "message": None}
+
+    def test_disabled_allows(self, hermes_home):
+        _set_gate(hermes_home, enabled=False, require_approval=["send_mail"])
+        assert approval_module.check_tool_approval("send_mail", {})["approved"] is True
+
+    def test_unlisted_tool_allows(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["send_mail"])
+        assert approval_module.check_tool_approval("read_file", {})["approved"] is True
+
+    def test_glob_match_is_gated(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["send_*"],
+                  force_deferred=["send_*"])
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("send_sms", {"to": "x"})
+        assert r["status"] == "staged"
+
+    def test_yolo_bypasses(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["send_mail"])
+        os.environ["HERMES_YOLO_MODE"] = "1"
+        # _YOLO_MODE_FROZEN is read at import; patch it directly.
+        approval_module._YOLO_MODE_FROZEN = True
+        try:
+            assert approval_module.check_tool_approval("send_mail", {})["approved"] is True
+        finally:
+            approval_module._YOLO_MODE_FROZEN = False
+
+    def test_mode_off_bypasses(self, hermes_home):
+        import hermes_cli.config as cfg
+        c = cfg.load_config()
+        c.setdefault("approvals", {})["mode"] = "off"
+        c["approvals"]["tool_gate"] = {"enabled": True, "require_approval": ["send_mail"]}
+        cfg.save_config(c)
+        assert approval_module.check_tool_approval("send_mail", {})["approved"] is True
+
+    def test_prior_session_approval_allows(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["send_mail"])
+        os.environ["HERMES_SESSION_KEY"] = "sk1"
+        approval_module.approve_session("sk1", approval_module._tool_key("send_mail"))
+        assert approval_module.check_tool_approval("send_mail", {})["approved"] is True
+
+
+# ---------------------------------------------------------------------------
+# Mode selection
+# ---------------------------------------------------------------------------
+
+class TestModeSelection:
+    def _cfg(self, **kw):
+        base = {"enabled": True, "require_approval": ["t"], "default_mode": "deferred"}
+        base.update(kw)
+        return base
+
+    def test_no_channel_is_deferred(self, hermes_home):
+        assert approval_module._select_tool_mode("t", self._cfg(), "sk") == "deferred"
+
+    def test_cron_is_deferred_even_with_channel(self, hermes_home):
+        approval_module.register_gateway_notify("sk", lambda d: None)
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        assert approval_module._select_tool_mode("t", self._cfg(allow_inline=["t"]), "sk") == "deferred"
+
+    def test_force_deferred_overrides_inline(self, hermes_home):
+        approval_module.register_gateway_notify("sk", lambda d: None)
+        cfg = self._cfg(allow_inline=["t"], force_deferred=["t"])
+        assert approval_module._select_tool_mode("t", cfg, "sk") == "deferred"
+
+    def test_allow_inline_with_channel_is_inline(self, hermes_home):
+        approval_module.register_gateway_notify("sk", lambda d: None)
+        assert approval_module._select_tool_mode("t", self._cfg(allow_inline=["t"]), "sk") == "inline"
+
+    def test_default_mode_inline_with_channel(self, hermes_home):
+        approval_module.register_gateway_notify("sk", lambda d: None)
+        assert approval_module._select_tool_mode("t", self._cfg(default_mode="inline"), "sk") == "inline"
+
+    def test_default_mode_deferred_with_channel(self, hermes_home):
+        approval_module.register_gateway_notify("sk", lambda d: None)
+        assert approval_module._select_tool_mode("t", self._cfg(default_mode="deferred"), "sk") == "deferred"
+
+
+# ---------------------------------------------------------------------------
+# Deferred staging
+# ---------------------------------------------------------------------------
+
+class TestDeferredStaging:
+    def test_stage_creates_pending_and_card(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"],
+                  deferred={"pending_ttl_hours": 72})
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+
+        assert r["approved"] is False
+        assert r["status"] == "staged"
+        assert "do NOT retry" in r["message"].lower() or "do not retry" in r["message"].lower()
+        pid = r["pending_id"]
+        assert pid
+
+        # Pending record persisted with replayable payload + token + status.
+        rec = wa.get_pending(tool_gate.SUBSYSTEM, pid)
+        assert rec is not None
+        assert rec["payload"]["tool_name"] == "echo_tool"
+        assert rec["payload"]["args"] == {"msg": "hi"}
+        assert rec["status"] == "pending"
+        assert rec["token"]
+        assert rec["expires_at"] > time.time()
+
+        # Kanban approval card created and linked both ways.
+        card_id = r["card_id"]
+        assert card_id
+        assert rec["card_id"] == card_id
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        task = kb.get_task(conn, card_id)
+        assert task is not None
+        assert tool_gate.APPROVAL_MARKER in (task.body or "")
+        assert pid in (task.body or "")
+
+    def test_empty_board_assignee_uses_nonprofile_sentinel(self, hermes_home):
+        # An empty board_assignee must NOT leave the card unassigned (a set
+        # kanban.default_assignee could then auto-spawn it). It gets the
+        # non-profile REVIEW_ASSIGNEE sentinel so the dispatcher skips it.
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"], deferred={"board_assignee": ""})
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        task = kb.get_task(conn, r["card_id"])
+        assert task.assignee == tool_gate.REVIEW_ASSIGNEE
+        from hermes_cli.profiles import profile_exists
+        assert not profile_exists(task.assignee)  # never auto-dispatched
+
+    def test_background_origin_defers(self, hermes_home, monkeypatch):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"])
+        approval_module.register_gateway_notify("sk", lambda d: None)
+        os.environ["HERMES_SESSION_KEY"] = "sk"
+        monkeypatch.setattr(tool_gate, "_current_profile", lambda: "default")
+        # Background review origin → deferred even though a channel exists.
+        import tools.skill_provenance as sp
+        tok = sp.set_current_write_origin("background_review")
+        try:
+            mode = approval_module._select_tool_mode("echo_tool",
+                                                     tool_gate.get_tool_gate_config(), "sk")
+        finally:
+            sp.reset_current_write_origin(tok)
+        assert mode == "deferred"
+
+
+# ---------------------------------------------------------------------------
+# Inline (blocking) approval
+# ---------------------------------------------------------------------------
+
+class TestInlineApproval:
+    SK = "tg-inline-sk"
+
+    def _run_in_thread(self, tool, args):
+        holder = {}
+
+        def _go():
+            holder["r"] = approval_module.check_tool_approval(tool, args)
+
+        t = threading.Thread(target=_go, daemon=True)
+        t.start()
+        for _ in range(100):
+            if approval_module._gateway_queues.get(self.SK):
+                break
+            time.sleep(0.02)
+        return holder, t
+
+    def test_inline_approve_once(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  allow_inline=["echo_tool"], default_mode="inline")
+        os.environ["HERMES_SESSION_KEY"] = self.SK
+        approval_module.register_gateway_notify(self.SK, lambda d: None)
+
+        holder, t = self._run_in_thread("echo_tool", {"x": 1})
+        approval_module.resolve_gateway_approval(self.SK, "once")
+        t.join(timeout=5)
+        assert holder["r"] == {"approved": True, "message": None}
+        # "once" must NOT grant a session allowlist entry.
+        assert not approval_module.is_approved(self.SK, approval_module._tool_key("echo_tool"))
+
+    def test_inline_session_grants_allowlist(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  allow_inline=["echo_tool"], default_mode="inline")
+        os.environ["HERMES_SESSION_KEY"] = self.SK
+        approval_module.register_gateway_notify(self.SK, lambda d: None)
+
+        holder, t = self._run_in_thread("echo_tool", {"x": 1})
+        approval_module.resolve_gateway_approval(self.SK, "session")
+        t.join(timeout=5)
+        assert holder["r"]["approved"] is True
+        assert approval_module.is_approved(self.SK, approval_module._tool_key("echo_tool"))
+
+    def test_inline_deny_blocks(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  allow_inline=["echo_tool"], default_mode="inline")
+        os.environ["HERMES_SESSION_KEY"] = self.SK
+        approval_module.register_gateway_notify(self.SK, lambda d: None)
+
+        holder, t = self._run_in_thread("echo_tool", {"x": 1})
+        approval_module.resolve_gateway_approval(self.SK, "deny")
+        t.join(timeout=5)
+        r = holder["r"]
+        assert r["approved"] is False
+        assert r["status"] == "blocked"
+        assert "do not retry" in r["message"].lower()
+
+    def test_inline_notify_payload_carries_tool_fields(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  allow_inline=["echo_tool"], default_mode="inline")
+        os.environ["HERMES_SESSION_KEY"] = self.SK
+        seen = {}
+        approval_module.register_gateway_notify(self.SK, lambda d: seen.update(d))
+
+        holder, t = self._run_in_thread("echo_tool", {"x": 1})
+        approval_module.resolve_gateway_approval(self.SK, "once")
+        t.join(timeout=5)
+        assert seen.get("kind") == "tool"
+        assert seen.get("tool_name") == "echo_tool"
+        assert "echo_tool" in seen.get("command", "")
+
+
+# ---------------------------------------------------------------------------
+# Replay token / TTL / idempotency
+# ---------------------------------------------------------------------------
+
+class TestReplay:
+    def test_replay_token_allows_once(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"])
+        tok = tool_gate.set_replay_token(
+            {"pending_id": "p1", "tool_name": "echo_tool", "token": "t"})
+        try:
+            assert approval_module.check_tool_approval("echo_tool", {})["approved"] is True
+            # Token is one-shot: a second call re-gates (deferred, no channel).
+            r2 = approval_module.check_tool_approval("echo_tool", {})
+            assert r2["approved"] is False
+        finally:
+            tool_gate.reset_replay_token(tok)
+
+    def test_replay_token_wrong_tool_ignored(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"])
+        tok = tool_gate.set_replay_token(
+            {"pending_id": "p1", "tool_name": "other", "token": "t"})
+        try:
+            r = approval_module.check_tool_approval("echo_tool", {})
+            assert r["approved"] is False  # token for a different tool → staged
+        finally:
+            tool_gate.reset_replay_token(tok)
+
+    def test_replay_executes_and_discards(self, hermes_home, monkeypatch):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"])
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+        pid = r["pending_id"]
+
+        calls = []
+
+        def _fake_hfc(name, args):
+            calls.append((name, args))
+            return '{"ok": true}'
+
+        monkeypatch.setattr("model_tools.handle_function_call", _fake_hfc)
+        out = tool_gate.replay_pending_action(pid)
+        assert out["ok"] is True
+        assert calls == [("echo_tool", {"msg": "hi"})]
+        # Pending discarded after success → cannot replay again.
+        assert wa.get_pending(tool_gate.SUBSYSTEM, pid) is None
+        out2 = tool_gate.replay_pending_action(pid)
+        assert out2["ok"] is False
+
+    def test_replay_refuses_expired(self, hermes_home, monkeypatch):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"])
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+        pid = r["pending_id"]
+        wa.update_pending(tool_gate.SUBSYSTEM, pid, {"expires_at": time.time() - 1})
+
+        called = []
+        monkeypatch.setattr("model_tools.handle_function_call",
+                            lambda n, a: called.append(1) or "x")
+        out = tool_gate.replay_pending_action(pid)
+        assert out["ok"] is False
+        assert "expired" in out["message"].lower()
+        assert not called
+
+    def test_replay_refuses_double_execute(self, hermes_home, monkeypatch):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"])
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+        pid = r["pending_id"]
+        # Simulate an in-flight execution (status flipped by another worker).
+        wa.update_pending(tool_gate.SUBSYSTEM, pid, {"status": "executing"})
+        monkeypatch.setattr("model_tools.handle_function_call", lambda n, a: "x")
+        out = tool_gate.replay_pending_action(pid)
+        assert out["ok"] is False
+        assert "executing" in out["message"].lower()
+
+    def test_replay_concurrent_race_executes_exactly_once(self, hermes_home, monkeypatch):
+        """Two threads racing replay_pending_action must not both execute.
+
+        The prior implementation read status then wrote "executing" as two
+        separate steps, so two concurrent callers could both observe
+        "pending" before either wrote — both then "won" and the tool ran
+        twice. write_approval.claim_pending closes that window with a
+        lock-guarded check-and-set.
+        """
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"])
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+        pid = r["pending_id"]
+
+        calls = []
+        call_lock = threading.Lock()
+        start_barrier = threading.Barrier(2)
+
+        def _fake_hfc(name, args):
+            with call_lock:
+                calls.append((name, args))
+            return '{"ok": true}'
+
+        monkeypatch.setattr("model_tools.handle_function_call", _fake_hfc)
+
+        results = []
+
+        def _run():
+            start_barrier.wait()
+            results.append(tool_gate.replay_pending_action(pid))
+
+        threads = [threading.Thread(target=_run) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(calls) == 1
+        oks = [r for r in results if r["ok"]]
+        not_oks = [r for r in results if not r["ok"]]
+        assert len(oks) == 1
+        assert len(not_oks) == 1
+        assert "already" in not_oks[0]["message"].lower() or "executing" in not_oks[0]["message"].lower()
+
+    def test_approve_action_spawns_exec_card(self, hermes_home):
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"])
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+        pid = r["pending_id"]
+
+        approval_card = r["card_id"]
+        out = tool_gate.approve_action(pid)
+        assert out["ok"] is True
+        exec_card = out["exec_card_id"]
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        task = kb.get_task(conn, exec_card)
+        assert task is not None
+        assert tool_gate.parse_replay_marker(task.body) == pid
+        # Assigned to a real profile so the dispatcher will spawn it.
+        assert task.assignee
+        # Born READY (no blocking parent) so the dispatcher claims it — a parent
+        # link would strand it in 'todo' until the review-only approval card is
+        # 'done' (which never happens).
+        assert task.status == "ready"
+        # The human approval card is archived once approved (off the active board).
+        approval = kb.get_task(conn, approval_card)
+        assert approval is not None and approval.status == "archived"
+        # Idempotent: approving again returns the same exec card (no dup).
+        rec = wa.get_pending(tool_gate.SUBSYSTEM, pid)
+        assert rec["status"] == "approved"
+        out2 = tool_gate.approve_action(pid)
+        assert out2["ok"] is False  # already approved
+
+
+# ---------------------------------------------------------------------------
+# Common dispatch choke point: model_tools.handle_function_call
+# ---------------------------------------------------------------------------
+# tool_executor.py (sequential) and agent_runtime_helpers.py (concurrent) are
+# not the only ways a tool call reaches execution — the execute_code sandbox
+# IPC handler and the MCP tool server both call
+# ``model_tools.handle_function_call`` directly, bypassing those two choke
+# points entirely. The gate must live inside handle_function_call itself so
+# every dispatch path is covered, with a ``skip_tool_approval_gate`` escape
+# hatch for callers (tool_executor.py, agent_runtime_helpers.py) that already
+# ran the gate at their own choke point — otherwise a replay token consumed
+# by the outer check would be gone by the time the inner check re-runs.
+
+class TestHandleFunctionCallChokePoint:
+    def test_direct_dispatch_is_gated(self, hermes_home, monkeypatch):
+        """A caller that skips invoke_tool/execute_tool_calls_sequential
+        entirely (like the sandbox IPC handler or the MCP server) and calls
+        handle_function_call directly must still be gated."""
+        import model_tools
+
+        monkeypatch.setattr(
+            "tools.approval.check_tool_approval",
+            lambda name, args: {"approved": False, "status": "blocked",
+                                "message": "BLOCKED: denied"},
+        )
+        result = model_tools.handle_function_call("definitely_not_a_real_tool", {})
+        payload = json.loads(result)
+        assert payload["status"] == "blocked"
+        assert "denied" in payload["error"]
+
+    def test_direct_dispatch_staged_short_circuits(self, hermes_home, monkeypatch):
+        import model_tools
+
+        monkeypatch.setattr(
+            "tools.approval.check_tool_approval",
+            lambda name, args: {"approved": False, "status": "staged",
+                                "message": "Queued for approval", "pending_id": "p1"},
+        )
+        result = model_tools.handle_function_call("definitely_not_a_real_tool", {})
+        payload = json.loads(result)
+        assert payload["status"] == "staged"
+        assert payload["message"] == "Queued for approval"
+
+    def test_skip_flag_bypasses_gate(self, hermes_home, monkeypatch):
+        """Callers that already gated (tool_executor.py, agent_runtime_helpers.py)
+        pass skip_tool_approval_gate=True so the inner check — and any replay
+        token it would try to consume — doesn't run a second time."""
+        import model_tools
+
+        gate = MagicMock(return_value={"approved": False, "status": "blocked",
+                                       "message": "should not be reached"})
+        monkeypatch.setattr("tools.approval.check_tool_approval", gate)
+        # Would raise/error past the gate for an unregistered tool, but the
+        # point here is only that the gate itself is never consulted.
+        model_tools.handle_function_call(
+            "definitely_not_a_real_tool", {}, skip_tool_approval_gate=True,
+        )
+        gate.assert_not_called()
+
+    def test_allowed_dispatch_is_not_short_circuited(self, hermes_home, monkeypatch):
+        import model_tools
+
+        monkeypatch.setattr(
+            "tools.approval.check_tool_approval",
+            lambda name, args: {"approved": True, "message": None},
+        )
+        # An allowed, unregistered tool should fail past the gate with the
+        # normal "unknown tool" style error, not a gate-shaped one.
+        result = model_tools.handle_function_call("definitely_not_a_real_tool", {})
+        payload = json.loads(result)
+        assert "status" not in payload or payload.get("status") not in {"blocked", "staged"}
+

--- a/tests/tools/test_tool_gate.py
+++ b/tests/tools/test_tool_gate.py
@@ -416,6 +416,97 @@ class TestReplay:
         assert len(not_oks) == 1
         assert "already" in not_oks[0]["message"].lower() or "executing" in not_oks[0]["message"].lower()
 
+    def test_maybe_replay_kanban_task_not_an_exec_card(self, hermes_home):
+        """A normal (non-exec-card) task must fall through to None so the
+        caller proceeds with the regular LLM worker turn."""
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        task_id = kb.create_task(
+            conn, title="Normal work", body="Please do the normal thing.",
+            assignee="default", created_by="default",
+        )
+        assert tool_gate.maybe_replay_kanban_task(task_id) is None
+
+    def test_maybe_replay_kanban_task_success_completes_task(self, hermes_home, monkeypatch):
+        """An exec card whose replay succeeds must call kanban_complete, not
+        hand the replay off to an LLM turn."""
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"])
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+        pid = r["pending_id"]
+        approve = tool_gate.approve_action(pid)
+        exec_card_id = approve["exec_card_id"]
+
+        calls = []
+        import model_tools
+        _real_hfc = model_tools.handle_function_call
+
+        def _fake_hfc(name, args=None, **kwargs):
+            calls.append((name, args))
+            if name == "echo_tool":
+                return '{"ok": true}'
+            # kanban_complete/kanban_block must go through for real so the
+            # task's board state is actually observable.
+            return _real_hfc(name, args or {}, **kwargs)
+
+        monkeypatch.setattr("model_tools.handle_function_call", _fake_hfc)
+        os.environ["HERMES_KANBAN_TASK"] = exec_card_id
+        try:
+            outcome = tool_gate.maybe_replay_kanban_task(exec_card_id)
+        finally:
+            os.environ.pop("HERMES_KANBAN_TASK", None)
+
+        assert outcome is not None
+        assert outcome["ok"] is True
+        called_names = [c[0] for c in calls]
+        assert "echo_tool" in called_names
+        assert "kanban_complete" in called_names
+        assert "kanban_block" not in called_names
+
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        task = kb.get_task(conn, exec_card_id)
+        assert task.status == "done"
+
+    def test_maybe_replay_kanban_task_failure_blocks_task(self, hermes_home, monkeypatch):
+        """A replay that fails must call kanban_block, not silently vanish."""
+        _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
+                  force_deferred=["echo_tool"])
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        r = approval_module.check_tool_approval("echo_tool", {"msg": "hi"})
+        pid = r["pending_id"]
+        approve = tool_gate.approve_action(pid)
+        exec_card_id = approve["exec_card_id"]
+
+        calls = []
+        import model_tools
+        _real_hfc = model_tools.handle_function_call
+
+        def _fake_hfc(name, args=None, **kwargs):
+            calls.append((name, args))
+            if name == "echo_tool":
+                raise RuntimeError("boom")
+            return _real_hfc(name, args or {}, **kwargs)
+
+        monkeypatch.setattr("model_tools.handle_function_call", _fake_hfc)
+        os.environ["HERMES_KANBAN_TASK"] = exec_card_id
+        try:
+            outcome = tool_gate.maybe_replay_kanban_task(exec_card_id)
+        finally:
+            os.environ.pop("HERMES_KANBAN_TASK", None)
+
+        assert outcome is not None
+        assert outcome["ok"] is False
+        called_names = [c[0] for c in calls]
+        assert "kanban_block" in called_names
+        assert "kanban_complete" not in called_names
+
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        task = kb.get_task(conn, exec_card_id)
+        assert task.status == "blocked"
+
     def test_approve_action_spawns_exec_card(self, hermes_home):
         _set_gate(hermes_home, enabled=True, require_approval=["echo_tool"],
                   force_deferred=["echo_tool"])

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3634,6 +3634,152 @@ def check_all_command_guards(command: str, env_type: str,
             "user_approved": True, "description": combined_desc}
 
 
+# =========================================================================
+# Generic tool-level approval gate (config-driven; default OFF)
+# =========================================================================
+# Sibling to check_all_command_guards: gates *designated tool calls* (by name
+# or glob, from approvals.tool_gate) behind human approval, resolving either
+# inline (block the thread, reuse _await_gateway_decision) or deferred (stage
+# + Kanban card, never block). The deferred mechanics, config reader, replay
+# token, and execution-on-approval live in tools/tool_gate.py.
+
+
+def _tool_key(tool_name: str) -> str:
+    """Allowlist namespace for tool approvals, distinct from command keys."""
+    return f"tool:{tool_name}"
+
+
+def _inline_channel(session_key: str):
+    """Return the live gateway notify callback for ``session_key``, or None."""
+    with _lock:
+        return _gateway_notify_cbs.get(session_key)
+
+
+def _select_tool_mode(tool_name: str, gate_cfg: dict, session_key: str) -> str:
+    """Resolve the approval mode for one call: 'inline' or 'deferred' (§2)."""
+    channel = _inline_channel(session_key) is not None
+
+    try:
+        from tools.write_approval import is_background
+        background = is_background()
+    except Exception:
+        background = False
+
+    # 1. Unattended (cron / background / no live channel) → never block.
+    if env_var_enabled("HERMES_CRON_SESSION") or background or not channel:
+        return "deferred"
+
+    force_deferred = gate_cfg.get("force_deferred") or []
+    allow_inline = gate_cfg.get("allow_inline") or []
+
+    # 2. Explicitly force-deferred tools never block a thread.
+    if tool_name in force_deferred:
+        return "deferred"
+
+    # 3. Inline-eligible tools with a live channel may block.
+    if tool_name in allow_inline:
+        return "inline"
+
+    # 4. Fall back to the configured default (channel is guaranteed present).
+    default_mode = str(gate_cfg.get("default_mode", "deferred")).strip().lower()
+    return "inline" if default_mode == "inline" else "deferred"
+
+
+def check_tool_approval(tool_name: str, args: dict | None = None) -> dict:
+    """Decide whether a designated tool call may execute.
+
+    Returns one of:
+      * ``{"approved": True,  "message": None}``                         — allow
+      * ``{"approved": False, "status": "blocked", "message": str}``     — denied/timeout
+      * ``{"approved": False, "status": "staged",  "message": str,
+           "pending_id": str, "card_id": str|None}``                     — deferred
+
+    Default OFF: with no ``approvals.tool_gate`` config every call is allowed,
+    so behaviour is unchanged unless an operator opts in.
+    """
+    from tools import tool_gate
+
+    gate_cfg = tool_gate.get_tool_gate_config()
+
+    # 1. Gate disabled → allow.
+    if not tool_gate.gate_enabled(gate_cfg):
+        return {"approved": True, "message": None}
+
+    # 2. Tool not designated → allow.
+    if not tool_gate.requires_approval(tool_name, gate_cfg):
+        return {"approved": True, "message": None}
+
+    # 3. YOLO / approvals.mode == off → allow (mirror command-guard bypass).
+    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or _get_approval_mode() == "off":
+        return {"approved": True, "message": None}
+
+    # 4. One-shot replay token for THIS tool (per-pending-id, not a blanket
+    #    allowlist) → allow and consume it.
+    if tool_gate.consume_replay_token(tool_name) is not None:
+        return {"approved": True, "message": None}
+
+    session_key = get_current_session_key()
+
+    # 5. Prior inline session/permanent approval for this tool → allow.
+    if is_approved(session_key, _tool_key(tool_name)):
+        return {"approved": True, "message": None}
+
+    # 6. Select resolution mode.
+    mode = _select_tool_mode(tool_name, gate_cfg, session_key)
+    summary = tool_gate.summarize_tool_call(tool_name, args)
+
+    if mode == "inline":
+        return _tool_approval_inline(tool_name, args, summary, session_key, gate_cfg)
+    return tool_gate.stage_deferred(tool_name, args, summary=summary, config=gate_cfg)
+
+
+def _tool_approval_inline(tool_name: str, args: dict | None, summary: str,
+                          session_key: str, gate_cfg: dict) -> dict:
+    """Inline (blocking) tool approval — reuse the dangerous-command engine."""
+    from tools import tool_gate
+
+    notify_cb = _inline_channel(session_key)
+    if notify_cb is None:
+        # No live channel — fall back to deferred rather than fail closed when
+        # a board exists to review it.
+        return tool_gate.stage_deferred(tool_name, args, summary=summary, config=gate_cfg)
+
+    key = _tool_key(tool_name)
+    approval_data = {
+        "command": summary,
+        "description": f"tool: {tool_name}",
+        "pattern_key": key,
+        "pattern_keys": [key],
+        "kind": "tool",
+        "tool_name": tool_name,
+    }
+    decision = _await_gateway_decision(session_key, notify_cb, approval_data, surface="tool")
+    if decision.get("notify_failed"):
+        # Could not reach the user — stage instead of silently dropping.
+        return tool_gate.stage_deferred(tool_name, args, summary=summary, config=gate_cfg)
+
+    choice = decision.get("choice")
+    if not decision.get("resolved") or choice in (None, "deny"):
+        return {
+            "approved": False,
+            "status": "blocked",
+            "message": (
+                f"BLOCKED: the user did not approve running '{tool_name}'. "
+                f"Do NOT retry, do NOT rephrase, and do NOT attempt the same "
+                f"outcome via another tool. Wait for the user."
+            ),
+        }
+
+    if choice == "session":
+        approve_session(session_key, key)
+    elif choice == "always":
+        approve_session(session_key, key)
+        approve_permanent(key)
+        save_permanent_allowlist(_permanent_approved)
+    # choice == "once": no persistence.
+    return {"approved": True, "message": None}
+
+
 def check_execute_code_guard(code: str, env_type: str,
                              has_host_access: bool = False) -> dict:
     """Approve an execute_code script before its child process is spawned.

--- a/tools/tool_gate.py
+++ b/tools/tool_gate.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""Generic, config-driven, human-in-the-loop approval gate for tool calls.
+
+This module is the **deferred (staged)** half of the tool-approval gate plus
+its shared config/replay plumbing. The **inline (blocking)** half — and the
+top-level :func:`check_tool_approval` decision ladder — live in
+``tools/approval.py`` next to the dangerous-command guard engine they reuse.
+
+Design (see docs/hermes-tool-approval-gate.fork.md):
+
+* A designated tool (listed in ``approvals.tool_gate.require_approval``) must
+  get human approval before it executes. **Default OFF** — with no
+  ``tool_gate`` config the behaviour is unchanged everywhere.
+* **Deferred mode** (cron / background / no live approval channel, or config
+  ``force_deferred``): do not block. Serialize the call to the file-backed
+  pending store (``pending/actions/<id>.json``, reusing
+  ``tools.write_approval``), open a Kanban approval card for a human via the
+  in-process ``hermes_cli.kanban_db`` engine, and return a non-error
+  ``staged`` result so the agent continues.
+* **Execution-on-approval (Path A — Hermes-native):** approving the card via
+  :func:`approve_action` mints an *agent-assigned* execution card. The kanban
+  dispatcher wakes that agent; its worker calls :func:`replay_pending_action`,
+  which re-invokes the tool with a **one-shot per-pending-id token** so the
+  gate (step 4 of the ladder) lets it through exactly once. TTL/staleness and
+  a ``status`` state machine (``pending`` → ``executing`` → ``done``) guard
+  against double execution.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import fnmatch
+import json
+import logging
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Pending-store subsystem for staged tool calls.
+SUBSYSTEM = "actions"
+
+# Body marker that flags a Kanban card as a deferred tool-approval artifact so
+# a UI / the worker-side replay hook can recognise it without parsing prose.
+APPROVAL_MARKER = "hermes-action-approval"
+REPLAY_MARKER = "hermes-action-replay"
+
+_DEFAULT_TTL_HOURS = 72
+_SUMMARY_CAP = 600
+
+# Sentinel assignee for approval cards when no human ``board_assignee`` is
+# configured. It is deliberately NOT a real Hermes profile, so the kanban
+# dispatcher buckets the card ``skipped_nonspawnable`` and never auto-runs it —
+# even when ``kanban.default_assignee`` is set (which would otherwise claim and
+# spawn an *unassigned* ready card). Approval cards are review-only by design.
+REVIEW_ASSIGNEE = "human-review"
+
+
+# ---------------------------------------------------------------------------
+# One-shot replay token (consumed by the gate ladder in approval.py)
+# ---------------------------------------------------------------------------
+# When an approved action is replayed, the worker sets this context value to
+# ``{"pending_id": ..., "tool_name": ..., "token": ...}`` before invoking the
+# tool. ``check_tool_approval`` consumes it on first use for the matching tool
+# so the replay is allowed through once instead of re-staging. It is NEVER a
+# blanket allowlist entry — it authorises exactly one pending id.
+_replay_token: contextvars.ContextVar[Optional[Dict[str, Any]]] = contextvars.ContextVar(
+    "hermes_tool_replay_token", default=None
+)
+
+
+def set_replay_token(info: Optional[Dict[str, Any]]) -> contextvars.Token:
+    """Bind a one-shot replay token to the current context. Returns the token
+    handle for :func:`reset_replay_token`."""
+    return _replay_token.set(info)
+
+
+def reset_replay_token(token: contextvars.Token) -> None:
+    """Restore the prior replay-token context."""
+    try:
+        _replay_token.reset(token)
+    except Exception:
+        pass
+
+
+def consume_replay_token(tool_name: str) -> Optional[str]:
+    """Return and clear the replay token's pending id iff it authorises
+    ``tool_name``; otherwise return ``None`` and leave any token in place.
+
+    One-shot: a matching token is cleared so a second call to the same tool in
+    the same run re-stages instead of silently replaying twice.
+    """
+    info = _replay_token.get()
+    if not info:
+        return None
+    if info.get("tool_name") != tool_name:
+        return None
+    _replay_token.set(None)
+    return info.get("pending_id")
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def get_tool_gate_config() -> dict:
+    """Return the ``approvals.tool_gate`` config block (``{}`` when unset).
+
+    Reads via ``load_config`` (mtime-cached) + ``cfg_get`` so a config edit
+    takes effect mid-session, matching ``_get_approval_config``.
+    """
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        cfg = load_config()
+        block = cfg_get(cfg, "approvals", "tool_gate", default={})
+        return block if isinstance(block, dict) else {}
+    except Exception as e:  # pragma: no cover - config load failure
+        logger.debug("tool_gate config load failed: %s", e)
+        return {}
+
+
+def gate_enabled(config: Optional[dict] = None) -> bool:
+    cfg = config if config is not None else get_tool_gate_config()
+    return _truthy(cfg.get("enabled", False))
+
+
+def requires_approval(tool_name: str, config: Optional[dict] = None) -> bool:
+    """True when ``tool_name`` matches an entry in ``require_approval``.
+
+    Match by exact name first, then ``fnmatch.fnmatchcase`` glob (so
+    ``send_*`` works). Entries are plain strings.
+    """
+    cfg = config if config is not None else get_tool_gate_config()
+    patterns = cfg.get("require_approval") or []
+    if not isinstance(patterns, (list, tuple)):
+        return False
+    for pat in patterns:
+        if not isinstance(pat, str):
+            continue
+        if pat == tool_name or fnmatch.fnmatchcase(tool_name, pat):
+            return True
+    return False
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"on", "true", "yes", "1", "enabled"}
+    return False
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Display + replay serialization
+# ---------------------------------------------------------------------------
+
+def summarize_tool_call(tool_name: str, args: Optional[dict]) -> str:
+    """Build a short, **display-only**, length-capped summary of a tool call.
+
+    Argument values may be agent/LLM-generated from untrusted input; this
+    string is shown to a human (chat prompt, Kanban card) and is NEVER
+    interpreted as a command. Capped at ~600 chars.
+    """
+    name = tool_name or "tool"
+    if not isinstance(args, dict) or not args:
+        return name
+    parts = []
+    for key, val in args.items():
+        try:
+            sval = val if isinstance(val, str) else json.dumps(val, ensure_ascii=False, default=str)
+        except Exception:
+            sval = str(val)
+        sval = " ".join(sval.split())  # collapse whitespace/newlines
+        if len(sval) > 120:
+            sval = sval[:117] + "…"
+        parts.append(f"{key}={sval}")
+    summary = f"{name}(" + ", ".join(parts) + ")"
+    if len(summary) > _SUMMARY_CAP:
+        summary = summary[: _SUMMARY_CAP - 1] + "…"
+    return summary
+
+
+def serialize_tool_call(tool_name: str, args: Optional[dict]) -> dict:
+    """Return the full replayable args payload for a deferred call.
+
+    JSON-round-trips ``args`` so only serializable kwargs survive (the staged
+    record must persist to disk and be replayed in a fresh process). Values
+    that don't serialize are coerced via ``default=str``.
+    """
+    if not isinstance(args, dict):
+        return {}
+    try:
+        return json.loads(json.dumps(args, ensure_ascii=False, default=str))
+    except Exception:
+        # Fall back to a shallow string coercion so we never lose the call.
+        return {k: (v if isinstance(v, (str, int, float, bool, type(None))) else str(v))
+                for k, v in args.items()}
+
+
+# ---------------------------------------------------------------------------
+# Context resolution helpers
+# ---------------------------------------------------------------------------
+
+def _current_profile() -> str:
+    """Best-effort name of the profile this process is running as."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _session_env(name: str, default: str = "") -> str:
+    try:
+        from gateway.session_context import get_session_env
+        return get_session_env(name, default) or default
+    except Exception:
+        import os
+        return os.getenv(name, default) or default
+
+
+def _resolve_tenant(deferred: dict) -> str:
+    if _truthy(deferred.get("tenant_from_session", True)):
+        return _session_env("HERMES_TENANT", "")
+    return str(deferred.get("fixed_tenant") or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Deferred staging + Kanban card
+# ---------------------------------------------------------------------------
+
+def _post_mattermost_approval(pending_id: str, summary: str) -> None:
+    """Post approve/deny buttons to the Mattermost approvals channel for a
+    staged action (best-effort). No-op unless ``MATTERMOST_URL`` + ``_TOKEN`` +
+    ``MATTERMOST_APPROVALS_CHANNEL_ID`` + ``MATTERMOST_APPROVAL_CALLBACK_URL``
+    are all set.
+
+    Runs in the staging process — which for the cron sweep is an *unattended
+    worker* with no live Mattermost adapter — so it talks to the Mattermost REST
+    API directly. The per-action shared secret is persisted to the pending
+    record (``mm_secret``) so the gateway's always-on callback site can validate
+    the button click cross-process. Never raises: a Mattermost hiccup must not
+    fail staging (the Kanban card + ``hermes action`` CLI still work).
+    """
+    import os
+    # Ensure the PROFILE .env is loaded into os.environ. Not every staging
+    # context has it: the TUI worker (tui_gateway.slash_worker) and some
+    # entrypoints load the *default* ~/.hermes/.env at import time and only
+    # switch to the profile's config.yaml on demand — so the gate fires
+    # (config-driven) but os.environ lacks the profile's MATTERMOST_* secrets.
+    # HERMES_HOME points at the profile here (the pending store is profile-
+    # scoped), so this idempotently fills in the profile .env (override=True).
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv()
+    except Exception:
+        pass
+    url = os.getenv("MATTERMOST_URL", "").rstrip("/")
+    token = os.getenv("MATTERMOST_TOKEN", "")
+    channel = os.getenv("MATTERMOST_APPROVALS_CHANNEL_ID", "")
+    callback = os.getenv("MATTERMOST_APPROVAL_CALLBACK_URL", "")
+    logger.info("MMAPPROVAL[%s]: entry url=%s token=%s channel=%s callback=%s",
+                pending_id, bool(url), bool(token), bool(channel), bool(callback))
+    if not (url and token and channel and callback):
+        logger.info("MMAPPROVAL[%s]: skipped (missing config)", pending_id)
+        return
+    try:
+        import json as _json
+        import urllib.request
+        from tools import write_approval as wa
+        from plugins.platforms.mattermost import approval as mm_approval
+
+        secret = uuid.uuid4().hex
+        post_ref = uuid.uuid4().hex
+        wa.update_pending(SUBSYSTEM, pending_id,
+                          {"mm_secret": secret, "mm_post_ref": post_ref})
+        text = (f"🛂 **Outbound action awaiting approval**\n"
+                f"```\n{summary[:1500]}\n```\n(pending `{pending_id}`)")
+        attachment = mm_approval.build_approval_attachment(
+            text=text, callback_url=callback, kind="card",
+            token=secret, post_ref=post_ref, pending_id=pending_id,
+            include_scopes=False)
+        payload = _json.dumps({
+            "channel_id": channel,
+            "message": "",
+            "props": {"attachments": [attachment]},
+        }).encode()
+        req = urllib.request.Request(
+            f"{url}/api/v4/posts", data=payload, method="POST",
+            headers={"Authorization": f"Bearer {token}",
+                     "Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = _json.loads(resp.read().decode())
+        wa.update_pending(SUBSYSTEM, pending_id,
+                          {"mm_post_id": data.get("id"), "mm_channel_id": channel})
+        logger.info("MMAPPROVAL[%s]: posted ok, post_id=%s", pending_id, data.get("id"))
+    except Exception as e:  # pragma: no cover - network/runtime best-effort
+        logger.warning("MMAPPROVAL[%s]: post FAILED: %s", pending_id, e)
+
+
+def stage_deferred(tool_name: str, args: Optional[dict], *,
+                   summary: str, config: dict) -> Dict[str, Any]:
+    """Stage a tool call for out-of-band approval and open a Kanban card.
+
+    Returns ``{"approved": False, "status": "staged", "message": str,
+    "pending_id": str, "card_id": str|None}``. Never blocks; never raises for
+    expected failures (a staging miss returns a ``staged`` result anyway so
+    the agent does not loop — the action is simply not executed).
+    """
+    from tools import write_approval as wa
+
+    deferred = config.get("deferred") or {}
+    if not isinstance(deferred, dict):
+        deferred = {}
+    ttl_hours = _int(deferred.get("pending_ttl_hours"), _DEFAULT_TTL_HOURS)
+    now = time.time()
+    expires_at = now + max(ttl_hours, 0) * 3600
+    token = uuid.uuid4().hex
+    tenant = _resolve_tenant(deferred)
+    profile = _current_profile()
+
+    # Resolve the session key without importing approval at module load
+    # (approval.py imports this module lazily; keep the dependency one-way).
+    try:
+        from tools.approval import get_current_session_key
+        session_key = get_current_session_key(default="")
+    except Exception:
+        session_key = ""
+
+    payload = {
+        "tool_name": tool_name,
+        "args": serialize_tool_call(tool_name, args),
+        "tenant": tenant,
+        "session_key": session_key,
+        "expires_at": expires_at,
+    }
+    record = wa.stage_write(SUBSYSTEM, payload, summary=summary,
+                            origin=wa.current_origin())
+    pending_id = record.get("id", "")
+
+    # Annotate top-level orchestration fields (mutable across the lifecycle).
+    wa.update_pending(SUBSYSTEM, pending_id, {
+        "token": token,
+        "expires_at": expires_at,
+        "tenant": tenant,
+        "profile": profile,
+        "session_key": session_key,
+        "status": "pending",
+        "tool_name": tool_name,
+    })
+
+    card_id = _open_approval_card(
+        pending_id=pending_id,
+        tool_name=tool_name,
+        summary=summary,
+        expires_at=expires_at,
+        # Empty board_assignee → a non-profile sentinel (NOT None) so a
+        # configured kanban.default_assignee can't auto-spawn this card.
+        assignee=(str(deferred.get("board_assignee") or "").strip() or REVIEW_ASSIGNEE),
+        tenant=tenant or None,
+        created_by=profile or None,
+    )
+    if card_id:
+        wa.update_pending(SUBSYSTEM, pending_id, {"card_id": card_id})
+
+    # Surface the action in the Mattermost approvals channel with approve/deny
+    # buttons (best-effort; no-op unless configured). Runs here in the staging
+    # process — possibly an unattended worker — so it posts via REST directly.
+    _post_mattermost_approval(pending_id, summary)
+
+    card_note = f" as card {card_id}" if card_id else ""
+    return {
+        "approved": False,
+        "status": "staged",
+        "message": (
+            f"Queued for human approval{card_note}; continuing without running "
+            f"'{tool_name}'. This is expected — do NOT retry or re-issue the "
+            f"call. The action will run automatically once approved "
+            f"(pending id {pending_id})."
+        ),
+        "pending_id": pending_id,
+        "card_id": card_id,
+    }
+
+
+def _approval_card_body(pending_id: str, tool_name: str, summary: str,
+                        expires_at: float) -> str:
+    expiry = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(expires_at))
+    return (
+        f"{APPROVAL_MARKER}: {pending_id}\n"
+        f"tool: {tool_name}\n"
+        f"expires: {expiry}\n\n"
+        f"A tool call is awaiting human approval before it runs:\n\n"
+        f"    {summary}\n\n"
+        f"Approve it with `hermes action approve {pending_id}` (or the "
+        f"approve button if posted to chat). Approval spawns a one-shot "
+        f"execution worker; rejecting / letting it expire drops the action."
+    )
+
+
+def _open_approval_card(*, pending_id: str, tool_name: str, summary: str,
+                        expires_at: float, assignee: Optional[str],
+                        tenant: Optional[str], created_by: Optional[str]) -> Optional[str]:
+    """Create the human-facing approval card via the in-process kanban engine.
+
+    Assignee is a free-text human or the :data:`REVIEW_ASSIGNEE` sentinel —
+    either way it is not a Hermes profile, so the dispatcher buckets it
+    ``skipped_nonspawnable`` (review-only) and never auto-spawns it.
+    ``idempotency_key`` guards against a double-stage racing two cards for the
+    same pending id.
+    """
+    try:
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        title = f"Approve: {summary}"
+        if len(title) > 200:
+            title = title[:199] + "…"
+        return kb.create_task(
+            conn,
+            title=title,
+            body=_approval_card_body(pending_id, tool_name, summary, expires_at),
+            assignee=assignee,
+            created_by=created_by,
+            tenant=tenant,
+            idempotency_key=f"approval:{pending_id}",
+        )
+    except Exception as e:
+        logger.warning("Failed to open approval card for %s: %s", pending_id, e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Execution-on-approval (Path A): mint an agent-assigned execution card
+# ---------------------------------------------------------------------------
+
+def approve_action(pending_id: str) -> Dict[str, Any]:
+    """Approve a staged action: spawn a one-shot agent execution card.
+
+    The execution card is assigned to the **profile that staged the action**
+    (a real Hermes profile), so the kanban dispatcher wakes that agent; its
+    worker runs :func:`replay_pending_action`. ``parents`` links it under the
+    approval card; ``idempotency_key=exec:<id>`` is the double-spawn guard.
+
+    Returns ``{"ok": bool, "message": str, "exec_card_id"?: str}``. Refuses
+    expired / already-resolved actions.
+    """
+    from tools import write_approval as wa
+
+    rec = wa.get_pending(SUBSYSTEM, pending_id)
+    if rec is None:
+        return {"ok": False, "message": f"No pending action {pending_id}."}
+
+    status = rec.get("status", "pending")
+    if status in {"approved", "executing", "done"}:
+        return {"ok": False,
+                "message": f"Action {pending_id} already {status}; not re-running."}
+
+    expires_at = rec.get("expires_at")
+    if isinstance(expires_at, (int, float)) and time.time() > expires_at:
+        wa.update_pending(SUBSYSTEM, pending_id, {"status": "expired"})
+        return {"ok": False,
+                "message": f"Action {pending_id} expired — re-stage to run it."}
+
+    # Atomic claim: two concurrent approve clicks (double-tap, or a retry
+    # racing the original) must not both spawn an execution card. The
+    # kanban idempotency_key below is a second, independent guard against
+    # double-spawn, but this claim is what makes the *decision* to proceed
+    # exclusive rather than racy.
+    claimed = wa.claim_pending(
+        SUBSYSTEM, pending_id,
+        expected_status=status,
+        claimed_status="approving",
+    )
+    if claimed is None:
+        return {"ok": False, "message": f"Action {pending_id} is already being approved."}
+    rec = claimed
+
+    payload = rec.get("payload") or {}
+    tool_name = rec.get("tool_name") or payload.get("tool_name") or "tool"
+    profile = rec.get("profile") or _current_profile()
+    tenant = rec.get("tenant") or payload.get("tenant") or None
+    summary = rec.get("summary") or summarize_tool_call(tool_name, payload.get("args"))
+    card_id = rec.get("card_id")
+
+    try:
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        exec_body = (
+            f"{REPLAY_MARKER}: {pending_id}\n"
+            f"tool: {tool_name}\n"
+            f"approval_card: {card_id or '-'}\n\n"
+            f"Approved action — replay the staged tool call:\n\n    {summary}\n"
+        )
+        # NOTE: do NOT link the exec card under the approval card via ``parents``.
+        # A parent dependency keeps a child in ``todo`` until every parent is
+        # ``done`` (see kb.create_task), but the approval card is human-review-only
+        # and is archived (below), never ``done`` — so a parent link would strand
+        # the exec card in ``todo`` and the dispatcher would never claim it.
+        # Approval *already happened* (it's what created this card), so execution
+        # must not be re-gated by the approval card's lifecycle. The link is kept
+        # for traceability via the ``approval_card:`` body line + idempotency_key.
+        exec_card_id = kb.create_task(
+            conn,
+            title=f"Run approved: {summary}"[:200],
+            body=exec_body,
+            assignee=profile,
+            created_by=profile,
+            tenant=tenant,
+            idempotency_key=f"exec:{pending_id}",
+        )
+        # Archive the human approval card: it has served its purpose, so it
+        # leaves the active board (mirrors reject, which also archives).
+        if card_id:
+            try:
+                kb.archive_task(conn, card_id)
+            except Exception as arch_err:
+                logger.warning("approve_action: could not archive approval card %s: %s",
+                               card_id, arch_err)
+    except Exception as e:
+        logger.error("Failed to create execution card for %s: %s", pending_id, e)
+        # Release the claim so a retry isn't permanently blocked by a
+        # record stuck in "approving" from this failed attempt.
+        wa.update_pending(SUBSYSTEM, pending_id, {"status": status})
+        return {"ok": False, "message": f"Could not spawn execution card: {e}"}
+
+    wa.update_pending(SUBSYSTEM, pending_id, {
+        "status": "approved",
+        "exec_card_id": exec_card_id,
+    })
+    return {
+        "ok": True,
+        "message": f"Approved {pending_id}; execution queued as card {exec_card_id}.",
+        "exec_card_id": exec_card_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Worker-side deterministic replay
+# ---------------------------------------------------------------------------
+
+def _ensure_tool_registered(tool_name: str) -> None:
+    """Best-effort: make sure ``tool_name`` is in the tool registry.
+
+    Built-in tools self-register at import; MCP tools only appear after
+    ``discover_mcp_tools()`` connects to their servers. When a gated tool is
+    not yet registered (the worker's background MCP discovery hasn't completed
+    at replay time), run discovery synchronously once. Idempotent and never
+    raises — a still-missing tool just produces the normal "unknown tool"
+    error from the dispatcher.
+    """
+    try:
+        from tools.registry import registry
+        if registry.get_entry(tool_name) is not None:
+            return
+    except Exception:
+        return
+    try:
+        from tools.mcp_tool import discover_mcp_tools
+        discover_mcp_tools()
+    except Exception as e:
+        logger.debug("MCP discovery during replay failed: %s", e)
+
+
+def parse_replay_marker(body: str) -> Optional[str]:
+    """Return the pending id from an execution card body, or ``None``."""
+    if not body:
+        return None
+    for line in body.splitlines():
+        line = line.strip()
+        if line.lower().startswith(REPLAY_MARKER + ":"):
+            return line.split(":", 1)[1].strip() or None
+    return None
+
+
+def replay_pending_action(pending_id: str) -> Dict[str, Any]:
+    """Execute an approved, staged tool call exactly once, deterministically.
+
+    Invoked by the kanban worker (no LLM turn). Enforces TTL/staleness and an
+    atomic ``pending`` → ``executing`` → ``done`` transition so a button click
+    racing the dispatcher cannot double-execute. Sets a one-shot replay token
+    so the re-invoked tool passes the gate instead of re-staging, then routes
+    through the normal tool dispatcher (``handle_function_call``).
+
+    Returns ``{"ok": bool, "message": str, "result"?: str}``.
+    """
+    from tools import write_approval as wa
+
+    rec = wa.get_pending(SUBSYSTEM, pending_id)
+    if rec is None:
+        return {"ok": False, "message": f"No pending action {pending_id} (already executed?)."}
+
+    status = rec.get("status", "pending")
+    if status == "done":
+        return {"ok": True, "message": f"Action {pending_id} already done; nothing to do."}
+    if status == "executing":
+        return {"ok": False, "message": f"Action {pending_id} is already executing; refusing to double-run."}
+
+    expires_at = rec.get("expires_at")
+    if isinstance(expires_at, (int, float)) and time.time() > expires_at:
+        wa.update_pending(SUBSYSTEM, pending_id, {"status": "expired"})
+        return {"ok": False, "message": f"Action {pending_id} expired — re-stage to run it."}
+
+    # Atomic claim: a lock-guarded check-and-set on status, not a plain
+    # read-then-write. A button click racing the dispatcher (or two dispatcher
+    # ticks racing each other) both landing here concurrently must result in
+    # exactly one winner — see write_approval.claim_pending for why the
+    # earlier read-then-write pattern allowed both to "win" and double-run
+    # the tool call.
+    claimed = wa.claim_pending(
+        SUBSYSTEM, pending_id,
+        expected_status=status,
+        claimed_status="executing",
+    )
+    if claimed is None:
+        return {"ok": False, "message": f"Action {pending_id} is already claimed or no longer pending; refusing to double-run."}
+    rec = claimed
+
+    payload = rec.get("payload") or {}
+    tool_name = rec.get("tool_name") or payload.get("tool_name")
+    args = payload.get("args") or {}
+    token = rec.get("token") or ""
+
+    if not tool_name:
+        wa.update_pending(SUBSYSTEM, pending_id, {"status": "error"})
+        return {"ok": False, "message": f"Pending action {pending_id} has no tool_name."}
+
+    # Ensure the tool is actually registered before dispatching. The kanban
+    # worker (``hermes chat -q "work kanban task …"``) discovers MCP tools in a
+    # background thread whose bounded join happens at the agent's first tool
+    # snapshot — but this deterministic replay short-circuits *before* that
+    # point, so an MCP-backed gated tool may not be in the registry yet. When
+    # it's missing, run MCP discovery synchronously (idempotent) once so the
+    # replay doesn't spuriously fail closed on a connection race.
+    _ensure_tool_registered(tool_name)
+
+    tok = set_replay_token({"pending_id": pending_id, "tool_name": tool_name, "token": token})
+    try:
+        from model_tools import handle_function_call
+        result = handle_function_call(tool_name, args)
+    except Exception as e:
+        logger.error("Replay of %s (%s) failed: %s", pending_id, tool_name, e, exc_info=True)
+        wa.update_pending(SUBSYSTEM, pending_id, {"status": "error", "error": str(e)})
+        return {"ok": False, "message": f"Execution of '{tool_name}' failed: {e}"}
+    finally:
+        reset_replay_token(tok)
+
+    # Success: mark done then discard the pending record so it cannot replay.
+    wa.update_pending(SUBSYSTEM, pending_id, {"status": "done"})
+    wa.discard_pending(SUBSYSTEM, pending_id)
+    return {
+        "ok": True,
+        "message": f"Executed '{tool_name}' for approved action {pending_id}.",
+        "result": result if isinstance(result, str) else str(result),
+    }

--- a/tools/tool_gate.py
+++ b/tools/tool_gate.py
@@ -660,3 +660,67 @@ def replay_pending_action(pending_id: str) -> Dict[str, Any]:
         "message": f"Executed '{tool_name}' for approved action {pending_id}.",
         "result": result if isinstance(result, str) else str(result),
     }
+
+
+def maybe_replay_kanban_task(task_id: str) -> Optional[Dict[str, Any]]:
+    """Entry point for a kanban worker: replay iff ``task_id`` is an exec card.
+
+    The dispatcher spawns a plain ``hermes chat -q "work kanban task <id>"``
+    subprocess for every task, exec cards included — there is no separate
+    code path today that recognises an exec card and runs
+    :func:`replay_pending_action` deterministically instead of a full LLM
+    turn. Without this, an approved action's exec card would just prompt a
+    model to "replay the staged tool call" in prose, which is neither
+    deterministic nor guaranteed to actually call the tool.
+
+    Callers should invoke this *before* starting the agent loop, using it as
+    a short-circuit: ``None`` means "not an exec card, proceed normally";
+    otherwise the worker should report the returned message and exit,
+    skipping the LLM entirely.
+
+    Terminates the kanban task itself (mirroring what a normal worker turn
+    does by calling the ``kanban_complete`` / ``kanban_block`` tools) so the
+    dispatcher sees a clean completion rather than a protocol violation from
+    a worker that exited without a terminal board tool.
+
+    Returns ``None`` when ``task_id`` is not an exec card (or the task can't
+    be read), else ``{"ok": bool, "message": str}``.
+    """
+    try:
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        try:
+            task = kb.get_task(conn, task_id)
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.debug("maybe_replay_kanban_task: could not read task %s: %s", task_id, e)
+        return None
+
+    body = getattr(task, "body", "") if task is not None else ""
+    pending_id = parse_replay_marker(body)
+    if not pending_id:
+        return None
+
+    outcome = replay_pending_action(pending_id)
+
+    from model_tools import handle_function_call
+    try:
+        if outcome.get("ok"):
+            handle_function_call(
+                "kanban_complete",
+                {"summary": outcome.get("message") or "Replayed approved action."},
+            )
+        else:
+            handle_function_call(
+                "kanban_block",
+                {"reason": outcome.get("message") or "Replay failed."},
+            )
+    except Exception as e:
+        # The tool call above is best-effort bookkeeping — the replay itself
+        # already ran and its own status/message is authoritative. A failure
+        # here just means the dispatcher sees this task time out instead of
+        # a clean terminal state; log it but don't mask the replay outcome.
+        logger.error("maybe_replay_kanban_task: failed to terminate task %s: %s", task_id, e)
+
+    return outcome

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -57,7 +57,15 @@ logger = logging.getLogger(__name__)
 # Subsystem identifiers
 MEMORY = "memory"
 SKILLS = "skills"
+# ``actions`` is the generic tool-call approval gate's pending store (see
+# tools/tool_gate.py). It reuses the same on-disk pending format and CRUD
+# helpers below, but is NOT governed by the per-subsystem ``write_approval``
+# boolean — its gating lives under ``approvals.tool_gate`` config — so it is
+# intentionally absent from the ``write_approval_enabled`` allowlist while
+# still being a recognised pending subsystem for list/count/discard.
+ACTIONS = "actions"
 _SUBSYSTEMS = (MEMORY, SKILLS)
+_PENDING_SUBSYSTEMS = (MEMORY, SKILLS, ACTIONS)
 
 # Config key (per subsystem). A single boolean: the approval gate is OFF by
 # default (writes flow freely, the pre-gate behaviour), and ON means stage /
@@ -187,6 +195,95 @@ def discard_pending(subsystem: str, pending_id: str) -> bool:
     except Exception as e:  # pragma: no cover
         logger.error("Failed to discard pending %s/%s: %s", subsystem, pending_id, e)
     return False
+
+
+def update_pending(subsystem: str, pending_id: str,
+                   updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Merge ``updates`` into a pending record's top-level fields and persist.
+
+    Returns the updated record, or ``None`` if it no longer exists. Uses the
+    same atomic write-then-rename as :func:`stage_write` so a concurrent
+    reader never sees a half-written file. Used by the tool-approval gate to
+    link a Kanban card id back into the staged action and to flip the
+    ``status`` field (``pending`` → ``executing`` → ``done``) for the
+    double-execution guard.
+    """
+    rec = get_pending(subsystem, pending_id)
+    if rec is None:
+        return None
+    rec.update(updates)
+    try:
+        d = _pending_dir(subsystem)
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / f"{pending_id}.json"
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(rec, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception as e:  # pragma: no cover - disk failure path
+        logger.error("Failed to update pending %s/%s: %s", subsystem, pending_id, e)
+        return None
+    return rec
+
+
+# A claim lock older than this is assumed to belong to a crashed claimant
+# (process killed between acquiring the lock and releasing it) rather than a
+# live race, and is stolen rather than left to block claims forever.
+_CLAIM_LOCK_STALE_SECS = 60
+
+
+def claim_pending(subsystem: str, pending_id: str, *, expected_status: str,
+                  claimed_status: str,
+                  extra: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+    """Atomically transition a pending record's status, guarding a race.
+
+    :func:`get_pending` + :func:`update_pending` is a plain read-then-write:
+    two concurrent callers (e.g. a button-click handler and a kanban worker
+    both replaying the same approved action) can both read ``status ==
+    expected_status`` before either writes, and both then "win" the update —
+    double-executing the underlying tool call. This wraps the check-and-set
+    in an exclusive lock file (``open(..., O_CREAT | O_EXCL)`` is atomic at
+    the OS level) so only the first caller to acquire it proceeds; the loser
+    gets ``None`` back and must not execute.
+
+    Returns the updated record on a successful claim, or ``None`` if the
+    record is missing, not in ``expected_status``, or another caller holds
+    the claim.
+    """
+    d = _pending_dir(subsystem)
+    d.mkdir(parents=True, exist_ok=True)
+    lock_path = d / f"{pending_id}.lock"
+    try:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
+    except FileExistsError:
+        try:
+            age = time.time() - lock_path.stat().st_mtime
+        except OSError:
+            return None
+        if age < _CLAIM_LOCK_STALE_SECS:
+            return None
+        # Stale lock from a crashed claimant — steal it. Racing stealers can
+        # both reach here, but only one os.open(O_CREAT|O_EXCL) below wins;
+        # the other retries and, finding the winner's fresh lock, backs off.
+        try:
+            os.remove(lock_path)
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+        except OSError:
+            return None
+    try:
+        rec = get_pending(subsystem, pending_id)
+        if rec is None or rec.get("status") != expected_status:
+            return None
+        updates = {"status": claimed_status}
+        if extra:
+            updates.update(extra)
+        return update_pending(subsystem, pending_id, updates)
+    finally:
+        try:
+            os.remove(lock_path)
+        except OSError:
+            pass
 
 
 def pending_count(subsystem: str) -> int:


### PR DESCRIPTION
## Summary

Adds a human-in-the-loop approval gate for designated tool calls. **Default OFF** — with no config the behaviour is unchanged everywhere.

### Why

Some deployments need certain tools (e.g. `send_email`, `delete_*`, API write-back tools) to require human sign-off before executing, without blocking every call and without a custom wrapper per tool. The existing dangerous-command engine has all the right primitives (inline ask, session/permanent allowlist, Kanban staging); this wires those to named or glob-matched tool names.

### Two approval modes

| Mode | When | Behaviour |
|------|------|-----------|
| **Inline** | Live gateway session, channel present | Blocks the call; sends approve/deny prompt to the user (same UX as dangerous commands) |
| **Deferred** | Unattended (cron, background, no live channel), or `force_deferred` | Stages to `pending/actions/<id>.json`, opens a Kanban approval card, returns a non-error `"staged"` result so the agent continues |

Execution-on-approval is Hermes-native: approving the card mints an agent-assigned execution card; the dispatcher wakes a worker, which replays the staged call with a one-shot per-pending-id token (consumed on first match so it passes through exactly once; TTL + status state machine guard against double-execution).

### Decision ladder in `check_tool_approval`

1. Gate disabled → allow.
2. Tool not designated → allow.
3. YOLO / `approvals.mode == off` → allow.
4. One-shot replay token for this `pending_id` → allow + consume.
5. Prior inline session/permanent approval → allow.
6. Select mode (inline vs deferred) → resolve.

### Config example

```yaml
approvals:
  tool_gate:
    require_approval:
      - send_email      # exact name
      - delete_*        # glob pattern
    default_mode: deferred    # or inline
    force_deferred: [send_email]
    allow_inline: [delete_file]
```

### Files

| File | Change |
|------|--------|
| `tools/tool_gate.py` | New — staged-approval mechanics, config reader, replay token, `summarize_tool_call`, `approve_action`, `replay_pending_action`, Kanban card helpers. Optional Mattermost notification is no-op unless credentials are set. |
| `tools/approval.py` | Add `check_tool_approval` + helpers before `check_execute_code_guard`. |
| `tools/write_approval.py` | Add `ACTIONS` subsystem + `update_pending()` atomic helper. |
| `agent/tool_executor.py` | Gate at **sequential** dispatch choke point. |
| `agent/agent_runtime_helpers.py` | Gate at **concurrent** dispatch choke point (`invoke_tool`). |
| `gateway/run.py` | Tool-flavoured approval header for `kind == "tool"` prompts. |
| `tests/tools/test_tool_gate.py` | 27 unit tests (gate on/off, modes, staging, inline approve/deny, session/permanent, replay, TTL, double-exec). |
| `tests/run_agent/test_tool_gate_dispatch.py` | 3 integration tests at each choke point. |

### Test plan

- [x] `tests/tools/test_tool_gate.py` — 27 unit tests pass
- [x] `tests/run_agent/test_tool_gate_dispatch.py` — 3 integration tests pass (sequential + concurrent)
- [x] Gate is default-OFF: no config → every existing test unaffected
- [x] Branch is from `upstream/main` (not the fork's feature branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)