### PR TITLE
fix(tui_gateway): prefer profile terminal.cwd over stale client-sent cwd on profile switch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -195,8 +195,11 @@ def test_completion_cwd_prefers_profile_over_stale_env(monkeypatch, tmp_path):
     assert server._completion_cwd({}) == str(stale)
 
 
-def test_completion_cwd_explicit_cwd_wins_over_profile(monkeypatch, tmp_path):
-    """An explicit client-provided cwd still beats the profile config."""
+def test_completion_cwd_profile_cwd_wins_over_client_sent(monkeypatch, tmp_path):
+    """Issue #54990: when a profile is specified, the profile's terminal.cwd
+    takes precedence over the client-sent cwd.  On a profile switch the desktop
+    races the gateway swap, so the client-sent cwd can be stale from the
+    previous profile.  The profile config is the ground-truth workspace."""
     explicit = tmp_path / "explicit"
     explicit.mkdir()
     profile_b = tmp_path / "configured"
@@ -205,7 +208,7 @@ def test_completion_cwd_explicit_cwd_wins_over_profile(monkeypatch, tmp_path):
 
     monkeypatch.setattr(server, "_profile_home", lambda name: home if name else None)
     result = server._completion_cwd({"cwd": str(explicit), "profile": "ef-design"})
-    assert result == str(explicit)
+    assert result == str(profile_b)
 
 
 def test_terminal_task_cwd_local_backend_uses_session_cwd(monkeypatch, tmp_path):
@@ -8588,3 +8591,40 @@ def test_get_usage_clamps_post_compression_sentinel():
     usage = server._get_usage(agent)
     assert "context_used" not in usage
     assert "context_percent" not in usage
+
+
+def test_completion_cwd_profile_switch_discards_stale_cwd(monkeypatch, tmp_path):
+    """Issue #54990 regression: when the desktop switches from default to a
+    named profile, the client-sent cwd is stale from the default profile's
+    project tree.  The profile's configured terminal.cwd must take precedence."""
+    default_project = tmp_path / "default_project"
+    default_project.mkdir()
+    profile_project = tmp_path / "sinan_project"
+    profile_project.mkdir()
+    home = _write_profile_cfg(tmp_path / "sinan-home", str(profile_project))
+
+    # Simulate: desktop sends default profile's CWD but targets sinan profile.
+    monkeypatch.setattr(server, "_profile_home", lambda name: home if name else None)
+    result = server._completion_cwd({
+        "cwd": str(default_project),
+        "profile": "sinan",
+    })
+    assert result == str(profile_project)
+
+
+def test_completion_cwd_profile_no_configured_cwd_falls_back(monkeypatch, tmp_path):
+    """When a profile has no terminal.cwd configured, fall back to the
+    client-sent cwd (or other sources)."""
+    client_cwd = tmp_path / "client_chose"
+    client_cwd.mkdir()
+    home = tmp_path / "bare-home"
+    home.mkdir()
+    (home / "state.db").touch()
+    # No config.yaml → _profile_configured_cwd returns None.
+
+    monkeypatch.setattr(server, "_profile_home", lambda name: home if name else None)
+    result = server._completion_cwd({
+        "cwd": str(client_cwd),
+        "profile": "bare",
+    })
+    assert result == str(client_cwd)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1357,12 +1357,20 @@ def _normalize_completion_path(path_part: str) -> str:
 
 def _completion_cwd(params: dict | None = None) -> str:
     params = params or {}
+    # When a *profile* is specified (desktop app-global remote mode), the
+    # profile's own ``terminal.cwd`` takes precedence over whatever the client
+    # sent as ``cwd``.  On a profile switch the desktop races the gateway
+    # swap: ``$currentCwd`` is seeded from the *previous* profile's project
+    # tree before ``ensureGatewayProfile`` completes, so the client-sent cwd
+    # can be stale.  The profile's config is always the ground-truth workspace
+    # for a cross-profile session, so honour it first.  (issue #54990)
+    profile_home = _profile_home(params.get("profile"))
+    profile_cwd = _profile_configured_cwd(profile_home) if profile_home else None
     raw = (
-        params.get("cwd")
+        (profile_cwd if profile_home else None)
+        or params.get("cwd")
         or _sessions.get(params.get("session_id") or "", {}).get("cwd")
-        # A session bound to another profile resolves its workspace from THAT
-        # profile's config before falling back to the launch profile's env var.
-        or _profile_configured_cwd(_profile_home(params.get("profile")))
+        or profile_cwd
         or os.environ.get("TERMINAL_CWD")
         or os.getcwd()
     )


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in the Desktop app where switching profiles causes the terminal CWD (working directory) to remain stuck on the previous profile's workspace.

**Root cause:** `selectProfile()` calls `requestFreshSession()` synchronously before the async `ensureGatewayProfile()` completes. At that point, `$currentCwd` is still seeded from the *previous* profile's project tree. The desktop sends this stale CWD in the `session.create` request, and `_completion_cwd()` in the gateway uses it (highest priority) instead of the target profile's configured `terminal.cwd`.

**Fix:** When a `profile` parameter is specified in the `session.create` request, the profile's configured `terminal.cwd` now takes precedence over the client-sent `cwd`. This aligns with the existing intent of #40334 (profile-scoped CWD resolution) and extends it to cover the client-sent CWD race.

## Related Issue

Fixes #54990

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — `_completion_cwd()`: when `params` contains a `profile` key and `_profile_home()` resolves to a non-launch profile, the profile's configured `terminal.cwd` now takes precedence over `params.get("cwd")` in the resolution chain. Falls back to client-sent CWD when the profile has no configured CWD.
- `tests/test_tui_gateway_server.py` — Updated `test_completion_cwd_explicit_cwd_wins_over_profile` → `test_completion_cwd_profile_cwd_wins_over_client_sent` to reflect the new precedence. Added `test_completion_cwd_profile_switch_discards_stale_cwd` (regression test for #54990) and `test_completion_cwd_profile_no_configured_cwd_falls_back` (graceful fallback when profile has no `terminal.cwd`).

## How to Test

1. Configure two profiles: `default` (with `terminal.cwd: /path/to/app1`) and `sinan` (with `terminal.cwd: /path/to/app2`)
2. In the Desktop app, open a session in the `default` profile, run `pwd` — should show `/path/to/app1`
3. Switch to `sinan` profile via the sidebar, create a new session, run `pwd`
4. **Expected:** `/path/to/app2` (the `sinan` profile's configured workspace)
5. **Before fix:** `/path/to/app1` (stale from `default` profile)
6. Run `python -m pytest tests/test_tui_gateway_server.py -k "completion_cwd" -v` — all 4 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_tui_gateway_server.py -k "completion_cwd" -v` and all tests pass (note: `test_browser_manage_connect_default_local_reports_launch_hint` is a pre-existing environment-dependent failure unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (server-side CWD resolution, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
