### PR TITLE
fix(plugin-llm): handle reasoning-model responses in _extract_text

### DIFF
--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -518,13 +518,25 @@ def _extract_usage(response: Any) -> PluginLlmUsage:
 
 
 def _extract_text(response: Any) -> str:
-    """Pull the assistant text out of an OpenAI-shaped response object."""
+    """Pull the assistant text out of an OpenAI-shaped response object.
+
+    Mirrors ``agent.auxiliary_client.extract_content_or_reasoning``'s handling
+    of reasoning models so the plugin LLM host behaves like the main loop:
+
+    * inline ``<think>``/reasoning blocks are stripped, so they don't leak into
+      a plugin's ``complete()`` text or break ``complete_structured()`` JSON
+      parsing (an unstripped ``<think>`` prefix makes the body non-JSON); and
+    * a response whose ``content`` is ``None`` because the visible answer landed
+      in a structured ``reasoning`` field (DeepSeek-R1 / Qwen-QwQ, etc.) falls
+      back to that field instead of returning an empty string.
+    """
     try:
         msg = response.choices[0].message
         content = getattr(msg, "content", None)
+        text = ""
         if isinstance(content, str):
-            return content
-        if isinstance(content, list):
+            text = content
+        elif isinstance(content, list):
             parts: List[str] = []
             for part in content:
                 if isinstance(part, dict):
@@ -534,7 +546,19 @@ def _extract_text(response: Any) -> str:
                     txt = getattr(part, "text", None)
                     if isinstance(txt, str):
                         parts.append(txt)
-            return "".join(parts)
+            text = "".join(parts)
+
+        from agent.agent_runtime_helpers import strip_think_blocks
+        text = strip_think_blocks(None, text)
+        if text.strip():
+            return text
+
+        # Reasoning-only response: the visible answer is in a structured
+        # reasoning field, not ``content``.
+        for field in ("reasoning", "reasoning_content"):
+            val = getattr(msg, field, None)
+            if isinstance(val, str) and val.strip():
+                return val
     except (AttributeError, IndexError, TypeError):
         pass
     return ""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1841,6 +1841,7 @@ AUTHOR_MAP = {
     "poli.koltsova@gmail.com": "wnuuee1",  # commit 9fd2b2cb PR author
     "yosapol@jitrak.dev": "Eji4h",  # direct email match
     "kiljadn@gmail.com": "designnotdrum",  # PR #56480 salvage (toolset static-inference fix)
+    "drexux0@gmail.com": "Drexuxux",
 }
 
 

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -71,6 +71,48 @@ def _trusted_policy(plugin_id: str = "trusted-plugin", **overrides: Any) -> _Tru
 
 
 # ---------------------------------------------------------------------------
+# Response text extraction (reasoning-model handling)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractText:
+    @staticmethod
+    def _resp(content, **extra):
+        msg = SimpleNamespace(content=content, **extra)
+        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+    def test_plain_text_passthrough(self):
+        from agent.plugin_llm import _extract_text
+
+        assert _extract_text(self._resp("hello world")) == "hello world"
+
+    def test_strips_inline_think_block(self):
+        """Reasoning models (MiniMax M2 / NIM / Gemma) emit <think> inline in
+        content. It must not leak into a plugin's text or break the
+        complete_structured() JSON parse (a <think> prefix makes the body
+        non-JSON)."""
+        from agent.plugin_llm import _extract_text
+
+        r = self._resp("<think>let me work it out</think>The answer is 42.")
+        assert _extract_text(r) == "The answer is 42."
+
+    def test_falls_back_to_reasoning_field_when_content_none(self):
+        """DeepSeek-R1 / Qwen-QwQ shape: content=None, answer in `reasoning`.
+        Mirrors extract_content_or_reasoning — must not return empty."""
+        from agent.plugin_llm import _extract_text
+
+        r = self._resp(None, reasoning="The answer is 42.")
+        assert _extract_text(r) == "The answer is 42."
+
+    def test_list_content_still_joined(self):
+        """Multimodal list content parts are still concatenated (no regression)."""
+        from agent.plugin_llm import _extract_text
+
+        r = self._resp([{"type": "text", "text": "foo"}, {"type": "text", "text": "bar"}])
+        assert _extract_text(r) == "foobar"
+
+
+# ---------------------------------------------------------------------------
 # Trust gate
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Ran into this building a plugin that uses a DeepSeek-R1 model through the host
LLM interface — the plugin kept getting either garbage or nothing back, and it
turned out the host side never accounts for reasoning models at all.

`_extract_text()` in `agent/plugin_llm.py` just grabs
`resp.choices[0].message.content` and hands it back untouched. Everywhere else
in the codebase that pulls text off a completion goes through
`extract_content_or_reasoning()`, which knows about reasoning-model quirks — but
this one path reimplemented extraction by hand and skipped all of that. Two
concrete ways it bites you:

1. If the model inlines its reasoning (`<think>…</think>answer` — MiniMax M2,
   Gemma-on-OpenRouter, various NIM endpoints do this), the whole reasoning
   dump gets returned to the plugin as-is. For `complete()` that's just noise in
   the output; for `complete_structured()` it's worse — the leading `<think>`
   makes the string invalid JSON, `_parse_structured_text` can't parse it, and
   it quietly downgrades to raw-text mode. So structured output silently stops
   being structured.
2. If the model returns its answer in the `reasoning` field with `content=None`
   (R1 / QwQ style), the hand-rolled extractor matches neither the `str` nor the
   `list` branch and returns `""`. The plugin just gets an empty response.

Since `complete()` targets whatever the user has set as their active model, and
plenty of people run a reasoning model there, this isn't an edge case — it's the
normal path for that audience.

The change makes `_extract_text()` behave like the rest of the codebase: run the
extracted text through the shared reasoning scrubber, and if there's nothing
left, look in `reasoning` / `reasoning_content` before giving up. The existing
multimodal (list-of-parts) handling stays exactly as it was.

Quick before/after:

```python
from types import SimpleNamespace
from agent.plugin_llm import _extract_text
mk = lambda c, **k: SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=c, **k))])

_extract_text(mk("<think>reasoning…</think>42"))     # was "<think>reasoning…</think>42", now "42"
_extract_text(mk(None, reasoning="42"))              # was "", now "42"
```

Covered by four new cases in `tests/agent/test_plugin_llm.py::TestExtractText`
(inline-think, reasoning fallback, plus plain-string and list-content guards so
the common paths don't regress). `pytest tests/agent/test_plugin_llm.py -q` is
green at 60; dropping the two-line change back out flips the two reasoning cases
red, so the tests actually pin the behavior.

Not tied to an existing issue — closest relative is #18529, same "read `.content`
straight instead of extracting reasoning" mistake, just in a different spot.