### PR TITLE
feat: add secure input broker

### DIFF
--- a/agent/secure_input_broker.py
+++ b/agent/secure_input_broker.py
@@ -1,0 +1,180 @@
+"""Ephemeral secure input broker.
+
+The model may ask a UI surface to collect a secret, but the raw value must not
+enter the LLM transcript.  This module stores such values in process memory and
+returns opaque ``secret://...`` references that tools can consume under a narrow
+scope.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import secrets
+import threading
+import time
+from typing import Iterable
+
+
+_SECRET_REF_PREFIX = "secret://session/"
+_DEFAULT_TTL_SECONDS = 600
+_MAX_TTL_SECONDS = 3600
+
+
+@dataclass
+class SecretRecord:
+    value: str
+    purpose: str
+    created_at: float
+    expires_at: float
+    allowed_consumers: set[str] = field(default_factory=set)
+    single_use: bool = True
+    consumed: bool = False
+    label: str = ""
+
+
+_lock = threading.Lock()
+_records: dict[str, SecretRecord] = {}
+_redaction_values: dict[str, float] = {}
+
+
+class SecretBrokerError(ValueError):
+    """Raised when a secure-input reference cannot be used."""
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _normalize_consumers(consumers: Iterable[str] | None) -> set[str]:
+    values = {str(c).strip() for c in (consumers or []) if str(c).strip()}
+    return values or {"terminal"}
+
+
+def _clamp_ttl(ttl_seconds: int | float | None) -> int:
+    try:
+        ttl = int(ttl_seconds or _DEFAULT_TTL_SECONDS)
+    except (TypeError, ValueError):
+        ttl = _DEFAULT_TTL_SECONDS
+    return max(1, min(ttl, _MAX_TTL_SECONDS))
+
+
+def _purge_expired_locked(now: float | None = None) -> None:
+    now = _now() if now is None else now
+    for ref, rec in list(_records.items()):
+        if rec.expires_at <= now:
+            _records.pop(ref, None)
+    for value, expires_at in list(_redaction_values.items()):
+        if expires_at <= now:
+            _redaction_values.pop(value, None)
+
+
+def register_secret(
+    value: str,
+    *,
+    purpose: str,
+    allowed_consumers: Iterable[str] | None = None,
+    ttl_seconds: int | float | None = None,
+    single_use: bool = True,
+    label: str = "",
+) -> dict:
+    """Store *value* temporarily and return redacted metadata with a ref."""
+    if not isinstance(value, str) or not value:
+        raise SecretBrokerError("secure input was empty or cancelled")
+
+    ttl = _clamp_ttl(ttl_seconds)
+    now = _now()
+    ref = _SECRET_REF_PREFIX + secrets.token_urlsafe(18)
+    rec = SecretRecord(
+        value=value,
+        purpose=str(purpose or "secure_input"),
+        created_at=now,
+        expires_at=now + ttl,
+        allowed_consumers=_normalize_consumers(allowed_consumers),
+        single_use=bool(single_use),
+        label=str(label or ""),
+    )
+    with _lock:
+        _purge_expired_locked(now)
+        _records[ref] = rec
+        # Keep exact-value redaction alive until expiry even after single-use
+        # consumption, because the child process may echo the value after the
+        # broker has marked it consumed.
+        _redaction_values[value] = rec.expires_at
+
+    return {
+        "secret_ref": ref,
+        "purpose": rec.purpose,
+        "expires_at": rec.expires_at,
+        "ttl_seconds": ttl,
+        "single_use": rec.single_use,
+        "allowed_consumers": sorted(rec.allowed_consumers),
+        "redacted": True,
+    }
+
+
+def consume_secret(secret_ref: str, *, consumer: str) -> str:
+    """Return the secret value for an authorized tool consumer.
+
+    The returned value is intentionally only available to trusted tool runtime
+    code. Tool schemas should pass refs, never raw values.
+    """
+    ref = str(secret_ref or "").strip()
+    consumer = str(consumer or "").strip()
+    if not ref.startswith(_SECRET_REF_PREFIX):
+        raise SecretBrokerError("invalid secure input reference")
+    if not consumer:
+        raise SecretBrokerError("missing secure input consumer")
+
+    now = _now()
+    with _lock:
+        _purge_expired_locked(now)
+        rec = _records.get(ref)
+        if rec is None:
+            raise SecretBrokerError("secure input reference not found or expired")
+        if consumer not in rec.allowed_consumers:
+            allowed = ", ".join(sorted(rec.allowed_consumers)) or "none"
+            raise SecretBrokerError(
+                f"secure input reference is not scoped for {consumer!r} (allowed: {allowed})"
+            )
+        if rec.single_use and rec.consumed:
+            raise SecretBrokerError("secure input reference has already been consumed")
+        rec.consumed = True
+        return rec.value
+
+
+def describe_secret(secret_ref: str) -> dict | None:
+    """Return non-sensitive metadata for *secret_ref*, or None."""
+    now = _now()
+    with _lock:
+        _purge_expired_locked(now)
+        rec = _records.get(secret_ref)
+        if rec is None:
+            return None
+        return {
+            "secret_ref": secret_ref,
+            "purpose": rec.purpose,
+            "expires_at": rec.expires_at,
+            "single_use": rec.single_use,
+            "consumed": rec.consumed,
+            "allowed_consumers": sorted(rec.allowed_consumers),
+            "redacted": True,
+        }
+
+
+def redact_known_secrets(text: str) -> str:
+    """Replace exact broker-held secret values in text with a sentinel."""
+    if not text:
+        return text
+    with _lock:
+        _purge_expired_locked()
+        values = list(_redaction_values)
+    for value in values:
+        if value:
+            text = text.replace(value, "[REDACTED SECURE INPUT]")
+    return text
+
+
+def clear_all() -> None:
+    """Test helper: clear every in-memory secret."""
+    with _lock:
+        _records.clear()
+        _redaction_values.clear()

--- a/cli.py
+++ b/cli.py
@@ -882,7 +882,7 @@ def get_job(*args, **kwargs):
     return _get_job(*args, **kwargs)
 
 # Resource cleanup imports for safe shutdown (terminal VMs, browser sessions)
-from hermes_cli.callbacks import prompt_for_secret
+from hermes_cli.callbacks import prompt_for_secret, prompt_for_secure_input
 
 
 def _cleanup_all_terminals(*args, **kwargs):
@@ -907,6 +907,12 @@ def set_secret_capture_callback(*args, **kwargs):
     from tools.skills_tool import set_secret_capture_callback as _set_secret_capture_callback
 
     return _set_secret_capture_callback(*args, **kwargs)
+
+
+def set_secure_input_callback(*args, **kwargs):
+    from tools.secure_input_tool import set_secure_input_callback as _set_secure_input_callback
+
+    return _set_secure_input_callback(*args, **kwargs)
 
 
 def _cleanup_all_browsers(*args, **kwargs):
@@ -5983,6 +5989,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         set_sudo_password_callback(self._sudo_password_callback)
         set_approval_callback(self._approval_callback)
         set_secret_capture_callback(self._secret_capture_callback)
+        set_secure_input_callback(self._secure_input_callback)
         try:
             from tools.computer_use_tool import set_approval_callback as _set_cu_cb
 
@@ -11721,6 +11728,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     def _secret_capture_callback(self, var_name: str, prompt: str, metadata=None) -> dict:
         return prompt_for_secret(self, var_name, prompt, metadata)
 
+    def _secure_input_callback(self, purpose: str, prompt: str, metadata=None) -> str:
+        return prompt_for_secure_input(self, purpose, prompt, metadata)
+
     def _capture_modal_input_snapshot(self) -> None:
         """Temporarily clear the input buffer and save the user's in-progress draft."""
         if self._modal_input_snapshot is not None or not getattr(self, "_app", None):
