### PR TITLE
fix(error-classifier): retry HTTP 408 as timeout instead of aborting as format_error

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -991,6 +991,17 @@ def _classify_by_status(
             )
         return result_fn(FailoverReason.overloaded, retryable=True)
 
+    # 408 Request Timeout — a transient timing failure the server itself flags
+    # as safe to retry (RFC 9110 §15.5.9), not a malformed request. Commonly
+    # emitted by reverse proxies sitting in front of self-hosted backends
+    # (llama.cpp / Ollama / vLLM) when a long generation outruns the proxy's
+    # request-read window. Route to the dedicated ``timeout`` reason (rebuild
+    # client + retry) instead of falling through to the generic 4xx bucket
+    # below, which would abort the turn on a retry-safe error the same way it
+    # aborts a 400 Bad Request.
+    if status_code == 408:
+        return result_fn(FailoverReason.timeout, retryable=True)
+
     # Other 4xx — non-retryable
     if 400 <= status_code < 500:
         return result_fn(

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -375,6 +375,26 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
 
+    def test_408_request_timeout_is_retryable_timeout(self):
+        """HTTP 408 Request Timeout is a transient timing failure the server
+        itself flags as safe to retry (RFC 9110 §15.5.9) — commonly emitted by
+        reverse proxies in front of self-hosted backends (llama.cpp / Ollama /
+        vLLM) when a long generation outruns the proxy's request-read window.
+        It must NOT fall into the generic 4xx bucket as a non-retryable
+        format_error, which would abort the turn on a retry-safe error."""
+        e = MockAPIError("Request Timeout", status_code=408)
+        result = classify_api_error(e, provider="vllm")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    def test_400_bad_request_still_non_retryable_format_error(self):
+        """Guard the boundary: a genuine 400 Bad Request must remain a
+        non-retryable format_error and must not be swept up by the 408 branch."""
+        e = MockAPIError("Bad Request", status_code=400)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
     def test_message_only_overloaded_without_status_is_overloaded(self):
         """Some Anthropic-compatible proxies surface 'overloaded' in the
         message with no 503/529 status_code. It must classify as overloaded


### PR DESCRIPTION
## What does this PR do?

`_classify_by_status()` in `agent/error_classifier.py` routes every other
transient HTTP status to a **retryable** reason — `500/502 → server_error`,
`503/529 → overloaded`, `429 → rate_limit`, `413 → payload_too_large` — but
**HTTP 408 Request Timeout** fell through to the generic `400 <= status < 500`
branch and was classified as a **non-retryable `format_error`**, i.e. the same
bucket as a 400 Bad Request.

A 408 is a transient timing failure the server itself flags as safe to retry
(RFC 9110 §15.5.9), not a malformed request. Classifying it as `format_error`
sends `retryable=False` to the retry loop, so the turn is **aborted** when a
simple retry would recover.

Common trigger: a reverse proxy sitting in front of a self-hosted backend
(llama.cpp / Ollama / vLLM) returns 408 when a long generation outruns the
proxy's request-read window — a setup Hermes explicitly supports.

Fix: route `408` to the existing `FailoverReason.timeout` (rebuild client +
retry), consistent with how the other transient statuses are handled.

## Related Issue

N/A — no existing issue. Happy to open one first if maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` — in `_classify_by_status()`, add an explicit `status_code == 408 → FailoverReason.timeout (retryable=True)` branch **before** the generic non-retryable 4xx fallback.
- `tests/agent/test_error_classifier.py` — add `test_408_request_timeout_is_retryable_timeout` and a boundary test `test_400_bad_request_still_non_retryable_format_error`.

## How to Test

1. Before the fix, an error carrying `status_code=408` classifies as `format_error` with `retryable=False`:

```python
from agent.error_classifier import classify_api_error
class E(Exception):
    def __init__(self, s): super().__init__("Request Timeout"); self.status_code = s
c = classify_api_error(E(408), provider="vllm")
print(c.reason.value, c.retryable)   # before: format_error False  |  after: timeout True
```

2. Run `pytest tests/agent/test_error_classifier.py -q` → 181 passed (500/503/429/400 behaviour unchanged).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/agent/test_error_classifier.py -q` and all tests pass (181)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docstrings updated / N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (status-code logic, platform-independent)
- [x] Tool descriptions/schemas — N/A