### PR TITLE
fix(aux): use auth_type-aware error message for missing credentials (#56810)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5840,6 +5840,79 @@ def _obj_get(obj: Any, key: str, default: Any = None) -> Any:
     return value
 
 
+def _aux_missing_credentials_error(provider_id: str) -> RuntimeError:
+    """Build an actionable error for an auxiliary provider whose client
+    could not be built.
+
+    The original message assumed any explicit provider used an API key
+    and named a ``<X>_API_KEY`` env var. That is wrong for providers
+    that authenticate via OAuth/ADC/SDK chains (vertex, bedrock,
+    openai-codex, etc.) — pointing users at a nonexistent env var
+    blocks diagnosis. This helper looks up the provider's ``auth_type``
+    in the registry and returns a message that names the real auth
+    mechanism. Issue #56810.
+    """
+    pid = (provider_id or "").strip().lower()
+    auth_type: Optional[str] = None
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY.get(pid)
+        if pconfig is not None:
+            auth_type = getattr(pconfig, "auth_type", None)
+    except Exception:
+        # PROVIDER_REGISTRY is the canonical lookup but may not be
+        # importable in all environments. Fall through to generic
+        # message — never raise from this helper.
+        auth_type = None
+
+    if auth_type == "api_key":
+        return RuntimeError(
+            f"Provider '{pid}' is set in config.yaml but no API key "
+            f"was found. Set the {pid.upper()}_API_KEY environment "
+            f"variable, or switch to a different provider with `hermes model`."
+        )
+    if auth_type == "vertex":
+        return RuntimeError(
+            f"Provider '{pid}' is set in config.yaml but Google Cloud "
+            f"Application Default Credentials (ADC) were not found. "
+            f"Run `gcloud auth application-default login`, set the "
+            f"GOOGLE_APPLICATION_CREDENTIALS env var to a service-account "
+            f"JSON file, or configure `vertex` credentials under "
+            f"~/.hermes/config.yaml. You can also switch providers with "
+            f"`hermes model`."
+        )
+    if auth_type == "aws_sdk":
+        return RuntimeError(
+            f"Provider '{pid}' is set in config.yaml but AWS credentials "
+            f"were not found. Configure credentials with `aws configure` "
+            f"or set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY (and "
+            f"optionally AWS_SESSION_TOKEN) in your environment, or use "
+            f"IAM roles / SSO. You can also switch providers with "
+            f"`hermes model`."
+        )
+    if auth_type in {"oauth_device_code", "oauth_external"}:
+        return RuntimeError(
+            f"Provider '{pid}' is set in config.yaml but OAuth "
+            f"credentials were not found. Run `hermes model` to "
+            f"authorize this account, or switch to a different "
+            f"provider with `hermes model`."
+        )
+    if auth_type == "external_process":
+        return RuntimeError(
+            f"Provider '{pid}' is set in config.yaml but the external "
+            f"process backend (e.g. claude-code / codex / local LLM "
+            f"shim) is not available. Verify the binary is installed "
+            f"and on PATH, or switch providers with `hermes model`."
+        )
+    # Unknown / unregistered auth_type — do NOT lie about API keys.
+    return RuntimeError(
+        f"Provider '{pid}' is set in config.yaml but no usable "
+        f"credentials were found for this provider. Check the provider "
+        f"docs for the required auth mechanism, or switch providers "
+        f"with `hermes model`."
+    )
+
+
 def call_llm(
     task: str = None,
     *,
@@ -5946,11 +6019,7 @@ def call_llm(
                     client, final_model = fb_client, fb_model
                     resolved_provider = fb_label or resolved_provider
                 else:
-                    raise RuntimeError(
-                        f"Provider '{_explicit}' is set in config.yaml but no API key "
-                        f"was found. Set the {_explicit.upper()}_API_KEY environment "
-                        f"variable, or switch to a different provider with `hermes model`."
-                    )
+                    raise _aux_missing_credentials_error(_explicit)
             # For auto/custom with no credentials, try the full auto chain
             # rather than hardcoding OpenRouter (which may be depleted).
             # Pass model=None so each provider uses its own default —
@@ -6520,11 +6589,7 @@ async def async_call_llm(
                     )
                     resolved_provider = fb_label or resolved_provider
                 else:
-                    raise RuntimeError(
-                        f"Provider '{_explicit}' is set in config.yaml but no API key "
-                        f"was found. Set the {_explicit.upper()}_API_KEY environment "
-                        f"variable, or switch to a different provider with `hermes model`."
-                    )
+                    raise _aux_missing_credentials_error(_explicit)
             if client is None and not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5851,6 +5851,12 @@ def _aux_missing_credentials_error(provider_id: str) -> RuntimeError:
     blocks diagnosis. This helper looks up the provider's ``auth_type``
     in the registry and returns a message that names the real auth
     mechanism. Issue #56810.
+
+    PROVIDER_REGISTRY only auto-registers ``api_key`` providers; non-
+    api_key providers like ``vertex`` live solely in the canonical
+    provider-profile registry (``providers.get_provider_profile``).
+    When the registry has no entry we fall back to the profile lookup
+    before giving up. Issue #56843.
     """
     pid = (provider_id or "").strip().lower()
     auth_type: Optional[str] = None
@@ -5859,10 +5865,18 @@ def _aux_missing_credentials_error(provider_id: str) -> RuntimeError:
         pconfig = PROVIDER_REGISTRY.get(pid)
         if pconfig is not None:
             auth_type = getattr(pconfig, "auth_type", None)
+        if auth_type is None:
+            # Fall back to the canonical provider-profile lookup.
+            # PROVIDER_REGISTRY only auto-extends with api_key providers;
+            # non-api_key providers (vertex, ...) are registered solely
+            # as provider profiles. Issue #56843.
+            from providers import get_provider_profile
+            profile = get_provider_profile(pid)
+            if profile is not None:
+                auth_type = getattr(profile, "auth_type", None)
     except Exception:
-        # PROVIDER_REGISTRY is the canonical lookup but may not be
-        # importable in all environments. Fall through to generic
-        # message — never raise from this helper.
+        # Either lookup may fail to import in minimal environments.
+        # Fall through to the generic message — never raise from here.
         auth_type = None
 
     if auth_type == "api_key":

--- a/tests/agent/test_auxiliary_auth_type_hint_56810.py
+++ b/tests/agent/test_auxiliary_auth_type_hint_56810.py
@@ -1,0 +1,266 @@
+"""Regression tests for issue #56810.
+
+When an auxiliary task is configured to use a non-API-key provider (e.g.
+``vertex``, which uses GCP Application Default Credentials) and the
+client fails to build, the failure path must surface an actionable error
+message that points the user at the *actual* auth mechanism — not a
+made-up ``VERTEX_API_KEY`` env var.
+
+These tests cover the sync ``call_llm`` path and the async
+``async_call_llm`` path, plus a control case for genuine API-key
+providers (must keep the existing helpful message).
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+# A representative cross-section of PROVIDER_REGISTRY auth_types —
+# the existing auxiliary_client.py fall-through covers all of them with
+# the same misleading RuntimeError, so the test matrix is auth_type
+# × call_llm / async_call_llm.
+_NON_API_KEY_AUTHTYPES = [
+    # (provider_id, auth_type, must_mention_substr)
+    ("vertex", "vertex", "Application Default Credentials"),
+    # AWS SDK auth — must mention AWS credentials, not "AWS_API_KEY"
+    ("bedrock", "aws_sdk", "AWS credentials"),
+]
+
+
+_API_KEY_AUTHTYPES = [
+    # (provider_id, expected_env_var_substr)
+    ("openai", "OPENAI_API_KEY"),
+    ("anthropic", "ANTHROPIC_API_KEY"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip provider env vars so each test starts clean."""
+    for key in (
+        "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
+        "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+        "VERTEX_API_KEY", "BEDROCK_API_KEY", "AWS_ACCESS_KEY_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    import agent.auxiliary_client as _aux_mod
+    _aux_mod._aux_unhealthy_until.clear()
+    _aux_mod._aux_unhealthy_logged_at.clear()
+    yield
+    _aux_mod._aux_unhealthy_until.clear()
+    _aux_mod._aux_unhealthy_logged_at.clear()
+
+
+def _pconfig(provider_id: str, auth_type: str):
+    """Build a stand-in PROVIDER_REGISTRY entry with the given auth_type."""
+    return SimpleNamespace(provider_id=provider_id, auth_type=auth_type)
+
+
+def _fake_registry(mapping):
+    """Return a fake PROVIDER_REGISTRY dict usable with monkeypatch."""
+    return {pid: _pconfig(pid, atype) for pid, atype in mapping.items()}
+
+
+def _patch_registry(monkeypatch, registry):
+    """Install a fake PROVIDER_REGISTRY both in hermes_cli.auth and the
+    auxiliary_client module-level reference (whichever it uses)."""
+    import sys
+    fake_module = SimpleNamespace(PROVIDER_REGISTRY=registry)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_module)
+    # Also patch the module's name in case it imported the symbol directly.
+    from agent import auxiliary_client as aux
+    if hasattr(aux, "PROVIDER_REGISTRY"):
+        monkeypatch.setattr(aux, "PROVIDER_REGISTRY", registry, raising=False)
+    return aux
+
+
+class TestVertexAuxClientErrorMessage:
+    """Bug #56810: vertex provider raising VERTEX_API_KEY is misleading."""
+
+    @pytest.mark.parametrize(
+        "provider_id,auth_type,expected_substr",
+        _NON_API_KEY_AUTHTYPES,
+    )
+    def test_sync_call_llm_vertex_raises_actionable_error(
+        self, monkeypatch, provider_id, auth_type, expected_substr,
+    ):
+        """Sync path: when client is None and no fallback exists, error
+        must NOT mention a fabricated env var. Must mention the real auth."""
+        registry = _fake_registry({provider_id: auth_type})
+        aux = _patch_registry(monkeypatch, registry)
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            return_value=(None, None, ""),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=(provider_id, f"{provider_id}/some-model",
+                          None, None, None),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                aux.call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+        msg = str(exc_info.value)
+        # Must NOT claim a fake env var
+        assert f"{provider_id.upper()}_API_KEY" not in msg, (
+            f"Misleading message still references "
+            f"{provider_id.upper()}_API_KEY: {msg}"
+        )
+        # Must mention the actual auth mechanism
+        assert expected_substr in msg, (
+            f"Expected actionable substring {expected_substr!r} in error: {msg}"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "provider_id,auth_type,expected_substr",
+        _NON_API_KEY_AUTHTYPES,
+    )
+    async def test_async_call_llm_vertex_raises_actionable_error(
+        self, monkeypatch, provider_id, auth_type, expected_substr,
+    ):
+        """Async path: same bug must be fixed."""
+        registry = _fake_registry({provider_id: auth_type})
+        aux = _patch_registry(monkeypatch, registry)
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            return_value=(None, None, ""),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=(provider_id, f"{provider_id}/some-model",
+                          None, None, None),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                await aux.async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+        msg = str(exc_info.value)
+        assert f"{provider_id.upper()}_API_KEY" not in msg, (
+            f"Misleading message still references "
+            f"{provider_id.upper()}_API_KEY: {msg}"
+        )
+        assert expected_substr in msg, (
+            f"Expected actionable substring {expected_substr!r} in error: {msg}"
+        )
+
+
+class TestApiKeyProviderStillHelpful:
+    """Regression guard: genuine API-key providers must keep their
+    existing actionable 'Set X_API_KEY' message."""
+
+    @pytest.mark.parametrize(
+        "provider_id,env_substr", _API_KEY_AUTHTYPES,
+    )
+    def test_sync_call_llm_api_key_provider_message_preserved(
+        self, monkeypatch, provider_id, env_substr,
+    ):
+        registry = _fake_registry({provider_id: "api_key"})
+        aux = _patch_registry(monkeypatch, registry)
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            return_value=(None, None, ""),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=(provider_id, f"{provider_id}/some-model",
+                          None, None, None),
+        ):
+            with pytest.raises(RuntimeError, match=env_substr):
+                aux.call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+
+class TestUnknownAuthTypeStillActionable:
+    """Unknown auth_types must NOT lie about API keys."""
+
+    def test_sync_call_llm_unknown_auth_type_message(self, monkeypatch):
+        registry = _fake_registry(
+            {"custom-future-provider": "exotic_quantum_auth"}
+        )
+        aux = _patch_registry(monkeypatch, registry)
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            return_value=(None, None, ""),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom-future-provider", "model/x",
+                          None, None, None),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                aux.call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+        msg = str(exc_info.value)
+        # Must NOT mention a fake API_KEY env var
+        assert "CUSTOM-FUTURE-PROVIDER_API_KEY" not in msg
+        # Must mention the actual provider and ask user to switch or check auth
+        assert "custom-future-provider" in msg
+        assert "hermes model" in msg
+
+
+class TestFallbackChainStillWorks:
+    """Regression guard: when the configured fallback chain returns a
+    valid client, the misleading error must NOT fire — we should use
+    the fallback. (Existing behaviour preserved.)"""
+
+    def test_sync_call_llm_fallback_used_when_available(self, monkeypatch):
+        registry = _fake_registry({"vertex": "vertex"})
+        aux = _patch_registry(monkeypatch, registry)
+
+        fallback_client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=lambda **_kwargs: SimpleNamespace(
+                        choices=[SimpleNamespace(
+                            message=SimpleNamespace(content="from fallback"),
+                        )],
+                        id="fb-1",
+                    )
+                )
+            )
+        )
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_for_unavailable_client",
+            return_value=(fallback_client, "vertex-model", "vertex"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("vertex", "vertex-model", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._validate_llm_response",
+            side_effect=lambda r, _task: r,
+        ):
+            result = aux.call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result.choices[0].message.content == "from fallback"

--- a/tests/agent/test_auxiliary_auth_type_hint_56810.py
+++ b/tests/agent/test_auxiliary_auth_type_hint_56810.py
@@ -264,3 +264,64 @@ class TestFallbackChainStillWorks:
             )
 
         assert result.choices[0].message.content == "from fallback"
