### PR TITLE
fix(gateway): preserve compression routing integrity

### DIFF
--- a/docs/plans/2026-07-02-001-fix-compression-routing-integrity-plan.md
+++ b/docs/plans/2026-07-02-001-fix-compression-routing-integrity-plan.md
@@ -209,13 +209,13 @@ The change must keep prompt caching stable: session keys identify cached agent i
   - `hermes_state.py`
   - `tests/gateway/test_telegram_topic_mode.py`
   - `tests/test_hermes_state.py`
-- **Approach:** Add or reuse a lineage helper such as `SessionDB.is_session_descendant()` so `_handle_message_with_agent()` can distinguish “binding points at a stale ancestor” from “binding intentionally restored.” If the current `SessionEntry.session_id` is a descendant of the bound session and the binding is not restored, prefer the current descendant and rewrite the binding through `_sync_telegram_topic_binding()`.
-- **Patterns to follow:** PR #43766’s descendant-preference logic; existing `get_telegram_topic_binding()` / `bind_telegram_topic()` tests.
+- **Approach:** Use `SessionDB.get_compression_tip()` so `_handle_message_with_agent()` follows only compression-continuation lineage. Do not treat generic `parent_session_id` descendants as topic-binding replacements. If the binding is not restored and the compression tip differs from the bound parent, switch the route and rewrite the binding through `_sync_telegram_topic_binding()`.
+- **Patterns to follow:** Existing `get_compression_tip()`, `get_telegram_topic_binding()`, and `bind_telegram_topic()` tests.
 - **Test scenarios:**
   - Happy path: topic binding points at old parent A, session store points at descendant B, and the next Telegram message runs on B without `switch_session()` rewinding to A.
   - Restored binding: managed mode is `restored`; the binding stays on the restored session even if a descendant exists.
   - Compression-tip path: `get_compression_tip()` returns canonical child B and the binding is rewritten to B.
-  - Lineage helper: `is_session_descendant()` returns true for direct and multi-hop descendants, false for siblings and unrelated sessions.
+  - Generic descendants: non-compression parent/child lineage is not followed for topic binding repair.
 - **Verification:** Telegram topic mode cannot drag a compressed conversation back to an old parent unless the operator explicitly restored that binding.
 
 ### U6. Make background and delegation notifications compression-tip-aware

