### PR TITLE
fix(desktop): keep markdown previews rendered after edits

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultPreviewViewMode } from './preview-file'
+
+describe('defaultPreviewViewMode', () => {
+  it('keeps Markdown previews rendered even when the file has a diff', () => {
+    expect(defaultPreviewViewMode(true, true)).toBe('rendered')
+  })
+
+  it('defaults changed non-Markdown text files to diff review', () => {
+    expect(defaultPreviewViewMode(false, true)).toBe('diff')
+  })
+
+  it('defaults clean non-Markdown text files to source', () => {
+    expect(defaultPreviewViewMode(false, false)).toBe('source')
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -551,7 +551,13 @@ function SourceView({ filePath, language, text }: { filePath: string; language: 
   )
 }
 
-type PreviewViewMode = 'diff' | 'rendered' | 'source'
+export type PreviewViewMode = 'diff' | 'rendered' | 'source'
+
+export function defaultPreviewViewMode(isMarkdown: boolean, hasDiff: boolean): PreviewViewMode {
+  // Markdown previews are documents first. A background agent edit should update
+  // the rendered page in place; diff remains available for deliberate review.
+  return isMarkdown ? 'rendered' : hasDiff ? 'diff' : 'source'
+}
 
 export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; target: PreviewTarget }) {
   const { t } = useI18n()
@@ -913,7 +919,7 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
       modes.push('diff')
     }
 
-    const autoMode: PreviewViewMode = hasDiff ? 'diff' : isMarkdown ? 'rendered' : 'source'
+    const autoMode = defaultPreviewViewMode(isMarkdown, hasDiff)
     const mode = userMode && modes.includes(userMode) ? userMode : autoMode
 
     return (


### PR DESCRIPTION
## Summary
- keep Markdown file previews on the rendered view after background edits
- preserve the diff tab as an explicit review option
- add focused coverage for preview default-mode selection

## Tests
- npm run test:ui -- src/app/chat/right-rail/preview-file.test.ts
- npm run typecheck
