### PR TITLE
fix(sessions): hide empty placeholder rows

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1566,6 +1566,7 @@ def _sessions_list(_engine: HermesConsoleEngine, args: list[str]) -> str:
     if ns.limit < 1 or ns.limit > 200:
         raise ConsoleCommandError("sessions list --limit must be between 1 and 200")
 
+    from hermes_cli.session_listing import is_empty_session_placeholder
     from hermes_state import SessionDB
 
     db = SessionDB()
@@ -1575,6 +1576,9 @@ def _sessions_list(_engine: HermesConsoleEngine, args: list[str]) -> str:
             limit=ns.limit,
             order_by_last_active=True,
         )
+        sessions = [
+            row for row in sessions if not is_empty_session_placeholder(row)
+        ]
     finally:
         db.close()
     return _format_sessions(sessions)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13960,6 +13960,7 @@ def main():
         # Hide third-party tool sessions by default, but honour explicit --source
         _source = getattr(args, "source", None)
         _exclude = None if _source else ["tool"]
+        from hermes_cli.session_listing import is_empty_session_placeholder
 
         if action == "list":
             from hermes_state import workspace_key as _ws_key
@@ -13967,7 +13968,6 @@ def main():
             sessions = db.list_sessions_rich(
                 source=args.source, exclude_sources=_exclude, limit=args.limit
             )
-
             # Workspace filter: match a session by its workspace key (git repo
             # root, else cwd) — path substring or exact basename.
             _ws_filter = (getattr(args, "workspace", None) or "").strip()
@@ -13982,6 +13982,7 @@ def main():
 
                 sessions = [s for s in sessions if _in_workspace(s)]
 
+            sessions = [s for s in sessions if not is_empty_session_placeholder(s)]
             if not sessions:
                 print("No sessions found.")
                 return
@@ -14589,6 +14590,7 @@ def main():
             sessions = db.list_sessions_rich(
                 source=source, exclude_sources=_browse_exclude, limit=limit
             )
+            sessions = [s for s in sessions if not is_empty_session_placeholder(s)]
             db.close()
             if not sessions:
                 print("No sessions found.")

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from typing import Any
 
 
+def is_empty_session_placeholder(row: dict[str, Any]) -> bool:
+    """Return True only for valid, empty, zero-message placeholder rows."""
+    message_count = row.get("message_count")
+    if type(message_count) is not int or message_count != 0:
+        return False
+    title = str(row.get("title") or "").strip()
+    preview = str(row.get("preview") or "").strip()
+    return not title and not preview
+
+
 def parse_session_listing_args(raw_args: str) -> tuple[bool, bool, str, str | None]:
     """Parse `/sessions`-style args into listing flags, a resume target, and a search query.
 
@@ -74,6 +84,8 @@ def query_session_listing(
     )
     result: list[dict[str, Any]] = []
     for row in rows:
+        if is_empty_session_placeholder(row):
+            continue
         if current_session_id and row.get("id") == current_session_id:
             continue
         if not include_unnamed and not row.get("title") and not search:

--- a/tests/gateway/test_session_list_allowed_sources.py
+++ b/tests/gateway/test_session_list_allowed_sources.py
@@ -102,3 +102,30 @@ def test_session_list_preserves_ordering_after_filter(monkeypatch):
     ids = [s["id"] for s in resp["result"]["sessions"]]
 
     assert ids == ["newest", "middle", "also-visible", "oldest"]
+
+
+def test_session_list_skips_empty_placeholder_rows(monkeypatch):
+    rows = [
+        {
+            "id": "ghost",
+            "source": "tui",
+            "title": "",
+            "preview": "",
+            "message_count": 0,
+            "started_at": 6,
+        },
+        {
+            "id": "real",
+            "source": "tui",
+            "title": "Real session",
+            "preview": "hello",
+            "message_count": 2,
+            "started_at": 5,
+        },
+    ]
+    monkeypatch.setattr(server, "_get_db", lambda: _StubDB(rows))
+
+    resp = _call()
+    ids = [s["id"] for s in resp["result"]["sessions"]]
+
+    assert ids == ["real"]

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -586,6 +586,7 @@ def test_sessions_list_and_stats_use_isolated_session_store(_isolate_hermes_home
     db = SessionDB()
     try:
         db.create_session("chat-session", source="cli", model="test/model")
+        db.append_message("chat-session", role="user", content="hello")
         db.create_session("tool-session", source="tool", model="test/model")
     finally:
         db.close()
@@ -599,6 +600,28 @@ def test_sessions_list_and_stats_use_isolated_session_store(_isolate_hermes_home
     assert "tool-session" not in listed.output
     assert "Total sessions: 2" in stats.output
     assert "Listable sessions: 1" in stats.output
+
+
+def test_sessions_list_hides_only_valid_empty_placeholders(
+    _isolate_hermes_home, monkeypatch
+):
+    from hermes_state import SessionDB
+
+    rows = [
+        {"id": "ghost", "source": "cli", "message_count": 0},
+        {"id": "negative", "source": "cli", "message_count": -1},
+        {"id": "malformed", "source": "cli", "message_count": "invalid"},
+        {"id": "named", "source": "cli", "message_count": 0, "title": "Keep"},
+    ]
+    monkeypatch.setattr(SessionDB, "list_sessions_rich", lambda *_args, **_kwargs: rows)
+
+    result = HermesConsoleEngine().execute("sessions list --limit 10")
+
+    assert result.status == "ok"
+    assert "ghost" not in result.output
+    assert "negative" in result.output
+    assert "malformed" in result.output
+    assert "named" in result.output
 
 
 def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home):

--- a/tests/hermes_cli/test_session_listing.py
+++ b/tests/hermes_cli/test_session_listing.py
@@ -3,9 +3,33 @@
 import pytest
 
 from hermes_cli.session_listing import (
+    is_empty_session_placeholder,
     parse_session_listing_args,
     query_session_listing,
 )
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        {},
+        {"message_count": None},
+        {"message_count": "0"},
+        {"message_count": "invalid"},
+        {"message_count": -1},
+        {"message_count": False},
+        {"message_count": 0, "title": "Named"},
+        {"message_count": 0, "preview": "Existing preview"},
+    ],
+)
+def test_empty_session_placeholder_keeps_non_placeholder_rows(row):
+    assert not is_empty_session_placeholder(row)
+
+
+def test_empty_session_placeholder_matches_exact_zero_with_blank_text():
+    assert is_empty_session_placeholder(
+        {"message_count": 0, "title": "  ", "preview": "\n"}
+    )
 
 
 class TestParseSessionListingArgs:
@@ -51,6 +75,7 @@ class TestQuerySessionListingSearch:
         db.create_session("sess_winton", "whatsapp", user_id="1", chat_id="2")
         db.set_session_title("sess_winton", "Winton Email Sheet Update #3")
         db.create_session("sess_untitled", "telegram", user_id="1", chat_id="2")
+        db.append_message("sess_untitled", role="user", content="unnamed session")
         yield db
         db.close()
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6792,6 +6792,44 @@ def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     assert resp["result"]["session_id"] is None
 
 
+def test_session_most_recent_skips_empty_placeholder_rows(monkeypatch):
+    class _DB:
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
+            return [
+                {
+                    "id": "ghost",
+                    "source": "tui",
+                    "title": "",
+                    "preview": "",
+                    "message_count": 0,
+                    "started_at": 100,
+                },
+                {
+                    "id": "real",
+                    "source": "tui",
+                    "title": "Real session",
+                    "message_count": 2,
+                    "started_at": 99,
+                },
+            ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+
+    assert resp["result"]["session_id"] == "real"
+    assert resp["result"]["title"] == "Real session"
+
+
 def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     """Per contract, errors are folded into the null-result shape so
     callers don't have to special-case JSON-RPC error envelopes for

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5354,6 +5354,8 @@ def _(rid, params: dict) -> dict:
     if db is None:
         return _db_unavailable_error(rid, code=5006)
     try:
