### PR TITLE
fix: forward request_overrides to cron jobs and subagents

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2803,6 +2803,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
             api_mode=runtime.get("api_mode"),
+            request_overrides=runtime.get("request_overrides"),
             acp_command=runtime.get("command"),
             acp_args=runtime.get("args"),
             max_iterations=max_iterations,

--- a/tests/cron/test_cron_request_overrides.py
+++ b/tests/cron/test_cron_request_overrides.py
@@ -1,0 +1,60 @@
+"""Standalone regression test for cron runtime request_overrides forwarding.
+
+Split out of tests/cron/test_scheduler.py as an independent, upgrade-safe file
+(registered in the local-patch ledger's allowed_untracked list) so the local
+request_overrides forwarding hotfix no longer collides with upstream inserting
+new tests around its anchor in the large test_scheduler.py module.
+
+The functional change under test lives in cron/scheduler.py (run_job forwards
+runtime['request_overrides'] into the ephemeral AIAgent); that hunk stays in the
+source patch. Only this test moved here.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from cron.scheduler import run_job
+
+
+class TestRunJobRequestOverrides:
+    def test_run_job_forwards_runtime_request_overrides_to_agent(self, tmp_path):
+        # runtime_provider may resolve provider-specific request_overrides;
+        # cron must pass them into the ephemeral AIAgent or scheduled jobs
+        # regress to SDK-default request settings.
+        job = {
+            "id": "request-overrides-job",
+            "name": "request-overrides",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+        overrides = {
+            "extra_headers": {
+                "User-Agent": "codex_cli_rs/0.138.0 (Windows 10.0.26100; x86_64)"
+            }
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "custom",
+                     "api_mode": "codex_responses",
+                     "request_overrides": overrides,
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["request_overrides"] == overrides

--- a/tests/tools/test_delegate_request_overrides.py
+++ b/tests/tools/test_delegate_request_overrides.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from tools import delegate_tool
+
+
+def _parent(**overrides):
+    parent = MagicMock()
+    parent.base_url = "https://provider.example.invalid/v1"
+    parent.api_key = "test-key"
+    parent.provider = "custom:test-provider"
+    parent.api_mode = "codex_responses"
+    parent.model = "gpt-5.5"
+    parent.enabled_toolsets = ["terminal"]
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent.openrouter_min_coding_score = None
+    parent._session_db = None
+    parent._delegate_depth = 0
+    parent._delegate_spinner = None
+    parent.tool_progress_callback = None
+    parent._active_children = []
+    parent._active_children_lock = None
+    parent._print_fn = None
+    parent.session_id = "parent-session"
+    parent.request_overrides = {}
+    for key, value in overrides.items():
+        setattr(parent, key, value)
+    return parent
+
+
+def _capture_child_kwargs(monkeypatch):
+    captured = {}
+
+    class FakeAgent(SimpleNamespace):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            super().__init__(session_id="child-session", **kwargs)
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {})
+    return captured
+
+
+def test_subagent_inherits_parent_request_overrides(monkeypatch):
+    captured = _capture_child_kwargs(monkeypatch)
+    parent_overrides = {
+        "extra_headers": {"User-Agent": "codex_cli_rs/0.138.0"},
+        "extra_body": {"trace": "parent"},
+    }
+
+    delegate_tool._build_child_agent(
+        task_index=0,
+        goal="audit",
+        context=None,
+        toolsets=None,
+        model=None,
+        max_iterations=3,
+        task_count=1,
+        parent_agent=_parent(request_overrides=parent_overrides),
+    )
+
+    assert captured["request_overrides"] == parent_overrides
+    assert captured["request_overrides"] is not parent_overrides
+
+
+def test_subagent_does_not_leak_parent_overrides_to_explicit_provider(monkeypatch):
+    captured = _capture_child_kwargs(monkeypatch)
+
+    delegate_tool._build_child_agent(
+        task_index=0,
+        goal="audit",
+        context=None,
+        toolsets=None,
+        model="mini",
+        max_iterations=3,
+        task_count=1,
+        parent_agent=_parent(
+            request_overrides={"extra_headers": {"User-Agent": "toolcode-only"}},
+        ),
+        override_provider="custom:other-provider",
+        override_base_url="https://other-provider.example.invalid/anthropic",
+        override_api_key="child-key",
+        override_api_mode="anthropic_messages",
+    )
+
+    assert captured["request_overrides"] == {}
+
+
+def test_subagent_uses_explicit_delegation_request_overrides(monkeypatch):
+    captured = _capture_child_kwargs(monkeypatch)
+    child_overrides = {"extra_headers": {"User-Agent": "child-route"}}
+
+    delegate_tool._build_child_agent(
+        task_index=0,
+        goal="audit",
+        context=None,
+        toolsets=None,
+        model="gpt-5.5",
+        max_iterations=3,
+        task_count=1,
+        parent_agent=_parent(
+            request_overrides={"extra_headers": {"User-Agent": "parent-route"}},
+        ),
+        override_provider="custom:test-provider",
+        override_base_url="https://provider.example.invalid/v1",
+        override_api_key="child-key",
+        override_api_mode="codex_responses",
+        override_request_overrides=child_overrides,
+    )
+
+    assert captured["request_overrides"] == child_overrides
+    assert captured["request_overrides"] is not child_overrides

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1057,6 +1057,7 @@ def _build_child_agent(
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
+    override_request_overrides: Optional[Dict[str, Any]] = None,
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -1202,6 +1203,18 @@ def _build_child_agent(
     if not override_base_url:
         effective_base_url = _inherit_parent_base_url(parent_agent, effective_base_url)
     effective_api_key = override_api_key or parent_api_key
+    parent_request_overrides = getattr(parent_agent, "request_overrides", None)
+    if override_request_overrides is not None:
+        effective_request_overrides = dict(override_request_overrides or {})
+    elif override_provider or override_base_url or override_api_mode:
+        # A configured delegation target is a distinct runtime route; do not
+        # leak parent provider-specific request overrides into it.
+        effective_request_overrides = {}
+    else:
+        # Normal delegation inherits the parent's resolved runtime route.  This
+        # must include request_overrides so provider-specific request settings
+        # survive into subagents instead of reverting to SDK defaults.
+        effective_request_overrides = dict(parent_request_overrides or {})
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface
     # (e.g. MiniMax uses anthropic_messages, DeepSeek uses chat_completions).
@@ -1329,6 +1342,7 @@ def _build_child_agent(
         provider_sort=child_provider_sort,
         openrouter_min_coding_score=child_openrouter_min_coding_score,
         tool_progress_callback=child_progress_cb,
+        request_overrides=effective_request_overrides,
         iteration_budget=None,  # fresh budget per subagent
     )
     child._print_fn = getattr(parent_agent, "_print_fn", None)
@@ -2500,6 +2514,7 @@ def delegate_task(
                 override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],
+                override_request_overrides=creds.get("request_overrides"),
                 override_acp_command=t.get("acp_command")
                 or acp_command
                 or creds.get("command"),
@@ -3047,6 +3062,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            "request_overrides": {},
         }
 
     if not configured_provider:
@@ -3057,6 +3073,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": None,
             "api_key": None,
             "api_mode": None,
+            "request_overrides": None,
         }
 
     # Provider is configured — resolve full credentials
@@ -3085,6 +3102,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
         "api_mode": runtime.get("api_mode"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }


### PR DESCRIPTION
## Summary

Forward provider-derived `request_overrides` through two remaining async paths:

- cron jobs created from an agent session now preserve the runtime provider's request overrides
- delegated subagents inherit parent request overrides unless an explicit provider/runtime override supplies its own request overrides

This keeps custom-provider `extra_body` / `extra_headers` behavior consistent for scheduled jobs and delegate_task children.

## Why

`resolve_runtime_provider()` can attach provider-specific request overrides, but cron job creation and subagent construction were dropping them. That means a configured provider can behave correctly in the parent conversation while losing its request overrides in cron/subagent calls.

## Prior art / non-duplication check

Related open PRs cover adjacent paths but not these files:

- #56653 covers background review and curator agents
- #53765 covers gateway / Open WebUI / TUI / CLI model-switch paths
- #39429 covers gateway and `/model` switches

This PR intentionally stays narrow to `cron/scheduler.py` and `tools/delegate_tool.py`.

## Tests

```bash
PYTHONPATH="$PWD" /opt/hermes/.venv/bin/python -m pytest -q -o 'addopts=' \
  tests/cron/test_cron_request_overrides.py \
  tests/tools/test_delegate_request_overrides.py
# 4 passed

PYTHONPATH="$PWD" /opt/hermes/.venv/bin/python -m py_compile \
  cron/scheduler.py \
  tools/delegate_tool.py \
  tests/cron/test_cron_request_overrides.py \
  tests/tools/test_delegate_request_overrides.py

git diff --cached --check
```