@@ -11835,6 +11845,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Single-query and direct chat callers do not go through run(), so
         # register secure secret capture here as well.
         set_secret_capture_callback(self._secret_capture_callback)
+        set_secure_input_callback(self._secure_input_callback)
 
         # Reset the per-turn interrupt flag. Any subsequent path that
         # discovers an interrupt (below, after run_conversation) will flip
@@ -12125,6 +12136,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         set_sudo_password_callback(None)
                         set_approval_callback(None)
                         set_secret_capture_callback(None)
+                        set_secure_input_callback(None)
                     except Exception:
                         pass
                     # Release the per-turn approval session key. ``_session_yolo``
@@ -15266,6 +15278,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             set_sudo_password_callback(None)
             set_approval_callback(None)
             set_secret_capture_callback(None)
+            set_secure_input_callback(None)
             # Flush any in-memory turn transcript before marking the session
             # closed.  On SIGHUP/SIGTERM/window close the agent thread may not
             # reach its normal run_conversation() persistence path before the

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -183,6 +183,59 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
     }
 
 
+def prompt_for_secure_input(cli, purpose: str, prompt: str, metadata=None) -> str:
+    """Prompt for an ephemeral secret without persisting it.
+
+    The return value goes straight to the secure input broker. The model only
+    receives the broker's opaque secret_ref.
+    """
+    if not getattr(cli, "_app", None):
+        try:
+            return masked_secret_prompt(f"{prompt} (hidden, empty Enter to cancel): ")
+        except (EOFError, KeyboardInterrupt):
+            return ""
+
+    timeout = 120
+    response_queue = queue.Queue()
+    cli._secret_state = {
+        "var_name": purpose,
+        "prompt": prompt,
+        "metadata": {**(metadata or {}), "secure_input": True},
+        "response_queue": response_queue,
+    }
+    cli._secret_deadline = _time.monotonic() + timeout
+    if hasattr(cli, "_clear_secret_input_buffer"):
+        try:
+            cli._clear_secret_input_buffer()
+        except Exception:
+            pass
+
+    if hasattr(cli, "_app") and cli._app:
+        cli._app.invalidate()
+
+    while True:
+        try:
+            value = response_queue.get(timeout=1)
+            cli._secret_state = None
+            cli._secret_deadline = 0
+            if hasattr(cli, "_app") and cli._app:
+                cli._app.invalidate()
+            return value or ""
+        except queue.Empty:
+            remaining = cli._secret_deadline - _time.monotonic()
+            if remaining <= 0:
+                break
+            if hasattr(cli, "_app") and cli._app:
+                cli._app.invalidate()
+
+    cli._secret_state = None
+    cli._secret_deadline = 0
+    if hasattr(cli, "_app") and cli._app:
+        cli._app.invalidate()
+    cprint(f"\n{_DIM}  ⏱ Timeout - secure input cancelled{_RST}")
+    return ""
+
+
 def approval_callback(cli, command: str, description: str) -> str:
     """Prompt for dangerous command approval through the TUI.
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1600,7 +1600,7 @@ class CLICommandsMixin:
         When it completes, prints the result to the CLI without modifying
         the active session's conversation history.
         """
-        from cli import AIAgent, ChatConsole, _accent_hex, _cprint, _maybe_remap_for_light_mode, _render_final_assistant_content, set_approval_callback, set_secret_capture_callback, set_sudo_password_callback
+        from cli import AIAgent, ChatConsole, _accent_hex, _cprint, _maybe_remap_for_light_mode, _render_final_assistant_content, set_approval_callback, set_secret_capture_callback, set_secure_input_callback, set_sudo_password_callback
         parts = cmd.strip().split(maxsplit=1)
         if len(parts) < 2 or not parts[1].strip():
             _cprint("  Usage: /background <prompt>")
@@ -1629,6 +1629,7 @@ class CLICommandsMixin:
             set_approval_callback(self._approval_callback)
             try:
                 set_secret_capture_callback(self._secret_capture_callback)
+                set_secure_input_callback(getattr(self, "_secure_input_callback"))
             except Exception:
                 pass
             try:
@@ -1735,6 +1736,7 @@ class CLICommandsMixin:
                     set_sudo_password_callback(None)
                     set_approval_callback(None)
                     set_secret_capture_callback(None)
+                    set_secure_input_callback(None)
                 except Exception:
                     pass
                 self._background_tasks.pop(task_id, None)

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -52,6 +52,12 @@ class TestHermesApiServerToolset:
         tools = resolve_toolset("hermes-api-server")
         assert "send_message" not in tools
 
+    def test_toolset_excludes_request_secure_input(self):
+        # The HTTP API server has no interactive UI to capture a masked secret,
+        # so request_secure_input must not be advertised on this surface.
+        tools = resolve_toolset("hermes-api-server")
+        assert "request_secure_input" not in tools
+
     def test_toolset_excludes_text_to_speech(self):
         tools = resolve_toolset("hermes-api-server")
         assert "text_to_speech" not in tools

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -15,7 +15,8 @@ class _TestableEnv(BaseEnvironment):
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
 
-    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None,
+                  secret_env=None):
         raise NotImplementedError("Use mock")
 
     def cleanup(self):
@@ -160,8 +161,10 @@ class TestAtomicSnapshotWrite:
         env = _TestableEnv()
         captured = {}
 
-        def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None,
+                          secret_env=None):
             captured["cmd"] = cmd_string
+            captured["secret_env"] = secret_env
             raise RuntimeError("stop after capture")  # we only need the script
 
         env._run_bash = fake_run_bash  # type: ignore[assignment]
@@ -345,7 +348,8 @@ class TestInitSessionFailure:
         env._snapshot_ready = False
 
         calls = []
-        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None,
+                          secret_env=None):
             calls.append({"login": login})
             # Return a mock process handle
             mock = MagicMock()

--- a/tests/tools/test_init_session_cwd_respect.py
+++ b/tests/tools/test_init_session_cwd_respect.py
@@ -25,7 +25,7 @@ class _TestableEnv(BaseEnvironment):
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
 
-    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, secret_env=None):
         raise NotImplementedError("Use mock")
 
     def cleanup(self):
@@ -42,7 +42,7 @@ class TestInitSessionCwdRespect:
         # Capture the bootstrap script that init_session would pass to _run_bash
         captured = {}
 
-        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None, secret_env=None):
             captured["cmd"] = cmd_string
             mock = MagicMock()
             mock.poll.return_value = 0
@@ -81,7 +81,7 @@ class TestInitSessionCwdRespect:
 
         marker = env._cwd_marker
 
-        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None, secret_env=None):
             mock = MagicMock()
             mock.poll.return_value = 0
             mock.returncode = 0
@@ -106,7 +106,7 @@ class TestInitSessionCwdRespect:
 
         marker = env._cwd_marker
 
-        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None, secret_env=None):
             mock = MagicMock()
             mock.poll.return_value = 0
             mock.returncode = 0
@@ -128,7 +128,7 @@ class TestInitSessionCwdRespect:
 
         captured = {}
 
-        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None, secret_env=None):
             captured["cmd"] = cmd_string
             mock = MagicMock()
             mock.poll.return_value = 0

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -255,7 +255,7 @@ class TestWrapCommandWindowsNativeCwd:
 
         captured = {}
 
-        def fake_run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def fake_run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, secret_env=None):
             captured["script"] = cmd_string
             raise RuntimeError("stop after capturing bootstrap")
 

