### PR TITLE
fix(cli): harden profile cloning against dangling skill symlinks

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -142,6 +142,20 @@ def has_bundled_skills_opt_out(profile_dir: Path) -> bool:
         return False
 
 
+def _ignore_dangling_symlinks(directory: str, names: List[str]) -> List[str]:
+    """Return symlink entries in *directory* whose targets no longer exist."""
+    ignored: list[str] = []
+    base = Path(directory)
+    for name in names:
+        path = base / name
+        try:
+            if path.is_symlink() and not path.exists():
+                ignored.append(name)
+        except OSError:
+            ignored.append(name)
+    return ignored
+
+
 def _clone_all_copytree_ignore(source_dir: Path):
     """Exclude infrastructure artifacts when cloning a profile via --clone-all.
 
@@ -167,7 +181,7 @@ def _clone_all_copytree_ignore(source_dir: Path):
     is_default_source = source_resolved == _get_default_hermes_home().resolve()
 
     def _ignore(directory: str, names: List[str]) -> List[str]:
-        ignored: list[str] = []
+        ignored: list[str] = _ignore_dangling_symlinks(directory, names)
         for entry in names:
             # Universal exclusions at any depth.
             if (
@@ -1076,7 +1090,12 @@ def create_profile(
             # same agent capabilities as the source profile.
             source_skills = source_dir / "skills"
             if source_skills.is_dir():
-                shutil.copytree(source_skills, profile_dir / "skills", dirs_exist_ok=True)
+                shutil.copytree(
+                    source_skills,
+                    profile_dir / "skills",
+                    dirs_exist_ok=True,
+                    ignore=_ignore_dangling_symlinks,
+                )
 
             # Clone memory and other subdirectory files
             for relpath in _CLONE_SUBDIR_FILES:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -20,6 +20,7 @@ Usage::
 """
 
 import json
+import logging
 import os
 import re
 import shlex
@@ -33,6 +34,8 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+
+logger = logging.getLogger(__name__)
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
@@ -154,6 +157,20 @@ def _ignore_dangling_symlinks(directory: str, names: List[str]) -> List[str]:
         except OSError:
             ignored.append(name)
     return ignored
+
+
+def _cleanup_partial_profile(profile_dir: Path) -> None:
+    """Best-effort removal of a profile directory created by a failed create."""
+    try:
+        shutil.rmtree(profile_dir)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning(
+            "Could not remove partial profile directory %s after creation failure: %s",
+            profile_dir,
+            exc,
+        )
 
 
 def _clone_all_copytree_ignore(source_dir: Path):
@@ -1051,132 +1068,140 @@ def create_profile(
                 f"Source profile '{clone_from or 'active'}' does not exist at {source_dir}"
             )
 
