### PR TITLE
fix(whatsapp): lazy-install aiohttp so the adapter starts (closes #54217)

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -339,6 +339,26 @@ def check_whatsapp_requirements() -> bool:
     
     WhatsApp requires a Node.js bridge for most implementations.
     """
+    # The Python side of the adapter talks to the Node.js bridge over HTTP via
+    # aiohttp. It is not a core dependency, so lazy-install it on first use like
+    # every other messaging platform. Without this the gateway crashed with
+    # ModuleNotFoundError: No module named 'aiohttp' and fell back to cron-only
+    # mode (issue #54217).
+    try:
+        import aiohttp  # noqa: F401
+    except ImportError:
+        try:
+            from tools.lazy_deps import ensure
+
+            ensure("platform.whatsapp", prompt=False)
+            import aiohttp  # noqa: F401
+        except Exception as e:
+            logger.warning(
+                "[whatsapp] aiohttp is required but could not be installed: %s",
+                e,
+            )
+            return False
+
     # Prefer Hermes-managed Node/npm so Windows installs are not broken by a
     # bad or elevation-triggering system Node on PATH.
     _node = find_node_executable("node")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ nemo-relay = ["nemo-relay==0.3"]
 homeassistant = ["aiohttp==3.14.1"]
 sms = ["aiohttp==3.14.1"]
 teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"]  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525
+whatsapp = ["aiohttp==3.14.1"]  # Python side of the WhatsApp Node-bridge adapter; aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525
 # Computer use — macOS background desktop control via cua-driver (MCP stdio).
 # The cua-driver binary itself is installed via `hermes tools` post-setup
 # (curl install script); this extra just pins the MCP client used to talk

--- a/tests/plugins/test_whatsapp_lazy_aiohttp.py
+++ b/tests/plugins/test_whatsapp_lazy_aiohttp.py
@@ -1,0 +1,37 @@
+"""Regression tests for issue #54217.
+
+The WhatsApp adapter's Python side talks to the Node.js bridge over HTTP via
+aiohttp, which is not a core dependency. Before the fix `platform.whatsapp` was
+missing from LAZY_DEPS (and pyproject had no `whatsapp` extra), so a gateway
+with WhatsApp configured crashed with ``ModuleNotFoundError: No module named
+'aiohttp'`` and fell back to cron-only mode.
+"""
+
+import tomllib
+from pathlib import Path
+
+from tools import lazy_deps
+
+
+def test_whatsapp_feature_registered_in_lazy_deps():
+    assert "platform.whatsapp" in lazy_deps.LAZY_DEPS
+    specs = lazy_deps.LAZY_DEPS["platform.whatsapp"]
+    assert any(s.startswith("aiohttp==") for s in specs), specs
+
+
+def test_whatsapp_extra_declared_in_pyproject():
+    root = Path(__file__).resolve().parents[2]
+    data = tomllib.loads((root / "pyproject.toml").read_text())
+    extras = data["project"]["optional-dependencies"]
+    assert "whatsapp" in extras
+    assert any(s.startswith("aiohttp==") for s in extras["whatsapp"])
+
+
+def test_whatsapp_and_teams_pin_the_same_aiohttp():
+    """The lazy WhatsApp aiohttp pin must match the other messaging platforms
+    so a CVE bump can't leave WhatsApp on a vulnerable already-installed
+    aiohttp."""
+    wa = [s for s in lazy_deps.LAZY_DEPS["platform.whatsapp"] if s.startswith("aiohttp==")]
+    teams = [s for s in lazy_deps.LAZY_DEPS["platform.teams"] if s.startswith("aiohttp==")]
+    assert wa and teams
+    assert wa[0] == teams[0]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -432,6 +432,7 @@ _REQUIRED_SECURITY_PINS = {
         "platform.slack",
         "platform.matrix",
         "platform.teams",
+        "platform.whatsapp",
     },
 }
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -200,6 +200,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # installed on demand like every other messaging platform; also exposed
     # as the `teams` extra in pyproject for packagers / explicit installs.
     "platform.teams": ("microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"),  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525
+    # WhatsApp adapter — the Python side talks to the Node.js bridge over HTTP
+    # via aiohttp. Lazy-installed on demand like every other messaging
+    # platform; without this the gateway crashed with
+    # ModuleNotFoundError: No module named 'aiohttp' and fell back to
+    # cron-only mode (issue #54217).
+    "platform.whatsapp": ("aiohttp==3.14.1",),  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),


### PR DESCRIPTION
## Summary

- The WhatsApp adapter's Python side talks to the Node.js bridge over HTTP via `aiohttp`, but `aiohttp` is not a core dependency and `platform.whatsapp` was missing from `LAZY_DEPS`.
- With WhatsApp configured, the gateway crashed with `ModuleNotFoundError: No module named 'aiohttp'` and fell back to cron-only mode.

## Motivation

Closes #54217.

Every other messaging platform (`platform.slack`, `platform.teams`, …) lazy-installs its HTTP/SDK deps on first use via `tools.lazy_deps.ensure(...)`. WhatsApp never registered a feature, so aiohttp was never installed and the adapter failed to start.

## Fix

- Add `platform.whatsapp` to `LAZY_DEPS` with `aiohttp==3.14.1` — the same patched-floor pin the other messaging platforms carry (CVE-2026-34993 RCE / 47265 + 34513/34518/34519/34520/34525).
- Add a `whatsapp` extra to `pyproject.toml` for packagers / explicit installs (mirrors `teams`, `slack`, etc.).
- `ensure("platform.whatsapp", prompt=False)` in `check_whatsapp_requirements()` so aiohttp is auto-installed on first use; if it still can't be imported, the check fails gracefully (logs, returns False) instead of crashing the gateway.
- Extend the `_REQUIRED_SECURITY_PINS` coverage contract to `platform.whatsapp` so a future CVE bump can't leave WhatsApp on a vulnerable already-installed aiohttp.

## Verification

- `python3 -m pytest tests/plugins/test_whatsapp_lazy_aiohttp.py tests/test_packaging_metadata.py` — 14 passed
- New tests assert the feature is registered, the extra is declared, and the WhatsApp aiohttp pin matches the other platforms.

## Did NOT change

- The Node.js bridge bootstrap / npm-install path in `connect()` — unrelated to the Python aiohttp import.
