### PR TITLE
fix(error-classifier): classify HTTP 408 as retryable timeout, not a non-retryable 4xx

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -899,6 +899,41 @@ def _classify_by_status(
             should_compress=True,
         )
 
+    if status_code == 408:
+        # HTTP 408 is a timeout, NOT a permanent client error. Without this
+        # branch it falls through to the generic "other 4xx -> non-retryable
+        # format_error" catch-all at the bottom of this function, which aborts
+        # the turn and persists an empty assistant bubble (the "disappeared
+        # conversation" / blank-turn symptom).
+        #
+        # We classify ALL 408s as a transient ``timeout`` (retryable, NO
+        # compression). This deliberately covers the GitHub Copilot
+        # ``user_request_timeout`` / "Timed out reading request body ... use a
+        # smaller request size" case too, even though that one is nominally
+        # about request SIZE. Field evidence (long copilot/opus-4.8 session,
+        # 2026-07-02): the 408 is PROBABILISTIC/jitter in a wide band well
+        # BELOW the hard prompt ceiling — the same ~785k-token request that
+        # 408'd once succeeded on the very next attempt at ~786k. The edge
+        # occasionally reads the large body too slowly and times out; it is
+        # not a hard "body exceeds the limit" rejection until the prompt
+        # actually approaches the ceiling (~936k for opus-4.8). So the correct,
+        # least-destructive recovery is a plain retry (the SAME body usually
+        # succeeds on the next attempt), NOT auto-compression.
+        #
+        # We intentionally do NOT set should_compress here: auto-compaction on
+        # a 408 would silently delete conversation history the moment a request
+        # merely jitters, which is a heavy, surprising, user-visible side
+        # effect for a transient timeout. Genuine "prompt too large for the
+        # window" is a SEPARATE signal (413 / context_overflow) and stays on
+        # its own compression path. When retries here are exhausted the loop
+        # falls back to another provider (transport-failure eager-fallback
+        # after 2 attempts); the user can always compact deliberately with
+        # ``/compress`` if a long session keeps timing out.
+        return result_fn(
+            FailoverReason.timeout,
+            retryable=True,
+        )
+
     if status_code == 429:
         # Already checked long_context_tier above. Some providers (notably
         # Z.AI / Zhipu) reuse HTTP 429 for server-wide overload — same status

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1881,3 +1881,77 @@ class TestOpenRouterUpstreamRateLimit:
         # Overload disambiguation runs first; the outer message is the overload
         # phrase, so this is an overload, not an upstream rate-limit.
         assert result.reason == FailoverReason.overloaded
+
+
+# ── HTTP 408 request timeout ────────────────────────────────────────────
+
+class Test408RequestTimeout:
+    """HTTP 408 must never fall through to the non-retryable 'other 4xx'
+    bucket (that abort persists an empty assistant turn — the "disappeared
+    conversation" / blank-bubble symptom). ALL 408s are classified as a transient
+    ``timeout``: retryable, and explicitly NOT should_compress.
+
+    Design decision (field 2026-07-02): even the GitHub Copilot
+    ``user_request_timeout`` / "Timed out reading request body ... use a
+    smaller request size" case is a plain retry, NOT auto-compression. Real
+    data showed the 408 is probabilistic jitter well below the hard prompt
+    ceiling — the same ~785k-token request that 408'd once succeeded on the
+    next attempt at ~786k — so retrying the same body usually works, and
+    auto-compaction would silently delete conversation history for a merely
+    transient timeout. Genuine over-window prompts surface as 413 /
+    context_overflow (their own compression path); users compact 408-prone
+    long sessions deliberately via ``/compress``.
+    """
+
+    def test_copilot_oversized_body_408_retries_as_timeout_not_compress(self):
+        # The exact shape GitHub Copilot returns on a long session. It must
+        # retry (timeout), and must NOT auto-compress.
+        e = MockAPIError(
+            "Error code: 408 - {'error': {'message': 'Timed out reading "
+            "request body. Try again, or use a smaller request size.', "
+            "'code': 'user_request_timeout'}}",
+            status_code=408,
+            body={"error": {"message": "Timed out reading request body. "
+                            "Try again, or use a smaller request size.",
+                            "code": "user_request_timeout"}},
+        )
+        result = classify_api_error(e, provider="copilot", model="claude-opus-4.8")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_408_never_auto_compresses(self):
+        # Hard guard on the user's explicit preference: a 408 must NEVER
+        # trigger auto-compaction (which would delete history unprompted).
+        # This must FAIL if anyone re-routes 408 to payload_too_large.
+        for msg, body in [
+            ("Timed out reading request body. Use a smaller request size.", {}),
+            ("Request timed out.", {"error": {"code": "user_request_timeout"}}),
+            ("Request Timeout", {}),
+        ]:
+            e = MockAPIError(msg, status_code=408, body=body)
+            result = classify_api_error(e, provider="copilot", model="claude-opus-4.8")
+            assert result.should_compress is False, msg
+            assert result.reason != FailoverReason.payload_too_large, msg
+
+    def test_oversized_body_408_is_not_non_retryable_format_error(self):
+        # Falsification guard: if the 408 branch is removed, this 408 would
+        # be classified as a non-retryable format_error and the turn would
+        # abort into a blank bubble. This assertion must FAIL on buggy code.
+        e = MockAPIError(
+            "Timed out reading request body. Try again, or use a smaller "
+            "request size.",
+            status_code=408,
+        )
+        result = classify_api_error(e, provider="copilot", model="claude-opus-4.8")
+        assert result.retryable is True
+        assert result.reason != FailoverReason.format_error
+
+    def test_plain_408_is_transient_timeout(self):
+        # A generic gateway/request timeout must retry as a transport timeout.
+        e = MockAPIError("Request Timeout", status_code=408)
+        result = classify_api_error(e, provider="openai", model="gpt-5.5")
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+        assert result.should_compress is False
+