-    if clone_all and source_dir:
-        # Full copy of source profile (exclude sibling ~/.hermes/profiles/)
-        shutil.copytree(
-            source_dir,
-            profile_dir,
-            ignore=_clone_all_copytree_ignore(source_dir),
-        )
-        # Strip runtime files
-        for stale in _CLONE_ALL_STRIP:
-            (profile_dir / stale).unlink(missing_ok=True)
-    else:
-        # Bootstrap directory structure
-        profile_dir.mkdir(parents=True, exist_ok=True)
-        for subdir in _PROFILE_DIRS:
-            (profile_dir / subdir).mkdir(parents=True, exist_ok=True)
-
-        # Clone config files from source
-        if source_dir is not None:
-            for filename in _CLONE_CONFIG_FILES:
-                src = source_dir / filename
-                if src.exists():
-                    dst = profile_dir / filename
-                    shutil.copy2(src, dst)
-                    # Tighten .env to owner-only after copy. shutil.copy2
-                    # preserves source mode bits, but if the source's .env
-                    # was loose (host umask 0o022 leaving 0o644), tighten
-                    # explicitly so the clone doesn't inherit weak perms.
-                    if filename == ".env":
-                        try:
-                            os.chmod(str(dst), 0o600)
-                        except OSError:
-                            pass
-
-            # Clone installed skills from the source profile. The dashboard's
-            # "clone from default" flow is expected to preserve both bundled
-            # and user-installed skills so the new profile immediately has the
-            # same agent capabilities as the source profile.
-            source_skills = source_dir / "skills"
-            if source_skills.is_dir():
-                shutil.copytree(
-                    source_skills,
-                    profile_dir / "skills",
-                    dirs_exist_ok=True,
-                    ignore=_ignore_dangling_symlinks,
-                )
-
-            # Clone memory and other subdirectory files
-            for relpath in _CLONE_SUBDIR_FILES:
-                src = source_dir / relpath
-                if src.exists():
-                    dst = profile_dir / relpath
-                    dst.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(src, dst)
-
-    # Seed an empty .env so the profile has its own credentials file from
-    # day one. Without it, profile-scoped env writes (dashboard Channels /
-    # Keys pages, `hermes -p <name> auth add`) had no file until first
-    # write, and the profile silently inherited API keys from the shell
-    # environment — users reasonably read that as "the new profile reads
-    # the root .env". Skipped when --clone/--clone-all already copied one.
-    env_path = profile_dir / ".env"
-    if not env_path.exists():
-        try:
-            env_path.write_text(
-                "# Per-profile secrets for this Hermes profile.\n"
-                "# API keys and tokens set here override the shell environment.\n"
-                "# Behavioral settings belong in config.yaml, not here.\n",
-                encoding="utf-8",
-            )
-            os.chmod(str(env_path), 0o600)
-        except OSError:
-            pass  # best-effort — save_env_value creates the file on demand
-
-    # Seed a default SOUL.md so the user has a file to customize immediately.
-    # Skipped when the profile already has one (from --clone / --clone-all).
-    soul_path = profile_dir / "SOUL.md"
-    if not soul_path.exists():
-        try:
-            from hermes_cli.default_soul import DEFAULT_SOUL_MD
-            soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
-        except Exception:
-            pass  # best-effort — don't fail profile creation over this
-
-    # Write the opt-out marker so seed_profile_skills() and `hermes update`'s
-    # all-profile sync loop both skip this profile for bundled-skill seeding.
-    if no_skills:
-        try:
-            (profile_dir / NO_BUNDLED_SKILLS_MARKER).write_text(
-                "This profile opted out of bundled-skill seeding "
-                "(`hermes profile create --no-skills`).\n"
-                "Delete this file to re-enable sync on the next `hermes update`.\n",
-                encoding="utf-8",
-            )
-        except OSError:
-            pass  # best-effort — the feature still works via the empty skills/ dir
-
-    # Cloned configs can be older than the running Hermes (or predate schema
-    # tracking entirely). Migrate config-only clones immediately so
-    # desktop/status surfaces don't warn that a just-created profile is
-    # v0/outdated. Leave --clone-all snapshots byte-for-byte apart from the
-    # explicit runtime/history stripping above.
-    if not clone_all:
-        _migrate_profile_config_if_outdated(profile_dir)
-
-    # Persist description if the caller provided one. Done last so a
-    # partial-create failure doesn't strand a description file in an
-    # incomplete profile.
-    if description and description.strip():
-        try:
-            write_profile_meta(
+    creation_started = False
+    try:
+        if clone_all and source_dir:
+            creation_started = True
+            # Full copy of source profile (exclude sibling ~/.hermes/profiles/)
+            shutil.copytree(
+                source_dir,
                 profile_dir,
-                description=description.strip(),
-                description_auto=False,
+                ignore=_clone_all_copytree_ignore(source_dir),
             )
-        except Exception:
-            pass  # non-fatal — user can describe later with `hermes profile describe`
+            # Strip runtime files
+            for stale in _CLONE_ALL_STRIP:
+                (profile_dir / stale).unlink(missing_ok=True)
+        else:
+            # Bootstrap directory structure
+            profile_dir.mkdir(parents=True, exist_ok=True)
+            creation_started = True
+            for subdir in _PROFILE_DIRS:
+                (profile_dir / subdir).mkdir(parents=True, exist_ok=True)
 
-    # Phase 4: when running inside a container under s6, register the
-    # new profile's gateway as a runtime s6 service so
-    # `hermes -p <profile> gateway start` can supervise it via
-    # `s6-svc -u` instead of spawning a bare process. On host (systemd
-    # / launchd / windows) this is a no-op — the existing per-profile
-    # unit-generation paths handle gateway lifecycle.
-    _maybe_register_gateway_service(canon)
+            # Clone config files from source
+            if source_dir is not None:
+                for filename in _CLONE_CONFIG_FILES:
+                    src = source_dir / filename
+                    if src.exists():
+                        dst = profile_dir / filename
+                        shutil.copy2(src, dst)
+                        # Tighten .env to owner-only after copy. shutil.copy2
+                        # preserves source mode bits, but if the source's .env
+                        # was loose (host umask 0o022 leaving 0o644), tighten
+                        # explicitly so the clone doesn't inherit weak perms.
+                        if filename == ".env":
+                            try:
+                                os.chmod(str(dst), 0o600)
+                            except OSError:
+                                pass
 
-    return profile_dir
+                # Clone installed skills from the source profile. The dashboard's
+                # "clone from default" flow is expected to preserve both bundled
+                # and user-installed skills so the new profile immediately has the
+                # same agent capabilities as the source profile.
+                source_skills = source_dir / "skills"
+                if source_skills.is_dir():
+                    shutil.copytree(
+                        source_skills,
+                        profile_dir / "skills",
+                        dirs_exist_ok=True,
+                        ignore=_ignore_dangling_symlinks,
+                    )
+
+                # Clone memory and other subdirectory files
+                for relpath in _CLONE_SUBDIR_FILES:
+                    src = source_dir / relpath
+                    if src.exists():
+                        dst = profile_dir / relpath
+                        dst.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(src, dst)
+
+        # Seed an empty .env so the profile has its own credentials file from
+        # day one. Without it, profile-scoped env writes (dashboard Channels /
+        # Keys pages, `hermes -p <name> auth add`) had no file until first
+        # write, and the profile silently inherited API keys from the shell
+        # environment — users reasonably read that as "the new profile reads
+        # the root .env". Skipped when --clone/--clone-all already copied one.
+        env_path = profile_dir / ".env"
+        if not env_path.exists():
+            try:
+                env_path.write_text(
+                    "# Per-profile secrets for this Hermes profile.\n"
+                    "# API keys and tokens set here override the shell environment.\n"
+                    "# Behavioral settings belong in config.yaml, not here.\n",
+                    encoding="utf-8",
+                )
+                os.chmod(str(env_path), 0o600)
+            except OSError:
+                pass  # best-effort — save_env_value creates the file on demand
+
+        # Seed a default SOUL.md so the user has a file to customize immediately.
+        # Skipped when the profile already has one (from --clone / --clone-all).
+        soul_path = profile_dir / "SOUL.md"
+        if not soul_path.exists():
+            try:
+                from hermes_cli.default_soul import DEFAULT_SOUL_MD
+                soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
+            except Exception:
+                pass  # best-effort — don't fail profile creation over this
+
+        # Write the opt-out marker so seed_profile_skills() and `hermes update`'s
+        # all-profile sync loop both skip this profile for bundled-skill seeding.
+        if no_skills:
+            try:
+                (profile_dir / NO_BUNDLED_SKILLS_MARKER).write_text(
+                    "This profile opted out of bundled-skill seeding "
+                    "(`hermes profile create --no-skills`).\n"
+                    "Delete this file to re-enable sync on the next `hermes update`.\n",
+                    encoding="utf-8",
+                )
+            except OSError:
+                pass  # best-effort — the feature still works via the empty skills/ dir
+
+        # Cloned configs can be older than the running Hermes (or predate schema
+        # tracking entirely). Migrate config-only clones immediately so
+        # desktop/status surfaces don't warn that a just-created profile is
+        # v0/outdated. Leave --clone-all snapshots byte-for-byte apart from the
+        # explicit runtime/history stripping above.
+        if not clone_all:
+            _migrate_profile_config_if_outdated(profile_dir)
+
+        # Persist description if the caller provided one. Done last so a
+        # partial-create failure doesn't strand a description file in an
+        # incomplete profile.
+        if description and description.strip():
+            try:
+                write_profile_meta(
+                    profile_dir,
+                    description=description.strip(),
+                    description_auto=False,
+                )
+            except Exception:
+                pass  # non-fatal — user can describe later with `hermes profile describe`
+
+        # Phase 4: when running inside a container under s6, register the
+        # new profile's gateway as a runtime s6 service so
+        # `hermes -p <profile> gateway start` can supervise it via
+        # `s6-svc -u` instead of spawning a bare process. On host (systemd
+        # / launchd / windows) this is a no-op — the existing per-profile
+        # unit-generation paths handle gateway lifecycle.
+        _maybe_register_gateway_service(canon)
+
+        return profile_dir
+    except Exception:
+        if creation_started and profile_dir.exists():
+            _cleanup_partial_profile(profile_dir)
+        raise
 
 
 def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict]:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -249,6 +249,27 @@ class TestCreateProfile:
             / "SKILL.md"
         ).read_text() == "---\nname: installed-skill\n---\n"
 
