### PR TITLE
fix(agent): collapse stacked FTS5 boolean operators in session search

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4096,10 +4096,30 @@ class SessionDB:
         sanitized = re.sub(r"\*+", "*", sanitized)
         sanitized = re.sub(r"(^|\s)\*", r"\1", sanitized)
 
-        # Step 4: Remove dangling boolean operators at start/end that would
-        # cause syntax errors (e.g. "hello AND" or "OR world")
-        sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
-        sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
+        # Step 4: Remove boolean operators sitting in a syntactically invalid
+        # position — at the start, at the end, or adjacent to another operator.
+        # FTS5 rejects bare, leading, trailing and stacked operators ("AND",
+        # "OR world", "a AND OR b", "AND NOT x", "a AND AND b") as syntax
+        # errors; the swallowed error turns a query that has real search terms
+        # into silent zero results (same class as the colon bug fixed in
+        # search_messages). A single start/end regex only caught one operator
+        # at one edge, so stacked/adjacent operators still leaked through. Walk
+        # the tokens instead, keeping the first operator of any consecutive run
+        # and dropping leading/trailing ones.
+        _bool_ops = {"AND", "OR", "NOT"}
+        cleaned_tokens: list[str] = []
+        prev_was_operator = True  # start-of-query counts as "after an operator"
+        for token in sanitized.split():
+            if token.upper() in _bool_ops:
+                if prev_was_operator:
+                    continue  # leading or adjacent operator — drop it
+                prev_was_operator = True
+            else:
+                prev_was_operator = False
+            cleaned_tokens.append(token)
+        while cleaned_tokens and cleaned_tokens[-1].upper() in _bool_ops:
+            cleaned_tokens.pop()
+        sanitized = " ".join(cleaned_tokens)
 
         # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
         # quotes.  FTS5's tokenizer splits on dots and hyphens, turning

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1329,6 +1329,34 @@ class TestFTS5Search:
         assert any("deployment" in (r.get("snippet") or r.get("content", "")).lower()
                    for r in results)
 
