### PR TITLE
feat(tui): add mechanism status capsule

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4031,6 +4031,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
+        # Turn-scoped runtime mechanisms observed by the classic CLI.  The
+        # React/Ink TUI has a typed StatusCapsule fed by gateway events; the
+        # prompt_toolkit CLI has no gateway, so it must maintain the same
+        # positive-only evidence locally.  Cleared at the start of each chat
+        # turn; e.g. `deep:` should show `deep` for that turn and not leak into
+        # the next ordinary prompt.
+        self._observed_mechanisms = []
         # When True, the input separator rules and the dynamic status bar are
         # hidden until the next user input. Set by _recover_after_resize() so a
         # SIGWINCH cannot stamp a freshly-drawn status bar on top of one that
@@ -4453,6 +4460,73 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         idle = max(0.0, time.time() - last_finished_at)
         return f"✓ {format_duration_compact(idle)}"
 
+    @staticmethod
+    def _deep_prefix_instruction(text: str) -> Optional[str]:
+        """Return the instruction for an explicit leading `deep:` invocation.
+
+        This mirrors the gateway path: only a prompt whose first non-whitespace
+        characters are exactly `deep:` activates the skill. Ordinary text that
+        mentions deep remains ordinary text.
+        """
+        stripped = text.lstrip()
+        if not stripped.lower().startswith("deep:"):
+            return None
+        return stripped[len("deep:") :].lstrip()
+
+    @staticmethod
+    def _deep_mechanism_payload(source: str) -> dict:
+        return {
+            "key": "skill:deep",
+            "kind": "skill",
+            "label": "deep",
+            "name": "deep",
+            "phase": "start",
+            "scope": "turn",
+            "source": source,
+        }
+
+    def _observe_cli_mechanism(self, payload: dict) -> None:
+        """Record a positive runtime mechanism observation for the current turn."""
+        if not isinstance(payload, dict):
+            return
+        mechanisms = getattr(self, "_observed_mechanisms", None)
+        if not isinstance(mechanisms, list):
+            mechanisms = []
+            self._observed_mechanisms = mechanisms
+        mechanisms.append(payload)
+        del mechanisms[:-8]
+
+    def _prepare_deep_prompt_for_cli(self, message: Any) -> tuple[Any, Optional[dict]]:
+        """Expand classic-CLI `deep:` prompts into a real deep skill invocation."""
+        if not isinstance(message, str):
+            return message, None
+        instruction = self._deep_prefix_instruction(message)
+        if instruction is None:
+            return message, None
+        try:
+            from agent.skill_commands import build_skill_invocation_message
+
+            expanded = build_skill_invocation_message(
+                "/deep",
+                user_instruction=instruction,
+                task_id=str(getattr(self, "session_id", "") or "") or None,
+            )
+        except Exception:
+            expanded = None
+        if not expanded:
+            return message, None
+        return expanded, self._deep_mechanism_payload("explicit_skill_invocation")
+
+    def _observed_mechanism_names(self) -> list[str]:
+        names: list[str] = []
+        for payload in getattr(self, "_observed_mechanisms", []) or []:
+            if not isinstance(payload, dict):
+                continue
+            if payload.get("kind") == "skill" and str(payload.get("name") or "").lower() == "deep":
+                if "deep" not in names:
+                    names.append("deep")
+        return names
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -4495,6 +4569,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "active_background_tasks": 0,
             "active_background_processes": 0,
             "active_background_subagents": 0,
+            "observed_mechanisms": self._observed_mechanism_names(),
         }
 
         # Count live /background tasks. The dict entry is removed in the
@@ -4970,15 +5045,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
+            mechanisms = list(snapshot.get("observed_mechanisms") or [])
 
             yolo_active = self._is_session_yolo_active()
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                parts = [f"⚕ {snapshot['model_short']}"]
+                parts.extend(mechanisms)
+                parts.append(duration_label)
                 if yolo_active:
-                    text += " · ⚠ YOLO"
-                return self._trim_status_bar_text(text, width)
+                    parts.append("⚠ YOLO")
+                return self._trim_status_bar_text(" · ".join(parts), width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {snapshot['model_short']}"]
+                parts.extend(mechanisms)
+                parts.append(percent_label)
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5004,7 +5084,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {snapshot['model_short']}"]
+            parts.extend(mechanisms)
+            parts.extend([context_label, percent_label])
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5041,15 +5123,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
+            mechanisms = list(snapshot.get("observed_mechanisms") or [])
             yolo_active = self._is_session_yolo_active()
 
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
+                ]
+                for mechanism in mechanisms:
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append(("class:status-bar-strong", mechanism))
+                frags.extend([
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
-                ]
+                ])
                 if yolo_active:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -5065,9 +5153,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                    ]
+                    for mechanism in mechanisms:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-strong", mechanism))
+                    frags.extend([
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
-                    ]
+                    ])
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5104,13 +5197,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                    ]
+                    for mechanism in mechanisms:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-strong", mechanism))
+                    frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
-                    ]
+                    ])
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -11841,6 +11939,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # this to True. Early returns (credential refresh failure, etc.)
         # leave it False, which is correct — those aren't user interrupts.
         self._last_turn_interrupted = False
+        self._observed_mechanisms = []
 
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
@@ -11946,6 +12045,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if isinstance(message, str):
             from run_agent import _sanitize_surrogates
             message = _sanitize_surrogates(message)
+
+        agent_api_message = message
+        persist_user_message_override = None
+        if isinstance(message, str):
+            agent_api_message, mechanism_payload = self._prepare_deep_prompt_for_cli(message)
+            if mechanism_payload:
+                self._observe_cli_mechanism(mechanism_payload)
+                # The API-facing prompt is the loaded skill scaffold, but the
+                # transcript should preserve the clean user text (`deep: ...`).
+                persist_user_message_override = message
 
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
@@ -12064,7 +12173,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 except Exception:
                     reset_current_session_key = None  # type: ignore[assignment]
                     _approval_session_token = None
-                agent_message = _voice_prefix + message if _voice_prefix else message
+                agent_message = agent_api_message
+                if _voice_prefix and isinstance(agent_message, str):
+                    agent_message = _voice_prefix + agent_message
                 # Prepend pending notes via _prepend_note_to_message, which
                 # handles both plain-string and multimodal content-parts list
                 # messages. Naive ``note + "\n\n" + agent_message`` crashed with
@@ -12091,7 +12202,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         conversation_history=self.conversation_history[:-1],  # Exclude the message we just added
                         stream_callback=stream_callback,
                         task_id=self.session_id,