+    def test_clone_config_skips_dangling_skill_symlinks(self, profile_env):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        skills_dir = default_home / "skills"
+        valid_skill = skills_dir / "valid-skill"
+        valid_skill.mkdir(parents=True)
+        (valid_skill / "SKILL.md").write_text("---\nname: valid-skill\n---\n")
+        linked_skill = skills_dir / "linked-skill"
+        dangling = skills_dir / "missing-plugin-skill"
+        try:
+            linked_skill.symlink_to("valid-skill")
+            dangling.symlink_to("missing-plugin-skill")
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        assert (profile_dir / "skills" / "valid-skill" / "SKILL.md").exists()
+        assert (profile_dir / "skills" / "linked-skill" / "SKILL.md").exists()
+        assert not (profile_dir / "skills" / "missing-plugin-skill").exists()
+
     def test_clone_all_copies_entire_tree(self, profile_env):
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"
@@ -256,7 +277,7 @@ class TestCreateProfile:
         (default_home / "memories").mkdir(exist_ok=True)
         (default_home / "memories" / "note.md").write_text("remember this")
         (default_home / "config.yaml").write_text("model: gpt-4")
-        # Runtime files that should be stripped
+        # Runtime files should be stripped
         (default_home / "gateway.pid").write_text("12345")
         (default_home / "gateway_state.json").write_text("{}")
         (default_home / "processes.json").write_text("[]")