--- a/docs/plans/2026-07-02-001-fix-compression-routing-integrity-plan.md
+++ b/docs/plans/2026-07-02-001-fix-compression-routing-integrity-plan.md
@@ -1,0 +1,330 @@
+---
+title: "fix: Preserve gateway routing across compression handoffs"
+date: 2026-07-02
+type: fix
+status: planned
+origin: telegram-incident-follow-up
+plan_depth: deep
+---
+
+# fix: Preserve gateway routing across compression handoffs
+
+## Summary
+
+Make Hermes compression routing durable: when a gateway session compresses into a child session, every routing surface must follow the child, and stale background/process notifications must not resurrect an older session in the same Telegram topic.
+
+The implementation should be upstream-first: consume or adapt the official last-30-day PRs that already target this bug class, preserve contributor credit where possible, and fill the remaining background-notification gap with focused regression coverage.
+
+---
+
+## Problem Frame
+
+The incident shape is a real gateway/session-routing failure, not model confusion. Compression can rotate an agent from a parent session into a child session, but the gateway routing index, durable session metadata, Telegram topic binding, and background notification source can temporarily disagree. If a stale route still points at the compression-ended parent, a synthetic completion notification can re-enter the wrong live session and revive old context in the same Telegram thread.
+
+Hermes already treats conversation prompt caching, role alternation, and route isolation as core invariants. This fix must keep those invariants by repairing the session identity handoff at the compression boundary rather than adding a manual recovery path after the wrong session is selected.
+
+---
+
+## Due Diligence Findings
+
+### Public recent-signal scan
+
+A `/last30days` scan across GitHub, Hacker News, Reddit, X, and web grounding for the last 30 days found no broad public cluster of users reporting this exact Telegram compression-routing failure. The only notable non-official signal was weak X chatter about a “delivery-edge” class of agent messages landing in old sessions; it was useful as color, not as implementation evidence.
+
+### Official GitHub-only scan, last 30 days
+
+All official references below were created or updated inside the last-30-day window.
+
+| Source | Status | Relevance to this fix |
+|---|---:|---|
+| [PR #55300](https://github.com/NousResearch/hermes-agent/pull/55300) `fix(gateway): preserve peer routing across compression recovery` | Open, LGTM comment, blocked checks | Direct hit: records gateway peer metadata after compression session-id rotation and repoints stale `sessions.json` entries to recovered live children. |
+| [PR #55721](https://github.com/NousResearch/hermes-agent/pull/55721) `fix(gateway): ignore stale compression session splits` | Open, blocked/no checks | Direct hit: identity-guards stale in-flight runs so old compression children cannot overwrite a newer `/new` or moved binding. |
+| [PR #43766](https://github.com/NousResearch/hermes-agent/pull/43766) `fix(gateway): keep Telegram topic bindings on compression descendants` | Open, dirty | Direct hit for Telegram topic rewind: prefers compression descendants when topic binding and session-store entry disagree, while preserving explicitly restored bindings. |
+| [PR #50517](https://github.com/NousResearch/hermes-agent/pull/50517) `fix(gateway): preserve platform + gateway_session_key on /compress temporary agent` | Open, approved, dirty | Adjacent compression identity fix: manual `/compress` temporary agents should carry the same platform/session key as normal gateway turns. |
+| [PR #56416](https://github.com/NousResearch/hermes-agent/pull/56416) `fix(gateway): queue interrupts during in-flight context compression` | Merged | Related downstream fix already on `origin/main`; local checkout is behind and should pick this up before new work lands. |
+| [Issue #51058](https://github.com/NousResearch/hermes-agent/issues/51058) | Closed | User-visible wrong-chat/wrong-session symptom after compression across TUI/Desktop surfaces. |
+| [Issue #39260](https://github.com/NousResearch/hermes-agent/issues/39260) | Closed | Root cause family: gateway sessions not persisting enough chat metadata for reliable recovery. |
+| [Issue #52804](https://github.com/NousResearch/hermes-agent/issues/52804) | Closed | Stale `sessions.json` / live-gateway stale route variant related to routing-time healing. |
+
+Conclusion: a fix is coming downstream, but not as one fully-merged patch yet. The safest plan is to base local work on current `origin/main`, cherry-pick or adapt the relevant open PRs with attribution, then add the missing background-notification regression before shipping.
+
+---
+
+## Requirements
+
+- R1. Compression session-id rotation preserves the gateway peer tuple in durable state: `session_key`, source platform, user id, chat id, chat type, and thread id.
+- R2. A stale `sessions.json` entry pointing at a compression-ended parent is recovered to the live compression descendant for the same peer instead of being dropped or resolving to an unrelated older session.
+- R3. Telegram topic bindings follow compression descendants without overwriting explicit restored bindings or rewinding a topic to an old parent.
+- R4. Background process, watch, completion, and async-delegation notifications re-enter the owning session’s current compression tip, not merely the original parent session id captured when the process started.
+- R5. Stale in-flight runs cannot publish their compressed child after the session binding or run generation has moved to a newer session.
+- R6. Manual `/compress` temporary agents carry the same platform and gateway session key identity as normal gateway turns.
+- R7. The implementation preserves Hermes’ prompt-cache and message-alternation invariants: no synthetic notification should become a same-role duplicate or rebuild the system prompt unnecessarily.
+- R8. Regression tests cover the incident shape end-to-end enough to fail if Telegram routing metadata, topic binding, or background notification delivery regresses again.
+
+---
+
+## Key Technical Decisions
+
+- **Upstream-first integration:** Start from `origin/main` and salvage the official PR work rather than rewriting it. The repo guidance explicitly prefers contributor-credit-preserving salvage, and the open PRs already isolate most of the bug class.
+- **Durable peer metadata is the canonical recovery key:** Recovery should key off the full gateway peer tuple stored in `state.db`, with `sessions.json` treated as a fast routing index that can be healed.
+- **Compression lineage beats timestamp guesses:** Prefer `SessionDB.get_compression_tip()` / lineage checks over `started_at >= ended_at` heuristics; existing code documents that gateway/compression races can invert those timestamps.
+- **Identity-guard session split publication:** When a run starts on session A and later reports child C, only publish C if the active binding is still A and the run generation is current.
+- **Synthetic notifications must resolve late:** Process/delegation notifications should use the captured routing metadata for the peer, but resolve the live session id at injection time so long-running work survives compression.
+- **Telegram restored bindings stay explicit:** Topic bindings with restored/manual meaning should not be auto-rewritten just because a descendant exists; otherwise recovery can destroy operator intent.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+    participant G as GatewayRunner
+    participant S as SessionStore / sessions.json
+    participant DB as SessionDB / state.db
+    participant T as Telegram binding
+    participant P as Process watcher
+
+    G->>DB: parent session ends with end_reason=compression
+    G->>S: agent reports compressed child session_id
+    G->>DB: record_gateway_session_peer(child, full peer tuple)
+    G->>S: update session_key -> child, identity-guarded
+    G->>T: sync topic binding to child unless explicit restored binding wins
+    P->>G: completion/delegation notification for captured peer
+    G->>DB: resolve peer/current session through compression tip
+    G->>S: ensure active route points at current child
+    G->>G: inject synthetic event into current child session only
+```
+
+The critical design point is late binding: the process watcher may capture the original parent session id, but the injection path must resolve the current compression descendant before it creates a synthetic gateway message.
+
+---
+
+## Scope Boundaries
+
+### In scope
+
+- Gateway session routing around compression, including `sessions.json`, `state.db`, Telegram topic bindings, and process/delegation notification injection.
+- Regression tests for stale compression parents, stale run publication, Telegram topic rewind, manual `/compress` identity, and background notification re-entry after compression.
+- A light documentation update to keep session lifecycle docs aligned with the new invariant.
+
+### Deferred to Follow-Up Work
+
+- A broader refactor of `gateway/run.py` into smaller mixins/modules. This bug touches a god-file, but the durable fix should be narrow.
+- General session-store cleanup or schema redesign unrelated to compression routing.
+- Public release/update automation after the fix is merged; this plan covers the implementation-ready fix, not deployment scheduling.
+
+---
+
+## System-Wide Impact
+
+This change crosses the gateway hot path, durable session state, Telegram topic mode, and long-running tool notification delivery. It affects multi-platform behavior even though the visible incident was Telegram-first, because `SessionStore`, `SessionDB`, and synthetic notification injection are shared infrastructure.
+
+The change must keep prompt caching stable: session keys identify cached agent instances, and compression is the sanctioned exception that may rotate context. The plan therefore updates route metadata and bindings rather than creating a new session family or forcing a `/new`-style reset.
+
+---
+
+## Implementation Units
+
+### U1. Rebaseline onto current upstream compression fixes
+
+- **Goal:** Put the working branch on a current `origin/main` baseline and identify which official fixes are already present before writing local code.
+- **Requirements:** R1, R2, R3, R5, R6
+- **Dependencies:** None
+- **Files:**
+  - `gateway/run.py`
+  - `gateway/session.py`
+  - `hermes_state.py`
+  - `gateway/slash_commands.py`
+  - `tests/gateway/test_session_store_stale_prune.py`
+  - `tests/gateway/test_compression_failure_session_sync.py`
+  - `tests/gateway/test_telegram_topic_mode.py`
+  - `tests/gateway/test_compress_command.py`
+  - `tests/test_hermes_state.py`
+- **Approach:** Start by diffing local code against `origin/main` and the official PRs. Keep already-merged PR #56416 from upstream. Cherry-pick or adapt PR #55300, PR #55721, PR #43766, and PR #50517 where they still apply, preserving authorship where practical.
+- **Patterns to follow:** `AGENTS.md` contributor-credit guidance; existing comments in `hermes_state.py` around `get_compression_tip()`; existing gateway session recovery helpers in `gateway/session.py`.
+- **Test scenarios:**
+  - Test expectation: none directly for this unit; it is integration preparation. Behavioral coverage lands in U2–U6.
+- **Verification:** The implementer can point to which upstream fixes are present, adapted, or intentionally deferred, and no unrelated local work is mixed into the routing fix.
+
+### U2. Preserve peer metadata when compression rotates session ids
+
+- **Goal:** When an agent returns a different `session_id` after compression, persist the new child session’s full gateway peer metadata immediately.
+- **Requirements:** R1, R2
+- **Dependencies:** U1
+- **Files:**
+  - `gateway/run.py`
+  - `gateway/session.py`
+  - `tests/gateway/test_session_store_stale_prune.py`
+- **Approach:** Extend the session-id-rotation path in `GatewayRunner._handle_message_with_agent()` and the failed-turn/approval-notification path in `_run_agent()` so a successful compression handoff updates `SessionEntry.session_id`, saves `sessions.json`, and calls the existing `SessionStore._record_gateway_session_peer()` helper for the child. Do not bypass the existing `SessionStore` abstraction.
+- **Patterns to follow:** Existing `SessionStore._record_gateway_session_peer()` and `SessionDB.record_gateway_session_peer()`; PR #55300’s direct patch shape.
+- **Test scenarios:**
+  - Happy path: a Telegram gateway turn starts on parent A, compression returns child B, and `record_gateway_session_peer()` is called with B plus the original peer tuple.
+  - Error path: peer recording raises; the gateway logs/debugs but still completes the response without dropping the user turn.
+  - Integration scenario: a failed model turn that compressed before failing still records the child session id for recovery, matching `tests/gateway/test_compression_failure_session_sync.py` behavior.
+- **Verification:** After compression, durable state can recover the child by the original `session_key` and Telegram peer tuple.
+
+### U3. Recover stale `sessions.json` entries to compression descendants
+
+- **Goal:** Startup and routing-time stale-entry pruning should repoint compression-ended parents to live descendants when the peer matches exactly.
+- **Requirements:** R2, R8
+- **Dependencies:** U2
+- **Files:**
+  - `gateway/session.py`
+  - `tests/gateway/test_session_store_stale_prune.py`
+  - `tests/gateway/test_session_store_runtime_stale_guard.py`
+- **Approach:** In `_prune_stale_sessions_locked()`, treat an entry whose DB row has `end_reason='compression'` as recoverable when `entry.origin` is present. Use `_recover_session_from_db()` to find the latest durable peer row and reopen/repoint only when it returns a different session id. If recovery finds the same ended session or no match, keep the existing prune behavior.
+- **Patterns to follow:** Existing `_recover_session_from_db()` / `_create_entry_from_recovered_row()` and PR #55300’s stale-parent repoint tests.
+- **Test scenarios:**
+  - Happy path: `sessions.json` points at compression parent A, DB finder returns live child B for the same peer, and the store keeps the key mapped to B.
+  - Runtime path: a live gateway route whose session id has become ended in `state.db` is recovered or dropped before it can swallow a follow-up message.
+  - Failure path: DB finder raises; the store does not crash startup and falls back to safe prune behavior.
+  - Safety path: finder returns A or an unrelated peer; the stale entry is pruned rather than reopened.
+  - Persistence path: a recovered entry causes `_save()` so the on-disk route is repaired before the next message.
+- **Verification:** A gateway restart after compression cannot leave the conversation with no resumable route or silently route to an older live session.
+
+### U4. Guard stale in-flight compression publication
+
+- **Goal:** Old runs that finish after `/stop`, `/new`, or another lifecycle move must not overwrite the active session binding with their compressed child.
+- **Requirements:** R5, R7
+- **Dependencies:** U2
+- **Files:**
+  - `gateway/run.py`
+  - `tests/gateway/test_compression_failure_session_sync.py`
+- **Approach:** Capture the run-start session id before `_run_agent()` and only publish `agent_result['session_id']` if the active `SessionEntry.session_id` still equals that run-start id. In `_run_agent()`’s failed-turn compression sync, also require the run generation to remain current before saving the child or syncing Telegram binding.
+- **Patterns to follow:** PR #55721’s identity guard and existing `_session_run_generation` stale-result checks.
+- **Test scenarios:**
+  - Happy path: current run starts on A, compresses to B, and updates the binding because the active entry still points at A.
+  - Stale generation: run generation 1 returns after generation 2 exists; no session-store save or topic-binding sync happens.
+  - Moved binding: active entry has moved from A to fresh session N; compressed child B from old run is ignored.
+  - Failure path: a failed turn that compressed before failing still publishes the split only when identity guards pass.
+- **Verification:** A stale compressed child cannot replace a newer conversation lane.
+
+### U5. Heal Telegram topic binding lineage without destroying restored bindings
+
+- **Goal:** Telegram topic routes should follow compression descendants when stale, while explicit restored/manual bindings stay authoritative.
+- **Requirements:** R3, R8
+- **Dependencies:** U2, U3, U4
+- **Files:**
+  - `gateway/run.py`
+  - `hermes_state.py`
+  - `tests/gateway/test_telegram_topic_mode.py`
+  - `tests/test_hermes_state.py`
+- **Approach:** Add or reuse a lineage helper such as `SessionDB.is_session_descendant()` so `_handle_message_with_agent()` can distinguish “binding points at a stale ancestor” from “binding intentionally restored.” If the current `SessionEntry.session_id` is a descendant of the bound session and the binding is not restored, prefer the current descendant and rewrite the binding through `_sync_telegram_topic_binding()`.
+- **Patterns to follow:** PR #43766’s descendant-preference logic; existing `get_telegram_topic_binding()` / `bind_telegram_topic()` tests.
+- **Test scenarios:**
+  - Happy path: topic binding points at old parent A, session store points at descendant B, and the next Telegram message runs on B without `switch_session()` rewinding to A.
+  - Restored binding: managed mode is `restored`; the binding stays on the restored session even if a descendant exists.
+  - Compression-tip path: `get_compression_tip()` returns canonical child B and the binding is rewritten to B.
+  - Lineage helper: `is_session_descendant()` returns true for direct and multi-hop descendants, false for siblings and unrelated sessions.
+- **Verification:** Telegram topic mode cannot drag a compressed conversation back to an old parent unless the operator explicitly restored that binding.
+
+### U6. Make background and delegation notifications compression-tip-aware
+
+- **Goal:** Synthetic notifications generated after the user turn ends should resolve the current compression descendant before re-entering the gateway.
+- **Requirements:** R4, R7, R8
+- **Dependencies:** U2, U3, U5
+- **Files:**
+  - `gateway/run.py`
+  - `tools/process_registry.py`
+  - `tools/terminal_tool.py`
+  - `tests/gateway/test_background_process_notifications.py`
+  - `tests/gateway/test_compression_notification_routing.py`
+  - `tests/gateway/test_internal_event_never_interrupts_busy_session.py`
+  - `tests/gateway/test_internal_event_bypass_pairing.py`
+- **Approach:** Keep process watcher metadata capture unchanged for platform/chat/thread/user identity, but update the injection path around `_build_process_event_source()` / `_inject_watch_notification()` to late-resolve the owning session by `session_key` and compression lineage before creating the synthetic `MessageEvent`. If a current descendant is found, ensure the session store route and event source are aligned to that descendant. If no route can be resolved, drop rather than guessing across peers.
+- **Technical design:** Directional only: `captured peer tuple -> find current session by session_key -> get_compression_tip(current or captured session id) -> verify same peer metadata -> inject synthetic event using current session key/source`.
+- **Patterns to follow:** Existing agent-triggered completion flow in `_run_process_watcher()`; `_enrich_async_delegation_routing()` for async delegation routing metadata; `SessionStore._recover_session_from_db()` for conservative peer matching.
+- **Test scenarios:**
+  - Happy path: process starts under parent A, compression rotates to child B before process completion, and `notify_on_complete` re-enters B.
+  - Async delegation path: delegation completion event with captured parent route resolves to child B before `_inject_watch_notification()`.
+  - Busy-session path: an internal completion event queues behind an active user turn instead of interrupting it, preserving the existing internal-event behavior.
+  - Pairing path: internal completion events keep bypassing platform authorization/pairing checks while still using compression-tip routing.
+  - Missing metadata: completion event without `session_key` or platform peer metadata is dropped/logged rather than routed to any live session in the topic.
+  - Wrong-peer safety: another live Telegram session exists in the same chat/thread, but the peer tuple does not match; notification does not re-enter that session.
+  - Alternation safety: injected notification is handled as a synthetic user event through the existing gateway path without creating duplicate same-role assistant messages.
+- **Verification:** The original incident shape fails before this unit and passes after it: long-running background work finishing after compression continues the compressed child session, not an older session in the same topic.
+
+### U7. Preserve manual `/compress` gateway identity
+
+- **Goal:** Manual `/compress` should use the same platform and `gateway_session_key` identity as a normal gateway turn.
+- **Requirements:** R6, R8
+- **Dependencies:** U1
+- **Files:**
+  - `gateway/slash_commands.py`
+  - `tests/gateway/test_compress_command.py`
+- **Approach:** Adapt PR #50517 so the temporary compression agent gets the source-derived platform config key and stable gateway session key in runtime kwargs, overriding stale resolver values without passing duplicate keyword arguments.
+- **Patterns to follow:** `_platform_config_key()` in `gateway/run.py`; existing `/compress` tests.
+- **Test scenarios:**
+  - Happy path: a Telegram `/compress` temporary agent receives `platform='telegram'` and the same gateway session key as the live turn.
+  - Stale resolver path: runtime kwargs already contain stale platform/session values; source-derived identity wins and no duplicate-kwarg error is raised.
+  - Backward compatibility: source without platform metadata keeps the previous default behavior.
+- **Verification:** Manual compression cannot create an unbound “cli” identity for a gateway conversation.
+
+### U8. Document and verify the invariant
+
+- **Goal:** Make the new compression-routing invariant discoverable for future gateway work.
+- **Requirements:** R7, R8
+- **Dependencies:** U2, U3, U4, U5, U6, U7
+- **Files:**
+  - `docs/session-lifecycle.md`
+  - `website/docs/user-guide/sessions.md`
+  - `website/docs/developer-guide/session-storage.md`
+  - `tests/gateway/test_session_store_stale_prune.py`
+  - `tests/gateway/test_session_store_runtime_stale_guard.py`
+  - `tests/gateway/test_compression_failure_session_sync.py`
+  - `tests/gateway/test_compression_concurrent_sessions.py`
+  - `tests/gateway/test_telegram_topic_mode.py`
+  - `tests/gateway/test_background_process_notifications.py`
+  - `tests/gateway/test_compression_notification_routing.py`
+  - `tests/gateway/test_internal_event_never_interrupts_busy_session.py`
+  - `tests/gateway/test_internal_event_bypass_pairing.py`
+  - `tests/gateway/test_compress_command.py`
+  - `tests/test_hermes_state.py`
+- **Approach:** Add a concise “Compression routing handoff” note to the session lifecycle docs: `sessions.json` is a fast index, `state.db` peer metadata is the recovery source, Telegram bindings must follow compression descendants, and synthetic notifications resolve late. Keep the docs factual and linked to existing concepts rather than adding a new policy surface.
+- **Test scenarios:**
+  - Integration suite: the targeted gateway/session tests pass together so fixes do not only work in isolation.
+  - Regression naming: test names explicitly mention stale compression parent, stale run split, Telegram topic descendant, and background notification routing so future maintainers can map failures to the invariant.
+- **Verification:** A reviewer can understand the compression handoff rule from `docs/session-lifecycle.md` and confirm every rule has an executable regression.
+
+---
+
+## Risks & Dependencies
+
+- **Local branch drift:** The checkout is behind `origin/main`; rebasing or merging upstream first is necessary to avoid re-solving fixes already merged downstream.
+- **Open PR conflicts:** PR #43766 and PR #50517 are dirty against current main; they should be adapted, not blindly applied.
+- **CI signal is mixed:** PR #55300 has an LGTM comment and many passing checks, but required checks are blocked by at least one test slice, attribution, and Docker arm failures. Treat it as strong design evidence, not a ready merge.
+- **Gateway god-file risk:** Several changes touch `gateway/run.py`; keep units narrow and regression-led to avoid accidental behavior drift.
+- **Synthetic notification safety:** The background notification fix is the least-covered upstream area. It needs its own regression rather than relying on PR #55300/#55721 transitively.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a Telegram topic session A compresses into child B, when the gateway restarts with `sessions.json` still pointing at A, then startup recovery repoints the route to B for the same peer.
+- AE2. Given a background process started under A and finishes after compression to B, when `notify_on_complete` fires, then the synthetic event re-enters B and not an older live Telegram session.
+- AE3. Given `/new` moves the active binding from A to N while old run A finishes compression into B, then B does not replace N.
+- AE4. Given a Telegram topic binding intentionally restored to session R, when a descendant exists, then automatic compression healing does not rewrite the restored binding.
+- AE5. Given manual `/compress` is invoked from Telegram, when the temporary agent is constructed, then it uses Telegram platform identity and the gateway session key rather than an unbound CLI identity.
+
+---
+
+## Sources / Research
+
+- `AGENTS.md` — repo contribution rubric: fix the whole bug class, preserve contributor credit, verify real paths with temp `HERMES_HOME` where integration matters.
+- `docs/session-lifecycle.md` — current session key, `sessions.json`, reset/restart recovery, background expiry, and agent cache contracts.
+- `website/docs/user-guide/sessions.md` — public docs state that `state.db` is the canonical session/message store and `sessions/sessions.json` is only the gateway routing index.
+- `website/docs/developer-guide/session-storage.md` — developer docs state that session storage uses WAL, FTS5, `parent_session_id` lineage, and source tagging.
+- `gateway/session.py` — `SessionStore`, `_recover_session_from_db()`, `_record_gateway_session_peer()`, stale prune, session-key mapping persistence.
+- `gateway/run.py` — gateway turn handling, compression session-id publication, Telegram topic binding sync, process/delegation notification injection.
+- `hermes_state.py` — `SessionDB`, durable peer metadata, `get_compression_tip()`, session lineage and topic binding tables.
+- `tools/process_registry.py` and `tools/terminal_tool.py` — captured process watcher metadata and completion event construction.
+- `tests/gateway/test_background_process_notifications.py`, `tests/gateway/test_internal_event_never_interrupts_busy_session.py`, and `tests/gateway/test_internal_event_bypass_pairing.py` — existing background/internal notification invariants to preserve while adding compression-tip routing.
+- `tests/gateway/test_session_store_runtime_stale_guard.py` and `tests/gateway/test_compression_concurrent_sessions.py` — existing live stale-route and concurrent-compression coverage to extend rather than duplicating.
+- Official GitHub last-30-day sources: PR #55300, PR #55721, PR #43766, PR #50517, PR #56416, issues #51058, #39260, and #52804.
+- `/last30days` public scan — no broad external cluster found; official GitHub evidence is the load-bearing external input.
+
+---
+
+## Handoff Notes
+
+Start with U1 and do not implement U6 last “if there is time”; the background notification path is the incident-specific gap and must be regression-tested before the fix is considered complete. If upstream merges PR #55300/#55721/#43766/#50517 before implementation starts, consume the merged commits instead of carrying local copies, then run the same acceptance examples against the merged code.

--- a/docs/plans/2026-07-02-002-finish-compression-routing-review-plan.md
+++ b/docs/plans/2026-07-02-002-finish-compression-routing-review-plan.md
@@ -1,0 +1,93 @@
+---
+title: Finish compression routing integrity review fixes
+status: ready
+execution: code
+created: 2026-07-02
+---
+
+# Finish compression routing integrity review fixes
+
+## Context
+
+The main compression-routing fix is implemented on `fix/compression-routing-integrity` and already had the gateway suite green before the final review-fix pass. Two review batches then surfaced remaining finish work around restored topic bindings, stale generic-descendant logic, integration coverage, and docs/test alignment.
+
+## Requirements
+
+- R1: Background/process/delegation notification routing must late-resolve compression tips without blocking the event loop.
+- R2: Automatic compression healing must follow only compression-continuation lineage, not arbitrary `parent_session_id` descendants.
+- R3: Explicit `/topic restore` bindings (`managed_mode='restored'`) must remain authoritative; background notifications must not silently rewrite them to auto bindings.
+- R4: Stale compression publications must be rejected when the session key no longer points at the parent that produced the child.
+- R5: Tests must cover direct notification injection and the real `_run_process_watcher()` notify-on-complete path.
+- R6: Docs and tests must reflect the implemented helpers; no references to removed helper APIs or overclaims like fully atomic peer/topic refresh if those steps are best-effort.
+- R7: Finish with targeted tests, lint/compile, full gateway suite, and a focused commit.
+
+## Scope Boundaries
+
+- Do not restart the live Hermes gateway.
+- Do not broaden into a full `SessionStore` API refactor unless required by tests; keep this as a review-fix pass.
+- Do not rewrite the already-shipped main compression implementation unless a regression proves it necessary.
+
+## Implementation Units
+
+### F1: Settle compression-tip and restored-binding semantics
+
+**Files:**
+- Modify: `gateway/run.py`
+- Modify: `hermes_state.py`
+- Modify: `tests/gateway/test_telegram_topic_mode.py`
+- Modify: `tests/gateway/test_background_process_notifications.py`
+
+**Approach:**
+- Keep `_build_process_event_source()` offloaded with `asyncio.to_thread()`.
+- Ensure topic healing uses `SessionDB.get_compression_tip()` only.
+- Remove any generic parent-descendant helper call/implementation/test if it is not part of final behavior.
+- Guard topic sync during synthetic notification compression-tip advancement so restored bindings stay restored or are not auto-rewritten.
+
+**Verification:**
+- Restored binding test still uses the parent session and preserves `managed_mode='restored'`.
+- A restored binding plus background notification does not rewrite the binding to auto or child.
+
+### F2: Add end-to-end process watcher compression-tip coverage
+
+**Files:**
+- Modify: `tests/gateway/test_background_process_notifications.py`
+
+**Approach:**
+- Add an integration-style `_run_process_watcher()` test where a notify-on-complete watcher starts with parent route metadata, the DB reports a compression child by completion time, and the injected synthetic event routes through the child/tip-aware source.
+- Keep existing direct `_inject_watch_notification()` coverage for the helper path.
+
+**Verification:**
+- The watcher test asserts `adapter.handle_message` receives an internal event with the original Telegram route and that the session store entry advances to the child.
+
+### F3: Align docs and remove brittle/stale test expectations
+
+**Files:**
+- Modify: `docs/session-lifecycle.md`
+- Modify: `tests/gateway/test_compression_session_id_persistence.py` if necessary
+- Modify: any stale tests found by targeted pytest
+
+**Approach:**
+- Replace stale generic-descendant docs with `SessionDB.get_compression_tip()`.
+- Clarify that route update/save is guarded and peer/topic refresh is best-effort after the route save.
+- Replace stale structural/change-detector assertions only if they fail or still encode removed APIs.
+
+**Verification:**
+- Docs mention `state.db` canonicality and `sessions.json` as routing index.
+- No removed helper name remains in docs/tests/code.
+
+### F4: Validation and commit
+
+**Files:**
+- All touched files.
+
+**Approach:**
+- Run py_compile for touched Python files.
+- Run ruff on touched Python files.
+- Run targeted gateway/session tests.
+- Run full `HOME=/home/deploy scripts/run_tests.sh tests/gateway -q`.
+- Commit review-fix changes with a conventional message.
+
+**Verification:**
+- `git diff --check` is clean.
+- Targeted and full gateway suites pass.
+- Branch is clean except intended commits.

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Gateway developers and maintainers
 > **Source files:** `gateway/session.py` (~1444 lines), `gateway/run.py` (~16800 lines), `gateway/config.py`
-> **Last updated:** 2026-06-16
+> **Last updated:** 2026-07-02
 
 ## Overview
 
@@ -201,6 +201,41 @@ The canonical transcript store is SQLite via `SessionDB` (from `hermes_state`). 
 `sessions.json` file persists the `session_key → session_id` mapping and entry metadata
 (flags, timestamps, token counts). If SQLite is unavailable, the store falls back to
 JSONL, but this is a degradation path.
+
+### Compression Continuation Invariant
+
+`state.db` is the canonical source for compression lineage. `sessions.json` is only the
+live gateway routing index. When compression creates a child session, the gateway must
+publish the child as the current value for the same stable `session_key` and preserve the
+peer metadata needed to recover that route later.
+
+The invariant is:
+
+1. The compression child keeps the same external route: `session_key`, platform, chat,
+   thread/topic, user, and gateway peer metadata.
+2. A run may publish a compression child only if its run generation is still current and
+   the session key still points at the parent that run started from. Late results from an
+   interrupted, queued, or superseded turn must not overwrite `/new`, `/stop`, or another
+   fresh lane.
+3. On startup, a `sessions.json` entry whose `session_id` ended with
+   `end_reason='compression'` is repaired by walking durable peer metadata to the latest
+   live compression descendant before pruning is considered.
+4. Telegram topic bindings that point at a compression parent are advanced to the
+   compression tip on the next inbound message, except explicit `managed_mode='restored'`
+   bindings created by `/topic restore`.
+5. Synthetic background/delegation notifications late-resolve their stored `session_key`
+   through `state.db` immediately before injection so completion messages re-enter the
+   compression child instead of reviving an oversized parent.
+
+The gateway helpers enforcing this are:
+
+- `GatewayRunner._publish_compression_session_split()` — atomically updates the
+  `SessionEntry`, persists `sessions.json`, records gateway peer metadata, and refreshes
+  topic bindings for a live compression rotation.
+- `GatewayRunner._advance_session_entry_to_compression_tip()` — delivery-time repair for
+  synthetic events that may fire long after the spawning turn compressed.
+- `SessionDB.get_compression_tip()` / `SessionDB.is_session_descendant()` — lineage checks
+  against `parent_session_id` in `state.db`.
 
 ---
 

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -229,13 +229,13 @@ The invariant is:
 
 The gateway helpers enforcing this are:
 
-- `GatewayRunner._publish_compression_session_split()` — atomically updates the
-  `SessionEntry`, persists `sessions.json`, records gateway peer metadata, and refreshes
-  topic bindings for a live compression rotation.
+- `GatewayRunner._publish_compression_session_split()` — guards the live route,
+  updates the `SessionEntry`, persists `sessions.json`, then best-effort records
+  gateway peer metadata and refreshes topic bindings for a live compression rotation.
 - `GatewayRunner._advance_session_entry_to_compression_tip()` — delivery-time repair for
   synthetic events that may fire long after the spawning turn compressed.
-- `SessionDB.get_compression_tip()` / `SessionDB.is_session_descendant()` — lineage checks
-  against `parent_session_id` in `state.db`.
+- `SessionDB.get_compression_tip()` — follows compression-only continuation lineage
+  through `parent_session_id` in `state.db`.
 
 ---
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3413,6 +3413,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self,
         source: SessionSource,
         session_entry,
+        *,
+        managed_mode: str = "auto",
     ) -> None:
         """Persist the Telegram topic -> Hermes session binding for topic lanes."""
         session_db = getattr(self, "_session_db", None)
@@ -3426,6 +3428,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(source.user_id or ""),
             session_key=session_entry.session_key,
             session_id=session_entry.session_id,
+            managed_mode=managed_mode,
         )
 
     def _sync_telegram_topic_binding(
@@ -3448,11 +3451,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not self._is_telegram_topic_lane(source):
             return
         try:
-            self._record_telegram_topic_binding(source, session_entry)
+            managed_mode = (
+                "restored"
+                if self._telegram_topic_binding_is_restored(source)
+                else "auto"
+            )
+            self._record_telegram_topic_binding(
+                source,
+                session_entry,
+                managed_mode=managed_mode,
+            )
         except Exception:
             logger.debug(
                 "telegram topic binding refresh failed (%s)", reason, exc_info=True,
             )
+
+    def _telegram_topic_binding_is_restored(self, source: Optional[SessionSource]) -> bool:
+        """Return True when ``source`` points at an explicit /topic restore binding.
+
+        Compression healing may advance fast routing indexes, but restored topic
+        bindings are operator intent and must not be silently rewritten back to
+        ``managed_mode='auto'`` by a later background notification.
+        """
+        if source is None:
+            return False
+        try:
+            if not self._is_telegram_topic_lane(source):
+                return False
+        except Exception:
+            return False
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return False
+        # This helper is called from off-loop compression publication paths;
+        # unwrap the async facade so the binding check stays synchronous.
+        session_db = getattr(session_db, "_db", session_db)
+        getter = getattr(session_db, "get_telegram_topic_binding", None)
+        if not callable(getter):
+            return False
+        try:
+            binding = getter(
+                chat_id=str(source.chat_id),
+                thread_id=str(source.thread_id),
+            )
+        except Exception:
+            logger.debug("telegram topic binding restored check failed", exc_info=True)
+            return False
+        return bool(binding and str(binding.get("managed_mode") or "") == "restored")
 
     def _publish_compression_session_split(
         self,
@@ -3463,7 +3508,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         new_session_id: str,
         reason: str,
         run_generation: Optional[int] = None,
-        sync_topic: bool = True,
     ):
         """Publish a compression-created child as the live gateway session.
 
@@ -3571,7 +3615,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exc_info=True,
             )
 
-        if sync_topic and route_source is not None:
+        if route_source is not None:
             self._sync_telegram_topic_binding(route_source, entry, reason=reason)
         return entry
 
@@ -3639,7 +3683,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             previous_session_id=current_session_id,
             new_session_id=tip_session_id,
             reason=reason,
-            sync_topic=True,
         ) or entry
 
     def _recover_telegram_topic_thread_id(
@@ -10361,23 +10404,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if binding:
                 bound_session_id = str(binding.get("session_id") or "")
                 binding_is_restored = str(binding.get("managed_mode") or "") == "restored"
-                # Heal bindings that point at a pre-compression parent: walk
-                # the compression-continuation chain forward to its tip so the
-                # next message resumes the compressed child instead of
-                # reloading the oversized parent transcript (#20470/#29712/
-                # #33414). Explicit /topic restored bindings stay authoritative
-                # until the operator changes them.
+                # Heal bindings that point at a pre-compression parent by
+                # walking only the compression-continuation chain. Generic
+                # parent/child lineage is intentionally ignored here: branch,
+                # delegate, and tool sessions also have parents, but they are
+                # not sanctioned replacements for the Telegram topic binding.
+                # Explicit /topic restored bindings stay authoritative until
+                # the operator changes them.
                 if bound_session_id and self._session_db is not None and not binding_is_restored:
                     try:
-                        if await self._session_db.is_session_descendant(
+                        canonical_session_id = await self._session_db.get_compression_tip(
                             bound_session_id,
-                            session_entry.session_id,
-                        ):
-                            canonical_session_id = session_entry.session_id
-                        else:
-                            canonical_session_id = await self._session_db.get_compression_tip(
-                                bound_session_id,
-                            )
+                        )
                     except Exception:
                         logger.debug(
                             "compression-tip lookup failed for %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1338,7 +1338,7 @@ def _current_max_iterations() -> int:
         return 90
 
 
-from contextlib import contextmanager as _contextmanager
+from contextlib import contextmanager as _contextmanager, nullcontext as _nullcontext
 
 
 # Platforms that bind a host TCP port (HTTP/webhook listeners). In a profile
@@ -3454,6 +3454,194 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "telegram topic binding refresh failed (%s)", reason, exc_info=True,
             )
 
+    def _publish_compression_session_split(
+        self,
+        *,
+        session_key: str,
+        source: Optional[SessionSource],
+        previous_session_id: str,
+        new_session_id: str,
+        reason: str,
+        run_generation: Optional[int] = None,
+        sync_topic: bool = True,
+    ):
+        """Publish a compression-created child as the live gateway session.
+
+        Compression is the one sanctioned path that rotates a gateway session's
+        durable row while keeping the same external route.  That route update is
+        only safe if the run that produced the child is still current AND the
+        session key still points at the run's original parent.  Otherwise a
+        stale agent result can overwrite a newer /new, /stop, or queued-turn
+        lane and resurrect the wrong conversation.
+        """
+        session_key = str(session_key or "").strip()
+        previous_session_id = str(previous_session_id or "").strip()
+        new_session_id = str(new_session_id or "").strip()
+        if not session_key or not previous_session_id or not new_session_id:
+            return None
+        if new_session_id == previous_session_id:
+            return None
+
+        if run_generation is not None:
+            try:
+                if not self._is_session_run_current(session_key, run_generation):
+                    logger.info(
+                        "Ignoring compression session split %s -> %s for %s "
+                        "(%s): generation %s is no longer current",
+                        previous_session_id,
+                        new_session_id,
+                        session_key,
+                        reason,
+                        run_generation,
+                    )
+                    return None
+            except Exception:
+                logger.debug(
+                    "compression split generation check failed for %s (%s)",
+                    session_key,
+                    reason,
+                    exc_info=True,
+                )
+                return None
+
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return None
+        try:
+            lock = getattr(store, "_lock", None)
+            lock_ctx = lock if lock is not None else _nullcontext()
+            with lock_ctx:
+                ensure_loaded_locked = getattr(store, "_ensure_loaded_locked", None)
+                ensure_loaded = getattr(store, "_ensure_loaded", None)
+                if callable(ensure_loaded_locked):
+                    ensure_loaded_locked()
+                elif callable(ensure_loaded):
+                    ensure_loaded()
+                entry = getattr(store, "_entries", {}).get(session_key)
+                if entry is None:
+                    logger.info(
+                        "Ignoring compression session split %s -> %s for %s (%s): "
+                        "session key has no active route",
+                        previous_session_id,
+                        new_session_id,
+                        session_key,
+                        reason,
+                    )
+                    return None
+
+                active_session_id = str(getattr(entry, "session_id", "") or "")
+                if active_session_id != previous_session_id:
+                    logger.info(
+                        "Ignoring compression session split %s -> %s for %s (%s): "
+                        "active route is %s",
+                        previous_session_id,
+                        new_session_id,
+                        session_key,
+                        reason,
+                        active_session_id or "<none>",
+                    )
+                    return None
+
+                entry.session_id = new_session_id
+                try:
+                    store._save()
+                except Exception:
+                    entry.session_id = previous_session_id
+                    raise
+        except Exception:
+            logger.debug(
+                "compression split route update failed for %s (%s)",
+                session_key,
+                reason,
+                exc_info=True,
+            )
+            return None
+
+        route_source = source or getattr(entry, "origin", None)
+
+        try:
+            recorder = getattr(store, "_record_gateway_session_peer", None)
+            if callable(recorder):
+                recorder(new_session_id, session_key, route_source)
+        except Exception:
+            logger.debug(
+                "compression split peer record failed for %s (%s)",
+                session_key,
+                reason,
+                exc_info=True,
+            )
+
+        if sync_topic and route_source is not None:
+            self._sync_telegram_topic_binding(route_source, entry, reason=reason)
+        return entry
+
+    def _advance_session_entry_to_compression_tip(
+        self,
+        *,
+        session_key: str,
+        source: Optional[SessionSource] = None,
+        reason: str,
+    ):
+        """Late-resolve a session-store route to its compression tip.
+
+        Background process and delegation notifications can be delivered long
+        after the turn that spawned them.  They capture the stable
+        ``session_key``/peer tuple at spawn time, then this helper resolves that
+        key's current session through ``state.db`` immediately before synthetic
+        event injection.  This keeps stale completions attached to the compressed
+        child instead of reviving an old parent route.
+        """
+        session_key = str(session_key or "").strip()
+        if not session_key:
+            return None
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return None
+        try:
+            ensure_loaded = getattr(store, "_ensure_loaded", None)
+            if callable(ensure_loaded):
+                ensure_loaded()
+            entry = getattr(store, "_entries", {}).get(session_key)
+        except Exception:
+            logger.debug(
+                "process-event compression-tip route lookup failed for %s",
+                session_key,
+                exc_info=True,
+            )
+            return None
+        if entry is None:
+            return None
+
+        current_session_id = str(getattr(entry, "session_id", "") or "")
+        if not current_session_id:
+            return entry
+        db = getattr(self, "_session_db", None)
+        db = getattr(db, "_db", db)
+        tip_finder = getattr(db, "get_compression_tip", None)
+        if not callable(tip_finder):
+            return entry
+        try:
+            tip_session_id = str(tip_finder(current_session_id) or current_session_id)
+        except Exception:
+            logger.debug(
+                "process-event compression-tip lookup failed for %s (%s)",
+                current_session_id,
+                session_key,
+                exc_info=True,
+            )
+            return entry
+        if tip_session_id == current_session_id:
+            return entry
+
+        return self._publish_compression_session_split(
+            session_key=session_key,
+            source=source or getattr(entry, "origin", None),
+            previous_session_id=current_session_id,
+            new_session_id=tip_session_id,
+            reason=reason,
+            sync_topic=True,
+        ) or entry
+
     def _recover_telegram_topic_thread_id(
         self,
         source: SessionSource,
@@ -3698,9 +3886,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         lists, desktop/dashboard details, and follow-up session tooling report the
         backend that actually answered the latest turn.
 
-        Called from the ``run_sync`` closure, which executes off the event loop
-        in the executor thread — so the synchronous ``SessionDB`` (``_db``) is
-        used directly rather than awaiting the AsyncSessionDB forwarder.
+        Called via ``asyncio.to_thread`` from loop-side code — so the
+        synchronous ``SessionDB`` (``_db``) is used directly rather than awaiting
+        the AsyncSessionDB forwarder.
         """
         if not session_id or agent is None or self._session_db is None:
             return
@@ -5046,7 +5234,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             effective_mode = "queue"
         demoted_for_compression = (
             effective_mode == "interrupt"
-            and self._session_has_compression_in_flight(session_key)
+            and await asyncio.to_thread(
+                self._session_has_compression_in_flight,
+                session_key,
+            )
         )
         if demoted_for_compression:
             logger.info(
@@ -10169,17 +10360,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 binding = None
             if binding:
                 bound_session_id = str(binding.get("session_id") or "")
+                binding_is_restored = str(binding.get("managed_mode") or "") == "restored"
                 # Heal bindings that point at a pre-compression parent: walk
                 # the compression-continuation chain forward to its tip so the
                 # next message resumes the compressed child instead of
                 # reloading the oversized parent transcript (#20470/#29712/
-                # #33414). Returns the input unchanged when the session isn't
-                # a compression parent, so this is cheap and safe.
-                if bound_session_id and self._session_db is not None:
+                # #33414). Explicit /topic restored bindings stay authoritative
+                # until the operator changes them.
+                if bound_session_id and self._session_db is not None and not binding_is_restored:
                     try:
-                        canonical_session_id = await self._session_db.get_compression_tip(
+                        if await self._session_db.is_session_descendant(
                             bound_session_id,
-                        )
+                            session_entry.session_id,
+                        ):
+                            canonical_session_id = session_entry.session_id
+                        else:
+                            canonical_session_id = await self._session_db.get_compression_tip(
+                                bound_session_id,
+                            )
                     except Exception:
                         logger.debug(
                             "compression-tip lookup failed for %s",
@@ -10608,19 +10806,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     # a new session_id.  Write compressed messages into
                                     # the NEW session so the old transcript stays intact
                                     # and searchable via session_search.
+                                    _hyg_old_sid = session_entry.session_id
                                     _hyg_new_sid = _hyg_agent.session_id
-                                    _hyg_rotated = _hyg_new_sid != session_entry.session_id
+                                    _hyg_requested_rotation = _hyg_new_sid != _hyg_old_sid
+                                    _hyg_rotated = False
                                     _hyg_in_place = bool(
                                         getattr(_hyg_agent, "_last_compaction_in_place", False)
                                     )
-                                    if _hyg_rotated:
-                                        session_entry.session_id = _hyg_new_sid
-                                        self.session_store._save()
-                                        await asyncio.to_thread(
-                                            self._sync_telegram_topic_binding,
-                                            source, session_entry,
+                                    if _hyg_requested_rotation:
+                                        _hyg_entry = await asyncio.to_thread(
+                                            self._publish_compression_session_split,
+                                            session_key=session_key,
+                                            source=source,
+                                            previous_session_id=_hyg_old_sid,
+                                            new_session_id=_hyg_new_sid,
                                             reason="hygiene-compression",
+                                            run_generation=run_generation,
                                         )
+                                        if _hyg_entry is not None:
+                                            session_entry = _hyg_entry
+                                            _hyg_rotated = True
 
                                     # Only rewrite the transcript when rotation produced
                                     # a NEW session id OR in-place compaction succeeded.
@@ -10892,12 +11097,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self.hooks.emit("agent:start", hook_ctx)
 
             # Run the agent
+            run_start_session_id = session_entry.session_id
             agent_result = await self._run_agent(
                 message=message_text,
                 context_prompt=context_prompt,
                 history=history,
                 source=source,
-                session_id=session_entry.session_id,
+                session_id=run_start_session_id,
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
@@ -10995,16 +11201,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 response = _sanitize_gateway_final_response(source.platform, response)
 
             # Ordering contract: the agent thread already updated the contextvar
-            # in conversation_compression.py; propagate to SessionEntry + _save().
-            # If the agent's session_id changed during compression, update
-            # session_entry so transcript writes below go to the right session.
-            if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-                session_entry.session_id = agent_result["session_id"]
-                self.session_store._save()
-                await asyncio.to_thread(
-                    self._sync_telegram_topic_binding,
-                    source, session_entry, reason="agent-result-compression",
+            # in conversation_compression.py; publish any compression child as
+            # the live route before transcript writes below pick a session id.
+            rotated_session_id = str(agent_result.get("session_id") or "")
+            if rotated_session_id and rotated_session_id != session_entry.session_id:
+                published_entry = await asyncio.to_thread(
+                    self._publish_compression_session_split,
+                    session_key=session_key,
+                    source=source,
+                    previous_session_id=run_start_session_id,
+                    new_session_id=rotated_session_id,
+                    reason="agent-result-compression",
+                    run_generation=run_generation,
                 )
+                if published_entry is not None:
+                    session_entry = published_entry
 
             # Prepend reasoning/thinking if display is enabled (per-platform).
             # Mattermost requires explicit per-platform opt-in because this is
@@ -14455,8 +14666,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if session_key:
             try:
-                self.session_store._ensure_loaded()
-                entry = self.session_store._entries.get(session_key)
+                entry = self._advance_session_entry_to_compression_tip(
+                    session_key=session_key,
+                    reason="process-event-compression-tip",
+                )
                 if entry and getattr(entry, "origin", None):
                     return entry.origin
             except Exception as exc:
@@ -14516,7 +14729,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Routing must come from the queued watch event itself, not from whatever
         foreground message happened to be active when the queue was drained.
         """
-        source = self._build_process_event_source(evt)
+        source = await asyncio.to_thread(self._build_process_event_source, evt)
         if not source:
             logger.warning(
                 "Dropping watch notification with no routing metadata for process %s",
@@ -14702,15 +14915,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     })
                     if not synth_text:
                         break
-                    source = self._build_process_event_source({
-                        "session_id": session_id,
-                        "session_key": session_key,
-                        "platform": platform_name,
-                        "chat_id": chat_id,
-                        "thread_id": thread_id,
-                        "user_id": user_id,
-                        "user_name": user_name,
-                    })
+                    source = await asyncio.to_thread(
+                        self._build_process_event_source,
+                        {
+                            "session_id": session_id,
+                            "session_key": session_key,
+                            "platform": platform_name,
+                            "chat_id": chat_id,
+                            "thread_id": thread_id,
+                            "user_id": user_id,
+                            "user_name": user_name,
+                        },
+                    )
                     if not source:
                         logger.warning(
                             "Dropping completion notification with no routing metadata for process %s",
@@ -17708,10 +17924,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Session split detected: %s → %s (compression)",
                     session_id, agent_session_id,
                 )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent_session_id
-                    self.session_store._save()
 
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it
@@ -17744,10 +17956,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Failed to restore thread_id from binding after session split",
                             exc_info=True,
                         )
-                if entry:
-                    self._sync_telegram_topic_binding(
-                        source, entry, reason="agent-run-compression",
-                    )
+                self._publish_compression_session_split(
+                    session_key=session_key,
+                    source=source,
+                    previous_session_id=session_id,
+                    new_session_id=agent_session_id,
+                    reason="agent-run-compression",
+                    run_generation=run_generation,
+                )
 
             effective_session_id = agent_session_id
             self._sync_session_model_from_agent(effective_session_id, agent)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -952,30 +952,54 @@ class SessionStore:
         self._prune_stale_sessions_locked()
 
     def _prune_stale_sessions_locked(self) -> None:
-        """Remove sessions.json entries whose session has ended in state.db.
+        """Remove or repair sessions.json entries whose session ended in state.db.
 
         Called once during startup (from ``_ensure_loaded_locked``, lock held).
         A ``session_id`` is stale when state.db reports ``end_reason IS NOT
         NULL`` for it. Sessions absent from the DB (never persisted / pre-SQLite
         legacy) are left alone, and a ``None`` DB handle (SQLite unavailable) is
         a no-op. DB errors are non-fatal — startup must never fail here.
+
+        Compression-ended parents are special: they are not conversation
+        boundaries, they are handoff points.  If the entry still has its peer
+        metadata, first try to recover the live compression descendant for the
+        same route before falling back to pruning the stale parent.
         """
         db = getattr(self, "_db", None)
         if not db or not self._entries:
             return
 
         stale_keys: list = []
+        recovered_entries: dict = {}
         try:
             for key, entry in self._entries.items():
                 row = db.get_session(entry.session_id)
                 # row is None        -> not in DB (legacy / pre-SQLite) — keep
                 # end_reason is None  -> session alive — keep
-                # end_reason not None -> session ended — prune
-                if row is not None and row.get("end_reason") is not None:
+                # end_reason not None -> recover compression child or prune
+                end_reason = row.get("end_reason") if row is not None else None
+                if row is not None and end_reason is not None:
+                    origin = getattr(entry, "origin", None)
+                    if end_reason == "compression" and origin is not None:
+                        recovered = self._recover_session_from_db(
+                            session_key=key,
+                            source=origin,
+                            now=_now(),
+                        )
+                        if recovered is not None and recovered.session_id != entry.session_id:
+                            logger.warning(
+                                "gateway.session: repairing stale compression "
+                                "sessions.json entry %r -> %s as %s",
+                                key,
+                                entry.session_id,
+                                recovered.session_id,
+                            )
+                            recovered_entries[key] = recovered
+                            continue
                     logger.warning(
                         "gateway.session: pruning stale sessions.json entry "
                         "%r -> %s (end_reason=%r); left by a crashed gateway",
-                        key, entry.session_id, row["end_reason"],
+                        key, entry.session_id, end_reason,
                     )
                     stale_keys.append(key)
         except Exception as exc:
@@ -985,10 +1009,12 @@ class SessionStore:
             )
             return
 
+        for key, recovered in recovered_entries.items():
+            self._entries[key] = recovered
         for key in stale_keys:
             del self._entries[key]
 
-        if stale_keys:
+        if stale_keys or recovered_entries:
             self._save()
 
     def _save(self) -> None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3083,21 +3083,12 @@ class GatewaySlashCommandsMixin:
                     partial = False
                     head = msgs
 
-            agent_runtime_kwargs = dict(runtime_kwargs)
-            for _identity_key in (
-                "model",
-                "platform",
-                "user_id",
-                "user_id_alt",
-                "user_name",
-                "chat_id",
-                "chat_name",
-                "chat_type",
-                "thread_id",
-                "gateway_session_key",
-                "session_db",
-            ):
-                agent_runtime_kwargs.pop(_identity_key, None)
+            turn_route = self._resolve_turn_agent_config(
+                "manual /compress",
+                model,
+                runtime_kwargs,
+            )
+            agent_runtime_kwargs = dict(turn_route.get("runtime") or {})
 
             tmp_agent = AIAgent(
                 **agent_runtime_kwargs,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3054,6 +3054,7 @@ class GatewaySlashCommandsMixin:
             from run_agent import AIAgent
             from agent.manual_compression_feedback import summarize_manual_compression
             from agent.model_metadata import estimate_request_tokens_rough
+            from gateway.run import _platform_config_key
 
             session_key = self._session_key_for_source(source)
             model, runtime_kwargs = self._resolve_session_agent_runtime(
@@ -3082,14 +3083,39 @@ class GatewaySlashCommandsMixin:
                     partial = False
                     head = msgs
 
+            agent_runtime_kwargs = dict(runtime_kwargs)
+            for _identity_key in (
+                "model",
+                "platform",
+                "user_id",
+                "user_id_alt",
+                "user_name",
+                "chat_id",
+                "chat_name",
+                "chat_type",
+                "thread_id",
+                "gateway_session_key",
+                "session_db",
+            ):
+                agent_runtime_kwargs.pop(_identity_key, None)
+
             tmp_agent = AIAgent(
-                **runtime_kwargs,
+                **agent_runtime_kwargs,
                 model=model,
                 max_iterations=4,
                 quiet_mode=True,
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
+                platform=_platform_config_key(source.platform),
+                user_id=source.user_id,
+                user_id_alt=source.user_id_alt,
+                user_name=source.user_name,
+                chat_id=source.chat_id,
+                chat_name=source.chat_name,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
+                gateway_session_key=session_key,
                 session_db=getattr(self._session_db, "_db", self._session_db),
             )
             try:
@@ -3165,12 +3191,20 @@ class GatewaySlashCommandsMixin:
                             f"session {new_session_id}"
                         )
                     if rotated:
-                        session_entry.session_id = new_session_id
-                        self.session_store._save()
-                        await asyncio.to_thread(
-                            self._sync_telegram_topic_binding,
-                            source, session_entry, reason="compress-command",
+                        published_entry = await asyncio.to_thread(
+                            self._publish_compression_session_split,
+                            session_key=session_key,
+                            source=source,
+                            previous_session_id=session_entry.session_id,
+                            new_session_id=new_session_id,
+                            reason="compress-command",
                         )
+                        if published_entry is None:
+                            raise RuntimeError(
+                                f"failed to publish compressed session route "
+                                f"{session_entry.session_id} -> {new_session_id}"
+                            )
+                        session_entry = published_entry
                 else:
                     logger.warning(
                         "Manual /compress: session rotation did not occur "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2672,43 +2672,6 @@ class SessionDB:
             current = child_id
         return current
 
-    def is_session_descendant(self, ancestor_session_id: str, candidate_session_id: str) -> bool:
-        """Return True when ``candidate_session_id`` descends from ``ancestor_session_id``.
-
-        Used by gateway routing to distinguish a stale topic binding that still
-        points at a compression ancestor from an unrelated/restored session.  The
-        check walks parent links upward from the candidate, so siblings and
-        unrelated sessions never match.
-        """
-        ancestor_session_id = str(ancestor_session_id or "").strip()
-        candidate_session_id = str(candidate_session_id or "").strip()
-        if not ancestor_session_id or not candidate_session_id:
-            return False
-        if ancestor_session_id == candidate_session_id:
-            return False
-
-        current = candidate_session_id
-        seen = {current}
-        with self._lock:
-            for _ in range(100):
-                row = self._conn.execute(
-                    "SELECT parent_session_id FROM sessions WHERE id = ?",
-                    (current,),
-                ).fetchone()
-                if row is None:
-                    return False
-                parent_id = row["parent_session_id"] if hasattr(row, "keys") else row[0]
-                parent_id = str(parent_id or "").strip()
-                if not parent_id:
-                    return False
-                if parent_id == ancestor_session_id:
-                    return True
-                if parent_id in seen:
-                    return False
-                seen.add(parent_id)
-                current = parent_id
-        return False
-
     def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         """Distinct non-empty session cwds with usage stats, for repo discovery.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2672,6 +2672,43 @@ class SessionDB:
             current = child_id
         return current
 
+    def is_session_descendant(self, ancestor_session_id: str, candidate_session_id: str) -> bool:
+        """Return True when ``candidate_session_id`` descends from ``ancestor_session_id``.
+
+        Used by gateway routing to distinguish a stale topic binding that still
+        points at a compression ancestor from an unrelated/restored session.  The
+        check walks parent links upward from the candidate, so siblings and
+        unrelated sessions never match.
+        """
+        ancestor_session_id = str(ancestor_session_id or "").strip()
+        candidate_session_id = str(candidate_session_id or "").strip()
+        if not ancestor_session_id or not candidate_session_id:
+            return False
+        if ancestor_session_id == candidate_session_id:
+            return False
+
+        current = candidate_session_id
+        seen = {current}
+        with self._lock:
+            for _ in range(100):
+                row = self._conn.execute(
+                    "SELECT parent_session_id FROM sessions WHERE id = ?",
+                    (current,),
+                ).fetchone()
+                if row is None:
+                    return False
+                parent_id = row["parent_session_id"] if hasattr(row, "keys") else row[0]
+                parent_id = str(parent_id or "").strip()
+                if not parent_id:
+                    return False
+                if parent_id == ancestor_session_id:
+                    return True
+                if parent_id in seen:
+                    return False
+                seen.add(parent_id)
+                current = parent_id
+        return False
+
     def distinct_session_cwds(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         """Distinct non-empty session cwds with usage stats, for repo discovery.
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -9,6 +9,7 @@ Verifies that the agent cache correctly:
 - Preserves frozen system prompt across turns
 """
 
+import os
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -377,7 +378,12 @@ class TestExtractCacheBustingConfig:
         assert first["honcho.user_peer_aliases"] == [("123", "eri")]
         assert parse_calls == [config_path]
 
+        # Some CI filesystems keep the same mtime_ns for immediate rewrites;
+        # force a distinct timestamp so this test checks memo invalidation, not
+        # the platform's timestamp granularity.
+        next_mtime_ns = config_path.stat().st_mtime_ns + 1_000_000_000
         config_path.write_text("{\n  \"changed\": true\n}")
+        os.utime(config_path, ns=(next_mtime_ns, next_mtime_ns))
         third = GatewayRunner._extract_honcho_cache_busting_config()
 
         assert third == first

--- a/tests/gateway/test_async_session_db.py
+++ b/tests/gateway/test_async_session_db.py
@@ -149,6 +149,7 @@ _OFFLOADED_SYNC_HELPERS = frozenset({
     "_session_has_compression_in_flight",
     "_publish_compression_session_split",
     "_advance_session_entry_to_compression_tip",
+    "_telegram_topic_binding_is_restored",
     "_build_process_event_source",
 })
 

--- a/tests/gateway/test_async_session_db.py
+++ b/tests/gateway/test_async_session_db.py
@@ -145,6 +145,11 @@ _OFFLOADED_SYNC_HELPERS = frozenset({
     "_telegram_topic_new_header",
     "_schedule_telegram_topic_title_rename",
     "_apply_topic_recovery",
+    "_sync_session_model_from_agent",
+    "_session_has_compression_in_flight",
+    "_publish_compression_session_split",
+    "_advance_session_entry_to_compression_tip",
+    "_build_process_event_source",
 })
 
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from hermes_state import SessionDB
 from gateway.config import GatewayConfig, Platform
 from gateway.run import GatewayRunner, _parse_session_key
 
@@ -331,6 +332,103 @@ async def test_inject_watch_notification_advances_session_route_to_compression_t
     adapter.handle_message.assert_awaited_once()
     synth_event = adapter.handle_message.await_args.args[0]
     assert synth_event.source.thread_id == "42"
+    assert synth_event.source.user_id == "proc_owner"
+
+
+@pytest.mark.asyncio
+async def test_run_process_watcher_advances_to_compression_tip_and_preserves_restored_binding(
+    monkeypatch, tmp_path
+):
+    """notify_on_complete follows compression tips without downgrading restored topics.
+
+    This exercises the real watcher path rather than only calling
+    ``_inject_watch_notification`` directly.
+    """
+    from datetime import datetime
+
+    import tools.process_registry as pr_module
+    from gateway.session import SessionEntry, SessionSource
+
+    sessions = [SimpleNamespace(
+        output_buffer="done\n", exited=True, exit_code=0, command="sleep 1",
+    )]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="123", user_id="proc_owner")
+    session_db.create_session(
+        session_id="parent-session", source="telegram", user_id="proc_owner",
+    )
+    session_db.end_session("parent-session", end_reason="compression")
+    session_db.create_session(
+        session_id="child-session",
+        source="telegram",
+        user_id="proc_owner",
+        parent_session_id="parent-session",
+    )
+    key = "agent:main:telegram:dm:123:24296"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        thread_id="24296",
+        user_id="proc_owner",
+        user_name="alice",
+    )
+    session_db.bind_telegram_topic(
+        chat_id="123",
+        thread_id="24296",
+        user_id="proc_owner",
+        session_key=key,
+        session_id="parent-session",
+        managed_mode="restored",
+    )
+    runner._session_db = SimpleNamespace(_db=session_db)
+    entry = SessionEntry(
+        session_key=key,
+        session_id="parent-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=source,
+    )
+    runner.session_store._entries[key] = entry
+    runner.session_store._loaded = True
+    runner.session_store._record_gateway_session_peer = MagicMock()
+
+    await runner._run_process_watcher({
+        "session_id": "proc_restored",
+        "check_interval": 0,
+        "session_key": key,
+        "platform": "telegram",
+        "chat_id": "123",
+        "thread_id": "24296",
+        "user_id": "proc_owner",
+        "user_name": "alice",
+        "notify_on_complete": True,
+    })
+
+    assert entry.session_id == "child-session"
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="123", thread_id="24296",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "child-session"
+    assert binding["managed_mode"] == "restored"
+    runner.session_store._record_gateway_session_peer.assert_called_once_with(
+        "child-session", key, source
+    )
+    adapter.handle_message.assert_awaited_once()
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.internal is True
+    assert synth_event.source.thread_id == "24296"
     assert synth_event.source.user_id == "proc_owner"
 
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -9,7 +9,7 @@ Contributed by @PeterFile (PR #593), reimplemented on current main.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -281,6 +281,57 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
     assert synth_event.source.thread_id == "42"
     assert synth_event.source.user_id == "123"
     assert synth_event.source.user_name == "Emiliyan"
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_advances_session_route_to_compression_tip(monkeypatch, tmp_path):
+    from datetime import datetime
+
+    from gateway.session import SessionEntry, SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    key = "agent:main:telegram:group:-100:42"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100",
+        chat_type="group",
+        thread_id="42",
+        user_id="proc_owner",
+        user_name="alice",
+    )
+    entry = SessionEntry(
+        session_key=key,
+        session_id="parent-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+        origin=source,
+    )
+    runner.session_store._entries[key] = entry
+    runner.session_store._record_gateway_session_peer = MagicMock()
+    runner._session_db = SimpleNamespace(
+        _db=SimpleNamespace(
+            get_compression_tip=lambda session_id: (
+                "child-session" if session_id == "parent-session" else session_id
+            )
+        )
+    )
+
+    await runner._inject_watch_notification("[SYSTEM: Background process matched]", {
+        "session_id": "proc_watch",
+        "session_key": key,
+    })
+
+    assert entry.session_id == "child-session"
+    runner.session_store._record_gateway_session_peer.assert_called_once_with(
+        "child-session", key, source
+    )
+    adapter.handle_message.assert_awaited_once()
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.source.thread_id == "42"
+    assert synth_event.source.user_id == "proc_owner"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -50,10 +50,13 @@ def _make_runner(history: list[dict[str, str]]):
     )
     runner.session_store = MagicMock()
     runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store._entries = {session_entry.session_key: session_entry}
+    runner.session_store._ensure_loaded = MagicMock()
     runner.session_store.load_transcript.return_value = history
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
     runner.session_store._save = MagicMock()
+    runner.session_store._record_gateway_session_peer = MagicMock()
     runner._session_db = None
     return runner
 
@@ -295,8 +298,15 @@ async def test_compress_command_passes_session_db_and_persists_rotated_session()
 
     assert "Compressed:" in result
     mock_agent_cls.assert_called_once()
-    assert mock_agent_cls.call_args.kwargs["session_db"] is runner._session_db
+    kwargs = mock_agent_cls.call_args.kwargs
+    assert kwargs["session_db"] is runner._session_db
+    assert kwargs["platform"] == "telegram"
+    assert kwargs["gateway_session_key"] == build_session_key(_make_source())
+    assert kwargs["chat_id"] == "c1"
     runner.session_store._save.assert_called_once()
+    runner.session_store._record_gateway_session_peer.assert_called_once_with(
+        "sess-2", build_session_key(_make_source()), _make_source()
+    )
     runner.session_store.rewrite_transcript.assert_called_once_with(
         "sess-2", compressed
     )

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -21,9 +21,16 @@ class _SessionStore:
         )
         self._entries = {SESSION_KEY: self.entry}
         self.save_calls = 0
+        self.peer_records = []
+
+    def _ensure_loaded(self):
+        return None
 
     def _save(self):
         self.save_calls += 1
+
+    def _record_gateway_session_peer(self, session_id, session_key, source):
+        self.peer_records.append((session_id, session_key, source))
 
 
 class _CompressionThenFailureAgent:
@@ -155,6 +162,35 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     assert result["history_offset"] == 0
     assert session_store.entry.session_id == "session-after-compression"
     assert session_store.save_calls == 1
+    assert session_store.peer_records == [
+        ("session-after-compression", SESSION_KEY, source)
+    ]
     runner._sync_telegram_topic_binding.assert_called_once_with(
         source, session_store.entry, reason="agent-run-compression"
     )
+
+
+def test_stale_generation_cannot_publish_compression_split():
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    runner._session_run_generation = {SESSION_KEY: 2}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+    result = runner._publish_compression_session_split(
+        session_key=SESSION_KEY,
+        source=source,
+        previous_session_id="session-before-compression",
+        new_session_id="late-compressed-child",
+        reason="unit-test",
+        run_generation=1,
+    )
+
+    assert result is None
+    assert session_store.entry.session_id == "session-before-compression"
+    assert session_store.save_calls == 0
+    assert session_store.peer_records == []

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -194,3 +194,30 @@ def test_stale_generation_cannot_publish_compression_split():
     assert session_store.entry.session_id == "session-before-compression"
     assert session_store.save_calls == 0
     assert session_store.peer_records == []
+
+
+def test_moved_active_binding_cannot_publish_late_compression_split():
+    session_store = _SessionStore()
+    session_store.entry.session_id = "fresh-session-after-new"
+    runner = _runner(session_store)
+    runner._session_run_generation = {SESSION_KEY: 1}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+    result = runner._publish_compression_session_split(
+        session_key=SESSION_KEY,
+        source=source,
+        previous_session_id="session-before-compression",
+        new_session_id="late-compressed-child",
+        reason="unit-test",
+        run_generation=1,
+    )
+
+    assert result is None
+    assert session_store.entry.session_id == "fresh-session-after-new"
+    assert session_store.save_calls == 0
+    assert session_store.peer_records == []

--- a/tests/gateway/test_compression_session_id_persistence.py
+++ b/tests/gateway/test_compression_session_id_persistence.py
@@ -125,7 +125,6 @@ class TestCompressionSessionPropagation:
             new_session_id=new_sid,
             reason="test",
             run_generation=1,
-            sync_topic=False,
         )
 
         assert published is session_entry
@@ -154,7 +153,6 @@ class TestCompressionSessionPropagation:
             new_session_id=same_sid,
             reason="test",
             run_generation=1,
-            sync_topic=False,
         )
 
         assert published is None
@@ -180,7 +178,6 @@ class TestCompressionSessionPropagation:
             new_session_id=new_sid,
             reason="test",
             run_generation=1,
-            sync_topic=False,
         )
 
         contextvar_sid = get_session_env("HERMES_SESSION_ID", "")

--- a/tests/gateway/test_compression_session_id_persistence.py
+++ b/tests/gateway/test_compression_session_id_persistence.py
@@ -1,20 +1,13 @@
-"""Regression tests for #29335 — gateway must persist ``session_entry.session_id``
-after the agent's compression path mutates it.
+"""Regression tests for #29335 — gateway must persist compression session splits.
 
 When ``_compress_context()`` rolls the agent forward into a new session, the
-agent now returns the new ``session_id`` in its result dict. The gateway
-updates ``session_entry.session_id`` in memory AND must call
-``session_store._save()`` so the new mapping survives a gateway restart.
-Without ``_save()``, the next turn loads the OLD session's transcript and
-re-triggers compression forever.
+agent returns the new ``session_id`` in its result dict. The gateway must publish
+that child through one durability helper, update the live routing entry, call
+``session_store._save()``, and preserve gateway peer metadata so the mapping
+survives restarts and background notifications.
 
-Three sites in ``gateway/run.py`` mutate ``session_entry.session_id`` after
-a compression-induced session split. All three MUST be followed by a
-``_save()`` call. This test pins that invariant.
-
-``TestCompressionSessionPropagation`` adds behavioral tests that exercise the
-actual propagation path inline, verifying that the mock session_entry update
-and _save() semantics are correct without requiring a live gateway.
+Without the durable publish step, the next turn loads the OLD session's
+transcript and re-triggers compression forever.
 """
 
 from __future__ import annotations
@@ -28,20 +21,13 @@ from gateway import run as gateway_run
 from gateway.session_context import set_current_session_id, get_session_env
 
 
-def _session_id_assignments_followed_by_save(source: str) -> list[tuple[int, bool]]:
-    """For each ``session_entry.session_id = ...`` assignment in *source*,
-    return ``(lineno, saved_within_5_stmts)`` — True iff a
-    ``self.session_store._save()`` call appears in the same block within the
-    next 5 statements (covers normal control flow without false-flagging
-    cleanup that lives 200 lines away).
-    """
+def _session_entry_assignments(source: str) -> list[int]:
+    """Return line numbers for direct ``session_entry.session_id = ...`` writes."""
     tree = ast.parse(textwrap.dedent(source))
-    results: list[tuple[int, bool]] = []
+    results: list[int] = []
 
     class _Visitor(ast.NodeVisitor):
-        def _is_session_id_assign(self, node: ast.AST) -> bool:
-            if not isinstance(node, ast.Assign):
-                return False
+        def visit_Assign(self, node: ast.Assign) -> None:
             for target in node.targets:
                 if (
                     isinstance(target, ast.Attribute)
@@ -49,122 +35,100 @@ def _session_id_assignments_followed_by_save(source: str) -> list[tuple[int, boo
                     and isinstance(target.value, ast.Name)
                     and target.value.id == "session_entry"
                 ):
-                    return True
-            return False
-
-        def _block_has_save_after(self, body: list[ast.stmt], idx: int) -> bool:
-            for stmt in body[idx : idx + 6]:
-                for sub in ast.walk(stmt):
-                    if (
-                        isinstance(sub, ast.Call)
-                        and isinstance(sub.func, ast.Attribute)
-                        and sub.func.attr == "_save"
-                    ):
-                        return True
-            return False
-
-        def _walk_body(self, body: list[ast.stmt]) -> None:
-            for i, stmt in enumerate(body):
-                if self._is_session_id_assign(stmt):
-                    results.append((stmt.lineno, self._block_has_save_after(body, i)))
-                for child in ast.iter_child_nodes(stmt):
-                    if isinstance(child, (ast.If, ast.For, ast.While, ast.With,
-                                          ast.Try, ast.AsyncWith, ast.AsyncFor)):
-                        self._walk_node(child)
-
-        def _walk_node(self, node: ast.AST) -> None:
-            for attr in ("body", "orelse", "finalbody"):
-                inner = getattr(node, attr, None)
-                if isinstance(inner, list):
-                    self._walk_body(inner)
-            if hasattr(node, "handlers"):
-                for handler in node.handlers:
-                    self._walk_body(handler.body)
-
-        def visit(self, node: ast.AST) -> None:
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                self._walk_body(node.body)
-            for child in ast.iter_child_nodes(node):
-                self.visit(child)
+                    results.append(node.lineno)
+            self.generic_visit(node)
 
     _Visitor().visit(tree)
     return results
 
 
-def test_every_post_compression_session_id_assignment_persists():
-    """Every ``session_entry.session_id = ...`` in gateway/run.py must be
-    followed by a ``session_store._save()`` call within the same block.
+def _helper_persists_entry_assignment(source: str) -> bool:
+    """Return True iff the publish helper writes ``entry.session_id`` and saves."""
+    tree = ast.parse(textwrap.dedent(source))
+    assigned = False
+    saved = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "session_id"
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "entry"
+                ):
+                    assigned = True
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_save"
+        ):
+            saved = True
+    return assigned and saved
 
-    Regression for #29335 — the assignment at the end of
-    ``_handle_message_with_agent`` used to skip ``_save()`` while two sibling
-    sites (hygiene rewrite, manual /compress) already persisted. The agent
-    would compress correctly, the gateway would update its in-memory
-    session_id, then drop it on next gateway restart.
+
+def test_compression_session_id_publishing_is_centralized_and_persisted():
+    """Compression route mutation must go through the durable publish helper.
+
+    Regression for #29335 and follow-ons: direct ``session_entry.session_id``
+    writes are easy to forget to save or to race with stale generations. The
+    helper performs the generation guard, active-route guard, save, peer record,
+    and topic binding refresh in one place.
     """
     source = inspect.getsource(gateway_run)
-    assignments = _session_id_assignments_followed_by_save(source)
-    assert assignments, (
-        "No ``session_entry.session_id = ...`` assignments found in gateway/run.py — "
-        "either the structure changed or the AST walker is broken."
+    helper_source = inspect.getsource(
+        gateway_run.GatewayRunner._publish_compression_session_split
     )
-    missing = [lineno for lineno, saved in assignments if not saved]
-    assert not missing, (
-        f"{len(missing)} ``session_entry.session_id = ...`` site(s) in gateway/run.py "
-        f"are not followed by ``session_store._save()`` within the same block "
-        f"(lines: {missing}). Every post-compression session_id update must persist "
-        f"or the next turn loads the pre-compression transcript and triggers an "
-        f"infinite compression loop. See issue #29335."
+
+    assert _helper_persists_entry_assignment(helper_source), (
+        "_publish_compression_session_split() must assign the live entry's "
+        "session_id and call _save() so compression children survive restarts."
+    )
+
+    direct_assignments = _session_entry_assignments(source)
+    assert not direct_assignments, (
+        "Compression session id publication must be centralized in "
+        "_publish_compression_session_split(); direct session_entry.session_id "
+        f"assignments found at gateway/run.py AST lines {direct_assignments}."
     )
 
 
 class TestCompressionSessionPropagation:
-    """Behavioral tests for post-compression session_id propagation.
+    """Behavioral tests for durable compression session publication."""
 
-    The structural AST test above pins that every ``session_entry.session_id``
-    assignment in gateway/run.py is followed by ``_save()``.  These tests
-    exercise the *behavior* of that propagation path inline, using mocks that
-    mirror the objects gateway/run.py works with (``session_entry`` and
-    ``session_store``), verifying the semantics are correct without requiring a
-    live gateway instance.
-
-    Ordering contract (from the comments added to the source in this PR):
-    1. The agent thread updates the contextvar in ``conversation_compression.py``
-       via ``set_current_session_id(agent.session_id)``.
-    2. After ``run_in_executor`` returns, the gateway propagates the new id to
-       ``session_entry.session_id`` and calls ``session_store._save()``.
-    Both halves must agree for the next turn to route correctly.
-    """
+    def _runner_with_entry(self, session_key: str, session_entry: MagicMock):
+        runner = object.__new__(gateway_run.GatewayRunner)
+        session_store = MagicMock()
+        session_store._entries = {session_key: session_entry}
+        session_store._ensure_loaded = MagicMock()
+        session_store._save = MagicMock()
+        session_store._record_gateway_session_peer = MagicMock()
+        runner.session_store = session_store
+        runner._is_session_run_current = MagicMock(return_value=True)
+        runner._sync_telegram_topic_binding = MagicMock()
+        return runner, session_store
 
     def test_gateway_session_entry_follows_compression_rotation(self) -> None:
-        """The gateway handler must update session_entry and call _save() when
-        the agent result carries a rotated session_id.
-
-        Simulates the inline propagation block in gateway/run.py:
-
-            if agent_result.get("session_id") and \\
-                    agent_result["session_id"] != session_entry.session_id:
-                session_entry.session_id = agent_result["session_id"]
-                self.session_store._save()
-
-        Verifies that session_entry.session_id is mutated and _save is called
-        exactly once — the minimal contract that prevents the restart-loop bug.
-        """
+        """The publish helper must update the live entry and persist it."""
         old_sid = "20260101_000000_aaaaaa"
         new_sid = "20260101_000001_bbbbbb"
+        session_key = "agent:main:telegram:dm:123"
 
         session_entry = MagicMock()
         session_entry.session_id = old_sid
+        session_entry.origin = None
+        runner, session_store = self._runner_with_entry(session_key, session_entry)
 
-        session_store = MagicMock()
+        published = runner._publish_compression_session_split(
+            session_key=session_key,
+            source=None,
+            previous_session_id=old_sid,
+            new_session_id=new_sid,
+            reason="test",
+            run_generation=1,
+            sync_topic=False,
+        )
 
-        agent_result = {"session_id": new_sid, "response": "hello"}
-
-        # Inline the propagation logic exactly as it appears in gateway/run.py
-        # (around line 9459). This is the behavior we are pinning.
-        if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-            session_entry.session_id = agent_result["session_id"]
-            session_store._save()
-
+        assert published is session_entry
         assert session_entry.session_id == new_sid, (
             "session_entry.session_id was not updated to the compressed session id. "
             "The next turn would load the old transcript and re-trigger compression."
@@ -175,57 +139,49 @@ class TestCompressionSessionPropagation:
         )
 
     def test_no_update_when_session_id_unchanged(self) -> None:
-        """The propagation block must be a no-op when the agent did not compress.
-
-        If the agent returns the same session_id (normal turn, no compression),
-        session_entry must not be touched and _save must not be called — avoiding
-        spurious writes on every turn.
-        """
+        """Publishing the same session id is a no-op."""
         same_sid = "20260101_000000_aaaaaa"
+        session_key = "agent:main:telegram:dm:123"
 
         session_entry = MagicMock()
         session_entry.session_id = same_sid
+        runner, session_store = self._runner_with_entry(session_key, session_entry)
 
-        session_store = MagicMock()
+        published = runner._publish_compression_session_split(
+            session_key=session_key,
+            source=None,
+            previous_session_id=same_sid,
+            new_session_id=same_sid,
+            reason="test",
+            run_generation=1,
+            sync_topic=False,
+        )
 
-        # Normal turn: agent returns same session_id (or none at all)
-        agent_result = {"response": "hello"}  # no "session_id" key
-
-        if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-            session_entry.session_id = agent_result["session_id"]
-            session_store._save()
-
-        # session_entry.session_id was set during mock construction; the
-        # propagation block must not have set it again.
+        assert published is None
+        assert session_entry.session_id == same_sid
         session_store._save.assert_not_called()
 
     def test_contextvar_and_session_entry_agree_after_compression(self) -> None:
-        """After compression, the contextvar and session_entry must carry the
-        same session_id.
-
-        The agent thread calls ``set_current_session_id(new_sid)`` inside
-        ``conversation_compression.py`` (step 1).  The gateway then propagates
-        ``new_sid`` to ``session_entry.session_id`` (step 2).  If either step
-        is missing, tool calls and transcript writes will disagree on which
-        session is active.
-
-        This test simulates both steps and asserts agreement.
-        """
+        """After compression, the contextvar and live entry should agree."""
         old_sid = "20260101_000000_cccccc"
         new_sid = "20260101_000002_dddddd"
+        session_key = "agent:main:telegram:dm:123"
 
-        # Step 1: agent thread updates contextvar (mirrors conversation_compression.py
-        # around line 511-513)
         set_current_session_id(new_sid)
-
-        # Step 2: gateway propagates to session_entry (mirrors gateway/run.py
-        # around line 9459-9461)
         session_entry = MagicMock()
         session_entry.session_id = old_sid
-        agent_result = {"session_id": new_sid}
+        session_entry.origin = None
+        runner, _session_store = self._runner_with_entry(session_key, session_entry)
 
-        if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-            session_entry.session_id = agent_result["session_id"]
+        runner._publish_compression_session_split(
+            session_key=session_key,
+            source=None,
+            previous_session_id=old_sid,
+            new_session_id=new_sid,
+            reason="test",
+            run_generation=1,
+            sync_topic=False,
+        )
 
         contextvar_sid = get_session_env("HERMES_SESSION_ID", "")
         assert contextvar_sid == new_sid, (

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -12,14 +12,14 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from gateway.config import GatewayConfig, Platform, SessionResetPolicy
-from gateway.session import SessionEntry, SessionStore
+from gateway.session import SessionEntry, SessionSource, SessionStore
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_entry(key: str, session_id: str) -> SessionEntry:
+def _make_entry(key: str, session_id: str, **kwargs) -> SessionEntry:
     now = datetime.now()
     return SessionEntry(
         session_key=key,
@@ -28,6 +28,7 @@ def _make_entry(key: str, session_id: str) -> SessionEntry:
         updated_at=now - timedelta(hours=1),
         platform=Platform.TELEGRAM,
         chat_type="dm",
+        **kwargs,
     )
 
 
@@ -45,6 +46,8 @@ def _db_returning(rows: dict) -> MagicMock:
     """SessionDB mock where get_session maps session_id -> row dict."""
     db = MagicMock()
     db.get_session.side_effect = lambda sid: rows.get(sid)
+    db.find_latest_gateway_session_for_peer.return_value = None
+    db.reopen_session.return_value = None
     return db
 
 
@@ -145,6 +148,37 @@ class TestPruneStaleSessionsLocked:
         with patch.object(store, "_save") as mock_save:
             store._prune_stale_sessions_locked()
             mock_save.assert_not_called()
+
+    def test_repairs_compression_parent_to_recovered_child(self, tmp_path):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            user_id="123",
+        )
+        key = "agent:main:telegram:dm:123"
+        db = _db_returning({"parent": {"end_reason": "compression", "id": "parent"}})
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "child",
+            "started_at": (datetime.now() - timedelta(minutes=5)).timestamp(),
+        }
+        store = _make_store_with_db(tmp_path, db)
+        store._entries[key] = _make_entry(key, "parent", origin=source)
+
+        with patch.object(store, "_save") as mock_save:
+            store._prune_stale_sessions_locked()
+
+        assert store._entries[key].session_id == "child"
+        db.find_latest_gateway_session_for_peer.assert_called_once_with(
+            source="telegram",
+            user_id="123",
+            session_key=key,
+            chat_id="123",
+            chat_type="dm",
+            thread_id=None,
+        )
+        db.reopen_session.assert_called_once_with("child")
+        mock_save.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -591,22 +591,6 @@ async def test_restored_topic_binding_does_not_follow_compression_tip(tmp_path, 
     assert binding["managed_mode"] == "restored"
 
 
-def test_is_session_descendant_handles_direct_multihop_and_siblings(tmp_path):
-    db = SessionDB(db_path=tmp_path / "state.db")
-    db.create_session(session_id="root", source="telegram")
-    db.create_session(session_id="child", source="telegram", parent_session_id="root")
-    db.create_session(session_id="grandchild", source="telegram", parent_session_id="child")
-    db.create_session(session_id="sibling", source="telegram", parent_session_id="root")
-    db.create_session(session_id="unrelated", source="telegram")
-
-    assert db.is_session_descendant("root", "child") is True
-    assert db.is_session_descendant("root", "grandchild") is True
-    assert db.is_session_descendant("child", "grandchild") is True
-    assert db.is_session_descendant("child", "sibling") is False
-    assert db.is_session_descendant("root", "unrelated") is False
-    assert db.is_session_descendant("root", "root") is False
-
-
 @pytest.mark.asyncio
 async def test_topic_root_command_explicitly_migrates_and_enables_topic_mode(tmp_path, monkeypatch):
     import gateway.run as gateway_run

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -536,6 +536,78 @@ async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_restored_topic_binding_does_not_follow_compression_tip(tmp_path, monkeypatch):
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="restored-parent", source="telegram", user_id="208214988",
+    )
+    session_db.end_session("restored-parent", end_reason="compression")
+    session_db.create_session(
+        session_id="restored-child",
+        source="telegram",
+        user_id="208214988",
+        parent_session_id="restored-parent",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=topic_key,
+        session_id="restored-parent",
+        managed_mode="restored",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    captured = {}
+
+    async def fake_run_agent(*args, **kwargs):
+        captured["session_id"] = kwargs.get("session_id")
+        return {
+            "success": True,
+            "final_response": "restored response",
+            "session_id": kwargs.get("session_id"),
+            "messages": [],
+        }
+
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("continue restored", thread_id="17585"))
+
+    assert result == "restored response"
+    assert captured["session_id"] == "restored-parent"
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "restored-parent"
+    assert binding["managed_mode"] == "restored"
+
+
+def test_is_session_descendant_handles_direct_multihop_and_siblings(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="root", source="telegram")
+    db.create_session(session_id="child", source="telegram", parent_session_id="root")
+    db.create_session(session_id="grandchild", source="telegram", parent_session_id="child")
+    db.create_session(session_id="sibling", source="telegram", parent_session_id="root")
+    db.create_session(session_id="unrelated", source="telegram")
+
+    assert db.is_session_descendant("root", "child") is True
+    assert db.is_session_descendant("root", "grandchild") is True
+    assert db.is_session_descendant("child", "grandchild") is True
+    assert db.is_session_descendant("child", "sibling") is False
+    assert db.is_session_descendant("root", "unrelated") is False
+    assert db.is_session_descendant("root", "root") is False
+
+
+@pytest.mark.asyncio
 async def test_topic_root_command_explicitly_migrates_and_enables_topic_mode(tmp_path, monkeypatch):
     import gateway.run as gateway_run
 


### PR DESCRIPTION
## Summary

Compressed gateway sessions now stay attached to the conversation that created them instead of letting stale routes or late background notifications fall back to an older live session. `state.db` remains the canonical lineage store, while `sessions.json` is treated as a repairable routing index that can be advanced to the current compression tip when the active route still matches the expected parent.

This fixes the incident class where Telegram topic metadata was lost across compression, then a process/delegation notification re-entered the wrong session. Manual `/compress`, automatic compression, stale-route recovery, Telegram topic healing, and synthetic process/delegation delivery now all preserve gateway identity and avoid overwriting explicit restored topic bindings.

| Area | Before | Now |
|---|---|---|
| Compression child routing | Child sessions could miss durable gateway metadata | Route publication saves the compression child and records peer metadata |
| Stale `sessions.json` entries | Ended compression parents could be dropped and replaced by the wrong live session | Compression-ended parents resolve through `state.db` to the current compression tip |
| Background/delegation notifications | Late events could target the pre-compression parent or old topic session | Event-source resolution is offloaded and repairs to the compression tip before delivery |
| Telegram topic restore | Auto-repair could treat generic descendants as canonical | Only compression lineage is followed, and restored bindings stay restored |
| Manual `/compress` | Temporary compressor agent could lose platform/session identity | Compressor construction reuses the normal turn runtime config and passes explicit gateway identity |

## Tests

- `python3 -m py_compile gateway/run.py gateway/session.py gateway/slash_commands.py hermes_state.py tests/gateway/test_agent_cache.py tests/gateway/test_async_session_db.py tests/gateway/test_background_process_notifications.py tests/gateway/test_compress_command.py tests/gateway/test_compression_failure_session_sync.py tests/gateway/test_compression_session_id_persistence.py tests/gateway/test_session_store_stale_prune.py tests/gateway/test_telegram_topic_mode.py`
- `ruff check gateway/run.py gateway/session.py gateway/slash_commands.py hermes_state.py tests/gateway/test_agent_cache.py tests/gateway/test_async_session_db.py tests/gateway/test_background_process_notifications.py tests/gateway/test_compress_command.py tests/gateway/test_compression_failure_session_sync.py tests/gateway/test_compression_session_id_persistence.py tests/gateway/test_session_store_stale_prune.py tests/gateway/test_telegram_topic_mode.py`
- `git diff --check origin/main..HEAD`
- `HOME=/home/deploy scripts/run_tests.sh tests/gateway -q` — 420 files, 8577 tests passed, 0 failed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.5](https://img.shields.io/badge/GPT_5.5-000000)