+        from hermes_cli.session_listing import is_empty_session_placeholder
+
         # Resume picker should surface human conversation sessions from every
         # user-facing surface — CLI, TUI, all gateway platforms (including new
         # ones not enumerated here), ACP adapter clients, webhook sessions,
@@ -5373,6 +5375,7 @@ def _(rid, params: dict) -> dict:
             s
             for s in db.list_sessions_rich(source=None, limit=fetch_limit, order_by_last_active=True, compact_rows=True)
             if (s.get("source") or "").strip().lower() not in deny
+            and not is_empty_session_placeholder(s)
         ][:limit]
         return _ok(
             rid,
@@ -5413,6 +5416,8 @@ def _(rid, params: dict) -> dict:
     if db is None:
         return _ok(rid, {"session_id": None})
     try:
+        from hermes_cli.session_listing import is_empty_session_placeholder
+
         deny = frozenset({"tool"})
         # Over-fetch by a generous bounded amount so heavy sub-agent
         # users (lots of recent ``tool`` rows) don't get a false
@@ -5422,6 +5427,8 @@ def _(rid, params: dict) -> dict:
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:
+                continue
+            if is_empty_session_placeholder(row):
                 continue
             return _ok(
                 rid,


### PR DESCRIPTION
### Summary

- Add a narrow helper for non-conversational placeholder rows: explicit `message_count == 0` with no title and no preview.
- Hide those rows from user-facing session listing surfaces: CLI `sessions list` / `sessions browse`, shared `/sessions` listing helper, and TUI/Desktop `session.list` / `session.most_recent`.
- Preserve `list_sessions_rich()` itself so cleanup and management paths can still inspect empty rows directly.

### Root Cause

User-facing session pickers filtered noisy `tool` sessions but did not filter empty shell rows. A deleted or lifecycle-recreated session with `message_count = 0`, no title, and no preview could therefore still appear as a resumable session.

### Tests

- `python -m pytest tests/gateway/test_session_list_allowed_sources.py -q`
- `python -m pytest tests/test_tui_gateway_server.py::test_session_most_recent_returns_first_non_denied tests/test_tui_gateway_server.py::test_session_most_recent_returns_null_when_only_tool_rows tests/test_tui_gateway_server.py::test_session_most_recent_skips_empty_placeholder_rows tests/test_tui_gateway_server.py::test_session_most_recent_folds_db_exception_into_null_result tests/test_tui_gateway_server.py::test_session_most_recent_handles_db_unavailable -q`
- `python -m pytest tests/hermes_cli/test_session_browse.py -q`
- `python -m py_compile hermes_cli/session_listing.py hermes_cli/main.py tui_gateway/server.py tests/gateway/test_session_list_allowed_sources.py tests/test_tui_gateway_server.py`
- `git diff --check`

Fixes #56733