### PR TITLE
feat: add DeepSeek cache observability and baseline probe

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -404,30 +404,43 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("0.14"),
         output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-03-16",
+        pricing_version="deepseek-pricing-2026-07-02",
     ),
     (
         "deepseek",
         "deepseek-reasoner",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.55"),
-        output_cost_per_million=Decimal("2.19"),
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-03-16",
+        pricing_version="deepseek-pricing-2026-07-02",
+    ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-07-02",
     ),
     (
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.74"),
-        output_cost_per_million=Decimal("3.48"),
-        cache_read_cost_per_million=Decimal("0.0145"),
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.003625"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-05-12",
+        pricing_version="deepseek-pricing-2026-07-02",
     ),
     # Google Gemini
     (
@@ -578,6 +591,12 @@ def _to_int(value: Any) -> int:
         return int(value or 0)
     except Exception:
         return 0
+
+
+def _usage_value(usage: Any, key: str, default: Any = 0) -> Any:
+    if isinstance(usage, dict):
+        return usage.get(key, default)
+    return getattr(usage, key, default)
 
 
 def resolve_billing_route(
@@ -784,45 +803,51 @@ def normalize_usage(
     mode = (api_mode or "").strip().lower()
 
     if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
+        input_tokens = _to_int(_usage_value(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_value(response_usage, "output_tokens", 0))
+        cache_read_tokens = _to_int(_usage_value(response_usage, "cache_read_input_tokens", 0))
+        cache_write_tokens = _to_int(_usage_value(response_usage, "cache_creation_input_tokens", 0))
     elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        input_total = _to_int(_usage_value(response_usage, "input_tokens", 0))
+        output_tokens = _to_int(_usage_value(response_usage, "output_tokens", 0))
+        details = _usage_value(response_usage, "input_tokens_details", None)
+        cache_read_tokens = _to_int(_usage_value(details, "cached_tokens", 0) if details else 0)
         cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
+            _usage_value(details, "cache_creation_tokens", 0) if details else 0
         )
         input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
     else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
-        details = getattr(response_usage, "prompt_tokens_details", None)
+        prompt_total = _to_int(_usage_value(response_usage, "prompt_tokens", 0))
+        output_tokens = _to_int(_usage_value(response_usage, "completion_tokens", 0))
+        details = _usage_value(response_usage, "prompt_tokens_details", None)
         # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
         # top-level fields that some OpenAI-compatible proxies (OpenRouter, Cline)
         # expose when routing Claude models — without this
         # fallback, cache writes are undercounted as 0 and cache reads can be
         # missed when the proxy only surfaces them at the top level.
         # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
+        cache_read_tokens = _to_int(_usage_value(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+            cache_read_tokens = _to_int(_usage_value(response_usage, "prompt_cache_hit_tokens", 0))
+        if not cache_read_tokens:
+            cache_read_tokens = _to_int(_usage_value(response_usage, "cache_read_input_tokens", 0))
         cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
+            _usage_value(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
+                _usage_value(response_usage, "cache_creation_input_tokens", 0)
             )
-        input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
+        prompt_cache_miss = _usage_value(response_usage, "prompt_cache_miss_tokens", None)
+        if prompt_cache_miss is not None:
+            input_tokens = _to_int(prompt_cache_miss)
+        else:
+            input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
     reasoning_tokens = 0
-    output_details = getattr(response_usage, "output_tokens_details", None)
+    output_details = _usage_value(response_usage, "output_tokens_details", None)
     if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+        reasoning_tokens = _to_int(_usage_value(output_details, "reasoning_tokens", 0))
 
     return CanonicalUsage(
         input_tokens=input_tokens,

--- a/cli.py
+++ b/cli.py
@@ -9413,6 +9413,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print(f"  {'─' * 40}")
         print(f"  Model:                     {agent.model}")
         print(f"  Input tokens:              {input_tokens:>10,}")
+        cache_read_tokens = getattr(agent, "session_cache_read_tokens", 0) or 0
+        cache_write_tokens = getattr(agent, "session_cache_write_tokens", 0) or 0
+        if cache_read_tokens:
+            print(f"  Cache read tokens:         {cache_read_tokens:>10,}")
+        if cache_write_tokens:
+            print(f"  Cache write tokens:        {cache_write_tokens:>10,}")
         print(f"  Output tokens:             {output_tokens:>10,}")
         if reasoning_tokens:
             print(f"  ↳ Reasoning (subset):      {reasoning_tokens:>10,}")

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3874,10 +3874,16 @@ class GatewaySlashCommandsMixin:
             # Session token usage — detailed breakdown matching CLI
             input_tokens = getattr(agent, "session_input_tokens", 0) or 0
             output_tokens = getattr(agent, "session_output_tokens", 0) or 0
+            cache_read_tokens = getattr(agent, "session_cache_read_tokens", 0) or 0
+            cache_write_tokens = getattr(agent, "session_cache_write_tokens", 0) or 0
 
             lines.append(t("gateway.usage.header_session"))
             lines.append(t("gateway.usage.label_model", model=agent.model))
             lines.append(t("gateway.usage.label_input_tokens", count=f"{input_tokens:,}"))
+            if cache_read_tokens:
+                lines.append(t("gateway.usage.label_cache_read", count=f"{cache_read_tokens:,}"))
+            if cache_write_tokens:
+                lines.append(t("gateway.usage.label_cache_write", count=f"{cache_write_tokens:,}"))
             lines.append(t("gateway.usage.label_output_tokens", count=f"{output_tokens:,}"))
             lines.append(t("gateway.usage.label_total", count=f"{agent.session_total_tokens:,}"))
             lines.append(t("gateway.usage.label_api_calls", count=agent.session_api_calls))

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -90,6 +90,8 @@ deepseek = DeepSeekProfile(
     description="DeepSeek — native DeepSeek API",
     signup_url="https://platform.deepseek.com/",
     fallback_models=(
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
         "deepseek-chat",
         "deepseek-reasoner",
     ),

--- a/scripts/dev/deepseek_cache_baseline_probe.py
+++ b/scripts/dev/deepseek_cache_baseline_probe.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Deterministic DeepSeek context-cache baseline probe.
+
+Dry-run mode is the default and never touches the network. Live mode uses the
+OpenAI-compatible DeepSeek endpoint with an API key read from an environment
+variable, but never prints the key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, cast
+
+MODEL = "deepseek-v4-flash"
+BASE_URL = "https://api.deepseek.com"
+PRICE_PER_1M = {
+    "input_cache_hit": 0.0028,
+    "input_cache_miss": 0.14,
+    "output": 0.28,
+}
+DOCS = {
+    "context_caching": "https://api-docs.deepseek.com/guides/kv_cache",
+    "pricing": "https://api-docs.deepseek.com/quick_start/pricing",
+}
+
+SYSTEM_PROMPT = "You are a precise cache-baseline probe. Answer in one short sentence."
+TAIL_ASKS = [
+    "Return the three section ids that discuss cache persistence.",
+    "Return the two usage field names that report cache hit status.",
+    "Return the pricing ratio between cache-miss and cache-hit input for flash.",
+]
+
+
+@dataclass
+class ProbeRow:
+    request_index: int
+    mode: str
+    model: str
+    prompt_tokens: int
+    prompt_cache_hit_tokens: int
+    prompt_cache_miss_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    cache_hit_rate: float
+    estimated_usd: float
+    usage_fields_present: bool
+    elapsed_seconds: float | None = None
+    response_preview: str | None = None
+
+
+def stable_prefix(repetitions: int = 96) -> str:
+    """Return a byte-stable prefix large enough to make cache behavior visible."""
+    base = [
+        "DEEPSEEK CACHE BASELINE PREFIX v1",
+        "Source: official DeepSeek context caching and pricing docs.",
+        "Invariant: this prefix must remain byte-identical across all probe requests.",
+        "The variable question is appended after CACHE_PROBE_TAIL_START.",
+        "DeepSeek documents cache hits for fully matched persisted cache prefix units.",
+        "DeepSeek exposes usage.prompt_cache_hit_tokens and usage.prompt_cache_miss_tokens.",
+        "deepseek-v4-flash pricing snapshot: hit=$0.0028/M, miss=$0.14/M, output=$0.28/M.",
+    ]
+    for i in range(repetitions):
+        base.append(
+            f"stable-record-{i:03d}: prompt-cache engineering keeps identity, rules, "
+            "references, and examples before volatile task asks."
+        )
+    return "\n".join(base)
+
+
+def build_messages(tail_ask: str, prefix: str) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": f"{prefix}\n\nCACHE_PROBE_TAIL_START\n{tail_ask}"},
+    ]
+
+
+def _usage_value(usage: Any, name: str, default: int = 0) -> int:
+    if isinstance(usage, dict):
+        value = usage.get(name, default)
+    else:
+        value = getattr(usage, name, default)
+    return int(value or 0)
+
+
+def estimate_usd(hit_tokens: int, miss_tokens: int, completion_tokens: int) -> float:
+    return round(
+        (
+            hit_tokens * PRICE_PER_1M["input_cache_hit"]
+            + miss_tokens * PRICE_PER_1M["input_cache_miss"]
+            + completion_tokens * PRICE_PER_1M["output"]
+        )
+        / 1_000_000,
+        10,
+    )
+
+
+def row_from_usage(
+    *,
+    request_index: int,
+    mode: str,
+    model: str,
+    usage: Any,
+    elapsed_seconds: float | None = None,
+    response_preview: str | None = None,
+) -> ProbeRow:
+    prompt_tokens = _usage_value(usage, "prompt_tokens")
+    hit_tokens = _usage_value(usage, "prompt_cache_hit_tokens")
+    miss_tokens = _usage_value(usage, "prompt_cache_miss_tokens")
+    completion_tokens = _usage_value(usage, "completion_tokens")
+    total_tokens = _usage_value(usage, "total_tokens", prompt_tokens + completion_tokens)
+    usage_fields_present = _has_usage_field(usage, "prompt_cache_hit_tokens") and _has_usage_field(
+        usage, "prompt_cache_miss_tokens"
+    )
+    denom = hit_tokens + miss_tokens
+    cache_hit_rate = round(hit_tokens / denom, 6) if denom else 0.0
+    return ProbeRow(
+        request_index=request_index,
+        mode=mode,
+        model=model,
+        prompt_tokens=prompt_tokens,
+        prompt_cache_hit_tokens=hit_tokens,
+        prompt_cache_miss_tokens=miss_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cache_hit_rate=cache_hit_rate,
+        estimated_usd=estimate_usd(hit_tokens, miss_tokens, completion_tokens),
+        usage_fields_present=usage_fields_present,
+        elapsed_seconds=round(elapsed_seconds, 3) if elapsed_seconds is not None else None,
+        response_preview=response_preview,
+    )
+
+
+def _has_usage_field(usage: Any, name: str) -> bool:
+    if isinstance(usage, dict):
+        return name in usage
+    return hasattr(usage, name)
+
+
+def fake_usages() -> Iterable[dict[str, int]]:
+    """Deterministic dry-run usages shaped like DeepSeek usage objects."""
+    yield {
+        "prompt_tokens": 1680,
+        "prompt_cache_hit_tokens": 0,
+        "prompt_cache_miss_tokens": 1680,
+        "completion_tokens": 18,
+        "total_tokens": 1698,
+    }
+    yield {
+        "prompt_tokens": 1684,
+        "prompt_cache_hit_tokens": 0,
+        "prompt_cache_miss_tokens": 1684,
+        "completion_tokens": 20,
+        "total_tokens": 1704,
+    }
+    yield {
+        "prompt_tokens": 1688,
+        "prompt_cache_hit_tokens": 1500,
+        "prompt_cache_miss_tokens": 188,
+        "completion_tokens": 19,
+        "total_tokens": 1707,
+    }
+
+
+def run_dry(model: str) -> list[ProbeRow]:
+    return [
+        row_from_usage(request_index=i, mode="dry_run", model=model, usage=usage)
+        for i, usage in enumerate(fake_usages(), start=1)
+    ]
+
+
+def run_live(*, model: str, base_url: str, api_key_env: str, delay_seconds: float) -> list[ProbeRow]:
+    api_key = os.environ.get(api_key_env)
+    if not api_key:
+        raise RuntimeError(f"missing API key env var: {api_key_env}")
+
+    try:
+        from openai import OpenAI
+    except ImportError as exc:  # pragma: no cover - core dependency in Hermes, safety for direct copies
+        raise RuntimeError("openai package is required for --live") from exc
+
+    client = OpenAI(api_key=api_key, base_url=base_url)
+    prefix = stable_prefix()
+    rows: list[ProbeRow] = []
+    for i, tail_ask in enumerate(TAIL_ASKS, start=1):
+        start = time.perf_counter()
+        response = client.chat.completions.create(
+            model=model,
+            messages=cast(Any, build_messages(tail_ask, prefix)),
+            temperature=0,
+            max_tokens=64,
+        )
+        elapsed = time.perf_counter() - start
+        usage = response.usage
+        content = response.choices[0].message.content if response.choices else ""
+        rows.append(
+            row_from_usage(
+                request_index=i,
+                mode="live",
+                model=model,
+                usage=usage,
+                elapsed_seconds=elapsed,
+                response_preview=(content or "")[:160],
+            )
+        )
+        if delay_seconds and i < len(TAIL_ASKS):
+            time.sleep(delay_seconds)
+    return rows
+
+
+def summarize(rows: list[ProbeRow]) -> dict[str, Any]:
+    total_hit = sum(row.prompt_cache_hit_tokens for row in rows)
+    total_miss = sum(row.prompt_cache_miss_tokens for row in rows)
+    denom = total_hit + total_miss
+    return {
+        "requests": len(rows),
+        "prompt_cache_hit_tokens": total_hit,
+        "prompt_cache_miss_tokens": total_miss,
+        "cache_hit_rate": round(total_hit / denom, 6) if denom else 0.0,
+        "prompt_tokens": sum(row.prompt_tokens for row in rows),
+        "completion_tokens": sum(row.completion_tokens for row in rows),
+        "total_tokens": sum(row.total_tokens for row in rows),
+        "estimated_usd": round(sum(row.estimated_usd for row in rows), 10),
+        "all_usage_fields_present": all(row.usage_fields_present for row in rows),
+    }
+
+
+def build_output(*, rows: list[ProbeRow], args: argparse.Namespace, credential_available: bool) -> dict[str, Any]:
+    return {
+        "probe": "deepseek_cache_baseline",
+        "schema_version": 1,
+        "mode": "live" if args.live else "dry_run",
+        "model": args.model,
+        "base_url": args.base_url,
+        "credential_env": args.api_key_env,
+        "credential_available": credential_available,
+        "docs": DOCS,
+        "prices_per_1m_usd": PRICE_PER_1M,
+        "prefix_sha256": _sha256_text(stable_prefix()),
+        "variable_tail_count": len(TAIL_ASKS),
+        "summary": summarize(rows),
+        "rows": [asdict(row) for row in rows],
+    }
+
+
+def _sha256_text(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--live", action="store_true", help="call the DeepSeek API; default is deterministic dry-run")
+    parser.add_argument("--model", default=MODEL, help=f"DeepSeek model name (default: {MODEL})")
+    parser.add_argument("--base-url", default=BASE_URL, help=f"OpenAI-compatible base URL (default: {BASE_URL})")
+    parser.add_argument("--api-key-env", default="DEEPSEEK_API_KEY", help="environment variable holding the API key")
+    parser.add_argument("--delay-seconds", type=float, default=3.0, help="delay between live requests so cache persistence can settle")
+    parser.add_argument("--output", type=Path, help="write JSON output to this path instead of stdout")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    credential_available = bool(os.environ.get(args.api_key_env))
+    try:
+        rows = (
+            run_live(
+                model=args.model,
+                base_url=args.base_url,
+                api_key_env=args.api_key_env,
+                delay_seconds=args.delay_seconds,
+            )
+            if args.live
+            else run_dry(args.model)
+        )
+        output = build_output(rows=rows, args=args, credential_available=credential_available)
+        exit_code = 0
+    except Exception as exc:
+        output = {
+            "probe": "deepseek_cache_baseline",
+            "schema_version": 1,
+            "mode": "live" if args.live else "dry_run",
+            "model": args.model,
+            "credential_env": args.api_key_env,
+            "credential_available": credential_available,
+            "error": str(exc),
+        }
+        exit_code = 2
+
+    text = json.dumps(output, indent=2, sort_keys=True)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text + "\n", encoding="utf-8")
+    else:
+        print(text)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -86,6 +86,39 @@ def test_normalize_usage_openai_reads_top_level_cache_read_when_details_missing(
     assert normalized.input_tokens == 200
 
 
+def test_normalize_usage_deepseek_prompt_cache_hit_miss_fields():
+    """DeepSeek reports cache hit/miss as top-level prompt_cache_* fields."""
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        prompt_cache_hit_tokens=800,
+        prompt_cache_miss_tokens=200,
+        completion_tokens=100,
+    )
+
+    normalized = normalize_usage(usage, provider="deepseek", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 200
+    assert normalized.cache_read_tokens == 800
+    assert normalized.cache_write_tokens == 0
+    assert normalized.output_tokens == 100
+    assert normalized.prompt_tokens == 1000
+
+
+def test_normalize_usage_deepseek_prompt_cache_fields_support_dicts():
+    usage = {
+        "prompt_tokens": 1000,
+        "prompt_cache_hit_tokens": 800,
+        "prompt_cache_miss_tokens": 200,
+        "completion_tokens": 100,
+    }
+
+    normalized = normalize_usage(usage, provider="deepseek", api_mode="chat_completions")
+
+    assert normalized.input_tokens == 200
+    assert normalized.cache_read_tokens == 800
+    assert normalized.output_tokens == 100
+
+
 def test_normalize_usage_openai_prefers_prompt_tokens_details_over_top_level():
     """When both prompt_tokens_details and top-level Anthropic fields are
     present, we prefer the OpenAI-standard nested fields. Top-level Anthropic
@@ -233,9 +266,22 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 1.74
-    assert float(entry.output_cost_per_million) == 3.48
-    assert float(entry.cache_read_cost_per_million) == 0.0145
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+    assert float(entry.cache_read_cost_per_million) == 0.003625
+
+
+def test_deepseek_v4_flash_pricing_entry_exists():
+    entry = get_pricing_entry(
+        "deepseek-v4-flash",
+        provider="deepseek",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
+    assert entry.cache_write_cost_per_million is None
 
 
 def test_deepseek_v4_pro_estimate_usage_cost():
@@ -248,8 +294,20 @@ def test_deepseek_v4_pro_estimate_usage_cost():
 
     assert result.status == "estimated"
     assert result.amount_usd is not None
-    # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
-    assert float(result.amount_usd) == 3.48
+    # 1M input × $0.435/M + 500K output × $0.87/M = $0.435 + $0.435 = $0.87
+    assert float(result.amount_usd) == 0.87
+
+
+def test_deepseek_v4_flash_estimate_usage_cost_with_cache_read():
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        CanonicalUsage(input_tokens=200, cache_read_tokens=800, output_tokens=100),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    assert result.amount_usd > 0
 
 
 def test_bedrock_claude_rows_all_carry_cache_pricing():

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -507,7 +507,41 @@ class TestCLIStatusBar:
 
 
 class TestCLIUsageReport:
-    def test_show_usage_omits_cost_reporting(self, capsys):
+    def test_show_usage_shows_cache_reporting_when_nonzero(self, capsys):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            compressions=1,
+            cache_read_tokens=800,
+            cache_write_tokens=200,
+        )
+        cli_obj.verbose = False
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        # Token counts and session metadata still shown.
+        assert "Model:" in output
+        assert "Input tokens:" in output
+        assert "Output tokens:" in output
+        assert "Total tokens:" in output
+        assert "Session duration:" in output
+        assert "Compressions:" in output
+        assert "Cache read tokens:" in output
+        assert "800" in output
+        assert "Cache write tokens:" in output
+        assert "200" in output
+        # Cost reporting stays omitted.
+        assert "Total cost:" not in output
+        assert "Cost status:" not in output
+        assert "Cost source:" not in output
+
+    def test_show_usage_omits_cache_reporting_when_zero(self, capsys):
         cli_obj = _attach_agent(
             _make_cli(),
             prompt_tokens=10_230,
@@ -523,17 +557,6 @@ class TestCLIUsageReport:
         cli_obj._show_usage()
         output = capsys.readouterr().out
 
-        # Token counts and session metadata still shown.
-        assert "Model:" in output
-        assert "Input tokens:" in output
-        assert "Output tokens:" in output
-        assert "Total tokens:" in output
-        assert "Session duration:" in output
-        assert "Compressions:" in output
-        # Cost and cache-hit reporting is removed everywhere.
-        assert "Total cost:" not in output
-        assert "Cost status:" not in output
-        assert "Cost source:" not in output
         assert "Cache read tokens:" not in output
         assert "Cache write tokens:" not in output
 

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -86,10 +86,10 @@ class TestUsageCachedAgent:
         assert "50,000" in result  # total
         assert "30,000" in result  # context
         assert "Compressions: 1" in result
-        # Cost and cache-hit reporting is removed everywhere.
+        # Cost reporting stays omitted; nonzero cache buckets are visible.
         assert "$" not in result
-        assert "Cache read" not in result
-        assert "Cache write" not in result
+        assert "Cache read tokens: 5,000" in result
+        assert "Cache write tokens: 2,000" in result
         assert "Cost" not in result
 
     @pytest.mark.asyncio

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -205,3 +205,13 @@ class TestDeepSeekAuxModel:
     def test_consumer_api_returns_non_empty(self):
         from agent.auxiliary_client import _get_aux_model_for_provider
         assert _get_aux_model_for_provider("deepseek") != ""
+
+
+class TestDeepSeekFallbackModels:
+    def test_profile_fallback_models_include_current_v4_and_legacy_aliases(self, deepseek_profile):
+        assert deepseek_profile.fallback_models == (
+            "deepseek-v4-flash",
+            "deepseek-v4-pro",
+            "deepseek-chat",
+            "deepseek-reasoner",
+        )

--- a/tests/scripts/test_deepseek_cache_baseline_probe.py
+++ b/tests/scripts/test_deepseek_cache_baseline_probe.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "dev" / "deepseek_cache_baseline_probe.py"
+
+
+def run_probe(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    if env is not None:
+        merged_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        env=merged_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_dry_run_outputs_cache_schema(tmp_path):
+    output = tmp_path / "probe.json"
+    result = run_probe("--output", str(output))
+
+    assert result.returncode == 0, result.stderr
+    data = json.loads(output.read_text(encoding="utf-8"))
+
+    assert data["probe"] == "deepseek_cache_baseline"
+    assert data["mode"] == "dry_run"
+    assert data["model"] == "deepseek-v4-flash"
+    assert data["summary"]["prompt_cache_hit_tokens"] == 1500
+    assert data["summary"]["prompt_cache_miss_tokens"] == 3552
+    assert 0 < data["summary"]["cache_hit_rate"] < 1
+    assert data["summary"]["all_usage_fields_present"] is True
+    assert len(data["prefix_sha256"]) == 64
+    for row in data["rows"]:
+        assert "prompt_cache_hit_tokens" in row
+        assert "prompt_cache_miss_tokens" in row
+        assert "cache_hit_rate" in row
+        assert "estimated_usd" in row
+
+
+def test_live_missing_credential_reports_only_env_name(monkeypatch):
+    monkeypatch.delenv("TEST_DEEPSEEK_API_KEY", raising=False)
+    result = run_probe("--live", "--api-key-env", "TEST_DEEPSEEK_API_KEY")
+
+    assert result.returncode == 2
+    data = json.loads(result.stdout)
+    assert data["credential_available"] is False
+    assert data["credential_env"] == "TEST_DEEPSEEK_API_KEY"
+    assert "TEST_DEEPSEEK_API_KEY" in data["error"]
+    assert "sk-" not in result.stdout

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8322,6 +8322,28 @@ def test_get_usage_safe_when_active_count_raises(monkeypatch):
     assert usage["model"] == "x"
 
 
+def test_get_usage_includes_nonzero_cache_buckets(monkeypatch):
+    import tools.async_delegation as ad_mod
+
+    class _CacheAgent(_BareAgent):
+        session_cache_read_tokens = 800
+        session_cache_write_tokens = 200
+
+    monkeypatch.setattr(ad_mod, "active_count", lambda: 0)
+    usage = server._get_usage(_CacheAgent())
+    assert usage["cache_read"] == 800
+    assert usage["cache_write"] == 200
+
+
+def test_get_usage_omits_zero_cache_buckets(monkeypatch):
+    import tools.async_delegation as ad_mod
+
+    monkeypatch.setattr(ad_mod, "active_count", lambda: 0)
+    usage = server._get_usage(_BareAgent())
+    assert "cache_read" not in usage
+    assert "cache_write" not in usage
+
+
 def test_persist_model_switch_preserves_sibling_model_keys(tmp_path, monkeypatch):
     """#48305: switching models from the TUI must NOT destroy sibling keys under
     `model:` (model_slots, model_fallback, etc.). _persist_model_switch now uses

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2971,6 +2971,12 @@ def _get_usage(agent) -> dict:
         "total": g("session_total_tokens"),
         "calls": g("session_api_calls"),
     }
+    cache_read = g("session_cache_read_tokens")
+    cache_write = g("session_cache_write_tokens")
+    if cache_read:
+        usage["cache_read"] = cache_read
+    if cache_write:
+        usage["cache_write"] = cache_write
     comp = getattr(agent, "context_compressor", None)
     if comp:
         # context_used is the *current-window* occupancy. Do NOT fall back to


### PR DESCRIPTION
## Summary
- Add a deterministic DeepSeek cache baseline probe for dry-run and live measurement.
- Preserve DeepSeek `prompt_cache_hit_tokens` /
`prompt_cache_miss_tokens` in normalized usage accounting.
- Surface cache read/write buckets in CLI, gateway, and TUI usage reporting.
- Update DeepSeek V4 Flash / V4 Pro pricing and fallback model exposure.

## Why
DeepSeek V4 Flash has a large price gap between cache-hit and cache-miss input tokens, so Hermes needs to preserve and display cache hit/miss usage fields instead of collapsing them into aggregate prompt tokens.

## Validation
Focused tests passed locally:
- `tests/scripts/test_deepseek_cache_baseline_probe.py`
- `tests/agent/test_usage_pricing.py`
- `tests/cli/test_cli_status_bar.py -k TestCLIUsageReport`
- `tests/gateway/test_usage_command.py`
- `tests/plugins/model_providers/test_deepseek_profile.py`
- `tests/test_tui_gateway_server.py -k usage`

Additional local live measurement via OpenCode Go / DeepSeek V4 Flash showed warm gateway-shaped prompts reaching high cache-read rates, but this PR intentionally only adds observability/tooling and does not change default provider/model rollout behavior.

## Scope
No default model/provider changes, no prompt architecture rewrite, and no deployment rollout.