--- a/tests/tools/test_secure_input_tool.py
+++ b/tests/tools/test_secure_input_tool.py
@@ -1,0 +1,197 @@
+import json
+
+from agent import secure_input_broker as broker
+from tools.secure_input_tool import request_secure_input, set_secure_input_callback
+from tools.terminal_tool import terminal_tool
+
+
+def setup_function():
+    broker.clear_all()
+    set_secure_input_callback(None)
+
+
+def teardown_function():
+    broker.clear_all()
+    set_secure_input_callback(None)
+
+
+def test_request_secure_input_returns_only_reference():
+    set_secure_input_callback(lambda purpose, prompt, metadata=None: "ghp_exampleSecretValue123456")
+
+    result = json.loads(
+        request_secure_input(
+            purpose="github_token",
+            title="GitHub token",
+            allowed_consumers=["terminal"],
+        )
+    )
+
+    assert result["success"] is True
+    assert result["secret_ref"].startswith("secret://session/")
+    assert result["redacted"] is True
+    assert "ghp_exampleSecretValue123456" not in json.dumps(result)
+
+
+def test_terminal_can_consume_stdin_secret_ref_without_echoing_secret(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    info = broker.register_secret(
+        "plain-secret-no-prefix",
+        purpose="unit_test",
+        allowed_consumers=["terminal"],
+        single_use=True,
+    )
+
+    result = json.loads(
+        terminal_tool(
+            command="python -c 'import sys; data=sys.stdin.read(); print(len(data)); print(data)'",
+            workdir=str(tmp_path),
+            stdin_secret_ref=info["secret_ref"],
+            timeout=30,
+        )
+    )
+
+    assert result["exit_code"] == 0
+    assert "22" in result["output"]
+    assert "plain-secret-no-prefix" not in result["output"]
+    assert "[REDACTED SECURE INPUT]" in result["output"]
+
+
+def test_single_use_secret_ref_is_rejected_after_first_consume(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    info = broker.register_secret(
+        "reuse-secret-value",
+        purpose="unit_test",
+        allowed_consumers=["terminal"],
+        single_use=True,
+    )
+
+    first = json.loads(
+        terminal_tool(
+            command="python -c 'import sys; sys.stdin.read(); print(\"ok\")'",
+            workdir=str(tmp_path),
+            stdin_secret_ref=info["secret_ref"],
+            timeout=30,
+        )
+    )
+    second = json.loads(
+        terminal_tool(
+            command="python -c 'print(\"should not run\")'",
+            workdir=str(tmp_path),
+            stdin_secret_ref=info["secret_ref"],
+            timeout=30,
+        )
+    )
+
+    assert first["exit_code"] == 0
+    assert second["exit_code"] == -1
+    assert "already been consumed" in second["error"]
+
+
+def test_terminal_validation_does_not_consume_secret_ref(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    info = broker.register_secret(
+        "validation-secret-value",
+        purpose="unit_test",
+        allowed_consumers=["terminal"],
+        single_use=True,
+    )
+
+    rejected = json.loads(
+        terminal_tool(
+            command="python -m http.server 8000",
+            workdir=str(tmp_path),
+            stdin_secret_ref=info["secret_ref"],
+            timeout=30,
+        )
+    )
+    accepted = json.loads(
+        terminal_tool(
+            command="python -c 'import sys; print(sys.stdin.read())'",
+            workdir=str(tmp_path),
+            stdin_secret_ref=info["secret_ref"],
+            timeout=30,
+        )
+    )
+
+    assert rejected["exit_code"] == -1
+    assert "background=true" in rejected["error"]
+    assert accepted["exit_code"] == 0
+    assert "[REDACTED SECURE INPUT]" in accepted["output"]
+
+
+def test_terminal_blocks_heredoc_backends_without_consuming_ref(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "daytona")
+    info = broker.register_secret(
+        "heredoc-secret-value",
+        purpose="unit_test",
+        allowed_consumers=["terminal"],
+        single_use=True,
+    )
+
+    blocked = json.loads(
+        terminal_tool(
+            command="python -c 'print(\"nope\")'",
+            workdir=str(tmp_path),
+            stdin_secret_ref=info["secret_ref"],
+            timeout=30,
+        )
+    )
+
+    assert blocked["exit_code"] == -1
+    assert "embed stdin in command text" in blocked["error"]
+    assert broker.consume_secret(info["secret_ref"], consumer="terminal") == "heredoc-secret-value"
+
+
+def test_env_secret_ref_is_transient_and_redacted(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    info = broker.register_secret(
+        "env-secret-no-prefix",
+        purpose="unit_test",
+        allowed_consumers=["terminal"],
+        single_use=True,
+    )
+
+    first = json.loads(
+        terminal_tool(
+            command="python -c 'import os; print(os.environ[\"HERMES_TEST_SECRET\"])'",
+            workdir=str(tmp_path),
+            env_secret_refs={"HERMES_TEST_SECRET": info["secret_ref"]},
+            timeout=30,
+        )
+    )
+    second = json.loads(
+        terminal_tool(
+            command="python -c 'import os; print(os.getenv(\"HERMES_TEST_SECRET\", \"missing\"))'",
+            workdir=str(tmp_path),
+            timeout=30,
+        )
+    )
+
+    assert first["exit_code"] == 0
+    assert "env-secret-no-prefix" not in first["output"]
+    assert "[REDACTED SECURE INPUT]" in first["output"]
+    assert second["exit_code"] == 0
+    assert second["output"].strip() == "missing"
+
+
+def test_env_secret_ref_blocks_external_api_backends_without_consuming_ref(tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "daytona")
+    info = broker.register_secret(
+        "env-heredoc-secret-value",
+        purpose="unit_test",
+        allowed_consumers=["terminal"],
+        single_use=True,
+    )
+
+    blocked = json.loads(
+        terminal_tool(
+            command="python -c 'print(\"nope\")'",
+            workdir=str(tmp_path),
+            env_secret_refs={"HERMES_TEST_SECRET": info["secret_ref"]},
+            timeout=30,
+        )
+    )
+
+    assert blocked["exit_code"] == -1
+    assert "external APIs" in blocked["error"]
+    assert broker.consume_secret(info["secret_ref"], consumer="terminal") == "env-heredoc-secret-value"

--- a/tests/tools/test_secure_input_tool.py
+++ b/tests/tools/test_secure_input_tool.py
@@ -193,5 +193,122 @@ def test_env_secret_ref_blocks_external_api_backends_without_consuming_ref(tmp_p
     )
 
     assert blocked["exit_code"] == -1
-    assert "external APIs" in blocked["error"]
+    assert "no out-of-band env channel" in blocked["error"]
     assert broker.consume_secret(info["secret_ref"], consumer="terminal") == "env-heredoc-secret-value"
+
+
+def test_workdir_rejection_does_not_consume_ref(tmp_path, monkeypatch):
+    # Regression for the deferred-consumption fix: a command rejected by
+    # workdir validation must leave a single-use ref usable, because
+    # consumption is deferred until after workdir validation succeeds.
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    info = broker.register_secret(
+        "workdir-secret-value",
+        purpose="unit_test",
+        allowed_consumers=["terminal"],
+        single_use=True,
+    )
+
+    rejected = json.loads(
+        terminal_tool(
+            command="echo hi",
+            workdir="/tmp; rm -rf /",  # disallowed characters -> blocked
+            stdin_secret_ref=info["secret_ref"],
+            timeout=30,
+        )
+    )
+
+    assert rejected["exit_code"] == -1
+    assert rejected["status"] == "blocked"
+    # Ref survives the rejection and is still consumable exactly once.
+    assert broker.consume_secret(info["secret_ref"], consumer="terminal") == "workdir-secret-value"
+
+
+def test_env_secret_ref_background_blocked_on_non_local_without_consuming(tmp_path, monkeypatch):
+    # env_secret_refs in background is only supported on the local backend.
+    # Docker background goes through spawn_via_env (no secure env channel), so
+    # it must be blocked and must not consume the ref.
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    info = broker.register_secret(
+        "bg-env-secret-value",
+        purpose="unit_test",
+        allowed_consumers=["terminal"],
+        single_use=True,
+    )
+
+    blocked = json.loads(
+        terminal_tool(
+            command="sleep 1",
+            workdir=str(tmp_path),
+            env_secret_refs={"HERMES_TEST_SECRET": info["secret_ref"]},
+            background=True,
+            timeout=30,
+        )
+    )
+
+    assert blocked["exit_code"] == -1
+    assert blocked["status"] == "blocked"
+    assert "background" in blocked["error"]
+    assert broker.consume_secret(info["secret_ref"], consumer="terminal") == "bg-env-secret-value"
+
+
+def test_docker_run_bash_injects_secret_env_out_of_band(monkeypatch):
+    # Regression for finding #1: Docker must forward secret env vars via
+    # `docker exec -e KEY` (name only) with the value supplied through the
+    # docker CLI process environment — never on argv, never in the snapshot.
+    from tools.environments import docker as docker_mod
+
+    captured = {}
+
+    def _fake_popen_bash(cmd, stdin_data=None, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(docker_mod, "_popen_bash", _fake_popen_bash)
+
+    env = object.__new__(docker_mod.DockerEnvironment)
+    env._docker_exe = "docker"
+    env._container_id = "deadbeef"
+    env._init_env_args = []
+
+    env._run_bash("echo hi", login=False, secret_env={"GH_TOKEN": "supersecret"})
+
+    cmd = captured["cmd"]
+    # Name-only -e flag present...
+    assert "-e" in cmd
+    assert "GH_TOKEN" in cmd
+    # ...but the value must never appear on argv (host `ps` exposure).
+    assert "supersecret" not in cmd
+    assert "GH_TOKEN=supersecret" not in cmd
+    # Value is delivered via the docker CLI process environment instead.
+    assert captured["kwargs"]["env"]["GH_TOKEN"] == "supersecret"
+
+
+def test_docker_advertises_secret_env_capability_and_ssh_does_not():
+    from tools.environments.docker import DockerEnvironment
+    from tools.environments.local import LocalEnvironment
+    from tools.environments.singularity import SingularityEnvironment
+    from tools.environments.ssh import SSHEnvironment
+
+    assert DockerEnvironment.supports_secret_env is True
+    assert LocalEnvironment.supports_secret_env is True
+    assert SingularityEnvironment.supports_secret_env is True
+    # SSH has no reliable out-of-band env channel; it must not advertise support.
+    assert getattr(SSHEnvironment, "supports_secret_env", False) is False
+
+
+def test_check_secure_input_requirements_reflects_callback():
+    # Finding #3: the tool must only be advertised where a masked-capture
+    # callback exists. With no callback registered the requirement is False so
+    # the registry filters the tool from non-interactive surfaces.
+    from tools import secure_input_tool
+
+    set_secure_input_callback(None)
+    assert secure_input_tool.check_secure_input_requirements() is False
+
+    set_secure_input_callback(lambda purpose, prompt, metadata=None: "x")
+    try:
+        assert secure_input_tool.check_secure_input_requirements() is True
+    finally:
+        set_secure_input_callback(None)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -460,7 +460,7 @@ class BaseEnvironment(ABC):
             return f"$HOME/{shlex.quote(cwd[2:])}"
         return shlex.quote(cwd)
 
-    def _wrap_command(self, command: str, cwd: str) -> str:
+    def _wrap_command(self, command: str, cwd: str, transient_env_keys: list[str] | None = None) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
         escaped = command.replace("'", "'\\''")
@@ -502,6 +502,10 @@ class BaseEnvironment(ABC):
         # Run the actual command
         parts.append(f"eval '{escaped}'")
         parts.append("__hermes_ec=$?")
+
+        if transient_env_keys:
+            quoted_keys = " ".join(shlex.quote(k) for k in transient_env_keys)
+            parts.append(f"unset -- {quoted_keys} 2>/dev/null || true")
 
         # Re-dump env vars to snapshot (atomic replacement to avoid races).
         # Chain mv on the export succeeding so a failed/partial dump never
@@ -893,6 +897,7 @@ class BaseEnvironment(ABC):
         *,
         timeout: int | None = None,
         stdin_data: str | None = None,
+        transient_env: dict[str, str] | None = None,
         rewrite_compound_background: bool = True,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}."""
@@ -921,16 +926,31 @@ class BaseEnvironment(ABC):
             exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
             effective_stdin = None
 
-        wrapped = self._wrap_command(exec_command, effective_cwd)
+        previous_env = None
+        transient_env_keys = None
+        if transient_env:
+            transient_env_keys = list(transient_env)
+            previous_env = {key: self.env.get(key) for key in transient_env}
+            self.env.update(transient_env)
+
+        wrapped = self._wrap_command(exec_command, effective_cwd, transient_env_keys=transient_env_keys)
 
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-        )
-        result = self._wait_for_process(proc, timeout=effective_timeout)
-        self._update_cwd(result)
+        try:
+            proc = self._run_bash(
+                wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            )
+            result = self._wait_for_process(proc, timeout=effective_timeout)
+            self._update_cwd(result)
+        finally:
+            if previous_env is not None:
+                for key, old_value in previous_env.items():
+                    if old_value is None:
+                        self.env.pop(key, None)
+                    else:
+                        self.env[key] = old_value
 
         return result
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -298,8 +298,21 @@ class BaseEnvironment(ABC):
     # Subclasses that embed stdin as a heredoc (Modal, Daytona) set this.
     _stdin_mode: str = "pipe"  # "pipe" or "heredoc"
 
+    # Backends that can inject secret env vars out-of-band at exec time
+    # (never on argv / in the snapshot) set this True in ``_run_bash``.
+    # Consumed by the terminal tool to gate ``env_secret_refs`` so a secret
+    # ref is never consumed for a backend that cannot deliver it.
+    supports_secret_env: bool = False
+
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
+
+    @property
+    def supports_secret_stdin(self) -> bool:
+        """True when stdin is delivered via a real pipe rather than embedded
+        in command text (heredoc/payload). Secret stdin is only safe on pipe
+        backends, since embedding would place the secret in the command."""
+        return self._stdin_mode == "pipe"
 
     def get_temp_dir(self) -> str:
         """Return the backend temp directory used for session artifacts.
@@ -333,11 +346,18 @@ class BaseEnvironment(ABC):
         login: bool = False,
         timeout: int = 120,
         stdin_data: str | None = None,
+        secret_env: dict[str, str] | None = None,
     ) -> ProcessHandle:
         """Spawn a bash process to run *cmd_string*.
 
         Returns a ProcessHandle (subprocess.Popen or _ThreadedProcessHandle).
         Must be overridden by every backend.
+
+        *secret_env*, when provided, holds ephemeral secret env vars that must
+        be injected into the command's environment out-of-band (never on the
+        command line / argv, never persisted to the session snapshot). Only
+        backends advertising :attr:`supports_secret_env` receive a non-empty
+        value; others may ignore it.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement _run_bash()")
 
@@ -926,31 +946,28 @@ class BaseEnvironment(ABC):
             exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
             effective_stdin = None
 
-        previous_env = None
-        transient_env_keys = None
-        if transient_env:
-            transient_env_keys = list(transient_env)
-            previous_env = {key: self.env.get(key) for key in transient_env}
-            self.env.update(transient_env)
+        # ``transient_env`` (e.g. secure-input secrets) is injected out-of-band
+        # by each backend's ``_run_bash`` at the process boundary — NOT written
+        # into ``self.env``. Writing to ``self.env`` only reaches the subprocess
+        # for the local backend (Popen ``env=``); Docker/Singularity/SSH read
+        # their environment from the session snapshot, so a ``self.env`` update
+        # would never reach the command while still consuming the secret ref.
+        # We still pass ``transient_env_keys`` to ``_wrap_command`` so the keys
+        # are ``unset`` before the snapshot is re-dumped and the value is never
+        # persisted to disk (see :meth:`_wrap_command`).
+        transient_env_keys = list(transient_env) if transient_env else None
 
         wrapped = self._wrap_command(exec_command, effective_cwd, transient_env_keys=transient_env_keys)
 
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
 
-        try:
-            proc = self._run_bash(
-                wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-            )
-            result = self._wait_for_process(proc, timeout=effective_timeout)
-            self._update_cwd(result)
-        finally:
-            if previous_env is not None:
-                for key, old_value in previous_env.items():
-                    if old_value is None:
-                        self.env.pop(key, None)
-                    else:
-                        self.env[key] = old_value
+        proc = self._run_bash(
+            wrapped, login=login, timeout=effective_timeout,
+            stdin_data=effective_stdin, secret_env=transient_env,
+        )
+        result = self._wait_for_process(proc, timeout=effective_timeout)
+        self._update_cwd(result)
 
         return result
 

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -218,8 +218,14 @@ class DaytonaEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
-        """Return a _ThreadedProcessHandle wrapping a blocking Daytona SDK call."""
+                  stdin_data: str | None = None,
+                  secret_env: dict[str, str] | None = None):
+        """Return a _ThreadedProcessHandle wrapping a blocking Daytona SDK call.
+
+        ``secret_env`` is ignored: this backend serializes execution through an
+        external API, so the terminal tool gates ``env_secret_refs`` off
+        (``supports_secret_env`` is False) and never passes a value here.
+        """
         sandbox = self._sandbox
         lock = self._lock
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1015,9 +1015,15 @@ class DockerEnvironment(BaseEnvironment):
             args.extend(["-e", f"{key}={exec_env[key]}"])
         return args
 
+    # Secret env vars are forwarded via ``docker exec -e KEY`` (name only) with
+    # the value supplied through the docker CLI's own process environment, so
+    # the value never appears on argv (host ``ps``) or in the container snapshot.
+    supports_secret_env = True
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  secret_env: dict[str, str] | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
         assert self._container_id, "Container not started"
         cmd = [self._docker_exe, "exec"]
@@ -1029,6 +1035,18 @@ class DockerEnvironment(BaseEnvironment):
         if login:
             cmd.extend(self._init_env_args)
 
+        # Inject ephemeral secret env vars for this exec only. Use the
+        # name-only form (``-e KEY``) so the value is read from this docker
+        # CLI process's environment rather than placed on argv (which would
+        # be visible in host ``ps``). The value is unset inside the container
+        # before the snapshot is re-dumped (see BaseEnvironment._wrap_command),
+        # so it is never persisted.
+        popen_env = None
+        if secret_env:
+            for key in secret_env:
+                cmd.extend(["-e", key])
+            popen_env = {**os.environ, **secret_env}
+
         cmd.extend([self._container_id])
 
         if login:
@@ -1036,6 +1054,8 @@ class DockerEnvironment(BaseEnvironment):
         else:
             cmd.extend(["bash", "-c", cmd_string])
 
+        if popen_env is not None:
+            return _popen_bash(cmd, stdin_data, env=popen_env)
         return _popen_bash(cmd, stdin_data)
 
     # ------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -948,9 +948,14 @@ class LocalEnvironment(BaseEnvironment):
         """Use native paths for Python, but Git Bash-friendly paths for cd."""
         return BaseEnvironment._quote_cwd_for_cd(_windows_to_msys_path(cwd))
 
+    # Secret env vars are merged into the Popen ``env=`` mapping below — never
+    # placed on argv and never written to the session snapshot.
+    supports_secret_env = True
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  secret_env: dict[str, str] | None = None) -> subprocess.Popen:
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
@@ -964,6 +969,11 @@ class LocalEnvironment(BaseEnvironment):
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
+        # Inject ephemeral secret env vars into the child environment only.
+        # These are not part of ``self.env`` (so they never reach the snapshot)
+        # and never appear on the command line.
+        if secret_env:
+            run_env.update(secret_env)
 
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -407,8 +407,14 @@ class ModalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
-        """Return a _ThreadedProcessHandle wrapping an async Modal sandbox exec."""
+                  stdin_data: str | None = None,
+                  secret_env: dict[str, str] | None = None):
+        """Return a _ThreadedProcessHandle wrapping an async Modal sandbox exec.
+
+        ``secret_env`` is ignored: this backend serializes execution through an
+        external API, so the terminal tool gates ``env_secret_refs`` off
+        (``supports_secret_env`` is False) and never passes a value here.
+        """
         sandbox = self._sandbox
         worker = self._worker
 

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -229,9 +229,16 @@ class SingularityEnvironment(BaseEnvironment):
         except subprocess.TimeoutExpired:
             raise RuntimeError("Instance start timed out")
 
+    # Secret env vars are forwarded via the ``SINGULARITYENV_``/``APPTAINERENV_``
+    # convention: the launcher reads these from its own environment and strips
+    # the prefix inside the container, so the value never appears on argv or in
+    # the container snapshot.
+    supports_secret_env = True
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  secret_env: dict[str, str] | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Singularity instance."""
         if not self._instance_started:
             raise RuntimeError("Singularity instance not started")
@@ -242,6 +249,17 @@ class SingularityEnvironment(BaseEnvironment):
             cmd.extend(["bash", "-l", "-c", cmd_string])
         else:
             cmd.extend(["bash", "-c", cmd_string])
+
+        # Inject ephemeral secret env vars via the launcher's environment using
+        # both the Singularity and Apptainer prefixes for compatibility. The
+        # value is unset inside the container before the snapshot is re-dumped
+        # (see BaseEnvironment._wrap_command), so it is never persisted.
+        if secret_env:
+            popen_env = dict(os.environ)
+            for key, value in secret_env.items():
+                popen_env[f"SINGULARITYENV_{key}"] = value
+                popen_env[f"APPTAINERENV_{key}"] = value
+            return _popen_bash(cmd, stdin_data, env=popen_env)
 
         return _popen_bash(cmd, stdin_data)
 

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -342,8 +342,16 @@ class SSHEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
-        """Spawn an SSH process that runs bash on the remote host."""
+                  stdin_data: str | None = None,
+                  secret_env: dict[str, str] | None = None) -> subprocess.Popen:
+        """Spawn an SSH process that runs bash on the remote host.
+
+        ``secret_env`` is intentionally ignored: there is no reliable
+        out-of-band env channel over multiplexed SSH (SetEnv depends on remote
+        ``AcceptEnv`` and would expose the value on the local argv), so the
+        terminal tool gates ``env_secret_refs`` off for SSH via
+        :attr:`supports_secret_env` (False) and never passes a value here.
+        """
         cmd = self._build_ssh_command()
         if login:
             cmd.extend(["bash", "-l", "-c", shlex.quote(cmd_string)])

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2159,12 +2159,18 @@ def _redact_process_result(result: dict) -> dict:
     if not isinstance(result, dict):
         return result
     from agent.redact import redact_sensitive_text, redact_terminal_output
+    try:
+        from agent.secure_input_broker import redact_known_secrets
+    except Exception:
+        redact_known_secrets = None
 
     command = result.get("command") or ""
     for field in ("output", "output_preview"):
         value = result.get(field)
         if isinstance(value, str) and value:
             result[field] = redact_terminal_output(value, command)
+            if redact_known_secrets is not None:
+                result[field] = redact_known_secrets(result[field])
     if isinstance(result.get("command"), str) and result["command"]:
         result["command"] = redact_sensitive_text(result["command"], code_file=True)
     return result

--- a/tools/secure_input_tool.py
+++ b/tools/secure_input_tool.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Secure input tool.
+
+Allows an agent to request a secret through an interactive UI without receiving
+or storing the raw value in the model transcript. The tool returns an opaque
+``secret_ref`` that scoped runtime tools can consume.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable
+
+from agent.secure_input_broker import SecretBrokerError, register_secret
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_secure_input_callback: Callable[..., str] | None = None
+
+
+def set_secure_input_callback(callback) -> None:
+    """Register a UI callback that returns the raw secret to runtime code only."""
+    global _secure_input_callback
+    _secure_input_callback = callback
+
+
+def check_secure_input_requirements() -> bool:
+    return True
+
+
+def _normalize_allowed_consumers(value: Any) -> list[str]:
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return ["terminal"]
+    consumers = [str(item).strip() for item in value if str(item).strip()]
+    return consumers or ["terminal"]
+
+
+def request_secure_input(
+    *,
+    purpose: str,
+    title: str = "Secure input required",
+    description: str = "Paste the secret. It will not be sent to the model.",
+    secret_type: str = "token",
+    ttl_seconds: int = 600,
+    single_use: bool = True,
+    allowed_consumers: list[str] | None = None,
+    task_id: str | None = None,
+) -> str:
+    """Prompt the user for a secret and return a redacted broker reference."""
+    if _secure_input_callback is None:
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    "No secure input UI is available in this session. Ask the user "
+                    "to provide the secret through a local secret file or run the "
+                    "auth command directly."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    purpose = str(purpose or "secure_input").strip() or "secure_input"
+    title = str(title or "Secure input required").strip()
+    description = str(description or "").strip()
+    consumers = _normalize_allowed_consumers(allowed_consumers)
+    metadata = {
+        "purpose": purpose,
+        "title": title,
+        "description": description,
+        "secret_type": str(secret_type or "secret"),
+        "ttl_seconds": ttl_seconds,
+        "single_use": bool(single_use),
+        "allowed_consumers": consumers,
+        "secure_input": True,
+    }
+
+    try:
+        value = _secure_input_callback(purpose, title, metadata)
+        info = register_secret(
+            value,
+            purpose=purpose,
+            allowed_consumers=consumers,
+            ttl_seconds=ttl_seconds,
+            single_use=single_use,
+            label=title,
+        )
+        return json.dumps(
+            {
+                "success": True,
+                **info,
+                "message": (
+                    "Secret captured securely. The raw value was not exposed to "
+                    "the model; pass secret_ref to a compatible tool."
+                ),
+            },
+            ensure_ascii=False,
+        )
+    except SecretBrokerError as exc:
+        return json.dumps({"success": False, "error": str(exc)}, ensure_ascii=False)
+    except Exception as exc:
+        logger.debug("secure input capture failed", exc_info=True)
+        return json.dumps({"success": False, "error": str(exc)}, ensure_ascii=False)
+
+
+REQUEST_SECURE_INPUT_SCHEMA = {
+    "name": "request_secure_input",
+    "description": (
+        "Ask the active Hermes UI to collect a password/token/API key in a secure "
+        "masked prompt. The raw secret bypasses the LLM and is stored only in an "
+        "ephemeral in-memory broker; this tool returns an opaque secret_ref for "
+        "compatible tools such as terminal. Use this instead of asking the user to "
+        "paste secrets into chat."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "purpose": {
+                "type": "string",
+                "description": "Short machine-readable purpose, e.g. github_token or npm_token.",
+            },
+            "title": {
+                "type": "string",
+                "description": "Human-facing prompt title shown by the UI.",
+            },
+            "description": {
+                "type": "string",
+                "description": "Human-facing explanation of how the secret will be used.",
+            },
+            "secret_type": {
+                "type": "string",
+                "description": "Kind of secret: token, password, api_key, oauth_code, etc.",
+                "default": "token",
+            },
+            "ttl_seconds": {
+                "type": "integer",
+                "description": "How long the secret_ref remains usable. Capped at 3600 seconds.",
+                "minimum": 1,
+                "default": 600,
+            },
+            "single_use": {
+                "type": "boolean",
+                "description": "When true, the secret_ref can be consumed only once.",
+                "default": True,
+            },
+            "allowed_consumers": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Tool consumers allowed to use the ref. Defaults to ['terminal'].",
+            },
+        },
+        "required": ["purpose"],
+    },
+}
+
+
+def _handle_request_secure_input(args, **kw):
+    return request_secure_input(
+        purpose=args.get("purpose", "secure_input"),
+        title=args.get("title", "Secure input required"),
+        description=args.get("description", "Paste the secret. It will not be sent to the model."),
+        secret_type=args.get("secret_type", "token"),
+        ttl_seconds=args.get("ttl_seconds", 600),
+        single_use=args.get("single_use", True),
+        allowed_consumers=args.get("allowed_consumers"),
+        task_id=kw.get("task_id"),
+    )
+
+
+registry.register(
+    name="request_secure_input",
+    toolset="secure_input",
+    schema=REQUEST_SECURE_INPUT_SCHEMA,
+    handler=_handle_request_secure_input,
+    check_fn=check_secure_input_requirements,
+    emoji="🔐",
+)

