### PR TITLE
fix(tts): transcode OpenAI-compatible TTS to OGG/Opus when backend lacks opus

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2105,6 +2105,13 @@ DEFAULT_CONFIG = {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
             # Voices: alloy, echo, fable, onyx, nova, shimmer
+            # response_format: only needed for OpenAI-*compatible* backends
+            # that cannot encode opus (e.g. self-hosted Speaches/Kokoro, which
+            # support only mp3/flac/wav/pcm). Set to one of those formats and
+            # Hermes synthesizes in it, then transcodes to OGG/Opus locally via
+            # ffmpeg for Telegram/Matrix voice bubbles. Leave unset for the
+            # real OpenAI API, which encodes opus natively (issue #54589).
+            # "response_format": "mp3",
         },
         "gemini": {
             "model": "gemini-2.5-flash-preview-tts",

--- a/tests/tools/test_tts_openai_opus_transcode.py
+++ b/tests/tools/test_tts_openai_opus_transcode.py
@@ -1,0 +1,97 @@
+"""Regression tests for issue #54589.
+
+An OpenAI-*compatible* TTS backend (e.g. self-hosted Speaches/Kokoro) may not
+encode opus and only support mp3/flac/wav/pcm. Requesting response_format="opus"
+against such a backend fails and no voice bubble is delivered. When the user
+pins ``tts.openai.response_format`` to a supported format, Hermes must
+synthesize in that format and transcode to OGG/Opus locally.
+"""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tools import tts_tool
+
+
+class _FakeResponse:
+    def __init__(self, fmt: str):
+        self._fmt = fmt
+
+    def stream_to_file(self, path: str) -> None:
+        Path(path).write_bytes(b"audio-" + self._fmt.encode())
+
+
+class _FakeClient:
+    """Captures the create() kwargs and records the synth path written."""
+
+    def __init__(self, *args, **kwargs):
+        self.created_kwargs = None
+        self.audio = SimpleNamespace(speech=SimpleNamespace(create=self._create))
+
+    def _create(self, **kwargs):
+        self.created_kwargs = kwargs
+        return _FakeResponse(kwargs["response_format"])
+
+    def close(self):
+        pass
+
+
+def _patch_client(monkeypatch, holder):
+    def _factory(*args, **kwargs):
+        client = _FakeClient()
+        holder.append(client)
+        return client
+
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: _factory)
+    monkeypatch.setattr(
+        tts_tool,
+        "_resolve_openai_audio_client_config",
+        lambda: ("key", "http://x/v1", False),
+    )
+
+
+def test_ogg_target_defaults_to_opus(tmp_path, monkeypatch):
+    """Real OpenAI API path: .ogg target still asks the backend for opus."""
+    clients: list = []
+    _patch_client(monkeypatch, clients)
+    convert = MagicMock()
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    out = tmp_path / "speech.ogg"
+    cfg = {"openai": {"model": "m", "voice": "v"}}
+
+    result = tts_tool._generate_openai_tts("hi", str(out), cfg)
+
+    assert result == str(out)
+    assert clients[0].created_kwargs["response_format"] == "opus"
+    convert.assert_not_called()
+
+
+def test_ogg_target_transcodes_when_backend_lacks_opus(tmp_path, monkeypatch):
+    """Speaches/Kokoro path: synthesize in mp3, transcode to .ogg locally."""
+    clients: list = []
+    _patch_client(monkeypatch, clients)
+
+    def fake_convert(path: str) -> str:
+        # backend-format temp file should exist when we transcode it
+        assert path.endswith(".mp3")
+        assert os.path.exists(path)
+        ogg = path.rsplit(".", 1)[0] + ".ogg"
+        Path(ogg).write_bytes(b"ogg")
+        return ogg
+
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", fake_convert)
+
+    out = tmp_path / "speech.ogg"
+    cfg = {"openai": {"model": "m", "voice": "v", "response_format": "mp3"}}
+
+    result = tts_tool._generate_openai_tts("hi", str(out), cfg)
+
+    assert result == str(out)
+    # Backend was asked for mp3, never opus.
+    assert clients[0].created_kwargs["response_format"] == "mp3"
+    assert out.exists()
+    # Intermediate mp3 is cleaned up.
+    assert not (tmp_path / "speech.mp3").exists()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1113,6 +1113,30 @@ def _generate_openai_tts(
 
     response_format = _tts_response_format_from_path(output_path)
 
+    # For an .ogg target we normally ask the backend for "opus" directly. But
+    # OpenAI-*compatible* backends (e.g. self-hosted Speaches/Kokoro) may not
+    # encode opus and only support mp3/flac/wav/pcm. Such a backend rejects
+    # response_format="opus" and no voice bubble is delivered (issue #54589).
+    # When the user pins a non-opus format via ``tts.openai.response_format``,
+    # synthesize in that format and transcode to OGG/Opus locally with ffmpeg
+    # — mirroring how the Edge provider produces voice bubbles via
+    # ``_convert_to_opus()``.
+    configured_format = oai_config.get("response_format")
+    transcode_to_opus = False
+    if (
+        output_path.endswith(".ogg")
+        and configured_format
+        and configured_format != "opus"
+    ):
+        response_format = configured_format
+        transcode_to_opus = True
+
+    # When transcoding, synthesize to a temp file in the backend-supported
+    # format, then convert that to the requested .ogg output path.
+    synth_path = output_path
+    if transcode_to_opus:
+        synth_path = output_path[: -len(".ogg")] + "." + response_format
+
     OpenAIClient = _import_openai_client()
     client = OpenAIClient(api_key=api_key, base_url=base_url)
     try:
@@ -1127,7 +1151,24 @@ def _generate_openai_tts(
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         response = client.audio.speech.create(**create_kwargs)
 
-        response.stream_to_file(output_path)
+        response.stream_to_file(synth_path)
+
+        if transcode_to_opus:
+            opus_path = _convert_to_opus(synth_path)
+            try:
+                if synth_path != output_path and os.path.exists(synth_path):
+                    os.remove(synth_path)
+            except OSError:
+                pass
+            if not opus_path:
+                raise RuntimeError(
+                    "OpenAI-compatible TTS produced "
+                    f"{response_format!r} audio but ffmpeg OGG/Opus "
+                    "transcode failed (is ffmpeg installed?)."
+                )
+            # _convert_to_opus derives the .ogg name from synth_path, which
+            # shares output_path's stem, so opus_path == output_path already.
+            return opus_path
         return output_path
     finally:
         close = getattr(client, "close", None)

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -56,6 +56,13 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
     speed: 1.0                  # 0.25 - 4.0
+    # response_format: "mp3"    # Only for OpenAI-compatible backends that can't
+                                # encode opus (e.g. self-hosted Speaches/Kokoro,
+                                # which support only mp3/flac/wav/pcm). Hermes
+                                # synthesizes in this format then transcodes to
+                                # OGG/Opus locally via ffmpeg for Telegram voice
+                                # bubbles. Leave unset for the real OpenAI API,
+                                # which encodes opus natively.
   minimax:
     model: "speech-2.8-hd"     # speech-2.8-hd (default), speech-2.8-turbo
     voice_id: "English_Graceful_Lady"  # See https://platform.minimax.io/faq/system-voice-id
@@ -170,6 +177,9 @@ Only positive integers are honored. Zero, negative, non-numeric, or boolean valu
 Telegram voice bubbles require Opus/OGG audio format:
 
 - **OpenAI, ElevenLabs, and Mistral** produce Opus natively — no extra setup
+  - OpenAI-*compatible* backends that can't encode opus (e.g. self-hosted
+    Speaches/Kokoro) can set `tts.openai.response_format: mp3`; Hermes then
+    uses **ffmpeg** to convert to OGG/Opus for Telegram voice bubbles
 - **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles


### PR DESCRIPTION
## Summary

- `_generate_openai_tts()` hardcoded `response_format="opus"` for any `.ogg` target, breaking OpenAI-*compatible* backends that can't encode opus.
- Honor an optional `tts.openai.response_format`; when set to a non-opus format for an `.ogg` target, synthesize in that format and transcode to OGG/Opus locally via ffmpeg.

## Motivation

Closes #54589.

Self-hosted OpenAI-compatible TTS backends (e.g. Speaches/Kokoro) only support `mp3`/`flac`/`wav`/`pcm`. Because Telegram/Matrix voice bubbles use an `.ogg` output path, `_generate_openai_tts()` sent `response_format="opus"` straight to the endpoint, which rejected it — so no voice bubble was delivered. This mirrors the Edge provider, which already synthesizes MP3 and transcodes to OGG/Opus via `_convert_to_opus()`.

## Fix

- When `tts.openai.response_format` is set to a non-opus format and the target is `.ogg`: synthesize to a temp file in that format, transcode to `.ogg` with `_convert_to_opus()`, and clean up the intermediate file. If ffmpeg transcode fails, raise a clear error.
- Default behavior is unchanged: without the option, `.ogg` targets still request `opus` directly (real OpenAI API path).

## Verification

- `python3 -m pytest tests/tools/test_tts_openai_opus_transcode.py tests/tools/test_tts_opus_routing.py` — 4 passed
- `test_ogg_target_defaults_to_opus` proves the default path is untouched (still requests opus, no transcode).
- `test_ogg_target_transcodes_when_backend_lacks_opus` proves the new path asks the backend for mp3, transcodes to `.ogg`, and removes the temp mp3.

## Did NOT change

- The opus-preference/`want_opus` routing in `text_to_speech_tool()` — this fix is scoped to the synthesis format negotiation inside `_generate_openai_tts()`.
