### PR TITLE
fix(auxiliary): preserve max_tokens for OpenRouter to prevent 402

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5751,9 +5751,11 @@ def _build_call_kwargs(
             _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
+        _is_openrouter = base_url_host_matches(_effective_base, "openrouter.ai")
         if (
             _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim
+            or _is_openrouter
         ):
             kwargs["max_tokens"] = max_tokens
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -185,7 +185,6 @@ class TestBuildCallKwargsMaxTokens:
             ("copilot", "gpt-5.4", "https://api.githubcopilot.com"),
             ("copilot", "gpt-5.5", "https://api.githubcopilot.com"),
             ("custom", "gpt-5", "https://api.openai.com/v1"),
-            ("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1"),
             ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1"),
             ("custom", "qwen", "http://localhost:8080/v1"),
             ("zai", "glm-4v-flash", "https://open.bigmodel.cn/api/paas/v4"),
@@ -235,6 +234,20 @@ class TestBuildCallKwargsMaxTokens:
             base_url="https://integrate.api.nvidia.com/v1",
         )
         assert kwargs["max_tokens"] == 4096
+
+    def test_keeps_max_tokens_for_openrouter(self):
+        """OpenRouter defaults to 65536 when max_tokens is omitted, which
+        exceeds free-tier limits.  Preserve the caller's cap (#56901)."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert kwargs["max_tokens"] == 500
 
 
 class TestNousTagsScoping:


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary title generation (and other auxiliary tasks) failing with HTTP 402 when routed to OpenRouter with a caller-specified `max_tokens`. OpenRouter defaults to 65536 output tokens when `max_tokens` is omitted, which exceeds free-tier credit limits (~13333 tokens).

The fix adds OpenRouter to the list of providers that preserve the caller's `max_tokens` in `_build_call_kwargs()`, alongside the existing Anthropic Messages and NVIDIA NIM exceptions.

## Related Issue

Fixes #56901

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: Added `_is_openrouter` check in `_build_call_kwargs()` to preserve `max_tokens` when routing to OpenRouter, preventing the provider from defaulting to 65536 tokens
- `tests/agent/test_auxiliary_client.py`: Moved OpenRouter from the "omits max_tokens" parametrize list to a dedicated `test_keeps_max_tokens_for_openrouter` test that verifies the caller's cap is preserved

## How to Test

1. Configure a non-OpenRouter main provider (e.g., custom, deepseek)
2. Have `OPENROUTER_API_KEY` in `.env` (as a fallback)
3. Start a new chat — title generation should succeed without HTTP 402
4. Run `pytest tests/agent/test_auxiliary_client.py -x -q -k "max_tokens"` — all 13 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before:**
```
Auxiliary title generation failed: HTTP 402: This request requires more credits,
or fewer max_tokens. You requested up to 65536 tokens, but can only afford 13333.
```

**After:**
Title generation succeeds with the caller's `max_tokens=500` preserved.
