### PR TITLE
fix(dashboard): prefer bundled TUI for wheel chat

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1749,9 +1749,6 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         )
         sys.exit(1)
 
-    if not ext_dir:
-        _ensure_tui_workspace(tui_dir)
-
     # 1. Prebuilt bundle (nix / packaged release): just run it.
     if not tui_dev:
         if ext_dir:
@@ -1765,6 +1762,9 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if bundled is not None:
             node = _node_bin("node")
             return [node, "--expose-gc", str(bundled)], bundled.parent
+
+    if not ext_dir:
+        _ensure_tui_workspace(tui_dir)
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1050,6 +1050,31 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
 
 
+def test_make_tui_argv_uses_bundled_wheel_tui_without_workspace(
+    monkeypatch, main_mod, tmp_path
+):
+    """Wheel installs ship hermes_cli/tui_dist but not the source ui-tui tree."""
+    missing_tui_dir = tmp_path / "ui-tui"
+    bundled = tmp_path / "hermes_cli" / "tui_dist" / "entry.js"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("console.log('bundled tui')\n", encoding="utf-8")
+
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda bin_name: f"/usr/bin/{bin_name}")
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled)
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+
+    def fail_workspace_check(_tui_dir):
+        raise AssertionError("bundled wheel TUI must not require ui-tui workspace")
+
+    monkeypatch.setattr(main_mod, "_ensure_tui_workspace", fail_workspace_check)
+
+    argv, cwd = main_mod._make_tui_argv(missing_tui_dir, tui_dev=False)
+
+    assert argv == ["/usr/bin/node", "--expose-gc", str(bundled)]
+    assert cwd == bundled.parent
+
+
 def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, capsys):
     import hermes_cli.main as main_mod
 


### PR DESCRIPTION
## Summary
- Prefer the wheel-bundled TUI entrypoint before requiring the source `ui-tui/` workspace.
- Keep source checkout behavior unchanged when no bundled TUI exists.
- Add regression coverage for pip/pipx-style installs where `hermes_cli/tui_dist/entry.js` exists but `ui-tui/` does not.

Fixes #56665

## Test Plan
- `uv run --with pytest --with pyyaml --with ruamel.yaml python -m pytest tests/hermes_cli/test_tui_resume_flow.py::test_make_tui_argv_uses_bundled_wheel_tui_without_workspace -q -o 'addopts='`
  - `1 passed in 0.30s`
- `uv run --with pytest --with pyyaml --with ruamel.yaml python -m pytest tests/hermes_cli/test_tui_resume_flow.py -q -o 'addopts='`
  - `49 passed in 3.79s`
- `git diff --check`
  - passed

## Notes
- The RED regression failed before the code change because `_make_tui_argv()` called `_ensure_tui_workspace()` before it checked the bundled wheel TUI fallback.
- This keeps `--dev` and normal source-checkout paths intact; only packaged non-dev launches can skip the workspace check when a bundled `tui_dist/entry.js` exists.
