### PR TITLE
fix(desktop): fast-path model options and validate provider matches

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -38,7 +38,12 @@ function Harness({
 }: {
   activeSessionId: string | null
   onReady: (controls: Controls) => void
-  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: <T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<T>
 }) {
   const controls = useModelControls({
     activeSessionId,
@@ -128,7 +133,7 @@ describe('useModelControls', () => {
       session_id: 'session-1',
       key: 'model',
       value: 'claude-sonnet-4.6 --provider anthropic'
-    })
+    }, 45_000)
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -15,7 +15,12 @@ interface ModelSelection {
 interface ModelControlsOptions {
   activeSessionId: string | null
   queryClient: QueryClient
-  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: <T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<T>
 }
 
 export function useModelControls({ activeSessionId, queryClient, requestGateway }: ModelControlsOptions) {
@@ -97,7 +102,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
           session_id: activeSessionId,
           key: 'model',
           value: `${selection.model} --provider ${selection.provider}`
-        })
+        }, 45_000)
 
         void queryClient.invalidateQueries({ queryKey: ['model-options', activeSessionId] })
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -33,6 +33,8 @@ Substrate facts (verified May 2026):
 
 from __future__ import annotations
 
+import concurrent.futures
+import copy
 from dataclasses import dataclass, replace
 from typing import Optional
 