-                        persist_user_message=message if _voice_prefix else None,
+                        persist_user_message=(
+                            persist_user_message_override
+                            if persist_user_message_override is not None
+                            else (message if _voice_prefix else None)
+                        ),
                         moa_config=_moa_cfg,
                     )
                     if getattr(self, "_pending_moa_disable_after_turn", False):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1726,6 +1726,11 @@ DEFAULT_CONFIG = {
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",
+        # Mechanism Status Bar v1: show a compact runtime capsule in the Ink
+        # status rule.  It reports only observed runtime signals and labels token
+        # / elapsed readouts as observed/unknown (never exact).  Set false to
+        # hide this extra capsule while keeping the rest of the status bar.
+        "tui_mechanism_statusbar": True,
         # Seconds between prompt_toolkit redraws in the classic CLI when idle.
         # Default 1.0 keeps the wall-clock status-bar read-outs (idle-since-
         # last-turn) ticking and keeps the bottom chrome alive during idle —

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -164,6 +164,64 @@ class TestCLIStatusBar:
         assert "⚕" in text
         assert "claude-sonnet-4-20250514" in text
 
+    def test_deep_prefix_expands_to_real_skill_invocation(self):
+        cli_obj = _make_cli()
+        cli_obj.session_id = "sid"
+
+        with patch("agent.skill_commands.build_skill_invocation_message", return_value="DEEP_SCAFFOLD") as mock_build:
+            prompt, payload = cli_obj._prepare_deep_prompt_for_cli("deep: explain this")
+
+        assert prompt == "DEEP_SCAFFOLD"
+        assert payload == {
+            "key": "skill:deep",
+            "kind": "skill",
+            "label": "deep",
+            "name": "deep",
+            "phase": "start",
+            "scope": "turn",
+            "source": "explicit_skill_invocation",
+        }
+        mock_build.assert_called_once_with("/deep", user_instruction="explain this", task_id="sid")
+
+    def test_plain_deep_mention_does_not_expand(self):
+        cli_obj = _make_cli()
+
+        prompt, payload = cli_obj._prepare_deep_prompt_for_cli("why did deep not show?")
+
+        assert prompt == "why did deep not show?"
+        assert payload is None
+
+    def test_cli_status_bar_shows_observed_deep(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj._observe_cli_mechanism(cli_obj._deep_mechanism_payload("explicit_skill_invocation"))
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "deep" in text
+
+    def test_cli_status_bar_does_not_show_unobserved_deep(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "deep" not in text
+
     def test_compression_count_shown_in_wide_status_bar(self):
         cli_obj = _attach_agent(
             _make_cli(),

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3920,6 +3920,324 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     assert captured["session_key"] == "session-key"
 
 
+def test_prompt_submit_expands_deep_prefix_and_emits_mechanism_observation(monkeypatch):
+    captured = {}
+    emitted = []
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    def fake_skill_message(cmd_key, user_instruction, task_id=None, runtime_note=""):
+        assert cmd_key == "/deep"
+        assert user_instruction == "write the plan"
+        return (
+            '[IMPORTANT: The user has invoked the "deep" skill, indicating they want you to follow its instructions. '
+            'The full skill content is loaded below.]\n\n# deep\n\n'
+            f'The user has provided the following instruction alongside the skill invocation: {user_instruction}'
+        )
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_build_skill_invocation_message_for_gateway", fake_skill_message, raising=False)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "deep: write the plan"},
+            }
+        )
+
+        assert resp["result"]["status"] == "streaming"
+        assert captured["prompt"].startswith('[IMPORTANT: The user has invoked the "deep" skill')
+        assert any(
+            len(call) == 3
+            and call[0] == "mechanism.observed"
+            and call[1] == "sid"
+            and call[2] == {
+                "key": "skill:deep",
+                "kind": "skill",
+                "label": "deep",
+                "name": "deep",
+                "phase": "start",
+                "scope": "turn",
+                "source": "explicit_skill_invocation",
+            }
+            for call in emitted
+        )
+        assert [event for event, *_ in emitted].index("message.start") < [event for event, *_ in emitted].index("mechanism.observed")
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_does_not_emit_deep_for_plain_text_mentions(monkeypatch):
+    emitted = []
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    try:
+        server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "why did deep skill not appear?"},
+            }
+        )
+
+        assert all(event != "mechanism.observed" for event, *_ in emitted)
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_does_not_emit_deep_for_unmarked_skill_scaffold(monkeypatch):
+    emitted = []
+    skill_scaffold = (
+        '[IMPORTANT: The user has invoked the "deep" skill, indicating they want you to follow its instructions. '
+        'The full skill content is loaded below.]\n\n# deep'
+    )
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    try:
+        server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": skill_scaffold},
+            }
+        )
+
+        assert all(event != "mechanism.observed" for event, *_ in emitted)
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_command_dispatch_deep_skill_payload_marks_only_next_same_session_submit(monkeypatch):
+    captured = {}
+    emitted = []
+    skill_scaffold = (
+        '[IMPORTANT: The user has invoked the "deep" skill, indicating they want you to follow its instructions. '
+        'The full skill content is loaded below.]\n\n# deep'
+    )
+
+    class _Agent:
+        def __init__(self, label):
+            self.label = label
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            captured[self.label] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    from agent import skill_commands
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": {}})
+    monkeypatch.setattr(skill_commands, "scan_skill_commands", lambda: {"/deep": {"name": "deep", "skill_dir": "unused"}})
+    monkeypatch.setattr(skill_commands, "build_skill_invocation_message", lambda key, arg, task_id=None, runtime_note="": skill_scaffold)
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    server._sessions["sid-a"] = _session(agent=_Agent("a"), session_key="session-a")
+    server._sessions["sid-b"] = _session(agent=_Agent("b"), session_key="session-b")
+    try:
+        dispatch = server.handle_request(
+            {
+                "id": "dispatch",
+                "method": "command.dispatch",
+                "params": {"arg": "write the plan", "name": "deep", "session_id": "sid-a"},
+            }
+        )
+
+        assert dispatch["result"] == {"message": skill_scaffold, "name": "deep", "type": "skill"}
+
+        server.handle_request(
+            {
+                "id": "unrelated-same-session",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid-a", "text": "ordinary unrelated turn"},
+            }
+        )
+        assert all(event != "mechanism.observed" for event, *_ in emitted)
+        assert server._sessions["sid-a"].get("pending_mechanism_observations") == []
+
+        dispatch = server.handle_request(
+            {
+                "id": "dispatch-again",
+                "method": "command.dispatch",
+                "params": {"arg": "write the plan", "name": "deep", "session_id": "sid-a"},
+            }
+        )
+        assert dispatch["result"] == {"message": skill_scaffold, "name": "deep", "type": "skill"}
+
+        server.handle_request(
+            {
+                "id": "wrong-session",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid-b", "text": skill_scaffold},
+            }
+        )
+        assert all(event != "mechanism.observed" for event, *_ in emitted)
+
+        server.handle_request(
+            {
+                "id": "same-session",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid-a", "text": skill_scaffold},
+            }
+        )
+
+        assert captured["a"] == skill_scaffold
+        assert any(
+            len(call) == 3
+            and call[0] == "mechanism.observed"
+            and call[1] == "sid-a"
+            and call[2]["key"] == "skill:deep"
+            and call[2]["source"] == "slash_command"
+            for call in emitted
+        )
+        assert server._sessions["sid-a"].get("pending_mechanism_observations") == []
+    finally:
+        server._sessions.pop("sid-a", None)
+        server._sessions.pop("sid-b", None)
+
+
+def test_deep_prefix_submit_clears_stale_slash_marker(monkeypatch):
+    emitted = []
+    skill_scaffold = (
+        '[IMPORTANT: The user has invoked the "deep" skill, indicating they want you to follow its instructions. '
+        'The full skill content is loaded below.]\n\n# deep'
+    )
+
+    class _Agent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    from agent import skill_commands
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": {}})
+    monkeypatch.setattr(skill_commands, "scan_skill_commands", lambda: {"/deep": {"name": "deep", "skill_dir": "unused"}})
+    monkeypatch.setattr(skill_commands, "build_skill_invocation_message", lambda key, arg, task_id=None, runtime_note="": skill_scaffold)
+    monkeypatch.setattr(server, "_build_skill_invocation_message_for_gateway", lambda key, instruction, task_id=None, runtime_note="": "expanded deep prefix")
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    server._sessions["sid"] = _session(agent=_Agent(), session_key="session-key")
+    try:
+        dispatch = server.handle_request(
+            {
+                "id": "dispatch",
+                "method": "command.dispatch",
+                "params": {"arg": "write the plan", "name": "deep", "session_id": "sid"},
+            }
+        )
+        assert dispatch["result"] == {"message": skill_scaffold, "name": "deep", "type": "skill"}
+
+        server.handle_request(
+            {
+                "id": "deep-prefix",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "deep: other instruction"},
+            }
+        )
+        assert server._sessions["sid"].get("pending_mechanism_observations") == []
+
+        server.handle_request(
+            {
+                "id": "stale-scaffold",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": skill_scaffold},
+            }
+        )
+
+        assert any(
+            len(call) == 3
+            and call[0] == "mechanism.observed"
+            and call[2]["source"] == "explicit_skill_invocation"
+            for call in emitted
+        )
+        assert all(
+            not (len(call) == 3 and call[0] == "mechanism.observed" and call[2]["source"] == "slash_command")
+            for call in emitted
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_prompt_submit_expands_context_refs(monkeypatch):
     captured = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8449,6 +8449,110 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
+def _deep_prefix_instruction(text: str) -> Optional[str]:
+    """Return the instruction for an explicit leading `deep:` invocation.
+
+    This is deliberately not a text classifier: only a turn whose first
+    non-whitespace characters are exactly `deep:` activates the skill. Plain
+    mentions such as "why did deep skill not appear?" remain ordinary text.
+    """
+    stripped = text.lstrip()
+    if not stripped.lower().startswith("deep:"):
+        return None
+    return stripped[len("deep:") :].lstrip()
+
+
+def _is_deep_skill_invocation_scaffold(text: str) -> bool:
+    """Detect Hermes' own skill-invocation scaffold for the deep skill."""
+    return text.startswith('[IMPORTANT: The user has invoked the "deep" skill')
+
+
+def _deep_mechanism_payload(source: str) -> dict:
+    return {
+        "key": "skill:deep",
+        "kind": "skill",
+        "label": "deep",
+        "name": "deep",
+        "phase": "start",
+        "scope": "turn",
+        "source": source,
+    }
+
+
+def _prompt_fingerprint(prompt: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(prompt.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def _record_pending_mechanism_observation(session: Optional[dict], prompt: str, payload: dict) -> None:
+    if not session or not prompt:
+        return
+
+    pending = session.setdefault("pending_mechanism_observations", [])
+    if not isinstance(pending, list):
+        pending = []
+        session["pending_mechanism_observations"] = pending
+    pending.append({"fingerprint": _prompt_fingerprint(prompt), "payload": payload})
+    del pending[:-8]
+
+
+def _consume_pending_mechanism_observation(session: dict, prompt: str) -> Optional[dict]:
+    pending = session.get("pending_mechanism_observations")
+    if not isinstance(pending, list) or not pending:
+        return None
+
+    fingerprint = _prompt_fingerprint(prompt)
+    session["pending_mechanism_observations"] = []
+    for item in pending:
+        if not isinstance(item, dict) or item.get("fingerprint") != fingerprint:
+            continue
+        payload = item.get("payload")
+        return payload if isinstance(payload, dict) else None
+
+    return None
+
+
+def _build_skill_invocation_message_for_gateway(
+    cmd_key: str,
+    user_instruction: str = "",
+    task_id: Optional[str] = None,
+    runtime_note: str = "",
+) -> Optional[str]:
+    from agent.skill_commands import build_skill_invocation_message
+
+    return build_skill_invocation_message(
+        cmd_key,
+        user_instruction=user_instruction,
+        task_id=task_id,
+        runtime_note=runtime_note,
+    )
+
+
+def _emit_mechanism_observed(sid: str, payload: dict) -> None:
+    _emit("mechanism.observed", sid, payload)
+
+
+def _prepare_deep_prompt_for_gateway(prompt: str, session: dict) -> tuple[str, Optional[dict]]:
+    """Expand explicit deep invocations and return runtime-backed observation payload."""
+    pending_payload = _consume_pending_mechanism_observation(session, prompt)
+    instruction = _deep_prefix_instruction(prompt)
+    if instruction is not None:
+        expanded = _build_skill_invocation_message_for_gateway(
+            "/deep",
+            instruction,
+            task_id=str(session.get("session_key") or "") or None,
+        )
+        if expanded:
+            return expanded, _deep_mechanism_payload("explicit_skill_invocation")
+        return prompt, None
+
+    if pending_payload and _is_deep_skill_invocation_scaffold(prompt):
+        return prompt, pending_payload
+
+    return prompt, None
+
+
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
     with session["history_lock"]:
         history = list(session["history"])
@@ -8494,6 +8598,10 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
             prompt = text
+            if isinstance(prompt, str):
+                prompt, mechanism_payload = _prepare_deep_prompt_for_gateway(prompt, session)
+                if mechanism_payload:
+                    _emit_mechanism_observed(sid, mechanism_payload)
 
             if isinstance(prompt, str) and "@" in prompt:
                 from agent.context_references import preprocess_context_references
@@ -11401,12 +11509,19 @@ def _(rid, params: dict) -> dict:
                 key, arg, task_id=session.get("session_key", "") if session else ""
             )
             if msg:
+                skill_name = str(cmds[key].get("name", name))
+                if key == "/deep" or skill_name == "deep":
+                    _record_pending_mechanism_observation(
+                        session,
+                        msg,
+                        _deep_mechanism_payload("slash_command"),
+                    )
                 return _ok(
                     rid,
                     {
                         "type": "skill",
                         "message": msg,
-                        "name": cmds[key].get("name", name),
+                        "name": skill_name,
                     },
                 )
     except Exception:

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -179,6 +179,56 @@ describe('StatusRule background-subagent indicator', () => {
   })
 })
 
