### PR TITLE
fix(sessions): show active compression tips from archived roots

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2775,9 +2775,15 @@ class SessionDB:
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
+        defer_archived_filter = (
+            project_compression_tips
+            and not include_children
+            and not include_archived
+            and not archived_only
+        )
         if archived_only:
             where_clauses.append("s.archived = 1")
-        elif not include_archived:
+        elif not include_archived and not defer_archived_filter:
             where_clauses.append("s.archived = 0")
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
@@ -2936,12 +2942,15 @@ class SessionDB:
                     "id", "ended_at", "end_reason", "message_count",
                     "tool_call_count", "title", "last_active", "preview",
                     "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                    "archived",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]
                 merged["_lineage_root_id"] = s["id"]
                 projected.append(merged)
             sessions = projected
+            if defer_archived_filter:
+                sessions = [s for s in sessions if not s.get("archived")]
 
         return sessions
 

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -49,3 +49,15 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_archived_compression_root_projects_to_unarchived_tip(db):
+    _compression_pair(db)
+    db._conn.execute("UPDATE sessions SET archived = 1 WHERE id = 'root'")
+    db._conn.execute("UPDATE sessions SET archived = 0 WHERE id = 'tip'")
+    db._conn.commit()
+
+    rows = db.list_sessions_rich(order_by_last_active=True)
+
+    assert [s["id"] for s in rows] == ["tip"]
+    assert rows[0]["archived"] == 0


### PR DESCRIPTION
## Summary
- Defer the default archived-session filter until after compression roots are projected to their live tips.
- Copy the tip `archived` state into projected session rows so active tips remain visible even when an archived root was admitted for projection.
- Add a regression test for an archived compression root with an unarchived live tip.

## Root Cause
`list_sessions_rich()` applied `s.archived = 0` in SQL before compression-chain projection. An archived root was filtered out, while its active continuation was hidden as a compression child, so the whole conversation disappeared from the default session list.

## Tests
- `python -m pytest tests/hermes_state/test_session_archiving.py -q -k 'archived_compression_root'`
- `python -m pytest tests/hermes_state/test_session_archiving.py -q`
- `scripts/run_tests.sh tests/hermes_state/test_session_archiving.py -q`

Fixes #55588