--- a/tools/secure_input_tool.py
+++ b/tools/secure_input_tool.py
@@ -26,7 +26,17 @@ def set_secure_input_callback(callback) -> None:
 
 
 def check_secure_input_requirements() -> bool:
-    return True
+    """Gate ``request_secure_input`` to surfaces that can actually capture a
+    masked secret. Only interactive surfaces (CLI/TUI/gateway) register a
+    callback via :func:`set_secure_input_callback`; non-interactive surfaces
+    (API server, headless) leave it unset, so the tool is filtered from the
+    toolset instead of being advertised and then failing at runtime.
+
+    The registry TTL-caches this, and interactive surfaces register their
+    callback at session start (before tool listing), so the gate settles
+    correctly for the session.
+    """
+    return _secure_input_callback is not None
 
 
 def _normalize_allowed_consumers(value: Any) -> list[str]:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1999,6 +1999,8 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    stdin_secret_ref: Optional[str] = None,
+    env_secret_refs: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2014,6 +2016,8 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        stdin_secret_ref: Optional secure-input broker reference to pipe to stdin.
+        env_secret_refs: Optional environment variable to secure-input broker ref mapping.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2118,6 +2122,69 @@ def terminal_tool(
                     "exit_code": -1,
                     "error": guidance,
                     "status": "error",
+                }, ensure_ascii=False)
+
+        stdin_secret_value = None
+        secret_env_values: Dict[str, str] = {}
+        if stdin_secret_ref:
+            if background:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": "stdin_secret_ref is only supported for foreground terminal commands.",
+                    "status": "blocked",
+                }, ensure_ascii=False)
+            if env_type in {"modal", "daytona"}:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": (
+                        "stdin_secret_ref is not supported for terminal backends "
+                        "that embed stdin in command text. Use a local, Docker, "
+                        "Singularity, or SSH terminal backend."
+                    ),
+                    "status": "blocked",
+                }, ensure_ascii=False)
+            try:
+                from agent.secure_input_broker import consume_secret
+
+                stdin_secret_value = consume_secret(stdin_secret_ref, consumer="terminal")
+            except Exception as exc:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": f"Invalid stdin_secret_ref: {exc}",
+                    "status": "blocked",
+                }, ensure_ascii=False)
+
+        if env_secret_refs:
+            if env_type in {"modal", "daytona"}:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": (
+                        "env_secret_refs are not supported for terminal backends "
+                        "that may serialize command execution through external APIs. "
+                        "Use a local, Docker, Singularity, or SSH terminal backend."
+                    ),
+                    "status": "blocked",
+                }, ensure_ascii=False)
+            try:
+                from agent.secure_input_broker import consume_secret
+
+                for key, ref in env_secret_refs.items():
+                    key = str(key or "").strip()
+                    if not key:
+                        continue
+                    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+                        raise ValueError(f"invalid env var name {key!r}")
+                    secret_env_values[key] = consume_secret(str(ref), consumer="terminal")
+            except Exception as exc:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": f"Invalid env_secret_refs: {exc}",
+                    "status": "blocked",
                 }, ensure_ascii=False)
 
         # Start cleanup thread
