### PR TITLE
fix(registry): log repeated check_fn unavailability at DEBUG after first WARNING

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -730,3 +730,73 @@ class TestDeregisterAuthorization:
             evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
             reg.register(name="protected", toolset="evil-ts", schema={}, handler=evil_handler, override=True)
         assert reg._tools["protected"].handler({}) == "built-in"
+
+
+class TestCheckFnWarnOnce:
+    """A persistently failing check_fn warns once, then logs repeats at DEBUG."""
+
+    def _expire_ttl(self, fn):
+        import time as _time
+        from tools import registry as reg_mod
+        with reg_mod._check_fn_cache_lock:
+            ts, value = reg_mod._check_fn_cache[fn]
+            reg_mod._check_fn_cache[fn] = (
+                ts - reg_mod._CHECK_FN_TTL_SECONDS - 1, value
+            )
+
+    def test_repeat_failures_log_debug_after_first_warning(self, caplog):
+        import logging
+        from tools import registry as reg_mod
+
+        reg_mod.invalidate_check_fn_cache()
+        failing = lambda: False  # noqa: E731
+
+        with caplog.at_level(logging.DEBUG, logger="tools.registry"):
+            assert reg_mod._check_fn_cached(failing) is False
+            self._expire_ttl(failing)
+            assert reg_mod._check_fn_cached(failing) is False
+
+        records = [
+            r for r in caplog.records
+            if "dependent tools will be unavailable" in r.getMessage()
+        ]
+        assert [r.levelno for r in records] == [logging.WARNING, logging.DEBUG]
+
+    def test_recovery_rearms_the_warning(self, caplog):
+        import logging
+        from tools import registry as reg_mod
+
+        reg_mod.invalidate_check_fn_cache()
+        state = {"ok": False}
+
+        def flapping():
+            return state["ok"]
+
+        with caplog.at_level(logging.DEBUG, logger="tools.registry"):
+            assert reg_mod._check_fn_cached(flapping) is False
+            state["ok"] = True
+            self._expire_ttl(flapping)
+            assert reg_mod._check_fn_cached(flapping) is True
+            state["ok"] = False
+            self._expire_ttl(flapping)
+            # Grace period after the True would flake-suppress; clear last_good
+            # to model a distinct outage rather than a flake.
+            with reg_mod._check_fn_cache_lock:
+                reg_mod._check_fn_last_good.pop(flapping, None)
+            assert reg_mod._check_fn_cached(flapping) is False
+
+        records = [
+            r for r in caplog.records
+            if "dependent tools will be unavailable" in r.getMessage()
+        ]
+        assert [r.levelno for r in records] == [logging.WARNING, logging.WARNING]
+
+    def test_invalidate_clears_warned_state(self):
+        from tools import registry as reg_mod
+
+        reg_mod.invalidate_check_fn_cache()
+        failing = lambda: False  # noqa: E731
+        assert reg_mod._check_fn_cached(failing) is False
+        assert failing in reg_mod._check_fn_warned
+        reg_mod.invalidate_check_fn_cache()
+        assert failing not in reg_mod._check_fn_warned

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -139,6 +139,12 @@ _CHECK_FN_FAILURE_GRACE_SECONDS = 60.0
 _check_fn_cache: Dict[Callable, tuple[float, bool]] = {}
 # Monotonic timestamp of the most recent True result per check_fn.
 _check_fn_last_good: Dict[Callable, float] = {}
+# check_fns whose unavailability has already been logged at WARNING. A
+# persistently-absent backend (no browser CDP, kanban mode off, ...) would
+# otherwise emit the same WARNING every TTL expiry on every turn, drowning
+# real errors; repeats go to DEBUG until the check recovers or the cache is
+# invalidated.
+_check_fn_warned: set = set()
 _check_fn_cache_lock = threading.Lock()
 
 
@@ -170,6 +176,8 @@ def _check_fn_cached(fn: Callable) -> bool:
         if value:
             _check_fn_last_good[fn] = now
             _check_fn_cache[fn] = (now, True)
+            # Recovered — re-arm the WARNING for the next distinct outage.
+            _check_fn_warned.discard(fn)
             return True
 
         last_good = _check_fn_last_good.get(fn)
@@ -186,9 +194,13 @@ def _check_fn_cached(fn: Callable) -> bool:
             )
             return True
 
-        # No recent success (or grace expired) — honor the failure. Log it so
-        # silent tool loss in quiet mode (subagents) is diagnosable.
-        logger.warning(
+        # No recent success (or grace expired) — honor the failure. Log the
+        # first occurrence at WARNING so silent tool loss in quiet mode
+        # (subagents) is diagnosable; repeats of the same ongoing outage at
+        # DEBUG so a permanently-absent backend can't flood the error log.
+        log = logger.debug if fn in _check_fn_warned else logger.warning
+        _check_fn_warned.add(fn)
+        log(
             "check_fn %s %s; dependent tools will be unavailable this turn",
             getattr(fn, "__qualname__", fn),
             "raised" if raised else "returned False",
@@ -203,6 +215,7 @@ def invalidate_check_fn_cache() -> None:
     with _check_fn_cache_lock:
         _check_fn_cache.clear()
         _check_fn_last_good.clear()
+        _check_fn_warned.clear()
 
 
 class ToolRegistry:


### PR DESCRIPTION
## Summary

A persistently-absent backend (no browser CDP endpoint, kanban mode off, computer-use not configured, …) re-emits the same `check_fn … returned False; dependent tools will be unavailable this turn` WARNING on every TTL expiry of every turn. On a long-running gateway this floods the error log with thousands of identical lines — on our production deployment these warnings are roughly 80% of `errors.log` by volume, burying real errors.

This keeps the first occurrence per `check_fn` at WARNING (so silent tool loss stays diagnosable, including in quiet subagent mode) and logs repeats of the same ongoing outage at DEBUG:

- recovery (check returns True) re-arms the WARNING for the next distinct outage
- `invalidate_check_fn_cache()` (config changes) also re-arms, so availability changes after `hermes tools enable` still surface
- the transient-flake grace path is unchanged

## Testing

- 3 new tests in `tests/tools/test_registry.py` covering WARNING→DEBUG demotion, re-arm on recovery, and re-arm on cache invalidation
- `pytest tests/tools/test_registry.py` — 44 passed
- `pytest tests/tools/test_terminal_tool_requirements.py tests/tools/test_kanban_tools.py` — 105 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)