### PR TITLE
fix(kanban): strip think blocks before parsing decomposer JSON

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -346,6 +346,17 @@ def decompose_task(
     except Exception:
         raw = ""
 
+    # Think-enabled auxiliary models (MiniMax M2, DeepSeek-R1, Qwen-QwQ) emit
+    # inline <think> reasoning even for this structured-output prompt. That
+    # reasoning routinely contains braces (schema sketches, set notation), which
+    # breaks _extract_json_blob's naive first-"{" .. last-"}" slice and makes
+    # decompose fail as "malformed JSON" even when the model produced a valid
+    # object. An unterminated block (token-limit truncation) is just as likely.
+    # Strip think blocks first via the canonical scrubber, mirroring
+    # title_generator and kanban_specify.
+    from agent.agent_runtime_helpers import strip_think_blocks
+    raw = strip_think_blocks(None, raw)
+
     parsed = _extract_json_blob(raw)
     if parsed is None:
         return DecomposeOutcome(task_id, False, "LLM returned malformed JSON")

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -112,6 +112,46 @@ def test_decompose_with_fanout_creates_children(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_decompose_strips_think_block_before_json_parse(kanban_home):
+    """Think-enabled auxiliary models (MiniMax M2, DeepSeek-R1, Qwen-QwQ) emit
+    inline <think> reasoning even for this structured-output prompt, and that
+    reasoning routinely contains braces. Without a think-strip pass those braces
+    break _extract_json_blob's naive first-"{" .. last-"}" slice, so decompose
+    fails as "malformed JSON" even though the model produced a valid object.
+    Mirrors title_generator / kanban_specify."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a feature", triage=True)
+
+    payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test split",
+        "tasks": [
+            {"title": "research", "body": "look it up", "assignee": "researcher", "parents": []},
+            {"title": "build", "body": "code it", "assignee": "engineer", "parents": [0]},
+        ],
+    })
+    # Reasoning with braces BEFORE the real JSON — exactly what breaks the
+    # naive slice when think blocks aren't stripped first.
+    raw = (
+        "<think>\nThe child schema is {title, body}; I'll split into "
+        "{research, build}.\n</think>\n" + payload
+    )
+
+    patches = _patch_list_profiles(["orchestrator", "researcher", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(raw), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.fanout is True
+    assert outcome.child_ids and len(outcome.child_ids) == 2
+
+
 def test_decompose_fanout_false_assigns_default_when_unassigned(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="just one thing", triage=True)


### PR DESCRIPTION
## What does this PR do?

`decompose_task()` in `hermes_cli/kanban_decompose.py` reads the auxiliary
model's raw response (`resp.choices[0].message.content`) and feeds it straight
to `_extract_json_blob()`, which does a naive first-`{` … last-`}` slice.

Think-enabled auxiliary models (MiniMax M2, DeepSeek-R1, Qwen-QwQ) emit inline
`<think>` reasoning **even for this structured-output prompt**, and that
reasoning routinely contains braces (schema sketches, set notation like
`{title, body}`). Those braces break the slice, so decompose fails with
**`"LLM returned malformed JSON"` even when the model produced a valid object** —
i.e. kanban decompose is effectively broken for anyone using a reasoning model
as their auxiliary model.

Fix: route the raw response through the canonical `strip_think_blocks()`
scrubber before `_extract_json_blob`, mirroring the already-merged
`title_generator` fix (3b739b990) and the sibling `kanban_specify` path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_decompose.py` — in `decompose_task()`, strip `<think>`
  blocks via `agent.agent_runtime_helpers.strip_think_blocks(None, raw)` before
  `_extract_json_blob(raw)`.
- `tests/hermes_cli/test_kanban_decompose.py` — add
  `test_decompose_strips_think_block_before_json_parse` (a valid fanout payload
  wrapped in a brace-containing `<think>` block still decomposes).

## How to Test

1. Before the fix, a think-model response fails to parse:

```python
from hermes_cli.kanban_decompose import _extract_json_blob
raw = '<think>schema is {title, body}</think>\n{"fanout": false, "title": "x", "body": "y"}'
print(_extract_json_blob(raw))   # before: None (-> "LLM returned malformed JSON")
```

2. Run the suite:

```
pytest tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py -q
```

→ 21 passed. Mutation-verified: reverting the strip makes the new test fail with the historical `LLM returned malformed JSON`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_kanban_decompose.py -q` and all tests pass (21)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docstrings / N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure text handling)
- [x] Tool descriptions/schemas — N/A