### PR TITLE
fix(kanban): stabilize SQLite opens and dispatch caps

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -641,7 +641,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_disp.add_argument("--dry-run", action="store_true",
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,
-                        help="Cap number of spawns this pass")
+                        help="Live worker cap for this dispatch pass (overrides kanban.max_spawn)")
     p_disp.add_argument("--failure-limit", type=int,
                         default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
                         help=f"Auto-block a task after this many consecutive non-success attempts "
@@ -921,20 +921,13 @@ def kanban_command(args: argparse.Namespace) -> int:
             return 1
         board_scope = kb.scoped_current_board(normed)
 
-    # Auto-initialize the DB before dispatching any subcommand. init_db
-    # is idempotent, so running it every invocation is cheap (one
-    # SELECT against sqlite_master when tables already exist) and
-    # prevents "no such table: tasks" on first use from a fresh
-    # HERMES_HOME. Previously only `init` and `daemon` triggered
-    # schema creation; `create` / `list` / every other command would
-    # error out on a fresh install.
+    # Do not force kb.init_db() before every subcommand. connect() already
+    # auto-initializes fresh/legacy boards, while current boards take a cheap
+    # schema-probe fast path. Re-running init_db() here discards that cache and
+    # turns harmless CLI reads into full integrity/migration passes against a
+    # live WAL database, which is exactly the intermittent malformed-image class
+    # this command path used to trigger under worker load.
     with board_scope:
-        try:
-            kb.init_db()
-        except Exception as exc:
-            print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
-            return 1
-
         handlers = {
             "init":     _cmd_init,
             "create":   _cmd_create,
@@ -2116,10 +2109,10 @@ def _cmd_tail(args: argparse.Namespace) -> int:
 
 def _cmd_dispatch(args: argparse.Namespace) -> int:
     # Honour kanban.default_assignee as the fallback for unassigned ready
-    # tasks (#27145), kanban.max_in_progress as the global concurrency cap
+    # tasks (#27145), kanban.max_in_progress as the global safety cap
     # (#33488), kanban.max_in_progress_per_profile as the per-profile
-    # cap (#21582), and kanban.max_spawn as the per-tick spawn limit
-    # (#28805). Same semantics as the gateway dispatch path so behavior
+    # cap (#21582), and kanban.max_spawn as the dispatcher's live worker
+    # cap (#28805). Same semantics as the gateway dispatch path so behavior
     # matches whether the user runs the CLI directly or relies on the
     # gateway-embedded dispatcher.
     try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1292,6 +1292,22 @@ DEFAULT_BUSY_TIMEOUT_MS = 120_000
 # lock (the in-process _INIT_LOCK + idempotent init remain the backstop).
 _INIT_LOCK_TIMEOUT_SECONDS = 10.0
 _INIT_LOCK_POLL_SECONDS = 0.05
+_MALFORMED_IMAGE_RETRY_ATTEMPTS = 3
+_MALFORMED_IMAGE_RETRY_MIN_S = 0.050
+_MALFORMED_IMAGE_RETRY_MAX_S = 0.250
+
+_CURRENT_TASK_COLUMNS = frozenset({
+    "tenant", "result", "branch_name", "project_id", "idempotency_key",
+    "consecutive_failures", "worker_pid", "last_failure_error",
+    "max_runtime_seconds", "last_heartbeat_at", "current_run_id",
+    "workflow_template_id", "current_step_key", "skills", "max_retries",
+    "model_override", "goal_mode", "goal_max_turns", "session_id",
+    "block_kind", "block_recurrences",
+})
+_CURRENT_TASK_RUN_COLUMNS = frozenset({
+    "claim_lock", "claim_expires", "worker_pid", "max_runtime_seconds",
+    "last_heartbeat_at", "ended_at", "outcome", "summary", "metadata", "error",
+})
 
 
 def _resolve_busy_timeout_ms() -> int:
@@ -1325,6 +1341,126 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
     # changes. Parameter binding is not supported for PRAGMA assignments.
     conn.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
     return conn
+
+
+def _configure_connection(conn: sqlite3.Connection, path: Path) -> None:
+    """Apply the standard Kanban connection pragmas to an open connection."""
+    from hermes_state import apply_wal_with_fallback
+
+    apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+    conn.execute("PRAGMA synchronous=FULL")
+    conn.execute("PRAGMA wal_autocheckpoint=100")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("PRAGMA secure_delete=ON")
+    conn.execute("PRAGMA cell_size_check=ON")
+
+
+def _open_configured_connection(path: Path) -> sqlite3.Connection:
+    """Open a Kanban connection and apply standard pragmas."""
+    conn = _sqlite_connect(path)
+    try:
+        conn.row_factory = sqlite3.Row
+        with _INIT_LOCK:
+            _configure_connection(conn, path)
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
+def _is_malformed_image_error(exc: BaseException) -> bool:
+    """True for SQLite's malformed-image class."""
+    return (
+        isinstance(exc, sqlite3.DatabaseError)
+        and "database disk image is malformed" in str(exc).lower()
+    )
+
+
+def _malformed_retry_sleep() -> None:
+    time.sleep(random.uniform(_MALFORMED_IMAGE_RETRY_MIN_S, _MALFORMED_IMAGE_RETRY_MAX_S))
+
+
+def _schema_needs_init_or_migration(conn: sqlite3.Connection) -> bool:
+    """Return True iff the opened DB needs schema creation or migration.
+
+    This is a cheap schema probe, not a full integrity check. Short-lived CLI
+    commands and dashboard probes can open a busy Kanban board many times per
+    minute while workers append events. Running ``PRAGMA integrity_check`` and
+    the additive migration pass on every new process turned ordinary reads into
+    heavyweight whole-file scans against a live WAL database, which surfaced
+    intermittent ``database disk image is malformed`` failures even though a
+    subsequent integrity check was OK. Existing current-schema DBs therefore
+    take the steady-state path; fresh/legacy DBs still run the guarded migration
+    path before use.
+    """
+    tables = {
+        row["name"]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    required_tables = {
+        "tasks", "task_links", "task_comments", "task_events", "task_runs",
+        "task_attachments", "kanban_notify_subs",
+    }
+    if not required_tables.issubset(tables):
+        return True
+
+    task_cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    if not _CURRENT_TASK_COLUMNS.issubset(task_cols):
+        return True
+
+    event_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
+    if "run_id" not in event_cols:
+        return True
+
+    run_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+    if not _CURRENT_TASK_RUN_COLUMNS.issubset(run_cols):
+        return True
+
+    notify_cols = {
+        row["name"] for row in conn.execute("PRAGMA table_info(kanban_notify_subs)")
+    }
+    if "notifier_profile" not in notify_cols:
+        return True
+
+    for table in ("task_events", "task_comments", "task_runs", "kanban_notify_subs"):
+        if _table_has_drifted(conn, table):  # defined below; resolved at runtime
+            return True
+    return False
+
+
+def _existing_db_needs_init_or_migration(path: Path) -> bool:
+    """Cheaply decide whether an existing DB needs init/migration.
+
+    Missing and zero-byte files are fresh and need init. Existing current DBs
+    skip the expensive integrity/migration path. A malformed-image error is
+    retried on a fresh connection before being treated as real corruption,
+    because live WAL/checkpoint contention can produce transient failures on an
+    otherwise healthy board.
+    """
+    try:
+        if not path.exists() or path.stat().st_size == 0:
+            return True
+    except OSError:
+        return True
+
+    for attempt in range(_MALFORMED_IMAGE_RETRY_ATTEMPTS):
+        conn = None
+        try:
+            conn = _sqlite_connect(path)
+            conn.row_factory = sqlite3.Row
+            return _schema_needs_init_or_migration(conn)
+        except sqlite3.DatabaseError as exc:
+            if _is_malformed_image_error(exc) and attempt < _MALFORMED_IMAGE_RETRY_ATTEMPTS - 1:
+                _malformed_retry_sleep()
+                continue
+            raise
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+    return True
 
 
 @contextlib.contextmanager
@@ -1682,6 +1818,7 @@ def connect(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    _force_init: bool = False,
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
@@ -1707,32 +1844,31 @@ def connect(
         path = kanban_db_path(board=board)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Fast path: once THIS process has initialized this path, the expensive
-    # first-open work (header validation, integrity probe, schema + additive
-    # migrations) is already done and cached in _INITIALIZED_PATHS. Acquiring
-    # the cross-process init lock on every connect is what let a single stalled
-    # holder (e.g. an external `hermes kanban list` mid-integrity-probe) block
-    # the long-lived gateway dispatcher's next-tick connect() forever — an
-    # unbounded flock with no timeout, no LOCK_NB, no recovery (#36644). On the
-    # steady-state path there is nothing for the cross-process lock to protect
-    # (no schema/migration writes run), so skip it entirely and just open the
-    # connection with WAL/pragmas under the cheap in-process _INIT_LOCK.
+    # Fast path: once the DB is known current, skip the expensive first-open
+    # work (full integrity probe + additive migrations). Short-lived CLI
+    # processes have an empty _INITIALIZED_PATHS cache, so use a cheap schema
+    # probe as the cross-process steady-state test before taking the init lock.
     resolved = str(path.resolve())
-    if resolved in _INITIALIZED_PATHS:
-        conn = _sqlite_connect(path)
+    if resolved in _INITIALIZED_PATHS and not _force_init:
+        return _open_configured_connection(path)
+
+    schema_needs_init = True
+    if not _force_init:
         try:
-            conn.row_factory = sqlite3.Row
-            with _INIT_LOCK:
-                from hermes_state import apply_wal_with_fallback
-                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-                conn.execute("PRAGMA synchronous=FULL")
-                conn.execute("PRAGMA wal_autocheckpoint=100")
-                conn.execute("PRAGMA foreign_keys=ON")
-                conn.execute("PRAGMA secure_delete=ON")
-                conn.execute("PRAGMA cell_size_check=ON")
-        except Exception:
-            conn.close()
-            raise
+            _validate_sqlite_header(path)
+            schema_needs_init = _existing_db_needs_init_or_migration(path)
+        except sqlite3.DatabaseError as exc:
+            if not _is_malformed_image_error(exc):
+                raise
+            # Retry/probe exhausted on the fast path. Fall through to the full
+            # guarded integrity check so persistent corruption still gets preserved
+            # via KanbanDbCorruptError instead of being silently ignored.
+            schema_needs_init = True
+
+    if not schema_needs_init:
+        conn = _open_configured_connection(path)
+        with _INIT_LOCK:
+            _INITIALIZED_PATHS.add(resolved)
         return conn
 
     with _cross_process_init_lock(path):
@@ -1752,23 +1888,8 @@ def connect(
                 # sidecar files for a fresh database. Keep it in the same process-local
                 # critical section as schema initialization so concurrent gateway
                 # startup threads do not race before _INITIALIZED_PATHS is populated.
-                # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-                # falls back to DELETE with one WARNING so kanban stays usable there.
-                # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-                from hermes_state import apply_wal_with_fallback
-                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-                # FULL (was NORMAL): fsync before each checkpoint to narrow the
-                # crash window that can leave a b-tree page header torn.
-                conn.execute("PRAGMA synchronous=FULL")
-                conn.execute("PRAGMA wal_autocheckpoint=100")
-                conn.execute("PRAGMA foreign_keys=ON")
-                # Zero freed pages so a later torn write cannot expose stale
-                # cell content; persisted in the DB header for new DBs.
-                conn.execute("PRAGMA secure_delete=ON")
-                # Surface corrupt cells as read errors instead of silent
-                # wrong-data returns.
-                conn.execute("PRAGMA cell_size_check=ON")
-                needs_init = resolved not in _INITIALIZED_PATHS
+                _configure_connection(conn, path)
+                needs_init = _force_init or resolved not in _INITIALIZED_PATHS
                 if needs_init:
                     # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
                     # migrations. Cached so subsequent connect() calls in the same
@@ -1844,7 +1965,7 @@ def init_db(
     # schema + migration pass unconditionally.
     with _INIT_LOCK:
         _INITIALIZED_PATHS.discard(resolved)
-    with contextlib.closing(connect(path)):
+    with contextlib.closing(connect(path, _force_init=True)):
         pass
     return path
 
@@ -7066,40 +7187,32 @@ def _dispatch_once_locked(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
-    # Count tasks already running so max_spawn enforces concurrency rather
-    # than a per-tick spawn budget. See the docstring above for the full
-    # rationale; the short version is that a 60-second tick interval with a
-    # per-tick budget of N would grow concurrency by N every tick on a busy
-    # board, since "running" tasks aren't reclaimed by completion alone —
-    # they sit in status='running' until the worker calls
-    # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
-    running_count = 0
-    if max_spawn is not None:
-        running_count = int(
-            conn.execute(
-                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-            ).fetchone()[0]
-        )
+    # Count tasks already running once, then enforce both global knobs as live
+    # concurrency caps. ``max_spawn`` is the dispatcher's live worker cap;
+    # ``max_in_progress`` is a broader safety cap. When both are set, the
+    # effective cap is the stricter one. Do not rewrite one cap into a
+    # "remaining slots" value: the loop condition also adds running_count, and
+    # double-counting is what made max_spawn=4 + max_in_progress=4 spawn zero
+    # new workers whenever any task was already running.
+    running_count = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+        ).fetchone()[0]
+    )
+    cap_candidates: list[int] = []
+    if isinstance(max_spawn, int) and max_spawn > 0:
+        cap_candidates.append(max_spawn)
+    if isinstance(max_in_progress, int) and max_in_progress > 0:
+        cap_candidates.append(max_in_progress)
+    live_spawn_cap = min(cap_candidates) if cap_candidates else None
 
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
-    # Honour kanban.max_in_progress: if the board already has enough running
-    # tasks, skip spawning this tick so slow workers (local LLMs,
-    # resource-constrained hosts) can finish what they have before more tasks
-    # pile up and time out.
-    if max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
-        if in_progress >= max_in_progress:
-            return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
+    if live_spawn_cap is not None and ready_rows and running_count >= live_spawn_cap:
+        return result
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -7138,7 +7251,7 @@ def _dispatch_once_locked(
             # there, with the existing diagnostic.
             _default_assignee_resolved = True
     for row in ready_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if live_spawn_cap is not None and running_count + spawned >= live_spawn_cap:
             break
         row_assignee = row["assignee"]
         if not row_assignee:
@@ -7243,6 +7356,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            spawned += 1
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -7329,7 +7443,7 @@ def _dispatch_once_locked(
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     for row in review_rows:
-        if max_spawn is not None and running_count + spawned >= max_spawn:
+        if live_spawn_cap is not None and running_count + spawned >= live_spawn_cap:
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
@@ -7343,6 +7457,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -566,3 +566,16 @@ def test_run_slash_board_override_does_not_change_boards_show_current(kanban_hom
     out = kc.run_slash("--board beta boards show")
 
     assert "Current board: alpha" in out
+
+
+def test_run_slash_list_does_not_force_global_init_on_current_db(kanban_home, monkeypatch):
+    """Current boards should not run kb.init_db() before every CLI command."""
+    kc.run_slash("create 'fast path task' --assignee default")
+
+    def _fail_init_db(*_args, **_kwargs):
+        raise AssertionError("run_slash list should use connect() fast path, not init_db()")
+
+    monkeypatch.setattr(kb, "init_db", _fail_init_db)
+    out = kc.run_slash("list")
+
+    assert "fast path task" in out

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -69,6 +69,46 @@ def _table_struct(conn: sqlite3.Connection, table: str):
     return cols, idx
 
 
+def test_current_schema_connect_skips_full_integrity_guard(tmp_path, monkeypatch):
+    """Current DBs should use the cheap schema fast path across processes."""
+    db_path = _setup_home(tmp_path, monkeypatch)
+    with kb.connect(db_path) as conn:
+        kb.create_task(conn, title="persisted")
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    def _fail_full_guard(_path):
+        raise AssertionError("full integrity guard should not run for current schema")
+
+    monkeypatch.setattr(kb, "_guard_existing_db_is_healthy", _fail_full_guard)
+    with kb.connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+
+
+def test_schema_fast_path_retries_transient_malformed_image(tmp_path, monkeypatch):
+    """A transient malformed-image read during the schema probe is retried."""
+    db_path = _setup_home(tmp_path, monkeypatch)
+    with kb.connect(db_path) as conn:
+        kb.create_task(conn, title="persisted")
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    real_probe = kb._schema_needs_init_or_migration
+    calls = {"n": 0}
+
+    def _flaky_probe(conn):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise sqlite3.DatabaseError("database disk image is malformed")
+        return real_probe(conn)
+
+    monkeypatch.setattr(kb, "_schema_needs_init_or_migration", _flaky_probe)
+    monkeypatch.setattr(kb, "_malformed_retry_sleep", lambda: None)
+
+    with kb.connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+    assert calls["n"] == 2
+
+
 def test_connect_initialization_is_thread_safe(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -47,6 +47,86 @@ def test_no_cap_all_tasks_dispatched(isolated_kanban_home_with_profiles):
     assert not res.skipped_per_profile_capped
 
 
+def test_live_caps_fill_remaining_slots_when_equal(isolated_kanban_home_with_profiles):
+    """max_spawn and max_in_progress are both live caps.
+
+    With two workers already running and both caps set to 4, dispatch should
+    spawn two more workers. The regression double-counted running tasks by
+    rewriting max_spawn to the remaining max_in_progress slots and then adding
+    running_count again in the loop, producing zero spawns.
+    """
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        running_ids = [
+            kb.create_task(conn, title=f"running {i}", assignee="alpha")
+            for i in range(2)
+        ]
+        with kb.write_txn(conn):
+            for tid in running_ids:
+                conn.execute(
+                    "UPDATE tasks SET status = 'running', claim_lock = 'test:running' WHERE id = ?",
+                    (tid,),
+                )
+        for i in range(4):
+            kb.create_task(conn, title=f"ready {i}", assignee="alpha")
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_spawn=4,
+            max_in_progress=4,
+        )
+
+    assert len(res.spawned) == 2
+
+
+def test_dry_run_counts_simulated_spawns_against_live_cap(isolated_kanban_home_with_profiles):
+    """Dry-run must not over-declare spawns beyond the live cap."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        for i in range(5):
+            kb.create_task(conn, title=f"ready {i}", assignee="alpha")
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_spawn=2,
+            max_in_progress=8,
+        )
+
+    assert len(res.spawned) == 2
+
+
+def test_dry_run_counts_review_spawns_against_live_cap(isolated_kanban_home_with_profiles):
+    """Review-column dry-run uses the same live-cap accounting."""
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        review_ids = [
+            kb.create_task(conn, title=f"review {i}", assignee="alpha")
+            for i in range(4)
+        ]
+        with kb.write_txn(conn):
+            for tid in review_ids:
+                conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (tid,))
+
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=_fake_spawn,
+            dry_run=True,
+            max_spawn=2,
+        )
+
+    assert len(res.spawned) == 2
+
+
 def test_cap_2_balances_two_profiles(isolated_kanban_home_with_profiles):
     """With cap=2: 2 alpha + 2 beta dispatched; remaining 3 alpha + 1 beta
     deferred to skipped_per_profile_capped."""


### PR DESCRIPTION
## Summary

- avoid forcing the full Kanban DB initialization path before every CLI subcommand
- add a cheap current-schema fast path for existing Kanban SQLite databases, with retries for transient `database disk image is malformed` reads before falling back to the guarded init/integrity path
- treat `max_spawn` and `max_in_progress` consistently as live worker caps, and make dry-run accounting consume simulated slots so it does not over-report spawns

## Why

Short-lived `hermes kanban ...` CLI commands could repeatedly run the heavyweight init/integrity/migration path against an active WAL database while workers were writing. Under load this can surface intermittent malformed-image errors even when later integrity checks pass. The dispatcher also double-counted running workers when `max_spawn` and `max_in_progress` were equal, leaving ready tasks unspawned despite available capacity.

## Tests

- `python -m py_compile hermes_cli/kanban.py hermes_cli/kanban_db.py`
- `python -m pytest tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py -q`
  - `71 passed`
- `git diff --check origin/main..HEAD`