+describe('StatusRule mechanism capsule', () => {
+  it('renders the Auto Session mechanism entry with token/elapsed uncertainty', () => {
+    const element = StatusRule({
+      ...baseProps,
+      statusCapsule: {
+        elapsedSource: 'unknown',
+        observed: { deep: 'unknown', delegate: 'unknown', moa: 'unknown', opencode: 'unknown' },
+        precision: { elapsed: 'unknown', tokens: 'unknown' },
+        route: 'Auto Session',
+        schemaVersion: 1,
+        state: 'session_starting',
+        tokenSource: 'unknown',
+        tools: []
+      }
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).toContain('Auto Session')
+    expect(rendered).toContain('50k/200k')
+    expect(rendered).toContain('tok?')
+    expect(rendered).toContain('time?')
+    expect(rendered).not.toContain('exact')
+  })
+
+  it('shows observed delegate/MoA mechanisms but keeps OpenCode unknown unless directly observed', () => {
+    const element = StatusRule({
+      ...baseProps,
+      statusCapsule: {
+        elapsedSource: 'local_wall_clock',
+        observed: { deep: 'unknown', delegate: 'observed', moa: 'observed', opencode: 'unknown' },
+        precision: { elapsed: 'observed', tokens: 'observed' },
+        route: 'MoA',
+        schemaVersion: 1,
+        state: 'delegating',
+        tokenSource: 'provider_usage',
+        tools: ['delegate_task']
+      }
+    })
+
+    const rendered = textContent(element)
+
+    expect(rendered).toContain('MoA')
+    expect(rendered).toContain('delegate')
+    expect(rendered).toContain('opencode?')
+    expect(rendered).toContain('tok obs')
+    expect(rendered).toContain('time obs')
+  })
+})
+
 describe('StatusRule session count click target', () => {
   it('makes the live session count itself clickable', () => {
     const openSwitcher = vi.fn()

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -180,6 +180,57 @@ describe('createGatewayEventHandler', () => {
     expect(getUiState().status).toBe('⏸ goal paused')
   })
 
+  it('folds runtime mechanism events into the status capsule without upgrading unknown OpenCode/Deep state', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    patchUiState({ mechanismStatusBar: true, sid: 'sess-1' } as any)
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    expect((getUiState() as any).statusCapsule).toMatchObject({ route: 'Hermes', state: 'running' })
+
+    onEvent({ payload: { name: 'terminal', tool_id: 'tool-1' }, type: 'tool.start' } as any)
+    expect((getUiState() as any).statusCapsule).toMatchObject({
+      observed: { deep: 'unknown', opencode: 'unknown' },
+      state: 'tooling',
+      tools: ['terminal']
+    })
+
+    onEvent({ payload: { goal: 'check implementation', subagent_id: 'sa-1', task_index: 0 }, type: 'subagent.start' } as any)
+    expect((getUiState() as any).statusCapsule.observed.delegate).toBe('observed')
+
+    onEvent({ payload: { count: 2, index: 1, label: 'openrouter:openai/gpt-5.5', text: 'draft' }, type: 'moa.reference' } as any)
+    expect((getUiState() as any).statusCapsule).toMatchObject({
+      observed: { moa: 'observed', opencode: 'unknown' },
+      route: 'MoA'
+    })
+
+    onEvent({ payload: { text: 'done', usage: { calls: 1, input: 20, output: 5, total: 25 } }, type: 'message.complete' } as any)
+    expect((getUiState() as any).statusCapsule).toMatchObject({
+      precision: { elapsed: 'observed', tokens: 'observed' },
+      state: 'idle'
+    })
+  })
+
+  it('keeps resetting hidden mechanism state while the status capsule is disabled', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    patchUiState({ mechanismStatusBar: true, sid: 'sess-1' } as any)
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { label: 'reference', text: 'draft' }, type: 'moa.reference' } as any)
+    expect((getUiState() as any).statusCapsule.route).toBe('MoA')
+
+    patchUiState({ mechanismStatusBar: false } as any)
+    onEvent({ payload: {}, type: 'message.start' } as any)
+
+    expect((getUiState() as any).statusCapsule).toMatchObject({
+      observed: { delegate: 'unknown', moa: 'unknown', opencode: 'unknown' },
+      route: 'Hermes',
+      state: 'running'
+    })
+  })
+
   it('surfaces self-improvement review summaries as a persistent system line', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -231,6 +231,47 @@ describe('createGatewayEventHandler', () => {
     })
   })
 
