### PR TITLE
fix(cron): preserve due runs on same schedule update

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -749,6 +749,27 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     return None
 
 
+def _schedule_run_identity(schedule: Any) -> Tuple[Any, ...]:
+    """Return the run-affecting identity of a parsed schedule."""
+    if isinstance(schedule, str):
+        schedule = parse_schedule(schedule)
+
+    if not isinstance(schedule, dict):
+        return ("raw", json.dumps(schedule, sort_keys=True, default=str))
+
+    kind = schedule.get("kind")
+    if kind == "interval":
+        return ("interval", schedule.get("minutes"))
+    if kind == "cron":
+        return ("cron", schedule.get("expr"))
+    if kind == "once":
+        return ("once", schedule.get("run_at"))
+    return (
+        "unknown",
+        json.dumps(schedule, sort_keys=True, separators=(",", ":"), default=str),
+    )
+
+
 # =============================================================================
 # Ticker heartbeat (liveness signal for `hermes cron status`)
 # =============================================================================
@@ -1316,6 +1337,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = _normalize_workdir(_wd)
 
             previous_inference_axes = _normalized_inference_axes(job)
+            previous_schedule_identity = (
+                _schedule_run_identity(job.get("schedule"))
+                if "schedule" in updates
+                else None
+            )
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
             inference_fields_changed = bool(
@@ -1340,7 +1366,18 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updated_schedule.get("display", updated.get("schedule_display")),
                 )
                 if updated.get("state") != "paused":
-                    updated_next_run = compute_next_run(updated_schedule)
+                    run_schedule_changed = (
+                        _schedule_run_identity(updated_schedule)
+                        != previous_schedule_identity
+                    )
+                    recurring_schedule = updated_schedule.get("kind") in {
+                        "interval",
+                        "cron",
+                    }
+                    if recurring_schedule and not run_schedule_changed:
+                        updated_next_run = updated.get("next_run_at")
+                    else:
+                        updated_next_run = compute_next_run(updated_schedule)
                     # Same guard as create_job: an UPDATE that sets a one-shot
                     # to a time >ONESHOT_GRACE_SECONDS in the past would store
                     # next_run_at=None with state="scheduled", re-creating the

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -402,6 +402,71 @@ class TestUpdateJob:
         assert updated["schedule"]["kind"] == "once"
         assert updated["next_run_at"] is not None
 
+    def test_resaving_same_past_oneshot_is_still_rejected(self, tmp_cron_dir, monkeypatch):
+        now = [datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)]
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now[0])
+        schedule = (now[0] + timedelta(minutes=1)).isoformat()
+        job = create_job(prompt="One shot", schedule=schedule, deliver="local")
+
+        now[0] += timedelta(minutes=10)
+        with pytest.raises(ValueError, match="past and cannot be scheduled"):
+            update_job(
+                job["id"],
+                {
+                    "name": "Renamed one shot",
+                    "schedule": job["schedule"],
+                    "schedule_display": job["schedule_display"],
+                },
+            )
+
+        fetched = get_job(job["id"])
+        assert fetched["name"] == job["name"]
+        assert fetched["schedule"] == job["schedule"]
+
+    def test_resaving_same_interval_schedule_preserves_due_run(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 6, 29, 14, 0, 10, tzinfo=timezone.utc)
+        due_run = datetime(2026, 6, 29, 13, 0, 0, tzinfo=timezone.utc).isoformat()
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        job = create_job(prompt="Hourly report", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = due_run
+        save_jobs(jobs)
+
+        updated = update_job(
+            job["id"],
+            {
+                "name": "Renamed hourly report",
+                "schedule": job["schedule"],
+                "schedule_display": job["schedule_display"],
+            },
+        )
+
+        assert updated["next_run_at"] == due_run
+        assert get_job(job["id"])["next_run_at"] == due_run
+
+    def test_resaving_same_cron_schedule_preserves_due_run(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 6, 29, 14, 0, 10, tzinfo=timezone.utc)
+        due_run = datetime(2026, 6, 29, 13, 0, 0, tzinfo=timezone.utc).isoformat()
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        job = create_job(prompt="Hourly cron report", schedule="0 * * * *")
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = due_run
+        save_jobs(jobs)
+
+        updated = update_job(
+            job["id"],
+            {
+                "name": "Renamed cron report",
+                "schedule": job["schedule"],
+                "schedule_display": job["schedule_display"],
+            },
+        )
+
+        assert updated["next_run_at"] == due_run
+        assert get_job(job["id"])["next_run_at"] == due_run
+
     def test_update_enable_disable(self, tmp_cron_dir):
         job = create_job(prompt="Toggle me", schedule="every 1h")
         assert job["enabled"] is True


### PR DESCRIPTION
## Summary
- Preserve an existing `next_run_at` when `update_job()` receives the same run-affecting schedule alongside unrelated edits.
- Add interval and cron regression coverage for due jobs that should not be skipped by a schedule re-save.

## Root Cause
`update_job()` treated any payload containing `schedule` as a real schedule change and recomputed `next_run_at` from the current time. UI/API saves that re-submit the same schedule could therefore move an already-due recurring job into the future without firing it.

## Tests
- `python -m pytest tests/cron/test_jobs.py -q -k 'resaving_same'`
- `python -m pytest tests/cron/test_jobs.py -q`
- `scripts/run_tests.sh tests/cron/test_jobs.py -q`

Fixes #55313