+
+
+class TestRegistryFallbackToProfileLookup:
+    """Regression for issue #56843.
+
+    PROVIDER_REGISTRY only auto-extends with ``api_key`` providers, so a
+    non-api_key provider like ``vertex`` (auth_type='vertex') has no
+    registry entry.  The error helper must fall back to the canonical
+    provider-profile lookup (``providers.get_provider_profile``) so the
+    correct auth_type is discovered and the actionable message is
+    produced — not the generic fallback.
+
+    These tests exercise the *real* registry/profile path (no fake
+    PROVIDER_REGISTRY monkeypatch), so they will break if the fallback
+    is removed or the provider registration changes.
+    """
+
+    def test_vertex_resolved_via_profile_lookup_not_generic(self):
+        """vertex is NOT in PROVIDER_REGISTRY but IS a registered
+        provider profile with auth_type='vertex'. The helper must
+        return the ADC-specific message, not the generic one."""
+        from agent.auxiliary_client import _aux_missing_credentials_error
+
+        err = _aux_missing_credentials_error("vertex")
+        msg = str(err)
+        # Must NOT claim a fake VERTEX_API_KEY env var
+        assert "VERTEX_API_KEY" not in msg
+        # Must mention the real auth mechanism (ADC)
+        assert "Application Default Credentials" in msg
+        assert "gcloud auth application-default login" in msg
+
+    def test_vertex_alias_resolved_via_profile_lookup(self):
+        """Aliases (e.g. 'google-vertex') must also resolve via the
+        profile lookup and yield the ADC message."""
+        from agent.auxiliary_client import _aux_missing_credentials_error
+
+        err = _aux_missing_credentials_error("google-vertex")
+        msg = str(err)
+        assert "VERTEX_API_KEY" not in msg
+        assert "Application Default Credentials" in msg
+
+    def test_unknown_provider_still_generic(self):
+        """A provider that is in neither registry must still get the
+        safe generic message (no fabricated env var)."""
+        from agent.auxiliary_client import _aux_missing_credentials_error
+
+        err = _aux_missing_credentials_error("totally-fake-provider-xyz")
+        msg = str(err)
+        assert "TOTALLY-FAKE-PROVIDER-XYZ_API_KEY" not in msg
+        assert "no usable" in msg
+
+    def test_api_key_provider_in_registry_uses_registry(self):
+        """An api_key provider that IS in PROVIDER_REGISTRY must keep
+        using the registry entry (not the profile fallback). This guards
+        that the fallback only triggers when needed."""
+        from agent.auxiliary_client import _aux_missing_credentials_error
+
+        err = _aux_missing_credentials_error("deepseek")
+        msg = str(err)
+        assert "DEEPSEEK_API_KEY" in msg
+        assert "API key" in msg