+  it('folds typed deep mechanism observations and clears only turn-scoped observations', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    patchUiState({ mechanismStatusBar: false, sid: 'sess-1' } as any)
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({
+      payload: {
+        key: 'skill:deep',
+        kind: 'skill',
+        label: 'deep',
+        name: 'deep',
+        phase: 'start',
+        scope: 'turn',
+        source: 'explicit_skill_invocation'
+      },
+      type: 'mechanism.observed'
+    } as any)
+
+    expect((getUiState() as any).statusCapsule).toMatchObject({
+      mechanisms: [expect.objectContaining({ key: 'skill:deep', name: 'deep', scope: 'turn' })],
+      observed: { deep: 'observed' }
+    })
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    expect((getUiState() as any).statusCapsule).toMatchObject({
+      mechanisms: [],
+      observed: { deep: 'unknown' }
+    })
+
+    onEvent({
+      payload: { key: 'skill:deep', kind: 'skill', name: 'deep', scope: 'session', source: 'preloaded_skill' },
+      type: 'mechanism.observed'
+    } as any)
+    onEvent({ payload: {}, type: 'message.start' } as any)
+
+    expect((getUiState() as any).statusCapsule).toMatchObject({
+      mechanisms: [expect.objectContaining({ key: 'skill:deep', name: 'deep', scope: 'session' })],
+      observed: { deep: 'observed' }
+    })
+  })
+
   it('surfaces self-improvement review summaries as a persistent system line', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/__tests__/statusCapsule.test.ts
+++ b/ui-tui/src/__tests__/statusCapsule.test.ts
@@ -113,6 +113,84 @@ describe('StatusCapsule runtime event folding', () => {
     expect(formatStatusCapsule(capsule)).not.toContain('delegate')
   })
 
+  it('folds explicit deep mechanism observations without inferring from plain text', () => {
+    let capsule = initialStatusCapsule()
+
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+    capsule = foldStatusCapsuleEvent(capsule, {
+      payload: {
+        key: 'skill:deep',
+        kind: 'skill',
+        label: 'deep',
+        name: 'deep',
+        phase: 'start',
+        scope: 'turn',
+        source: 'explicit_skill_invocation'
+      },
+      type: 'mechanism.observed'
+    })
+
+    expect(capsule.observed.deep).toBe('observed')
+    expect(capsule.mechanisms).toEqual([
+      expect.objectContaining({ key: 'skill:deep', kind: 'skill', name: 'deep', scope: 'turn', source: 'explicit_skill_invocation' })
+    ])
+    expect(formatStatusCapsule(capsule)).toContain('deep')
+
+    capsule = foldStatusCapsuleEvent(capsule, {
+      payload: { text: 'deep analysis is mentioned as prose only' },
+      type: 'message.delta'
+    })
+
+    expect(capsule.observed.deep).toBe('observed')
+    expect(capsule.mechanisms).toHaveLength(1)
+  })
+
+  it('clears turn-scoped deep observations on the next message start while preserving session-scoped ones', () => {
+    let capsule = initialStatusCapsule()
+
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+    capsule = foldStatusCapsuleEvent(capsule, {
+      payload: { key: 'skill:deep', kind: 'skill', name: 'deep', scope: 'turn', source: 'slash_command' },
+      type: 'mechanism.observed'
+    })
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+
+    expect(capsule.observed.deep).toBe('unknown')
+    expect(capsule.mechanisms).toEqual([])
+
+    capsule = foldStatusCapsuleEvent(capsule, {
+      payload: { key: 'skill:deep', kind: 'skill', name: 'deep', scope: 'session', source: 'preloaded_skill' },
+      type: 'mechanism.observed'
+    })
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+
+    expect(capsule.observed.deep).toBe('observed')
+    expect(capsule.mechanisms).toEqual([
+      expect.objectContaining({ key: 'skill:deep', name: 'deep', scope: 'session', source: 'preloaded_skill' })
+    ])
+  })
+
+  it('does not evict session-scoped deep when a long turn records many observations', () => {
+    let capsule = initialStatusCapsule()
+
+    capsule = foldStatusCapsuleEvent(capsule, {
+      payload: { key: 'skill:deep', kind: 'skill', name: 'deep', scope: 'session', source: 'preloaded_skill' },
+      type: 'mechanism.observed'
+    })
+
+    for (let i = 0; i < 12; i += 1) {
+      capsule = foldStatusCapsuleEvent(capsule, {
+        payload: { key: `runtime:${i}`, kind: 'runtime', name: `probe-${i}`, scope: 'turn', source: 'runtime_event' },
+        type: 'mechanism.observed'
+      })
+    }
+
+    expect(capsule.mechanisms).toContainEqual(expect.objectContaining({ key: 'skill:deep', scope: 'session' }))
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+    expect(capsule.observed.deep).toBe('observed')
+    expect(capsule.mechanisms).toEqual([expect.objectContaining({ key: 'skill:deep', scope: 'session' })])
+  })
+
   it('preserves folded live states when the render path rebuilds from usage and timing', () => {
     let capsule = initialStatusCapsule()
 

--- a/ui-tui/src/__tests__/statusCapsule.test.ts
+++ b/ui-tui/src/__tests__/statusCapsule.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildStatusCapsule,
+  foldStatusCapsuleEvent,
+  formatStatusCapsule,
+  initialStatusCapsule
+} from '../domain/statusCapsule.js'
+
+const usage = { calls: 0, input: 0, output: 0, total: 0 }
+
+describe('StatusCapsule schema and accuracy boundaries', () => {
+  it('creates an Auto Session capsule without pretending token or elapsed accuracy is exact', () => {
+    const capsule = buildStatusCapsule({
+      autoSession: true,
+      busy: false,
+      lastTurnEndedAt: null,
+      sessionStartedAt: null,
+      status: 'forging session…',
+      turnStartedAt: null,
+      usage
+    })
+
+    expect(capsule.schemaVersion).toBe(1)
+    expect(capsule.route).toBe('Auto Session')
+    expect(capsule.state).toBe('session_starting')
+    expect(capsule.precision.tokens).toBe('unknown')
+    expect(capsule.precision.elapsed).toBe('unknown')
+    expect(capsule.observed.opencode).toBe('unknown')
+    expect(capsule.observed.deep).toBe('unknown')
+    expect(formatStatusCapsule(capsule)).toContain('Auto Session')
+    expect(formatStatusCapsule(capsule)).not.toContain('exact')
+  })
+
+  it('marks token and elapsed numbers as observed rather than exact', () => {
+    const now = Date.now()
+
+    const capsule = buildStatusCapsule({
+      busy: true,
+      lastTurnEndedAt: null,
+      sessionStartedAt: now - 90_000,
+      status: 'running…',
+      turnStartedAt: now - 12_000,
+      usage: { calls: 2, context_max: 200_000, context_used: 50_000, input: 100, output: 40, total: 140 }
+    })
+
+    expect(capsule.route).toBe('Hermes')
+    expect(capsule.state).toBe('running')
+    expect(capsule.precision.tokens).toBe('observed')
+    expect(capsule.precision.elapsed).toBe('observed')
+    expect(capsule.tokenSource).toBe('provider_usage')
+    expect(capsule.elapsedSource).toBe('local_wall_clock')
+  })
+  it('marks context-window occupancy as observed without calling it provider usage', () => {
+    const capsule = buildStatusCapsule({
+      busy: false,
+      lastTurnEndedAt: null,
+      sessionStartedAt: null,
+      status: 'ready',
+      turnStartedAt: null,
+      usage: { calls: 0, context_max: 200_000, context_used: 50_000, input: 0, output: 0, total: 0 }
+    })
+
+    expect(capsule.precision.tokens).toBe('observed')
+    expect(capsule.tokenSource).toBe('context_window')
+  })
+})
+
+describe('StatusCapsule runtime event folding', () => {
+  it('folds tools, MoA, and delegation as observed while leaving OpenCode/Deep unknown without direct evidence', () => {
+    let capsule = initialStatusCapsule()
+
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+    expect(capsule.state).toBe('running')
+
+    capsule = foldStatusCapsuleEvent(capsule, { payload: { name: 'terminal' }, type: 'tool.start' })
+    expect(capsule.state).toBe('tooling')
+    expect(capsule.tools).toEqual(['terminal'])
+    expect(capsule.observed.opencode).toBe('unknown')
+    expect(capsule.observed.deep).toBe('unknown')
+
+    capsule = foldStatusCapsuleEvent(capsule, { payload: { subagent_id: 'sa-1' }, type: 'subagent.start' })
+    expect(capsule.observed.delegate).toBe('observed')
+
+    capsule = foldStatusCapsuleEvent(capsule, { payload: { label: 'openrouter:openai/gpt-5.5' }, type: 'moa.reference' })
+    expect(capsule.route).toBe('MoA')
+    expect(capsule.observed.moa).toBe('observed')
+    expect(capsule.observed.opencode).toBe('unknown')
+
+    capsule = foldStatusCapsuleEvent(capsule, {
+      payload: { usage: { calls: 1, input: 10, output: 5, total: 15 } },
+      type: 'message.complete'
+    })
+    expect(capsule.state).toBe('idle')
+    expect(capsule.precision.tokens).toBe('observed')
+  })
+
+  it('does not leak MoA or delegate observations into the next plain Hermes turn', () => {
+    let capsule = initialStatusCapsule()
+
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+    capsule = foldStatusCapsuleEvent(capsule, { payload: { subagent_id: 'sa-1' }, type: 'subagent.start' })
+    capsule = foldStatusCapsuleEvent(capsule, { payload: { label: 'reference' }, type: 'moa.reference' })
+    capsule = foldStatusCapsuleEvent(capsule, { payload: {}, type: 'message.complete' })
+
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+
+    expect(capsule.route).toBe('Hermes')
+    expect(capsule.observed.delegate).toBe('unknown')
+    expect(capsule.observed.moa).toBe('unknown')
+    expect(capsule.observed.opencode).toBe('unknown')
+    expect(formatStatusCapsule(capsule)).not.toContain('MoA')
+    expect(formatStatusCapsule(capsule)).not.toContain('delegate')
+  })
+
+  it('preserves folded live states when the render path rebuilds from usage and timing', () => {
+    let capsule = initialStatusCapsule()
+
+    capsule = foldStatusCapsuleEvent(capsule, { type: 'message.start' })
+    capsule = foldStatusCapsuleEvent(capsule, { payload: { name: 'terminal' }, type: 'tool.start' })
+
+    const rebuilt = buildStatusCapsule({
+      busy: true,
+      lastTurnEndedAt: null,
+      prior: capsule,
+      sessionStartedAt: Date.now() - 30_000,
+      status: 'running…',
+      turnStartedAt: Date.now() - 5_000,
+      usage
+    })
+
+    expect(rebuilt.state).toBe('tooling')
+    expect(rebuilt.tools).toEqual(['terminal'])
+  })
+})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -40,6 +40,7 @@ describe('applyDisplay', () => {
     expect(s.compact).toBe(true)
     expect(s.detailsMode).toBe('expanded')
     expect(s.inlineDiffs).toBe(false)
+    expect(s.mechanismStatusBar).toBe(true)
     expect(s.showReasoning).toBe(true)
     expect(s.statusBar).toBe('off')
     expect(s.streaming).toBe(false)
@@ -63,6 +64,7 @@ describe('applyDisplay', () => {
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(false)
     expect(s.inlineDiffs).toBe(true)
+    expect(s.mechanismStatusBar).toBe(true)
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
@@ -160,6 +162,22 @@ describe('applyDisplay', () => {
 
     applyDisplay({ config: { display: { tui_statusbar: 'top' } } }, setBell)
     expect($uiState.get().statusBar).toBe('top')
+  })
+  it('threads display.tui_mechanism_statusbar into $uiState', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { tui_mechanism_statusbar: false } } }, setBell)
+    expect($uiState.get().mechanismStatusBar).toBe(false)
+
+    applyDisplay({ config: { display: { tui_mechanism_statusbar: true } } }, setBell)
+    expect($uiState.get().mechanismStatusBar).toBe(true)
+  })
+
+  it('treats missing display.tui_mechanism_statusbar as enabled for v1 visibility', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: {} } }, setBell)
+    expect($uiState.get().mechanismStatusBar).toBe(true)
   })
 })
 

