### PR TITLE
fix(file): block proc leaks in search results

### DIFF
--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -277,9 +277,46 @@ def test_search_tool_filters_credential_results(fake_home, tmp_path, monkeypatch
     assert "public note" in raw
     assert str(safe) in returned_paths
     assert out["_omitted"].startswith("4 result(s) omitted")
-    assert out["total_count"] == 5
+    assert out["total_count"] == 2
     assert out["truncated"] is True
     assert "[Hint: Results truncated." in search_response
+
+
+def test_search_tool_preserves_count_mode_total_after_filtering(fake_home, tmp_path, monkeypatch):
+    """Count-mode total_count remains sum(visible counts), not visible file count."""
+    import json
+
+    from tools.file_operations import SearchResult
+    import tools.file_tools as ft
+
+    auth = _create(fake_home, "auth.json")
+    safe = _create(fake_home, "notes.txt")
+
+    class FakeFileOps:
+        def search(self, **kwargs):
+            return SearchResult(
+                counts={str(auth): 7, str(safe): 2},
+                total_count=9,
+                truncated=False,
+            )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": FakeFileOps())
+    monkeypatch.setattr(
+        ft, "_get_live_tracking_cwd", lambda task_id="default": None
+    )
+
+    search_response = ft.search_tool(
+        pattern="SEARCH",
+        path=str(fake_home),
+        output_mode="count",
+        task_id="search-filter-counts",
+    )
+    out = json.loads(search_response.split("\n\n[Hint:", 1)[0])
+
+    assert out["counts"] == {str(safe): 2}
+    assert out["total_count"] == 2
+    assert out["_omitted"].startswith("1 result(s) omitted")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -163,9 +163,45 @@ def test_search_tool_filters_credential_results(fake_home, tmp_path, monkeypatch
     assert "public note" in raw
     assert str(safe) in returned_paths
     assert out["_omitted"].startswith("4 result(s) omitted")
-    assert out["total_count"] == 5
+    assert out["total_count"] == 2
     assert out["truncated"] is True
     assert out["_hint"].startswith("Results truncated. Use offset=")
+
+
+def test_search_tool_preserves_count_mode_total_after_filtering(fake_home, tmp_path, monkeypatch):
+    """Count-mode total_count remains sum(visible counts), not visible file count."""
+    import json
+
+    from tools.file_operations import SearchResult
+    import tools.file_tools as ft
+    import tools.terminal_tool as terminal_tool
+
+    auth = _create(fake_home, "auth.json")
+    safe = _create(fake_home, "notes.txt")
+
+    class FakeFileOps:
+        def search(self, **kwargs):
+            return SearchResult(
+                counts={str(auth): 7, str(safe): 2},
+                total_count=9,
+                truncated=False,
+            )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": FakeFileOps())
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+
+    search_response = ft.search_tool(
+        pattern="SEARCH",
+        path=str(fake_home),
+        output_mode="count",
+        task_id="search-filter-counts",
+    )
+    out = json.loads(search_response.split("\n\n[Hint:", 1)[0])
+
+    assert out["counts"] == {str(safe): 2}
+    assert out["total_count"] == 2
+    assert out["_omitted"].startswith("1 result(s) omitted")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -14,8 +14,10 @@ import time
 import unittest
 from unittest.mock import patch, MagicMock
 
+from tools.file_operations import SearchMatch, SearchResult
 from tools.file_tools import (
     read_file_tool,
+    search_tool,
     write_file_tool,
     reset_file_dedup,
     _is_blocked_device,
@@ -219,6 +221,51 @@ class TestDevicePathBlocking(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("device file", result["error"])
         mock_ops.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_rejects_device_path_before_io(self, mock_ops):
+        result = json.loads(search_tool("stack", path="/proc/self/maps", task_id="proc_search_path"))
+
+        self.assertIn("error", result)
+        self.assertIn("device file", result["error"])
+        mock_ops.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_filters_proc_sensitive_content_matches(self, mock_ops):
+        mock_ops.return_value.search.return_value = SearchResult(
+            matches=[
+                SearchMatch("/proc/self/smaps", 1, "7fff0000-7fff1000 rw-p [stack]"),
+                SearchMatch("/proc/self/task/1234/auxv", 1, "AT_RANDOM bytes"),
+                SearchMatch("/proc/self/status", 1, "Name:\tpython"),
+            ],
+            total_count=3,
+        )
+
+        result = json.loads(search_tool("stack", path="/proc/self", task_id="proc_search"))
+
+        paths = [m["path"] for m in result.get("matches", [])]
+        self.assertNotIn("/proc/self/smaps", paths)
+        self.assertNotIn("/proc/self/task/1234/auxv", paths)
+        self.assertIn("/proc/self/status", paths)
+        self.assertEqual(result["total_count"], 1)
+        self.assertIn("omitted", result.get("_omitted", ""))
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_filters_proc_sensitive_file_results(self, mock_ops):
+        mock_ops.return_value.search.return_value = SearchResult(
+            files=[
+                "/proc/self/maps",
+                "/proc/self/smaps_rollup",
+                "/proc/self/status",
+            ],
+            total_count=3,
+        )
+
+        result = json.loads(search_tool("*maps*", target="files", path="/proc/self", task_id="proc_find"))
+
+        self.assertEqual(result.get("files"), ["/proc/self/status"])
+        self.assertEqual(result["total_count"], 1)
+        self.assertIn("omitted", result.get("_omitted", ""))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -14,8 +14,10 @@ import time
 import unittest
 from unittest.mock import patch, MagicMock
 
+from tools.file_operations import SearchMatch, SearchResult
 from tools.file_tools import (
     read_file_tool,
+    search_tool,
     write_file_tool,
     _is_blocked_device,
     _DEFAULT_MAX_READ_CHARS,
@@ -211,6 +213,51 @@ class TestDevicePathBlocking(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("device file", result["error"])
         mock_ops.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_rejects_device_path_before_io(self, mock_ops):
+        result = json.loads(search_tool("stack", path="/proc/self/maps", task_id="proc_search_path"))
+
+        self.assertIn("error", result)
+        self.assertIn("device file", result["error"])
+        mock_ops.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_filters_proc_sensitive_content_matches(self, mock_ops):
+        mock_ops.return_value.search.return_value = SearchResult(
+            matches=[
+                SearchMatch("/proc/self/smaps", 1, "7fff0000-7fff1000 rw-p [stack]"),
+                SearchMatch("/proc/self/task/1234/auxv", 1, "AT_RANDOM bytes"),
+                SearchMatch("/proc/self/status", 1, "Name:\tpython"),
+            ],
+            total_count=3,
+        )
+
+        result = json.loads(search_tool("stack", path="/proc/self", task_id="proc_search"))
+
+        paths = [m["path"] for m in result.get("matches", [])]
+        self.assertNotIn("/proc/self/smaps", paths)
+        self.assertNotIn("/proc/self/task/1234/auxv", paths)
+        self.assertIn("/proc/self/status", paths)
+        self.assertEqual(result["total_count"], 1)
+        self.assertIn("omitted", result.get("_omitted", ""))
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_search_tool_filters_proc_sensitive_file_results(self, mock_ops):
+        mock_ops.return_value.search.return_value = SearchResult(
+            files=[
+                "/proc/self/maps",
+                "/proc/self/smaps_rollup",
+                "/proc/self/status",
+            ],
+            total_count=3,
+        )
+
+        result = json.loads(search_tool("*maps*", target="files", path="/proc/self", task_id="proc_find"))
+
+        self.assertEqual(result.get("files"), ["/proc/self/status"])
+        self.assertEqual(result["total_count"], 1)
+        self.assertIn("omitted", result.get("_omitted", ""))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -439,7 +439,11 @@ def _search_result_read_block_error(path: str, task_id: str = "default") -> str 
     try:
         resolved = _resolve_path_for_task(path, task_id)
     except (OSError, ValueError, RuntimeError):
+        if _is_blocked_device(path):
+            return "blocked device path"
         return get_read_block_error(path)
+    if _is_blocked_device(str(resolved)):
+        return "blocked device path"
     return get_read_block_error(str(resolved))
 
 
@@ -473,6 +477,17 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
                 continue
             allowed_counts[file_path] = count
         result.counts = allowed_counts
+
+    if omitted and hasattr(result, "total_count"):
+        if hasattr(result, "counts") and result.counts:
+            result.total_count = sum(result.counts.values())
+        else:
+            remaining = 0
+            if hasattr(result, "matches") and result.matches:
+                remaining += len(result.matches)
+            if hasattr(result, "files") and result.files:
+                remaining += len(result.files)
+            result.total_count = remaining
 
     return omitted
 
@@ -1802,6 +1817,14 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             resolved_path = _resolve_path_for_task(path, task_id)
         except (OSError, ValueError, RuntimeError):
             resolved_path = None
+        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(task_id)
+        if _is_blocked_device(path, base_dir=device_base):
+            return json.dumps({
+                "error": (
+                    f"Cannot search '{path}': this is a device file that would "
+                    "block or produce infinite output."
+                ),
+            }, ensure_ascii=False)
         block_error = get_read_block_error(str(resolved_path) if resolved_path else path)
         if block_error:
             return json.dumps({"error": block_error}, ensure_ascii=False)
@@ -1821,7 +1844,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if omitted:
             result_dict["_omitted"] = (
                 f"{omitted} result(s) omitted because they target credential, "
-                "token, cache, or secret-bearing environment files."
+                "token, cache, secret-bearing environment, or blocked device/proc files."
             )
 
         if count >= 3:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -227,6 +227,9 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
             target = str(_resolve_path_for_task(path, task_id))
         except (OSError, ValueError, RuntimeError):
             target = path
+        if _is_blocked_device(path) or _is_blocked_device(target):
+            omitted += 1
+            return False
         if get_read_block_error(target):
             omitted += 1
             return False
@@ -238,6 +241,16 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
         result.files = [f for f in result.files if _allowed(f)]
     if getattr(result, "counts", None):
         result.counts = {f: c for f, c in result.counts.items() if _allowed(f)}
+    if omitted and hasattr(result, "total_count"):
+        if getattr(result, "counts", None):
+            result.total_count = sum(result.counts.values())
+        else:
+            remaining = 0
+            if getattr(result, "matches", None):
+                remaining += len(result.matches)
+            if getattr(result, "files", None):
+                remaining += len(result.files)
+            result.total_count = remaining
     return omitted
 
 
@@ -962,6 +975,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         block_error = get_read_block_error(resolved_search_path)
         if block_error:
             return tool_error(block_error)
+        if _is_blocked_device(resolved_search_path):
+            return tool_error(
+                f"Cannot search '{path}': this is a device file that would "
+                "block or produce infinite output.")
 
         # A missing search root costs two shells (search + parent listing for
         # "Similar paths"); cache the miss so a retry skips both.
@@ -981,7 +998,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if omitted:
             result_dict["_omitted"] = (
                 f"{omitted} result(s) omitted because they target credential, "
-                "token, cache, or secret-bearing environment files.")
+                "token, cache, secret-bearing environment, or blocked "
+                "device/proc files.")
 
         # No early return on a cached miss — same rationale as the read path.
         _search_err = result_dict.get("error") or ""


### PR DESCRIPTION
## What does this PR do?

Extends the `/proc` sensitive-read hardening from `read_file` to the sibling `search_files` surface.

PR #56219 blocked `read_file` from returning ASLR- and secret-sensitive `/proc/*/{maps,smaps,smaps_rollup,numa_maps,mem,auxv,pagemap}` pseudo-files, including `/proc/<pid>/task/<tid>/...` aliases. `search_files` could still return the same data through content matches, file listings, and count results, or search a blocked pseudo-file root directly.

This change applies the same device/proc guard to `search_files`: blocked search roots are refused before I/O, and blocked proc/device paths are omitted from search results after backend execution.

## Related Issue

Follow-up sibling hardening for #56219.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_tools.py`
  - Refuses `search_files(path=...)` when the search root is a blocked device/proc pseudo-file.
  - Applies the same blocked proc/device check while filtering search matches, file results, and count results.
  - Recomputes `total_count` after omitting blocked results so the response only counts returned results.
  - Updates the omission message to include blocked device/proc files.
- `tests/tools/test_file_read_guards.py`
  - Adds regression coverage for direct blocked-root search refusal.
  - Adds regression coverage for filtering sensitive `/proc` content matches.
  - Adds regression coverage for filtering sensitive `/proc` file-list results.

## How to Test

1. Run the focused regression tests:

   ```bash
   python -m pytest \
     tests/tools/test_file_read_guards.py::TestDevicePathBlocking::test_search_tool_rejects_device_path_before_io \
     tests/tools/test_file_read_guards.py::TestDevicePathBlocking::test_search_tool_filters_proc_sensitive_content_matches \
     tests/tools/test_file_read_guards.py::TestDevicePathBlocking::test_search_tool_filters_proc_sensitive_file_results \
     -q
   ```

2. Run the full file-read guard suite:

   ```bash
   python -m pytest tests/tools/test_file_read_guards.py -q
   ```

3. Run adjacent file/search tests:

   ```bash
   python -m pytest \
     tests/tools/test_file_tools.py \
     tests/tools/test_search_error_guard.py \
     tests/tools/test_search_budget_truncation.py \
     tests/tools/test_search_hidden_dirs.py \
     -q
   ```

4. Run lint on changed files:

   ```bash
   python -m ruff check tools/file_tools.py tests/tools/test_file_read_guards.py
   ```

Observed locally:

- `tests/tools/test_file_read_guards.py`: 46 passed
- adjacent file/search tests listed above: 91 passed
- ruff: all checks passed

Manual sanity check after the fix:

- `search_files(path="/proc/self", pattern="stack")` omits `/proc/self/{maps,smaps,numa_maps}` matches and only returns safe files such as `/proc/self/limits`.
- `search_files(path="/proc/self", target="files", pattern="*maps*")` returns no blocked proc paths.
- `search_files(path="/proc/self/maps")` returns a pre-I/O device-file error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression tests:

```text
...                                                                      [100%]
3 passed in 0.17s
```

Full file-read guard suite:

```text
..............................................                           [100%]
46 passed in 0.98s
```

Adjacent file/search tests:

```text
........................................................................ [ 79%]
...................                                                      [100%]
91 passed in 2.48s
```

Ruff:

```text
All checks passed!
```
