### PR TITLE
fix(cli): resolve moa:<preset> model in non-interactive mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3746,6 +3746,28 @@ def save_config_value(key_path: str, value: any) -> bool:
 # HermesCLI Class
 # ============================================================================
 
+
+def _normalize_moa_model(model: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Map a ``moa:<preset>`` model string to ``(provider, preset)``.
+
+    Returns ``("moa", "<preset>")`` when *model* selects the MoA virtual
+    provider, otherwise ``(None, model)`` unchanged. This gives non-interactive
+    ``hermes chat -Q -m moa:<preset>`` the same routing the interactive
+    ``/moa`` command and the model picker already use: ``resolve_runtime_provider``
+    handles ``requested_provider == "moa"`` and ``agent_init`` builds the
+    MoAClient off ``provider == "moa"``. Without this the raw ``moa:<preset>``
+    string is sent to the real provider and rejected with a 401/400 "model not
+    supported" (#56828).
+    """
+    if isinstance(model, str):
+        stripped = model.strip()
+        if stripped.lower().startswith("moa:"):
+            preset = stripped.split(":", 1)[1].strip()
+            if preset:
+                return "moa", preset
+    return None, model
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -3876,6 +3898,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+        # A ``moa:<preset>`` model string selects the MoA virtual provider in
+        # one shot (parity with interactive ``/moa`` and the model picker). Do
+        # this before provider resolution so ``-Q -m moa:<preset>`` routes
+        # through MoA instead of hitting the real provider with an unknown
+        # model (#56828). A ``moa:`` prefix wins over an explicit ``--provider``.
+        _moa_provider_override, self.model = _normalize_moa_model(self.model)
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
         if _env_mt:
@@ -3911,7 +3939,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
-            provider
+            _moa_provider_override
+            or provider
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -230,6 +230,47 @@ def test_cli_prefers_config_provider_over_stale_env_override(monkeypatch):
     assert shell.requested_provider == "custom"
 
 
+def test_cli_init_wires_moa_preset_model_to_moa_provider(monkeypatch):
+    # #56828: constructing the CLI with `-m moa:<preset>` (the -Q one-shot
+    # path) must strip the prefix off self.model AND force
+    # requested_provider="moa", so the existing resolve_runtime_provider /
+    # agent_init MoA route runs non-interactively. The unit tests cover
+    # _normalize_moa_model() in isolation; this asserts the __init__ wiring
+    # the sweeper flagged as untested.
+    cli = _import_cli()
+
+    # Neutralize any config/env provider so a failure here can only come from
+    # the moa override, not an ambient default.
+    config_copy = dict(cli.CLI_CONFIG)
+    model_copy = dict(config_copy.get("model", {}))
+    model_copy["provider"] = None
+    config_copy["model"] = model_copy
+    monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+    shell = cli.HermesCLI(model="moa:strategy", compact=True, max_turns=1)
+
+    assert shell.requested_provider == "moa"
+    assert shell.model == "strategy"
+
+
+def test_cli_init_moa_prefix_overrides_explicit_provider(monkeypatch):
+    # The #56828 regression case: `--provider deepseek -m moa:strategy`
+    # silently dropped MoA because the explicit provider won. __init__ resolves
+    # requested_provider as `_moa_provider_override or provider or ...`, so the
+    # moa: prefix must win over the explicit --provider.
+    cli = _import_cli()
+
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+
+    shell = cli.HermesCLI(
+        model="moa:strategy", provider="deepseek", compact=True, max_turns=1
+    )
+
+    assert shell.requested_provider == "moa"
+    assert shell.model == "strategy"
+
+
 def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
     """When provider resolves to openai-codex and no model was explicitly
     chosen, the global config default (e.g. anthropic/claude-opus-4.6) must

--- a/tests/cli/test_moa_command.py
+++ b/tests/cli/test_moa_command.py
@@ -80,3 +80,52 @@ def test_decode_legacy_encoded_moa_turn_still_works():
     prompt, cfg = decode_moa_turn(encoded)
     assert prompt == "hello"
     assert cfg["reference_models"] == [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}]
