### PR TITLE
fix(tools): block sync_back writes into Hermes state

### DIFF
--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -14,6 +14,7 @@ fcntl = pytest.importorskip("fcntl")
 
 from tools.environments.file_sync import (
     FileSyncManager,
+    _is_safe_sync_back_target,
     _sha256_file,
     _SYNC_BACK_BACKOFF,
     _SYNC_BACK_MAX_RETRIES,
@@ -471,3 +472,100 @@ class TestSyncBackSizeCap:
         # Default cap (2 GiB) is far above our tiny tar; extraction should proceed
         mgr.sync_back(hermes_home=tmp_path / ".hermes")
         assert Path(host_file).read_bytes() == b"remote_version"
+
+
+class TestSyncBackSensitiveTargets:
+    """sync_back refuses inferred writes into host Hermes state."""
+
+    def test_sensitive_hermes_paths_are_unsafe(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert not _is_safe_sync_back_target(str(hermes_home / "skills" / "x.py"))
+        assert not _is_safe_sync_back_target(str(hermes_home / "plugins" / "x.py"))
+        assert not _is_safe_sync_back_target(str(hermes_home / "config.yaml"))
+        assert not _is_safe_sync_back_target(str(hermes_home / "config.yml"))
+        assert not _is_safe_sync_back_target(str(hermes_home / ".env"))
+        assert not _is_safe_sync_back_target(str(hermes_home / "Skills" / "x.py"))
+        assert not _is_safe_sync_back_target(str(hermes_home / "Plugins" / "x.py"))
+        assert not _is_safe_sync_back_target(str(hermes_home / "CONFIG.YAML"))
+        assert not _is_safe_sync_back_target(str(hermes_home / ".ENV"))
+
+    def test_dotdot_path_is_unsafe(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert not _is_safe_sync_back_target(
+            str(tmp_path / "workspace" / ".." / "escape.py")
+        )
+
+    def test_inferred_new_skill_file_is_blocked(self, tmp_path, monkeypatch, caplog):
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        anchor_host = hermes_home / "skills" / "existing.py"
+        mapping = [(str(anchor_host), "/root/.hermes/skills/existing.py")]
+        download_fn = _make_download_fn({
+            "root/.hermes/skills/injected.py": b"print('remote injected')\n",
+        })
+        mgr = _make_manager(
+            tmp_path,
+            file_mapping=mapping,
+            bulk_download_fn=download_fn,
+        )
+
+        target = hermes_home / "skills" / "injected.py"
+        with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+            mgr.sync_back(hermes_home=hermes_home)
+
+        assert not target.exists()
+        assert any("SECURITY" in record.message for record in caplog.records)
+
+    def test_explicit_sync_home_protects_even_when_env_differs(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        env_home = tmp_path / "env-home"
+        active_home = tmp_path / "active-home"
+        monkeypatch.setenv("HERMES_HOME", str(env_home))
+
+        anchor_host = active_home / "skills" / "existing.py"
+        mapping = [(str(anchor_host), "/root/.hermes/skills/existing.py")]
+        download_fn = _make_download_fn({
+            "root/.hermes/skills/injected.py": b"print('remote injected')\n",
+        })
+        mgr = _make_manager(
+            tmp_path,
+            file_mapping=mapping,
+            bulk_download_fn=download_fn,
+        )
+
+        target = active_home / "skills" / "injected.py"
+        with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+            mgr.sync_back(hermes_home=active_home)
+
+        assert not target.exists()
+        assert any("SECURITY" in record.message for record in caplog.records)
+
+    def test_non_sensitive_inferred_file_still_syncs(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        existing_host = tmp_path / "cache" / "existing.json"
+        _write_file(existing_host, b"{}")
+        mapping = [(str(existing_host), "/root/.hermes/cache/existing.json")]
+        download_fn = _make_download_fn({
+            "root/.hermes/cache/new_entry.json": b'{"new": true}',
+        })
+        mgr = _make_manager(
+            tmp_path,
+            file_mapping=mapping,
+            bulk_download_fn=download_fn,
+        )
+
+        mgr.sync_back(hermes_home=hermes_home)
+
+        expected = tmp_path / "cache" / "new_entry.json"
+        assert expected.read_bytes() == b'{"new": true}'

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -128,6 +128,76 @@ _SYNC_BACK_BACKOFF = (2, 4, 8)  # seconds between retries
 _SYNC_BACK_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB — refuse to extract larger tars
 
 
+def _resolved_path(path: Path) -> Path:
+    try:
+        return path.expanduser().resolve()
+    except (OSError, RuntimeError):
+        return path.expanduser().absolute()
+
+
+def _sensitive_sync_back_dirs(hermes_home: Path | None = None) -> list[Path]:
+    hermes_home = hermes_home or get_hermes_home()
+    return [
+        _resolved_path(hermes_home / "skills"),
+        _resolved_path(hermes_home / "plugins"),
+    ]
+
+
+def _sensitive_sync_back_files(hermes_home: Path | None = None) -> list[Path]:
+    hermes_home = hermes_home or get_hermes_home()
+    return [
+        _resolved_path(hermes_home / "config.yaml"),
+        _resolved_path(hermes_home / "config.yml"),
+        _resolved_path(hermes_home / ".env"),
+    ]
+
+
+def _casefolded_parts(path: Path) -> tuple[str, ...]:
+    return tuple(part.casefold() for part in path.parts)
+
+
+def _same_or_child_path(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        pass
+
+    path_parts = _casefolded_parts(path)
+    parent_parts = _casefolded_parts(parent)
+    return (
+        len(path_parts) >= len(parent_parts)
+        and path_parts[:len(parent_parts)] == parent_parts
+    )
+
+
+def _same_path(path: Path, other: Path) -> bool:
+    return path == other or _casefolded_parts(path) == _casefolded_parts(other)
+
+
+def _is_safe_sync_back_target(
+    host_path: str,
+    hermes_home: Path | None = None,
+) -> bool:
+    """Return whether sync_back may write to *host_path*."""
+    try:
+        raw_path = Path(host_path).expanduser()
+        if any(part == ".." for part in raw_path.parts):
+            return False
+        resolved = raw_path.resolve()
+    except (OSError, RuntimeError):
+        return False
+
+    for sensitive_dir in _sensitive_sync_back_dirs(hermes_home):
+        if _same_or_child_path(resolved, sensitive_dir):
+            return False
+
+    return not any(
+        _same_path(resolved, sensitive_file)
+        for sensitive_file in _sensitive_sync_back_files(hermes_home)
+    )
+
+
 class FileSyncManager:
     """Tracks local file changes and syncs to a remote environment.
 
@@ -259,13 +329,14 @@ class FileSyncManager:
             logger.debug("sync_back: no prior push state — skipping")
             return
 
-        lock_path = (hermes_home or get_hermes_home()) / ".sync.lock"
+        active_hermes_home = hermes_home or get_hermes_home()
+        lock_path = active_hermes_home / ".sync.lock"
         lock_path.parent.mkdir(parents=True, exist_ok=True)
 
         last_exc: Exception | None = None
         for attempt in range(_SYNC_BACK_MAX_RETRIES):
             try:
-                self._sync_back_once(lock_path)
+                self._sync_back_once(lock_path, active_hermes_home)
                 return
             except Exception as exc:
                 last_exc = exc
@@ -279,7 +350,7 @@ class FileSyncManager:
 
         logger.warning("sync_back: all %d attempts failed: %s", _SYNC_BACK_MAX_RETRIES, last_exc)
 
-    def _sync_back_once(self, lock_path: Path) -> None:
+    def _sync_back_once(self, lock_path: Path, hermes_home: Path) -> None:
         """Single sync-back attempt with SIGINT protection and file lock."""
         # signal.signal() only works from the main thread. In gateway
         # contexts cleanup() may run from a worker thread — skip SIGINT
@@ -297,23 +368,23 @@ class FileSyncManager:
 
             signal.signal(signal.SIGINT, _defer_sigint)
         try:
-            self._sync_back_locked(lock_path)
+            self._sync_back_locked(lock_path, hermes_home)
         finally:
             if on_main_thread and original_handler is not None:
                 signal.signal(signal.SIGINT, original_handler)
                 if deferred_sigint:
                     os.kill(os.getpid(), signal.SIGINT)
 
-    def _sync_back_locked(self, lock_path: Path) -> None:
+    def _sync_back_locked(self, lock_path: Path, hermes_home: Path) -> None:
         """Sync-back under file lock (serializes concurrent gateways)."""
         if fcntl is None:
             # Windows: no flock — run without serialization
-            self._sync_back_impl()
+            self._sync_back_impl(hermes_home)
             return
         lock_fd = open(lock_path, "w", encoding="utf-8")
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            self._sync_back_impl()
+            self._sync_back_impl(hermes_home)
         finally:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
@@ -321,7 +392,7 @@ class FileSyncManager:
                 pass
             lock_fd.close()
 
-    def _sync_back_impl(self) -> None:
+    def _sync_back_impl(self, hermes_home: Path) -> None:
         """Download, diff, and apply remote changes to host."""
         if self._bulk_download_fn is None:
             raise RuntimeError("_sync_back_impl called without bulk_download_fn")
@@ -390,6 +461,28 @@ class FileSyncManager:
                         if self._is_upload_only_host_path(host_path, upload_only_host_paths):
                             logger.debug(
                                 "sync_back: skipping upload-only credential file %s",
+                                remote_path,
+                            )
+                            continue
+
+                        if not _is_safe_sync_back_target(host_path, hermes_home):
+                            logger.warning(
+                                "sync_back: SECURITY: refusing to write "
+                                "sensitive host path %s (remote: %s)",
+                                host_path,
+                                remote_path,
+                            )
+                            continue
+
+                        try:
+                            resolved_target = Path(host_path).resolve()
+                            resolved_parent = Path(os.path.dirname(host_path)).resolve()
+                            resolved_target.relative_to(resolved_parent)
+                        except (OSError, RuntimeError, ValueError):
+                            logger.warning(
+                                "sync_back: SECURITY: path %s escapes its mapped "
+                                "directory — skipping (remote: %s)",
+                                host_path,
                                 remote_path,
                             )
                             continue


### PR DESCRIPTION
## What does this PR do?

Blocks `sync_back` from copying inferred remote files into active Hermes state such as `skills/`, `plugins/`, `config.yaml`, and `.env`.

The vulnerable path was that `sync_back` could infer a host destination for a new remote file from an existing mapping, then copy that file back during teardown. If the mapping pointed at Hermes state, a remote-side file could land in host procedural state instead of staying confined to ordinary synced cache or workspace files.

This change guards sync-back targets against traversal, active-home skills and plugin directories, and sensitive config files before copying staged files back to the host. Protected path comparisons are case-insensitive so default macOS filesystems get the same protection, and the active `HERMES_HOME` is threaded through the sync-back call path so explicit homes are checked correctly.

Salvages source PR: https://github.com/NousResearch/hermes-agent/pull/38715

Original author credited in git trailer: Ashish Patel <shriganesh.patel@gmail.com>

## Related Issue

Fixes #38026

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/environments/file_sync.py`
  - Adds sync-back target validation before copying remote files to host paths.
  - Blocks raw traversal, protected active-home subdirectories, and sensitive config/env files.
  - Uses case-insensitive component comparisons for protected paths.
  - Threads the active Hermes home through the sync-back lock/copy path.
- `tests/tools/test_file_sync_back.py`
  - Adds regression coverage for skills/plugins/config/env writeback denial.
  - Covers explicit `HERMES_HOME`, traversal rejection, safe cache writeback, and macOS-style case-insensitive matching.

## How to Test

1. Reproduced on pre-fix main by syncing a mapped remote `/root/.hermes/skills/injected.py` and observing it copy back into the host `HERMES_HOME/skills/injected.py`.
2. Verified after the fix with the same reproduction: protected writeback was skipped.
3. `scripts/run_tests.sh tests/tools/test_file_sync_back.py -q`
4. `.venv/bin/python scripts/check-windows-footguns.py tools/environments/file_sync.py tests/tools/test_file_sync_back.py`
5. `git diff --check origin/main...HEAD`
6. `coderabbit review --agent` before commit: zero findings.
7. Checked current `origin/main` after signing: `git merge-tree --write-tree origin/main HEAD` completed without conflicts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux workspace via Codex desktop harness

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A, behavior is covered by tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Security Notes

This follows `SECURITY.md` by treating the OS/filesystem boundary as the load-bearing boundary. The fix prevents sync-back from crossing from a remote/backend path into active host Hermes state; it does not rely on in-process output screening as containment.

## Agent Disclosure

- Created by: GPT-5.5-xhigh in Codex
- Human looked at and manually signed the commit
