### PR TITLE
fix(gateway): drop interrupt sentinel before chat delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -54,6 +54,7 @@ from typing import Callable, Dict, Optional, Any, List, Union
 # preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
+from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
@@ -423,6 +424,11 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
         return text
     if _gateway_surface_passes_raw_text(platform):
         return text
+
+    # Cancellation metadata, not assistant prose. ACP/TUI already suppress
+    # this sentinel; chat surfaces should too (#7921).
+    if str(text).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
+        return ""
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -144,6 +144,15 @@ def test_chat_gateways_keep_normal_answers(platform):
     assert _sanitize_gateway_final_response(platform, answer) == answer
 
 
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_chat_gateways_drop_interrupt_sentinel(platform):
+    """The interrupt-while-waiting sentinel is metadata, not a reply (#7921)."""
+    sentinel = "Operation interrupted: waiting for model response (1.7s elapsed)."
+
+    assert _sanitize_gateway_final_response(platform, sentinel) == ""
+    assert _sanitize_gateway_final_response("local", sentinel) == sentinel
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (


### PR DESCRIPTION
The "Operation interrupted: waiting for model response (N.Ns elapsed)." sentinel still gets delivered as a normal message on chat platforms (slack etc). ACP/TUI already suppress it via INTERRUPT_WAITING_FOR_MODEL_PREFIX (#41720), the gateway never got the same guard.

Reuses the shared constant in _sanitize_gateway_final_response so raw surfaces (local/api) keep it and chat surfaces drop it.

Fixes #7921