### PR TITLE
fix(backup): guard os.chmod on Windows where it is a no-op

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -289,6 +289,23 @@ def _format_size(nbytes: int) -> str:
     return f"{nbytes:.1f} TB"
 
 
+def _tighten_file_permissions(path: Path) -> None:
+    """Restrict file to owner-only read/write (POSIX 0600).
+
+    On Windows, ``os.chmod`` with Unix permission bits is a no-op — it
+    silently succeeds without changing anything.  NTFS ACLs already restrict
+    newly-created files to the owning user / SYSTEM / Administrators, so
+    the explicit chmod is redundant there.  Skip it to avoid a silent
+    no-op that looks like it worked but didn't (#56923).
+    """
+    if sys.platform == "win32":
+        return
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""
     hermes_root = get_default_hermes_root()
@@ -600,10 +617,7 @@ def run_import(args) -> None:
                         dst.write(src.read())
                     # External provider configs commonly hold credentials.
                     if target.suffix in {".json", ".env", ".conf"} or target.name in _SECRET_FILE_NAMES:
-                        try:
-                            os.chmod(target, 0o600)
-                        except OSError:
-                            pass
+                        _tighten_file_permissions(target)
                     restored += 1
                     restored_external += 1
                 except (PermissionError, OSError) as exc:
@@ -645,7 +659,7 @@ def run_import(args) -> None:
                 with zf.open(member) as src, open(target, "wb") as dst:
                     dst.write(src.read())
                 if target.name in _SECRET_FILE_NAMES:
-                    os.chmod(target, 0o600)
+                    _tighten_file_permissions(target)
                 restored += 1
             except (PermissionError, OSError) as exc:
                 errors.append(f"  {rel}: {exc}")

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sqlite3
+import sys
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -2467,8 +2468,11 @@ class TestMemoryProviderExternalPaths:
         restored = dst_home / ".honcho" / "config.json"
         assert restored.exists()
         assert restored.read_text() == '{"peer":"bob"}'
-        # Credential-shaped file tightened.
-        assert (restored.stat().st_mode & 0o777) == 0o600
+        # Credential-shaped file tightened (POSIX only; Windows NTFS ACLs
+        # already restrict to owner/SYSTEM/Administrators — os.chmod is a
+        # no-op there, so we skip the mode-bit assertion).
+        if sys.platform != "win32":
+            assert (restored.stat().st_mode & 0o777) == 0o600
         # External state did NOT leak into HERMES_HOME.
         assert not (hermes_home / "_external").exists()
 


### PR DESCRIPTION
## What does this PR do?

Fixes the backup import test failure on Windows where `os.chmod(target, 0o600)` is a silent no-op. On Windows, `os.chmod` with Unix permission bits succeeds without error but doesn't change anything — the file stays at default `0o666` permissions.

Extracts a `_tighten_file_permissions()` helper that skips the chmod on Windows (NTFS ACLs already restrict newly-created files to the owner / SYSTEM / Administrators), and makes the test assertion platform-aware.

## Related Issue

Fixes #56923

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/backup.py`: Added `_tighten_file_permissions()` helper that wraps `os.chmod(path, 0o600)` with a `sys.platform == "win32"` guard. Replaced both bare `os.chmod` calls (line 604 and 648) with the helper.
- `tests/hermes_cli/test_backup.py`: Added `import sys` and wrapped the `st_mode & 0o777 == 0o600` assertion in `if sys.platform != "win32":` so the test passes on both POSIX and Windows.

## How to Test

1. On macOS/Linux: `pytest tests/hermes_cli/test_backup.py::TestMemoryProviderExternalPaths::test_import_restores_external_to_home_relative_location -xvs` — should pass
2. On Windows: same test should now pass (previously failed with `assert (33206 & 511) == 384`)
3. Full backup test suite: `pytest tests/hermes_cli/test_backup.py -q` — all 145 tests should pass (verified on macOS)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before (Windows):**
```
>       assert (restored.stat().st_mode & 0o777) == 0o600
E       AssertionError: assert (33206 & 511) == 384
```

**After (macOS/Linux):**
```
tests/hermes_cli/test_backup.py::TestMemoryProviderExternalPaths::test_import_restores_external_to_home_relative_location PASSED
```
