### PR TITLE
feat(optional-skills): add dream — deterministic consolidation for built-in memory

### DIFF
--- a/optional-skills/autonomous-ai-agents/dream/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/dream/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: dream
+description: Sleep-cycle cleanup for agent memory files, budget-safe.
+version: 1.4.0
+author: Da7_Tech
+license: MIT
+platforms: [linux, macos, windows]
+prerequisites:
+  commands: [python3, curl]
+related_skills: [hermes-agent]
+metadata:
+  hermes:
+    tags: [Memory, Consolidation, Hygiene, Offline, Deterministic]
+    category: autonomous-ai-agents
+    homepage: https://github.com/Da7-Tech/dream
+---
+
+# dream Skill
+
+Consolidates the active Hermes profile's `MEMORY.md` and `USER.md` offline
+and deterministically: deduplicates, keeps the newest
+statement of a repeated subject, flags uncertain contradictions, and can
+squeeze the file under its exact character budget — with zero LLM calls
+(the char accounting matches Hermes' `§`-join math character-for-character — the same `len()` codepoint count Hermes uses). It does
+NOT rewrite prose the way a model would, and it never deletes: every
+removed entry is archived with a written reason.
+
+## When to Use
+
+- The user asks to clean up, consolidate, or "run a dream on" their memory
+- The built-in memory is at capacity and consolidation keeps failing
+- Scheduled memory hygiene
+- Any agent memory file: `--format bullets` handles Claude-Code-style
+  bullet memories, `paragraphs` handles free notes
+
+## Prerequisites
+
+- `python3` (3.9+) and `curl` on PATH — no API keys, no server, no
+  packages. The tool is one stdlib-only file, MIT-licensed, from
+  https://github.com/Da7-Tech/dream (72 tests + a 90-day soak test run in
+  its CI on Linux/macOS/Windows).
+
+## How to Run
+
+Install once through the `terminal` tool, pinned to a release tag and
+integrity-checked:
+
+POSIX shell (Linux/macOS):
+
+```bash
+HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"
+mkdir -p "$HERMES_ROOT/tools"
+cd "$HERMES_ROOT/tools"
+curl -fsSLo dream.py https://raw.githubusercontent.com/Da7-Tech/dream/v1.4.0/dream.py
+python3 -c "import hashlib;h=hashlib.sha256(open('dream.py','rb').read()).hexdigest();assert h=='616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052',h;print('dream.py: OK')"
+```
+
+PowerShell (native Windows):
+
+```powershell
+$HermesRoot = if ($env:HERMES_HOME) {
+  $env:HERMES_HOME
+} else {
+  Join-Path $env:LOCALAPPDATA "hermes"
+}
+$Tools = Join-Path $HermesRoot "tools"
+New-Item -ItemType Directory -Force $Tools | Out-Null
+$Dream = Join-Path $Tools "dream.py"
+Invoke-WebRequest "https://raw.githubusercontent.com/Da7-Tech/dream/v1.4.0/dream.py" -OutFile $Dream
+$Hash = (Get-FileHash $Dream -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($Hash -ne "616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052") {
+  throw "dream.py checksum mismatch: $Hash"
+}
+```
+
+Invoke the installed tool from that same active-profile location:
+
+POSIX:
+
+```bash
+HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"
+python3 "$HERMES_ROOT/tools/dream.py" --hermes
+```
+
+PowerShell:
+
+```powershell
+$HermesRoot = if ($env:HERMES_HOME) {
+  $env:HERMES_HOME
+} else {
+  Join-Path $env:LOCALAPPDATA "hermes"
+}
+$Dream = Join-Path $HermesRoot "tools\dream.py"
+python $Dream --hermes
+```
+
+## Quick Reference
+
+| User intent | Command (through `terminal`) |
+|---|---|
+| "Clean up my memory" | Run the active profile's installed `dream.py --hermes` (dry run) |
+| Apply after approval | add `--apply` |
+| "Memory is over its limit" | Run the active profile's `dream.py --hermes --apply` (budgets come from that profile's `config.yaml`) |
+| Consolidate any notes file | Run `dream.py <file>` then add `--apply` |
+
+## Procedure
+
+1. **Always dry-run first** and show the user the plan: the dry run prints
+   the journal (every action + reason) and a unified diff, writing nothing.
+2. Apply only on approval. `--apply` uses a recoverable transaction: it
+   durably writes a timestamped backup and every removed entry to
+   `<file>.dream-archive.md` before replacing the live memory, then appends
+   a report to `DREAMS.md`.
+3. Report `entries: N -> M | chars: X -> Y` plus backup/archive paths.
+   Never say an entry was "deleted" — it was archived.
+4. Nightly automation costs zero tokens. On POSIX, resolve the active profile
+   first with `HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"`. Use the
+   `write_file` tool to create the resolved absolute
+   `$HERMES_ROOT/scripts/dream_nightly.sh` path with this body:
+
+   ```sh
+   #!/bin/sh
+   set -eu
+   HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"
+   python3 "$HERMES_ROOT/tools/dream.py" --hermes --apply --quiet
+   ```
+
+   Then register only the relative script name; Hermes resolves it inside
+   the active profile's `scripts/` directory:
+
+   ```bash
+   hermes cron create "0 4 * * *" --name memory-dream --script dream_nightly.sh --no-agent
+   ```
+
+5. Native Windows does not run the POSIX shell script. Register the installed
+   tool with Windows Task Scheduler instead:
+
+   ```powershell
+   $HermesRoot = if ($env:HERMES_HOME) {
+     $env:HERMES_HOME
+   } else {
+     Join-Path $env:LOCALAPPDATA "hermes"
+   }
+   $Python = (Get-Command python).Source
+   $Dream = Join-Path $HermesRoot "tools\dream.py"
+   $Action = New-ScheduledTaskAction -Execute $Python -Argument "`"$Dream`" --hermes --apply --quiet"
+   $Trigger = New-ScheduledTaskTrigger -Daily -At 4am
+   Register-ScheduledTask -TaskName "Hermes memory dream" -Action $Action -Trigger $Trigger
+   ```
+
+## Pitfalls
+
+- Supersession assumes file order = recency (true for Hermes' append-style
+  memory). For non-chronological files use `--no-supersede`.
+- Merging is deterministic clause algebra, not LLM rewriting — wording can
+  be mechanical; information is preserved.
+- Pairwise comparison is O(n²), with hard ceilings: 10 MB, 10,000 entries,
+  and 200,000 comparisons. A limit failure writes no semantic change.
+- Apply is idempotent (unit-tested): a second run on clean memory changes
+  nothing.
+- `HERMES_HOME` always selects the profile. Without it, the native defaults
+  are `~/.hermes` on POSIX and `%LOCALAPPDATA%/hermes` on Windows.
+
+## Verification
+
+POSIX:
+
+```bash
+tmp="$(mktemp -d)"
+cd "$tmp"
+curl -fsSLo dream.py https://raw.githubusercontent.com/Da7-Tech/dream/v1.4.0/dream.py
+python3 -c "import hashlib;h=hashlib.sha256(open('dream.py','rb').read()).hexdigest();assert h=='616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052',h;print('OK')"
+printf 'project mode is blue\n§\nproject mode is blue' > MEMORY.md
+python3 dream.py MEMORY.md --apply --quiet
+cat MEMORY.md
+```
+
+PowerShell:
+
+```powershell
+$Tmp = Join-Path $env:TEMP ("dream-" + [guid]::NewGuid())
+New-Item -ItemType Directory $Tmp | Out-Null
+Set-Location $Tmp
+Invoke-WebRequest "https://raw.githubusercontent.com/Da7-Tech/dream/v1.4.0/dream.py" -OutFile dream.py
+if ((Get-FileHash dream.py -Algorithm SHA256).Hash.ToLowerInvariant() -ne "616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052") {
+  throw "checksum mismatch"
+}
+[IO.File]::WriteAllText((Join-Path $Tmp "MEMORY.md"), "project mode is blue`n§`nproject mode is blue")
+python dream.py MEMORY.md --apply --quiet
+Get-Content MEMORY.md
+```
+
+Expected: `MEMORY.md consolidated: 2 -> 1 entries, ...` and the file
+contains the fact once; the duplicate is in `MEMORY.md.dream-archive.md`.

--- a/tests/skills/test_dream_skill.py
+++ b/tests/skills/test_dream_skill.py
@@ -1,0 +1,113 @@
+"""Tests for optional-skills/autonomous-ai-agents/dream/SKILL.md.
+
+The skill wraps an external single-file tool, so these tests enforce the
+skill contract itself, hermetically: frontmatter standards, the modern
+section order, and internal consistency between the declared version, the
+pinned install URL, and the integrity checksum (a drifting pin is exactly
+the failure mode a wrapper skill can silently develop).
+"""
+import re
+from pathlib import Path
+
+SKILL = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "autonomous-ai-agents"
+    / "dream"
+    / "SKILL.md"
+)
+TEXT = SKILL.read_text(encoding="utf-8")
+FRONT = TEXT.split("---")[1]
+
+
+def _front_value(key):
+    m = re.search(r"^%s: (.+)$" % key, FRONT, re.MULTILINE)
+    return m.group(1).strip() if m else None
+
+
+class TestFrontmatter:
+    def test_description_within_60_chars_one_sentence(self):
+        desc = _front_value("description")
+        assert desc is not None
+        assert len(desc) <= 60, len(desc)
+        assert desc.endswith(".")
+        assert desc.count(".") == 1
+
+    def test_description_has_no_marketing_words(self):
+        desc = _front_value("description").lower()
+        for banned in ("powerful", "comprehensive", "seamless", "advanced"):
+            assert banned not in desc
+
+    def test_platforms_declared(self):
+        assert _front_value("platforms") == "[linux, macos, windows]"
+
+    def test_prerequisite_commands_declared(self):
+        assert "commands: [python3, curl]" in FRONT
+
+    def test_pseudonymous_author_only(self):
+        assert _front_value("author") == "Da7_Tech"
+
+
+class TestSectionOrder:
+    def test_modern_section_order(self):
+        wanted = ["## When to Use", "## Prerequisites", "## How to Run",
+                  "## Quick Reference", "## Procedure", "## Pitfalls",
+                  "## Verification"]
+        positions = [TEXT.find(h) for h in wanted]
+        assert all(p != -1 for p in positions), positions
+        assert positions == sorted(positions), "sections out of order"
+
+    def test_title_is_skill_form(self):
+        assert "\n# dream Skill\n" in TEXT
+
+
+class TestInstallPinConsistency:
+    def test_version_matches_pinned_url(self):
+        version = _front_value("version")
+        pinned = re.findall(r"raw\.githubusercontent\.com/Da7-Tech/dream/v([\d.]+)/dream\.py", TEXT)
+        assert pinned, "install must pin a release tag, not a branch"
+        assert all(v == version for v in pinned), (version, pinned)
+
+    def test_no_install_from_moving_branch(self):
+        assert "/dream/main/dream.py" not in TEXT
+
+    def test_integrity_checksum_present_and_wellformed(self):
+        # cross-platform form: a python3 hashlib assert (`shasum` does not
+        # exist on Windows, which this skill declares as a platform)
+        shas = re.findall(r"h=='([0-9a-f]{64})'", TEXT)
+        assert shas, "install must include a sha256 integrity check"
+        assert len(set(shas)) == 1, "install/verification checksums differ"
+        assert len(shas) >= 2, "the Verification block must integrity-check too"
+        assert "shasum" not in TEXT, "shasum is not available on Windows"
+
+    def test_terminal_tool_framing(self):
+        assert "`terminal`" in TEXT
+
+
+class TestProfileAndPlatformSafety:
+    def test_active_profile_is_used_everywhere(self):
+        assert TEXT.count("HERMES_HOME") >= 6
+        assert 'HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"' in TEXT
+        assert 'python3 "$HERMES_ROOT/tools/dream.py" --hermes' in TEXT
+        assert '$Dream = Join-Path $HermesRoot "tools\\dream.py"' in TEXT
+        assert "python $Dream --hermes" in TEXT
+        assert "python3 ~/.hermes/" not in TEXT
+        assert "mkdir -p ~/.hermes/" not in TEXT
+
+    def test_cron_uses_active_scripts_dir_and_relative_name(self):
+        assert "`write_file`" in TEXT
+        assert "$HERMES_ROOT/scripts/dream_nightly.sh" in TEXT
+        assert "--script dream_nightly.sh" in TEXT
+        assert "--script ~/.hermes/" not in TEXT
+        assert "cat >" not in TEXT and "<<EOF" not in TEXT
+
+    def test_native_windows_workflow_is_documented(self):
+        assert "```powershell" in TEXT
+        assert "$env:LOCALAPPDATA" in TEXT
+        assert "Windows Task Scheduler" in TEXT
+        assert "Register-ScheduledTask" in TEXT
+
+    def test_release_pin_matches_hardened_dream(self):
+        assert _front_value("version") == "1.4.0"
+        assert "72 tests" in TEXT
+        assert "recoverable transaction" in TEXT

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -33,6 +33,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**antigravity-cli**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli) | Operate the Antigravity CLI (agy): plugins, auth, sandbox. |
 | [**blackbox**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox) | Delegate coding tasks to Blackbox AI CLI agent. Multi-model agent with built-in judge that runs tasks through multiple LLMs and picks the best result. Requires the blackbox CLI and a Blackbox AI API key. |
