### PR TITLE
fix(state): repair orphan FTS5 shadow tables on SessionDB open

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -439,6 +439,51 @@ _MALFORMED_SCHEMA_MARKERS = (
     "database disk image is malformed",
 )
 
+# FTS5 shadow table suffixes created internally by the virtual table engine.
+# When a virtual table is removed from sqlite_master but these shadow tables
+# survive (e.g. interrupted sqlite_master surgery), subsequent
+# CREATE VIRTUAL TABLE fails with "shadow table … already exists".
+_FTS5_SHADOW_TABLE_SUFFIXES = (
+    "content",
+    "data",
+    "docsize",
+    "idx",
+    "config",
+)
+
+
+def _repair_orphan_fts_shadow_tables(
+    conn: sqlite3.Connection,
+    base_name: str,
+) -> bool:
+    """Drop orphan FTS5 shadow tables whose virtual table definition is missing.
+
+    Returns True if any orphan tables were found and dropped.
+    """
+    expected = {f"{base_name}_{s}" for s in _FTS5_SHADOW_TABLE_SUFFIXES}
+    if not expected:
+        return False
+    placeholders = ",".join("?" for _ in expected)
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        f"AND name IN ({placeholders})",
+        list(expected),
+    )
+    existing = {row[0] for row in cursor.fetchall()}
+    if not existing:
+        return False
+    # Virtual table still exists → shadows are legitimate.
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='virtual' AND name=?",
+        (base_name,),
+    ).fetchone()
+    if row:
+        return False
+    for tbl in sorted(existing):
+        conn.execute(f"DROP TABLE IF EXISTS {tbl}")
+    return True
+
+
 # Process-global guard so auto-repair is attempted at most once per DB path
 # per process (prevents repair loops and serialises concurrent web_server /
 # gateway opens against the same malformed file).
@@ -897,6 +942,7 @@ class SessionDB:
         self._fts_enabled = False
         self._trigram_available = False
         self._fts_unavailable_warned = False
+        self._fts_orphan_repair_needed = False
         self._conn = None
         try:
             if read_only:
@@ -1108,6 +1154,19 @@ class SessionDB:
         status = self._fts_table_probe(cursor, table_name)
         if status is None:
             return False
+
+        # Detect orphan FTS5 shadow tables before attempting CREATE.
+        # When a virtual table is removed from sqlite_master but its internal
+        # shadow tables survive (e.g. interrupted sqlite_master surgery),
+        # CREATE VIRTUAL TABLE fails with "shadow table … already exists".
+        # Detecting proactively avoids the exception path entirely.
+        if status is False:
+            conn = cursor.connection
+            if _repair_orphan_fts_shadow_tables(conn, table_name):
+                logger.warning(
+                    "Dropped orphan FTS5 shadow tables for %s", table_name
+                )
+                self._fts_orphan_repair_needed = True
         try:
             # Run even when the virtual table exists so any dropped or missing
             # triggers are recreated after a previous no-FTS5 runtime disabled
@@ -1115,6 +1174,20 @@ class SessionDB:
             cursor.executescript(ddl)
             return True
         except sqlite3.OperationalError as exc:
+            err_lower = str(exc).lower()
+            # Handle residual orphan shadow tables that the proactive check
+            # missed (e.g. partial cleanup or race with concurrent open).
+            if "shadow table" in err_lower and "already exists" in err_lower:
+                conn = cursor.connection
+                if _repair_orphan_fts_shadow_tables(conn, table_name):
+                    logger.warning(
+                        "Repaired orphan FTS5 shadow tables for %s "
+                        "on error recovery",
+                        table_name,
+                    )
+                    self._fts_orphan_repair_needed = True
+                    cursor.executescript(ddl)
+                    return True
             if not self._is_fts5_unavailable_error(exc):
                 raise
             # Only disable FTS entirely when the whole FTS5 module is missing.
@@ -1552,7 +1625,7 @@ class SessionDB:
                     cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                 )
                 self._trigram_available = trigram_enabled
