### PR TITLE
Fix: avoid bare skill_view() call syntax in plain-text prompt guidance (z.ai 429/1305)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -139,8 +139,9 @@ HERMES_AGENT_HELP_GUIDANCE = (
     "it — or when you need to understand your own features, tools, or capabilities, "
     "the documentation at https://hermes-agent.nousresearch.com/docs is your "
     "authoritative reference and always holds the latest, most up-to-date "
-    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "for additional guidance and proven workflows, but treat the docs as the source "
+    "information. Load the `hermes-agent` skill via the skill_view tool "
+    "(skill name: hermes-agent) for additional guidance and proven workflows, "
+    "but treat the docs as the source "
     "of truth when the two differ."
 )
 
@@ -1615,7 +1616,7 @@ def build_skills_system_prompt(
         hidden_note = (
             "\n(Categories marked [names only] are outside the current coding "
             "context, so their descriptions are omitted — the skills work "
-            "normally and load with skill_view(name) as usual.)"
+            "normally and load via the skill_view tool (by name) as usual.)"
         )
 
     if not skills_by_category:
@@ -1646,7 +1647,7 @@ def build_skills_system_prompt(
         result = (
             "## Skills (mandatory)\n"
             "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+            "to your task, you MUST load it via the skill_view tool (by name) and follow its instructions. "
             "Err on the side of loading — it is always better to have context you don't need "
             "than to miss critical steps, pitfalls, or established workflows. "
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "


### PR DESCRIPTION
## Summary

Fixes #56816

`HERMES_AGENT_HELP_GUIDANCE` in `agent/prompt_builder.py`, along with two related skill-loading guidance strings in `build_skills_system_prompt()`, contained literal function-call syntax (`skill_view(name='hermes-agent')`, `skill_view(name)`) as plain text. The z.ai Coding Plan endpoint (or a safety filter in front of it) appears to treat plain-text function-call syntax outside the structured `tools` field as suspected prompt/code injection, and rejects the request with `HTTP 429` (real upstream error: `{"error":{"code":"1305", ...}}`).

@leandroknorre bisected and verified this in the issue: replacing only the `skill_view(name='hermes-agent')` substring with neutral text of the same length changes the response from 429 to 200, reproducible every time.

## Changes

Reworded all three occurrences of bare `skill_view(...)` call syntax to describe loading skills via the skill_view tool in prose, without literal call syntax:

- `agent/prompt_builder.py:142` — `HERMES_AGENT_HELP_GUIDANCE`
- `agent/prompt_builder.py:1619` — `hidden_note` in `build_skills_system_prompt()`
- `agent/prompt_builder.py:1650` — mandatory skills-loading instruction in `build_skills_system_prompt()`

No behavior change for the model — this is purely a wording change to plain-text guidance strings. The structured tool-calling mechanism is untouched.

## Scope note

The issue reported only the first occurrence (line 142), but I found two more instances of the same pattern elsewhere in the same file while investigating, so I've included all three in this PR rather than filing separate follow-ups.

This is a distinct trigger from the previously reported "Hermes Agent" phrase issue (#47685 / #53002) — different string, different code path — so this fix is scoped independently.

## Testing

I don't have access to a z.ai Coding Plan endpoint to reproduce the original 429 directly, so I'm relying on the reporter's bisection in #56816 confirming that removing the bare `skill_view(...)` substring resolves it. Verified locally that:
- The replaced strings render correctly (no encoding/mojibake issues)
- No other bare `skill_view(...)` call-syntax patterns remain in `agent/prompt_builder.py`