### PR TITLE
fix(telegram): don't eat trailing space after @botname in _clean_bot_trigger_text

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6240,10 +6240,28 @@ class TelegramAdapter(BasePlatformAdapter):
         return self._telegram_guest_mode() and self._message_mentions_bot(message)
 
     def _clean_bot_trigger_text(self, text: Optional[str]) -> Optional[str]:
+        """Remove ``@botname`` trigger from inbound text.
+
+        In DMs Telegram sends ``/resume 2`` — nothing to clean.
+        In groups, the bot command menu auto-fills ``/resume@botname 2``.
+        The ``\b`` word-boundary anchors to the end of ``botname``; we must
+        NOT consume the trailing space after ``@botname`` because that space
+        separates the command name from its arguments.
+
+        Before fix: ``/resume@botname 2`` → ``/resume2`` (space eaten)
+        After fix:  ``/resume@botname 2`` → ``/resume 2`` (space preserved)
+
+        Leading spaces (e.g. ``@botname /resume 2``) are still stripped by
+        the ``.strip()`` call — ``@botname`` is replaced, leaving `` /resume
+        2``, which ``.strip()`` normalises to ``/resume 2``.
+        """
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
         username = re.escape(self._bot.username)
-        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
+        # NOTE: do NOT include \s* here — trailing space separates command
+        # name from args (``/resume 2``).  For ``@botname /resume 2`` the
+        # leading space survives the sub and is removed by .strip().
+        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*", "", text).strip()
         return cleaned or text
 
     def _should_observe_unmentioned_group_message(self, message: Message) -> bool:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 from gateway.platforms.base import MessageType
 from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
 
 
 def _make_adapter(
@@ -148,6 +149,60 @@ def _bot_command_entity(text, command):
     """
     offset = text.index(command)
     return SimpleNamespace(type="bot_command", offset=offset, length=len(command))
+
+
+# ------------------------------------------------------------------
+# _clean_bot_trigger_text regression tests (GH: slash args eaten in groups)
+# ------------------------------------------------------------------
+
+
+def test_clean_bot_trigger_text_drops_at_mention():
+    """Verify ``@botname`` prefix is stripped from command text."""
+    adapter = _make_adapter(bot_username="mybot")
+    assert adapter._clean_bot_trigger_text("@mybot /resume 2") == "/resume 2"
+
+
+def test_clean_bot_trigger_text_drops_at_mention_followed_by_comma():
+    """Variation with a comma between mention and command."""
+    adapter = _make_adapter(bot_username="mybot")
+    assert adapter._clean_bot_trigger_text("@mybot, /resume 2") == "/resume 2"
+
+
+def test_clean_bot_trigger_text_preserves_trailing_space_after_mention():
+    """Key regression test: the space between command and args must NOT be eaten.
+
+    In groups, Telegram command menu auto-fills ``/resume@botname 2``.
+    The old regex ``@botname\\s*`` would eat the space, turning it into
+    ``/resume2`` — which Telegram then reports as "Unknown command /resume2".
+    """
+    adapter = _make_adapter(bot_username="hermes_bot")
+    # When text has NO @botname (DM path), nothing should change.
+    assert adapter._clean_bot_trigger_text("/resume 2") == "/resume 2"
+    # When @botname is present (group path), only @botname is removed,
+    # not the space that follows it.
+    assert adapter._clean_bot_trigger_text("/resume@hermes_bot 2") == "/resume 2"
+
+
+def test_clean_bot_trigger_text_preserves_args_with_multiple_words():
+    """Arguments with spaces must survive intact."""
+    adapter = _make_adapter(bot_username="bot")
+    assert adapter._clean_bot_trigger_text("/new my topic name") == "/new my topic name"
+    assert adapter._clean_bot_trigger_text("@bot /new my topic name") == "/new my topic name"
+
+
+def test_clean_bot_trigger_text_none_input():
+    adapter = _make_adapter(bot_username="bot")
+    assert adapter._clean_bot_trigger_text(None) is None
+    assert adapter._clean_bot_trigger_text("") == ""
+
+
+def test_clean_bot_trigger_text_no_bot_username():
+    """When bot has no username (edge case), text passes through unchanged."""
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra={})
+    adapter._bot = SimpleNamespace(id=999, username=None)
+    assert adapter._clean_bot_trigger_text("/resume 2") == "/resume 2"
 
 
 def test_group_messages_can_be_opened_via_config():


### PR DESCRIPTION
## Problem

When a user triggers a slash command via the Telegram bot menu in a group chat, Telegram auto-fills the bot username into the command: `/resume@botname 2`.

The `_clean_bot_trigger_text` method in `plugins/platforms/telegram/adapter.py` is designed to strip `@botname` so the command reaches the gateway cleanly. But the regex:

```python
cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
```

has `\s*` at the end, which **consumes the space between the command name and its arguments**. Result:

- Input: `/resume@botname 2`
- Output: `/resume2` (space eaten)
- Telegram response: `"Unknown command /resume2. Type /commands to see what's available, or resend without the leading slash to send as a regular message."`

This affects **all slash commands with arguments** in group chats (not just `/resume`), e.g.:
- `/new my topic name` → `/newmy topic name`
- `/model anthropic/claude-sonnet-4` → `/modelanthropic/claude-sonnet-4`

In DMs, Telegram sends the command as-is (`/resume 2`) so the bug never manifests there.

## Root Cause

File: `plugins/platforms/telegram/adapter.py` line ~6246

The `\s*` was likely added out of caution for the `@botname /cmd args` form (where `@botname` precedes the command), but `\b` already anchors to the word boundary, and `strip()` handles leading/trailing whitespace after removal. The space after `@botname` when it follows the command name (`/cmd@botname args`) is not part of the trigger — it separates the command from arguments.

## Fix

Remove `\s*` from the regex:

```diff
-        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
+        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*", "", text).strip()
```

For `@botname /cmd args` — `@botname` is removed, leaving ` /cmd args`, and `strip()` cleans the leading space → `/cmd args`.
For `/cmd@botname args` — `@botname` is removed, the trailing space is **not** consumed → `/cmd args`.

## Testing

6 regression tests added in `tests/gateway/test_telegram_group_gating.py`:
- `test_clean_bot_trigger_text_drops_at_mention`
- `test_clean_bot_trigger_text_drops_at_mention_followed_by_comma`
- `test_clean_bot_trigger_text_preserves_trailing_space_after_mention` — **key regression test**
- `test_clean_bot_trigger_text_preserves_args_with_multiple_words`
- `test_clean_bot_trigger_text_none_input`
- `test_clean_bot_trigger_text_no_bot_username`

All 55 tests in the file pass (6 new + 49 existing).

Closes #56910
