### PR TITLE
fix(desktop): suppress ERR_NETWORK_IO_SUSPENDED main-process crash after sleep/wake

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -271,11 +271,36 @@ async function resolveReadableFileForIpc(filePath, options = {}) {
   return { realPath, resolvedPath, stat }
 }
 
+// Network errors that indicate the OS-level network stack was suspended
+// (sleep, hibernation, VPN disconnect). These are recoverable — they should
+// not crash the app; the caller should retry or surface a reconnect indicator.
+const NETWORK_SUSPEND_ERROR_CODES = new Set([
+  'ERR_NETWORK_IO_SUSPENDED',
+  'ERR_NETWORK_CHANGED',
+  'ERR_INTERNET_DISCONNECTED',
+  'ERR_NETWORK_ACCESS_DENIED'
+])
+
+function isNetworkSuspendError(error) {
+  if (!error || typeof error !== 'object') return false
+  // Electron wraps Chromium net errors; the code field is the canonical key.
+  const code = error.code
+  if (typeof code === 'string' && NETWORK_SUSPEND_ERROR_CODES.has(code)) return true
+  // Also check the message — some Electron versions surface the code only
+  // in the message string (e.g. "net::ERR_NETWORK_IO_SUSPENDED").
+  const message = typeof error.message === 'string' ? error.message : ''
+  for (const knownCode of NETWORK_SUSPEND_ERROR_CODES) {
+    if (message.includes(knownCode)) return true
+  }
+  return false
+}
+
 module.exports = {
   DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
   encryptDesktopSecret,
+  isNetworkSuspendError,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,

--- a/apps/desktop/electron/hardening.test.cjs
+++ b/apps/desktop/electron/hardening.test.cjs
@@ -4,10 +4,11 @@ const os = require('node:os')
 const path = require('node:path')
 const test = require('node:test')
 const { pathToFileURL } = require('node:url')
-
 const {
+  DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
+  isNetworkSuspendError,
   resolveDirectoryForIpc,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
@@ -276,4 +277,27 @@ test('resolveDirectoryForIpc accepts directory symlinks or junctions', async t =
   const resolved = await resolveDirectoryForIpc(linkPath)
   assert.equal(resolved.resolvedPath, linkPath)
   assert.equal(resolved.stat.isDirectory(), true)
+})
+
+test('isNetworkSuspendError detects OS-level network suspension errors', () => {
+  // Canonical code field
+  assert.equal(isNetworkSuspendError({ code: 'ERR_NETWORK_IO_SUSPENDED' }), true)
+  assert.equal(isNetworkSuspendError({ code: 'ERR_NETWORK_CHANGED' }), true)
+  assert.equal(isNetworkSuspendError({ code: 'ERR_INTERNET_DISCONNECTED' }), true)
+  assert.equal(isNetworkSuspendError({ code: 'ERR_NETWORK_ACCESS_DENIED' }), true)
+
+  // Message-only detection (some Electron versions surface the code in message)
+  assert.equal(isNetworkSuspendError({ message: 'net::ERR_NETWORK_IO_SUSPENDED' }), true)
+  assert.equal(isNetworkSuspendError({ message: 'Error: net::ERR_NETWORK_CHANGED at ...' }), true)
+
+  // Non-network errors are not detected
+  assert.equal(isNetworkSuspendError({ code: 'ECONNREFUSED' }), false)
+  assert.equal(isNetworkSuspendError({ code: 'ETIMEDOUT' }), false)
+  assert.equal(isNetworkSuspendError({ message: 'Something else failed' }), false)
+
+  // Non-error inputs
+  assert.equal(isNetworkSuspendError(null), false)
+  assert.equal(isNetworkSuspendError(undefined), false)
+  assert.equal(isNetworkSuspendError('ERR_NETWORK_IO_SUSPENDED'), false)
+  assert.equal(isNetworkSuspendError(42), false)
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -115,6 +115,7 @@ const {
   DEFAULT_FETCH_TIMEOUT_MS,
   TEXT_PREVIEW_SOURCE_MAX_BYTES,
   encryptDesktopSecret: encryptDesktopSecretStrict,
+  isNetworkSuspendError,
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs
@@ -750,10 +751,26 @@ function registerMediaProtocol() {
     // Delegate to Electron's net stack on a file:// URL — it resolves the
     // content-type and honors Range requests so seeking works. Forward the
     // renderer's headers (notably Range) and skip custom-protocol re-entry.
-    return electronNet.fetch(pathToFileURL(resolvedPath).toString(), {
+    //
+    // electronNet.fetch returns a Promise. Chromium's net stack can synchronously
+    // reject with "ERR_NETWORK_IO_SUSPENDED" on resume from sleep/suspend when
+    // pending requests are aborted; without a catch, that rejection escapes the
+    // protocol handler and crashes the main process. Issue #56835.
+    const fetchPromise = electronNet.fetch(pathToFileURL(resolvedPath).toString(), {
       bypassCustomProtocolHandlers: true,
       headers: request.headers
     })
+    if (fetchPromise && typeof fetchPromise.catch === 'function') {
+      fetchPromise.catch(error => {
+        if (isNetworkSuspendError(error)) {
+          rememberLog(`[media] suppressing network-suspend error on fetch: ${error && error.message}`)
+          return null
+        }
+        rememberLog(`[media] fetch failed: ${error && error.message}`)
+        return null
+      })
+    }
+    return fetchPromise
   })
 }
 
@@ -4497,13 +4514,24 @@ function fetchJsonViaOauthSession(url, options = {}) {
     const body = serializeJsonBody(options.body)
     const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
-    const request = electronNet.request({
-      method: options.method || 'GET',
-      url,
-      session: sess,
-      useSessionCookies: true,
-      redirect: 'follow'
-    })
+    let request
+    try {
+      request = electronNet.request({
+        method: options.method || 'GET',
+        url,
+        session: sess,
+        useSessionCookies: true,
+        redirect: 'follow'
+      })
+    } catch (error) {
+      // electronNet.request() can throw synchronously on network suspension
+      // (sleep/wake) when the underlying URLLoader rejects before the JS
+      // wrapper is wired up. Without this guard, the throw escapes the IPC
+      // handler and surfaces as an "Uncaught Exception" dialog (issue #56835).
+      rememberLog(`[net] electronNet.request threw synchronously: ${error && error.message}`)
+      reject(new Error(`Network request could not start: ${error && error.message}`))
+      return
+    }
     setJsonRequestHeaders(request)
 
     let timedOut = false
@@ -7548,6 +7576,37 @@ app.whenReady().then(() => {
     }
   })
 })
+
+// Last-line defense for OS-level network suspension (sleep/wake,
+// VPN drop, captive portal re-auth). Without this, a Chromium net request that
+// escapes its own request.on('error', …) handler — typical symptom:
+// ERR_NETWORK_IO_SUSPENDED from SimpleURLLoaderWrapper during a media-stream
+// reopen or a tail call issued right at the moment of resume — bubbles to the
+// main process as an uncaught exception and Electron pops a modal dialog that
+// bricks the desktop (issue #56835). Log, suppress, and tell the renderer to
+// reconnect; let everything else propagate normally.
+if (!process._hermesNetworkSuspendGuardInstalled) {
+  process._hermesNetworkSuspendGuardInstalled = true
+  process.on('uncaughtException', error => {
+    if (isNetworkSuspendError(error)) {
+      rememberLog(
+        `[net] suppressed uncaught network-suspend exception: ${error && (error.message || String(error))}`
+      )
+      try {
+        if (typeof sendPowerResume === 'function') sendPowerResume()
+      } catch {
+        // best-effort — we're already suppressing the underlying error
+      }
+      return
+    }
+    // Not a network-suspend case: re-throw so the regular crash reporter
+    // stack still fires. Without this we'd silently swallow unrelated bugs.
+    // Queue the original error onto next tick so we don't recurse.
+    setImmediate(() => {
+      throw error
+    })
+  })
+}
 
 // Seed Chromium's spellchecker with the system locale (falling back to en-US).
 // On macOS Electron uses the native spellchecker which ignores this list, but

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -7587,7 +7587,7 @@ app.whenReady().then(() => {
 // reconnect; let everything else propagate normally.
 if (!process._hermesNetworkSuspendGuardInstalled) {
   process._hermesNetworkSuspendGuardInstalled = true
-  process.on('uncaughtException', error => {
+  const suspendGuardListener = error => {
     if (isNetworkSuspendError(error)) {
       rememberLog(
         `[net] suppressed uncaught network-suspend exception: ${error && (error.message || String(error))}`
@@ -7600,12 +7600,15 @@ if (!process._hermesNetworkSuspendGuardInstalled) {
       return
     }
     // Not a network-suspend case: re-throw so the regular crash reporter
-    // stack still fires. Without this we'd silently swallow unrelated bugs.
-    // Queue the original error onto next tick so we don't recurse.
+    // stack still fires. Detach this listener before re-throwing so the
+    // re-throw does NOT recurse back into us (which would loop forever
+    // for any non-suspend error that slipped past).
+    process.removeListener('uncaughtException', suspendGuardListener)
     setImmediate(() => {
       throw error
     })
-  })
+  }
+  process.on('uncaughtException', suspendGuardListener)
 }
 
 // Seed Chromium's spellchecker with the system locale (falling back to en-US).


### PR DESCRIPTION
## Summary

electronNet.fetch / electronNet.request calls made just as the OS resumes from sleep can synchronously throw or reject with net::ERR_NETWORK_IO_SUSPENDED. This change adds local guards and one last-line defense so the desktop swallows that recoverable event and kicks the renderer-side power-resume reconnect (already plumbed for sleep/wake) without a crash dialog.

---

## Changes

`apps/desktop/electron/main.cjs`
- electronNet.fetch in registerMediaProtocol — attach .catch so the promise cannot escape the protocol handler.
- electronNet.request in fetchJsonViaOauthSession — wrap in try/catch so a synchronous throw surfaces as a normal rejection.
- app.whenReady tail — install a once-only process.on('uncaughtException') that consumes network-suspend errors and re-throws unrelated ones on next tick so the regular crash reporter path still fires.
- Import isNetworkSuspendError from hardening.cjs.

`apps/desktop/electron/hardening.cjs`
- Add isNetworkSuspendError helper covering the four Chromium net codes (sleep/wake, VPN drop, captive portal).

`apps/desktop/electron/hardening.test.cjs`
- 1 new unit test.

---

## How to Test

```bash
node electron/hardening.test.cjs
# ✅ 13/13 passed
```

---

## Checklist

- [x] Tests pass — 13/13
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only — 3 files
- [x] No public API changes, no env vars

---

## Risk & Impact

Low. Three narrow guards around existing Electron API calls plus a focused uncaughtException filter. The regular crash reporter path is preserved for all non-network-suspend exceptions.

Type: 🐛 Bug fix
Closes: #56835