@@ -266,10 +287,28 @@ class TestCreateProfile:
         # Content should be copied
         assert (profile_dir / "memories" / "note.md").read_text() == "remember this"
         assert (profile_dir / "config.yaml").read_text() == "model: gpt-4"
-        # Runtime files should be stripped
+        # Runtime files stripped
         assert not (profile_dir / "gateway.pid").exists()
         assert not (profile_dir / "gateway_state.json").exists()
         assert not (profile_dir / "processes.json").exists()
+
+    def test_clone_all_skips_dangling_skill_symlinks(self, profile_env):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        skills_dir = default_home / "skills"
+        valid_skill = skills_dir / "valid-skill"
+        valid_skill.mkdir(parents=True)
+        (valid_skill / "SKILL.md").write_text("---\nname: valid-skill\n---\n")
+        dangling = skills_dir / "missing-plugin-skill"
+        try:
+            dangling.symlink_to("missing-plugin-skill")
+        except (NotImplementedError, OSError) as exc:
+            pytest.skip(f"symlinks unavailable: {exc}")
+
+        profile_dir = create_profile("coder", clone_all=True, no_alias=True)
+
+        assert (profile_dir / "skills" / "valid-skill" / "SKILL.md").exists()
+        assert not (profile_dir / "skills" / "missing-plugin-skill").exists()
 
     def test_clone_all_excludes_sibling_profiles_tree(self, profile_env):
         """--clone-all from default ~/.hermes must not copy profiles/* (nested explosion)."""

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -194,6 +194,38 @@ class TestCreateProfile:
         with pytest.raises(FileExistsError):
             create_profile("coder", no_alias=True)
 
