### PR TITLE
fix(agent): close max-iteration summary failures

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1707,6 +1707,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     except Exception as e:
         logger.warning(f"Failed to get summary response: {e}")
         final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        messages.append({"role": "assistant", "content": final_response})
 
     return final_response
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3664,6 +3664,19 @@ class TestHandleMaxIterations:
         assert "error" in result.lower()
         assert "API down" in result
 
+    def test_api_failure_closes_synthetic_summary_request(self, agent):
+        """Summary API failures must not leave a dangling synthetic user turn."""
+        agent.client.chat.completions.create.side_effect = Exception("API down")
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert "API down" in result
+        assert messages[-2]["role"] == "user"
+        assert "maximum number of tool-calling iterations" in messages[-2]["content"]
+        assert messages[-1] == {"role": "assistant", "content": result}
+
     def test_summary_skips_reasoning_for_unsupported_openrouter_model(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"
         agent.model = "minimax/minimax-m2.5"


### PR DESCRIPTION
### Summary

- Append an assistant error response when the max-iterations summary request fails.
- Prevent the synthetic summary-request user message from being left as the final persisted turn.
- Add a regression test for the summary API failure path.

### Root Cause

`handle_max_iterations()` appends a synthetic user request before asking the model for a final summary. If that summary API call raises, the exception path returned an error string but did not append an assistant message to close the synthetic user turn, leaving role alternation broken for resumed sessions.

### Tests

- `python -m pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations::test_api_failure_closes_synthetic_summary_request -q`
- `python -m pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations -q`
- `python -m py_compile agent/chat_completion_helpers.py tests/run_agent/test_run_agent.py`
- `git diff --check`

Fixes #56056