### PR TITLE
fix(gateway): compression routing integrity (salvage #55300 + #55721 + #50517)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11001,6 +11001,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 session_entry.session_id = agent_result["session_id"]
                 self.session_store._save()
+                self.session_store._record_gateway_session_peer(
+                    session_entry.session_id,
+                    session_key,
+                    source,
+                )
                 await asyncio.to_thread(
                     self._sync_telegram_topic_binding,
                     source, session_entry, reason="agent-result-compression",
@@ -17712,6 +17717,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if entry:
                     entry.session_id = agent_session_id
                     self.session_store._save()
+                    self.session_store._record_gateway_session_peer(
+                        agent_session_id,
+                        session_key,
+                        source,
+                    )
 
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10891,13 +10891,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
-            # Run the agent
+            # Run the agent. Capture the session id that this run was launched
+            # against so post-run compression publication can be identity-guarded
+            # below; a /new or another lifecycle transition may move
+            # session_entry.session_id while the old run is still unwinding.
+            _run_start_session_id = session_entry.session_id
             agent_result = await self._run_agent(
                 message=message_text,
                 context_prompt=context_prompt,
                 history=history,
                 source=source,
-                session_id=session_entry.session_id,
+                session_id=_run_start_session_id,
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
@@ -10999,17 +11003,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
-                session_entry.session_id = agent_result["session_id"]
-                self.session_store._save()
-                self.session_store._record_gateway_session_peer(
-                    session_entry.session_id,
-                    session_key,
-                    source,
-                )
-                await asyncio.to_thread(
-                    self._sync_telegram_topic_binding,
-                    source, session_entry, reason="agent-result-compression",
-                )
+                if session_entry.session_id == _run_start_session_id:
+                    session_entry.session_id = agent_result["session_id"]
+                    self.session_store._save()
+                    self.session_store._record_gateway_session_peer(
+                        session_entry.session_id,
+                        session_key,
+                        source,
+                    )
+                    await asyncio.to_thread(
+                        self._sync_telegram_topic_binding,
+                        source, session_entry, reason="agent-result-compression",
+                    )
+                else:
+                    logger.info(
+                        "Skipping agent-result session split sync for %s because "
+                        "the session binding moved from %s to %s before "
+                        "compression finished",
+                        session_key or "?",
+                        _run_start_session_id,
+                        session_entry.session_id,
+                    )
 
             # Prepend reasoning/thinking if display is enabled (per-platform).
             # Mattermost requires explicit per-platform opt-in because this is
@@ -17714,14 +17728,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_id, agent_session_id,
                 )
                 entry = self.session_store._entries.get(session_key)
+                _session_split_entry_persisted = False
                 if entry:
-                    entry.session_id = agent_session_id
-                    self.session_store._save()
-                    self.session_store._record_gateway_session_peer(
-                        agent_session_id,
-                        session_key,
-                        source,
-                    )
+                    entry_session_id = getattr(entry, "session_id", None)
+                    if not _run_still_current():
+                        logger.info(
+                            "Skipping session split sync for stale run %s — "
+                            "generation %s is no longer current",
+                            session_key or "?",
+                            run_generation,
+                        )
+                    elif entry_session_id == agent_session_id:
+                        _session_split_entry_persisted = True
+                    elif entry_session_id != session_id:
+                        logger.info(
+                            "Skipping session split sync for %s because the "
+                            "session binding moved from %s to %s before "
+                            "compression finished",
+                            session_key or "?",
+                            session_id,
+                            entry_session_id,
+                        )
+                    else:
+                        entry.session_id = agent_session_id
+                        self.session_store._save()
+                        self.session_store._record_gateway_session_peer(
+                            agent_session_id,
+                            session_key,
+                            source,
+                        )
+                        _session_split_entry_persisted = True
 
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it
@@ -17729,8 +17765,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # correct message_thread_id instead of routing to the General
                 # thread.  Failure here is non-fatal — we log and continue;
                 # worst case the message lands in General, which is the
-                # pre-fix behaviour.
-                if (
+                # pre-fix behaviour. Only do this after this run successfully
+                # published its session split; a stale /stop→/new predecessor
+                # must not mutate routing/binding state for the fresh session.
+                if _session_split_entry_persisted and (
                     getattr(source, "platform", None) == Platform.TELEGRAM
                     and getattr(source, "chat_type", None) == "dm"
                     and getattr(source, "thread_id", None) is None
@@ -17754,7 +17792,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Failed to restore thread_id from binding after session split",
                             exc_info=True,
                         )
-                if entry:
+                if _session_split_entry_persisted:
                     self._sync_telegram_topic_binding(
                         source, entry, reason="agent-run-compression",
                     )

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -965,6 +965,7 @@ class SessionStore:
             return
 
         stale_keys: list = []
+        recovered_keys = 0
         try:
             for key, entry in self._entries.items():
                 row = db.get_session(entry.session_id)
@@ -972,6 +973,43 @@ class SessionStore:
                 # end_reason is None  -> session alive — keep
                 # end_reason not None -> session ended — prune
                 if row is not None and row.get("end_reason") is not None:
+                    recovered_entry = None
+                    if entry.origin is not None:
+                        try:
+                            recovered_entry = self._recover_session_from_db(
+                                session_key=key,
+                                source=entry.origin,
+                                now=_now(),
+                            )
+                        except Exception as exc:
+                            logger.debug(
+                                "gateway.session: recovery lookup failed for stale "
+                                "sessions.json entry %r -> %s: %s",
+                                key,
+                                entry.session_id,
+                                exc,
+                            )
+
+                    # If the stale entry points at a compression-ended parent but
+                    # a newer live child session exists for the exact same gateway
+                    # peer, repoint the routing index instead of dropping it. A
+                    # hard restart between compression rotation and the next clean
+                    # save otherwise leaves Telegram with no resumable mapping, so
+                    # queued/resume-pending work disappears until the user sends a
+                    # fresh message.
+                    if recovered_entry is not None and recovered_entry.session_id != entry.session_id:
+                        logger.warning(
+                            "gateway.session: repointing stale sessions.json entry "
+                            "%r from ended %s (end_reason=%r) to recovered %s",
+                            key,
+                            entry.session_id,
+                            row["end_reason"],
+                            recovered_entry.session_id,
+                        )
+                        self._entries[key] = recovered_entry
+                        recovered_keys += 1
+                        continue
+
                     logger.warning(
                         "gateway.session: pruning stale sessions.json entry "
                         "%r -> %s (end_reason=%r); left by a crashed gateway",
@@ -988,7 +1026,7 @@ class SessionStore:
         for key in stale_keys:
             del self._entries[key]
 
-        if stale_keys:
+        if stale_keys or recovered_keys:
             self._save()
 
     def _save(self) -> None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3056,6 +3056,17 @@ class GatewaySlashCommandsMixin:
             from agent.model_metadata import estimate_request_tokens_rough
 
             session_key = self._session_key_for_source(source)
+            # Preserve the same platform + stable gateway session identity that a
+            # normal gateway turn passes (gateway/run.py main turn), so external
+            # context engines bind this temporary compression agent to the
+            # original platform conversation instead of falling back to an
+            # unbound/default "cli" host source — see #50422. _platform_config_key
+            # maps LOCAL->"cli" exactly like the live turn, avoiding a new
+            # "local" vs "cli" mismatch.
+            from gateway.run import _platform_config_key
+            platform_key = (
+                _platform_config_key(source.platform) if source.platform else None
+            )
             model, runtime_kwargs = self._resolve_session_agent_runtime(
                 source=source,
                 session_key=session_key,
@@ -3082,6 +3093,21 @@ class GatewaySlashCommandsMixin:
                     partial = False
                     head = msgs
 
+            # Bind the temporary compression agent to the originating source's
+            # platform + stable gateway session key. These are *authoritative*
+            # identity invariants (derived from `source`), so assign them into
+            # runtime_kwargs directly rather than via setdefault: a value already
+            # present there from the resolver would be a placeholder/stale
+            # identity and must not win. Assigning (vs passing a second explicit
+            # kwarg) also keeps each key single-valued, avoiding a "got multiple
+            # values for keyword argument" TypeError. platform is only set when
+            # known: for a source without platform metadata we leave it unset so
+            # AIAgent's default (platform=None -> source "cli") applies, exactly
+            # the prior behavior. _resolve_session_agent_runtime does not set
+            # either key today, so in practice this just adds them.
+            if platform_key is not None:
+                runtime_kwargs["platform"] = platform_key
+            runtime_kwargs["gateway_session_key"] = session_key
             tmp_agent = AIAgent(
                 **runtime_kwargs,
                 model=model,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,8 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "jvsantos.cunha@gmail.com": "plcunha",  # PR #55300 salvage (gateway: record child gateway peer metadata after a compression session-id rotation and repoint stale sessions.json compression-parent entries to the recovered live child; consolidated in the compression-routing-integrity salvage)
+    "jakepresent1@gmail.com": "jakepresent",  # PR #55721 salvage (gateway: identity-guard stale in-flight compression splits — a late run may publish its compressed child only if its run generation is still current and the session key still points at the run's original parent, so an old run can't overwrite a newer /new or moved binding)
     "zhangml@tech.icbc.com.cn": "zmlgit",  # PR #54872 salvage (multiplex-profile kanban: route task notifications via the owning profile's adapter + wake the creator agent with a synthetic internal MessageEvent on terminal events)
     "1079826437@qq.com": "nankingjing",  # PR #56404 salvage (gateway: while a state.db compression lock is held for the session, demote busy_input_mode 'interrupt' to 'queue' so a rapid message burst can't interrupt and fork orphaned compression siblings off a stale parent; #56391)
     "ud@arubangles.com": "udatny",  # PR #29433 salvage (subdirectory_hints: catch RuntimeError from Path.expanduser()/Path.home() so a literal ~ in tool-call args — e.g. LLM "~500-700" or ~unknownuser — can't escape the hint walker and crash the conversation loop)

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -413,3 +413,73 @@ async def test_compress_command_in_place_write_failure_reports_error():
     runner.session_store._save.assert_not_called()
     agent_instance.shutdown_memory_provider.assert_called_once()
     agent_instance.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_compress_command_preserves_platform_and_gateway_session_key():
+    """The temporary compression agent must carry the originating source's
+    platform and stable gateway session key, matching a normal gateway turn.
+    Without them ``_session_source_for_agent`` falls back to a default "cli"
+    host source, so an external context engine misattributes the retained
+    transcript tail and later duplicates it on resume (#50422)."""
+    history = _make_history()
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance) as mock_agent,
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        await runner._handle_compress_command(_make_event())
+
+    assert mock_agent.call_count == 1
+    _, kwargs = mock_agent.call_args
+    # Platform preserved as the live turn's config key (TELEGRAM -> "telegram"),
+    # not the unbound "cli"/"local" fallback.
+    assert kwargs.get("platform") == "telegram"
+    # Stable gateway session key preserved, identical to a normal gateway turn.
+    assert kwargs.get("gateway_session_key") == runner._session_key_for_source(_make_source())
+    assert kwargs["gateway_session_key"]
+
+
+@pytest.mark.asyncio
+async def test_compress_command_overrides_stale_resolver_identity():
+    """If the resolver already supplies platform/gateway_session_key, the
+    construction must (a) not raise "got multiple values for keyword argument",
+    and (b) let the originating-source identity win — a stale/placeholder
+    resolver value must not defeat the attribution fix."""
+    history = _make_history()
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+
+    # Resolver injects a WRONG platform and a stale session key.
+    runtime = {"api_key": "test-key", "platform": "discord", "gateway_session_key": "stale-key"}
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value=runtime),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance) as mock_agent,
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        await runner._handle_compress_command(_make_event())  # must not raise
+
+    assert mock_agent.call_count == 1
+    _, kwargs = mock_agent.call_args
+    # Source-derived identity overrides the stale resolver values, passed once.
+    assert kwargs["platform"] == "telegram"
+    assert kwargs["gateway_session_key"] == runner._session_key_for_source(_make_source())

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -170,6 +170,10 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     assert result["history_offset"] == 0
     assert session_store.entry.session_id == "session-after-compression"
     assert session_store.save_calls == 1
+    # #55300: the child's gateway peer metadata is recorded on the persist path.
+    assert session_store.peer_records == [
+        ("session-after-compression", SESSION_KEY, source)
+    ]
     runner._sync_telegram_topic_binding.assert_called_once_with(
         source, session_store.entry, reason="agent-run-compression"
     )
@@ -197,6 +201,7 @@ def test_stale_run_does_not_overwrite_new_session_after_compression(monkeypatch)
     assert result["history_offset"] == 0
     assert session_store.entry.session_id == "session-before-compression"
     assert session_store.save_calls == 0
+    assert session_store.peer_records == []
     assert getattr(runner._sync_telegram_topic_binding, "call_count") == 0
 
 
@@ -222,4 +227,5 @@ def test_session_split_sync_skips_when_binding_already_moved(monkeypatch):
     assert result["history_offset"] == 0
     assert session_store.entry.session_id == "fresh-session-after-new"
     assert session_store.save_calls == 0
+    assert session_store.peer_records == []
     assert getattr(runner._sync_telegram_topic_binding, "call_count") == 0

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -119,7 +119,7 @@ def _runner(session_store):
     return runner
 
 
-def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
+def _install_compression_failure_agent(monkeypatch):
     fake_run_agent = types.ModuleType("run_agent")
     fake_run_agent.AIAgent = _CompressionThenFailureAgent
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
@@ -132,11 +132,9 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
 
     monkeypatch.setattr(tools_config, "_get_platform_tools", lambda *_args, **_kwargs: {"core"})
 
-    session_store = _SessionStore()
-    runner = _runner(session_store)
-    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
 
-    result = asyncio.run(
+def _run_compression_failure_turn(runner, source, *, run_generation=None):
+    return asyncio.run(
         asyncio.wait_for(
             runner._run_agent(
                 message="continue",
@@ -145,10 +143,21 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
                 source=source,
                 session_id="session-before-compression",
                 session_key=SESSION_KEY,
+                run_generation=run_generation,
             ),
             timeout=2,
         )
     )
+
+
+def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+
+    result = _run_compression_failure_turn(runner, source)
 
     assert result["failed"] is True
     assert result["session_id"] == "session-after-compression"
@@ -158,3 +167,53 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     runner._sync_telegram_topic_binding.assert_called_once_with(
         source, session_store.entry, reason="agent-run-compression"
     )
+
+
+def test_stale_run_does_not_overwrite_new_session_after_compression(monkeypatch):
+    """A /stop + /new can invalidate a run while its compression is still unwinding.
+
+    The stale run may still return with a rotated agent.session_id, but it must
+    not publish that old compressed child back into the channel's active session
+    binding. The outer gateway stale-result check will discard the response too;
+    this regression covers the earlier side effect inside _run_agent().
+    """
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    runner._session_run_generation[SESSION_KEY] = 2
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+
+    result = _run_compression_failure_turn(runner, source, run_generation=1)
+
+    assert result["failed"] is True
+    assert result["session_id"] == "session-after-compression"
+    assert result["history_offset"] == 0
+    assert session_store.entry.session_id == "session-before-compression"
+    assert session_store.save_calls == 0
+    assert getattr(runner._sync_telegram_topic_binding, "call_count") == 0
+
+
+def test_session_split_sync_skips_when_binding_already_moved(monkeypatch):
+    """A live session binding is identity-guarded, not blindly overwritten.
+
+    This catches the exact race where an old run starts with session A, /new
+    moves the binding to fresh session B, and the old run finishes compression
+    into child C. C must not replace B.
+    """
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    session_store.entry.session_id = "fresh-session-after-new"
+    runner = _runner(session_store)
+    runner._session_run_generation[SESSION_KEY] = 1
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+
+    result = _run_compression_failure_turn(runner, source, run_generation=1)
+
+    assert result["failed"] is True
+    assert result["session_id"] == "session-after-compression"
+    assert result["history_offset"] == 0
+    assert session_store.entry.session_id == "fresh-session-after-new"
+    assert session_store.save_calls == 0
+    assert getattr(runner._sync_telegram_topic_binding, "call_count") == 0

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -21,9 +21,15 @@ class _SessionStore:
         )
         self._entries = {SESSION_KEY: self.entry}
         self.save_calls = 0
+        self.peer_records = []
 
     def _save(self):
         self.save_calls += 1
+
+    def _record_gateway_session_peer(self, session_id, session_key, source):
+        # #55300 records the child's gateway peer metadata after a compression
+        # split; the fake tracks the call so tests can assert it fired.
+        self.peer_records.append((session_id, session_key, source))
 
 
 class _CompressionThenFailureAgent:

--- a/tests/gateway/test_session_store_stale_prune.py
+++ b/tests/gateway/test_session_store_stale_prune.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from gateway.config import GatewayConfig, Platform, SessionResetPolicy
-from gateway.session import SessionEntry, SessionStore
+from gateway.session import SessionEntry, SessionSource, SessionStore
 
 
 # ---------------------------------------------------------------------------
@@ -29,6 +29,18 @@ def _make_entry(key: str, session_id: str) -> SessionEntry:
         platform=Platform.TELEGRAM,
         chat_type="dm",
     )
+
+
+def _make_entry_with_origin(key: str, session_id: str) -> SessionEntry:
+    entry = _make_entry(key, session_id)
+    entry.origin = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="5140768830",
+        chat_type="dm",
+        user_id="5140768830",
+        user_name="João",
+    )
+    return entry
 
 
 def _make_store_with_db(tmp_path, db_mock) -> SessionStore:
@@ -97,6 +109,47 @@ class TestPruneStaleSessionsLocked:
         assert "key_a" not in store._entries
         assert "key_b" not in store._entries
         assert "key_c" in store._entries
+
+    def test_repoints_stale_compression_parent_to_latest_live_child(self, tmp_path):
+        """Compression-ended parents should recover their live child mapping.
+
+        A gateway crash can leave sessions.json pointing at the pre-compression
+        parent (end_reason='compression') even though the agent already rotated
+        into a live child session. If the child has gateway peer metadata, the
+        startup prune pass must repoint the route instead of deleting it, or
+        restart auto-resume and queued follow-ups have no session to continue.
+        """
+        key = "agent:main:telegram:dm:5140768830"
+        db = _db_returning({
+            "sid_parent": {"end_reason": "compression", "id": "sid_parent"},
+        })
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_child",
+            "started_at": 1782744974.0,
+        }
+        store = _make_store_with_db(tmp_path, db)
+        store._entries[key] = _make_entry_with_origin(key, "sid_parent")
+
+        store._prune_stale_sessions_locked()
+
+        assert key in store._entries
+        assert store._entries[key].session_id == "sid_child"
+        db.find_latest_gateway_session_for_peer.assert_called_once()
+        db.reopen_session.assert_called_once_with("sid_child")
+
+    def test_prunes_stale_entry_when_recovery_only_finds_same_ended_session(self, tmp_path):
+        key = "agent:main:telegram:dm:5140768830"
+        db = _db_returning({"sid_parent": {"end_reason": "agent_close", "id": "sid_parent"}})
+        db.find_latest_gateway_session_for_peer.return_value = {
+            "id": "sid_parent",
+            "started_at": 1782744974.0,
+        }
+        store = _make_store_with_db(tmp_path, db)
+        store._entries[key] = _make_entry_with_origin(key, "sid_parent")
+
+        store._prune_stale_sessions_locked()
+
+        assert key not in store._entries
 
     def test_noop_when_db_is_none(self, tmp_path):
         config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))


