### PR TITLE
fix(feishu): adapter declares enforces_own_access_policy so gateway honors group_rules

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1413,6 +1413,16 @@ class FeishuAdapter(BasePlatformAdapter):
     supports_code_blocks = True  # Feishu renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
+    # Feishu gates DM/group access at intake via FEISHU_GROUP_POLICY +
+    # per-group group_rules.<chat_id>.allowlist (parsed from config.extra).
+    # The gateway's env-based FEISHU_ALLOWED_USERS check runs AFTER this; when
+    # no env allowlist is configured, the gateway consults this flag so it can
+    # honor the config-driven group_rules allowlist the adapter already
+    # enforced, instead of double-denying it. Mirrors WeCom / Weixin / Yuanbao.
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        return True
+
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -41,6 +41,7 @@ _OWN_POLICY_PLATFORMS = [
     Platform.YUANBAO,
     Platform.QQBOT,
     Platform.WHATSAPP,
+    Platform.FEISHU,
 ]
 
 
@@ -52,6 +53,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "QQ_ALLOWED_USERS",
         "QQ_GROUP_ALLOWED_USERS",
         "WHATSAPP_ALLOWED_USERS",
+        "FEISHU_ALLOWED_USERS",
         "TELEGRAM_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
@@ -60,6 +62,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "YUANBAO_ALLOW_ALL_USERS",
         "QQ_ALLOW_ALL_USERS",
         "WHATSAPP_ALLOW_ALL_USERS",
+        "FEISHU_ALLOW_ALL_USERS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -113,6 +116,7 @@ def test_base_adapter_defaults_to_not_owning_access_policy():
         ("gateway.platforms.yuanbao", "YuanbaoAdapter"),
         ("gateway.platforms.qqbot.adapter", "QQAdapter"),
         ("plugins.platforms.whatsapp.adapter", "WhatsAppAdapter"),
+        ("plugins.platforms.feishu.adapter", "FeishuAdapter"),
     ],
 )
 def test_own_policy_adapters_declare_the_flag(module_path, class_name):


### PR DESCRIPTION
## Summary

Feishu gates DM/group access at intake via `FEISHU_GROUP_POLICY` + per-group `group_rules.<chat_id>.allowlist` (parsed from `config.extra`). The gateway's env-based `FEISHU_ALLOWED_USERS` check runs AFTER this.

**Problem:** when no `FEISHU_ALLOWED_USERS` env allowlist is configured, the gateway had no way to honor the config-driven `group_rules` allowlist the adapter already enforced — it default-denied every Feishu group message regardless of `group_rules`. This is because `FeishuAdapter` did not declare `enforces_own_access_policy = True` (unlike WeCom / Weixin / Yuanbao / QQBot / WhatsApp), so the gateway's `_is_user_authorized` did not trust the adapter's intake-layer decision.

**Fix:** add `enforces_own_access_policy` property returning `True` on `FeishuAdapter`. The gateway now trusts the adapter's decision when `chat_type` is group, so `group_rules` becomes sufficient at the gateway layer without requiring a parallel `FEISHU_ALLOWED_USERS` env allowlist.

## Root cause

Two-layer gating gap:
1. **Adapter layer** (`_allow_group_message` in `plugins/platforms/feishu/adapter.py`): correctly uses `group_rules[chat_id].allowlist` — works.
2. **Gateway layer** (`_is_user_authorized` in `gateway/authz_mixin.py`): checks `_adapter_enforces_own_access_policy(platform)` via `getattr(adapter, "enforces_own_access_policy", False)`. Feishu returned `False` → gateway skipped the trust-adapter branch → default-deny for all Feishu group messages.

## Changes

- `plugins/platforms/feishu/adapter.py`: add `enforces_own_access_policy` property (returns `True`) to `FeishuAdapter`. Mirrors WeCom / Weixin / Yuanbao / QQBot / WhatsApp.
- `tests/gateway/test_config_driven_access_policy.py`: extend Feishu coverage — `_OWN_POLICY_PLATFORMS`, `_clear_auth_env` (`FEISHU_ALLOWED_USERS` / `FEISHU_ALLOW_ALL_USERS`), `test_own_policy_adapters_declare_the_flag`.

## Verification

```
./venv/bin/pytest tests/gateway/test_config_driven_access_policy.py tests/gateway/test_multiplex_profile_authz.py -q
# 85 passed
```

## Checklist

- [x] Patch only touches the two relevant files
- [x] No new core tools / model tool schema changes
- [x] Prompt caching unaffected (no system prompt / tool schema change)
- [x] Mirrors existing pattern (WeCom et al.) — no new API surface
