### PR TITLE
fix(webhook): allow raw payload template limits

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -851,8 +851,8 @@ class WebhookAdapter(BasePlatformAdapter):
         ``{pull_request.title}`` → ``payload["pull_request"]["title"]``
 
         Special token ``{__raw__}`` dumps the entire payload as indented
-        JSON (truncated to 4000 chars).  Useful for monitoring alerts or
-        any webhook where the agent needs to see the full payload.
+        JSON (truncated to 4000 chars by default). Use ``{__raw__:N}``
+        to raise/lower that limit for routes that expect larger payloads.
         """
         if not template:
             truncated = json.dumps(payload, indent=2)[:4000]
@@ -863,9 +863,13 @@ class WebhookAdapter(BasePlatformAdapter):
 
         def _resolve(match: re.Match) -> str:
             key = match.group(1)
+            raw_limit = match.group(2)
             # Special token: dump the entire payload as JSON
             if key == "__raw__":
-                return json.dumps(payload, indent=2)[:4000]
+                limit = int(raw_limit) if raw_limit else 4000
+                return json.dumps(payload, indent=2)[:limit]
+            if raw_limit:
+                return match.group(0)
             value: Any = payload
             for part in key.split("."):
                 if isinstance(value, dict):
@@ -876,7 +880,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 return json.dumps(value, indent=2)[:2000]
             return str(value)
 
-        return re.sub(r"\{([a-zA-Z0-9_.]+)\}", _resolve, template)
+        return re.sub(r"\{([a-zA-Z0-9_.]+)(?::(\d+))?\}", _resolve, template)
 
     def _render_delivery_extra(
         self, extra: dict, payload: dict

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -932,6 +932,16 @@ class TestRawTemplateToken:
         result = adapter._render_prompt("{__raw__}", payload, "push", "test")
         assert len(result) <= 4000
 
+    def test_raw_token_accepts_custom_truncation_limit(self):
+        """{__raw__:N} allows large JSON payloads without the default 4000-char cut."""
+        adapter = _make_adapter()
+        payload = {"data": "x" * 5000}
+
+        result = adapter._render_prompt("{__raw__:6000}", payload, "push", "test")
+
+        assert result == json.dumps(payload, indent=2)
+        assert json.loads(result) == payload
+
     def test_raw_mixed_with_other_variables(self):
         """{__raw__} can be mixed with regular template variables."""
         adapter = _make_adapter()
@@ -1084,4 +1094,3 @@ class TestInsecureNoAuthSafetyRail:
             assert result is True
         finally:
             await adapter.disconnect()
-


### PR DESCRIPTION
### Summary

- Add `{__raw__:N}` support to webhook prompt templates so routes can request a larger or smaller raw payload limit per template.
- Preserve the existing `{__raw__}` and no-template default 4000-character behavior.
- Keep non-raw `{name:limit}`-style text unchanged instead of treating it as a payload lookup.

### Root Cause

`WebhookAdapter._render_prompt()` only matched `{name}` placeholders and hardcoded `{__raw__}` to `json.dumps(payload, indent=2)[:4000]`. Large webhook payloads could therefore be cut mid-object or mid-string with no per-route escape hatch.

### Tests

- `python -m pytest tests/gateway/test_webhook_adapter.py::TestRawTemplateToken -q`
- `python -m pytest tests/gateway/test_webhook_adapter.py -q`
- `python -m py_compile gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py`
- `git diff --check`

Fixes #55829