--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -73,6 +73,7 @@ describe('resume scroll settle', () => {
     let sticky = true
     let lastManualScrollAt = 0
     const scrollToBottom = vi.fn()
+
     const cancel = scheduleResumeScrollToBottom(
       {
         current: {
@@ -101,6 +102,7 @@ describe('resume scroll settle', () => {
   it('cancels pending resume snaps', () => {
     vi.useFakeTimers()
     const scrollToBottom = vi.fn()
+
     const cancel = scheduleResumeScrollToBottom(
       {
         current: {
@@ -122,6 +124,7 @@ describe('resume scroll settle', () => {
     vi.useFakeTimers()
     let sticky = false
     const scrollToBottom = vi.fn()
+
     const cancel = scheduleResumeScrollToBottom(
       {
         current: {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -722,6 +722,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
 
+      case 'mechanism.observed':
+        patchMechanismCapsule(ev)
+
+        return
+
       case 'moa.reference':
         patchMechanismCapsule(ev)
         turnController.recordMoaReference(

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1,6 +1,7 @@
 import { STARTUP_IMAGE, STARTUP_QUERY } from '../config/env.js'
 import { STREAM_BATCH_MS } from '../config/timing.js'
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
+import { buildStatusCapsule, foldStatusCapsuleEvent } from '../domain/statusCapsule.js'
 import type {
   CommandsCatalogResponse,
   ConfigFullResponse,
@@ -28,6 +29,23 @@ import { getUiState, patchUiState } from './uiStore.js'
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
 
 const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
+
+const patchMechanismCapsule = (ev: GatewayEvent) => {
+  patchUiState(state => {
+    const base =
+      state.statusCapsule ??
+      buildStatusCapsule({
+        busy: state.busy,
+        lastTurnEndedAt: null,
+        sessionStartedAt: null,
+        status: state.status,
+        turnStartedAt: null,
+        usage: state.usage
+      })
+
+    return { ...state, statusCapsule: foldStatusCapsuleEvent(base, ev) }
+  })
+}
 
 const applySkin = (s: GatewaySkin) =>
   patchUiState({
@@ -423,12 +441,27 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'session.info': {
         const info = ev.payload
 
-        patchUiState(state => ({
-          ...state,
-          info,
-          status: state.status === 'starting agent…' ? 'ready' : state.status,
-          usage: info.usage ? { ...state.usage, ...info.usage } : state.usage
-        }))
+        patchUiState(state => {
+          const usage = info.usage ? { ...state.usage, ...info.usage } : state.usage
+
+          return {
+            ...state,
+            info,
+            status: state.status === 'starting agent…' ? 'ready' : state.status,
+            statusCapsule: state.mechanismStatusBar
+              ? buildStatusCapsule({
+                  busy: state.busy,
+                  lastTurnEndedAt: null,
+                  prior: state.statusCapsule,
+                  sessionStartedAt: null,
+                  status: state.status,
+                  turnStartedAt: null,
+                  usage
+                })
+              : state.statusCapsule,
+            usage
+          }
+        })
 
         setHistoryItems(prev => prev.map(m => (m.kind === 'intro' ? { ...m, info } : m)))
 
@@ -457,6 +490,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'message.start':
         resetAgentsNudgeTurnState()
         turnController.startMessage()
+        patchMechanismCapsule(ev)
 
         return
       case 'status.update': {
@@ -689,6 +723,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'moa.reference':
+        patchMechanismCapsule(ev)
         turnController.recordMoaReference(
           String(ev.payload?.label ?? 'reference'),
           String(ev.payload?.text ?? ''),
@@ -699,6 +734,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'moa.aggregating':
+        patchMechanismCapsule(ev)
+
         // Spinner/status transition only — the aggregator's response follows
         // through the normal message stream. No committed transcript entry.
         return
@@ -718,6 +755,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'tool.start':
+        patchMechanismCapsule(ev)
         turnController.recordTodos(ev.payload.todos)
         turnController.recordToolStart(
           ev.payload.tool_id,
@@ -820,6 +858,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       }
 
       case 'subagent.spawn_requested':
+        patchMechanismCapsule(ev)
         // Child built but not yet running (waiting on ThreadPoolExecutor slot).
         // Preserve completed state if a later event races in before this one.
         turnController.upsertSubagent(ev.payload, c => (isTerminalStatus(c.status) ? {} : { status: 'queued' }))
@@ -838,6 +877,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'subagent.start':
+        patchMechanismCapsule(ev)
         turnController.upsertSubagent(ev.payload, c => (isTerminalStatus(c.status) ? {} : { status: 'running' }))
 
         // `subagent.start` is the first delegation event the TUI reliably
@@ -848,6 +888,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
       case 'subagent.thinking': {
+        patchMechanismCapsule(ev)
         const text = String(ev.payload.text ?? '').trim()
 
         if (!text) {
@@ -869,6 +910,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       }
 
       case 'subagent.tool': {
+        patchMechanismCapsule(ev)
+
         const line = formatToolCall(
           ev.payload.tool_name ?? 'delegate_task',
           ev.payload.tool_preview ?? ev.payload.text ?? ''
@@ -887,6 +930,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       }
 
       case 'subagent.progress': {
+        patchMechanismCapsule(ev)
         const text = String(ev.payload.text ?? '').trim()
 
         if (!text) {
@@ -906,6 +950,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       }
 
       case 'subagent.complete':
+        patchMechanismCapsule(ev)
         turnController.upsertSubagent(
           ev.payload,
           c => ({
@@ -943,11 +988,14 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
         }
 
+        patchMechanismCapsule(ev)
+
         return
       }
 
       case 'error':
         turnController.recordError()
+        patchMechanismCapsule(ev)
         flashPet('failed')
 
         {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -2,6 +2,7 @@ import type { MouseTrackingMode, ScrollBoxHandle } from '@hermes/ink'
 import type { MutableRefObject, ReactNode, RefObject, SetStateAction } from 'react'
 
 import type { PasteEvent } from '../components/textInput.js'
+import type { StatusCapsule } from '../domain/statusCapsule.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { BillingStateResponse, ImageAttachResponse, SessionCloseResponse } from '../gatewayTypes.js'
 import type { ParsedVoiceRecordKey } from '../lib/platform.js'
@@ -167,6 +168,7 @@ export interface UiState {
   info: null | SessionInfo
   liveSessionCount: number
   inlineDiffs: boolean
+  mechanismStatusBar: boolean
   mouseTracking: MouseTrackingMode
   notice: Notice | null
   pasteCollapseLines: number
@@ -179,6 +181,7 @@ export interface UiState {
   sid: null | string
   status: string
   statusBar: StatusBarMode
+  statusCapsule: StatusCapsule
   streaming: boolean
   theme: Theme
   usage: Usage

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores'
 
 import { MOUSE_TRACKING } from '../config/env.js'
+import { initialStatusCapsule } from '../domain/statusCapsule.js'
 import { ZERO } from '../domain/usage.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -17,6 +18,7 @@ const buildUiState = (): UiState => ({
   info: null,
   liveSessionCount: 0,
   inlineDiffs: true,
+  mechanismStatusBar: true,
   mouseTracking: MOUSE_TRACKING,
   notice: null,
   pasteCollapseLines: 5,
@@ -27,6 +29,7 @@ const buildUiState = (): UiState => ({
   sid: null,
   status: 'summoning hermes…',
   statusBar: 'top',
+  statusCapsule: initialStatusCapsule(),
   streaming: true,
   theme: DEFAULT_THEME,
   usage: ZERO

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -223,6 +223,7 @@ export const applyDisplay = (
     detailsModeCommandOverride: false,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),
     inlineDiffs: d.inline_diffs !== false,
+    mechanismStatusBar: d.tui_mechanism_statusbar !== false,
     mouseTracking: normalizeMouseTracking(d),
     pasteCollapseLines: _pasteCollapseLinesFromConfig(cfg),
     pasteCollapseChars: _pasteCollapseCharsFromConfig(cfg),

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -6,6 +6,7 @@ import { type RefObject, useCallback, useEffect, useRef } from 'react'
 
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
 import { introMsg, toTranscriptMessages } from '../domain/messages.js'
+import { initialStatusCapsule } from '../domain/statusCapsule.js'
 import { ZERO } from '../domain/usage.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
@@ -73,6 +74,7 @@ export const scheduleResumeScrollToBottom = (
   delays: readonly number[] = [0, 80, 240]
 ) => {
   const startedAt = Date.now()
+
   const timers = delays.map((delay, index) =>
     setTimeout(() => {
       const scroll = scrollRef.current
@@ -148,6 +150,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       targetSid ? rpc<SessionCloseResponse>('session.close', { session_id: targetSid }) : Promise.resolve(null),
     [rpc]
   )
+
   const cancelResumeScrollRef = useRef<null | (() => void)>(null)
 
   const resetSession = useCallback(() => {
@@ -156,7 +159,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     turnController.fullReset()
     setVoiceRecording(false)
     setVoiceProcessing(false)
-    patchUiState({ bgTasks: new Set(), info: null, sid: null, usage: ZERO })
+    patchUiState({ bgTasks: new Set(), info: null, sid: null, statusCapsule: initialStatusCapsule(), usage: ZERO })
     setHistoryItems([])
     setLastUserMsg('')
     setStickyPrompt('')
@@ -186,7 +189,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       setLastUserMsg('')
       composerActions.setPasteSnips([])
       patchTurnState({ activity: [] })
-      patchUiState({ info, usage: usageFrom(info) })
+      patchUiState({ info, statusCapsule: initialStatusCapsule(), usage: usageFrom(info) })
     },
     [composerActions, setHistoryItems, setLastUserMsg, setStickyPrompt]
   )

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -10,6 +10,7 @@ import { DEV_CREDITS_MODE } from '../config/env.js'
 import { FACES } from '../content/faces.js'
 import { VERBS } from '../content/verbs.js'
 import { fmtDuration } from '../domain/messages.js'
+import { formatStatusCapsule, type StatusCapsule } from '../domain/statusCapsule.js'
 import { stickyPromptFromViewport } from '../domain/viewport.js'
 import { buildSubagentTree, treeTotals, widthByDepth } from '../lib/subagentTree.js'
 import { fmtK } from '../lib/text.js'
@@ -248,6 +249,7 @@ export interface StatusBarSegments {
   bg: boolean
   compactCtx: boolean
   compressions: boolean
+  cost: boolean
   duration: boolean
   subagents: boolean
   voice: boolean
@@ -263,7 +265,8 @@ export function statusBarSegments(cols: number): StatusBarSegments {
     compressions: w >= 80,
     voice: w >= 84,
     bg: w >= 88,
-    subagents: w >= 92
+    subagents: w >= 92,
+    cost: w >= 96
   }
 }
 
@@ -418,6 +421,7 @@ export function StatusRule({
   lastTurnEndedAt,
   liveSessionCount,
   sessionStartedAt,
+  statusCapsule,
   turnStartedAt,
   voiceLabel,
   onSessionCountClick,
@@ -474,9 +478,9 @@ export function StatusRule({
 
   // Whole-segment progressive disclosure for the tail: a segment renders only
   // if it fits in the space left after the pinned essentials, evaluated in
-  // descending priority order — bar, duration, compressions, voice, session
-  // count, bg, cost. Lower-priority segments drop first and nothing truncates
-  // mid-segment, so status/model/context are never crushed.
+  // descending priority order — mechanism capsule, bar, duration, compressions,
+  // voice, session count, bg, cost. Lower-priority segments drop first and
+  // nothing truncates mid-segment, so status/model/context are never crushed.
   const SEP = stringWidth(' │ ')
   let tailBudget = Math.max(0, leftWidth - essentialWidth)
 
@@ -492,6 +496,7 @@ export function StatusRule({
 
   const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
   const compressions = typeof usage.compressions === 'number' ? usage.compressions : 0
+  const capsuleText = statusCapsule ? formatStatusCapsule(statusCapsule) : ''
 
   // Dev-only readout (HERMES_DEV_CREDITS). The server omits the key entirely unless the
   // flag is on, so this segment self-hides for normal users. micros→cents is allowed money
@@ -502,6 +507,7 @@ export function StatusRule({
       ? `Δ ${(usage.dev_credits_spent_micros / 10000).toFixed(1)}¢`
       : ''
 
+  const showCapsule = !!capsuleText && fits(SEP + stringWidth(capsuleText))
   const showBar = !!bar && fits(SEP + stringWidth(`[${bar}] ${pct != null ? `${pct}%` : ''}`))
   const showDuration = segs.duration && !!sessionStartedAt && fits(SEP + MAX_DURATION_WIDTH)
 
@@ -530,7 +536,7 @@ export function StatusRule({
   const showResumeHint = !busy && subagentCount > 0 && fits(SEP + stringWidth(resumeHintText))
   // Dev-gated readout (HERMES_DEV_CREDITS), lowest priority,
   // so it consumes tail budget LAST and drops first on a narrow terminal.
-  const showDevCredits = !!devCreditsText && fits(SEP + stringWidth(devCreditsText))
+  const showDevCredits = segs.cost && !!devCreditsText && fits(SEP + stringWidth(devCreditsText))
 
   const handleSessionCountClick = (event: { stopImmediatePropagation?: () => void }) => {
     event.stopImmediatePropagation?.()
@@ -590,6 +596,12 @@ export function StatusRule({
             </Text>
           ) : null}
         </Box>
+        {showCapsule ? (
+          <Text color={t.color.accent} wrap="truncate-end">
+            {' │ '}
+            {capsuleText}
+          </Text>
+        ) : null}
         {showBar ? (
           <Text color={t.color.muted} wrap="truncate-end">
             {' │ '}
@@ -783,6 +795,7 @@ interface StatusRuleProps {
   notice?: Notice | null
   sessionStartedAt?: null | number
   status: string
+  statusCapsule?: null | StatusCapsule
   statusColor: string
   t: Theme
   turnStartedAt?: null | number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -11,6 +11,7 @@ import { usePet } from '../app/usePet.js'
 import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import { prevRenderedMsg } from '../domain/blockLayout.js'
+import { buildStatusCapsule } from '../domain/statusCapsule.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
   composerPromptWidth,
@@ -463,6 +464,19 @@ const StatusRulePane = memo(function StatusRulePane({
     return null
   }
 
+  const statusCapsule = ui.mechanismStatusBar
+    ? buildStatusCapsule({
+        autoSession: !ui.sid && /forging|resuming|recovering|starting agent/i.test(ui.status),
+        busy: ui.busy,
+        lastTurnEndedAt: status.lastTurnEndedAt,
+        prior: ui.statusCapsule,
+        sessionStartedAt: status.sessionStartedAt,
+        status: ui.status,
+        turnStartedAt: status.turnStartedAt,
+        usage: ui.usage
+      })
+    : null
+
   return (
     <Box marginTop={at === 'top' ? 1 : 0}>
       <StatusRule
@@ -480,6 +494,7 @@ const StatusRulePane = memo(function StatusRulePane({
         onSessionCountClick={() => patchOverlayState({ sessions: true })}
         sessionStartedAt={status.sessionStartedAt}
         status={ui.status}
+        statusCapsule={statusCapsule}
         statusColor={status.statusColor}
         t={ui.theme}
         turnStartedAt={status.turnStartedAt}

--- a/ui-tui/src/domain/statusCapsule.ts
+++ b/ui-tui/src/domain/statusCapsule.ts
@@ -1,0 +1,283 @@
+import type { GatewayEvent } from '../gatewayTypes.js'
+import type { Usage } from '../types.js'
+
+export type StatusCapsuleObservation = 'observed' | 'unknown'
+export type StatusCapsulePrecision = 'observed' | 'unknown'
+export type StatusCapsuleRoute = 'Auto Session' | 'Hermes' | 'MoA'
+export type StatusCapsuleState = 'delegating' | 'error' | 'idle' | 'interrupted' | 'running' | 'session_starting' | 'tooling'
+export type StatusCapsuleTokenSource = 'context_window' | 'provider_usage' | 'unknown'
+export type StatusCapsuleElapsedSource = 'local_wall_clock' | 'unknown'
+
+export interface StatusCapsuleObserved {
+  deep: StatusCapsuleObservation
+  delegate: StatusCapsuleObservation
+  moa: StatusCapsuleObservation
+  opencode: StatusCapsuleObservation
+}
+
+export interface StatusCapsulePrecisionBlock {
+  elapsed: StatusCapsulePrecision
+  tokens: StatusCapsulePrecision
+}
+
+export interface StatusCapsule {
+  elapsedSource: StatusCapsuleElapsedSource
+  observed: StatusCapsuleObserved
+  precision: StatusCapsulePrecisionBlock
+  route: StatusCapsuleRoute
+  schemaVersion: 1
+  state: StatusCapsuleState
+  tokenSource: StatusCapsuleTokenSource
+  tools: string[]
+}
+
+export interface BuildStatusCapsuleInput {
+  autoSession?: boolean
+  busy: boolean
+  lastTurnEndedAt?: null | number
+  prior?: null | StatusCapsule
+  sessionStartedAt?: null | number
+  status: string
+  turnStartedAt?: null | number
+  usage: Usage
+}
+
+const UNKNOWN_OBSERVED: StatusCapsuleObserved = {
+  deep: 'unknown',
+  delegate: 'unknown',
+  moa: 'unknown',
+  opencode: 'unknown'
+}
+
+const uniqAppend = (items: string[], item: string): string[] => {
+  const value = item.trim()
+
+  if (!value) {
+    return items
+  }
+
+  return items.includes(value) ? items : [...items, value].slice(-4)
+}
+
+const hasProviderUsage = (usage?: Partial<Usage> | null): boolean =>
+  Boolean(usage && ((usage.total ?? 0) > 0 || (usage.calls ?? 0) > 0 || (usage.input ?? 0) > 0 || (usage.output ?? 0) > 0))
+
+const hasContextWindowUsage = (usage?: Partial<Usage> | null): boolean =>
+  Boolean(usage && ((usage.context_used ?? 0) > 0 || (usage.context_max ?? 0) > 0))
+
+const tokenPrecisionFromUsage = (usage?: Partial<Usage> | null): StatusCapsulePrecision => {
+  return hasProviderUsage(usage) || hasContextWindowUsage(usage) ? 'observed' : 'unknown'
+}
+
+const tokenSourceFromUsage = (usage?: Partial<Usage> | null): StatusCapsuleTokenSource => {
+  if (hasProviderUsage(usage)) {
+    return 'provider_usage'
+  }
+
+  return hasContextWindowUsage(usage) ? 'context_window' : 'unknown'
+}
+
+const isAutoSessionStatus = (status: string): boolean => /forging|resuming|recovering|starting agent/i.test(status)
+
+const routeFrom = (input: BuildStatusCapsuleInput): StatusCapsuleRoute => {
+  if (input.autoSession || isAutoSessionStatus(input.status)) {
+    return 'Auto Session'
+  }
+
+  if (input.prior?.route === 'MoA' || input.prior?.observed.moa === 'observed') {
+    return 'MoA'
+  }
+
+  return 'Hermes'
+}
+
+const stateFrom = (input: BuildStatusCapsuleInput, prior: StatusCapsule): StatusCapsuleState => {
+  if (input.autoSession || isAutoSessionStatus(input.status)) {
+    return 'session_starting'
+  }
+
+  if (prior.state === 'error' || prior.state === 'interrupted') {
+    return prior.state
+  }
+
+  if ((input.usage.active_subagents ?? 0) > 0) {
+    return 'delegating'
+  }
+
+  if (input.busy && (prior.state === 'tooling' || prior.state === 'delegating')) {
+    return prior.state
+  }
+
+  return input.busy ? 'running' : 'idle'
+}
+
+export const initialStatusCapsule = (): StatusCapsule => ({
+  elapsedSource: 'unknown',
+  observed: { ...UNKNOWN_OBSERVED },
+  precision: { elapsed: 'unknown', tokens: 'unknown' },
+  route: 'Hermes',
+  schemaVersion: 1,
+  state: 'idle',
+  tokenSource: 'unknown',
+  tools: []
+})
+
+export function buildStatusCapsule(input: BuildStatusCapsuleInput): StatusCapsule {
+  const prior = input.prior ?? initialStatusCapsule()
+  const tokens = tokenPrecisionFromUsage(input.usage)
+
+  const elapsed: StatusCapsulePrecision =
+    input.turnStartedAt || input.lastTurnEndedAt || input.sessionStartedAt ? 'observed' : 'unknown'
+
+  const delegate = (input.usage.active_subagents ?? 0) > 0 ? 'observed' : prior.observed.delegate
+  const route = routeFrom(input)
+
+  return {
+    elapsedSource: elapsed === 'observed' ? 'local_wall_clock' : 'unknown',
+    observed: {
+      ...prior.observed,
+      delegate,
+      moa: route === 'MoA' ? 'observed' : prior.observed.moa
+    },
+    precision: { elapsed, tokens },
+    route,
+    schemaVersion: 1,
+    state: stateFrom(input, prior),
+    tokenSource: tokenSourceFromUsage(input.usage),
+    tools: prior.tools
+  }
+}
+
+export function foldStatusCapsuleEvent(previous: StatusCapsule | null | undefined, event: Pick<GatewayEvent, 'payload' | 'type'>): StatusCapsule {
+  const next: StatusCapsule = previous ? { ...previous, observed: { ...previous.observed }, precision: { ...previous.precision }, tools: [...previous.tools] } : initialStatusCapsule()
+
+  switch (event.type) {
+    case 'message.start':
+      return {
+        ...next,
+        elapsedSource: 'local_wall_clock',
+        observed: { ...UNKNOWN_OBSERVED },
+        precision: { elapsed: 'observed', tokens: 'unknown' },
+        route: 'Hermes',
+        state: 'running',
+        tokenSource: 'unknown',
+        tools: []
+      }
+    case 'tool.start': {
+      const payload = (event.payload ?? {}) as { name?: unknown }
+      const name = typeof payload.name === 'string' ? payload.name : 'tool'
+      const lower = name.toLowerCase()
+
+      return {
+        ...next,
+        observed: {
+          ...next.observed,
+          delegate: lower === 'delegate_task' ? 'observed' : next.observed.delegate,
+          opencode: lower === 'opencode' ? 'observed' : next.observed.opencode
+        },
+        state: lower === 'delegate_task' ? 'delegating' : 'tooling',
+        tools: uniqAppend(next.tools, name)
+      }
+    }
+
+    case 'subagent.spawn_requested':
+
+    case 'subagent.start':
+
+    case 'subagent.thinking':
+
+    case 'subagent.tool':
+
+    case 'subagent.progress':
+      return {
+        ...next,
+        observed: { ...next.observed, delegate: 'observed' },
+        state: 'delegating'
+      }
+
+    case 'subagent.complete':
+      return {
+        ...next,
+        observed: { ...next.observed, delegate: 'observed' }
+      }
+
+    case 'moa.aggregating':
+
+    case 'moa.reference':
+      return {
+        ...next,
+        observed: { ...next.observed, moa: 'observed' },
+        route: 'MoA',
+        state: next.state === 'idle' ? 'running' : next.state
+      }
+    case 'message.complete': {
+      const usage = event.payload && 'usage' in event.payload ? event.payload.usage : undefined
+      const status = event.payload && 'status' in event.payload ? String(event.payload.status ?? '') : ''
+      const tokens = tokenPrecisionFromUsage(usage)
+      const state: StatusCapsuleState = status === 'interrupted' ? 'interrupted' : status === 'error' ? 'error' : 'idle'
+
+      return {
+        ...next,
+        elapsedSource: 'local_wall_clock',
+        precision: {
+          elapsed: 'observed',
+          tokens: tokens === 'observed' ? 'observed' : next.precision.tokens
+        },
+        state,
+        tokenSource: tokens === 'observed' ? tokenSourceFromUsage(usage) : next.tokenSource
+      }
+    }
+
+    case 'error':
+      return {
+        ...next,
+        elapsedSource: 'local_wall_clock',
+        precision: { ...next.precision, elapsed: 'observed' },
+        state: 'error'
+      }
+
+    default:
+      return next
+  }
+}
+
+const stateLabel: Record<StatusCapsuleState, string> = {
+  delegating: 'delegating',
+  error: 'error',
+  idle: 'idle',
+  interrupted: 'interrupted',
+  running: 'running',
+  session_starting: 'starting',
+  tooling: 'tool'
+}
+
+export function formatStatusCapsule(capsule: StatusCapsule): string {
+  const parts = [`⚙ ${capsule.route}`]
+
+  if (capsule.state === 'session_starting' || capsule.state === 'tooling' || capsule.state === 'error' || capsule.state === 'interrupted') {
+    parts.push(stateLabel[capsule.state])
+  }
+
+  if (capsule.observed.delegate === 'observed') {
+    parts.push('delegate')
+  } else if (capsule.state === 'delegating') {
+    parts.push('delegating')
+  }
+
+  if (capsule.observed.moa === 'observed' && capsule.route !== 'MoA') {
+    parts.push('moa')
+  }
+
+  if (capsule.route === 'MoA' || capsule.observed.delegate === 'observed') {
+    parts.push(capsule.observed.opencode === 'observed' ? 'opencode' : 'opencode?')
+  }
+
+  if (capsule.observed.deep === 'observed') {
+    parts.push('deep')
+  }
+
+  parts.push(capsule.precision.tokens === 'observed' ? 'tok obs' : 'tok?')
+  parts.push(capsule.precision.elapsed === 'observed' ? 'time obs' : 'time?')
+
+  return parts.join(' · ')
+}

--- a/ui-tui/src/domain/statusCapsule.ts
+++ b/ui-tui/src/domain/statusCapsule.ts
@@ -7,6 +7,9 @@ export type StatusCapsuleRoute = 'Auto Session' | 'Hermes' | 'MoA'
 export type StatusCapsuleState = 'delegating' | 'error' | 'idle' | 'interrupted' | 'running' | 'session_starting' | 'tooling'
 export type StatusCapsuleTokenSource = 'context_window' | 'provider_usage' | 'unknown'
 export type StatusCapsuleElapsedSource = 'local_wall_clock' | 'unknown'
+export type StatusMechanismKind = 'delegate' | 'moa' | 'mode' | 'provider' | 'runtime' | 'skill' | 'tool'
+export type StatusMechanismScope = 'session' | 'turn'
+export type StatusMechanismPhase = 'active' | 'complete' | 'start'
 
 export interface StatusCapsuleObserved {
   deep: StatusCapsuleObservation
@@ -20,8 +23,22 @@ export interface StatusCapsulePrecisionBlock {
   tokens: StatusCapsulePrecision
 }
 
+export interface StatusMechanismObservation {
+  eventId?: string
+  key: string
+  kind: StatusMechanismKind
+  label: string
+  name: string
+  observedAt?: number
+  phase?: StatusMechanismPhase
+  scope: StatusMechanismScope
+  source: string
+  turnId?: string
+}
+
 export interface StatusCapsule {
   elapsedSource: StatusCapsuleElapsedSource
+  mechanisms: StatusMechanismObservation[]
   observed: StatusCapsuleObserved
   precision: StatusCapsulePrecisionBlock
   route: StatusCapsuleRoute
@@ -79,6 +96,70 @@ const tokenSourceFromUsage = (usage?: Partial<Usage> | null): StatusCapsuleToken
 
 const isAutoSessionStatus = (status: string): boolean => /forging|resuming|recovering|starting agent/i.test(status)
 
+const observedFromMechanisms = (mechanisms: StatusMechanismObservation[], base: StatusCapsuleObserved = { ...UNKNOWN_OBSERVED }): StatusCapsuleObserved => {
+  const observed = { ...base }
+
+  for (const mechanism of mechanisms) {
+    const name = mechanism.name.toLowerCase()
+
+    if (mechanism.kind === 'skill' && name === 'deep') {
+      observed.deep = 'observed'
+    }
+  }
+
+  return observed
+}
+
+const mechanismString = (value: unknown): string => (typeof value === 'string' ? value.trim() : '')
+
+const normalizeMechanism = (payload: unknown): StatusMechanismObservation | null => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null
+  }
+
+  const raw = payload as Record<string, unknown>
+  const kind = mechanismString(raw.kind) as StatusMechanismKind
+  const name = mechanismString(raw.name).toLowerCase()
+  const scope = mechanismString(raw.scope) as StatusMechanismScope
+  const source = mechanismString(raw.source)
+  const validKind = ['delegate', 'moa', 'mode', 'provider', 'runtime', 'skill', 'tool'].includes(kind)
+
+  if (!validKind || !name || !source || (scope !== 'session' && scope !== 'turn')) {
+    return null
+  }
+
+  const key = mechanismString(raw.key) || `${kind}:${name}`
+  const label = mechanismString(raw.label) || name
+  const phaseValue = mechanismString(raw.phase) as StatusMechanismPhase
+  const phase = phaseValue === 'active' || phaseValue === 'complete' || phaseValue === 'start' ? phaseValue : undefined
+  const eventId = mechanismString(raw.event_id) || mechanismString(raw.eventId)
+  const turnId = mechanismString(raw.turn_id) || mechanismString(raw.turnId)
+  const observedAtRaw = raw.observed_at ?? raw.observedAt
+  const observedAt = typeof observedAtRaw === 'number' && Number.isFinite(observedAtRaw) ? observedAtRaw : undefined
+
+  return {
+    ...(eventId ? { eventId } : {}),
+    key,
+    kind,
+    label,
+    name,
+    ...(observedAt ? { observedAt } : {}),
+    ...(phase ? { phase } : {}),
+    scope,
+    source,
+    ...(turnId ? { turnId } : {})
+  }
+}
+
+const appendMechanism = (items: StatusMechanismObservation[], item: StatusMechanismObservation): StatusMechanismObservation[] => {
+  const withoutSame = items.filter(existing => !(existing.key === item.key && existing.scope === item.scope))
+  const next = [...withoutSame, item]
+  const sessionItems = next.filter(existing => existing.scope === 'session')
+  const turnItems = next.filter(existing => existing.scope === 'turn').slice(-8)
+
+  return [...sessionItems, ...turnItems]
+}
+
 const routeFrom = (input: BuildStatusCapsuleInput): StatusCapsuleRoute => {
   if (input.autoSession || isAutoSessionStatus(input.status)) {
     return 'Auto Session'
@@ -113,6 +194,7 @@ const stateFrom = (input: BuildStatusCapsuleInput, prior: StatusCapsule): Status
 
 export const initialStatusCapsule = (): StatusCapsule => ({
   elapsedSource: 'unknown',
+  mechanisms: [],
   observed: { ...UNKNOWN_OBSERVED },
   precision: { elapsed: 'unknown', tokens: 'unknown' },
   route: 'Hermes',
@@ -131,14 +213,18 @@ export function buildStatusCapsule(input: BuildStatusCapsuleInput): StatusCapsul
 
   const delegate = (input.usage.active_subagents ?? 0) > 0 ? 'observed' : prior.observed.delegate
   const route = routeFrom(input)
+  const mechanisms = prior.mechanisms ?? []
+
+  const observed = observedFromMechanisms(mechanisms, {
+    ...prior.observed,
+    delegate,
+    moa: route === 'MoA' ? 'observed' : prior.observed.moa
+  })
 
   return {
     elapsedSource: elapsed === 'observed' ? 'local_wall_clock' : 'unknown',
-    observed: {
-      ...prior.observed,
-      delegate,
-      moa: route === 'MoA' ? 'observed' : prior.observed.moa
-    },
+    mechanisms,
+    observed,
     precision: { elapsed, tokens },
     route,
     schemaVersion: 1,
@@ -149,20 +235,27 @@ export function buildStatusCapsule(input: BuildStatusCapsuleInput): StatusCapsul
 }
 
 export function foldStatusCapsuleEvent(previous: StatusCapsule | null | undefined, event: Pick<GatewayEvent, 'payload' | 'type'>): StatusCapsule {
-  const next: StatusCapsule = previous ? { ...previous, observed: { ...previous.observed }, precision: { ...previous.precision }, tools: [...previous.tools] } : initialStatusCapsule()
+  const next: StatusCapsule = previous
+    ? { ...previous, mechanisms: [...(previous.mechanisms ?? [])], observed: { ...previous.observed }, precision: { ...previous.precision }, tools: [...previous.tools] }
+    : initialStatusCapsule()
 
   switch (event.type) {
-    case 'message.start':
+    case 'message.start': {
+      const sessionMechanisms = next.mechanisms.filter(mechanism => mechanism.scope === 'session')
+
       return {
         ...next,
         elapsedSource: 'local_wall_clock',
-        observed: { ...UNKNOWN_OBSERVED },
+        mechanisms: sessionMechanisms,
+        observed: observedFromMechanisms(sessionMechanisms),
         precision: { elapsed: 'observed', tokens: 'unknown' },
         route: 'Hermes',
         state: 'running',
         tokenSource: 'unknown',
         tools: []
       }
+    }
+
     case 'tool.start': {
       const payload = (event.payload ?? {}) as { name?: unknown }
       const name = typeof payload.name === 'string' ? payload.name : 'tool'
@@ -210,6 +303,22 @@ export function foldStatusCapsuleEvent(previous: StatusCapsule | null | undefine
         route: 'MoA',
         state: next.state === 'idle' ? 'running' : next.state
       }
+    case 'mechanism.observed': {
+      const mechanism = normalizeMechanism(event.payload)
+
+      if (!mechanism) {
+        return next
+      }
+
+      const mechanisms = appendMechanism(next.mechanisms, mechanism)
+
+      return {
+        ...next,
+        mechanisms,
+        observed: observedFromMechanisms(mechanisms, next.observed)
+      }
+    }
+
     case 'message.complete': {
       const usage = event.payload && 'usage' in event.payload ? event.payload.usage : undefined
       const status = event.payload && 'status' in event.payload ? String(event.payload.status ?? '') : ''

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -614,6 +614,19 @@ export interface SpawnTreeLoadResponse {
   subagents?: unknown[]
 }
 
+export interface MechanismObservedPayload {
+  event_id?: string
+  key: string
+  kind: 'delegate' | 'moa' | 'mode' | 'provider' | 'runtime' | 'skill' | 'tool'
+  label?: string
+  name: string
+  observed_at?: number
+  phase?: 'active' | 'complete' | 'start'
+  scope: 'session' | 'turn'
+  source: string
+  turn_id?: string
+}
+
 export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
@@ -659,6 +672,7 @@ export type GatewayEvent =
       session_id?: string
       type: 'reasoning.delta' | 'reasoning.available'
     }
+  | { payload: MechanismObservedPayload; session_id?: string; type: 'mechanism.observed' }
   | {
       payload: { count?: number; index?: number; label?: string; text?: string }
       session_id?: string

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -178,6 +178,7 @@ export interface ConfigDisplayConfig {
   // narrowing-and-autocomplete contract on a value that requires runtime
   // validation anyway.
   tui_status_indicator?: string
+  tui_mechanism_statusbar?: boolean
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
 }
 


### PR DESCRIPTION
## Summary

Adds Mechanism Status Bar v1 to the Hermes Ink TUI:

- introduces a pure `StatusCapsule` v1 domain model for mechanism route/state/precision
- folds runtime events (`message.start`, `tool.start`, MoA, subagent, completion, error) into mechanism status
- renders the mechanism capsule in `StatusRule` with explicit observed/unknown boundaries
- adds `display.tui_mechanism_statusbar` config toggle, defaulting to enabled
- resets capsule state across session/history boundaries to avoid stale MoA/delegate leakage

## Accuracy boundary

This PR intentionally does **not** claim exact token/cost/elapsed accounting.

- token and elapsed precision are represented as `observed` or `unknown`
- provider usage and context-window occupancy are separated (`provider_usage` vs `context_window`)
- OpenCode/Deep/MoA/delegate stay `unknown` unless directly observed from runtime evidence

## Verification

Passed:

- `npx eslint ...` on changed TUI source/test files
- `npm run test -- --run src/__tests__/statusCapsule.test.ts src/__tests__/appChromeStatusRule.test.tsx src/__tests__/createGatewayEventHandler.test.ts src/__tests__/useConfigSync.test.ts src/__tests__/useSessionLifecycle.test.ts src/__tests__/statusRule.test.ts src/__tests__/appChromeStatusRuleDevCredits.test.tsx`
  - 7 files passed, 160 tests passed
- `npm run typecheck && npm run build`
- `python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py -q`
  - 153 passed
- `git diff --check`
- added-line static scan for obvious secrets / shell injection / eval / pickle / SQL format patterns
- independent reviewer profile final pass: no diff-level blockers

Known non-blocking repo baseline issues not included in this PR:

- full `npm run test -- --run` still has unrelated failures in `virtualHeights.test.ts` and intermittent `cursorDriftRegression.test.ts`
- `scripts/run_tests.sh ...` wrapper is blocked by the selected shared venv missing pytest, while direct `python -m pytest` passes