@@ -2344,12 +2411,16 @@ def terminal_tool(
             )
             try:
                 if env_type == "local":
+                    spawn_env = env.env if hasattr(env, 'env') else None
+                    if secret_env_values:
+                        spawn_env = dict(spawn_env or {})
+                        spawn_env.update(secret_env_values)
                     proc_session = process_registry.spawn_local(
                         command=command,
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
-                        env_vars=env.env if hasattr(env, 'env') else None,
+                        env_vars=spawn_env,
                         use_pty=effective_pty,
                     )
                 else:
@@ -2593,6 +2664,10 @@ def terminal_tool(
                         "timeout": effective_timeout,
                         "cwd": command_cwd,
                     }
+                    if stdin_secret_value is not None:
+                        execute_kwargs["stdin_data"] = stdin_secret_value
+                    if secret_env_values:
+                        execute_kwargs["transient_env"] = secret_env_values
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()
@@ -2693,6 +2768,13 @@ def terminal_tool(
             # both modes. See issue #43025.
             from agent.redact import redact_terminal_output
             output = redact_terminal_output(output.strip(), command) if output else ""
+            if output:
+                try:
+                    from agent.secure_input_broker import redact_known_secrets
+
+                    output = redact_known_secrets(output)
+                except Exception:
+                    pass
 
             # Interpret non-zero exit codes that aren't real errors
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")
@@ -2946,6 +3028,15 @@ TERMINAL_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Strings to watch for in background process output. HARD RATE LIMIT: at most 1 notification per 15 seconds per process — matches arriving inside the cooldown are dropped. After 3 consecutive 15-second windows with dropped matches, watch_patterns is automatically disabled for that process and promoted to notify_on_complete behavior (one notification on exit, no more mid-process spam). USE ONLY for truly rare, one-shot mid-process signals on LONG-LIVED processes that will never exit on their own — e.g. ['Application startup complete'] on a server so you know when to hit its endpoint, or ['migration done'] on a daemon. DO NOT use for: (1) end-of-run markers like 'DONE'/'PASS' — use notify_on_complete instead; (2) error patterns like 'ERROR'/'Traceback' in loops or multi-item batch jobs — they fire on every iteration and you'll hit the strike limit fast; (3) anything you'd ever combine with notify_on_complete. When in doubt, choose notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both."
+            },
+            "stdin_secret_ref": {
+                "type": "string",
+                "description": "Opaque secret_ref returned by request_secure_input. The secret is piped to the foreground command's stdin without exposing it to the model or command string. Not supported with background=true."
+            },
+            "env_secret_refs": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "description": "Map environment variable names to secret_ref values returned by request_secure_input. Values are injected into the process environment by the runtime and redacted from output."
             }
         },
         "required": ["command"]