+| [**dream**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-dream) | Sleep-cycle cleanup for agent memory files, budget-safe. |
 | [**grok**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok) | Delegate coding to xAI Grok Build CLI (features, PRs). |
 | [**honcho**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho) | Configure and use Honcho memory with Hermes -- cross-session user modeling, multi-profile peer isolation, observation config, dialectic reasoning, session summaries, and context budget enforcement. Use when setting up Honcho, troubleshoo... |
 | [**openhands**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands) | Delegate coding to OpenHands CLI (model-agnostic, LiteLLM). |

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-dream.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-dream.md
@@ -1,0 +1,207 @@
+---
+title: "Dream — Sleep-cycle cleanup for agent memory files, budget-safe"
+sidebar_label: "Dream"
+description: "Sleep-cycle cleanup for agent memory files, budget-safe"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Dream
+
+Sleep-cycle cleanup for agent memory files, budget-safe.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/dream` |
+| Path | `optional-skills/autonomous-ai-agents/dream` |
+| Version | `1.4.0` |
+| Author | Da7_Tech |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Memory`, `Consolidation`, `Hygiene`, `Offline`, `Deterministic` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# dream Skill
+
+Consolidates the active Hermes profile's `MEMORY.md` and `USER.md` offline
+and deterministically: deduplicates, keeps the newest
+statement of a repeated subject, flags uncertain contradictions, and can
+squeeze the file under its exact character budget — with zero LLM calls
+(the char accounting matches Hermes' `§`-join math character-for-character — the same `len()` codepoint count Hermes uses). It does
+NOT rewrite prose the way a model would, and it never deletes: every
+removed entry is archived with a written reason.
+
+## When to Use
+
+- The user asks to clean up, consolidate, or "run a dream on" their memory
+- The built-in memory is at capacity and consolidation keeps failing
+- Scheduled memory hygiene
+- Any agent memory file: `--format bullets` handles Claude-Code-style
+  bullet memories, `paragraphs` handles free notes
+
+## Prerequisites
+
+- `python3` (3.9+) and `curl` on PATH — no API keys, no server, no
+  packages. The tool is one stdlib-only file, MIT-licensed, from
+  https://github.com/Da7-Tech/dream (72 tests + a 90-day soak test run in
+  its CI on Linux/macOS/Windows).
+
+## How to Run
+
+Install once through the `terminal` tool, pinned to a release tag and
+integrity-checked:
+
+POSIX shell (Linux/macOS):
+
+```bash
+HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"
+mkdir -p "$HERMES_ROOT/tools"
+cd "$HERMES_ROOT/tools"
+curl -fsSLo dream.py https://raw.githubusercontent.com/Da7-Tech/dream/v1.4.0/dream.py
+python3 -c "import hashlib;h=hashlib.sha256(open('dream.py','rb').read()).hexdigest();assert h=='616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052',h;print('dream.py: OK')"
+```
+
+PowerShell (native Windows):
+
+```powershell
+$HermesRoot = if ($env:HERMES_HOME) {
+  $env:HERMES_HOME
+} else {
+  Join-Path $env:LOCALAPPDATA "hermes"
+}
+$Tools = Join-Path $HermesRoot "tools"
+New-Item -ItemType Directory -Force $Tools | Out-Null
+$Dream = Join-Path $Tools "dream.py"
+Invoke-WebRequest "https://raw.githubusercontent.com/Da7-Tech/dream/v1.4.0/dream.py" -OutFile $Dream
+$Hash = (Get-FileHash $Dream -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($Hash -ne "616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052") {
+  throw "dream.py checksum mismatch: $Hash"
+}
+```
+
+Invoke the installed tool from that same active-profile location:
+
+POSIX:
+
+```bash
+HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"
+python3 "$HERMES_ROOT/tools/dream.py" --hermes
+```
+
+PowerShell:
+
+```powershell
+$HermesRoot = if ($env:HERMES_HOME) {
+  $env:HERMES_HOME
+} else {
+  Join-Path $env:LOCALAPPDATA "hermes"
+}
+$Dream = Join-Path $HermesRoot "tools\dream.py"
+python $Dream --hermes
+```
+
+## Quick Reference
+
+| User intent | Command (through `terminal`) |
+|---|---|
+| "Clean up my memory" | Run the active profile's installed `dream.py --hermes` (dry run) |
+| Apply after approval | add `--apply` |
+| "Memory is over its limit" | Run the active profile's `dream.py --hermes --apply` (budgets come from that profile's `config.yaml`) |
+| Consolidate any notes file | Run `dream.py <file>` then add `--apply` |
+
+## Procedure
+
+1. **Always dry-run first** and show the user the plan: the dry run prints
+   the journal (every action + reason) and a unified diff, writing nothing.
+2. Apply only on approval. `--apply` uses a recoverable transaction: it
+   durably writes a timestamped backup and every removed entry to
+   `<file>.dream-archive.md` before replacing the live memory, then appends
+   a report to `DREAMS.md`.
+3. Report `entries: N -> M | chars: X -> Y` plus backup/archive paths.
+   Never say an entry was "deleted" — it was archived.
+4. Nightly automation costs zero tokens. On POSIX, resolve the active profile
+   first with `HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"`. Use the
+   `write_file` tool to create the resolved absolute
+   `$HERMES_ROOT/scripts/dream_nightly.sh` path with this body:
+
+   ```sh
+   #!/bin/sh
+   set -eu
+   HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"
+   python3 "$HERMES_ROOT/tools/dream.py" --hermes --apply --quiet
+   ```
+
+   Then register only the relative script name; Hermes resolves it inside
+   the active profile's `scripts/` directory:
+
+   ```bash
+   hermes cron create "0 4 * * *" --name memory-dream --script dream_nightly.sh --no-agent
+   ```
+
+5. Native Windows does not run the POSIX shell script. Register the installed
+   tool with Windows Task Scheduler instead:
+
+   ```powershell
+   $HermesRoot = if ($env:HERMES_HOME) {
+     $env:HERMES_HOME
+   } else {
+     Join-Path $env:LOCALAPPDATA "hermes"
+   }
+   $Python = (Get-Command python).Source
+   $Dream = Join-Path $HermesRoot "tools\dream.py"
+   $Action = New-ScheduledTaskAction -Execute $Python -Argument "`"$Dream`" --hermes --apply --quiet"
+   $Trigger = New-ScheduledTaskTrigger -Daily -At 4am
+   Register-ScheduledTask -TaskName "Hermes memory dream" -Action $Action -Trigger $Trigger
+   ```
+
+## Pitfalls
+
+- Supersession assumes file order = recency (true for Hermes' append-style
+  memory). For non-chronological files use `--no-supersede`.
+- Merging is deterministic clause algebra, not LLM rewriting — wording can
+  be mechanical; information is preserved.
+- Pairwise comparison is O(n²), with hard ceilings: 10 MB, 10,000 entries,
+  and 200,000 comparisons. A limit failure writes no semantic change.
+- Apply is idempotent (unit-tested): a second run on clean memory changes
+  nothing.
+- `HERMES_HOME` always selects the profile. Without it, the native defaults
+  are `~/.hermes` on POSIX and `%LOCALAPPDATA%/hermes` on Windows.
+
+## Verification
+
+POSIX:
+
+```bash
+tmp="$(mktemp -d)"
+cd "$tmp"
+curl -fsSLo dream.py https://raw.githubusercontent.com/Da7-Tech/dream/v1.4.0/dream.py
+python3 -c "import hashlib;h=hashlib.sha256(open('dream.py','rb').read()).hexdigest();assert h=='616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052',h;print('OK')"
+printf 'project mode is blue\n§\nproject mode is blue' > MEMORY.md
+python3 dream.py MEMORY.md --apply --quiet
+cat MEMORY.md
+```
+
+PowerShell:
+
+```powershell
+$Tmp = Join-Path $env:TEMP ("dream-" + [guid]::NewGuid())
+New-Item -ItemType Directory $Tmp | Out-Null
+Set-Location $Tmp
+Invoke-WebRequest "https://raw.githubusercontent.com/Da7-Tech/dream/v1.4.0/dream.py" -OutFile dream.py
+if ((Get-FileHash dream.py -Algorithm SHA256).Hash.ToLowerInvariant() -ne "616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052") {
+  throw "checksum mismatch"
+}
+[IO.File]::WriteAllText((Join-Path $Tmp "MEMORY.md"), "project mode is blue`n§`nproject mode is blue")
+python dream.py MEMORY.md --apply --quiet
+Get-Content MEMORY.md
+```
+
+Expected: `MEMORY.md consolidated: 2 -> 1 entries, ...` and the file
+contains the fact once; the duplicate is in `MEMORY.md.dream-archive.md`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -349,6 +349,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox',
+                    'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-dream',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands',


### PR DESCRIPTION
## What does this PR do?

Adds an optional `dream` skill for deterministic, zero-LLM consolidation of Hermes' existing `MEMORY.md` and `USER.md` files.

The skill is dry-run-first, archives every removed entry with a reason, writes timestamped backups, reports to `DREAMS.md`, and pins the standalone stdlib-only tool to `v1.4.0` with SHA-256 `616997cb6caa4de403e34a1153fe9d15ec8196246039393946d1cb2fb06aa052`.

Maintainer feedback is fully addressed: installation, invocation, configuration lookup, and POSIX cron scripts use one active-profile location resolved from `HERMES_HOME`; native Windows has complete PowerShell install/invocation/verification instructions and uses Task Scheduler instead of the POSIX shell path.

## Related Issue

Related to #28424 and #30199.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Added `optional-skills/autonomous-ai-agents/dream/SKILL.md`.
- Added profile-safe POSIX install, invocation, and cron guidance.
- Added native-Windows PowerShell and Task Scheduler guidance.
- Added 15 hermetic contract tests covering format, release pins, checksums, profile isolation, cron resolution, and the platform split.
- Added the generator-synchronized docs page, optional-skills catalog row, and sidebar entry.

## How to Test

1. Run `scripts/run_tests.sh tests/skills/test_dream_skill.py tests/website/test_generate_skill_docs.py -q`.
2. Run the docs CI flow: install website dependencies, extract skills, regenerate skill docs, run diagram lint, then build both locales.
3. Download the pinned public release, verify its SHA-256, apply it to a temporary duplicate memory file, and confirm the consolidated live file, archive, backup, and `DREAMS.md` report.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

The full-suite checkbox remains open because pristine current `main` fails independently of this PR (`tests/agent/test_anthropic_adapter.py`: 171 passed, 3 failed under the required wrapper). The PR-specific suites and full docs build pass.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — N/A; this is optional
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

No model-backed Hermes session was used. The pinned deterministic tool itself was tested end-to-end from the public release tag.

## Screenshots / Logs

- Wrapper contract tests: 15/15 passed.
- Docs generator tests: 7/7 passed.
- Generated page matched repository generator output byte-for-byte.
- Diagram lint: 366 files, 0 errors.
- Full English and Chinese Docusaurus builds passed.
- Standalone `dream` v1.4.0 CI: 9/9 Linux/macOS/Windows jobs passed across Python 3.9, 3.12, and 3.14; each job ran 72 tests plus fuzz and soak coverage.