+
+
+class TestNormalizeMoaModel:
+    """#56828: `-Q -m moa:<preset>` must route through the MoA virtual provider.
+
+    ``_normalize_moa_model`` maps the model string to (provider, preset); the
+    __init__ wiring then forces ``requested_provider="moa"`` so the existing
+    resolve_runtime_provider / agent_init MoA path runs in non-interactive mode.
+    """
+
+    def test_moa_prefix_maps_to_provider_and_preset(self):
+        from cli import _normalize_moa_model
+        assert _normalize_moa_model("moa:strategy") == ("moa", "strategy")
+
+    def test_moa_prefix_is_case_insensitive_and_trims(self):
+        from cli import _normalize_moa_model
+        assert _normalize_moa_model("  MOA:code-review ") == ("moa", "code-review")
+
+    def test_bare_moa_without_preset_is_not_treated_as_virtual(self):
+        from cli import _normalize_moa_model
+        # No preset after the colon → leave untouched (no provider override).
+        assert _normalize_moa_model("moa:") == (None, "moa:")
+
+    def test_non_moa_model_unchanged(self):
+        from cli import _normalize_moa_model
+        assert _normalize_moa_model("anthropic/claude-opus-4.8") == (None, "anthropic/claude-opus-4.8")
+
+    def test_none_model_unchanged(self):
+        from cli import _normalize_moa_model
+        assert _normalize_moa_model(None) == (None, None)
+
+    def test_colon_model_that_is_not_moa_unchanged(self):
+        from cli import _normalize_moa_model
+        # A provider:model form for a real provider must not be hijacked.
+        assert _normalize_moa_model("openrouter:deepseek/deepseek-v4") == (
+            None,
+            "openrouter:deepseek/deepseek-v4",
+        )
+
+    def test_override_wins_over_explicit_provider(self):
+        # __init__ resolves requested_provider as
+        # ``_moa_provider_override or provider or ...``, so a moa: prefix must
+        # take precedence over an explicit --provider (the #56828 deepseek case
+        # where MoA was silently ignored).
+        from cli import _normalize_moa_model
+        override, model = _normalize_moa_model("moa:strategy")
+        requested_provider = override or "deepseek" or "auto"
+        assert requested_provider == "moa"
+        assert model == "strategy"


### PR DESCRIPTION
## What does this PR do?

`hermes chat -Q -m moa:strategy -q "..."` failed with `HTTP 401: Model moa:strategy is not supported` (and `HTTP 400` on Codex, or silently normalized to `deepseek-chat` with `--provider deepseek`). The MoA virtual provider was only wired up through the interactive `/moa` command and the model picker — never through the `-Q` one-shot startup path — so the raw `moa:<preset>` string was passed straight to the real provider.

## Root cause

The MoA execution path is already surface-agnostic: `hermes_cli/runtime_provider.py` handles `requested_provider == "moa"` (returns the `moa://local` virtual-provider bundle), and `agent/agent_init.py` builds the `MoAClient` off `agent.provider == "moa"`. The only missing link was mapping the `moa:<preset>` **model string** to that provider at startup. In `-Q` mode `requested_provider` stayed `"auto"` and `self.model` kept the literal `moa:strategy`, so neither hook fired.

## Fix

Add `_normalize_moa_model()` and apply it in `HermesCLI.__init__` before provider resolution: a `moa:<preset>` model sets `requested_provider="moa"` and `model=<preset>`, so the existing resolve/agent_init MoA path runs non-interactively too — matching `/moa`. The `moa:` prefix wins over an explicit `--provider` (previously `--provider deepseek -m moa:strategy` silently dropped MoA). Real `provider:model` strings (e.g. `openrouter:deepseek/...`) are untouched.

## Related Issue

Fixes #56828

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: new module-level `_normalize_moa_model(model) -> (provider, preset)`; call it in `HermesCLI.__init__` right after `self.model` resolves and feed the override into `requested_provider` (`_moa_provider_override or provider or ...`).
- `tests/cli/test_moa_command.py`: `TestNormalizeMoaModel` (7 cases) — prefix→(moa, preset), case-insensitive/trim, bare `moa:` left alone, non-moa and real `provider:model` untouched, None passthrough, and prefix-wins-over-explicit-provider.

## How to Test

1. `uv run python -m pytest tests/cli/test_moa_command.py -q` → 11 passed, ruff clean.
2. Manual: `hermes chat -Q -m moa:strategy -q "Say OK"` now runs the preset's reference models + aggregator instead of returning a 401.

## Notes

Scope is deliberately the resolution wiring — the downstream MoA execution (reference fan-out + aggregation) is unchanged and already proven by the interactive `/moa` path. Tests cover the resolution contract; end-to-end MoA needs live multi-provider keys.

## Checklist

- [x] Conventional Commits
- [x] Searched existing PRs — none open for this issue
- [x] Only changes related to this fix
- [x] Tests pass (`tests/cli/test_moa_command.py`, 11 passed; ruff clean)
- [x] Added tests
- [x] Tested on my platform: macOS 14
- [x] Cross-platform impact considered — pure string normalization, platform-independent