### PR TITLE
feat(optional-skills): add mind — brain-like offline project memory skill

### DIFF
--- a/optional-skills/autonomous-ai-agents/mind/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/mind/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: mind
+description: Project memory graph with recall, provenance, and dreams.
+version: 6.2.10
+author: Da7_Tech
+license: MIT
+platforms: [linux, macos, windows]
+prerequisites:
+  commands: [python3, curl]
+related_skills: [hermes-agent]
+metadata:
+  hermes:
+    tags: [Memory, Knowledge-Graph, Consolidation, Offline, Local-First]
+    category: autonomous-ai-agents
+    homepage: https://github.com/Da7-Tech/mind
+---
+
+# mind Skill
+
+Gives a project a persistent, self-organizing memory: a weighted concept
+graph in `.mind/` with spreading-activation recall, Ebbinghaus forgetting,
+and a deterministic dream cycle — exported into `AGENTS.md`/`CLAUDE.md`/
+`GEMINI.md` behind guard markers. It complements Hermes' built-in memory
+(small, curated, *global* user facts) with *per-project* knowledge. It does
+NOT store durable personal facts about the user — those belong in the
+built-in `memory` tool — and it is not a RAG system for large corpora.
+
+## When to Use
+
+- The user asks to remember project facts, decisions, or context across sessions
+- A project fact is needed that is not in context ("what database do we use?")
+- The user corrects a stored fact
+- Between-session housekeeping ("clean up / consolidate the project memory")
+
+## Prerequisites
+
+- `python3` (3.9+) and `curl` on PATH — nothing else: no API keys, no
+  server, no packages. The tool is one stdlib-only file, MIT-licensed,
+  from https://github.com/Da7-Tech/mind (267 tests + benchmarks incl.
+  10 languages + discrimination + fuzzer + 180-day soak test run in its CI
+  on Linux/macOS/Windows).
+
+## How to Run
+
+Install once per project through the `terminal` tool, pinned to a release
+tag and integrity-checked:
+
+POSIX shell (Linux/macOS):
+
+```bash
+cd <project>
+curl -fsSLO https://raw.githubusercontent.com/Da7-Tech/mind/v6.2.10/mind.py
+python3 -c "import hashlib;h=hashlib.sha256(open('mind.py','rb').read()).hexdigest();assert h=='7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c',h;print('mind.py: OK')"
+python3 mind.py init
+```
+
+PowerShell (native Windows):
+
+```powershell
+Set-Location <project>
+Invoke-WebRequest "https://raw.githubusercontent.com/Da7-Tech/mind/v6.2.10/mind.py" -OutFile mind.py
+$Hash = (Get-FileHash mind.py -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($Hash -ne "7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c") {
+  throw "mind.py checksum mismatch: $Hash"
+}
+python mind.py init
+```
+
+`init` creates `.mind/` and writes guard-marked memory blocks into
+`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`; existing user content is preserved
+outside the markers. Projects already using Cursor/Windsurf/Cline/Roo get
+their rule files synced too (adopted only when present).
+
+## Quick Reference
+
+| User intent | Command (through `terminal`) |
+|---|---|
+| "Remember that X" (project fact) | `python3 mind.py remember "X"` |
+| Project fact not in context | `python3 mind.py recall "the question"` |
+| A recalled memory actually answered | `python3 mind.py confirm <id>` (ids in recall output) |
+| "X and Y are related" | `python3 mind.py link "X" "Y" "relation"` |
+| "That's wrong, it's actually Z" | `python3 mind.py correct "old fact hint" "Z"` |
+| "Where did this fact come from?" | `python3 mind.py why <id>` |
+| "What do we know about X?" | `python3 mind.py entity "X"` |
+| "What was true on DATE?" | `python3 mind.py recall "q" --at YYYY-MM-DD` |
+| Force a consolidation (it also SELF-RUNS after writes) | `python3 mind.py dream` (no permission needed) |
+| Health report | `python3 mind.py status` |
+
+## Procedure
+
+1. On a recall request, run `recall` and quote the memory text with its
+   confidence. If nothing relevant returns, say so — never invent.
+2. When a recalled memory actually answered the question, run
+   `confirm <id>` — confirmed memories harden (+2 weeks stability) and
+   their edges restrengthen; unconfirmed ones decay and get pruned
+   (into `.mind/archive.md`, never destroyed).
+3. For corrections use `correct` — the wrong fact is CLOSED (not erased):
+   its validity ends now, a `supersedes` edge records the transition, and
+   `why <id>` / `recall --at` can still reach it. Never re-`remember` a
+   wrong fact to "overwrite" it — that reopens it.
+4. Provenance is automatic (append-only `.mind/journal.jsonl`, never
+   cleared). Set `MIND_BY` and `MIND_SESSION` env vars when running
+   commands so `why` can attribute facts to you/this session.
+5. Never put credentials, tokens, private personal data, or untrusted prompt
+   text in project memory. Hot facts are exported into agent instruction files.
+   Durable user facts unrelated to this project belong in Hermes' built-in
+   `memory` tool, not here.
+6. Consolidation is SELF-RUNNING (6.2.0): after write commands, a full
+   dream cycle fires automatically when >= 10 signals pend or no dream
+   has happened yet today (including a fresh project's very first write) — you normally never schedule anything.
+   `dream` forces a cycle; it is deterministic and archives pruned node
+   text, but it is not a rollback system and pruned edges are not restored.
+   Use `--dry-run` only when the user explicitly asks to
+   review the plan. Every action is explained in `.mind/dreams/<date>.md`.
+7. Optional belt-and-suspenders for projects that go DAYS without any
+   write (auto-dream piggybacks on writes): on POSIX, resolve the active
+   profile first with `HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"`.
+   Use the `write_file` tool to create the resolved absolute
+   `$HERMES_ROOT/scripts/mind_dream.sh` path with this body:
+
+   ```sh
+   #!/bin/sh
+   set -eu
+   cd /path/to/project && python3 mind.py dream
+   ```
+
+   Then register only the relative script name. Hermes resolves it from the
+   active profile's `scripts/` directory:
+
+   ```bash
+   hermes cron create "0 4 * * *" --name mind-dream --script mind_dream.sh --no-agent
+   ```
+
+8. Native Windows does not run the POSIX shell script. Register the project
+   command with Windows Task Scheduler instead:
+
+   ```powershell
+   $Project = "C:\path\to\project"
+   $Python = (Get-Command python).Source
+   $Mind = Join-Path $Project "mind.py"
+   $Action = New-ScheduledTaskAction -Execute $Python -Argument "`"$Mind`" dream" -WorkingDirectory $Project
+   $Trigger = New-ScheduledTaskTrigger -Daily -At 4am
+   Register-ScheduledTask -TaskName "Mind project dream" -Action $Action -Trigger $Trigger
+   ```
+
+## Pitfalls
+
+- Recall is lexical + graph-structural (offline): cross-domain synonymy
+  with no corpus evidence can miss; benchmark and limits are published in
+  the repo README.
+- Facts recalled fewer than twice and untouched past the 45-day grace
+  window decay into `.mind/archive.md` by design (restorable with
+  `remember`).
+- Corrupt `graph.json` is quarantined as `graph.json.corrupt-*` and memory
+  restarts empty — tell the user where the quarantined file is.
+- The tool refuses to write through symlinked agent/lock/archive files.
+- Operational limits are deliberate: 10,000 nodes, 100,000 directional
+  edges, 50 MB graph, 10,000-character memories/queries, 100 history entries
+  per node, 256 prunes / 4 MB of prune payload per dream, and a 30-second
+  graph-lock wait.
+- `HERMES_HOME` selects the profile that owns optional cron scripts. Without
+  it, the native defaults are `~/.hermes` on POSIX and
+  `%LOCALAPPDATA%/hermes` on Windows.
+
+## Verification
+
+POSIX:
+
+```bash
+tmp="$(mktemp -d)"
+cd "$tmp"
+curl -fsSLo mind.py https://raw.githubusercontent.com/Da7-Tech/mind/v6.2.10/mind.py
+python3 -c "import hashlib;h=hashlib.sha256(open('mind.py','rb').read()).hexdigest();assert h=='7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c',h;print('OK')"
+python3 mind.py init >/dev/null
+python3 mind.py remember "the sky signal is 7413" >/dev/null
+python3 mind.py recall "sky signal"
+```
+
+PowerShell:
+
+```powershell
+$Tmp = Join-Path $env:TEMP ("mind-" + [guid]::NewGuid())
+New-Item -ItemType Directory $Tmp | Out-Null
+Set-Location $Tmp
+Invoke-WebRequest "https://raw.githubusercontent.com/Da7-Tech/mind/v6.2.10/mind.py" -OutFile mind.py
+if ((Get-FileHash mind.py -Algorithm SHA256).Hash.ToLowerInvariant() -ne "7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c") {
+  throw "checksum mismatch"
+}
+python mind.py init | Out-Null
+python mind.py remember "the sky signal is 7413" | Out-Null
+python mind.py recall "sky signal"
+```
+
+Expected: one result containing `7413` with a printed memory id.

--- a/tests/skills/test_mind_skill.py
+++ b/tests/skills/test_mind_skill.py
@@ -1,0 +1,114 @@
+"""Tests for optional-skills/autonomous-ai-agents/mind/SKILL.md.
+
+The skill wraps an external single-file tool, so these tests enforce the
+skill contract itself, hermetically: frontmatter standards, the modern
+section order, and internal consistency between the declared version, the
+pinned install URL, and the integrity checksum (a drifting pin is exactly
+the failure mode a wrapper skill can silently develop).
+"""
+import re
+from pathlib import Path
+
+SKILL = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "autonomous-ai-agents"
+    / "mind"
+    / "SKILL.md"
+)
+TEXT = SKILL.read_text(encoding="utf-8")
+FRONT = TEXT.split("---")[1]
+
+
+def _front_value(key):
+    m = re.search(r"^%s: (.+)$" % key, FRONT, re.MULTILINE)
+    return m.group(1).strip() if m else None
+
+
+class TestFrontmatter:
+    def test_description_within_60_chars_one_sentence(self):
+        desc = _front_value("description")
+        assert desc is not None
+        assert len(desc) <= 60, len(desc)
+        assert desc.endswith(".")
+        assert desc.count(".") == 1
+
+    def test_description_has_no_marketing_words(self):
+        desc = _front_value("description").lower()
+        for banned in ("powerful", "comprehensive", "seamless", "advanced"):
+            assert banned not in desc
+
+    def test_platforms_declared(self):
+        assert _front_value("platforms") == "[linux, macos, windows]"
+
+    def test_prerequisite_commands_declared(self):
+        assert "commands: [python3, curl]" in FRONT
+
+    def test_pseudonymous_author_only(self):
+        assert _front_value("author") == "Da7_Tech"
+
+
+class TestSectionOrder:
+    def test_modern_section_order(self):
+        wanted = ["## When to Use", "## Prerequisites", "## How to Run",
+                  "## Quick Reference", "## Procedure", "## Pitfalls",
+                  "## Verification"]
+        positions = [TEXT.find(h) for h in wanted]
+        assert all(p != -1 for p in positions), positions
+        assert positions == sorted(positions), "sections out of order"
+
+    def test_title_is_skill_form(self):
+        assert "\n# mind Skill\n" in TEXT
+
+
+class TestInstallPinConsistency:
+    def test_version_matches_pinned_url(self):
+        version = _front_value("version")
+        pinned = re.findall(r"raw\.githubusercontent\.com/Da7-Tech/mind/v([\d.]+)/mind\.py", TEXT)
+        assert pinned, "install must pin a release tag, not a branch"
+        assert all(v == version for v in pinned), (version, pinned)
+
+    def test_no_install_from_moving_branch(self):
+        assert "/mind/main/mind.py" not in TEXT
+
+    def test_integrity_checksum_present_and_wellformed(self):
+        # cross-platform form: a python3 hashlib assert (`shasum` does not
+        # exist on Windows, which this skill declares as a platform)
+        shas = re.findall(r"h=='([0-9a-f]{64})'", TEXT)
+        assert shas, "install must include a sha256 integrity check"
+        assert len(set(shas)) == 1, "install/verification checksums differ"
+        assert len(shas) >= 2, "the Verification block must integrity-check too"
+        assert "shasum" not in TEXT, "shasum is not available on Windows"
+
+    def test_terminal_tool_framing(self):
+        assert "`terminal`" in TEXT
+
+    def test_no_banned_heredoc(self):
+        # HARDLINE standard #2: `cat <<EOF` / `echo > file` must be write_file
+        assert "cat >" not in TEXT and "<<'EOF'" not in TEXT and "<<EOF" not in TEXT
+
+    def test_write_file_framing_for_script_creation(self):
+        # the nightly-automation step must frame file creation via write_file
+        assert "write_file" in TEXT
+
+
+class TestProfileAndPlatformSafety:
+    def test_active_profile_scripts_directory(self):
+        assert 'HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"' in TEXT
+        assert "$HERMES_ROOT/scripts/mind_dream.sh" in TEXT
+        assert "~/.hermes/scripts/mind_dream.sh" not in TEXT
+
+    def test_cron_keeps_relative_script_name(self):
+        assert "--script mind_dream.sh" in TEXT
+        assert "--script ~/.hermes/" not in TEXT
+        assert "--script $HERMES_ROOT/" not in TEXT
+
+    def test_native_windows_uses_task_scheduler(self):
+        assert "```powershell" in TEXT
+        assert "Windows Task Scheduler" in TEXT
+        assert "Register-ScheduledTask" in TEXT
+        assert "-WorkingDirectory $Project" in TEXT
+
+    def test_windows_profile_default_is_documented(self):
+        assert "HERMES_HOME" in TEXT
+        assert "%LOCALAPPDATA%/hermes" in TEXT

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -35,6 +35,7 @@ hermes skills uninstall <skill-name>
 | [**blackbox**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox) | Delegate coding tasks to Blackbox AI CLI agent. Multi-model agent with built-in judge that runs tasks through multiple LLMs and picks the best result. Requires the blackbox CLI and a Blackbox AI API key. |
 | [**grok**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok) | Delegate coding to xAI Grok Build CLI (features, PRs). |
 | [**honcho**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho) | Configure and use Honcho memory with Hermes -- cross-session user modeling, multi-profile peer isolation, observation config, dialectic reasoning, session summaries, and context budget enforcement. Use when setting up Honcho, troubleshoo... |
+| [**mind**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-mind) | Project memory graph with recall, provenance, and dreams. |
 | [**openhands**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands) | Delegate coding to OpenHands CLI (model-agnostic, LiteLLM). |
 
 ## blockchain

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-mind.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-mind.md
@@ -1,0 +1,207 @@
+---
+title: "Mind — Project memory graph with recall, provenance, and dreams"
+sidebar_label: "Mind"
+description: "Project memory graph with recall, provenance, and dreams"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Mind
+
+Project memory graph with recall, provenance, and dreams.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/mind` |
+| Path | `optional-skills/autonomous-ai-agents/mind` |
+| Version | `6.2.10` |
+| Author | Da7_Tech |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Memory`, `Knowledge-Graph`, `Consolidation`, `Offline`, `Local-First` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# mind Skill
+
+Gives a project a persistent, self-organizing memory: a weighted concept
+graph in `.mind/` with spreading-activation recall, Ebbinghaus forgetting,
+and a deterministic dream cycle — exported into `AGENTS.md`/`CLAUDE.md`/
+`GEMINI.md` behind guard markers. It complements Hermes' built-in memory
+(small, curated, *global* user facts) with *per-project* knowledge. It does
+NOT store durable personal facts about the user — those belong in the
+built-in `memory` tool — and it is not a RAG system for large corpora.
+
+## When to Use
+
+- The user asks to remember project facts, decisions, or context across sessions
+- A project fact is needed that is not in context ("what database do we use?")
+- The user corrects a stored fact
+- Between-session housekeeping ("clean up / consolidate the project memory")
+
+## Prerequisites
+
+- `python3` (3.9+) and `curl` on PATH — nothing else: no API keys, no
+  server, no packages. The tool is one stdlib-only file, MIT-licensed,
+  from https://github.com/Da7-Tech/mind (267 tests + benchmarks incl.
+  10 languages + discrimination + fuzzer + 180-day soak test run in its CI
+  on Linux/macOS/Windows).
+
+## How to Run
+
+Install once per project through the `terminal` tool, pinned to a release
+tag and integrity-checked:
+
+POSIX shell (Linux/macOS):
+
+```bash
+cd <project>
+curl -fsSLO https://raw.githubusercontent.com/Da7-Tech/mind/v6.2.10/mind.py
+python3 -c "import hashlib;h=hashlib.sha256(open('mind.py','rb').read()).hexdigest();assert h=='7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c',h;print('mind.py: OK')"
+python3 mind.py init
+```
+
+PowerShell (native Windows):
+
+```powershell
+Set-Location <project>
+Invoke-WebRequest "https://raw.githubusercontent.com/Da7-Tech/mind/v6.2.10/mind.py" -OutFile mind.py
+$Hash = (Get-FileHash mind.py -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($Hash -ne "7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c") {
+  throw "mind.py checksum mismatch: $Hash"
+}
+python mind.py init
+```
+
+`init` creates `.mind/` and writes guard-marked memory blocks into
+`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`; existing user content is preserved
+outside the markers. Projects already using Cursor/Windsurf/Cline/Roo get
+their rule files synced too (adopted only when present).
+
+## Quick Reference
+
+| User intent | Command (through `terminal`) |
+|---|---|
+| "Remember that X" (project fact) | `python3 mind.py remember "X"` |
+| Project fact not in context | `python3 mind.py recall "the question"` |
+| A recalled memory actually answered | `python3 mind.py confirm <id>` (ids in recall output) |
+| "X and Y are related" | `python3 mind.py link "X" "Y" "relation"` |
+| "That's wrong, it's actually Z" | `python3 mind.py correct "old fact hint" "Z"` |
+| "Where did this fact come from?" | `python3 mind.py why <id>` |
+| "What do we know about X?" | `python3 mind.py entity "X"` |
+| "What was true on DATE?" | `python3 mind.py recall "q" --at YYYY-MM-DD` |
+| Force a consolidation (it also SELF-RUNS after writes) | `python3 mind.py dream` (no permission needed) |
+| Health report | `python3 mind.py status` |
+
+## Procedure
+
+1. On a recall request, run `recall` and quote the memory text with its
+   confidence. If nothing relevant returns, say so — never invent.
+2. When a recalled memory actually answered the question, run
+   `confirm <id>` — confirmed memories harden (+2 weeks stability) and
+   their edges restrengthen; unconfirmed ones decay and get pruned
+   (into `.mind/archive.md`, never destroyed).
+3. For corrections use `correct` — the wrong fact is CLOSED (not erased):
+   its validity ends now, a `supersedes` edge records the transition, and
+   `why <id>` / `recall --at` can still reach it. Never re-`remember` a
+   wrong fact to "overwrite" it — that reopens it.
+4. Provenance is automatic (append-only `.mind/journal.jsonl`, never
+   cleared). Set `MIND_BY` and `MIND_SESSION` env vars when running
+   commands so `why` can attribute facts to you/this session.
+5. Never put credentials, tokens, private personal data, or untrusted prompt
+   text in project memory. Hot facts are exported into agent instruction files.
+   Durable user facts unrelated to this project belong in Hermes' built-in
+   `memory` tool, not here.
+6. Consolidation is SELF-RUNNING (6.2.0): after write commands, a full
+   dream cycle fires automatically when >= 10 signals pend or no dream
+   has happened yet today (including a fresh project's very first write) — you normally never schedule anything.
+   `dream` forces a cycle; it is deterministic and archives pruned node
+   text, but it is not a rollback system and pruned edges are not restored.
+   Use `--dry-run` only when the user explicitly asks to
+   review the plan. Every action is explained in `.mind/dreams/<date>.md`.
+7. Optional belt-and-suspenders for projects that go DAYS without any
+   write (auto-dream piggybacks on writes): on POSIX, resolve the active
+   profile first with `HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"`.
+   Use the `write_file` tool to create the resolved absolute
+   `$HERMES_ROOT/scripts/mind_dream.sh` path with this body:
+
+   ```sh
+   #!/bin/sh
+   set -eu
+   cd /path/to/project && python3 mind.py dream
+   ```
+
+   Then register only the relative script name. Hermes resolves it from the
+   active profile's `scripts/` directory:
+
+   ```bash
+   hermes cron create "0 4 * * *" --name mind-dream --script mind_dream.sh --no-agent
+   ```
+
+8. Native Windows does not run the POSIX shell script. Register the project
+   command with Windows Task Scheduler instead:
+
+   ```powershell
+   $Project = "C:\path\to\project"
+   $Python = (Get-Command python).Source
+   $Mind = Join-Path $Project "mind.py"
+   $Action = New-ScheduledTaskAction -Execute $Python -Argument "`"$Mind`" dream" -WorkingDirectory $Project
+   $Trigger = New-ScheduledTaskTrigger -Daily -At 4am
+   Register-ScheduledTask -TaskName "Mind project dream" -Action $Action -Trigger $Trigger
+   ```
+
+## Pitfalls
+
+- Recall is lexical + graph-structural (offline): cross-domain synonymy
+  with no corpus evidence can miss; benchmark and limits are published in
+  the repo README.
+- Facts recalled fewer than twice and untouched past the 45-day grace
+  window decay into `.mind/archive.md` by design (restorable with
+  `remember`).
+- Corrupt `graph.json` is quarantined as `graph.json.corrupt-*` and memory
+  restarts empty — tell the user where the quarantined file is.
+- The tool refuses to write through symlinked agent/lock/archive files.
+- Operational limits are deliberate: 10,000 nodes, 100,000 directional
+  edges, 50 MB graph, 10,000-character memories/queries, 100 history entries
+  per node, 256 prunes / 4 MB of prune payload per dream, and a 30-second
+  graph-lock wait.
+- `HERMES_HOME` selects the profile that owns optional cron scripts. Without
+  it, the native defaults are `~/.hermes` on POSIX and
+  `%LOCALAPPDATA%/hermes` on Windows.
+
+## Verification
+
+POSIX:
+
+```bash
+tmp="$(mktemp -d)"
+cd "$tmp"
+curl -fsSLo mind.py https://raw.githubusercontent.com/Da7-Tech/mind/v6.2.10/mind.py
+python3 -c "import hashlib;h=hashlib.sha256(open('mind.py','rb').read()).hexdigest();assert h=='7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c',h;print('OK')"
+python3 mind.py init >/dev/null
+python3 mind.py remember "the sky signal is 7413" >/dev/null
+python3 mind.py recall "sky signal"
+```
+
+PowerShell:
+
+```powershell
+$Tmp = Join-Path $env:TEMP ("mind-" + [guid]::NewGuid())
+New-Item -ItemType Directory $Tmp | Out-Null
+Set-Location $Tmp
+Invoke-WebRequest "https://raw.githubusercontent.com/Da7-Tech/mind/v6.2.10/mind.py" -OutFile mind.py
+if ((Get-FileHash mind.py -Algorithm SHA256).Hash.ToLowerInvariant() -ne "7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c") {
+  throw "checksum mismatch"
+}
+python mind.py init | Out-Null
+python mind.py remember "the sky signal is 7413" | Out-Null
+python mind.py recall "sky signal"
+```
+
+Expected: one result containing `7413` with a printed memory id.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -351,6 +351,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho',
+                    'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-mind',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands',
                   ],
                 },


### PR DESCRIPTION
## What does this PR do?

Adds an optional `mind` skill wrapping a standalone, offline per-project memory graph with recall, provenance, temporal corrections, and deterministic dream consolidation.

The tool is one stdlib-only Python file, requires no API keys or server, preserves existing agent instruction files behind guard markers, and is pinned to `v6.2.10` with SHA-256 `7cb64a6bb96824a6ac00d8871b889b02d57526fc9a70cf33488ae443c8bf139c`.

Maintainer feedback is fully addressed: POSIX cron setup writes to the active profile's resolved `HERMES_HOME/scripts` directory while registration deliberately remains relative as `--script mind_dream.sh`; native Windows uses a separate PowerShell + Task Scheduler path with the project working directory.

## Related Issue

No linked issue; focused optional-skill contribution.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Added `optional-skills/autonomous-ai-agents/mind/SKILL.md`.
- Added active-profile-safe POSIX cron guidance with relative script registration.
- Added native-Windows PowerShell and Task Scheduler guidance.
- Added 17 hermetic contract tests covering format, release pins, checksums, profile isolation, cron resolution, and the platform split.
- Added the generator-synchronized docs page, optional-skills catalog row, and sidebar entry.

## How to Test

1. Run `scripts/run_tests.sh tests/skills/test_mind_skill.py tests/website/test_generate_skill_docs.py -q`.
2. Run the docs CI flow: install website dependencies, extract skills, regenerate skill docs, run diagram lint, then build both locales.
3. Download the pinned public release, verify its SHA-256, initialize a temporary project, remember a fact, and recall it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

The full-suite checkbox remains open because pristine current `main` fails independently of this PR (`tests/agent/test_anthropic_adapter.py`: 171 passed, 3 failed under the required wrapper). The PR-specific suites and full docs build pass.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — N/A; this is optional
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

No model-backed Hermes session was used. The pinned deterministic tool itself was tested end-to-end from the public release tag.

## Screenshots / Logs

- Wrapper contract tests: 17/17 passed.
- Docs generator tests: 7/7 passed.
- Generated page matched repository generator output byte-for-byte.
- Diagram lint: 366 files, 0 errors.
- Full English and Chinese Docusaurus builds passed.
- Public release black-box flow passed: checksum, init, remember, and recall.
- Standalone `mind` v6.2.10: 267 tests with 9 Linux/macOS/Windows CI jobs, plus fuzz, multilingual, discrimination, and 180-day soak coverage.

