### PR TITLE
fix(webhook): remove unused payload from retained delivery state (#2861 salvage)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -675,7 +675,6 @@ class WebhookAdapter(BasePlatformAdapter):
             "deliver_extra": self._render_delivery_extra(
                 route_config.get("deliver_extra", {}), payload
             ),
-            "payload": payload,
         }
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "aqdrgg19@gmail.com": "VolodymyrBg",  # PR #2861 salvage (webhook: drop the unused full request payload from retained _delivery_info entries — up to ~1MB dead weight per delivery for the 1h idempotency TTL)
     "sahibzada@fastino.ai": "sahibzada-allahyar",  # PR #39227 salvage (desktop: configured terminal.cwd overrides a stale remembered workspace-cwd localStorage value when no session is active; #38855)
     "jvsantos.cunha@gmail.com": "plcunha",  # PR #55300 salvage (gateway: record child gateway peer metadata after a compression session-id rotation and repoint stale sessions.json compression-parent entries to the recovered live child; consolidated in the compression-routing-integrity salvage)
     "jakepresent1@gmail.com": "jakepresent",  # PR #55721 salvage (gateway: identity-guard stale in-flight compression splits — a late run may publish its compressed child only if its run generation is still current and the session key still points at the run's original parent, so an old run can't overwrite a newer /new or moved binding)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -829,7 +829,6 @@ class TestDeliveryCleanup:
         adapter._delivery_info[chat_id] = {
             "deliver": "log",
             "deliver_extra": {},
-            "payload": {"x": 1},
         }
         adapter._delivery_info_created[chat_id] = time.time()
 


### PR DESCRIPTION
## Summary
Retained webhook delivery state no longer holds the full request payload — `_delivery_info` entries kept up to ~1MB of dead weight per delivery for the 1-hour idempotency TTL, and no consumer ever read it (all readers access only `deliver` / `deliver_extra`).

Salvage of #2861 by @VolodymyrBg (stale branch, cherry-picked onto current main with authorship preserved).

## Changes
- `gateway/platforms/webhook.py`: drop `"payload": payload` from the retained agent-mode `deliver_config` (the request-scoped deliver-only dict is untouched)
- `tests/gateway/test_webhook_adapter.py`: remove the matching fixture key
- `scripts/release.py`: AUTHOR_MAP entry for @VolodymyrBg

## Validation
| | Before | After |
|---|---|---|
| tests/gateway/test_webhook_adapter.py | — | all pass |
| payload retained per delivery | up to ~1MB × 1h TTL | none |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa09e1c/AiifbBEon2B0mjNeM6QHq_sl7FPJFC.png)

Nous Research
