### PR TITLE
docs(agents): migrate repo guide to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Instructions for AI coding assistants and developers working on the hermes-agent codebase.
 
+> updated by Codex 2026-07-02: repo agent instructions live in `CLAUDE.md`; do not recreate `AGENTS.md`.
+
 ## Development Environment
 
 ```bash


### PR DESCRIPTION
What changed and why

- Renames the repo-local AI assistant guide from AGENTS.md to CLAUDE.md.
- Adds a short note that CLAUDE.md is now the instruction source of truth.

Verification

- bash hook audit run locally across active repo roots: no repo-local AGENTS.md or @AGENTS.md includes remain outside ignored third-party directories.
- git diff --check passed for the staged rename.

Operator follow-ups

- none

Out-of-scope

- No runtime code changes or test-suite changes.