### PR TITLE
fix(tui_gateway): repair native-dialect model ids for aggregator providers

### DIFF
--- a/tests/tui_gateway/test_repair_aggregator_model_id.py
+++ b/tests/tui_gateway/test_repair_aggregator_model_id.py
@@ -1,0 +1,106 @@
+"""Regression tests for _repair_aggregator_model_id.
+
+The desktop composer persists its model pick as sticky UI state and ships it
+verbatim on every ``session.create``. A pick made while the profile ran a
+direct provider (anthropic's ``claude-opus-4-8``) survives a later switch to
+an aggregator (nous/openrouter), whose catalog serves vendor-slugged dot-form
+ids (``anthropic/claude-opus-4.8``) — every turn then fails with HTTP 404
+"Model 'claude-opus-4-8' not found". _make_agent repairs the id by
+canonical-form matching against the configured default + curated catalog.
+"""
+
+from unittest.mock import patch
+
+from tui_gateway.server import _repair_aggregator_model_id
+
+_CFG = {"model": {"default": "anthropic/claude-opus-4.8", "provider": "nous"}}
+_CURATED = [
+    "anthropic/claude-opus-4.8",
+    "anthropic/claude-sonnet-5",
+    "openai/gpt-5.5",
+]
+
+
+def _patched(fn):
+    return (
+        patch("tui_gateway.server._load_cfg", return_value=_CFG),
+        patch(
+            "hermes_cli.models.get_curated_nous_model_ids",
+            return_value=list(_CURATED),
+        ),
+    )
+
+
+def test_repairs_bare_hyphen_form_for_nous():
+    cfg_patch, curated_patch = _patched(None)
+    with cfg_patch, curated_patch:
+        assert (
+            _repair_aggregator_model_id("claude-opus-4-8", "nous")
+            == "anthropic/claude-opus-4.8"
+        )
+
+
+def test_repairs_slugged_hyphen_form_for_nous():
+    cfg_patch, curated_patch = _patched(None)
+    with cfg_patch, curated_patch:
+        assert (
+            _repair_aggregator_model_id("anthropic/claude-opus-4-8", "nous")
+            == "anthropic/claude-opus-4.8"
+        )
+
+
+def test_exact_catalog_id_passes_through():
+    cfg_patch, curated_patch = _patched(None)
+    with cfg_patch, curated_patch:
+        assert (
+            _repair_aggregator_model_id("anthropic/claude-opus-4.8", "nous")
+            == "anthropic/claude-opus-4.8"
+        )
+
+
+def test_unknown_id_untouched():
+    cfg_patch, curated_patch = _patched(None)
+    with cfg_patch, curated_patch:
+        assert (
+            _repair_aggregator_model_id("nousresearch/hermes-4-405b", "nous")
+            == "nousresearch/hermes-4-405b"
+        )
+
+
+def test_direct_provider_untouched():
+    cfg_patch, curated_patch = _patched(None)
+    with cfg_patch, curated_patch:
+        assert (
+            _repair_aggregator_model_id("claude-opus-4-8", "anthropic")
+            == "claude-opus-4-8"
+        )
+
+
+def test_empty_model_or_provider_untouched():
+    assert _repair_aggregator_model_id("", "nous") == ""
+    assert _repair_aggregator_model_id("claude-opus-4-8", None) == "claude-opus-4-8"
+
+
+def test_openrouter_repairs_via_config_default():
+    cfg_patch, curated_patch = _patched(None)
+    with cfg_patch, curated_patch:
+        # openrouter has no curated-list hook here; the configured default
+        # is still consulted as a candidate.
+        assert (
+            _repair_aggregator_model_id("claude-opus-4-8", "openrouter")
+            == "anthropic/claude-opus-4.8"
+        )
+
+
+def test_config_failure_is_nonfatal():
+    with (
+        patch("tui_gateway.server._load_cfg", side_effect=RuntimeError("boom")),
+        patch(
+            "hermes_cli.models.get_curated_nous_model_ids",
+            return_value=list(_CURATED),
+        ),
+    ):
+        assert (
+            _repair_aggregator_model_id("claude-opus-4-8", "nous")
+            == "anthropic/claude-opus-4.8"
+        )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4256,6 +4256,10 @@ def _repair_aggregator_model_id(model: str, provider: str | None) -> str:
                 return cand
         return model
     except Exception:
