### PR TITLE
fix(goals): strip think blocks before parsing the goal judge verdict

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -666,6 +666,21 @@ def _session_waiting(session_id: str) -> bool:
 _JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
 
 
+def _strip_reasoning(text: str) -> str:
+    """Strip <think>/reasoning blocks before the naive JSON extraction below.
+
+    Think-enabled auxiliary judges (DeepSeek-R1, QwQ, MiniMax M2) emit inline
+    reasoning that echoes the ``{"verdict": ...}`` / contract format shown in
+    the prompt. Left in place, the first-JSON-object fallback (``_JSON_OBJECT_RE``
+    is non-greedy) latches onto a brace from *inside* the reasoning, yielding a
+    wrong verdict or a spurious parse failure (which trips the consecutive-
+    failure auto-pause). Mirrors the canonical scrubber used by
+    title_generator / kanban_specify.
+    """
+    from agent.agent_runtime_helpers import strip_think_blocks
+    return strip_think_blocks(None, text)
+
+
 def _goal_judge_max_tokens() -> int:
     """Resolve auxiliary.goal_judge.max_tokens, falling back to the default.
 
@@ -710,7 +725,7 @@ def _parse_judge_response(raw: str) -> Tuple[str, str, bool, Optional[Dict[str, 
     if not raw:
         return "continue", "judge returned empty response", True, None
 
-    text = raw.strip()
+    text = _strip_reasoning(raw).strip()
 
     # Strip markdown code fences the model may wrap JSON in.
     if text.startswith("```"):
@@ -1050,7 +1065,7 @@ def _extract_json_object(raw: str) -> Optional[Dict[str, Any]]:
     """
     if not raw:
         return None
-    text = raw.strip()
+    text = _strip_reasoning(raw).strip()
     if text.startswith("```"):
         text = text.strip("`")
         nl = text.find("\n")

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -90,6 +90,52 @@ class TestParseJudgeResponse:
         v, _, _, _ = _parse_judge_response('{"verdict": "continue", "reason": "r"}')
         assert v == "continue"
 
+    def test_strips_think_block_before_verdict_extraction(self):
+        """Think-enabled judge models (DeepSeek-R1, QwQ, MiniMax M2) emit inline
+        <think> reasoning that echoes the {"verdict": ...} format from the
+        prompt. Without stripping it, the non-greedy first-object fallback
+        latches onto a brace inside the reasoning and returns the WRONG verdict.
+        Here the real verdict after </think> is 'done'."""
+        from hermes_cli.goals import _parse_judge_response
+
+        raw = (
+            '<think>The format is {"verdict": "continue"} or {"verdict": "done"}. '
+            'The deliverable was produced, so the goal is done.</think>\n'
+            '{"verdict": "done", "reason": "task completed"}'
+        )
+        verdict, reason, parse_failed, _w = _parse_judge_response(raw)
+        assert verdict == "done", f"got {verdict!r}"
+        assert parse_failed is False
+        assert reason == "task completed"
+
+    def test_think_block_with_braces_does_not_spuriously_parse_fail(self):
+        """A non-JSON brace inside the reasoning must not make a valid verdict
+        look unparseable — a spurious parse_failed trips the consecutive-failure
+        auto-pause and silently parks the goal loop."""
+        from hermes_cli.goals import _parse_judge_response
+
+        raw = (
+            "<think>Let me reason {step by step} about whether this is complete."
+            "</think>\n"
+            '{"verdict": "done", "reason": "finished"}'
+        )
+        verdict, _reason, parse_failed, _w = _parse_judge_response(raw)
+        assert verdict == "done"
+        assert parse_failed is False
+
+    def test_extract_json_object_strips_think_block(self):
+        """The goal-contract drafter parser shares the same first-object
+        fallback and must also strip reasoning first."""
+        from hermes_cli.goals import _extract_json_object
+
+        raw = (
+            '<think>A contract sketch looks like {goal, verification}.</think>\n'
+            '{"goal": "ship the feature", "verification": "tests pass"}'
+        )
+        data = _extract_json_object(raw)
+        assert isinstance(data, dict)
+        assert data.get("goal") == "ship the feature"
+
     def test_wait_verdict_with_pid(self):
         from hermes_cli.goals import _parse_judge_response
 


### PR DESCRIPTION
## What does this PR do?

The `/goal` (Ralph) loop asks an auxiliary **judge** model whether the standing
goal is done and parses a `{"verdict": ...}` object from the raw response. Both
`_parse_judge_response` and the goal-contract drafter's `_extract_json_object`
read `resp.choices[0].message.content` verbatim and, when a straight
`json.loads` fails, fall back to the **non-greedy** `_JSON_OBJECT_RE`
(`\{.*?\}`) to pull "the first JSON object" out.

Think-enabled auxiliary models (DeepSeek-R1, QwQ, MiniMax M2 — all strong
judges, so users routinely set them as `auxiliary.goal_judge`) emit inline
`<think>` reasoning that echoes the `{"verdict": ...}` format shown right in the
judge prompt. The non-greedy fallback then latches onto a brace from *inside*
the reasoning, producing one of two failures:

- **Wrong verdict** — an echoed `{"verdict": "continue"}` example is picked up
  while the real post-`</think>` verdict is `"done"`, so a finished goal keeps
  burning turns.
- **Spurious parse failure** — a non-JSON brace (`{step by step}`) makes a valid
  verdict look unparseable, and after `DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES`
  the loop auto-pauses and tells the user the judge model is broken.

Fix: strip `<think>`/reasoning blocks via the canonical scrubber before the
naive extraction in **both** parsers, mirroring the already-merged
`title_generator` fix (`3b739b990`) and the `kanban_specify` path.

## Related Issue

N/A — no existing issue. (Related in spirit to #18529, which flags the same
"read `.content` directly instead of stripping reasoning" class in
`title_generator`.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/goals.py` — add `_strip_reasoning()` (wraps the canonical
  `strip_think_blocks`) and call it before the naive JSON extraction in both
  `_parse_judge_response` and `_extract_json_object`.
- `tests/hermes_cli/test_goals.py` — 3 regression tests: think-wrapped verdict
  returns the correct verdict, a brace inside reasoning doesn't spuriously
  parse-fail, and the contract drafter parser strips reasoning too.

## How to Test

1. Before the fix, a think-model verdict is misread:

```python
from hermes_cli.goals import _parse_judge_response
raw = '<think>format is {"verdict": "continue"}; the goal is done.</think>\n{"verdict": "done", "reason": "x"}'
print(_parse_judge_response(raw)[0])   # before: "continue" (WRONG)  |  after: "done"
```

2. Run the suite:

```
pytest tests/hermes_cli/test_goals.py -q
```

→ 104 passed. Mutation-verified: reverting the strip makes the 3 new tests fail.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_goals.py -q` and all tests pass (104)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docstrings / N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure text handling)
- [x] Tool descriptions/schemas — N/A