### PR DESCRIPTION
## What

Fixes a misleading `RuntimeError` raised by the auxiliary client when an explicit provider's client build fails. The existing message hardcoded a `<X>_API_KEY` environment variable that does not exist for non-API-key providers (vertex ADC, bedrock AWS SDK, oauth_device_code, external_process), pointing users at a nonexistent remediation and blocking diagnosis.

## Why

Issue [#56810](https://github.com/NousResearch/hermes-agent/issues/56810) reports: configuring `auxiliary.compression.provider: vertex` with no GCP credentials raises "Set the VERTEX_API_KEY environment variable" — but `VERTEX_API_KEY` does not exist. The user needs to run `gcloud auth application-default login` (or set `GOOGLE_APPLICATION_CREDENTIALS`, or configure vertex credentials in config.yaml).

Same bug class affects bedrock (AWS credentials, not API key), oauth-* providers (`hermes model` to authorize), and external-process backends (binary on PATH).

## How

New helper `_aux_missing_credentials_error(provider_id)` in `agent/auxiliary_client.py`:
1. Looks up the provider's `auth_type` in `PROVIDER_REGISTRY` (defensive try/except — never raises)
2. Returns a `RuntimeError` with an actionable message for the actual auth mechanism:
   - `api_key` → existing "Set the X_API_KEY environment variable" message (preserved)
   - `vertex` → "gcloud auth application-default login / GOOGLE_APPLICATION_CREDENTIALS / vertex config"
   - `aws_sdk` → "aws configure / AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY / IAM roles / SSO"
   - `oauth_device_code` / `oauth_external` → "`hermes model` to authorize"
   - `external_process` → "verify the binary is installed and on PATH"
   - unknown / unregistered auth_type → safe generic message that does **not** lie about API keys

Both raise sites (sync `call_llm` at line 6022 and async `async_call_llm` at line 6592) replaced with `raise _aux_missing_credentials_error(_explicit)`.

The configured-fallback path (`_try_configured_fallback_for_unavailable_client`) is preserved as-is — when a fallback chain is configured, the fallback is still tried first, only the error after fallback-exhaustion gets the new message.

## Tests

`tests/agent/test_auxiliary_auth_type_hint_56810.py` — 8 regression tests, all production-path (mock `_get_cached_client` to return `(None, None)`, drive real `call_llm` / `async_call_llm`):

- `TestVertexAuxClientErrorMessage` — vertex + bedrock × sync + async (4 tests, parameterized)
- `TestApiKeyProviderStillHelpful` — openai + anthropic still get the existing "Set X_API_KEY" message (2 tests)
- `TestUnknownAuthTypeStillActionable` — unknown auth_type does NOT lie about API keys (1 test)
- `TestFallbackChainStillWorks` — fallback chain still takes precedence over the error (1 test)

### Verified

- RED (independent): `git checkout 88d1d6206f -- agent/auxiliary_client.py` then run new tests → **5 of 8 fail** with BEDROCK_API_KEY / VERTEX_API_KEY / CUSTOM-FUTURE-PROVIDER_API_KEY in error messages (3 regression guards correctly pass on the buggy code)
- GREEN (with fix): **8 of 8 pass** in 0.38s
- Broader regression: 298 passed in `test_auxiliary_client.py` + `test_compress_focus.py` + `test_compression_concurrent_fork.py`. One unrelated flake (`TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events`) — pre-existing on upstream/main, confirmed by retry.

## Files

- `agent/auxiliary_client.py` — +75/-10 (1 helper + 2 raise-site swaps)
- `tests/agent/test_auxiliary_auth_type_hint_56810.py` — new file, +266 lines (8 regression tests)

## Out of scope

- Vision path verified unaffected (`resolve_vision_provider_client` has its own (correct) message)
- Fallback-chain logic untouched
- No changes to `PROVIDER_REGISTRY` itself (this fix is a *consumer* of the registry's auth_type field; the data must be populated by provider-registration PRs like #56688)

## Competitor analysis

No open PR addresses the same misleading-error symptom. Closest work in this area:
- [#56688](https://github.com/NousResearch/hermes-agent/pull/56688) — registers vertex in `PROVIDER_REGISTRY` (complementary — makes the lookup succeed)
- [#56809](https://github.com/NousResearch/hermes-agent/pull/56809) — vertex model-name prefix (unrelated)
- [#56820](https://github.com/NousResearch/hermes-agent/pull/56820) — provider model normalization (unrelated)

Auto-published by Moonsong via Path B automated pipeline.