### PR TITLE
fix(webhook): enforce body-size limit when Content-Length is absent

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -22,7 +22,8 @@ Security:
   - HMAC secret is required per route (validated at startup)
   - Rate limiting per route (fixed-window, configurable)
   - Idempotency cache prevents duplicate agent runs on webhook retries
-  - Body size limits checked before reading payload
+  - Body size limits enforced both via Content-Length (fast path) and
+    against the bytes actually read (covers chunked / spoofed length)
   - Set secret to "INSECURE_NO_AUTH" to skip validation (testing only)
 """
 
@@ -469,7 +470,7 @@ class WebhookAdapter(BasePlatformAdapter):
             )
 
         # ── Auth-before-body ─────────────────────────────────────
-        # Check Content-Length before reading the full payload.
+        # Fast path: reject via Content-Length before reading the payload.
         content_length = request.content_length or 0
         if content_length > self._max_body_bytes:
             return web.json_response(
@@ -482,6 +483,23 @@ class WebhookAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[webhook] Failed to read body: %s", e)
             return web.json_response({"error": "Bad request"}, status=400)
+
+        # Enforce the size limit on the ACTUAL body too. A request that omits
+        # Content-Length (HTTP chunked transfer-encoding) or spoofs a small
+        # value slips past the fast-path check above, so the limit must be
+        # re-checked against the bytes we actually read — otherwise the
+        # per-route ``max_body_bytes`` guard is trivially bypassable by an
+        # unauthenticated caller. Mirrors the Feishu / WeCom webhook adapters.
+        if len(raw_body) > self._max_body_bytes:
+            logger.warning(
+                "[webhook] Body exceeds max_body_bytes (%d > %d) on route %s",
+                len(raw_body),
+                self._max_body_bytes,
+                route_name,
+            )
+            return web.json_response(
+                {"error": "Payload too large"}, status=413
+            )
 
         # Validate HMAC signature FIRST (skip only for the explicit local-test
         # INSECURE_NO_AUTH mode). Missing/empty secrets must fail closed here,

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -741,6 +741,30 @@ class TestBodySize:
             )
             assert resp.status == 413
 
+    @pytest.mark.asyncio
+    async def test_oversized_body_without_content_length_rejected(self):
+        """A body over the limit is rejected even when Content-Length is absent.
+
+        Chunked transfer-encoding (or a spoofed small Content-Length) makes
+        ``request.content_length`` None, so the fast-path check is skipped.
+        The post-read length check must still reject the oversized body — else
+        the per-route max_body_bytes guard is trivially bypassable.
+        """
+        routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes, max_body_bytes=100)
+
+        body = json.dumps({"data": "x" * 500}).encode()
+        req = _mock_request(
+            headers={},
+            body=body,
+            match_info={"route_name": "big"},
+        )
+        # Simulate a chunked request: aiohttp reports no Content-Length.
+        req.content_length = None
+        with patch.object(adapter, "_reload_dynamic_routes"):
+            resp = await adapter._handle_webhook(req)
+        assert resp.status == 413
+
 
 # ===================================================================
 # INSECURE_NO_AUTH


### PR DESCRIPTION
## Summary

The generic webhook adapter (`gateway/platforms/webhook.py`) enforced its per-route `max_body_bytes` limit **only** via the `Content-Length` header:

```python
content_length = request.content_length or 0
if content_length > self._max_body_bytes:
    return web.json_response({"error": "Payload too large"}, status=413)
raw_body = await request.read()   # reads the whole body, no re-check
```

A request using **`Transfer-Encoding: chunked`** (or a spoofed small `Content-Length`) makes `request.content_length` `None`, so `None or 0 == 0` and the check is skipped entirely. The full body is then buffered into memory regardless of the route's configured `max_body_bytes`.

This is reachable by an **unauthenticated** caller — the body must be read before HMAC signature verification — so it bypasses the documented size guard and is a DoS vector on an internet-exposed webhook endpoint. The module docstring even claims *"Body size limits checked before reading payload"*, which chunked requests defeat.

The sibling adapters **Feishu** (`plugins/platforms/feishu/adapter.py`) and **WeCom** already guard this exact case with a post-read length check and have regression tests for `content_length=None` — the generic adapter was the odd one out.

## Fix

- Re-check the limit against the bytes actually read (`len(raw_body) > self._max_body_bytes` → 413), keeping the `Content-Length` fast path.
- Update the module docstring to reflect the real guarantee.
- Add a regression test driving a chunked-style request (`Content-Length` None) with an over-limit body, asserting 413.

## Test plan

- [x] `tests/gateway/test_webhook_adapter.py` — 69 passed (68 existing + 1 new)
- [x] Full webhook suite (`test_webhook_adapter`, `test_webhook_signature_rate_limit`, `test_webhook_integration`, `test_webhook_dynamic_routes`, `test_webhook_deliver_only`) — 103 passed
- [x] Confirmed the new test fails without the fix (returns `202` instead of `413`) and passes with it