### PR TITLE
fix(doctor): stop false positives on vertex configs

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -755,14 +755,23 @@ def run_doctor(args):
                 pass
             try:
                 from hermes_cli.config import get_compatible_custom_providers as _compatible_custom_providers
+                from hermes_cli.models import _KNOWN_PROVIDER_NAMES as _MODEL_KNOWN_PROVIDER_NAMES
+                from hermes_cli.models import normalize_provider as _normalize_model_provider
                 from hermes_cli.providers import (
-                    normalize_provider as _normalize_catalog_provider,
                     resolve_provider_full as _resolve_provider_full,
                 )
             except Exception:
                 _compatible_custom_providers = None
-                _normalize_catalog_provider = None
+                _MODEL_KNOWN_PROVIDER_NAMES = None
+                _normalize_model_provider = None
                 _resolve_provider_full = None
+
+            if _MODEL_KNOWN_PROVIDER_NAMES is not None:
+                known_providers.update(
+                    str(name).strip().lower()
+                    for name in _MODEL_KNOWN_PROVIDER_NAMES
+                    if str(name).strip()
+                )
 
             custom_providers = []
             if _compatible_custom_providers is not None:
@@ -783,14 +792,20 @@ def run_doctor(args):
 
             valid_provider_ids = set(known_providers)
             provider_ids_to_accept = {provider} if provider else set()
-            if _normalize_catalog_provider is not None:
+            if _normalize_model_provider is not None:
                 for known_provider in known_providers:
                     try:
-                        valid_provider_ids.add(_normalize_catalog_provider(known_provider))
+                        valid_provider_ids.add(_normalize_model_provider(known_provider))
                     except Exception:
                         continue
 
             runtime_provider = provider
+            if provider and _normalize_model_provider is not None:
+                try:
+                    runtime_provider = _normalize_model_provider(provider)
+                    provider_ids_to_accept.add(runtime_provider)
+                except Exception:
+                    runtime_provider = provider
             if (
                 provider
                 and _resolve_auth_provider is not None
@@ -800,9 +815,15 @@ def run_doctor(args):
                     runtime_provider = _resolve_auth_provider(provider)
                     provider_ids_to_accept.add(runtime_provider)
                 except Exception:
-                    runtime_provider = provider
+                    pass
 
             catalog_provider = provider
+            if catalog_provider and _normalize_model_provider is not None:
+                try:
+                    catalog_provider = _normalize_model_provider(catalog_provider)
+                    provider_ids_to_accept.add(catalog_provider)
+                except Exception:
+                    catalog_provider = provider
             if (
                 provider
                 and _resolve_provider_full is not None
@@ -811,13 +832,18 @@ def run_doctor(args):
                 provider_def = _resolve_provider_full(provider, user_providers, custom_providers)
                 catalog_provider = provider_def.id if provider_def is not None else None
                 if catalog_provider is not None:
+                    if _normalize_model_provider is not None:
+                        try:
+                            catalog_provider = _normalize_model_provider(catalog_provider)
+                        except Exception:
+                            pass
                     provider_ids_to_accept.add(catalog_provider)
 
             if provider and provider != "auto":
-                if catalog_provider is None or (
-                    known_providers
-                    and not (provider_ids_to_accept & valid_provider_ids)
-                ):
+                provider_is_known = bool(provider_ids_to_accept & valid_provider_ids)
+                if catalog_provider is not None:
+                    provider_is_known = True
+                if not provider_is_known:
                     known_list = ", ".join(sorted(known_providers)) if known_providers else "(unavailable)"
                     _fail_and_issue(
                         f"model.provider '{provider_raw}' is not a recognised provider",
@@ -845,6 +871,9 @@ def run_doctor(args):
                 "lmstudio",
                 "nous",
                 "nvidia",
+                # Vertex's native model IDs are vendor-prefixed (e.g.
+                # google/gemini-3-flash-preview) by design.
+                "vertex",
             }
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -564,6 +564,61 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
         )
 
 
+@pytest.mark.parametrize(
+    "provider",
+    ["vertex", "google-vertex", "vertex-ai", "gcp-vertex", "vertexai"],
+)
+def test_run_doctor_accepts_vertex_provider_and_native_vendor_slug(
+    monkeypatch, tmp_path, provider
+):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        f"  provider: {provider}\n"
+        "  default: google/gemini-3-flash-preview\n"
+        "vertex:\n"
+        "  project_id: demo-project\n"
+        "  region: global\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert f"model.provider '{provider}' is not a recognised provider" not in out
+    assert f"model.provider '{provider}' is unknown" not in out
+    assert (
+        f"model.default 'google/gemini-3-flash-preview' uses a vendor/model slug but provider is '{provider}'"
+        not in out
+    )
+    assert (
+        f"model.default 'google/gemini-3-flash-preview' is vendor-prefixed but model.provider is '{provider}'."
+        not in out
+    )
+
+
 def test_run_doctor_accepts_vendor_slugs_for_named_custom_provider(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes doctor` false positives for Vertex configurations without changing Hermes' runtime provider loading.

This patch keeps the fix scoped to the doctor path:
- it validates configured providers through Hermes' user-facing provider namespace and aliases
- it treats Vertex's native `google/...` Gemini slugs as valid during doctor checks
- it leaves runtime Vertex OAuth / provider resolution unchanged

Note: this overlaps with #56930, but takes a narrower doctor-only approach instead of widening provider catalog resolution for other callers.

## Related Issue

Related to #56906

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize `model.provider` values in `hermes doctor` through `hermes_cli.models.normalize_provider()` before unknown-provider validation.
- Expand doctor's known-provider set with Hermes' configured provider ids and aliases from `hermes_cli.models`.
- Allow Vertex's native `google/gemini-*` slugs in the doctor vendor-prefix policy.
- Add regression coverage for `vertex` plus `google-vertex`, `vertex-ai`, `gcp-vertex`, and `vertexai`.

## How to Test

1. Create a config with `model.provider: vertex` and `model.default: google/gemini-3-flash-preview`, then run `hermes doctor` and confirm it does not report an unknown provider or vendor-slug warning.
2. Repeat with `model.provider: google-vertex` to confirm alias handling stays clean.
3. Run `pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_vertex_provider.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run:
- `pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_vertex_provider.py` → `85 passed`