@@ -116,6 +118,7 @@ def build_models_payload(
     canonical_order: bool = False,
     pricing: bool = False,
     capabilities: bool = False,
+    enrichment_timeout: float | None = None,
     force_fresh_nous_tier: bool = False,
     refresh: bool = False,
     max_models: int | None = None,
@@ -141,6 +144,10 @@ def build_models_payload(
       ``{model: {fast, reasoning}}`` so pickers can gate the model-options
       controls (fast toggle / reasoning) to what each model actually
       supports, instead of offering knobs the backend would reject.
+    - ``enrichment_timeout``: optional wall-clock budget for the
+      pricing/capabilities post-pass. When the budget is exceeded or the
+      enrichment code raises, the base providers/models payload is returned
+      with ``degraded=True`` and a warning instead of blocking the picker.
     - ``force_fresh_nous_tier``: bypass the short Nous free-tier cache when
       selecting Portal-recommended Nous models and applying tier gating. Keep
       this false for UI picker opens; explicit auth/model flows can opt in
@@ -218,16 +225,79 @@ def build_models_payload(
         _apply_picker_hints(rows)
     if canonical_order:
         rows = _reorder_canonical(rows)
-    if pricing:
-        _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier)
-    if capabilities:
-        _apply_capabilities(rows)
+    degraded = False
+    warnings: list[str] = []
+    if pricing or capabilities:
+        degraded, warnings = _apply_optional_enrichment(
+            rows,
+            pricing=pricing,
+            capabilities=capabilities,
+            force_fresh_nous_tier=force_fresh_nous_tier,
+            timeout=enrichment_timeout,
+        )
 
-    return {
+    payload = {
         "providers": rows,
         "model": ctx.current_model,
         "provider": ctx.current_provider,
     }
+    if degraded:
+        payload["degraded"] = True
+        payload["warnings"] = warnings
+    return payload
+
+
+def _apply_optional_enrichment(
+    rows: list[dict],
+    *,
+    pricing: bool,
+    capabilities: bool,
+    force_fresh_nous_tier: bool,
+    timeout: float | None,
+) -> tuple[bool, list[str]]:
+    """Best-effort pricing/capability enrichment for model pickers.
+
+    The base provider/model list is the critical UI payload. Pricing and
+    capability badges are helpful, but they may touch models.dev, Portal tier
+    checks, or provider catalog caches. Keep those extras isolated so a slow
+    metadata source cannot make ``/api/model/options`` time out.
+    """
+
+    work_rows = copy.deepcopy(rows)
+
+    def _run() -> None:
+        if pricing:
+            _apply_pricing(work_rows, force_fresh_nous_tier=force_fresh_nous_tier)
+        if capabilities:
+            _apply_capabilities(work_rows)
+
+    def _commit() -> None:
+        rows[:] = work_rows
+
+    if timeout is None or timeout <= 0:
+        try:
+            _run()
+            _commit()
+            return False, []
+        except Exception as exc:
+            return True, [f"model metadata enrichment failed: {exc}"]
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    fut = pool.submit(_run)
+    try:
+        fut.result(timeout=timeout)
+        _commit()
+        pool.shutdown(wait=True)
+        return False, []
+    except concurrent.futures.TimeoutError:
+        fut.cancel()
+        pool.shutdown(wait=False, cancel_futures=True)
+        return True, [
+            f"model metadata enrichment exceeded {timeout:.1f}s; returned base model list"
+        ]
+    except Exception as exc:
+        pool.shutdown(wait=False, cancel_futures=True)
+        return True, [f"model metadata enrichment failed: {exc}"]
 
 
 def _apply_capabilities(rows: list[dict]) -> None:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 from hermes_cli.providers import (
     ProviderDef,
@@ -271,6 +271,113 @@ def _ensure_direct_aliases() -> None:
     """
     if not DIRECT_ALIASES:
         DIRECT_ALIASES.update(_load_direct_aliases())
+
+
+def _declared_models_from_config(value: Any) -> list[str]:
+    """Return model IDs explicitly declared on a provider config entry."""
+    if isinstance(value, dict):
+        return [str(k).strip() for k in value.keys() if str(k).strip()]
+    if isinstance(value, (list, tuple, set)):
+        models: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item.strip():
+                models.append(item.strip())
+            elif isinstance(item, dict):
+                name = str(item.get("name") or item.get("id") or "").strip()
+                if name:
+                    models.append(name)
+        return models
+    return []
+
+
+def _explicit_provider_declared_models(
+    provider: str,
+    *,
+    base_url: str = "",
+    user_providers: dict | None = None,
+    custom_providers: list | None = None,
+) -> list[str]:
+    """Models the user explicitly declared for this provider/account group.
+
+    Empty means "no hard allow-list known". Non-empty means a desktop picker row
+    came from a concrete provider group, so selecting a model outside that row is
+    almost certainly a provider/model account-group mismatch.
+    """
+    provider_norm = str(provider or "").strip().lower()
+    base_norm = str(base_url or "").strip().rstrip("/").lower()
+
+    if user_providers and isinstance(user_providers, dict):
+        for slug, cfg in user_providers.items():
+            if str(slug).strip().lower() != provider_norm or not isinstance(cfg, dict):
+                continue
+            models = []
+            default_model = str(cfg.get("default_model") or cfg.get("model") or "").strip()
+            if default_model:
+                models.append(default_model)
+            models.extend(_declared_models_from_config(cfg.get("models")))
+            return list(dict.fromkeys(models))
+
+    if custom_providers and isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "").strip()
+            slug = custom_provider_slug(name).lower() if name else ""
+            entry_url = str(
+                entry.get("base_url") or entry.get("url") or entry.get("api") or ""
+            ).strip().rstrip("/").lower()
+            if provider_norm not in {slug, f"custom:{name}".lower()} and (
+                not base_norm or entry_url != base_norm
+            ):
+                continue
+            models = []
+            default_model = str(entry.get("model") or "").strip()
+            if default_model:
+                models.append(default_model)
+            models.extend(_declared_models_from_config(entry.get("models")))
+            return list(dict.fromkeys(models))
+
+    return []
+
+
+def _reject_if_model_outside_explicit_provider(
+    *,
+    explicit_provider: str,
+    target_provider: str,
+    new_model: str,
+    provider_label: str,
+    base_url: str,
+    user_providers: dict | None,
+    custom_providers: list | None,
+    is_global: bool,
+) -> ModelSwitchResult | None:
+    if not explicit_provider.strip() or not new_model.strip():
+        return None
+    declared = _explicit_provider_declared_models(
+        target_provider,
+        base_url=base_url,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    if not declared:
+        return None
+    by_lower = {m.lower(): m for m in declared}
+    if new_model.lower() in by_lower:
+        return None
+    sample = ", ".join(declared[:5])
+    more = "…" if len(declared) > 5 else ""
+    return ModelSwitchResult(
+        success=False,
+        new_model=new_model,
+        target_provider=target_provider,
+        provider_label=provider_label,
+        is_global=is_global,
+        error_message=(
+            f"Model `{new_model}` does not belong to provider `{target_provider}` "
+            f"({provider_label}). Available in this provider/account group: {sample}{more}. "
+            "Pick the matching provider row or update the provider's models list."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -929,6 +1036,19 @@ def switch_model(
         alias_result = resolve_alias(new_model, target_provider)
         if alias_result is not None:
             _, new_model, resolved_alias = alias_result
+
+        mismatch = _reject_if_model_outside_explicit_provider(
+            explicit_provider=explicit_provider,
+            target_provider=target_provider,
+            new_model=new_model,
+            provider_label=pdef.name,
+            base_url=pdef.base_url or current_base_url,
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+            is_global=is_global,
+        )
+        if mismatch is not None:
+            return mismatch
 
     # =================================================================
     # PATH B: No explicit provider — resolve from model input

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3850,8 +3850,14 @@ def get_model_options(profile: Optional[str] = None, refresh: bool = False):
                 include_unconfigured=True,
                 picker_hints=True,
                 canonical_order=True,
-                pricing=True,
-                capabilities=True,
+                # Normal picker opens must return the routable model list fast.
+                # Pricing/capability badges are best-effort metadata and may hit
+                # models.dev / Portal tier checks / provider catalogs; only do
+                # that work on an explicit refresh, with a short degradation
+                # budget so the desktop IPC layer does not hit its 15s timeout.
+                pricing=bool(refresh),
+                capabilities=bool(refresh),
+                enrichment_timeout=2.0 if refresh else None,
                 refresh=bool(refresh),
             )
     except HTTPException:

--- a/tests/hermes_cli/test_model_options_fast_path.py
+++ b/tests/hermes_cli/test_model_options_fast_path.py
@@ -1,0 +1,180 @@
+"""Regression tests for fast, degraded desktop model-picker payloads."""
+
+from __future__ import annotations
+
+import time
+
+
+def _ctx():
+    from hermes_cli.inventory import ConfigContext
+
+    return ConfigContext(
+        current_provider="hermes-direct-pro",
+        current_model="gpt-5.5",
+        current_base_url="https://api.weapi.pw/v1",
+        user_providers={
+            "hermes-direct-pro": {
+                "name": "Hermes Direct Pro",
+                "api": "https://api.weapi.pw/v1",
+                "transport": "codex_responses",
+                "default_model": "gpt-5.5",
+                "models": {"gpt-5.5": {}, "gpt-5.4-mini": {}},
+            },
+            "hermes-direct-cc": {
+                "name": "Hermes Direct CC",
+                "api": "https://api.weapi.pw/v1",
+                "transport": "openai",
+                "default_model": "claude-fable-5",
+                "models": {"claude-fable-5": {}, "claude-opus-4-8": {}},
+            },
+        },
+        custom_providers=[],
+    )
+
+
+def test_build_models_payload_fast_omits_slow_enrichment(monkeypatch):
+    """Normal picker opens must not block on pricing/capabilities enrichment."""
+    import hermes_cli.inventory as inv
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **kwargs: [
+            {
+                "slug": "hermes-direct-pro",
+                "name": "Hermes Direct Pro",
+                "is_current": True,
+                "is_user_defined": True,
+                "models": ["gpt-5.5", "gpt-5.4-mini"],
+                "total_models": 2,
+                "source": "user-config",
+            }
+        ],
+    )
+
+    def slow_pricing(_rows, **_kwargs):
+        raise AssertionError("pricing enrichment should not run on fast picker path")
+
+    def slow_capabilities(_rows):
+        raise AssertionError("capability enrichment should not run on fast picker path")
+
+    monkeypatch.setattr(inv, "_apply_pricing", slow_pricing)
+    monkeypatch.setattr(inv, "_apply_capabilities", slow_capabilities)
+
+    payload = inv.build_models_payload(
+        _ctx(),
+        include_unconfigured=True,
+        picker_hints=True,
+        canonical_order=True,
+        pricing=False,
+        capabilities=False,
+    )
+
+    row = next(p for p in payload["providers"] if p["slug"] == "hermes-direct-pro")
+    assert row["models"] == ["gpt-5.5", "gpt-5.4-mini"]
+    assert "pricing" not in row
+    assert "capabilities" not in row
+
+
+def test_build_models_payload_degrades_when_enrichment_is_slow(monkeypatch):
+    """Explicit enriched payloads should return the base list if enrichment stalls."""
+    import hermes_cli.inventory as inv
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **kwargs: [
+            {
+                "slug": "hermes-direct-pro",
+                "name": "Hermes Direct Pro",
+                "is_current": True,
+                "is_user_defined": True,
+                "models": ["gpt-5.5"],
+                "total_models": 1,
+                "source": "user-config",
+            }
+        ],
+    )
+
+    def slow_pricing(_rows, **_kwargs):
+        time.sleep(0.05)
+
+    def slow_capabilities(_rows):
+        raise RuntimeError("models.dev unavailable")
+
+    monkeypatch.setattr(inv, "_apply_pricing", slow_pricing)
+    monkeypatch.setattr(inv, "_apply_capabilities", slow_capabilities)
+
+    payload = inv.build_models_payload(
+        _ctx(),
+        include_unconfigured=True,
+        picker_hints=True,
+        canonical_order=True,
+        pricing=True,
+        capabilities=True,
+        enrichment_timeout=0.01,
+    )
+
+    row = next(p for p in payload["providers"] if p["slug"] == "hermes-direct-pro")
+    assert row["models"] == ["gpt-5.5"]
+    assert payload["degraded"] is True
+    assert any("model metadata enrichment" in warning for warning in payload["warnings"])
+
+
+def test_explicit_provider_rejects_model_outside_declared_provider_models(monkeypatch):
+    """A session /model switch must fail before hitting the upstream account group."""
+    from hermes_cli.model_switch import switch_model
+
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": "soft accepted",
+        },
+    )
+
+    result = switch_model(
+        raw_input="claude-fable-5",
+        current_provider="hermes-direct-pro",
+        current_model="gpt-5.5",
+        current_base_url="https://api.weapi.pw/v1",
+        explicit_provider="hermes-direct-pro",
+        user_providers=_ctx().user_providers,
+        custom_providers=[],
+    )
+
+    assert result.success is False
+    assert "does not belong to provider" in result.error_message
+    assert "hermes-direct-pro" in result.error_message
+
+
+def test_explicit_provider_accepts_declared_model(monkeypatch):
+    from hermes_cli.model_switch import switch_model
+
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="gpt-5.5",
+        current_provider="hermes-direct-pro",
+        current_model="gpt-5.4-mini",
+        current_base_url="https://api.weapi.pw/v1",
+        explicit_provider="hermes-direct-pro",
+        user_providers=_ctx().user_providers,
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.new_model == "gpt-5.5"
+    assert result.target_provider == "hermes-direct-pro"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12029,8 +12029,13 @@ def _(rid, params: dict) -> dict:
             include_unconfigured=True,
             picker_hints=True,
             canonical_order=True,
-            pricing=True,
-            capabilities=True,
+            # Session model pickers sit on the hot desktop websocket path. Keep
+            # normal opens metadata-light and deterministic; explicit refreshes
+            # may ask for richer pricing/capability badges, but must degrade
+            # before the Electron 15s REST/IPC timeout becomes user-visible.
+            pricing=bool(params.get("refresh")),
+            capabilities=bool(params.get("refresh")),
+            enrichment_timeout=2.0 if params.get("refresh") else None,
             refresh=bool(params.get("refresh")),
         )
         return _ok(rid, payload)


### PR DESCRIPTION
Fixes #44560

### What / 做了什么
- Fast-pathed `model.options` so normal picker opens no longer block on pricing / capabilities enrichment.
- Added a short timeout for explicit refreshes; if enrichment is slow, the API degrades gracefully and still returns the base model list.
- Validated explicit provider/model pairs before switching, so mismatched selections fail early instead of hitting the gateway/weapi and erroring later.
- Added regression coverage for fast path, degradation, and provider/model mismatch handling.

### Why / 为什么要改
- The Desktop model picker and in-session model switching both rely on `model.options`.
- Before this change, synchronous enrichment could stall the backend long enough to trigger the Desktop websocket timeout.
- Explicit provider/model switching also lacked a preflight check, so bad combinations could be sent downstream and fail later in weapi.

### Verification / 验证
- `python -m pytest tests/hermes_cli/test_model_options_fast_path.py -q --tb=short`
- `cd apps/desktop && npm run test:ui -- src/app/session/hooks/use-model-controls.test.tsx`
- `cd apps/desktop && npm run typecheck`

### Notes / 备注
- `package-lock.json` was reverted and is not part of this PR.
