### PR TITLE
fix(tests): make fresh-final timestamp tests robust to CI runner uptime

### DIFF
--- a/tests/gateway/test_stream_consumer_fresh_final.py
+++ b/tests/gateway/test_stream_consumer_fresh_final.py
@@ -11,6 +11,7 @@ time instead of first-token time.
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -89,7 +90,7 @@ class TestFreshFinalForLongLivedPreviews:
         )
         await consumer._send_or_edit("hello")
         # Force the preview to look stale (visible for > 60s).
-        consumer._message_created_ts = 0.0  # zero = ~uptime seconds old
+        consumer._message_created_ts = time.monotonic() - 70  # force age > 60s threshold
         await consumer._send_or_edit("hello world", finalize=True)
         # Fresh send happened; no edit of the old preview.
         assert adapter.send.call_count == 2
@@ -114,7 +115,7 @@ class TestFreshFinalForLongLivedPreviews:
             config=StreamConsumerConfig(fresh_final_after_seconds=60.0),
         )
         await consumer._send_or_edit("hello")
-        consumer._message_created_ts = 0.0
+        consumer._message_created_ts = time.monotonic() - 70  # force age > 60s threshold
         await consumer._send_or_edit("hello world", finalize=True)
         assert adapter.send.call_count == 2
         adapter.edit_message.assert_not_called()
@@ -135,7 +136,7 @@ class TestFreshFinalForLongLivedPreviews:
             config=StreamConsumerConfig(fresh_final_after_seconds=60.0),
         )
         await consumer._send_or_edit("hello")
-        consumer._message_created_ts = 0.0
+        consumer._message_created_ts = time.monotonic() - 70  # force age > 60s threshold
         ok = await consumer._send_or_edit("hello world", finalize=True)
         # Fresh send was attempted and failed → edit happened instead.
         assert adapter.send.call_count == 2


### PR DESCRIPTION
## Summary

Three tests in `TestFreshFinalForLongLivedPreviews` simulate a stale preview by setting `consumer._message_created_ts = 0.0`, relying on `time.monotonic()` being greater than the 60 s `fresh_final_after_seconds` threshold.

On freshly started CI runners (uptime < 60 s), `time.monotonic() - 0.0 < 60`, so `_should_send_fresh_final()` returns `False`, the test takes the edit path instead of the fresh-send path, and `assert adapter.send.call_count == 2` fails.

**Fix:** replace `0.0` with `time.monotonic() - 70` in the three affected tests. This guarantees the preview appears stale (age > 60 s threshold) regardless of when the runner booted, while leaving the other `0.0` usages untouched (they are either in a disabled-fresh-final test, a non-finalize path, or use a 1 ms threshold where `0.0` is always sufficient).

## Affected tests

- `test_long_lived_preview_sends_fresh_final`
- `test_fresh_final_without_delete_support_is_best_effort`
- `test_fresh_final_fallback_to_edit_on_send_failure`

## Test plan

- [ ] `pytest tests/gateway/test_stream_consumer_fresh_final.py` — 28/28 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)