@@ -2964,6 +3055,8 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        stdin_secret_ref=args.get("stdin_secret_ref"),
+        env_secret_refs=args.get("env_secret_refs"),
     )
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -954,6 +954,41 @@ from tools.managed_tool_gateway import is_managed_tool_gateway_ready
 import sys
 
 
+def _backend_class_for(env_type: str):
+    """Return the environment class for *env_type* without instantiating it, so
+    secure-input capability can be gated before the (possibly expensive)
+    backend is created. Returns None for unknown types."""
+    cls_map = {
+        "local": _LocalEnvironment,
+        "docker": _DockerEnvironment,
+        "singularity": _SingularityEnvironment,
+        "ssh": _SSHEnvironment,
+        "modal": _ModalEnvironment,
+    }
+    cls = cls_map.get(env_type)
+    if cls is None and env_type == "daytona":
+        try:
+            from tools.environments.daytona import DaytonaEnvironment as cls
+        except Exception:
+            cls = None
+    return cls
+
+
+def _backend_supports_secret_env(env_type: str) -> bool:
+    """True when the backend can inject secret env vars out-of-band (read from
+    the class-level ``supports_secret_env`` attribute)."""
+    cls = _backend_class_for(env_type)
+    return bool(getattr(cls, "supports_secret_env", False)) if cls else False
+
+
+def _backend_supports_secret_stdin(env_type: str) -> bool:
+    """True when the backend streams stdin via a real pipe (``_stdin_mode`` ==
+    "pipe") rather than embedding it in command text. Read at class level so it
+    works without an instance (mirrors BaseEnvironment.supports_secret_stdin)."""
+    cls = _backend_class_for(env_type)
+    return getattr(cls, "_stdin_mode", "pipe") == "pipe" if cls else False
+
+
 # Tool description for LLM
 TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
 
