### PR TITLE
fix(tui): route runtime check off read loop (#56888)

### DIFF
--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -64,9 +64,10 @@ def capture(server):
 # seconds when the GIL is contended by concurrent agent turns.
 
 FRONTEND_POLLED_RPCS = [
-    "session.list",   # loads session list — SQLite query
-    "pet.info",       # petdex poll — file/network read
-    "process.list",   # background process status — process registry scan
+    "session.list",          # loads session list — SQLite query
+    "pet.info",              # petdex poll — file/network read
+    "process.list",          # background process status — process registry scan
+    "setup.runtime_check",   # readiness probe — provider/config/runtime imports
 ]
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -216,6 +216,7 @@ _LONG_HANDLERS = frozenset(
         "session.compress",
         "session.list",
         "session.resume",
+        "setup.runtime_check",
         "shell.exec",
         "skills.manage",
         "slash.exec",


### PR DESCRIPTION
## Summary
- add setup.runtime_check to the TUI gateway long-handler pool
- extend the frontend-polled RPC regression coverage so readiness checks cannot block the WS read loop

## Tests
- scripts/run_tests.sh tests/tui_gateway/test_inline_rpc_gil_starvation.py