### PR TITLE
fix(cli): resolve MoA model prefixes in one-shot chat

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3710,7 +3710,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _model_config = CLI_CONFIG.get("model", {})
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
-        self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
+        _requested_model = model
+        _requested_provider_arg = provider
+        if isinstance(_requested_model, str):
+            _model_text = _requested_model.strip()
+            if _model_text.lower().startswith("moa:"):
+                _requested_provider_arg = _requested_provider_arg or "moa"
+                _requested_model = _model_text.split(":", 1)[1].strip()
+        self.model = _requested_model or _config_model or _DEFAULT_CONFIG_MODEL
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
         if _env_mt:
@@ -3746,7 +3753,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
-            provider
+            _requested_provider_arg
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -103,6 +103,19 @@ class TestVerboseAndToolProgress:
 
 
 class TestFallbackChainInit:
+    def test_moa_prefixed_model_selects_virtual_provider(self):
+        cli = _make_cli(model="moa:strategy")
+
+        assert cli.requested_provider == "moa"
+        assert cli.provider == "moa"
+        assert cli.model == "strategy"
+
+    def test_moa_provider_strips_prefixed_model(self):
+        cli = _make_cli(model="moa:code-review", provider="moa")
+
+        assert cli.requested_provider == "moa"
+        assert cli.model == "code-review"
+
     def test_merges_new_and_legacy_fallback_config(self):
         cli = _make_cli(config_overrides={
             "fallback_providers": [


### PR DESCRIPTION
Fixes #56828.\n\nThe CLI now recognizes -m/--model values like moa:strategy during initialization, routes them to the MoA virtual provider, and strips the prefix before constructing the agent. This prevents one-shot non-interactive chat from sending moa:* as a real upstream model slug.\n\nTests: scripts/run_tests.sh tests/cli/test_cli_init.py -k moa