-                if triggers_need_repair:
+                if triggers_need_repair or self._fts_orphan_repair_needed:
                     self._rebuild_fts_indexes(
                         cursor,
                         include_trigram=trigram_enabled,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -457,6 +457,7 @@ class SessionDB(
         # _fts_cjk_loaded: tokenizer on the writer connection; _fts_cjk_available: messages_fts_cjk
         # is queryable AND not marked stale.
         self._fts_cjk_loaded = self._fts_cjk_available = self._fts_unavailable_warned = False
+        self._fts_orphan_repair_needed = False
         self._conn = None
         # Async token accounting; distinct from self._lock so enqueue/flush never contends with writes.
         self._token_queue: deque = deque()

--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -122,6 +122,55 @@ def load_fts5_cjk_extension(conn: sqlite3.Connection) -> bool:
         return False
 
 
+# FTS5 shadow tables the virtual-table engine creates internally. A ``.recover``
+# restore re-materializes them as ordinary tables without the virtual table
+# entry, so every later CREATE VIRTUAL TABLE fails with
+# "shadow table ... already exists" until the orphans are dropped.
+_FTS5_SHADOW_TABLE_SUFFIXES = ("content", "data", "docsize", "idx", "config")
+
+
+def _fts5_vtable_exists(conn: sqlite3.Connection, base_name: str) -> bool:
+    """True when the named FTS5 virtual table itself is registered. SQLite
+    records virtual tables in sqlite_master with type='table' (not 'virtual'),
+    so the CREATE VIRTUAL TABLE prefix is what distinguishes a live vtable
+    from an ordinary table of the same name."""
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE name = ? AND type = 'table' "
+        "AND sql LIKE 'CREATE VIRTUAL TABLE%'",
+        (base_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _repair_orphan_fts_shadow_tables(
+    conn: sqlite3.Connection, base_name: str
+) -> bool:
+    """Drop FTS5 shadow tables whose virtual table is gone from sqlite_master.
+
+    Both vtables are external-content over ``messages``/its view, so the
+    shadows are pure derived index state: dropping them loses nothing and the
+    repaired index is rebuilt from the canonical table. Returns True when any
+    orphan was found and dropped."""
+    expected = {f"{base_name}_{suffix}" for suffix in _FTS5_SHADOW_TABLE_SUFFIXES}
+    placeholders = ",".join("?" for _ in expected)
+    existing = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' "
+            f"AND name IN ({placeholders})",
+            sorted(expected),
+        ).fetchall()
+    }
+    if not existing:
+        return False
+    if _fts5_vtable_exists(conn, base_name):
+        # The virtual table is live: these shadows belong to it.
+        return False
+    for tbl in sorted(existing):
+        conn.execute(f"DROP TABLE IF EXISTS {tbl}")
+    return True
+
+
 class SessionFtsSetupMixin:
     """FTS table/trigger lifecycle shared by schema init, optimize and the write path."""
 
@@ -239,6 +288,12 @@ class SessionFtsSetupMixin:
             self._fts_cjk_available = False
             return
         try:
+            # A .recover restore may also orphan these shadows; the helper is a
+            # no-op when the vtable is live, and the backfill markers below
+            # make a recreated index consistent again.
+            _repair_orphan_fts_shadow_tables(
+                getattr(cursor, "connection", cursor), "messages_fts_cjk"
+            )
             cursor.executescript(FTS_CJK_TABLE_SQL)
             if not cjk_present:
                 # An old stale breadcrumb refers to a table that no longer exists.
@@ -283,11 +338,25 @@ class SessionFtsSetupMixin:
         status = self._fts_table_probe(cursor, table_name)
         if status is None:
             return False
+        # Callers pass either a cursor or (conn-as-cursor) the connection itself.
+        conn = getattr(cursor, "connection", cursor)
+        if status is False and _repair_orphan_fts_shadow_tables(conn, table_name):
+            # A .recover restore left the shadow tables behind without the
+            # vtable: drop them so the DDL below can create the index.
+            self._note_fts_shadow_repair(table_name)
         try:
             # Run even when the table exists: recreates triggers a no-FTS5 runtime dropped.
             cursor.executescript(ddl)
             return True
         except sqlite3.OperationalError as exc:
+            err_lower = str(exc).lower()
+            if "shadow table" in err_lower and "already exists" in err_lower:
+                # Orphans the proactive check could not see (e.g. a race with a
+                # concurrent open): repair once, then retry the DDL once.
+                if _repair_orphan_fts_shadow_tables(conn, table_name):
+                    self._note_fts_shadow_repair(table_name)
+                    cursor.executescript(ddl)
+                    return True
             if not self._is_fts5_unavailable_error(exc):
                 raise
             # A missing tokenizer disables only that table; the base FTS5 table is fine.
@@ -296,6 +365,14 @@ class SessionFtsSetupMixin:
             else:
                 self._warn_fts5_unavailable(exc)
             return False
+
+    def _note_fts_shadow_repair(self, table_name: str) -> None:
+        logger.warning(
+            "Dropped orphan FTS5 shadow tables for %s; the index is recreated "
+            "from the canonical messages table on this open",
+            table_name,
+        )
+        self._fts_orphan_repair_needed = True
 
     @staticmethod
     def _is_fts_write_corruption_error(exc: sqlite3.DatabaseError) -> bool:

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1043,7 +1043,12 @@ class SessionSchemaMixin:
                 # Trigram is optional; without it CJK search falls back to LIKE.
                 trigram_enabled = self._ensure_fts_schema(cursor, "messages_fts_trigram", trigram_sql)
                 self._trigram_available = trigram_enabled
-                if base_triggers_missing or (trigram_enabled and trigram_triggers_missing):
+                if (
+                    base_triggers_missing
+                    or (trigram_enabled and trigram_triggers_missing)
+                    # An orphan-repaired index starts empty: backfill from messages.
+                    or self._fts_orphan_repair_needed
+                ):
                     self._run_admitted_startup_rebuild(
                         cursor,
                         lambda: self._rebuild_fts_indexes(cursor, legacy=legacy_fts, include_trigram=trigram_enabled),

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4881,3 +4881,78 @@ def test_refresh_compression_lock_requires_holder_and_preserves_reclaimability(d
 
     monkeypatch.setattr(hermes_state.time, "time", lambda: 1016.0)
     assert db.try_acquire_compression_lock("s1", "holder-b", ttl_seconds=10.0) is True
+
+
+def test_orphan_fts_shadow_tables_are_repaired_on_open(tmp_path):
+    """Orphan FTS5 shadow tables (virtual table entry missing from
+    sqlite_master but shadow tables present) must be detected and dropped
+    so CREATE VIRTUAL TABLE can succeed.  Regression test for #56815."""
+    db_path = tmp_path / "state.db"
+
+    # Phase 1: create a healthy DB with FTS and some data.
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s1", "cli")
+        db.append_message("s1", role="user", content="hello world")
+        assert db.search_messages("hello") != []
+    finally:
+        db.close()
+
+    # Phase 2: simulate orphan shadow tables by removing the virtual table
+    # entry from sqlite_master while keeping the shadow tables.
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    conn.execute("PRAGMA writable_schema = ON")
+    conn.execute(
+        "DELETE FROM sqlite_master WHERE name = 'messages_fts' AND type = 'table'"
+    )
+    conn.execute("PRAGMA writable_schema = OFF")
+    conn.commit()
+    # Verify orphan state.
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE name LIKE 'messages_fts_%'"
+    )
+    orphans = [row[0] for row in cursor.fetchall()]
+    assert len(orphans) > 0, "Shadow tables should remain after writable_schema removal"
+    cursor = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE name = 'messages_fts' AND type = 'table'"
+    )
+    assert cursor.fetchone() is None, "Virtual table entry should be gone"
+    conn.close()
+
+    # Phase 3: open a new SessionDB — it should self-heal by dropping the
+    # orphan shadow tables and recreating the virtual table.
+    db2 = SessionDB(db_path=db_path)
+    try:
+        assert db2._fts_enabled is True
+        # Data should be searchable after FTS rebuild.
+        assert db2.search_messages("hello") != []
+    finally:
+        db2.close()
+
+
+def test_orphan_fts_shadow_tables_proactive_detection(tmp_path):
+    """Proactive orphan detection (before CREATE) works even when the
+    virtual table probe returns False."""
+    from hermes_state import _repair_orphan_fts_shadow_tables
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s1", "cli")
+    finally:
+        db.close()
+
+    # Manually create orphan state.
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    conn.execute("PRAGMA writable_schema = ON")
+    conn.execute(
+        "DELETE FROM sqlite_master WHERE name = 'messages_fts' AND type = 'table'"
+    )
+    conn.execute("PRAGMA writable_schema = OFF")
+    conn.commit()
+
+    # Verify the repair helper detects and drops orphans.
+    assert _repair_orphan_fts_shadow_tables(conn, "messages_fts") is True
+    # Second call should be a no-op (orphan tables already gone).
+    assert _repair_orphan_fts_shadow_tables(conn, "messages_fts") is False
+    conn.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5945,3 +5945,61 @@ def test_repair_orphan_fts_shadow_tables_proactive_detection(tmp_path):
     assert _repair_orphan_fts_shadow_tables(conn, "messages_fts") is True
     assert _repair_orphan_fts_shadow_tables(conn, "messages_fts") is False
     conn.close()
+
+
+def test_orphan_base_family_repair_preserves_healthy_trigram(tmp_path):
+    """A ``.recover`` half-failure may orphan only the base ``messages_fts``
+    family while ``messages_fts_trigram`` stays healthy. The base-family repair
+    matches shadow tables by exact ``<family>_<suffix>`` names, so it must not
+    touch the trigram family's tables, and the family stays queryable after the
+    open-time repair. Field-report scenario from #103840."""
+    db_path = tmp_path / "state.db"
+
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s1", "cli")
+        db.append_message("s1", role="user", content="orphanbasetrigram 大别山项目")
+        assert [m["session_id"] for m in db.search_messages("大别山")] == ["s1"]
+    finally:
+        db.close()
+
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    trigram_rows_before = {
+        (row[0], row[1])
+        for row in conn.execute(
+            "SELECT rowid, name FROM sqlite_master "
+            "WHERE type = 'table' AND name LIKE 'messages_fts_trigram%'"
+        )
+    }
+    assert trigram_rows_before, "healthy trigram family should exist before repair"
+    # Orphan only the base family: drop its vtable entry, keep the shadows.
+    conn.execute("PRAGMA writable_schema = ON")
+    conn.execute(
+        "DELETE FROM sqlite_master WHERE name = 'messages_fts' AND type = 'table'"
+    )
+    conn.execute("PRAGMA writable_schema = OFF")
+    conn.commit()
+    conn.close()
+
+    db2 = SessionDB(db_path=db_path)
+    try:
+        # The base index is repaired and rebuilt from canonical messages.
+        assert db2._fts_enabled is True
+        assert (
+            [m["session_id"] for m in db2.search_messages("orphanbasetrigram")]
+            == ["s1"]
+        )
+        # The healthy trigram family survived untouched: same sqlite_master
+        # rows (rowid included), not dropped and recreated by the repair.
+        assert db2._trigram_available is True
+        trigram_rows_after = {
+            (row[0], row[1])
+            for row in db2._conn.execute(
+                "SELECT rowid, name FROM sqlite_master "
+                "WHERE type = 'table' AND name LIKE 'messages_fts_trigram%'"
+            )
+        }
+        assert trigram_rows_after == trigram_rows_before
+        assert [m["session_id"] for m in db2.search_messages("大别山")] == ["s1"]
+    finally:
+        db2.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5852,3 +5852,96 @@ class TestFts5SanitizerCharacterClass:
         # text; keep % intact there (pre-existing contract).
         sanitized = self._sanitize("完成50%")
         assert "%" in sanitized
+
+
+def test_orphan_fts_shadow_tables_are_repaired_on_open(tmp_path):
+    """Orphan FTS5 shadow tables (vtable gone from sqlite_master, shadows left
+    behind by a ``.recover`` restore) are dropped on open so the CREATE can
+    succeed again and the index is rebuilt from canonical messages. Regression
+    test for #56815 / #103840."""
+    db_path = tmp_path / "state.db"
+
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s1", "cli")
+        db.append_message("s1", role="user", content="hello world")
+        assert db.search_messages("hello") != []
+    finally:
+        db.close()
+
+    # Simulate the .recover aftermath: remove the vtable entry, keep shadows.
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    conn.execute("PRAGMA writable_schema = ON")
+    conn.execute(
+        "DELETE FROM sqlite_master WHERE name = 'messages_fts' AND type = 'table'"
+    )
+    conn.execute("PRAGMA writable_schema = OFF")
+    conn.commit()
+    orphans = [
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE name LIKE 'messages_fts_%'"
+        )
+    ]
+    assert orphans, "shadow tables should survive the vtable removal"
+    assert (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE name = 'messages_fts' AND type = 'table'"
+        ).fetchone()
+        is None
+    )
+    conn.close()
+
+    db2 = SessionDB(db_path=db_path)
+    try:
+        assert db2._fts_enabled is True
+        # The repaired index is rebuilt from the canonical messages table.
+        assert db2.search_messages("hello") != []
+    finally:
+        db2.close()
+
+
+def test_repair_orphan_fts_shadow_tables_noop_on_healthy_vtable(tmp_path):
+    """A healthy install must stay untouched: the helper never classifies the
+    shadows of a live vtable as orphaned (sqlite_master records vtables with
+    type='table', matched via their CREATE VIRTUAL TABLE SQL)."""
+    from hermes_state_fts import (
+        _fts5_vtable_exists,
+        _repair_orphan_fts_shadow_tables,
+    )
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", "cli")
+        db.append_message("s1", role="user", content="hello world")
+        assert db.search_messages("hello") != []
+        assert _fts5_vtable_exists(db._conn, "messages_fts") is True
+        assert _repair_orphan_fts_shadow_tables(db._conn, "messages_fts") is False
+        # The untouched index still serves search.
+        assert db.search_messages("hello") != []
+    finally:
+        db.close()
+
+
+def test_repair_orphan_fts_shadow_tables_proactive_detection(tmp_path):
+    """The helper itself detects and drops orphans; a second call is a no-op."""
+    from hermes_state_fts import _repair_orphan_fts_shadow_tables
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("s1", "cli")
+    finally:
+        db.close()
+
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    conn.execute("PRAGMA writable_schema = ON")
+    conn.execute(
+        "DELETE FROM sqlite_master WHERE name = 'messages_fts' AND type = 'table'"
+    )
+    conn.execute("PRAGMA writable_schema = OFF")
+    conn.commit()
+
+    assert _repair_orphan_fts_shadow_tables(conn, "messages_fts") is True
+    assert _repair_orphan_fts_shadow_tables(conn, "messages_fts") is False
+    conn.close()