@@ -2124,6 +2159,13 @@ def terminal_tool(
                     "status": "error",
                 }, ensure_ascii=False)
 
+        # Secure-input refs: validate structure and gate backend capability
+        # here (cheaply, before the backend is created), but do NOT consume the
+        # ref yet. Consumption is deferred until after approval + workdir
+        # validation (see the consumption block below) so that a denied,
+        # rejected, or capability-blocked command never burns a single-use ref —
+        # the broker marks a ref consumed on the first successful read and there
+        # is no un-consume.
         stdin_secret_value = None
         secret_env_values: Dict[str, str] = {}
         if stdin_secret_ref:
@@ -2134,7 +2176,7 @@ def terminal_tool(
                     "error": "stdin_secret_ref is only supported for foreground terminal commands.",
                     "status": "blocked",
                 }, ensure_ascii=False)
-            if env_type in {"modal", "daytona"}:
+            if not _backend_supports_secret_stdin(env_type):
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,
@@ -2145,45 +2187,41 @@ def terminal_tool(
                     ),
                     "status": "blocked",
                 }, ensure_ascii=False)
-            try:
-                from agent.secure_input_broker import consume_secret
-
-                stdin_secret_value = consume_secret(stdin_secret_ref, consumer="terminal")
-            except Exception as exc:
-                return json.dumps({
-                    "output": "",
-                    "exit_code": -1,
-                    "error": f"Invalid stdin_secret_ref: {exc}",
-                    "status": "blocked",
-                }, ensure_ascii=False)
-
         if env_secret_refs:
-            if env_type in {"modal", "daytona"}:
+            for _raw_key in env_secret_refs:
+                _key = str(_raw_key or "").strip()
+                if _key and not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", _key):
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": -1,
+                        "error": f"Invalid env_secret_refs: invalid env var name {_key!r}",
+                        "status": "blocked",
+                    }, ensure_ascii=False)
+            # Env injection needs an out-of-band channel. Foreground: the
+            # backend must advertise supports_secret_env. Background: only the
+            # local backend has a secure channel (spawn_local env_vars);
+            # non-local background runs through spawn_via_env, which has none.
+            if background:
+                if env_type != "local":
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": -1,
+                        "error": (
+                            "env_secret_refs are only supported for background "
+                            "commands on the local terminal backend. Run the "
+                            "command in the foreground, or use a local backend."
+                        ),
+                        "status": "blocked",
+                    }, ensure_ascii=False)
+            elif not _backend_supports_secret_env(env_type):
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,
                     "error": (
-                        "env_secret_refs are not supported for terminal backends "
-                        "that may serialize command execution through external APIs. "
-                        "Use a local, Docker, Singularity, or SSH terminal backend."
+                        "env_secret_refs are not supported for this terminal "
+                        "backend (no out-of-band env channel). Use a local, "
+                        "Docker, or Singularity terminal backend."
                     ),
