### PR TITLE
fix(search): normalize adjacent FTS booleans (#56871)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4096,10 +4096,27 @@ class SessionDB:
         sanitized = re.sub(r"\*+", "*", sanitized)
         sanitized = re.sub(r"(^|\s)\*", r"\1", sanitized)
 
-        # Step 4: Remove dangling boolean operators at start/end that would
-        # cause syntax errors (e.g. "hello AND" or "OR world")
-        sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
-        sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
+        # Step 4: Normalize bare boolean operators.  FTS5 rejects leading,
+        # trailing, and adjacent boolean operators (``a AND OR b``, ``AND NOT
+        # x``).  Keep valid infix operators, drop leading/trailing runs, and
+        # collapse adjacent runs to the last operator so surrounding search
+        # terms are still used instead of silently returning no matches.
+        tokens = sanitized.strip().split()
+        normalized_tokens: list[str] = []
+        for token in tokens:
+            if re.fullmatch(r"(?i)AND|OR|NOT", token):
+                op = token.upper()
+                if not normalized_tokens:
+                    continue
+                if re.fullmatch(r"(?i)AND|OR|NOT", normalized_tokens[-1]):
+                    normalized_tokens[-1] = op
+                else:
+                    normalized_tokens.append(op)
+            else:
+                normalized_tokens.append(token)
+        while normalized_tokens and re.fullmatch(r"(?i)AND|OR|NOT", normalized_tokens[-1]):
+            normalized_tokens.pop()
+        sanitized = " ".join(normalized_tokens)
 
         # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
         # quotes.  FTS5's tokenizer splits on dots and hyphens, turning

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1273,6 +1273,20 @@ class TestFTS5Search:
             results = db.search_messages(query)
             assert isinstance(results, list), f"Query {query!r} did not return a list"
 
+    def test_search_stacked_boolean_operators_still_find_content(self, db):
+        """Stacked/adjacent FTS5 boolean operators should not degrade to silent empty results."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="docker kubernetes deployment notes")
+
+        for query in [
+            "docker AND OR kubernetes",
+            "docker AND AND kubernetes",
+            "AND NOT docker",
+        ]:
+            results = db.search_messages(query)
+            assert isinstance(results, list)
+            assert len(results) >= 1, f"Query {query!r} should still find indexed terms"
+
     def test_search_sanitized_query_still_finds_content(self, db):
         """Sanitization must not break normal keyword search."""
         db.create_session(session_id="s1", source="cli")
@@ -1351,9 +1365,13 @@ class TestFTS5Search:
         assert '"' not in s('"unterminated')
         assert '(' not in s('(problem')
         assert '{' not in s('{test}')
-        # Dangling operators removed
+        # Dangling and adjacent operators normalized
         assert s('hello AND') == 'hello'
         assert s('OR world') == 'world'
+        assert s('AND NOT docker') == 'docker'
+        assert s('docker AND OR kubernetes') == 'docker OR kubernetes'
+        assert s('docker AND AND kubernetes') == 'docker AND kubernetes'
+        assert s('docker AND NOT kubernetes') == 'docker NOT kubernetes'
         # Leading bare * removed
         assert s('***') == ''
         # Valid prefix kept


### PR DESCRIPTION
## Summary
- normalize leading, trailing, and adjacent FTS5 boolean operator runs in session search queries
- add regression coverage for stacked boolean input returning real matches instead of silent empty results

## Tests
- scripts/run_tests.sh tests/test_hermes_state.py