+    def test_create_profile_failure_does_not_remove_existing_profile(self, profile_env):
+        profile_dir = create_profile("coder", no_alias=True)
+        marker = profile_dir / "marker.txt"
+        marker.write_text("keep me", encoding="utf-8")
+
+        with pytest.raises(FileExistsError):
+            create_profile("coder", clone_config=True, no_alias=True)
+
+        assert marker.read_text(encoding="utf-8") == "keep me"
+        assert profile_dir.exists()
+
+    def test_create_profile_cleans_partial_dir_on_clone_failure(
+        self,
+        profile_env,
+        monkeypatch,
+    ):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "config.yaml").write_text("model:\n  default: test\n")
+
+        import hermes_cli.profiles as profiles
+
+        def fail_copy2(*args, **kwargs):
+            raise RuntimeError("copy failed")
+
+        monkeypatch.setattr(profiles.shutil, "copy2", fail_copy2)
+
+        with pytest.raises(RuntimeError, match="copy failed"):
+            create_profile("coder", clone_config=True, no_alias=True)
+
+        assert not get_profile_dir("coder").exists()
+
     def test_default_raises_value_error(self, profile_env):
         with pytest.raises(ValueError, match="default"):
             create_profile("default", no_alias=True)


### PR DESCRIPTION
## What does this PR do?

Hardens `hermes profile create --clone` and `--clone-all` against source profile filesystem drift.

It fixes three related failure modes:
- dangling skill symlinks under the source profile's `skills/` directory no longer abort `--clone`
- the same dangling-symlink class is covered for `--clone-all`
- if profile creation fails after creating the target directory, Hermes removes the partial profile directory instead of leaving confusing state behind

Valid skill directories and valid skill symlinks are still copied.

## Related Issue

Fixes #56821

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/profiles.py`
  - Added dangling-symlink ignore helper for profile tree copying.
  - Applied dangling-symlink handling to both `--clone` and `--clone-all` paths.
  - Added best-effort cleanup for partial profile directories after create failure.
- `tests/hermes_cli/test_profiles.py`
  - Added regression coverage for dangling skill symlinks in `--clone`.
  - Added regression coverage for dangling skill symlinks in `--clone-all`.
  - Added regression coverage for partial-profile cleanup.
  - Added safety coverage that duplicate-create failure does not remove an existing profile.

## How to Test

1. Baseline before changes: `scripts/run_tests.sh tests/hermes_cli/test_profiles.py -q` → 150 passed, 0 failed.
2. Regression tests were observed failing before implementation:
   - `test_clone_config_skips_dangling_skill_symlinks`
   - `test_clone_all_skips_dangling_skill_symlinks`
   - `test_create_profile_cleans_partial_dir_on_clone_failure`
3. Final canonical run: `scripts/run_tests.sh tests/hermes_cli/test_profiles.py -q` → 154 passed, 0 failed.
4. Windows footgun scan: `python scripts/check-windows-footguns.py hermes_cli/profiles.py tests/hermes_cli/test_profiles.py` → no footguns found.
5. Manual isolated `HERMES_HOME` smoke passed for both `--clone` and `--clone-all` with a valid skill, valid skill symlink, and dangling skill symlink.
6. `git diff --check` passed and working tree was clean after commits.
7. Full-suite first-failure comparison: `.venv/bin/python -m pytest tests/ -q --maxfail=1 --tb=long` fails on both this branch and clean `origin/main` at `tests/acp/test_edit_approval.py::test_write_file_approval_mutates_and_request_includes_diff` before reaching the profile-clone tests. The failure is from the ACP edit approval path rejecting macOS `/private/var/folders/...` pytest temp files as sensitive system paths. It does not touch `hermes_cli/profiles.py`, so it is not caused by this profile-clone change.

## Final-gate closeout

- Must-fix before ship: none found.
- Evidence gaps to close: full repo suite does not pass locally because the same first failure reproduces on this branch and clean `origin/main` outside the changed profile-clone path; targeted profile tests cover the touched behaviour.
- Tests or checks that prove this: baseline and final canonical profile test runs, targeted RED/GREEN regression runs, isolated CLI smoke for both clone modes, Windows footgun scan, diff hygiene.
- Safe to proceed: yes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` — the suite currently fails locally on both this branch and clean `origin/main` at `tests/acp/test_edit_approval.py::test_write_file_approval_mutates_and_request_includes_diff` before reaching the profile-clone changes; targeted canonical profile tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal robustness fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — symlink tests skip when unsupported, Windows footgun check run
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/hermes_cli/test_profiles.py -q
=== Summary: 1 files, 154 tests passed, 0 failed (100% complete) in 2.0s (24 workers) ===

python scripts/check-windows-footguns.py hermes_cli/profiles.py tests/hermes_cli/test_profiles.py
✓ No Windows footguns found (2 file(s) scanned).
```


