### PR TITLE
fix(windows): hide console flashes in GUI-reachable exec paths and provider transports

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -503,6 +503,10 @@ class CopilotACPClient:
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
         try:
+            # Hide the console the CLI child would otherwise flash on Windows
+            # (#56747). Hide-only — stdio pipes stay intact for the ACP wire.
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
                 stdin=subprocess.PIPE,
@@ -512,6 +516,7 @@ class CopilotACPClient:
                 bufsize=1,
                 cwd=self._acp_cwd,
                 env=_build_subprocess_env(),
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError as exc:
             raise RuntimeError(

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -127,6 +127,10 @@ class CodexAppServerClient:
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 
+        # Hide the console the codex child would otherwise flash on Windows
+        # (#56747). Hide-only — stdio pipes stay intact for the app-server wire.
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         self._proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -134,6 +138,7 @@ class CodexAppServerClient:
             stderr=subprocess.PIPE,
             bufsize=0,
             env=spawn_env,
+            creationflags=windows_hide_flags(),
         )
         self._next_id = 1
         self._pending: dict[int, _Pending] = {}

--- a/cli.py
+++ b/cli.py
@@ -8745,9 +8745,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             # has all API keys in os.environ.
                             from tools.environments.local import _sanitize_subprocess_env
                             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+                            from hermes_cli._subprocess_compat import windows_hide_flags
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
-                                text=True, timeout=30, env=sanitized_env
+                                text=True, timeout=30, env=sanitized_env,
+                                # No console flash on Windows (#56747).
+                                creationflags=windows_hide_flags(),
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11279,6 +11279,10 @@ def _(rid, params: dict) -> dict:
     if hint:
         return _ok(rid, {"blocked": True, "hint": hint, "code": -1, "output": ""})
     try:
+        # CREATE_NO_WINDOW on Windows — under the desktop GUI's windowless
+        # parent, this spawn otherwise flashes a console (#56747).
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         r = subprocess.run(
             [sys.executable, "-m", "hermes_cli.main", *argv],
             capture_output=True,
@@ -11289,6 +11293,7 @@ def _(rid, params: dict) -> dict:
             # needs provider credentials. Tier-1 secrets still stripped (#29157).
             env=hermes_subprocess_env(inherit_credentials=True),
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         parts = [r.stdout or "", r.stderr or ""]
         out = "\n".join(p for p in parts if p).strip() or "(no output)"
@@ -11348,6 +11353,8 @@ def _(rid, params: dict) -> dict:
             # has all API keys in os.environ.
             from tools.environments.local import _sanitize_subprocess_env
             sanitized_env = _sanitize_subprocess_env(os.environ.copy())
+            from hermes_cli._subprocess_compat import windows_hide_flags
+
             r = subprocess.run(
                 qc.get("command", ""),
                 shell=True,
@@ -11356,6 +11363,7 @@ def _(rid, params: dict) -> dict:
                 timeout=30,
                 stdin=subprocess.DEVNULL,
                 env=sanitized_env,
+                creationflags=windows_hide_flags(),
             )
             output = (
                 (r.stdout or "")
@@ -13754,9 +13762,12 @@ def _(rid, params: dict) -> dict:
     except ImportError:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         return _ok(
             rid,


### PR DESCRIPTION
## What & why

Addresses #56747 (console windows flash on Windows desktop during conversations/tool execution).

Before writing this I re-verified the forensic map in #54220 against current `main` (`9be39de0f`): **all 9 spawn sites it lists as "still leaking" have since been fixed** — that map is now stale. The sites below are the remaining gaps found by a direct sweep, none covered by any open PR (checked "console window", "CREATE_NO_WINDOW", "windowsHide", "56747" searches; #51775 touches only `hermes_cli/main.py`, no overlap):

| Site | Path that reaches it |
|---|---|
| `tui_gateway/server.py` — `cli.exec` RPC | Desktop GUI "run CLI command" |
| `tui_gateway/server.py` — quick-commands `exec` dispatch | Desktop/TUI slash-command of a user quick command |
| `tui_gateway/server.py` — `shell.exec` RPC | Desktop GUI "run shell command" |
| `cli.py` — quick-commands `exec` handler | Interactive CLI/TUI REPL |
| `agent/copilot_acp_client.py` — ACP `Popen` | Every prompt on the Copilot provider |
| `agent/transports/codex_app_server.py` — app-server `Popen` | Session start on the Codex provider |

Each gets `creationflags=windows_hide_flags()` from `hermes_cli/_subprocess_compat` (no-op on POSIX) — the same one-line pattern already used at three other sites in `tui_gateway/server.py` and across the previously fixed #54220 sites.

## Scope discipline (per the #54220 revert history)

- **Hide-only, never detach**: the two `Popen` transports keep PIPE stdio intact; no `DETACHED_PROCESS`/breakaway flags anywhere.
- **No Electron changes**, no touch of the updater handoff legs (#54543 covers those), and no regression of `_resolve_detached_python` in the gateway watcher.
- Deliberately **not** a mass sweep — these six are the GUI-reachable exec paths matching #56747's report. Remaining lower-traffic gaps (e.g. `tools/environments/docker.py`, `computer_use/doctor.py`) can follow as separate scoped PRs if wanted — happy to do so.

## Test plan

Ran on **native Windows 11** (Python 3.11): `tests/test_windows_subprocess_no_window_flags.py` plus the ACP/codex transport suites — **345 passed**. One failure, `test_codex_app_server_persist.py::test_codex_turn_persists_each_message_exactly_once`, **fails identically on clean `main`** on Windows (WinError 32 tmpdir teardown lock — pre-existing flake, unrelated). `windows_hide_flags()` verified to resolve to `CREATE_NO_WINDOW` (0x08000000) on this machine; all four files compile clean.

I attempted a live A/B flash repro from a windowless `pythonw` parent on this machine; my headless session doesn't visually reproduce the flash in either direction, so I'm not claiming visual before/after evidence — the change relies on the mechanism documented in #54220 and the established in-tree pattern.