+        # "Never raises" contract: a repair failure must not break agent
+        # builds — but leave a trace, otherwise a broken import silently
+        # keeps the unrepaired (404-prone) id.
+        logger.exception("aggregator model-id repair failed; keeping %r", model)
         return model
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4203,6 +4203,62 @@ def _resolve_runtime_with_fallback(
         raise
 
 
+def _repair_aggregator_model_id(model: str, provider: str | None) -> str:
+    """Repair a native-dialect model id shipped to an aggregator provider.
+
+    The desktop composer persists its model pick as sticky UI state and ships
+    it verbatim on every ``session.create``. A pick made while the profile ran
+    a direct provider (e.g. anthropic's ``claude-opus-4-8``) survives a later
+    switch to an aggregator (nous/openrouter), whose catalogs serve
+    vendor-slugged dot-form ids (``anthropic/claude-opus-4.8``) — the raw
+    request then 404s on every turn. Generic normalization cannot restore the
+    dots, so repair by canonical-form matching against known catalog ids and
+    the configured default. Unknown ids pass through untouched; any failure
+    falls back to the original value (never raises).
+    """
+    try:
+        if not model or not provider:
+            return model
+        from hermes_cli.model_normalize import _AGGREGATOR_PROVIDERS
+
+        if provider not in _AGGREGATOR_PROVIDERS:
+            return model
+
+        def _canon(mid: str) -> str:
+            bare = mid.split("/", 1)[-1] if "/" in mid else mid
+            return bare.strip().lower().replace(".", "-")
+
+        candidates: list[str] = []
+        try:
+            cfg_model = ((_load_cfg().get("model") or {}).get("default") or "").strip()
+            if cfg_model:
+                candidates.append(cfg_model)
+        except Exception:
+            pass
+        if provider == "nous":
+            try:
+                from hermes_cli.models import get_curated_nous_model_ids
+
+                candidates.extend(get_curated_nous_model_ids() or [])
+            except Exception:
+                pass
+
+        # Already a known catalog id — nothing to repair.
+        if model in candidates:
+            return model
+        target = _canon(model)
+        for cand in candidates:
+            if "/" in cand and _canon(cand) == target:
+                logger.info(
+                    "session model %r repaired to %r for aggregator provider %s",
+                    model, cand, provider,
+                )
+                return cand
+        return model
+    except Exception:
+        return model
+
+
 def _make_agent(
     sid: str,
     key: str,
@@ -4317,6 +4373,10 @@ def _make_agent(
             "requested": requested_provider,
             "target_model": model or None,
         })
+    # Repair sticky/persisted model ids that don't match the resolved
+    # aggregator provider's dialect (composer picks from a direct-provider
+    # era, pre-switch DB rows) — see _repair_aggregator_model_id.
+    model = _repair_aggregator_model_id(model, runtime.get("provider"))
     _pr = _load_provider_routing()
     return AIAgent(
         model=model,


### PR DESCRIPTION
## Problem

The desktop composer persists its model pick as sticky UI state and ships it verbatim on every `session.create` (per-session override). A pick made while the profile ran a direct provider (e.g. anthropic's `claude-opus-4-8`) survives a later switch to an aggregator provider (nous/openrouter), whose catalogs serve vendor-slugged dot-form ids (`anthropic/claude-opus-4.8`).

Result: **every turn fails with HTTP 404** (`Model 'claude-opus-4-8' not found`) while OAuth login reports success and the providers page shows Connected — to the user it looks like the app "won't connect" even though auth is fine. The error surfaces only as an in-chat abort, and generic normalization can't fix it because the dots in the version suffix can't be reconstructed mechanically (`4-8` vs `4.8`).

Reproduced end-to-end on Windows (v0.17.0): CLI sessions worked (config default carries the correct slug), while every desktop/TUI session 404-ed with the mangled sticky id.

## Fix

`_make_agent` now repairs the id by canonical-form matching (lowercase, strip vendor prefix, dots→hyphens) against the configured default model and the curated Nous catalog. This covers new sessions, resumes and DB-restored rows via the single `_make_agent` choke point.

- Unknown ids pass through untouched (a user deliberately picking another model is unaffected)
- Only active for aggregator providers (`_AGGREGATOR_PROVIDERS`)
- Never raises: any failure falls back to the original value, with `logger.exception` so a broken import can't silently keep the 404-prone id

## Testing

- 8 new unit tests in `tests/tui_gateway/test_repair_aggregator_model_id.py` (bare/slugged hyphen forms, exact catalog id passthrough, unknown id passthrough, direct-provider no-op, empty inputs, openrouter via config default, non-fatal config failure)
- Existing `tests/tui_gateway/test_make_agent_provider.py` still green (19 passed total)
- Verified live: a stdio-gateway session created with the mangled sticky id (`claude-opus-4-8`, provider nous) completes a turn (assistant reply, `billing_provider=nous`) instead of 404-ing

🤖 Generated with [Claude Code](https://claude.com/claude-code)