### PR TITLE
fix(agent): repair orphaned FTS shadow tables

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1099,6 +1099,22 @@ class SessionDB:
                 return False
             raise
 
+    @staticmethod
+    def _drop_orphaned_fts_shadow_tables(cursor: sqlite3.Cursor, table_name: str) -> None:
+        """Remove FTS5 shadow tables left behind without a virtual table.
+
+        SQLite normally drops an FTS5 virtual table and its shadow tables as one
+        operation. If a migration is interrupted after the virtual-table row is
+        gone from sqlite_master but before all shadows are cleaned up, the next
+        ``CREATE VIRTUAL TABLE`` fails permanently with e.g.
+        ``table messages_fts_data already exists``. This helper is only called
+        after probing has proved the virtual table itself is absent, so dropping
+        the deterministic FTS5 shadows is a safe self-repair step.
+        """
+        safe_prefix = table_name.replace('"', '""')
+        for suffix in ("content", "data", "docsize", "idx", "config"):
+            cursor.execute(f'DROP TABLE IF EXISTS "{safe_prefix}_{suffix}"')
+
     def _ensure_fts_schema(
         self,
         cursor: sqlite3.Cursor,
@@ -1108,6 +1124,8 @@ class SessionDB:
         status = self._fts_table_probe(cursor, table_name)
         if status is None:
             return False
+        if status is False:
+            self._drop_orphaned_fts_shadow_tables(cursor, table_name)
         try:
             # Run even when the virtual table exists so any dropped or missing
             # triggers are recreated after a previous no-FTS5 runtime disabled

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -450,6 +450,36 @@ class TestSessionLifecycle:
         finally:
             db.close()
 
+    def test_orphaned_fts_shadow_tables_are_repaired(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        seeded = SessionDB(db_path=db_path)
+        try:
+            seeded.create_session(session_id="s1", source="cli")
+            seeded.append_message("s1", role="user", content="orphan shadow needle")
+        finally:
+            seeded.close()
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("DROP TABLE IF EXISTS messages_fts")
+            # Simulate an interrupted migration where sqlite_master no longer
+            # has the virtual table, but one or more FTS5 shadow tables remain.
+            # A plain CREATE VIRTUAL TABLE would fail with
+            # "table messages_fts_data already exists" unless init cleans it.
+            conn.execute("CREATE TABLE messages_fts_data(id INTEGER PRIMARY KEY, block BLOB)")
+            conn.commit()
+        finally:
+            conn.close()
+
+        repaired = SessionDB(db_path=db_path)
+        try:
+            assert repaired._fts_enabled is True
+            assert repaired._fts_table_exists("messages_fts") is True
+            repaired.append_message("s1", role="assistant", content="after orphan repair")
+            assert len(repaired.search_messages("repair")) == 1
+        finally:
+            repaired.close()
+
     def test_fts_runtime_restores_triggers_after_no_fts_open(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
Fixes #56815.\n\nWhen an interrupted migration leaves FTS5 shadow tables behind after the virtual table has disappeared, SessionDB now drops those orphaned shadows before recreating the virtual table. This lets session search recover automatically instead of failing permanently on startup.\n\nTests: scripts/run_tests.sh tests/test_hermes_state.py -k orphaned_fts_shadow_tables_are_repaired