--- a/tests/run_agent/test_408_request_timeout_loop.py
+++ b/tests/run_agent/test_408_request_timeout_loop.py
@@ -1,0 +1,235 @@
+"""Loop-level tests for HTTP 408 request-timeout recovery in AIAgent.
+
+Symptom-level companion to tests/agent/test_error_classifier.py::Test408RequestTimeout
+(which asserts the *classification*). These drive the REAL run_conversation loop
+and assert the *turn outcome*: a 408 must be retried as a transient timeout and
+produce a real assistant turn — NOT abort into an empty assistant bubble (the
+"disappeared conversation" / blank-turn symptom), and NOT silently compress
+away conversation history.
+
+Regression guarded: before agent/error_classifier.py grew a `408` branch, a 408
+fell through to the generic "other 4xx -> non-retryable format_error" abort,
+which persisted an empty assistant turn (blank bubble). The fix classifies 408
+as `timeout` (retryable, NOT should_compress) so the loop retries the SAME
+request — jitter-type 408s from GitHub Copilot near the prompt-size band clear
+on the next attempt without destroying history.
+"""
+
+import pytest
+
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+from run_agent import AIAgent
+import run_agent
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_sleep(monkeypatch):
+    """Short-circuit retry backoff so the loop tests run fast."""
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    resp = SimpleNamespace(choices=[choice], model="test/model")
+    resp.usage = None
+    return resp
+
+
+def _make_408_error(*, message="Request Timeout", use_status_code=True, oversized=False):
+    """Create an exception mimicking an HTTP 408.
+
+    oversized=True reproduces GitHub Copilot's user_request_timeout body
+    ("Timed out reading request body ... use a smaller request size").
+    """
+    if oversized:
+        message = ("Error code: 408 - {'error': {'message': 'Timed out reading "
+                   "request body. Try again, or use a smaller request size.', "
+                   "'code': 'user_request_timeout'}}")
+    err = Exception(message)
+    if use_status_code:
+        err.status_code = 408
+    return err
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://api.githubcopilot.com",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = True   # prove we DON'T compress even when enabled
+        a.save_trajectories = False
+        return a
+
+
+class TestHTTP408Loop:
+    """A 408 must retry-and-recover into a real turn, never abort blank,
+    never auto-compress."""
+
+    def test_408_recovers_into_real_turn_not_blank_bubble(self, agent):
+        """First call 408s, second succeeds → a real assistant answer, no abort."""
+        err_408 = _make_408_error()
+        ok_resp = _mock_response(content="Recovered after 408 retry", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_408, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        # Symptom assertion: 408 did NOT abort into a failed/blank turn.
+        assert result.get("failed") is not True
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after 408 retry"
+
+    def test_408_does_not_compress_history(self, agent):
+        """A 408 must NOT call _compress_context — history stays intact."""
+        err_408 = _make_408_error()
+        ok_resp = _mock_response(content="OK", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_408, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        # The core user-requested guarantee: 408 never silently compacts.
+        mock_compress.assert_not_called()
+        assert result["completed"] is True
+
+    def test_408_retries_same_request_not_shrunk(self, agent):
+        """Retry after 408 must resend the SAME request (plain retry), not a
+        compressed/shrunk one — proving it took the timeout path, not the
+        payload_too_large/compression path."""
+        err_408 = _make_408_error()
+        ok_resp = _mock_response(content="OK", finish_reason="stop")
+
+        request_payloads = []
+
+        def _side_effect(**kwargs):
+            request_payloads.append(kwargs)
+            if len(request_payloads) == 1:
+                raise err_408
+            return ok_resp
+
+        agent.client.chat.completions.create.side_effect = _side_effect
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        assert result["completed"] is True
+        assert len(request_payloads) == 2
+        mock_compress.assert_not_called()
+        # Same request body length on retry (no compression shrank it).
+        assert len(request_payloads[1]["messages"]) == len(request_payloads[0]["messages"])
+
+    def test_oversized_body_408_also_retries_without_compression(self, agent):
+        """The Copilot 'reading request body / smaller request size' 408 must
+        ALSO retry-not-compress — it is jitter near the size band, not a hard
+        overflow. (This is the exact case the user challenged: 'why must 408
+        compress?' — answer: it must not.)"""
+        err_408 = _make_408_error(oversized=True)
+        ok_resp = _mock_response(content="Recovered oversized 408", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err_408, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_not_called()
+        assert result.get("failed") is not True
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered oversized 408"
+
+    def test_408_via_message_string_without_status_code(self, agent):
+        """A 408 surfaced only via message text (no status_code attr) must
+        still recover, not abort."""
+        err = _make_408_error(use_status_code=False, message="error code: 408 Request Timeout")
+        ok_resp = _mock_response(content="OK", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [err, ok_resp]
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        mock_compress.assert_not_called()
+        assert result["completed"] is True


### PR DESCRIPTION
## Problem

On a long session against GitHub Copilot, the chat turn would occasionally end
as a **blank/empty assistant message** (no content) with a visible
`Error: HTTP 408: Timed out reading request body. Try again, or use a smaller
request size.` The turn aborted instead of recovering.

## Root cause

`agent/error_classifier.py::_classify_by_status` had **no branch for HTTP 408**.
It fell through to the generic tail:

```python
# Other 4xx — non-retryable
if 400 <= status_code < 500:
    return result_fn(FailoverReason.format_error, retryable=False, should_fallback=True)
```

But 408 is a **timeout**, not a permanent client error. GitHub Copilot returns
`408 {'code': 'user_request_timeout', 'message': 'Timed out reading request
body. ... use a smaller request size.'}` when a large prompt is slow to read.
Classified as non-retryable `format_error`, the loop took the client-error abort
path and persisted an empty assistant turn (the blank bubble).

## Fix

Add an explicit `408` branch classifying **all** 408s as a transient `timeout`
(`retryable=True`, **not** `should_compress`). The loop's existing transport
retry + eager-fallback-after-2-attempts path then recovers the turn.

## Why NOT route it to compression (payload_too_large)

The 408 message literally says "use a smaller request size", so compressing like
a 413 is tempting — but field data argued against it. On a long copilot/opus-4.8
session the 408 was **probabilistic jitter well below the hard prompt ceiling**:
the same ~785k-token request that 408'd once **succeeded on the very next attempt
at ~786k**. Retrying the same body usually works, so auto-compaction on a 408
would **silently delete conversation history for a merely transient timeout**.
Genuine over-window prompts already surface as 413 / `context_overflow` and keep
their own compression path; a user can compact a 408-prone long session
deliberately via `/compress`.

## Testing

- **Classification** (`tests/agent/test_error_classifier.py::Test408RequestTimeout`):
  oversized-body 408 and plain 408 both → `timeout / retryable / not-compress`,
  plus a `test_408_never_auto_compresses` guard.
- **Loop-level** (`tests/run_agent/test_408_request_timeout_loop.py`): a 408 in
  the real `run_conversation` loop retries into a real assistant turn (no blank
  turn), never calls `_compress_context`, and resends the same request body.
- **Mutation-verified**: deleting the 408 branch makes both suites fail with
  `format_error`/non-retryable (reproducing the blank-turn regression),
  confirming the tests guard the symptom rather than being tautological.

Full suite green on latest `main`: `tests/agent/test_error_classifier.py` +
`tests/run_agent/test_408_request_timeout_loop.py` (188 passed), and the sibling
`tests/run_agent/test_413_compression.py` unaffected.