+    def test_search_stacked_boolean_operators_still_finds_content(self, db):
+        """Queries with stacked/adjacent boolean operators must not silently
+        return empty.
+
+        FTS5 rejects stacked operators ("a AND OR b", "a AND AND b") and
+        stacked leading operators ("AND NOT x") as syntax errors. The step-4
+        sanitizer only stripped a single operator at one edge, so these leaked
+        through, MATCH raised, and the swallowed error turned a query with real
+        terms into zero results — the same silent-empty class as the colon bug
+        (test_search_colon_query_still_finds_content).
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="docker and kubernetes deployment notes")
+
+        # Control: the well-formed boolean query finds the message.
+        assert len(db.search_messages("docker AND kubernetes")) >= 1
+
+        # Stacked/adjacent operators must still find it, not silently return [].
+        for query in (
+            "docker AND OR kubernetes",   # adjacent operators
+            "docker AND AND kubernetes",  # doubled operator
+            "AND docker",                 # leading operator
+            "docker OR OR kubernetes",    # doubled OR
+        ):
+            results = db.search_messages(query)
+            assert isinstance(results, list)
+            assert len(results) >= 1, f"Query {query!r} silently returned []"
+
     def test_search_quoted_phrase_preserved(self, db):
         """User-provided quoted phrases should be preserved for exact matching."""
         db.create_session(session_id="s1", source="cli")
@@ -1362,6 +1390,25 @@ class TestFTS5Search:
         assert ':' not in s('TODO: fix')
         assert s('TODO: fix').split() == ['TODO', 'fix']
         assert ':' not in s('error:timeout')
+
+    def test_sanitize_fts5_query_collapses_stacked_operators(self):
+        """Stacked / adjacent / leading boolean operators are reduced to a
+        valid FTS5 query instead of leaking through as a syntax error."""
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+        # Adjacent operators collapse to the first of the run.
+        assert s('a AND OR b') == 'a AND b'
+        assert s('docker AND AND kubernetes') == 'docker AND kubernetes'
+        assert s('x OR OR y') == 'x OR y'
+        assert s('a NOT NOT b') == 'a NOT b'
+        # Stacked leading operators are all dropped.
+        assert s('AND NOT docker') == 'docker'
+        # A query that is only operators reduces to empty.
+        assert s('AND OR NOT') == ''
+        assert s('NOT') == ''
+        # Single-edge cases still behave as before.
+        assert s('hello AND') == 'hello'
+        assert s('OR world') == 'world'
 
     def test_sanitize_fts5_preserves_quoted_phrases(self):
         """Properly paired double-quoted phrases should be preserved."""


### PR DESCRIPTION
## What does this PR do?

`SessionDB._sanitize_fts5_query` (`hermes_state.py`) turns arbitrary user input into a valid FTS5 MATCH query. Its step 4 stripped only a **single** dangling boolean operator at one edge:

```python
sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
```

Stacked or adjacent operators leaked through and produced an invalid MATCH — `docker AND OR kubernetes`, `docker AND AND kubernetes`, `AND NOT docker` (only the leading `AND` is removed, leaving a leading `NOT`). `search_messages` catches the resulting `sqlite3.OperationalError` and returns `[]`, so instead of crashing, a query with real search terms **silently returns zero results**. That's the same silent-empty class already fixed for the `:` column-filter operator and guarded by `test_search_colon_query_still_finds_content`.

**Why this approach:** the two edge-only regexes can't express "no two operators may be adjacent." I replaced them with a single token walk that keeps the first operator of any consecutive run and drops leading/trailing operators, which yields a valid FTS5 query while preserving the user's real terms and primary connective (`docker AND OR kubernetes` → `docker AND kubernetes`). Behavior for the existing single-operator cases (`hello AND` → `hello`, `OR world` → `world`) is unchanged, and case-insensitive matching is preserved.

## Related Issue

Fixes #56871

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `_sanitize_fts5_query` step 4: replace the two edge-only regexes with a token walk that collapses stacked/adjacent boolean operators and strips leading/trailing ones.
- `tests/test_hermes_state.py` — add `test_sanitize_fts5_query_collapses_stacked_operators` (unit) and `test_search_stacked_boolean_operators_still_finds_content` (end-to-end through `search_messages`). Both fail on `main` and pass with the fix.

## How to Test

1. Reproduce on `main`:
   ```python
   from pathlib import Path; import tempfile
   from hermes_state import SessionDB
   db = SessionDB(db_path=Path(tempfile.mkdtemp()) / "state.db")
   db.create_session(session_id="s1", source="cli")
   db.append_message("s1", role="user", content="docker and kubernetes deployment notes")
   len(db.search_messages("docker AND kubernetes"))     # 1 (control)
   len(db.search_messages("docker AND OR kubernetes"))  # 0  -> should be 1
   len(db.search_messages("AND NOT docker"))            # 0  -> should be 1
   ```
2. On this branch those queries return `1`.
3. `scripts/run_tests.sh tests/test_hermes_state.py -q` → 305 passed.
4. Regression proof: revert only `hermes_state.py`, keep the tests, rerun `-k "stacked_boolean or collapses_stacked"` → both new tests fail.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests and all pass (`scripts/run_tests.sh tests/test_hermes_state.py` → 305 passed)
- [x] I've added tests for my changes (unit + end-to-end; both fail without the fix)
- [x] I've tested on my platform: macOS (Darwin 25.5.0), Python 3.12.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — step-4 comment rewritten to explain the invariant; no user docs affected
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — pure-Python string logic, no OS-specific code; `scripts/check-windows-footguns.py` clean
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/test_hermes_state.py -q
=== Summary: 1 files, 305 tests passed, 0 failed (100% complete) in 7.8s ===

# regression proof — fix reverted, tests kept:
$ scripts/run_tests.sh tests/test_hermes_state.py -q -k "stacked_boolean or collapses_stacked"
FAILED ...::test_search_stacked_boolean_operators_still_finds_content
FAILED ...::test_sanitize_fts5_query_collapses_stacked_operators
2 failed, 303 deselected
```
