### PR TITLE
fix(dashboard): cap password login limiter buckets

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -415,8 +415,23 @@ def _validate_post_login_target(raw: str) -> str:
 
 _PW_RATE_MAX_ATTEMPTS = 10
 _PW_RATE_WINDOW_SEC = 60.0
+_PW_RATE_MAX_CLIENT_IP_BUCKETS = 4096
 _pw_attempts: Dict[str, Deque[float]] = defaultdict(deque)
 _pw_attempts_lock = threading.Lock()
+
+
+def _prune_expired_password_rate_buckets(cutoff: float) -> None:
+    """Drop empty/expired password-rate buckets.
+
+    Caller must hold ``_pw_attempts_lock``. We prune every bucket before
+    enforcing the global bucket cap so stale IPs never force eviction of a
+    live client-IP bucket.
+    """
+    for key, bucket in list(_pw_attempts.items()):
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if not bucket:
+            del _pw_attempts[key]
 
 
 def _password_rate_limited(ip: str) -> bool:
@@ -432,9 +447,12 @@ def _password_rate_limited(ip: str) -> bool:
     cutoff = now - _PW_RATE_WINDOW_SEC
     key = ip or "_unknown_"
     with _pw_attempts_lock:
-        bucket = _pw_attempts[key]
-        while bucket and bucket[0] < cutoff:
-            bucket.popleft()
+        _prune_expired_password_rate_buckets(cutoff)
+        bucket = _pw_attempts.get(key)
+        if bucket is None:
+            while len(_pw_attempts) >= _PW_RATE_MAX_CLIENT_IP_BUCKETS:
+                _pw_attempts.pop(next(iter(_pw_attempts)))
+            bucket = _pw_attempts[key]
         if len(bucket) >= _PW_RATE_MAX_ATTEMPTS:
             return True
         bucket.append(now)

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -393,6 +393,60 @@ class TestRateLimit:
         )
         assert good.status_code == 429
 
+    def test_expired_ip_buckets_pruned_before_live_eviction(self, monkeypatch):
+        from collections import deque
+
+        from hermes_cli.dashboard_auth import routes
+
+        _reset_password_rate_limit()
+        now = 1_000.0
+        monkeypatch.setattr(routes.time, "monotonic", lambda: now)
+        monkeypatch.setattr(routes, "_PW_RATE_MAX_CLIENT_IP_BUCKETS", 3, raising=False)
+
+        with routes._pw_attempts_lock:
+            routes._pw_attempts["live-a"] = deque([now])
+            routes._pw_attempts["live-b"] = deque([now])
+            routes._pw_attempts["expired-a"] = deque([
+                now - routes._PW_RATE_WINDOW_SEC - 1.0
+            ])
+
+        assert routes._password_rate_limited("live-c") is False
+
+        with routes._pw_attempts_lock:
+            assert set(routes._pw_attempts) == {"live-a", "live-b", "live-c"}
+
+    def test_retained_client_ip_buckets_are_capped(self, monkeypatch):
+        from hermes_cli.dashboard_auth import routes
+
+        _reset_password_rate_limit()
+        monkeypatch.setattr(routes.time, "monotonic", lambda: 2_000.0)
+        monkeypatch.setattr(routes, "_PW_RATE_MAX_CLIENT_IP_BUCKETS", 3, raising=False)
+
+        for i in range(5):
+            assert routes._password_rate_limited(f"ip-{i}") is False
+
+        with routes._pw_attempts_lock:
+            assert len(routes._pw_attempts) == 3
+            assert "ip-4" in routes._pw_attempts
+
+    def test_bucket_cap_preserves_existing_ip_throttle(self, monkeypatch):
+        from hermes_cli.dashboard_auth import routes
+
+        _reset_password_rate_limit()
+        monkeypatch.setattr(routes.time, "monotonic", lambda: 3_000.0)
+        monkeypatch.setattr(routes, "_PW_RATE_MAX_ATTEMPTS", 2)
+        monkeypatch.setattr(routes, "_PW_RATE_MAX_CLIENT_IP_BUCKETS", 3, raising=False)
+
+        assert routes._password_rate_limited("active") is False
+        assert routes._password_rate_limited("active") is False
+
+        # Filling other buckets up to the cap must not evict or reset the
+        # already-active IP's sliding-window counter.
+        assert routes._password_rate_limited("other-a") is False
+        assert routes._password_rate_limited("other-b") is False
+
+        assert routes._password_rate_limited("active") is True
+
 
 # ---------------------------------------------------------------------------
 # Login page rendering


### PR DESCRIPTION
## Summary
- add a global cap for `/auth/password-login` per-client-IP rate-limit buckets
- prune expired password-login buckets before evicting any live bucket
- add regression coverage for bucket pruning, bucket cap enforcement, and preserving per-IP throttling

Fixes #55101

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_password_login.py -q -k TestRateLimit` (RED before fix: 2 failed, 2 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_password_login.py -q` (22 passed)
- `git diff --check` (OK)
