### PR TITLE
fix(api): advance responses chain after compression

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3297,17 +3297,19 @@ class APIServerAdapter(BasePlatformAdapter):
             response_env: Dict[str, Any],
             *,
             conversation_history_snapshot: Optional[List[Dict[str, Any]]] = None,
+            session_id_snapshot: Optional[str] = None,
         ) -> None:
             if not store:
                 return
             if conversation_history_snapshot is None:
                 conversation_history_snapshot = list(conversation_history)
                 conversation_history_snapshot.append({"role": "user", "content": user_message})
+            stored_session_id = session_id_snapshot if session_id_snapshot is not None else session_id
             self._response_store.put(response_id, {
                 "response": response_env,
                 "conversation_history": conversation_history_snapshot,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": stored_session_id,
             })
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
@@ -3704,15 +3706,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
                 }
-                full_history = self._build_response_conversation_history(
+                effective_session_id = self._response_effective_session_id(result, session_id)
+                full_history = self._build_response_store_conversation_history(
                     conversation_history,
                     user_message,
                     result,
                     final_response_text,
+                    compression_occurred=bool(result.get("compression_occurred")),
                 )
                 _persist_response_snapshot(
                     completed_env,
                     conversation_history_snapshot=full_history,
+                    session_id_snapshot=effective_session_id,
                 )
                 terminal_snapshot_persisted = True
                 await _write_event("response.completed", {
@@ -4015,20 +4020,22 @@ class APIServerAdapter(BasePlatformAdapter):
 
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
         created_at = int(time.time())
+        effective_session_id = self._response_effective_session_id(result, session_id)
 
         # Build the full conversation history for storage
         # (includes tool calls from the agent run)
-        full_history = self._build_response_conversation_history(
+        full_history = self._build_response_store_conversation_history(
             conversation_history,
             user_message,
             result,
             final_response,
+            compression_occurred=bool(result.get("compression_occurred")),
         )
 
         # Build output items from the current turn only.  AIAgent returns a
         # full transcript in result["messages"], while older/mocked paths may
         # return only the current turn suffix.
-        output_start_index = self._response_messages_turn_start_index(
+        output_start_index = self._response_current_turn_output_start_index(
             conversation_history,
             user_message,
             result,
@@ -4055,14 +4062,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "response": response_data,
                 "conversation_history": full_history,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": effective_session_id,
             })
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
 
-        response_headers = {"X-Hermes-Session-Id": session_id}
+        response_headers = {"X-Hermes-Session-Id": effective_session_id}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(response_data, headers=response_headers)
@@ -4444,6 +4451,40 @@ class APIServerAdapter(BasePlatformAdapter):
         return full_history
 
     @staticmethod
+    def _response_effective_session_id(result: Dict[str, Any], fallback: Optional[str]) -> Optional[str]:
+        """Return the session id that should anchor the next Responses turn."""
+        if isinstance(result, dict):
+            result_session_id = result.get("session_id")
+            if result_session_id:
+                return result_session_id
+        return fallback
+
+    @classmethod
+    def _build_response_store_conversation_history(
+        cls,
+        conversation_history: List[Dict[str, Any]],
+        user_message: Any,
+        result: Dict[str, Any],
+        final_response: Any,
+        *,
+        compression_occurred: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Build the transcript persisted for future ``previous_response_id`` calls."""
+        agent_messages = result.get("messages") if isinstance(result, dict) else None
+        if (
+            compression_occurred
+            and isinstance(agent_messages, list)
+            and cls._response_messages_include_current_user(agent_messages, user_message)
+        ):
+            return list(agent_messages)
+        return cls._build_response_conversation_history(
+            conversation_history,
+            user_message,
+            result,
+            final_response,
+        )
+
+    @staticmethod
     def _response_messages_turn_start_index(
         conversation_history: List[Dict[str, Any]],
         user_message: Any,
@@ -4461,6 +4502,51 @@ class APIServerAdapter(BasePlatformAdapter):
             return len(expected_prefix)
         if prior and agent_messages[:len(prior)] == prior:
             return len(prior)
+        return 0
+
+    @staticmethod
+    def _response_messages_include_current_user(
+        agent_messages: List[Dict[str, Any]],
+        user_message: Any,
+    ) -> bool:
+        """Return whether agent messages contain the current user turn."""
+        return any(
+            APIServerAdapter._response_message_matches_user(msg, user_message)
+            for msg in agent_messages
+        )
+
+    @staticmethod
+    def _response_message_matches_user(message: Any, user_message: Any) -> bool:
+        """Match a user turn while ignoring persistence-only metadata."""
+        return (
+            isinstance(message, dict)
+            and message.get("role") == "user"
+            and message.get("content") == user_message
+        )
+
+    @classmethod
+    def _response_current_turn_output_start_index(
+        cls,
+        conversation_history: List[Dict[str, Any]],
+        user_message: Any,
+        result: Dict[str, Any],
+    ) -> int:
+        """Find the first result message that belongs in the current output."""
+        prefix_start = cls._response_messages_turn_start_index(
+            conversation_history,
+            user_message,
+            result,
+        )
+        if prefix_start:
+            return prefix_start
+
+        agent_messages = result.get("messages") if isinstance(result, dict) else None
+        if not isinstance(agent_messages, list) or not agent_messages:
+            return 0
+
+        for index in range(len(agent_messages) - 1, -1, -1):
+            if cls._response_message_matches_user(agent_messages[index], user_message):
+                return index + 1
         return 0
 
     @classmethod
@@ -4693,6 +4779,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     _eff_sid = getattr(agent, "session_id", session_id)
                     if isinstance(_eff_sid, str) and _eff_sid:
                         result["session_id"] = _eff_sid
+                    result["compression_occurred"] = bool(
+                        getattr(agent, "_last_compaction_in_place", False)
+                        or (
+                            isinstance(session_id, str)
+                            and bool(session_id)
+                            and isinstance(_eff_sid, str)
+                            and bool(_eff_sid)
+                            and _eff_sid != session_id
+                        )
+                    )
                     return result, usage
                 finally:
                     clear_session_vars(tokens)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -697,6 +697,7 @@ class TestAgentExecution:
         mock_agent.session_prompt_tokens = 1
         mock_agent.session_completion_tokens = 2
         mock_agent.session_total_tokens = 3
+        mock_agent._last_compaction_in_place = False
 
         with patch.object(adapter, "_create_agent", return_value=mock_agent):
             result, usage = await adapter._run_agent(
@@ -711,12 +712,46 @@ class TestAgentExecution:
         # here doesn't set an explicit session_id string so the guard skips
         # the annotation — header will fall back to the provided session_id.
         assert result["final_response"] == "ok"
+        assert result["compression_occurred"] is False
         assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
         mock_agent.run_conversation.assert_called_once_with(
             user_message="hello",
             conversation_history=[],
             task_id="session-123",
         )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("effective_session_id", "compacted_in_place", "expected"),
+        [
+            ("session-123", False, False),
+            ("rotated-session", False, True),
+            ("session-123", True, True),
+        ],
+    )
+    async def test_run_agent_reports_compression_boundary(
+        self,
+        adapter,
+        effective_session_id,
+        compacted_in_place,
+        expected,
+    ):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_id = effective_session_id
+        mock_agent._last_compaction_in_place = compacted_in_place
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            result, _usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+            )
+
+        assert result["compression_occurred"] is expected
 
 
 # ---------------------------------------------------------------------------
@@ -2169,6 +2204,190 @@ class TestResponsesEndpoint:
             assert first_session_id == second_session_id
 
     @pytest.mark.asyncio
+    async def test_previous_response_id_advances_after_compression(self, adapter):
+        """Responses storage must follow the agent's compacted session."""
+        stale_history = [
+            {"role": "user", "content": "stale context " + ("x" * 200)},
+            {"role": "assistant", "content": "old answer"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(stale_history),
+                "session_id": "oversized-session",
+            },
+        )
+        compacted_history = [
+            {"role": "user", "content": "Summary of earlier context: compacted"},
+            {"role": "assistant", "content": "Ready for the follow-up."},
+            {"role": "user", "content": "Follow up after compression"},
+            {"role": "assistant", "content": "after compression"},
+        ]
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "after compression",
+                        "messages": list(compacted_history),
+                        "session_id": "compressed-session",
+                        "compression_occurred": True,
+                        "api_calls": 1,
+                    },
+                    usage,
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Follow up after compression",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+
+            assert resp.status == 200
+            assert resp.headers["X-Hermes-Session-Id"] == "compressed-session"
+            data = await resp.json()
+            stored = adapter._response_store.get(data["id"])
+            assert stored["session_id"] == "compressed-session"
+            assert stored["conversation_history"] == compacted_history
+            assert stale_history[0] not in stored["conversation_history"]
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "next",
+                        "messages": compacted_history + [
+                            {"role": "user", "content": "Next turn"},
+                            {"role": "assistant", "content": "next"},
+                        ],
+                        "session_id": "compressed-session",
+                        "api_calls": 1,
+                    },
+                    usage,
+                )
+                chained = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Next turn",
+                        "previous_response_id": data["id"],
+                    },
+                )
+
+            assert chained.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["session_id"] == "compressed-session"
+            assert call_kwargs["conversation_history"] == compacted_history
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_rotated_session_keeps_suffix_only_history(self, adapter):
+        """Session rotation alone must not treat legacy suffix-only messages as full history."""
+        prior_history = [
+            {"role": "user", "content": "Existing context"},
+            {"role": "assistant", "content": "Existing answer"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(prior_history),
+                "session_id": "old-session",
+            },
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "suffix answer",
+                        "messages": [{"role": "assistant", "content": "suffix answer"}],
+                        "session_id": "new-session",
+                        "compression_occurred": True,
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Follow up",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        stored = adapter._response_store.get(data["id"])
+        assert stored["session_id"] == "new-session"
+        assert stored["conversation_history"] == prior_history + [
+            {"role": "user", "content": "Follow up"},
+            {"role": "assistant", "content": "suffix answer"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_rebaselines_after_in_place_compression(self, adapter):
+        stale_history = [
+            {"role": "user", "content": "stale context"},
+            {"role": "assistant", "content": "stale answer"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(stale_history),
+                "session_id": "same-session",
+            },
+        )
+        compacted_history = [
+            {"role": "user", "content": "Compacted summary"},
+            {"role": "assistant", "content": "Ready."},
+            {
+                "role": "user",
+                "content": "Continue in place",
+                "_db_persisted": True,
+            },
+            {"role": "assistant", "content": "continued"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "continued",
+                        "messages": list(compacted_history),
+                        "session_id": "same-session",
+                        "compression_occurred": True,
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Continue in place",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+                data = await resp.json()
+
+        assert resp.status == 200
+        assert resp.headers["X-Hermes-Session-Id"] == "same-session"
+        stored = adapter._response_store.get(data["id"])
+        assert stored["session_id"] == "same-session"
+        assert stored["conversation_history"] == compacted_history
+        assert stale_history[0] not in stored["conversation_history"]
+        assert data["output"][-1]["content"][0]["text"] == "continued"
+        assert "Ready." not in json.dumps(data["output"])
+
+    @pytest.mark.asyncio
     async def test_invalid_previous_response_id_returns_404(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -2587,6 +2806,169 @@ class TestResponsesStreaming:
         assert stored_history == expected_history
         assert stored_history.count(prior_history[0]) == 1
         assert stored_history.count({"role": "user", "content": "Now add 1 more"}) == 1
+
+    @pytest.mark.asyncio
+    async def test_streamed_previous_response_id_advances_after_compression(self, adapter):
+        stale_history = [
+            {"role": "user", "content": "stale stream context " + ("x" * 200)},
+            {"role": "assistant", "content": "old streamed answer"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(stale_history),
+                "session_id": "oversized-session",
+            },
+        )
+        compacted_history = [
+            {"role": "user", "content": "Summary of streamed context: compacted"},
+            {"role": "assistant", "content": "Ready for streaming follow-up."},
+            {"role": "user", "content": "Stream after compression"},
+            {"role": "assistant", "content": "streamed after compression"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("streamed after compression")
+                return (
+                    {
+                        "final_response": "streamed after compression",
+                        "messages": list(compacted_history),
+                        "session_id": "compressed-stream-session",
+                        "compression_occurred": True,
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Stream after compression",
+                        "previous_response_id": "resp_prev",
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+            assert resp.status == 200
+            response_id = None
+            for line in body.splitlines():
+                if line.startswith("data: "):
+                    try:
+                        payload = json.loads(line[len("data: "):])
+                    except json.JSONDecodeError:
+                        continue
+                    if payload.get("type") == "response.completed":
+                        response_id = payload["response"]["id"]
+                        break
+
+            assert response_id
+            stored = adapter._response_store.get(response_id)
+            assert stored["session_id"] == "compressed-stream-session"
+            assert stored["conversation_history"] == compacted_history
+            assert stale_history[0] not in stored["conversation_history"]
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "next stream",
+                        "messages": compacted_history + [
+                            {"role": "user", "content": "Next stream turn"},
+                            {"role": "assistant", "content": "next stream"},
+                        ],
+                        "session_id": "compressed-stream-session",
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                chained = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Next stream turn",
+                        "previous_response_id": response_id,
+                    },
+                )
+
+            assert chained.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["session_id"] == "compressed-stream-session"
+            assert call_kwargs["conversation_history"] == compacted_history
+
+    @pytest.mark.asyncio
+    async def test_streamed_previous_response_id_rebaselines_after_in_place_compression(
+        self, adapter
+    ):
+        stale_history = [
+            {"role": "user", "content": "stale stream context"},
+            {"role": "assistant", "content": "stale stream answer"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(stale_history),
+                "session_id": "same-stream-session",
+            },
+        )
+        compacted_history = [
+            {"role": "user", "content": "Compacted stream summary"},
+            {"role": "assistant", "content": "Ready."},
+            {
+                "role": "user",
+                "content": "Continue stream in place",
+                "_db_persisted": True,
+            },
+            {"role": "assistant", "content": "stream continued"},
+        ]
+
+        async def _mock_run_agent(**kwargs):
+            callback = kwargs.get("stream_delta_callback")
+            if callback:
+                callback("stream continued")
+            return (
+                {
+                    "final_response": "stream continued",
+                    "messages": list(compacted_history),
+                    "session_id": "same-stream-session",
+                    "compression_occurred": True,
+                    "api_calls": 1,
+                },
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Continue stream in place",
+                        "previous_response_id": "resp_prev",
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        completed = [
+            json.loads(line.removeprefix("data: "))
+            for line in body.splitlines()
+            if line.startswith("data: ") and '"response.completed"' in line
+        ]
+        response_id = completed[-1]["response"]["id"]
+        stored = adapter._response_store.get(response_id)
+        assert stored["session_id"] == "same-stream-session"
+        assert stored["conversation_history"] == compacted_history
+        assert stale_history[0] not in stored["conversation_history"]
 
     @pytest.mark.asyncio
     async def test_stream_cancelled_persists_incomplete_snapshot(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Fixes `/v1/responses` `previous_response_id` chaining after context compression.

When an agent run rotates to a compressed continuation session, the Responses API now persists the effective post-run `session_id` and, when the returned transcript includes the current user turn, stores that compacted transcript as the next chaining baseline. This prevents `response_store.db` from reloading stale oversized pre-compression history and triggering compression again on every turn.

The fix covers both non-streaming and streaming Responses paths, while preserving legacy/mock suffix-only `result["messages"]` behavior so a session rotation alone does not accidentally replace history with an assistant-only suffix.

## Related Issue

Fixes #56895

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`: persist the effective Responses session id after successful runs, including streaming snapshots.
- `gateway/platforms/api_server.py`: store compacted post-compression transcripts as the next `previous_response_id` baseline when the agent result contains the current user turn.
- `gateway/platforms/api_server.py`: slice non-streaming output from the current turn when compacted transcripts no longer share the stale pre-compression prefix.
- `tests/gateway/test_api_server.py`: add non-streaming and streaming regressions for compression session advancement and next-hop chaining.
- `tests/gateway/test_api_server.py`: add a suffix-only rotated-session regression so legacy mocked agent results still append to prior history instead of replacing it.

## How to Test

1. Reproduction before fix: `.venv/bin/python -m pytest -q tests/gateway/test_api_server.py -k 'advances_after_compression'` failed because stored snapshots kept the old `oversized-session`.
2. After fix: `.venv/bin/python -m pytest -q tests/gateway/test_api_server.py -k 'previous_response_id'` -> `10 passed`.
3. After fix: `.venv/bin/python -m pytest -q tests/gateway/test_api_server.py` -> `179 passed`.
4. After fix: `.venv/bin/python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py` -> passed.
5. After fix: `git diff --check -- gateway/platforms/api_server.py tests/gateway/test_api_server.py` -> passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs/issues through #56895 and recent merged PR style before opening this
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure API server/session-store logic, covered by pytest
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

N/A