### PR TITLE
fix(agent): dedupe Codex gpt-5.5 autoraise notice across agent inits

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -86,6 +86,59 @@ def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
     )
 
 
+def _codex_gpt55_autoraise_notice_marker():
+    """Path to the per-profile marker recording that the autoraise notice ran.
+
+    Lives under ``$HERMES_HOME`` (which is profile-scoped) alongside the other
+    internal markers like ``.container-mode`` — so it is not a user-facing config
+    key, and every profile tracks its own notice state independently.
+    """
+    return get_hermes_home() / ".codex_gpt55_autoraise_notice"
+
+
+def _codex_gpt55_autoraise_notice_state(autoraise: Dict[str, float]) -> str:
+    """Stable identity for one autoraise notice, keyed on what it displays.
+
+    Uses the same from→to percentages the notice text shows, so an unchanged
+    threshold stays silent across restarts while a later change (e.g. the user
+    edits their global ``threshold``) re-notifies once.
+    """
+    from_pct = int(round(float(autoraise["from"]) * 100))
+    to_pct = int(round(float(autoraise["to"]) * 100))
+    return f"{from_pct}:{to_pct}"
+
+
+def _codex_gpt55_autoraise_notice_seen(autoraise: Dict[str, float]) -> bool:
+    """True if this exact autoraise notice was already shown for this profile.
+
+    A missing/unreadable marker (or one recording a different threshold) reads
+    as unseen, so the notice shows.
+    """
+    try:
+        current = _codex_gpt55_autoraise_notice_state(autoraise)
+        return _codex_gpt55_autoraise_notice_marker().read_text(
+            encoding="utf-8"
+        ).strip() == current
+    except (OSError, KeyError, TypeError, ValueError):
+        return False
+
+
+def _record_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> None:
+    """Persist that the autoraise notice was shown for this profile/config state.
+
+    Best-effort: a read-only or missing ``$HERMES_HOME`` just means the notice
+    may show again next init, which is preferable to breaking agent init.
+    """
+    try:
+        marker = _codex_gpt55_autoraise_notice_marker()
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(
+            _codex_gpt55_autoraise_notice_state(autoraise), encoding="utf-8"
+        )
+    except (OSError, KeyError, TypeError, ValueError):
+        pass
+
+
 def _normalized_custom_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -1826,17 +1879,27 @@ def init_agent(
             agent._ollama_num_ctx,
         )
 
+    # Codex gpt-5.5 autoraise notice: show at most once per profile/config
+    # state. Without the persisted marker the notice re-fires on every agent
+    # init — and the gateway rebuilds the agent per inbound message, so Discord
+    # etc. saw it repeatedly (#54432). A change in the raised threshold updates
+    # the marker state and re-notifies once.
+    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
+    _show_autoraise_notice = (
+        bool(_autoraise)
+        and compression_enabled
+        and not _codex_gpt55_autoraise_notice_seen(_autoraise)
+    )
+
     if not agent.quiet_mode:
         if compression_enabled:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
-        _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
+        # Notice with the exact opt-back-out command. Printed inline at startup
+        # for CLI users; gateway users get the same text replayed via
+        # _compression_warning on turn 1 (set below).
+        if _show_autoraise_notice:
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
     # Check immediately so CLI users see the warning at startup.
