### PR TITLE
fix(gateway): honor quiet tool progress for approval fallback

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -360,6 +360,7 @@ def _format_exec_approval_fallback(
     *,
     allow_permanent: bool = True,
     smart_denied: bool = False,
+    include_command: bool = True,
 ) -> str:
     """Render the text fallback from approval capabilities, not platform names."""
     cmd_preview = command[:200] + "..." if len(command) > 200 else command
@@ -375,8 +376,9 @@ def _format_exec_approval_fallback(
         if allow_permanent:
             choices.append(f"`{command_prefix}approve always` to approve permanently")
     choices.append(f"`{command_prefix}deny` to cancel")
+    command_block = f"```\n{cmd_preview}\n```\n" if include_command else ""
     return (
-        f"{heading}\n```\n{cmd_preview}\n```\nReason: {description}\n\n"
+        f"{heading}\n{command_block}Reason: {description}\n\n"
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
     )
 
@@ -19098,6 +19100,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _p,
                     allow_permanent=approval_data.get("allow_permanent", True),
                     smart_denied=approval_data.get("smart_denied", False),
+                    include_command=tool_progress_enabled,
                 )
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -186,3 +186,38 @@ class TestApprovalTextFallbackContract:
         )
         assert "`/approve session`" in text
         assert "`/approve always`" in text
+
+    def test_quiet_prompt_omits_preview_and_preserves_restricted_choices(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "curl -H 'Authorization: Bearer REDACTED' https://example.test",
+            "content warning",
+            "!",
+            allow_permanent=False,
+            smart_denied=False,
+            include_command=False,
+        )
+        assert "```" not in text
+        assert "Authorization" not in text
+        assert "Reason: content warning" in text
+        assert "`!approve session`" in text
+        assert "approve always" not in text
+
+    def test_quiet_smart_deny_prompt_keeps_owner_override_choices(self):
+        from gateway.run import _format_exec_approval_fallback
+
+        text = _format_exec_approval_fallback(
+            "rm -rf /",
+            "dangerous deletion",
+            "/",
+            allow_permanent=False,
+            smart_denied=True,
+            include_command=False,
+        )
+        assert "```" not in text
+        assert "rm -rf" not in text
+        assert "owner override" in text.lower()
+        assert "one operation" in text.lower()
+        assert "approve session" not in text
+        assert "approve always" not in text


### PR DESCRIPTION
## Summary
- Extract the gateway's plain-text dangerous-command approval fallback into a small formatter.
- Keep the existing full command preview when tool progress is enabled.
- Omit the command code block when `display.tool_progress` or `display.platforms.<platform>.tool_progress` resolves to `off`, while preserving approval instructions.

## Root Cause
The buttonless gateway approval fallback always formatted and sent the redacted shell command preview directly to the chat platform. That path did not consult the resolved per-platform `tool_progress` mode, so quiet chat surfaces still received full command details.

## Tests
- `scripts/run_tests.sh tests/gateway/test_exec_approval_prompt.py -q`
- `python3 -m py_compile gateway/run.py tests/gateway/test_exec_approval_prompt.py`
- `git diff --check`

Not run: `ruff` (the worktree does not have `uv` or a local `ruff` module available).

Fixes #56917
