### PR TITLE
fix(terminal): stop stripping CLAUDE_CODE_OAUTH_TOKEN from spawned subprocesses

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -80,7 +80,6 @@ class TestProviderEnvBlocklist:
         must also be blocked — not just the hand-written extras."""
         registry_vars = {
             "ANTHROPIC_TOKEN": "ant-tok",
-            "CLAUDE_CODE_OAUTH_TOKEN": "cc-tok",
             "ZAI_API_KEY": "zai-key",
             "Z_AI_API_KEY": "z-ai-key",
             "GLM_API_KEY": "glm-key",
@@ -326,11 +325,18 @@ class TestBlocklistCoverage:
 
     def test_registry_vars_are_in_blocklist(self):
         """Every api_key_env_var and base_url_env_var from PROVIDER_REGISTRY
-        must appear in the blocklist — ensures no drift."""
+        must appear in the blocklist — ensures no drift.
+
+        CLAUDE_CODE_OAUTH_TOKEN is the one deliberate exemption: it is owned
+        by the user's Claude Code install, not Hermes (#55878).
+        """
         from hermes_cli.auth import PROVIDER_REGISTRY
 
+        exempt = {"CLAUDE_CODE_OAUTH_TOKEN"}
         for pconfig in PROVIDER_REGISTRY.values():
             for var in pconfig.api_key_env_vars:
+                if var in exempt:
+                    continue
                 assert var in _HERMES_PROVIDER_ENV_BLOCKLIST, (
                     f"Registry var {var} (provider={pconfig.id}) missing from blocklist"
                 )
@@ -371,10 +377,18 @@ class TestBlocklistCoverage:
         )
 
     def test_extra_auth_vars_covered(self):
-        """Non-registry auth vars (ANTHROPIC_TOKEN, CLAUDE_CODE_OAUTH_TOKEN)
-        must also be in the blocklist."""
-        extras = {"ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}
+        """Non-registry auth vars (ANTHROPIC_TOKEN) must also be in the
+        blocklist."""
+        extras = {"ANTHROPIC_TOKEN"}
         assert extras.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
+
+    def test_claude_code_oauth_token_is_inheritable(self):
+        """CLAUDE_CODE_OAUTH_TOKEN is owned by the user's Claude Code install
+        (subscription OAuth), not a Hermes inference credential. Stripping it
+        made agent-spawned ``claude`` fall through to the shared Keychain /
+        ~/.claude credential store and clobber the user's interactive login
+        on auth failure (#55878). It must stay inheritable."""
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in _HERMES_PROVIDER_ENV_BLOCKLIST
 
     def test_non_registry_provider_vars_are_in_blocklist(self):
         extras = {

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -152,7 +152,6 @@ def _build_provider_env_blocklist() -> frozenset:
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_TOKEN",
-        "CLAUDE_CODE_OAUTH_TOKEN",
         "LLM_MODEL",
         "GOOGLE_API_KEY",
         # Path to a GCP service-account JSON, not a bare key, so
@@ -212,6 +211,16 @@ def _build_provider_env_blocklist() -> frozenset:
         "GATEWAY_RELAY_SECRET",
         "GATEWAY_RELAY_DELIVERY_KEY",
     })
+    # CLAUDE_CODE_OAUTH_TOKEN is deliberately NOT stripped.  It is set and
+    # owned by the user's Claude Code install (subscription OAuth), not a
+    # Hermes-managed inference credential — Claude subscription auth is not a
+    # working Hermes provider path.  Stripping it broke agent-spawned
+    # ``claude`` CLIs: the child fell through to the shared macOS Keychain /
+    # ``~/.claude/.credentials.json`` store and, on auth failure, cleared it,
+    # logging the user out of their interactive Claude sessions (#55878).
+    # It arrives via the registry loop above (anthropic api_key_env_vars),
+    # so remove it explicitly.
+    blocked.discard("CLAUDE_CODE_OAUTH_TOKEN")
     return frozenset(blocked)
 
 


### PR DESCRIPTION
## Summary
Agent-spawned `claude` CLIs now inherit `CLAUDE_CODE_OAUTH_TOKEN` — the terminal env blocklist no longer strips it, so spawned Claude Code authenticates with the user's subscription token instead of falling through to (and clobbering) the shared macOS Keychain / `~/.claude/.credentials.json` store.

Root cause (#55878): `CLAUDE_CODE_OAUTH_TOKEN` landed on `_HERMES_PROVIDER_ENV_BLOCKLIST` via the anthropic registry entry, but it's set and owned by the user's Claude Code install (subscription OAuth), not a Hermes-managed inference credential — Claude subscription auth is not a working Hermes provider path. With the token stripped, a spawned `claude` fell back to the shared credential store and cleared it on auth failure, logging the user out of interactive Claude sessions and the desktop app.

## Changes
- `tools/environments/local.py`: `blocked.discard("CLAUDE_CODE_OAUTH_TOKEN")` in `_build_provider_env_blocklist()` with rationale comment. Applies uniformly to all consumers of the blocklist (`_make_run_env`, `hermes_subprocess_env`, `_sanitize_subprocess_env`, env_passthrough's fail-closed guard).
- `tests/tools/test_local_env_blocklist.py`: pin the new invariant (`test_claude_code_oauth_token_is_inheritable`), exempt the var in the registry-drift test, drop it from the strip assertions.

## Validation
| | Before | After |
|---|---|---|
| `_make_run_env` child env | token stripped | token inherited |
| `ANTHROPIC_API_KEY` / other provider creds | stripped | stripped (unchanged) |
| GHSA-rhgp-j443-p4rf passthrough guard | fail-closed | fail-closed (unchanged for all blocklisted vars) |

E2E with real imports + temp `HERMES_HOME`: token present in `_make_run_env` and `hermes_subprocess_env` output; `ANTHROPIC_API_KEY`/`OPENROUTER_API_KEY` still stripped; passthrough still refuses `ANTHROPIC_API_KEY`. Targeted suites green (`tests/tools/test_local_env_blocklist.py`, `tests/tools/test_env_passthrough.py`).

Supersedes the mechanism in #55895 (thanks @sene1337 / @darbsllim for the diagnosis) with a minimal blocklist exemption instead of claude-spawn detection.

Fixes #55878

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa09da4/cdBlXrfA2ofbBp3eWujRS_v6VWFNdO.png)

---
Nous Research