### PR DESCRIPTION
## Summary

Consolidates the reviewable, credit-preserving subset of the open gateway compression-routing PRs into one branch, cherry-picked so each original author's commit authorship survives in git history.

The `chore(release)` commit lands first so the release contributor audit (`scripts/contributor_audit.py`) attributes the cherry-picked contributors when this merges.

## Commits (authorship preserved)

| Commit | Author | Source PR | What it fixes |
|---|---|---|---|
| `chore(release): add AUTHOR_MAP entries…` | me | — | Maps `plcunha` + `jakepresent` so the audit passes (r266-tech already mapped) |
| `fix(gateway): preserve peer routing across compression recovery` | @plcunha | #55300 | Records the compression child's gateway peer metadata after a session-id rotation and repoints stale `sessions.json` compression-parent entries to the recovered live child |
| `fix(gateway): ignore stale compression session splits` | @jakepresent | #55721 | Identity-guards stale in-flight compression splits — a late run publishes its compressed child only if its run generation is still current and the session key still points at the run's original parent (so an old run can't overwrite a newer `/new`, `/stop`, or moved binding) |
| `fix(gateway): preserve platform + gateway_session_key on /compress temp agent` | @r266-tech | #50517 | Manual `/compress` temporary agent carries the originating source's platform + stable gateway session key instead of an unbound "cli" identity |
| `test(gateway): align fake SessionStore with _record_gateway_session_peer` | me (Co-authored-by @plcunha) | — | #55300's peer-record call now fires on the failed-turn split path; the fake `_SessionStore` in `test_compression_failure_session_sync` (carried in with #55721's test changes) lacked that method — add a call-tracking no-op so the combined tests pass |

