### PR TITLE
fix(gateway): wait for launchd restart readiness in-band (#56524)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -236,6 +236,22 @@ def _request_gateway_self_restart(pid: int) -> bool:
     return True
 
 
+def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
+    """Wait until a specific PID no longer exists."""
+    if pid <= 0:
+        return True
+
+    import time as _time
+    from gateway.status import _pid_exists
+
+    deadline = _time.monotonic() + max(timeout, 1.0)
+    while _time.monotonic() < deadline:
+        if not _pid_exists(pid):
+            return True
+        _time.sleep(0.5)
+    return not _pid_exists(pid)
+
+
 def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     """Send SIGUSR1 to a gateway PID and wait for it to exit gracefully.
 
@@ -272,22 +288,7 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     except (PermissionError, OSError):
         return False
 
-    import time as _time
-
-    deadline = _time.monotonic() + max(drain_timeout, 1.0)
-    # IMPORTANT Windows note: ``os.kill(pid, 0)`` is NOT a no-op on
-    # Windows — Python's implementation calls ``TerminateProcess(handle, 0)``
-    # for sig=0, hard-killing the target. Use the cross-platform
-    # ``_pid_exists`` helper in gateway.status which does OpenProcess +
-    # WaitForSingleObject on Windows.
-    from gateway.status import _pid_exists
-
-    while _time.monotonic() < deadline:
-        if not _pid_exists(pid):
-            return True
-        _time.sleep(0.5)
-    # Drain didn't finish in time.
-    return False
+    return _wait_for_pid_exit(pid, drain_timeout)
 
 
 def _get_ancestor_pids() -> set[int]:
@@ -1091,6 +1092,248 @@ def _wait_for_systemd_service_restart(
         f"  Check logs:   journalctl {'--user ' if not system else ''}-u {svc} -l --since '2 min ago'"
     )
     return False
+
+
+def _wait_for_launchd_service_restart(
+    *,
+    previous_pid: int | None = None,
+    timeout: float = 60.0,
+) -> bool:
+    """Wait for the gateway runtime to come back after a launchd restart."""
+    import time
+    from hermes_constants import display_hermes_home as _dhh
+
+    deadline = time.monotonic() + timeout
+    printed_runtime_wait = False
+
+    while time.monotonic() < deadline:
+        try:
+            from gateway.status import get_running_pid
+
+            new_pid = get_running_pid()
+        except Exception:
+            new_pid = None
+
+        if new_pid and (previous_pid is None or new_pid != previous_pid):
+            runtime_state = _gateway_runtime_status_for_pid(new_pid)
+            gateway_state = (runtime_state or {}).get("gateway_state")
+            if gateway_state == "running":
+                print(f"✓ Service restarted (PID {new_pid})")
+                return True
+            if gateway_state == "startup_failed":
+                reason = (runtime_state or {}).get("exit_reason") or "startup failed"
+                print(
+                    f"⚠ Service process restarted (PID {new_pid}), but gateway startup failed: {reason}"
+                )
+                return False
+            if not printed_runtime_wait:
+                print(
+                    f"⏳ Service process started (PID {new_pid}); waiting for gateway runtime..."
+                )
+                printed_runtime_wait = True
+
+        time.sleep(2)
+
+    print(
+        f"⚠ Service did not become ready within {int(timeout)}s.\n"
+        "  Check status: hermes gateway status\n"
+        f"  Check logs:   tail -f {_dhh()}/logs/gateway.log"
+    )
+    return False
+
+
+def _spawn_launchd_service_restart_watcher(
+    *,
+    old_pid: int,
+    label: str,
+    graceful_timeout: float,
+    relaunch_timeout: float,
+) -> bool:
+    """Detach a watcher that ensures a launchd self-restart finishes cleanly.
+
+    The in-band `hermes gateway restart` / `hermes update` path can run inside a
+    gateway-hosted terminal tool. If the gateway drain later times out, the
+    interrupt cleanup kills that tool subprocess group before it can force a
+    fallback `launchctl kickstart -k`. This detached watcher survives that
+    interrupt, waits for the old PID to exit and a fresh runtime-ready PID to
+    appear, and only forces kickstart if the graceful handoff stalls.
+    """
+    if old_pid <= 0 or not label:
+        return False
+
+    log_path = get_hermes_home() / "logs" / "launchd-restart-watcher.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+
+    watcher = textwrap.dedent(
+        """
+        import sys
+        import time
+        from gateway.status import _pid_exists, get_running_pid, read_runtime_status
+        from hermes_cli.gateway import _kickstart_launchd_service_and_wait, _launchd_domain
+
+        old_pid = int(sys.argv[1])
+        label = sys.argv[2]
+        graceful_timeout = float(sys.argv[3])
+        relaunch_timeout = float(sys.argv[4])
+        log_path = sys.argv[5]
+
+        def _log(message):
+            try:
+                with open(log_path, "a", encoding="utf-8") as fh:
+                    fh.write(
+                        f"[{time.strftime('%Y-%m-%d %H:%M:%S %z')}] {message}\\n"
+                    )
+            except Exception:
+                pass
+
+        def _runtime_status_for_pid(pid):
+            if not pid:
+                return None
+            try:
+                state = read_runtime_status()
+            except Exception:
+                return None
+            if not isinstance(state, dict):
+                return None
+            try:
+                state_pid = int(state.get("pid", 0) or 0)
+            except (TypeError, ValueError):
+                return None
+            return state if state_pid == pid else None
+
+        def _wait_for_old_pid_exit(timeout):
+            deadline = time.monotonic() + max(timeout, 1.0)
+            while time.monotonic() < deadline:
+                if not _pid_exists(old_pid):
+                    return True
+                time.sleep(0.5)
+            return not _pid_exists(old_pid)
+
+        def _wait_for_runtime_ready(timeout):
+            deadline = time.monotonic() + max(timeout, 1.0)
+            while time.monotonic() < deadline:
+                try:
+                    new_pid = get_running_pid()
+                except Exception:
+                    new_pid = None
+                if new_pid and new_pid != old_pid:
+                    runtime_state = _runtime_status_for_pid(new_pid) or {}
+                    gateway_state = runtime_state.get("gateway_state")
+                    if gateway_state == "running":
+                        return True
+                    if gateway_state == "startup_failed":
+                        return False
+                time.sleep(2)
+            return False
+
+        old_pid_exited = _wait_for_old_pid_exit(graceful_timeout)
+        if old_pid_exited and _wait_for_runtime_ready(relaunch_timeout):
+            raise SystemExit(0)
+
+        try:
+            target = f"{_launchd_domain()}/{label}"
+            result = _kickstart_launchd_service_and_wait(
+                target=target,
+                previous_pid=old_pid,
+                timeout=relaunch_timeout,
+                exit_on_detached_failure=False,
+            )
+            if result != "ready":
+                _log(
+                    f"fallback result={result} old_pid={old_pid} target={target}"
+                )
+        except Exception:
+            _log(f"fallback raised unexpectedly for label={label}")
+        """
+    ).strip()
+
+    try:
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                watcher,
+                str(old_pid),
+                label,
+                str(graceful_timeout),
+                str(relaunch_timeout),
+                str(log_path),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError:
+        return False
+    return True
+
+
+def _kickstart_launchd_service_and_wait(
+    *,
+    target: str,
+    previous_pid: int | None,
+    timeout: float = 60.0,
+    exit_on_detached_failure: bool = True,
+) -> str:
+    """Run the launchd kickstart/recovery flow and wait for runtime-ready state.
+
+    Returns:
+        ``"ready"`` when a fresh runtime-ready PID was observed.
+        ``"detached"`` when launchd was unsupported and we fell back to a
+        detached background gateway.
+        ``"not_ready"`` when launchctl accepted the restart command but the
+        gateway never reached runtime-ready state.
+    """
+    try:
+        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+    except subprocess.CalledProcessError as exc:
+        if not _launchd_error_indicates_unloaded(exc):
+            if _launchctl_domain_unsupported(exc.returncode):
+                return (
+                    "detached"
+                    if _launchd_fallback_to_detached(
+                        f"launchctl kickstart exit {exc.returncode}",
+                        exit_on_failure=exit_on_detached_failure,
+                    )
+                    else "not_ready"
+                )
+            raise
+        print("↻ launchd job was unloaded; reloading")
+        plist_path = get_launchd_plist_path()
+        try:
+            subprocess.run(
+                ["launchctl", "bootout", target],
+                check=False,
+                timeout=90,
+            )
+            subprocess.run(
+                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+                check=True,
+                timeout=30,
+            )
+            subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+        except subprocess.CalledProcessError as exc2:
+            if not _launchctl_domain_unsupported(exc2.returncode):
+                raise
+            return (
+                "detached"
+                if _launchd_fallback_to_detached(
+                    f"launchctl exit {exc2.returncode}",
+                    exit_on_failure=exit_on_detached_failure,
+                )
+                else "not_ready"
+            )
+    return (
+        "ready"
+        if _wait_for_launchd_service_restart(
+            previous_pid=previous_pid,
+            timeout=timeout,
+        )
+        else "not_ready"
+    )
 
 
 def _systemd_unit_is_start_limited(props: dict[str, str]) -> bool:
@@ -4241,76 +4484,64 @@ def _wait_for_gateway_exit(
 
 def launchd_restart():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
     drain_timeout = _get_restart_drain_timeout()
+    relaunch_timeout = 60.0
     from gateway.status import get_running_pid
 
-    try:
-        pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
-            print("✓ Service restart requested")
-            _clear_launchd_unsupported_marker()
-            return
-        if pid is not None:
-            # Announce the drain BEFORE waiting on it. This wait can run for
-            # the full drain budget (180s by default) while the old gateway
-            # finishes in-flight agent runs, and it streams into surfaces with
-            # no other feedback — the desktop updater's live output most of
-            # all, where a silent stop here reads as "update stuck" (#44515).
-            # Mirrors the systemd branch's "draining (up to Ns)..." line.
-            print(
-                f"→ Stopping gateway (PID {pid}) — draining in-flight runs "
-                f"(up to {drain_timeout:.0f}s)..."
-            )
-            try:
-                terminate_pid(pid, force=False)
-            except (ProcessLookupError, PermissionError, OSError):
-                pid = None
-            if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
-                if not exited:
-                    print(
-                        f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
-                    )
-        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
-        print("✓ Service restarted")
-        _clear_launchd_unsupported_marker()
-    except subprocess.CalledProcessError as e:
-        if not _launchd_error_indicates_unloaded(e):
-            # Not a "job unloaded" code. If the domain is fundamentally
-            # unmanageable (error 5), degrade to detached; the old process was
-            # already drained/terminated above. Otherwise re-raise.
-            if _launchctl_domain_unsupported(e.returncode):
-                _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
+    pid = get_running_pid()
+    self_restart_requested = pid is not None and _request_gateway_self_restart(pid)
+    if self_restart_requested:
+        graceful_timeout = drain_timeout + 5
+        _spawn_launchd_service_restart_watcher(
+            old_pid=pid,
+            label=label,
+            graceful_timeout=graceful_timeout,
+            relaunch_timeout=relaunch_timeout,
+        )
+        print(f"⏳ Service restarting gracefully (PID {pid})...")
+        if _wait_for_pid_exit(pid, graceful_timeout):
+            if _wait_for_launchd_service_restart(
+                previous_pid=pid,
+                timeout=relaunch_timeout,
+            ):
+                _clear_launchd_unsupported_marker()
                 return
-            raise
-        # Job not loaded — bootstrap and start fresh
-        print("↻ launchd job was unloaded; reloading")
-        plist_path = get_launchd_plist_path()
+        print(
+            f"⚠ Graceful restart did not complete cleanly within {int(graceful_timeout)}s; "
+            "forcing launchd restart..."
+        )
+    elif pid is not None:
+        # Announce the drain BEFORE waiting on it. This wait can run for
+        # the full drain budget (180s by default) while the old gateway
+        # finishes in-flight agent runs, and it streams into surfaces with
+        # no other feedback — the desktop updater's live output most of
+        # all, where a silent stop here reads as "update stuck" (#44515).
+        # Mirrors the systemd branch's "draining (up to Ns)..." line.
+        print(
+            f"→ Stopping gateway (PID {pid}) — draining in-flight runs "
+            f"(up to {drain_timeout:.0f}s)..."
+        )
         try:
-            # Restart is the one path where the job is almost always still
-            # registered (we just drained it), so a plain bootstrap would hit
-            # EIO on the common case. Boot the stale label out first — cheaper
-            # and clearer here than routing through _launchctl_bootstrap's
-            # bootstrap-first/retry-on-EIO flow. See #23387, #42914.
-            subprocess.run(
-                ["launchctl", "bootout", target],
-                check=False,
-                timeout=90,
-            )
-            subprocess.run(
-                ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
-                check=True,
-                timeout=30,
-            )
-            subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
-        except subprocess.CalledProcessError as e2:
-            if not _launchctl_domain_unsupported(e2.returncode):
-                raise
-            _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
-            return
-        print("✓ Service restarted")
+            terminate_pid(pid, force=False)
+        except (ProcessLookupError, PermissionError, OSError):
+            pid = None
+        if pid is not None:
+            exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
+            if not exited:
+                print(
+                    f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
+                )
+    target = f"{_launchd_domain()}/{label}"
+    result = _kickstart_launchd_service_and_wait(
+        target=target,
+        previous_pid=pid,
+        timeout=relaunch_timeout,
+    )
+    if result == "ready":
         _clear_launchd_unsupported_marker()
+        return
+    if result == "detached":
+        return
 
 
 def launchd_status(deep: bool = False):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -839,6 +839,11 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda previous_pid=None, timeout=60.0: calls.append(("wait-restart", previous_pid, timeout)) or True,
+        )
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
@@ -856,6 +861,7 @@ class TestLaunchdServiceRecovery:
         assert calls == [
             ("term", 321, False),
             ["launchctl", "kickstart", "-k", target],
+            ("wait-restart", 321, 60.0),
         ]
         # The drain can silently hold for the full budget (180s default); the
         # desktop updater streams this output as its only progress feedback,
@@ -864,9 +870,13 @@ class TestLaunchdServiceRecovery:
         assert "draining in-flight runs" in out
         assert "up to 12s" in out
 
-    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
+    def test_launchd_restart_self_requests_graceful_restart_starts_watcher_and_waits_for_relaunch(
+        self, monkeypatch, capsys
+    ):
         calls = []
+        label = gateway_cli.get_launchd_label()
 
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
@@ -877,6 +887,21 @@ class TestLaunchdServiceRecovery:
             lambda pid: calls.append(("self", pid)) or True,
         )
         monkeypatch.setattr(
+            gateway_cli,
+            "_spawn_launchd_service_restart_watcher",
+            lambda **kwargs: calls.append(("watcher", kwargs["old_pid"], kwargs["label"], kwargs["graceful_timeout"], kwargs["relaunch_timeout"])) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_pid_exit",
+            lambda pid, timeout: calls.append(("wait-exit", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda previous_pid=None, timeout=60.0: calls.append(("wait-restart", previous_pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
             gateway_cli.subprocess,
             "run",
             lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
@@ -884,8 +909,119 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_restart()
 
-        assert calls == [("self", 321)]
-        assert "restart requested" in capsys.readouterr().out.lower()
+        assert calls == [
+            ("self", 321),
+            ("watcher", 321, label, 17.0, 60.0),
+            ("wait-exit", 321, 17.0),
+            ("wait-restart", 321, 60.0),
+        ]
+        out = capsys.readouterr().out.lower()
+        assert "restarting gracefully" in out
+
+    def test_launchd_restart_self_request_falls_back_to_kickstart_after_drain_timeout(
+        self, monkeypatch, capsys
+    ):
+        calls = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        label = gateway_cli.get_launchd_label()
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("self", pid)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_spawn_launchd_service_restart_watcher",
+            lambda **kwargs: calls.append(("watcher", kwargs["old_pid"], kwargs["label"], kwargs["graceful_timeout"], kwargs["relaunch_timeout"])) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_pid_exit",
+            lambda pid, timeout: calls.append(("wait-exit", pid, timeout)) or False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda previous_pid=None, timeout=60.0: calls.append(("wait-restart", previous_pid, timeout)) or True,
+        )
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ("self", 321),
+            ("watcher", 321, label, 17.0, 60.0),
+            ("wait-exit", 321, 17.0),
+            ["launchctl", "kickstart", "-k", target],
+            ("wait-restart", 321, 60.0),
+        ]
+        out = capsys.readouterr().out.lower()
+        assert "forcing launchd restart" in out
+
+    def test_launchd_restart_self_request_accepts_fast_relaunch_without_none_gap(
+        self, monkeypatch, capsys
+    ):
+        calls = []
+        pids = iter([321, 654])
+        pid_exists = iter([True, False])
+        label = gateway_cli.get_launchd_label()
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: next(pids))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: next(pid_exists))
+        monkeypatch.setattr("time.monotonic", lambda: 0.0)
+        monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("self", pid)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_spawn_launchd_service_restart_watcher",
+            lambda **kwargs: calls.append(("watcher", kwargs["old_pid"], kwargs["label"], kwargs["graceful_timeout"], kwargs["relaunch_timeout"])) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_gateway_runtime_status_for_pid",
+            lambda pid: calls.append(("runtime", pid)) or {"pid": pid, "gateway_state": "running"},
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls[0] == ("self", 321)
+        assert ("watcher", 321, label, 17.0, 60.0) in calls
+        assert ("runtime", 654) in calls
+        out = capsys.readouterr().out.lower()
+        assert "service restarted (pid 654)" in out
+        assert "forcing launchd restart" not in out
+
+    def test_wait_for_launchd_service_restart_timeout_reports_logs(self, monkeypatch, capsys):
+        ticks = iter([0.0, 0.0, 31.0])
+
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr("time.monotonic", lambda: next(ticks))
+        monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr("hermes_constants.display_hermes_home", lambda: "/tmp/hermes-home")
+
+        assert gateway_cli._wait_for_launchd_service_restart(timeout=30.0) is False
+
+        out = capsys.readouterr().out
+        assert "Service did not become ready within 30s." in out
+        assert "/tmp/hermes-home/logs/gateway.log" in out
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""
@@ -1134,6 +1270,11 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(
             gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True
         )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda previous_pid=None, timeout=60.0: calls.append(("wait-restart", previous_pid, timeout)) or True,
+        )
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
@@ -1157,6 +1298,7 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "bootout", target],
             ["launchctl", "bootstrap", domain, str(plist_path)],
             ["launchctl", "kickstart", target],
+            ("wait-restart", 321, 60.0),
         ]
 
     def test_launchd_stop_tolerates_domain_unsupported_bootout(self, monkeypatch, capsys):


### PR DESCRIPTION
## What does this PR do?

Fixes the macOS launchd in-band restart/update path so Hermes does not report success before a fresh gateway process is actually runtime-ready.

The old self-restart path returned immediately after sending `SIGUSR1`, which let `hermes update` / `hermes gateway restart` complete while the old gateway was still draining and before launchd had confirmed a healthy replacement. In the gateway-hosted terminal path, that also left fallback `launchctl kickstart -k` vulnerable to being killed with the old gateway process group.

This PR waits for the old PID to exit, waits for a fresh launchd-managed PID to reach `gateway_state=running`, and uses a detached watcher plus a shared launchd recovery helper so forced fallback survives in-band teardown.

## Related Issue

Fixes #56524

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`
  - add `_wait_for_pid_exit()` and `_wait_for_launchd_service_restart()` so launchd restart success means a fresh runtime-ready gateway PID, not just a signal request
  - add a detached launchd restart watcher for in-band self-restart / update flows so fallback restart survives gateway teardown
  - unify launchd `kickstart` / unloaded-job recovery / detached fallback behind `_kickstart_launchd_service_and_wait()`
  - route `launchd_restart()` through the shared recovery path and only clear the unsupported marker after runtime-ready recovery
- `tests/hermes_cli/test_gateway_service.py`
  - cover graceful self-restart watcher flow
  - cover drain-timeout fallback to `launchctl kickstart -k`
  - cover fast relaunch with no `None` PID gap
  - cover readiness timeout log guidance
  - cover unloaded-job recovery waiting for runtime-ready after `bootout -> bootstrap -> kickstart`

## How to Test

1. Reproduce the old behavior on the clean baseline for `#56524`:
   - self-restart requests return `✓ Service restart requested` immediately after `SIGUSR1`, before launchd runtime-ready confirmation
2. Verify the targeted launchd restart coverage:
   - `./scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k 'launchd_restart_drains_running_gateway_before_kickstart or launchd_restart_self_request or wait_for_launchd_service_restart_timeout_reports_logs or launchd_restart_boots_out_stale_registration_before_bootstrap or launchd_restart_falls_back_to_detached_on_error_5'`
   - `.venv/bin/python -m pytest -q tests/hermes_cli/test_gateway_service.py -k 'launchd_restart_self_request or wait_for_launchd_service_restart_timeout_reports_logs'`
3. Verify static checks:
   - `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
   - `git diff --check`
4. Optional broader check:
   - `.venv/bin/python -m pytest -q tests/hermes_cli/test_gateway_service.py`
   - On this macOS host it still ends at `182 passed, 6 failed`; the 6 failures are the pre-existing user-systemd baseline failures, unrelated to this patch

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3 / launchd

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