@@ -1846,9 +1909,14 @@ def init_agent(
     # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
+    if _show_autoraise_notice:
         agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
+
+    # Mark shown so repeated inits in this profile (e.g. every gateway message)
+    # stay silent. Recorded once, whether the notice went to the CLI print or
+    # the gateway replay slot.
+    if _show_autoraise_notice:
+        _record_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -1,0 +1,100 @@
+"""Tests for the Codex gpt-5.5 autoraise-notice dedupe gate (#54432).
+
+The notice ("auto-compaction was raised to 85%…") must be shown at most once
+per profile/config state. Before the fix it re-fired on every agent init, and
+because the gateway rebuilds the agent per inbound message it spammed Discord
+etc. The gate persists a marker under ``$HERMES_HOME`` (profile-scoped, isolated
+to a tempdir by the conftest autouse fixture) keyed on the displayed from→to
+percentages, so an unchanged threshold stays silent across restarts while a
+changed threshold re-notifies once.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_constants import get_hermes_home
+
+from agent.agent_init import (
+    _codex_gpt55_autoraise_notice_marker,
+    _codex_gpt55_autoraise_notice_seen,
+    _codex_gpt55_autoraise_notice_state,
+    _record_codex_gpt55_autoraise_notice,
+)
+
+# The (from, to) ratios agent_init stashes when the Codex gpt-5.5 override fires.
+AUTORAISE = {"from": 0.50, "to": 0.85}
+
+
+def test_marker_lives_under_hermes_home() -> None:
+    marker = _codex_gpt55_autoraise_notice_marker()
+    assert marker.parent == get_hermes_home()
+    assert marker.name == ".codex_gpt55_autoraise_notice"
+
+
+def test_state_keyed_on_displayed_percentages() -> None:
+    # Same percentages the notice text renders (int(round(ratio * 100))).
+    assert _codex_gpt55_autoraise_notice_state(AUTORAISE) == "50:85"
+    assert _codex_gpt55_autoraise_notice_state({"from": 0.75, "to": 0.85}) == "75:85"
+
+
+def test_unseen_before_anything_is_recorded() -> None:
+    assert _codex_gpt55_autoraise_notice_seen(AUTORAISE) is False
+
+
+def test_seen_after_record() -> None:
+    assert _codex_gpt55_autoraise_notice_seen(AUTORAISE) is False
+    _record_codex_gpt55_autoraise_notice(AUTORAISE)
+    # A "restart" is just another call: the marker persists on disk.
+    assert _codex_gpt55_autoraise_notice_seen(AUTORAISE) is True
+
+
+def test_changed_threshold_renotifies_once() -> None:
+    _record_codex_gpt55_autoraise_notice(AUTORAISE)
+    assert _codex_gpt55_autoraise_notice_seen(AUTORAISE) is True
+    # User raises their global threshold -> "from" changes -> notice re-fires.
+    changed = {"from": 0.60, "to": 0.85}
+    assert _codex_gpt55_autoraise_notice_seen(changed) is False
+    _record_codex_gpt55_autoraise_notice(changed)
+    assert _codex_gpt55_autoraise_notice_seen(changed) is True
+    # And the old state is now considered unseen (marker moved forward).
+    assert _codex_gpt55_autoraise_notice_seen(AUTORAISE) is False
+
+
+def test_record_is_idempotent() -> None:
+    _record_codex_gpt55_autoraise_notice(AUTORAISE)
+    _record_codex_gpt55_autoraise_notice(AUTORAISE)
+    assert _codex_gpt55_autoraise_notice_marker().read_text(encoding="utf-8") == "50:85"
+
+
+def test_malformed_marker_reads_as_unseen() -> None:
+    marker = _codex_gpt55_autoraise_notice_marker()
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("not-a-state", encoding="utf-8")
+    assert _codex_gpt55_autoraise_notice_seen(AUTORAISE) is False
+
+
+@pytest.mark.parametrize("bad", [{}, {"from": 0.5}, {"from": None, "to": None}])
+def test_seen_tolerates_malformed_autoraise(bad) -> None:
+    # Never raises even if the stashed dict is missing/garbage keys.
+    assert _codex_gpt55_autoraise_notice_seen(bad) is False
+
+
+def test_full_init_gate_shows_once_then_stays_silent() -> None:
+    # Mirror the decision agent_init makes on each build:
+    #   show = bool(autoraise) and compression_enabled and not seen(autoraise)
+    def decide(compression_enabled: bool) -> bool:
+        show = (
+            bool(AUTORAISE)
+            and compression_enabled
+            and not _codex_gpt55_autoraise_notice_seen(AUTORAISE)
+        )
+        if show:
+            _record_codex_gpt55_autoraise_notice(AUTORAISE)
+        return show
+
+    # First init (any surface) shows; every subsequent init in this profile
+    # stays silent — the gateway spam scenario from the issue.
+    assert decide(compression_enabled=True) is True
+    assert decide(compression_enabled=True) is False
+    assert decide(compression_enabled=True) is False

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -111,9 +111,13 @@ The ChatGPT Codex OAuth backend hard-caps gpt-5.5 at a **272K** context window
 GitHub Copilot). At the default 50% trigger, compaction would fire at ~136K —
 half the window the model can actually use. When the active route is Codex
 OAuth (`provider: openai-codex`) and the model is gpt-5.5, Hermes raises the
-trigger to **85%** (~231K) and prints a one-time notice with the opt-out
-command. Only this exact route is affected; gpt-5.5 on any other provider keeps
-your global `threshold`. To opt back down to the global value:
+trigger to **85%** (~231K) and shows a notice with the opt-out command. The
+notice is shown once per profile — a marker under `$HERMES_HOME`
+(`.codex_gpt55_autoraise_notice`) records that it ran, so repeated agent/session
+inits (e.g. every inbound gateway message) don't re-emit it; if the raised
+threshold later changes it re-notifies once. Only this exact route is affected;
+gpt-5.5 on any other provider keeps your global `threshold`. To opt back down to
+the global value:
 
 ```bash
 hermes config set compression.codex_gpt55_autoraise false


### PR DESCRIPTION
## What does this PR do?

The Codex gpt-5.5 compaction-threshold autoraise notice ("auto-compaction was raised to 85%…") is meant to be a one-time heads-up. In practice it re-fired on **every** agent init: the notice text is rebuilt in `init_agent()` each time, and the gateway rebuilds the agent per inbound message, so long-running Discord/Telegram/etc. sessions saw it repeatedly. The only documented way to stop the spam — `hermes config set compression.codex_gpt55_autoraise false` — throws away the useful autoraise behavior entirely.

This gates the notice on a persisted **per-profile** marker so it shows at most once per profile/config state, while keeping the autoraise on by default.

Within a single agent's lifetime the notice was already cleared after one replay (`turn_context.py`, `send once`), so the repetition comes purely from re-inits creating a fresh agent — hence a durable marker rather than an in-session flag.

## Related Issue

Fixes #54432

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`
  - Added `_codex_gpt55_autoraise_notice_marker/_state/_seen/_record` helpers. The marker lives at `$HERMES_HOME/.codex_gpt55_autoraise_notice` — `$HERMES_HOME` is already profile-scoped, and this matches the existing internal dot-marker pattern (`.container-mode`, `.managed`), so it is **not** a user-facing config key.
  - The marker stores the `from→to` percentages the notice displays. An unchanged threshold stays silent across restarts; a later change to the raised threshold re-notifies exactly once.
  - Both emission surfaces (the CLI startup `print` and the gateway `_compression_warning` replay slot) now share one `_show_autoraise_notice` gate, and the marker is recorded once when the notice is shown. All reads/writes are best-effort (a read-only/missing `$HERMES_HOME` never breaks agent init).
- `website/docs/developer-guide/context-compression-and-caching.md` — the "prints a one-time notice" line now accurately describes the persisted, once-per-profile behavior and the re-notify-on-change semantics.
- `tests/agent/test_codex_gpt55_autoraise_notice.py` — unit tests for the gate.

Acceptance criteria from the issue:
- ✅ Repeated agent/session init in the same profile no longer re-emits the notice.
- ✅ `codex_gpt55_autoraise: true` still raises the trigger to 85% (unchanged path).
- ✅ `codex_gpt55_autoraise: false` still disables the override (unchanged path).
- ✅ Docs match the behavior.
- ✅ Tests added for the notice gate.

## How to Test

Automated:

```bash
scripts/run_tests.sh tests/agent/test_codex_gpt55_autoraise_notice.py -q
```

The tests cover: state key = displayed percentages; unseen → record → seen (persists across a simulated restart); a changed threshold re-notifies once and supersedes the old state; idempotent record; malformed marker / malformed autoraise dict read as unseen (never raises); and the full init gate (`show once, then silent`, and never shown when compression is disabled).

Manual (Codex gpt-5.5 via ChatGPT OAuth, `provider: openai-codex`):

1. Start a fresh profile and send a message through a gateway platform (e.g. Discord). The autoraise notice appears once.
2. Send more messages / restart the gateway. The notice no longer reappears; `$HERMES_HOME/.codex_gpt55_autoraise_notice` contains `50:85`.
3. Change your global `compression.threshold` (e.g. to `0.60`) and init again — the notice appears once more, then goes quiet.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

> Note on the test run: this was prepared in a clean throwaway clone without the Hermes venv, so `pytest`/`scripts/run_tests.sh` couldn't run locally (importing `agent.agent_init` pulls the full runtime dependency set). `python -m py_compile` passes on all touched files, and a focused proof executing the exact helper source against a real temp `$HERMES_HOME` passes all the cases above. The added `tests/agent/test_codex_gpt55_autoraise_notice.py` runs under CI.

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] N/A — no config keys added (marker is internal profile state, not a config key)
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact (uses `pathlib`; `$HERMES_HOME` resolution is platform-native)
- [x] N/A — no tool behavior/schema change
