### PR TITLE
fix(yuanbao): block redirect-based SSRF in download_url

### DIFF
--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -220,18 +220,23 @@ async def download_url(
     # SSRF protection: yuanbao downloads model-supplied and inbound URLs
     # server-side. Reject private/internal targets up front, and re-validate
     # every redirect hop so a public URL can't 302 to http://169.254.169.254/.
-    from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
+    from tools.url_safety import (
+        create_ssrf_safe_async_client,
+        is_safe_url,
+        redirect_target_from_response,
+    )
 
     if not is_safe_url(url):
         raise ValueError(f"Blocked unsafe URL (SSRF protection): {url}")
 
     async def _redirect_guard(response: httpx.Response) -> None:
-        if response.is_redirect and response.next_request:
-            redirect_url = str(response.next_request.url)
-            if not is_safe_url(redirect_url):
-                raise ValueError(
-                    f"Blocked redirect to private/internal address: {redirect_url}"
-                )
+        # response.next_request is frequently None inside an httpx response hook
+        # even for a genuine 302, so resolve the hop from the Location header.
+        redirect_url = redirect_target_from_response(response)
+        if redirect_url and not is_safe_url(redirect_url):
+            raise ValueError(
+                f"Blocked redirect to private/internal address: {redirect_url}"
+            )
 
     max_bytes = max_size_mb * 1024 * 1024
     async with create_ssrf_safe_async_client(

--- a/tests/gateway/test_yuanbao_media_ssrf.py
+++ b/tests/gateway/test_yuanbao_media_ssrf.py
@@ -90,3 +90,71 @@ class TestDownloadUrlSSRF:
         # The guarded client must register a redirect event hook.
         assert fetched["hooks"] is not None
         assert "response" in fetched["hooks"]
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_metadata_blocked(self, monkeypatch):
+        """A 302 whose Location points at a metadata address is rejected even
+        though httpx leaves response.next_request unset inside the hook.
+
+        Regression: the guard used to key on response.next_request, which is
+        None inside an httpx response event hook, so redirect-based SSRF (a
+        public URL 302-ing to 169.254.169.254) was never blocked.
+        """
+        import gateway.platforms.yuanbao_media as ym
+        from tools import url_safety
+
+        # Public pre-flight passes; the redirect target does not.
+        monkeypatch.setattr(
+            url_safety, "is_safe_url", lambda u: str(u).startswith("https://example.com")
+        )
+
+        captured = {}
+
+        class _FakeResp:
+            headers = {"content-type": "image/png", "content-length": "3"}
+            is_redirect = False
+            next_request = None
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self, _n):
+                yield b"png"
+
+        class _FakeStream:
+            async def __aenter__(self):
+                return _FakeResp()
+
+            async def __aexit__(self, *a):
+                return False
+
+        class _FakeClient:
+            def __init__(self, *a, **kw):
+                captured["guard"] = kw["event_hooks"]["response"][0]
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def head(self, url):
+                return _FakeResp()
+
+            def stream(self, method, url, **kw):
+                return _FakeStream()
+
+        monkeypatch.setattr(ym.httpx, "AsyncClient", _FakeClient)
+
+        await download_url("https://example.com/image.png")
+        guard = captured["guard"]
+
+        class _RedirectResp:
+            # A genuine 302 as seen inside the hook: Location set, next_request None.
+            is_redirect = True
+            url = "https://example.com/image.png"
+            headers = {"location": "http://169.254.169.254/latest/meta-data/"}
+            next_request = None
+
+        with pytest.raises(ValueError, match="Blocked redirect"):
+            await guard(_RedirectResp())


### PR DESCRIPTION
## What does this PR do?

`gateway/platforms/yuanbao_media.py::download_url` fetches model-supplied and inbound URLs server-side. It has an `is_safe_url()` pre-flight, but its per-hop redirect guard was inert:

```python
async def _redirect_guard(response: httpx.Response) -> None:
    if response.is_redirect and response.next_request:   # <- next_request is None here
        ...
```

Inside an `httpx.AsyncClient` **response event hook**, `response.next_request` is `None` even for a genuine 302 (it is populated later by the redirect-following machinery). So the guard condition was always falsy and **never validated the redirect target**. A public URL that passes the pre-flight check can therefore 302-redirect to `http://169.254.169.254/` (cloud metadata / IMDS) or any private address, and httpx (`follow_redirects=True`) follows it — a redirect-based SSRF.

This is the same class that **#56160 (merged)** fixed across the other httpx download hooks by resolving the hop from the `Location` header via `redirect_target_from_response`; `yuanbao_media.py` was the one path that migration missed. (The broken `next_request` guard here was introduced by #54470.)

## Related Issue

No open issue — found while auditing the httpx redirect guards after #56160. N/A.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `gateway/platforms/yuanbao_media.py`: `_redirect_guard` now resolves the redirect target with `redirect_target_from_response(response)` (reads the `Location` header, `urljoin`-resolving relative Locations) instead of the always-`None` `response.next_request`, then rejects it with `is_safe_url`. This mirrors `gateway/platforms/base.py::_ssrf_redirect_guard`.
- `tests/gateway/test_yuanbao_media_ssrf.py`: added `test_redirect_to_metadata_blocked` — drives a 302 whose `Location` points at `169.254.169.254` with `next_request=None` (the real in-hook shape) through the registered guard and asserts `ValueError`. Fails on the old guard, passes on the fix.

## How to Test

```
$ python -m pytest tests/gateway/test_yuanbao_media_ssrf.py -q
6 passed
```

The new test reproduces the bug: with the previous `next_request`-based guard, a 302 to the metadata endpoint (with `next_request=None`, as httpx leaves it inside the hook) is **not** blocked; with the fix it raises `ValueError: Blocked redirect to private/internal address`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(yuanbao): ...`)
- [x] I searched existing PRs/issues to make sure this isn't a duplicate (no open PR/issue for the yuanbao redirect guard; #56160 fixed the sibling hooks and merged)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests (`pytest tests/gateway/test_yuanbao_media_ssrf.py -q` → 6 passed); the full suite runs in CI
- [x] I've added a regression test for this fix
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (server-side URL fetch; platform-independent)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

See **How to Test** above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