### PR DESCRIPTION
## What does this PR do?

Fixes a self-perpetuating startup failure when FTS5 shadow tables are orphaned — the virtual table entry is missing from `sqlite_master` but its internal shadow tables (`messages_fts_content`, `_data`, `_docsize`, `_idx`, `_config`) survive. In this state, every `SessionDB()` open attempt fails permanently with `fts5: error creating shadow table messages_fts_data: table 'messages_fts_data' already exists`, breaking `session_search()` and any component that opens a fresh DB connection.

The fix adds proactive orphan detection in `_ensure_fts_schema()`: before attempting `CREATE VIRTUAL TABLE`, it checks whether shadow tables exist without a corresponding virtual table entry, drops the orphans, and proceeds with clean creation. A reactive fallback also catches the error if the proactive check misses it. After repair, FTS indexes are rebuilt from the canonical `messages` table.

## Related Issue

Fixes #56815
Fixes #103840 (deterministic production repro on v0.21.0)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: Added `_FTS5_SHADOW_TABLE_SUFFIXES` constant and `_repair_orphan_fts_shadow_tables()` helper that detects and drops orphan FTS5 shadow tables when the virtual table definition is missing from `sqlite_master`
- `hermes_state.py`: Modified `_ensure_fts_schema()` to proactively check for orphan shadow tables before `CREATE VIRTUAL TABLE`, and reactively catch the "shadow table already exists" error as a fallback
- `hermes_state.py`: Added `_fts_orphan_repair_needed` flag to trigger FTS index rebuild after orphan repair (otherwise the recreated virtual table has an empty index)
- `tests/test_hermes_state.py`: Added `test_orphan_fts_shadow_tables_are_repaired_on_open` — end-to-end test that creates the orphan state via `PRAGMA writable_schema` surgery and verifies SessionDB self-heals with searchable FTS
- `tests/test_hermes_state.py`: Added `test_orphan_fts_shadow_tables_proactive_detection` — unit test for the `_repair_orphan_fts_shadow_tables` helper function

## How to Test

1. Run `python -m pytest tests/test_hermes_state.py -k "orphan" -v` — both new tests should pass
2. Run `python -m pytest tests/test_hermes_state.py -k "fts or Fts or FTS or schema or malformed" -v` — all 59 FTS/schema tests should pass (0 regressions)
3. Run `python -m pytest tests/test_state_db_malformed_repair.py -v` — all 14 malformed repair tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure SQLite logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A