### PR TITLE
fix(agent): avoid plaintext tool-call syntax in help guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -139,7 +139,7 @@ HERMES_AGENT_HELP_GUIDANCE = (
     "it — or when you need to understand your own features, tools, or capabilities, "
     "the documentation at https://hermes-agent.nousresearch.com/docs is your "
     "authoritative reference and always holds the latest, most up-to-date "
-    "information. Load the `hermes-agent` skill with skill_view(name='hermes-agent') "
+    "information. Load the `hermes-agent` skill via the skill_view tool "
     "for additional guidance and proven workflows, but treat the docs as the source "
     "of truth when the two differ."
 )

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -33,6 +33,7 @@ from agent.prompt_builder import (
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
+    HERMES_AGENT_HELP_GUIDANCE,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 
@@ -43,6 +44,11 @@ from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatu
 
 
 class TestGuidanceConstants:
+    def test_hermes_help_guidance_avoids_plaintext_tool_call_syntax(self):
+        assert "skill_view(name='hermes-agent')" not in HERMES_AGENT_HELP_GUIDANCE
+        assert "`hermes-agent` skill" in HERMES_AGENT_HELP_GUIDANCE
+        assert "skill_view tool" in HERMES_AGENT_HELP_GUIDANCE
+
     def test_memory_guidance_discourages_task_logs(self):
         assert "durable facts" in MEMORY_GUIDANCE
         assert "Do NOT save task progress" in MEMORY_GUIDANCE


### PR DESCRIPTION
Fixes #56816.\n\nThe universal Hermes help guidance no longer embeds literal skill_view(name='hermes-agent') call syntax in plain text. It now names the hermes-agent skill and the skill_view tool without looking like a function call, avoiding z.ai Coding Plan rejection while preserving the instruction.\n\nTests: scripts/run_tests.sh tests/agent/test_prompt_builder.py -k hermes_help_guidance_avoids_plaintext_tool_call_syntax