### PR TITLE
fix: use HERMES_REAL_HOME for HOME in s6 startup scripts

### DIFF
--- a/docker/hermes-exec-shim.sh
+++ b/docker/hermes-exec-shim.sh
@@ -82,6 +82,6 @@ fi
 # this, $HOME stays /root and any library that resolves paths off $HOME
 # (XDG caches, lockfiles, .config writes) will try to write to /root and
 # fail with EACCES. Mirrors main-wrapper.sh.
-export HOME=/opt/data
+export HOME=${HERMES_REAL_HOME:-/opt/data}
 
 exec "$S6_SUID" hermes "$REAL" "$@"

--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -53,14 +53,16 @@ fi
 # to the hermes user's home before dropping privileges so libraries that
 # resolve paths via $HOME (e.g. discord lockfile under XDG_STATE_HOME)
 # don't try to write to /root.
-export HOME=/opt/data
+# When HERMES_REAL_HOME is set (e.g. for custom bind-mount layouts),
+# use it instead of the default /opt/data.
+export HOME=${HERMES_REAL_HOME:-/opt/data}
 
 # Save the Docker -w (or default) working directory before init
-# scripts cd to /opt/data, so the container starts in the
+# scripts cd to the home directory, so the container starts in the
 # directory the user requested.
 _hermes_orig_cwd="${HERMES_ORIG_CWD:-$PWD}"
 
-cd /opt/data
+cd "${HERMES_REAL_HOME:-/opt/data}"
 # shellcheck disable=SC1091
 . /opt/hermes/.venv/bin/activate
 

--- a/docker/s6-rc.d/dashboard/run
+++ b/docker/s6-rc.d/dashboard/run
@@ -20,10 +20,11 @@ case "${HERMES_DASHBOARD:-}" in
 esac
 
 # with-contenv repopulates HOME from /init as /root. Reset it before
-# dropping privileges so HOME-anchored state lands under /opt/data.
-export HOME=/opt/data
+# dropping privileges so HOME-anchored state lands under the correct directory.
+# When HERMES_REAL_HOME is set, use it instead of the default /opt/data.
+export HOME=${HERMES_REAL_HOME:-/opt/data}
 
-cd /opt/data
+cd "${HERMES_REAL_HOME:-/opt/data}"
 # shellcheck disable=SC1091
 . /opt/hermes/.venv/bin/activate
 

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -18,6 +18,7 @@
 set -eu
 
 HERMES_HOME="${HERMES_HOME:-/opt/data}"
+HERMES_REAL_HOME="${HERMES_REAL_HOME:-}"
 INSTALL_DIR="/opt/hermes"
 
 # Drop to hermes via s6-setuidgid, but skip it when already non-root.
@@ -210,6 +211,26 @@ refuse_symlinked_path() {
     fi
     return 1
 }
+
+# --- Ensure HERMES_REAL_HOME exists and is hermes-owned when distinct ---
+# Custom bind-mount layouts may set HERMES_REAL_HOME to a directory other
+# than /opt/data. The s6 run scripts (main-wrapper.sh, dashboard/run,
+# hermes-exec-shim.sh) cd into $HERMES_REAL_HOME and export HOME=$HERMES_REAL_HOME
+# before s6-setuidgid drops privileges. If the directory doesn't exist or is
+# root-owned, every HOME-anchored write under it (.config, .cache, XDG_STATE_HOME,
+# library lockfiles) fails with EACCES after the drop. Create + chown it here
+# while we still have root, mirroring the HERMES_HOME bootstrap above. Only
+# act when HERMES_REAL_HOME is set AND differs from HERMES_HOME (no-op on the
+# default /opt/data layout where they coincide). (#56402)
+if [ -n "$HERMES_REAL_HOME" ] && [ "$HERMES_REAL_HOME" != "$HERMES_HOME" ]; then
+    mkdir -p "$HERMES_REAL_HOME"
+    if refuse_symlinked_path "chown" "$HERMES_REAL_HOME"; then
+        :
+    else
+        chown hermes:hermes "$HERMES_REAL_HOME" 2>/dev/null || \
+            echo "[stage2] Warning: chown $HERMES_REAL_HOME failed (rootless container?) — continuing"
+    fi
+fi
 
 chown_hermes_tree() {
     target="$1"

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -670,8 +670,8 @@ class S6ServiceManager:
             "#!/command/with-contenv sh",
             "# shellcheck shell=sh",
             "set -e",
-            "export HOME=/opt/data",
-            "cd /opt/data",
+            "export HOME=${HERMES_REAL_HOME:-/opt/data}",
+            "cd \"${HERMES_REAL_HOME:-/opt/data}\"",
             ". /opt/hermes/.venv/bin/activate",
         ]
         for k, v in sorted(extra_env.items()):

