### PR TITLE
fix(gateway): honor cmdline fallback for null-start_time locks when live start_time resolves

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -927,17 +927,22 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
-                # When start_time comparison is unavailable (macOS / Windows
-                # have no /proc, so both sides are None), fall back to
-                # checking the live process command line.  When cmdline is
-                # also unreadable (Windows has no ps), consult the lock
-                # record's own argv — the gateway writes it at startup and
+                # When the *record* has no start_time, a start_time comparison
+                # is impossible regardless of whether the live process exposes
+                # one — so fall back to checking the live process command line.
+                # This covers legacy locks and locks written on a build without
+                # the psutil start_time fallback (start_time serialized as
+                # null); once that fallback lands, current_start becomes a real
+                # value while the recorded start_time stays null, so gating on
+                # `current_start is None` would skip this branch and let the
+                # stale lock block startup forever after PID reuse.  When
+                # cmdline is also unreadable (Windows has no ps), consult the
+                # lock record's own argv — the gateway writes it at startup and
                 # it's the only identity signal on platforms without ps.
                 # Both oracles must indicate "not a gateway" to mark stale.
                 if (
                     not stale
                     and existing.get("start_time") is None
-                    and current_start is None
                     and not _looks_like_gateway_process(existing_pid)
                 ):
                     live_cmdline = _read_process_cmdline(existing_pid)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -736,6 +736,68 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_replaces_null_starttime_record_when_live_starttime_resolvable(self, tmp_path, monkeypatch):
+        """macOS regression: legacy record has start_time=None but the live PID now resolves one.
+
+        Builds without the psutil start_time fallback serialized locks with
+        start_time=None.  After that fallback landed, ``_get_process_start_time``
+        returns a real value for the live (reused) PID while the recorded
+        start_time stays None.  The old guard gated the cmdline fallback on
+        ``current_start is None`` too, so this branch was skipped and the stale
+        lock blocked the adapter forever once macOS reused the PID for an
+        unrelated process.  A record without a start_time must still fall back
+        to the cmdline identity check regardless of the live start_time.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 823,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["/Users/user/.hermes/hermes-agent/hermes_cli/main.py", "gateway", "run", "--replace"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        # The live PID resolves a real start_time now (psutil fallback), but the
+        # recorded start_time is still None so no comparison is possible.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 178297543424)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/System/Library/.../iCloudDriveFileProvider")
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
+    def test_acquire_scoped_lock_keeps_null_starttime_lock_when_live_pid_is_gateway(self, tmp_path, monkeypatch):
+        """A null-start_time record whose live PID still looks like a gateway must be honored.
+
+        Guards the fix above: dropping the ``current_start is None`` gate must
+        not delete a valid lock when the reused PID genuinely belongs to a
+        running gateway.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["/Users/user/.hermes/hermes-agent/hermes_cli/main.py", "gateway", "run", "--replace"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 178297543424)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is False
+        assert existing["pid"] == 99999
+
     def test_acquire_scoped_lock_keeps_lock_when_cmdline_unreadable_but_record_is_gateway(self, tmp_path, monkeypatch):
         """Windows regression: ps unavailable so cmdline cannot be read.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a residual macOS PID-reuse bug in `acquire_scoped_lock()` that the earlier fixes (#16376 family) left uncovered. A stale scoped lock with `start_time: null` can still permanently block a platform adapter once its recorded PID is reused by an unrelated system process — even on current `main`.

## Related Issue

Fixes #31890

## Root cause

`_get_process_start_time()` gained a psutil fallback (commit `012f40c98`) so it now returns a real value on macOS. But scoped locks written by *older* builds (or any build before that fallback) serialized `start_time` as `null`, and that value stays `null` in the lock file.

The stale-detection fallback in `acquire_scoped_lock()` was gated on **both** sides being `None`:

```python
if (
    not stale
    and existing.get("start_time") is None
    and current_start is None            # <-- too strict
    and not _looks_like_gateway_process(existing_pid)
):
```

After the psutil fallback landed, `current_start` resolves to a real value for the live (reused) PID, so `current_start is None` is false and the whole cmdline-identity fallback is skipped. `_pid_exists()` then reports the reused PID as alive and the lock is treated as live forever.

Observed in the wild on macOS 15 (Darwin 25.5): a Feishu/Weixin gateway lock recorded `pid: 823, start_time: null` from a build predating the fallback; PID 823 was later reused by `com.apple.CloudDocs.iCloudDriveFileProvider`, and every subsequent gateway start reported:

```
[Feishu] Another local Hermes gateway is already using this Feishu app_id (PID 823). Stop the other gateway before starting a second Feishu websocket client.
```

The adapter never reconnected until the stale lock file was deleted by hand.

## Fix

A record with no `start_time` can never be compared by `start_time`, regardless of what the live process reports. So drop the `current_start is None` gate and always fall back to the cmdline identity check when the *record* lacks a start_time:

- live PID still looks like a gateway → keep the lock (unchanged)
- live PID is not a gateway (or cmdline confirms reuse) → stale, replace it

This is a strict superset of the previous behavior: the both-`None` case still works, and the newly-covered case (record `None`, live resolvable) now correctly reclaims the lock.

## Changes Made

- `gateway/status.py`: drop the `current_start is None` gate on the null-record cmdline fallback in `acquire_scoped_lock()`; update the comment to explain the record-vs-live start_time asymmetry.
- `tests/gateway/test_status.py`: add two regression tests — (1) null-record + resolvable live start_time + PID reused by a non-gateway process → lock reclaimed; (2) same but live PID still looks like a gateway → lock honored.

## How to Test

```
pytest tests/gateway/test_status.py -q
```

The new test `test_acquire_scoped_lock_replaces_null_starttime_record_when_live_starttime_resolvable` fails on current `main` (asserts `acquired is True`, gets `False`) and passes with this change. Full `test_status.py` is green (89 passed).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Platforms tested

- macOS 15 (Darwin 25.5), Python 3.11