### PR TITLE
fix(discord): guard voice playback when discord.py is unavailable

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2812,6 +2812,10 @@ class DiscordAdapter(BasePlatformAdapter):
         reply can overlap the idle "thinking" loop seamlessly.  Otherwise we
         fall back to the legacy one-shot FFmpegPCMAudio path.
         """
+        if not check_discord_requirements():
+            logger.warning("Discord voice playback requested but discord.py is unavailable")
+            return False
+
         vc = self._voice_clients.get(guild_id)
         if not vc or not vc.is_connected():
             return False


### PR DESCRIPTION
## Summary

`play_in_voice_channel()` can be reached while `discord.py` is not importable — a failed lazy install, or an environment installed without the voice dependencies. Today that dies deep in the voice-client path with an unhelpful `NameError`/`AttributeError` mid-turn.

This adds the same `check_discord_requirements()` up-front guard the adapter's other entry points use, logging one WARNING and returning `False` so the caller's existing no-voice fallback handles delivery instead of the turn crashing.

## Testing

- `pytest tests/e2e/test_discord_adapter.py tests/tools/test_discord_tool.py` — 97 passed
- `py_compile` on the adapter
- Running in production on our fork since 2026-06-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)