--- a/tests/docker/test_home_override_scripts.py
+++ b/tests/docker/test_home_override_scripts.py
@@ -3,15 +3,44 @@
 Build the real image and verify the actual runtime behavior:
 
   1. main-wrapper preserves the Docker ``-w`` working directory
-  2. dashboard service resets HOME to /opt/data before privilege drop
+  2. dashboard service resets HOME (via HERMES_REAL_HOME) before privilege drop
   3. dashboard does not auto-add ``--insecure`` from a non-loopback bind host
   4. stage2 hook repairs profiles/ and cron/ ownership on every boot
 """
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 from tests.docker.conftest import docker_exec, docker_exec_sh, start_container, restart_container
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MAIN_WRAPPER = REPO_ROOT / "docker" / "main-wrapper.sh"
+DASHBOARD_RUN = REPO_ROOT / "docker" / "s6-rc.d" / "dashboard" / "run"
+
+
+def test_main_wrapper_uses_hermes_real_home() -> None:
+    """main-wrapper.sh must use ${HERMES_REAL_HOME:-/opt/data} for HOME
+    instead of hardcoded /opt/data, so custom bind-mount layouts work.
+    """
+    text = MAIN_WRAPPER.read_text(encoding="utf-8")
+    assert 'export HOME=${HERMES_REAL_HOME:-/opt/data}' in text
+    assert 'cd "${HERMES_REAL_HOME:-/opt/data}"' in text
+    # Must NOT contain the old hardcoded pattern
+    assert "export HOME=/opt/data\n" not in text
+    assert "cd /opt/data\n" not in text
+
+
+def test_dashboard_run_uses_hermes_real_home() -> None:
+    """dashboard/run must use ${HERMES_REAL_HOME:-/opt/data} for HOME
+    instead of hardcoded /opt/data.
+    """
+    text = DASHBOARD_RUN.read_text(encoding="utf-8")
+    assert 'export HOME=${HERMES_REAL_HOME:-/opt/data}' in text
+    assert 'cd "${HERMES_REAL_HOME:-/opt/data}"' in text
+    # Must NOT contain the old hardcoded pattern
+    assert "export HOME=/opt/data\n" not in text
+    assert "cd /opt/data\n" not in text
 
 
 def test_main_wrapper_preserves_docker_workdir(
@@ -43,15 +72,18 @@ def test_main_wrapper_preserves_docker_workdir(
 def test_dashboard_service_resets_home(
     built_image: str, container_name: str,
 ) -> None:
-    """The dashboard run script must export HOME=/opt/data before dropping
+    """The dashboard run script must export HOME before dropping
     privileges, so HOME-anchored state (discord lockfile, XDG dirs) doesn't
     try to write to /root (the /init context's HOME).
+
+    When HERMES_REAL_HOME is not set, HOME defaults to /opt/data.
+    When HERMES_REAL_HOME is set, HOME uses that value.
 
     We check this by inspecting the environment of the dashboard service
     process if it's running, or by verifying the run script sets HOME
     before the exec. At runtime, the cleanest check is: start the
     container with HERMES_DASHBOARD=1 and verify the dashboard process
-    (if it starts) has HOME=/opt/data.
+    (if it starts) has HOME=/opt/data (the default).
 
     Since the dashboard requires an auth provider on non-loopback binds,
     we bind to 127.0.0.1 where the auth gate doesn't engage, and check
@@ -64,12 +96,12 @@ def test_dashboard_service_resets_home(
         container_name,
         # Find the dashboard process (hermes dashboard) and read its HOME
         # from /proc/<pid>/environ. If not running, verify the run script
-        # itself exports HOME=/opt/data by grepping the script source.
+        # itself exports HOME via HERMES_REAL_HOME by grepping the script source.
         'pid=$(pgrep -f "hermes dashboard" | head -1); '
         'if [ -n "$pid" ]; then '
         '  tr "\\0" "\\n" < /proc/$pid/environ | grep "^HOME="; '
         'else '
-        '  grep -q "export HOME=/opt/data" '
+        '  grep -q "HERMES_REAL_HOME" '
         '    /opt/hermes/docker/s6-rc.d/dashboard/run && '
         '  echo "HOME=/opt/data"; '
         'fi',

--- a/tests/docker/test_home_override_scripts.py
+++ b/tests/docker/test_home_override_scripts.py
@@ -3,44 +3,15 @@
 Build the real image and verify the actual runtime behavior:
 
   1. main-wrapper preserves the Docker ``-w`` working directory
-  2. dashboard service resets HOME (via HERMES_REAL_HOME) before privilege drop
+  2. dashboard service resets HOME (via HERMES_REAL_HOME) before privilege drop — both the default fallback AND a custom HERMES_REAL_HOME
   3. dashboard does not auto-add ``--insecure`` from a non-loopback bind host
   4. stage2 hook repairs profiles/ and cron/ ownership on every boot
 """
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 
 from tests.docker.conftest import docker_exec, docker_exec_sh, start_container, restart_container
