### PR TITLE
fix(desktop): configured working directory overrides stale remembered workspace cwd

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook } from '@testing-library/react'
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getHermesConfig } from '@/hermes'
+import { persistString } from '@/lib/storage'
+import { $currentCwd, setCurrentCwd } from '@/store/session'
+
+import { useHermesConfig } from './use-hermes-config'
+
+vi.mock('@/hermes', () => ({
+  getHermesConfig: vi.fn(),
+  getHermesConfigDefaults: vi.fn().mockResolvedValue({}),
+}))
+
+const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
+
+describe('useHermesConfig refreshHermesConfig', () => {
+  beforeEach(() => {
+    // Reset atoms and localStorage between tests
+    setCurrentCwd('')
+    persistString(WORKSPACE_CWD_KEY, null)
+  })
+
+  it('applies terminal.cwd from config even when localStorage has a stale value', async () => {
+    // Simulate a stale remembered workspace cwd
+    persistString(WORKSPACE_CWD_KEY, '/Users/old/stale-project')
+    setCurrentCwd('/Users/old/stale-project')
+
+    vi.mocked(getHermesConfig).mockResolvedValue({
+      terminal: { cwd: '/Users/example/new-workspace' },
+    } as any)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    // The configured terminal.cwd must override the stale localStorage value
+    expect($currentCwd.get()).toBe('/Users/example/new-workspace')
+  })
+
+  it('uses empty string when terminal.cwd is not set and localStorage is empty', async () => {
+    vi.mocked(getHermesConfig).mockResolvedValue({} as any)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($currentCwd.get()).toBe('')
+  })
+
+  it('ignores terminal.cwd when it is "."', async () => {
+    vi.mocked(getHermesConfig).mockResolvedValue({
+      terminal: { cwd: '.' },
+    } as any)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect($currentCwd.get()).toBe('')
+  })
+
+  it('calls refreshProjectBranch with the configured cwd', async () => {
+    const refreshProjectBranch = vi.fn().mockResolvedValue(undefined)
+    setCurrentCwd('')
+
+    vi.mocked(getHermesConfig).mockResolvedValue({
+      terminal: { cwd: '/workspace/project-a' },
+    } as any)
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: null },
+        refreshProjectBranch,
+      }),
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect(refreshProjectBranch).toHaveBeenCalledWith('/workspace/project-a')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -1,5 +1,5 @@
-import { act, renderHook } from '@testing-library/react'
 // @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getHermesConfig } from '@/hermes'
@@ -10,10 +10,13 @@ import { useHermesConfig } from './use-hermes-config'
 
 vi.mock('@/hermes', () => ({
   getHermesConfig: vi.fn(),
-  getHermesConfigDefaults: vi.fn().mockResolvedValue({}),
+  getHermesConfigDefaults: vi.fn().mockResolvedValue({})
 }))
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
+
+const mockConfig = (config: Record<string, unknown>) =>
+  vi.mocked(getHermesConfig).mockResolvedValue(config as Awaited<ReturnType<typeof getHermesConfig>>)
 
 describe('useHermesConfig refreshHermesConfig', () => {
   beforeEach(() => {
@@ -27,15 +30,13 @@ describe('useHermesConfig refreshHermesConfig', () => {
     persistString(WORKSPACE_CWD_KEY, '/Users/old/stale-project')
     setCurrentCwd('/Users/old/stale-project')
 
-    vi.mocked(getHermesConfig).mockResolvedValue({
-      terminal: { cwd: '/Users/example/new-workspace' },
-    } as any)
+    mockConfig({ terminal: { cwd: '/Users/example/new-workspace' } })
 
     const { result } = renderHook(() =>
       useHermesConfig({
         activeSessionIdRef: { current: null },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
-      }),
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+      })
     )
 
     await act(async () => {
@@ -46,14 +47,35 @@ describe('useHermesConfig refreshHermesConfig', () => {
     expect($currentCwd.get()).toBe('/Users/example/new-workspace')
   })
 
+  it('keeps the active session workspace when a session is running', async () => {
+    setCurrentCwd('/workspace/attached-project')
+
+    mockConfig({ terminal: { cwd: '/Users/example/new-workspace' } })
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: 'session-1' },
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+      })
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    // Config refreshes mid-session must not yank the workspace out from
+    // under the attached session.
+    expect($currentCwd.get()).toBe('/workspace/attached-project')
+  })
+
   it('uses empty string when terminal.cwd is not set and localStorage is empty', async () => {
-    vi.mocked(getHermesConfig).mockResolvedValue({} as any)
+    mockConfig({})
 
     const { result } = renderHook(() =>
       useHermesConfig({
         activeSessionIdRef: { current: null },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
-      }),
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+      })
     )
 
     await act(async () => {
@@ -64,15 +86,13 @@ describe('useHermesConfig refreshHermesConfig', () => {
   })
 
   it('ignores terminal.cwd when it is "."', async () => {
-    vi.mocked(getHermesConfig).mockResolvedValue({
-      terminal: { cwd: '.' },
-    } as any)
+    mockConfig({ terminal: { cwd: '.' } })
 
     const { result } = renderHook(() =>
       useHermesConfig({
         activeSessionIdRef: { current: null },
-        refreshProjectBranch: vi.fn().mockResolvedValue(undefined),
-      }),
+        refreshProjectBranch: vi.fn().mockResolvedValue(undefined)
+      })
     )
 
     await act(async () => {
@@ -86,15 +106,13 @@ describe('useHermesConfig refreshHermesConfig', () => {
     const refreshProjectBranch = vi.fn().mockResolvedValue(undefined)
     setCurrentCwd('')
 
-    vi.mocked(getHermesConfig).mockResolvedValue({
-      terminal: { cwd: '/workspace/project-a' },
-    } as any)
+    mockConfig({ terminal: { cwd: '/workspace/project-a' } })
 
     const { result } = renderHook(() =>
       useHermesConfig({
         activeSessionIdRef: { current: null },
-        refreshProjectBranch,
-      }),
+        refreshProjectBranch
+      })
     )
 
     await act(async () => {
@@ -102,5 +120,25 @@ describe('useHermesConfig refreshHermesConfig', () => {
     })
 
     expect(refreshProjectBranch).toHaveBeenCalledWith('/workspace/project-a')
+  })
+
+  it('refreshes the branch for the session cwd (not config) when a session is active', async () => {
+    const refreshProjectBranch = vi.fn().mockResolvedValue(undefined)
+    setCurrentCwd('/workspace/attached-project')
+
+    mockConfig({ terminal: { cwd: '/Users/example/new-workspace' } })
+
+    const { result } = renderHook(() =>
+      useHermesConfig({
+        activeSessionIdRef: { current: 'session-1' },
+        refreshProjectBranch
+      })
+    )
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect(refreshProjectBranch).toHaveBeenCalledWith('/workspace/attached-project')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -3,7 +3,6 @@ import { type MutableRefObject, useCallback, useState } from 'react'
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import {
-  $currentCwd,
   setAvailablePersonalities,
   setCurrentCwd,
   setCurrentFastMode,
@@ -53,8 +52,8 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
       const cwd = (config.terminal?.cwd ?? '').trim()
 
       if (cwd && cwd !== '.') {
-        setCurrentCwd(prev => prev || cwd)
-        void refreshProjectBranch($currentCwd.get() || cwd)
+        setCurrentCwd(cwd)
+        void refreshProjectBranch(cwd)
       }
 
       const reasoning = (config.agent?.reasoning_effort ?? '').trim()

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -3,6 +3,7 @@ import { type MutableRefObject, useCallback, useState } from 'react'
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import {
+  $currentCwd,
   setAvailablePersonalities,
   setCurrentCwd,
   setCurrentFastMode,
@@ -52,8 +53,11 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
       const cwd = (config.terminal?.cwd ?? '').trim()
 
       if (cwd && cwd !== '.') {
-        setCurrentCwd(cwd)
-        void refreshProjectBranch(cwd)
+        // Configured terminal.cwd beats a stale remembered workspace cwd
+        // (#38855) — but never yank the workspace out from under an active
+        // session; those keep their own cwd until the user detaches.
+        setCurrentCwd(prev => (activeSessionIdRef.current ? prev : cwd))
+        void refreshProjectBranch($currentCwd.get() || cwd)
       }
 
       const reasoning = (config.agent?.reasoning_effort ?? '').trim()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "sahibzada@fastino.ai": "sahibzada-allahyar",  # PR #39227 salvage (desktop: configured terminal.cwd overrides a stale remembered workspace-cwd localStorage value when no session is active; #38855)
     "jvsantos.cunha@gmail.com": "plcunha",  # PR #55300 salvage (gateway: record child gateway peer metadata after a compression session-id rotation and repoint stale sessions.json compression-parent entries to the recovered live child; consolidated in the compression-routing-integrity salvage)
     "jakepresent1@gmail.com": "jakepresent",  # PR #55721 salvage (gateway: identity-guard stale in-flight compression splits — a late run may publish its compressed child only if its run generation is still current and the session key still points at the run's original parent, so an old run can't overwrite a newer /new or moved binding)
     "zhangml@tech.icbc.com.cn": "zmlgit",  # PR #54872 salvage (multiplex-profile kanban: route task notifications via the owning profile's adapter + wake the creator agent with a synthetic internal MessageEvent on terminal events)


### PR DESCRIPTION
## Summary

Desktop `Settings → Workspace → Working Directory` (`terminal.cwd`) now overrides a stale remembered workspace cwd in renderer localStorage, so new sessions start in the configured folder instead of wherever `hermes.desktop.workspace-cwd` was last pointed.

Fixes #38855. Salvages #39227 by @sahibzada-allahyar (cherry-picked, authorship preserved) with a follow-up guard.

Root cause: `$currentCwd` seeds from localStorage at module load, and `refreshHermesConfig()` only applied `terminal.cwd` when the current value was empty (`prev || cwd`) — the stale remembered value always won, and new-session creation prefers `$currentCwd`.

## Changes

- `apps/desktop/src/app/session/hooks/use-hermes-config.ts`: apply configured `terminal.cwd` over a stale remembered cwd — but only when no session is active (`activeSessionIdRef` gate, same pattern as the sibling reasoning/tier settings), so mid-session config refreshes can't yank the workspace out from under an attached session. Since `setCurrentCwd` persists back to localStorage, the stale key self-heals.
- `apps/desktop/src/app/session/hooks/use-hermes-config.test.ts` (new, from #39227 + extended): 6 tests — stale-localStorage override, active-session guard, empty config, `"."` handling, branch refresh for both idle and active-session paths.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

## Validation

| Check | Result |
|---|---|
| `vitest run --environment jsdom use-hermes-config.test.ts src/store/session.test.ts` | 25/25 passed |
| `npm run typecheck` (apps/desktop) | clean |
| `eslint` + `prettier --check` on touched files | clean |

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa09d41/H7igOO0VnKHy9E4JuUqYU_r9pJte4Q.png)
