### PR TITLE
fix: add explicit UTF-8 encoding to open()/fdopen() text mode calls

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -117,7 +117,7 @@ def record_nous_rate_limit(
         # Atomic write: write to temp file + rename
         fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(state, f)
             atomic_replace(tmp_path, path)
         except Exception:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -642,7 +642,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
             prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent),
         )
         try:
-            with os.fdopen(fd, "w") as fh:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(json.dumps(data, indent=2, sort_keys=True))
             atomic_replace(tmp_path, p)
         except Exception:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4456,7 +4456,7 @@ class GatewaySlashCommandsMixin:
                     with open(output_path, "wb") as f:
                         proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
                         rc = proc.wait(timeout=3600)
-                    with open(exit_code_path, "w") as f:
+                    with open(exit_code_path, "w", encoding="utf-8") as f:
                         f.write(str(rc))
                     """
                 ).strip()


### PR DESCRIPTION
## Summary

On Windows, `open()` in text mode defaults to the system locale encoding (often `cp1252`), not UTF-8. Writing JSON or structured data without explicit encoding causes `UnicodeEncodeError` when the data contains non-ASCII characters.

## Changes

| File | Line | What changed |
|------|------|-------------|
| `agent/shell_hooks.py` | 645 | `os.fdopen(fd, 'w')` -> added `encoding="utf-8"` (writes JSON config) |
| `agent/nous_rate_guard.py` | 120 | `os.fdopen(fd, 'w')` -> added `encoding="utf-8"` (writes JSON state) |
| `gateway/slash_commands.py` | 4433 | `open(path, 'w')` -> added `encoding="utf-8"` (writes exit code) |

## Why this matters

All three files write structured data (JSON or numeric strings) that could theoretically contain non-ASCII content in edge cases (e.g., locale-specific paths in JSON keys). Specifying `encoding="utf-8"` makes the behavior deterministic across platforms.

## Pattern

```python
# Before (platform-dependent encoding):
with os.fdopen(fd, "w") as f:
    json.dump(state, f)

# After (deterministic):
with os.fdopen(fd, "w", encoding="utf-8") as f:
    json.dump(state, f)
```