-
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-MAIN_WRAPPER = REPO_ROOT / "docker" / "main-wrapper.sh"
-DASHBOARD_RUN = REPO_ROOT / "docker" / "s6-rc.d" / "dashboard" / "run"
-
-
-def test_main_wrapper_uses_hermes_real_home() -> None:
-    """main-wrapper.sh must use ${HERMES_REAL_HOME:-/opt/data} for HOME
-    instead of hardcoded /opt/data, so custom bind-mount layouts work.
-    """
-    text = MAIN_WRAPPER.read_text(encoding="utf-8")
-    assert 'export HOME=${HERMES_REAL_HOME:-/opt/data}' in text
-    assert 'cd "${HERMES_REAL_HOME:-/opt/data}"' in text
-    # Must NOT contain the old hardcoded pattern
-    assert "export HOME=/opt/data\n" not in text
-    assert "cd /opt/data\n" not in text
-
-
-def test_dashboard_run_uses_hermes_real_home() -> None:
-    """dashboard/run must use ${HERMES_REAL_HOME:-/opt/data} for HOME
-    instead of hardcoded /opt/data.
-    """
-    text = DASHBOARD_RUN.read_text(encoding="utf-8")
-    assert 'export HOME=${HERMES_REAL_HOME:-/opt/data}' in text
-    assert 'cd "${HERMES_REAL_HOME:-/opt/data}"' in text
-    # Must NOT contain the old hardcoded pattern
-    assert "export HOME=/opt/data\n" not in text
-    assert "cd /opt/data\n" not in text
 
 
 def test_main_wrapper_preserves_docker_workdir(
@@ -76,14 +47,11 @@ def test_dashboard_service_resets_home(
     privileges, so HOME-anchored state (discord lockfile, XDG dirs) doesn't
     try to write to /root (the /init context's HOME).
 
-    When HERMES_REAL_HOME is not set, HOME defaults to /opt/data.
-    When HERMES_REAL_HOME is set, HOME uses that value.
+    Default fallback: when HERMES_REAL_HOME is not set, HOME defaults
+    to /opt/data.
 
     We check this by inspecting the environment of the dashboard service
-    process if it's running, or by verifying the run script sets HOME
-    before the exec. At runtime, the cleanest check is: start the
-    container with HERMES_DASHBOARD=1 and verify the dashboard process
-    (if it starts) has HOME=/opt/data (the default).
+    process via /proc/<pid>/environ.
 
     Since the dashboard requires an auth provider on non-loopback binds,
     we bind to 127.0.0.1 where the auth gate doesn't engage, and check
@@ -91,25 +59,71 @@ def test_dashboard_service_resets_home(
     """
     start_container(built_image, container_name, "HERMES_DASHBOARD=1", "HERMES_DASHBOARD_HOST=127.0.0.1")
 
-    # Check if the dashboard process is running and inspect its HOME.
     r = docker_exec_sh(
         container_name,
-        # Find the dashboard process (hermes dashboard) and read its HOME
-        # from /proc/<pid>/environ. If not running, verify the run script
-        # itself exports HOME via HERMES_REAL_HOME by grepping the script source.
         'pid=$(pgrep -f "hermes dashboard" | head -1); '
         'if [ -n "$pid" ]; then '
         '  tr "\\0" "\\n" < /proc/$pid/environ | grep "^HOME="; '
         'else '
-        '  grep -q "HERMES_REAL_HOME" '
-        '    /opt/hermes/docker/s6-rc.d/dashboard/run && '
-        '  echo "HOME=/opt/data"; '
+        '  echo "NO_DASHBOARD_PROCESS"; '
         'fi',
         timeout=15,
     )
     assert "HOME=/opt/data" in r.stdout, (
-        f"dashboard process or run script does not set HOME=/opt/data: "
+        f"dashboard process does not have HOME=/opt/data: "
         f"stdout={r.stdout!r} stderr={r.stderr!r}"
+    )
+
+
+def test_dashboard_service_resets_home_with_real_home(
+    built_image: str, container_name: str,
+) -> None:
+    """Custom HERMES_REAL_HOME: the dashboard process must have HOME set
+    to the configured value, and a privilege-dropped hermes process must
+    be able to write under it.
+
+    This exercises the stage2 hook's HERMES_REAL_HOME mkdir+chown path
+    and the dashboard run script's HOME export with a non-default value.
+    """
+    start_container(
+        built_image,
+        container_name,
+        "HERMES_DASHBOARD=1",
+        "HERMES_DASHBOARD_HOST=127.0.0.1",
+        "HERMES_REAL_HOME=/home/agent",
+    )
+
+    r = docker_exec_sh(
+        container_name,
+        'pid=$(pgrep -f "hermes dashboard" | head -1); '
+        'if [ -n "$pid" ]; then '
+        '  tr "\\0" "\\n" < /proc/$pid/environ | grep "^HOME="; '
+        'else '
+        '  echo "NO_DASHBOARD_PROCESS"; '
+        'fi',
+        timeout=15,
+    )
+    assert "HOME=/home/agent" in r.stdout, (
+        f"dashboard process does not have HOME=/home/agent: "
+        f"stdout={r.stdout!r} stderr={r.stderr!r}"
+    )
+    assert "NO_DASHBOARD_PROCESS" not in r.stdout, (
+        f"dashboard process did not start: stdout={r.stdout!r}"
+    )
+
+    write_r = docker_exec_sh(
+        container_name,
+        'export HOME="${HERMES_REAL_HOME:-/opt/data}"; '
+        'mkdir -p "$HOME/.config" && touch "$HOME/.config/hermes-real-home-marker" '
+        '&& stat -c "%U" "$HOME/.config/hermes-real-home-marker"',
+        timeout=10,
+    )
+    assert write_r.returncode == 0, (
+        f"write under $HOME failed: rc={write_r.returncode} "
+        f"stdout={write_r.stdout!r} stderr={write_r.stderr!r}"
+    )
+    assert "hermes" in write_r.stdout, (
+        f"marker not hermes-owned: {write_r.stdout!r}"
     )
 
 

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -547,7 +547,7 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
     assert run_path.is_file()
     assert run_path.stat().st_mode & 0o111  # executable
     run_text = run_path.read_text()
-    assert "export HOME=/opt/data" in run_text
+    assert 'export HOME=${HERMES_REAL_HOME:-/opt/data}' in run_text
     assert "hermes -p coder gateway run" in run_text
     assert "s6-setuidgid hermes" in run_text
     # Sentinel marking this as the supervised-child invocation. Without
@@ -676,8 +676,26 @@ def test_render_run_script_resets_home_before_exec() -> None:
 
     run_text = S6ServiceManager._render_run_script("coder", {})
 
-    assert "export HOME=/opt/data" in run_text
+    assert 'export HOME=${HERMES_REAL_HOME:-/opt/data}' in run_text
     assert "exec s6-setuidgid hermes hermes -p coder gateway run --replace" in run_text
+
+
+def test_render_run_script_uses_hermes_real_home_when_set() -> None:
+    """When HERMES_REAL_HOME is set in the container environment, the
+    gateway s6 run script should use it for HOME instead of /opt/data.
+
+    This allows custom bind-mount layouts (e.g. /home/agent) to work
+    without hardcoded paths in the run script.
+    """
+    run_text = S6ServiceManager._render_run_script("coder", {})
+
+    # The script uses shell parameter expansion: ${HERMES_REAL_HOME:-/opt/data}
+    # When HERMES_REAL_HOME is set, it's used; otherwise falls back to /opt/data.
+    assert 'export HOME=${HERMES_REAL_HOME:-/opt/data}' in run_text
+    assert 'cd "${HERMES_REAL_HOME:-/opt/data}"' in run_text
+    # Must NOT contain the old hardcoded path
+    assert 'export HOME=/opt/data"' not in run_text
+    assert '"cd /opt/data"' not in run_text
 
 
 def test_render_run_script_uses_replace_to_take_over_stale_holder() -> None:


### PR DESCRIPTION
## Summary

The official Docker image hardcodes `HOME=/opt/data` in three startup scripts, breaking custom bind-mount layouts (e.g. `/home/agent`). This causes:

- Gateway lock file permission errors (Telegram silently pauses)
- HOME-anchored state (XDG dirs, config caches) writing to wrong location
- Dashboard and gateway CWD pointing to `/opt/data` instead of bind mount
- `docker exec hermes ...` commands writing to wrong HOME

Fix: use `${HERMES_REAL_HOME:-/opt/data}` in all four scripts. When `HERMES_REAL_HOME` is set (e.g. via compose env), it's used instead of `/opt/data`. Falls back to `/opt/data` when unset — **backward-compatible**.

## Changes

| File | Change |
|---|---|
| `docker/stage2-hook.sh` | Create + chown `HERMES_REAL_HOME` when distinct from `HERMES_HOME` |
| `hermes_cli/service_manager.py` | Gateway s6 run script generation |
| `docker/main-wrapper.sh` | Container CMD wrapper |
| `docker/s6-rc.d/dashboard/run` | Dashboard s6 service |
| `docker/hermes-exec-shim.sh` | `docker exec` privilege-drop shim |

## How it works

```yaml
# compose.yaml — custom bind-mount layout
environment:
  - HERMES_HOME=/home/agent/.hermes
  - HERMES_REAL_HOME=/home/agent  # ← NEW: overrides HOME in s6 scripts
```

When `HERMES_REAL_HOME` is **not set**, behavior is identical to current (falls back to `/opt/data`). When set, all s6-supervised processes get `HOME=<value>`.

## Tests

-   Updated 2 existing assertions in `test_service_manager.py`
-   Rewrote `test_dashboard_service_resets_home` in `test_home_override_scripts.py` to inspect `/proc/<pid>/environ` only (no source-text reads)
-   Added `test_render_run_script_uses_hermes_real_home_when_set` (test_service_manager.py)
-   Added `test_dashboard_service_resets_home_with_real_home` — boots the image with `HERMES_REAL_HOME=/home/agent`, asserts the dashboard process has `HOME=/home/agent`, and verifies a privilege-dropped hermes write under `$HOME/.config` succeeds
 
All relevant tests pass (5/5 Docker runtime tests, plus the service_manager unit tests).

## Fixes

Closes #56402

## Impact

- **Zero impact** when `HERMES_REAL_HOME` is not set (default behavior unchanged)
- Enables custom bind-mount layouts without workarounds
- Python side already supports `HERMES_REAL_HOME` (`hermes_constants.py:701`) — this brings shell scripts in line