#55300 and #55721 both guard the same compression-split block; their changes were combined (peer-record **and** the run-generation/active-route identity guard) at both split sites.

## Deliberately NOT included

- **#43766** (`keep Telegram topic bindings on compression descendants`, @dykhalkin) — its core (heal a topic binding to the compression tip via `get_compression_tip`) is **already on `main`** (the `compression-tip-walk` rewrite + `get_compression_tip` are present in `gateway/run.py`). The only piece unique to #43766 is a generic `is_session_descendant()` helper that follows *any* `parent_session_id` lineage — which current `main` deliberately does **not** do (compression-tip-only is the chosen design). Recommend closing #43766 as already-fixed-on-main rather than resurrecting the rejected generic-descendant approach.
- **The centralized `_publish_compression_session_split` / `_advance_session_entry_to_compression_tip` chokepoint + the `sessions.json`↔`state.db` "repairable index" semantic reframe** proposed in PR #56819. That is a **maintainer-level design decision** (it changes stale-parent handling from prune → repair-and-repoint and reframes the recovery contract), not a routine salvage — it should be its own PR with explicit maintainer sign-off, plus a background-notification-routing regression it adds. This branch keeps the three focused, independently-correct contributor fixes without forking the design.

## Tests

- `scripts/run_tests.sh` equivalent PR-scoped set: **191 passed** — `tests/gateway/test_compress_command.py`, `test_compression_failure_session_sync.py`, `test_session_store_stale_prune.py`, `test_compression_session_id_persistence.py`, `test_telegram_topic_mode.py`, `test_background_process_notifications.py`, `test_agent_cache.py`, `test_async_session_db.py`.
- `ruff check` clean; `py_compile` clean on all touched Python.

## Supersedes (close with credit after merge)

- Supersedes #55300 by @plcunha (commit cherry-picked, authorship preserved)
- Supersedes #55721 by @jakepresent (commit cherry-picked, authorship preserved)
- Supersedes #50517 by @r266-tech (commit cherry-picked, authorship preserved)

Related: #43766 (already fixed on `main`), #56819 (consolidation proposal — chokepoint/semantic change deferred as a maintainer design decision; these three contributor fixes are salvaged here with credit intact).
