### PR TITLE
fix(doctor): recognize plugin-registered providers like vertex

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -753,6 +753,15 @@ def run_doctor(args):
             except Exception:
                 _resolve_auth_provider = None
                 pass
+            # Include plugin-registered providers (e.g. vertex, bedrock)
+            # that are not in PROVIDER_REGISTRY but are first-class at runtime.
+            try:
+                from providers import list_providers as _list_plugin_providers
+                for _pp in _list_plugin_providers():
+                    known_providers.add(_pp.name)
+                    known_providers.update(_pp.aliases)
+            except Exception:
+                pass
             try:
                 from hermes_cli.config import get_compatible_custom_providers as _compatible_custom_providers
                 from hermes_cli.providers import (
@@ -845,6 +854,7 @@ def run_doctor(args):
                 "lmstudio",
                 "nous",
                 "nvidia",
+                "vertex",
             }
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -465,6 +465,25 @@ def get_provider(name: str) -> Optional[ProviderDef]:
             source="hermes",
         )
 
+    # 3. Plugin registry — providers registered via plugins/model-providers/
+    #    (e.g. vertex, bedrock).  These are not in models.dev or HERMES_OVERLAYS
+    #    but are first-class providers at runtime.
+    try:
+        from providers import get_provider_profile as _get_plugin_profile
+        _plugin_profile = _get_plugin_profile(canonical)
+        if _plugin_profile is not None:
+            return ProviderDef(
+                id=canonical,
+                name=_plugin_profile.display_name or _plugin_profile.name,
+                transport=_plugin_profile.api_mode or "openai_chat",
+                api_key_env_vars=_plugin_profile.env_vars,
+                base_url=_plugin_profile.base_url,
+                auth_type=_plugin_profile.auth_type,
+                source="plugin",
+            )
+    except Exception:
+        pass
+
     return None
 
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -517,6 +517,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("kilocode", "anthropic/claude-sonnet-4.6"),
         ("kimi-coding", "kimi-k2"),
         ("nvidia", "qwen/qwen3.5-122b-a10b"),
+        ("vertex", "google/gemini-3-flash-preview"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes doctor` reporting "model provider 'vertex' is unknown" for the Vertex AI provider, even though the provider works correctly at runtime. Also fixes a false-positive vendor-prefix warning for `google/gemini-*` models on vertex.

The root cause is two-fold:
1. `hermes_cli/providers.py:get_provider()` only checks models.dev catalog and `HERMES_OVERLAYS`, missing plugin-registered providers (vertex, bedrock, etc.)
2. `hermes_cli/doctor.py` builds its `known_providers` set from `PROVIDER_REGISTRY` which only includes api-key providers, excluding OAuth/token-based plugin providers like vertex

## Related Issue

Fixes #56906

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/providers.py`: Added plugin registry fallback (step 3) in `get_provider()` — checks `providers.get_provider_profile()` after models.dev and HERMES_OVERLAYS, so plugin-registered providers (vertex, bedrock) are resolved correctly
- `hermes_cli/doctor.py`: Added plugin provider names and aliases to `known_providers` set so `hermes doctor` recognizes them as valid providers; added `"vertex"` to `providers_accepting_vendor_slugs` since vertex serves Gemini models with `google/` vendor prefixes
- `tests/hermes_cli/test_doctor.py`: Added `("vertex", "google/gemini-3-flash-preview")` to the parametrized provider acceptance test

## How to Test

1. Configure vertex as the model provider: `hermes config set model.provider vertex`
2. Set a vertex model: `hermes config set model.default google/gemini-3-flash-preview`
3. Run `hermes doctor` — should no longer report "vertex is unknown" or vendor-prefix warning
4. Run `pytest tests/hermes_cli/test_doctor.py -x -q -k "provider or vendor or accepts"` — all 19 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before:**
```
Found 2 issue(s) to address:
1. model provider 'vertex' is unknown. Valid providers: alibaba, alibaba-coding-plan, ...
2. model.default 'google/gemini-3-flash-preview' is vendor-prefixed but model.provider is 'vertex'.
```

**After:**
```
No issues found.
```