-                    "status": "blocked",
-                }, ensure_ascii=False)
-            try:
-                from agent.secure_input_broker import consume_secret
-
-                for key, ref in env_secret_refs.items():
-                    key = str(key or "").strip()
-                    if not key:
-                        continue
-                    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
-                        raise ValueError(f"invalid env var name {key!r}")
-                    secret_env_values[key] = consume_secret(str(ref), consumer="terminal")
-            except Exception as exc:
-                return json.dumps({
-                    "output": "",
-                    "exit_code": -1,
-                    "error": f"Invalid env_secret_refs: {exc}",
                     "status": "blocked",
                 }, ensure_ascii=False)
 
@@ -2369,6 +2407,41 @@ def terminal_tool(
                     "exit_code": -1,
                     "error": workdir_error,
                     "status": "blocked"
+                }, ensure_ascii=False)
+
+        # ------------------------------------------------------------------
+        # Consume secure-input secret refs — deferred to AFTER approval and
+        # workdir validation (and the early capability gate above) so a denied,
+        # rejected, or capability-blocked command never burns a single-use ref.
+        # This is the last gate before execution; nothing below returns without
+        # running the command.
+        # ------------------------------------------------------------------
+        if stdin_secret_ref:
+            try:
+                from agent.secure_input_broker import consume_secret
+                stdin_secret_value = consume_secret(stdin_secret_ref, consumer="terminal")
+            except Exception as exc:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": f"Invalid stdin_secret_ref: {exc}",
+                    "status": "blocked",
+                }, ensure_ascii=False)
+
+        if env_secret_refs:
+            try:
+                from agent.secure_input_broker import consume_secret
+                for key, ref in env_secret_refs.items():
+                    key = str(key or "").strip()
+                    if not key:
+                        continue
+                    secret_env_values[key] = consume_secret(str(ref), consumer="terminal")
+            except Exception as exc:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": f"Invalid env_secret_refs: {exc}",
+                    "status": "blocked",
                 }, ensure_ascii=False)
 
         # Prepare command for execution

--- a/toolsets.py
+++ b/toolsets.py
@@ -32,7 +32,7 @@ _HERMES_CORE_TOOLS = [
     # Web
     "web_search", "web_extract",
     # Terminal + process management
-    "terminal", "process",
+    "terminal", "process", "request_secure_input",
     # Read the desktop GUI's embedded terminal pane, and close an agent's
     # read-only terminal tab (both gated on HERMES_DESKTOP via check_fn —
     # hidden outside the GUI).
@@ -159,7 +159,13 @@ TOOLSETS = {
 
     "terminal": {
         "description": "Terminal/command execution and process management tools",
-        "tools": ["terminal", "process"],
+        "tools": ["terminal", "process", "request_secure_input"],
+        "includes": []
+    },
+
+    "secure_input": {
+        "description": "Secure masked input for secrets; returns opaque refs instead of raw values",
+        "tools": ["request_secure_input"],
         "includes": []
     },
     
@@ -347,7 +353,7 @@ TOOLSETS = {
         "description": "Coding-focused toolset: files, terminal, search, web docs, skills, todo, delegate, vision, browser",
         "tools": [
             "web_search", "web_extract",
-            "terminal", "process", "read_terminal", "close_terminal",
+            "terminal", "process", "request_secure_input", "read_terminal", "close_terminal",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
@@ -379,7 +385,7 @@ TOOLSETS = {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
         "tools": [
             "web_search", "web_extract",
-            "terminal", "process",
+            "terminal", "process", "request_secure_input",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
@@ -400,7 +406,7 @@ TOOLSETS = {
             # Web
             "web_search", "web_extract",
             # Terminal + process management
-            "terminal", "process",
+            "terminal", "process", "request_secure_input",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
             # Vision + image generation

--- a/toolsets.py
+++ b/toolsets.py
@@ -406,7 +406,11 @@ TOOLSETS = {
             # Web
             "web_search", "web_extract",
             # Terminal + process management
-            "terminal", "process", "request_secure_input",
+            # NOTE: request_secure_input is intentionally omitted — the HTTP API
+            # server has no interactive UI to capture a masked secret, so the
+            # tool's check_fn would filter it out anyway. Keeping it out of the
+            # list avoids advertising a capability this surface never provides.
+            "terminal", "process",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
             # Vision + image generation

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3709,6 +3709,7 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
 def _wire_callbacks(sid: str):
     from tools.terminal_tool import set_sudo_password_callback
     from tools.skills_tool import set_secret_capture_callback
+    from tools.secure_input_tool import set_secure_input_callback
     from tools.project_tools import set_project_workspace_callback
 
     set_sudo_password_callback(lambda: _block("sudo.request", sid, {}, timeout=120))
@@ -3736,6 +3737,12 @@ def _wire_callbacks(sid: str):
         }
 
     set_secret_capture_callback(secret_cb)
+
+    def secure_input_cb(purpose, prompt, metadata=None):
+        pl = {"prompt": prompt, "env_var": purpose, "metadata": {**(metadata or {}), "secure_input": True}}
+        return _block("secret.request", sid, pl, timeout=120) or ""
+
+    set_secure_input_callback(secure_input_cb)
 
 
 def _render_personality_prompt(value) -> str:

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -793,7 +793,12 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
       case 'secret.request':
         patchOverlayState({
-          secret: { envVar: ev.payload.env_var, prompt: ev.payload.prompt, requestId: ev.payload.request_id }
+          secret: {
+            envVar: ev.payload.env_var,
+            metadata: ev.payload.metadata,
+            prompt: ev.payload.prompt,
+            requestId: ev.payload.request_id
+          }
         })
         setStatus('secret input needed')
 

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -92,6 +92,7 @@ export function PromptZone({
   }
 
   if (overlay.secret) {
+    const isSecureInput = Boolean(overlay.secret.metadata?.secure_input)
     return (
       <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
         <MaskedPrompt
@@ -99,7 +100,7 @@ export function PromptZone({
           icon="🔑"
           label={overlay.secret.prompt}
           onSubmit={onSecretSubmit}
-          sub={`for ${overlay.secret.envVar}`}
+          sub={isSecureInput ? 'secure input - not sent to the model' : `for ${overlay.secret.envVar}`}
           t={theme}
         />
       </Box>

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -696,7 +696,11 @@ export type GatewayEvent =
       type: 'approval.request'
     }
   | { payload: { request_id: string }; session_id?: string; type: 'sudo.request' }
-  | { payload: { env_var: string; prompt: string; request_id: string }; session_id?: string; type: 'secret.request' }
+  | {
+      payload: { env_var: string; metadata?: Record<string, unknown>; prompt: string; request_id: string }
+      session_id?: string
+      type: 'secret.request'
+    }
   | { payload: { task_id: string; text: string }; session_id?: string; type: 'background.complete' }
   | { payload?: { text?: string }; session_id?: string; type: 'review.summary' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.spawn_requested' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -188,6 +188,7 @@ export interface SudoReq {
 
 export interface SecretReq {
   envVar: string
+  metadata?: Record<string, unknown>
   prompt: string
   requestId: string
 }


### PR DESCRIPTION
## Summary
- add an in-memory Secure Input Broker that returns opaque `secret://session/...` refs instead of exposing raw secrets to the model
- add `request_secure_input` tool plus CLI/TUI/gateway wiring to collect masked ephemeral secrets
- allow compatible terminal executions to consume refs via `stdin_secret_ref` and `env_secret_refs`, with scoped consumers, TTL, single-use semantics, and output redaction

## Security notes
- secrets stay process-local and are never persisted by the broker
- refs are scoped to allowed consumers and default to single-use
- stdin refs are blocked on backends that embed stdin into command text
- env refs are transient and unset before environment snapshots are persisted
- terminal/background process output is passed through broker exact-value redaction

## Verification
- `uv run --with pytest pytest tests/tools/test_secure_input_tool.py tests/cli/test_cli_secret_capture.py tests/test_tui_gateway_server.py -q` → 315 passed
- `npm run typecheck -w ui-tui -- --pretty false` → passed
- `git diff --check` → passed
