### PR TITLE
fix(desktop): read composer image preview locally in remote mode

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -5,7 +5,7 @@ import { droppedFileInlineRef } from '@/app/chat/composer/inline-refs'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { useI18n } from '@/i18n'
 import { attachmentId, contextPath, pathLabel } from '@/lib/chat-runtime'
-import { readDesktopFileDataUrl, selectDesktopPaths } from '@/lib/desktop-fs'
+import { readComposerImagePreview, selectDesktopPaths } from '@/lib/desktop-fs'
 import {
   addComposerAttachment,
   type ComposerAttachment,
@@ -367,7 +367,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
       attachToMain(baseAttachment)
 
       try {
-        const previewUrl = await readDesktopFileDataUrl(filePath)
+        const previewUrl = await readComposerImagePreview(filePath)
 
         if (previewUrl) {
           addComposerAttachment({ ...baseAttachment, previewUrl })

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -6,6 +6,7 @@ import {
   desktopDefaultCwd,
   desktopFileDiff,
   desktopGitRoot,
+  readComposerImagePreview,
   readDesktopDir,
   readDesktopFileDataUrl,
   readDesktopFileText,
@@ -152,5 +153,58 @@ describe('desktop filesystem facade', () => {
 
     expect(remoteSelect).toHaveBeenCalledWith({ directories: true, multiple: false })
     expect(selectPaths).not.toHaveBeenCalled()
+  })
+})
+
+describe('readComposerImagePreview', () => {
+  beforeEach(() => {
+    stubBridge()
+    $connection.set(null)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    $connection.set(null)
+  })
+
+  // The regression this guards: a composer image (paste/clipboard/drop) is
+  // written to the CLIENT's local Electron disk even in remote mode, so its
+  // preview MUST be read locally. Reading it through the remote-aware
+  // readDesktopFileDataUrl would GET /api/fs/read-data-url on the backend, which
+  // has no such file → 404 "File not found" → "Image preview failed" toast.
+  it('reads the preview from the LOCAL bridge in remote mode (never the backend)', async () => {
+    $connection.set({ mode: 'remote' } as never)
+
+    await expect(readComposerImagePreview('/Users/ace/Library/.../composer_x.png')).resolves.toBe(
+      'data:text/plain;base64,bG9jYWw='
+    )
+
+    expect(readFileDataUrl).toHaveBeenCalledWith('/Users/ace/Library/.../composer_x.png')
+    // The backend FS REST must NOT be touched — that's the whole bug.
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it('reads the preview from the local bridge in local mode too', async () => {
+    $connection.set({ mode: 'local' } as never)
+
+    await expect(readComposerImagePreview('/tmp/composer_y.png')).resolves.toBe('data:text/plain;base64,bG9jYWw=')
+
+    expect(readFileDataUrl).toHaveBeenCalledWith('/tmp/composer_y.png')
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the remote-aware read when the local bridge cannot read the path', async () => {
+    // A path dragged from the REMOTE file tree is not on local disk: the local
+    // bridge read throws, and we fall through to the backend read-data-url.
+    $connection.set({ mode: 'remote' } as never)
+    readFileDataUrl.mockRejectedValueOnce(new Error('ENOENT: no such file'))
+
+    await expect(readComposerImagePreview('/home/user/project/pic.png')).resolves.toBe(
+      'data:text/plain;base64,cmVtb3Rl'
+    )
+
+    expect(readFileDataUrl).toHaveBeenCalledWith('/home/user/project/pic.png')
+    expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-data-url?path=%2Fhome%2Fuser%2Fproject%2Fpic.png' })
   })
 })

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -104,6 +104,36 @@ export async function readDesktopFileDataUrl(path: string): Promise<string> {
   return typeof result === 'string' ? result : result.dataUrl || ''
 }
 
+// Read the preview data URL for a COMPOSER image (a pasted/clipboard/dropped/
+// picked image staged by the Electron main process via saveImageBuffer/
+// saveClipboardImage). Those bytes are always written to the CLIENT's local
+// Electron userData dir — even in remote mode — so the preview must be read
+// LOCALLY. Routing it through readDesktopFileDataUrl() is wrong in remote mode:
+// that hits the backend's GET /api/fs/read-data-url, and the backend (a
+// different machine) has no such file → 404 "File not found", surfacing as the
+// "Image preview failed" toast even though the attachment itself uploads fine
+// at submit (image.attach_bytes reads the same local path). Try the local
+// bridge first; fall back to the remote-aware read only if the local bridge is
+// unavailable or can't read it (e.g. a path dragged from the remote file tree).
+export async function readComposerImagePreview(path: string): Promise<string> {
+  const localReader = window.hermesDesktop?.readFileDataUrl
+
+  if (localReader) {
+    try {
+      const dataUrl = await localReader(path)
+
+      if (dataUrl) {
+        return dataUrl
+      }
+    } catch {
+      // Local bridge couldn't read it (not a client-local path, or unreadable) —
+      // fall through to the remote-aware read below.
+    }
+  }
+
+  return readDesktopFileDataUrl(path)
+}
+
 export async function desktopGitRoot(path: string): Promise<string | null> {
   const desktop = bridge()
 


### PR DESCRIPTION
## Problem

When the desktop app runs against a **remote gateway** (a thin client on one machine driving a `hermes dashboard`/gateway on another), pasting an image into the composer pops **"Image preview failed" / "file not found"** on every paste.

## Root cause

A pasted/clipboard/dropped/picked composer image is written to the **client's local** Electron `userData/composer-images/` dir (`saveImageBuffer` / `saveClipboardImage`) — even in remote mode, because the clipboard bytes only exist on the client. But the preview readback in `attachImagePath` went through `readDesktopFileDataUrl()`, which in remote mode routes to the backend's `GET /api/fs/read-data-url`. The backend is a *different machine* and has no such file → `404 File not found` → the "Image preview failed" toast.

The attachment itself was unaffected — submit uploads the bytes via `image.attach_bytes`, which already reads the local path through the Electron bridge (`readImageForRemoteAttach` → `window.hermesDesktop.readFileDataUrl`). Only the thumbnail preview was broken.

## Fix

Add `readComposerImagePreview()` which reads the preview from the **local Electron bridge first**, falling back to the remote-aware read only when the local bridge is unavailable or can't read the path (e.g. a path dragged from the remote file tree). This mirrors what the submit-time upload already does, and keeps local-mode behavior byte-identical.

## Tests

3 new cases in `desktop-fs.test.ts`:
- remote mode reads the **local** bridge and never touches the backend FS REST (the regression guard)
- local mode still reads the local bridge
- remote-file-tree path falls back to the backend read when the local read throws

`apps/desktop` typecheck, eslint, and prettier all clean; the two touched test files pass (19 tests). Verified end-to-end on a real remote-backend setup: paste now renders the thumbnail with no error toast.
