### PR TITLE
fix(config): accept 'on' as truthy for env flags (#2863 salvage)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
 from hermes_cli.config import get_hermes_home
-from utils import env_int, is_truthy_value
+from utils import env_int, env_var_enabled, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -1320,7 +1320,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         config.platforms[Platform.DISCORD].reply_to_mode = discord_reply_mode
     
     # WhatsApp (typically uses different auth mechanism)
-    whatsapp_enabled = os.getenv("WHATSAPP_ENABLED", "").lower() in {"true", "1", "yes"}
+    whatsapp_enabled = env_var_enabled("WHATSAPP_ENABLED")
     whatsapp_disabled_explicitly = os.getenv("WHATSAPP_ENABLED", "").lower() in {"false", "0", "no"}
     if Platform.WHATSAPP in config.platforms:
         # YAML config exists — respect explicit disable
@@ -1437,7 +1437,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         signal_config.extra.update({
             "http_url": signal_url,
             "account": signal_account,
-            "ignore_stories": os.getenv("SIGNAL_IGNORE_STORIES", "true").lower() in {"true", "1", "yes"},
+            "ignore_stories": env_var_enabled("SIGNAL_IGNORE_STORIES", "true"),
         })
     signal_home = os.getenv("SIGNAL_HOME_CHANNEL")
     if signal_home and Platform.SIGNAL in config.platforms:
@@ -1485,7 +1485,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         matrix_e2ee_mode = os.getenv("MATRIX_E2EE_MODE", "").strip().lower()
         matrix_e2ee = (
             matrix_e2ee_mode in ("required", "require", "optional", "prefer", "preferred")
-            or os.getenv("MATRIX_ENCRYPTION", "").lower() in ("true", "1", "yes")
+            or env_var_enabled("MATRIX_ENCRYPTION")
         )
         matrix_config.extra["encryption"] = matrix_e2ee
         if matrix_e2ee_mode:
@@ -1553,7 +1553,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # API Server
-    api_server_enabled = os.getenv("API_SERVER_ENABLED", "").lower() in {"true", "1", "yes"}
+    api_server_enabled = env_var_enabled("API_SERVER_ENABLED")
     api_server_key = os.getenv("API_SERVER_KEY", "")
     api_server_cors_origins = os.getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = os.getenv("API_SERVER_PORT")
@@ -1580,7 +1580,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.API_SERVER].extra["model_name"] = api_server_model_name
 
     # Webhook platform
-    webhook_enabled = os.getenv("WEBHOOK_ENABLED", "").lower() in {"true", "1", "yes"}
+    webhook_enabled = env_var_enabled("WEBHOOK_ENABLED")
     webhook_port = os.getenv("WEBHOOK_PORT")
     webhook_secret = os.getenv("WEBHOOK_SECRET", "")
     if webhook_enabled:
@@ -1596,11 +1596,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
 
     # Microsoft Graph webhook platform
-    msgraph_webhook_enabled = os.getenv("MSGRAPH_WEBHOOK_ENABLED", "").lower() in {
-        "true",
-        "1",
-        "yes",
-    }
+    msgraph_webhook_enabled = env_var_enabled("MSGRAPH_WEBHOOK_ENABLED")
     msgraph_webhook_port = os.getenv("MSGRAPH_WEBHOOK_PORT")
     msgraph_webhook_client_state = os.getenv("MSGRAPH_WEBHOOK_CLIENT_STATE", "")
     msgraph_webhook_resources = os.getenv("MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES", "")
@@ -1794,7 +1790,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
             "webhook_port": env_int("BLUEBUBBLES_WEBHOOK_PORT", 8645),
             "webhook_path": os.getenv("BLUEBUBBLES_WEBHOOK_PATH", "/bluebubbles-webhook"),
-            "send_read_receipts": os.getenv("BLUEBUBBLES_SEND_READ_RECEIPTS", "true").lower() in {"true", "1", "yes"},
+            "send_read_receipts": env_var_enabled("BLUEBUBBLES_SEND_READ_RECEIPTS", "true"),
         })
         bluebubbles_require_mention = os.getenv("BLUEBUBBLES_REQUIRE_MENTION")
         if bluebubbles_require_mention is not None:

--- a/tests/gateway/test_env_flag_truthy.py
+++ b/tests/gateway/test_env_flag_truthy.py
@@ -1,0 +1,49 @@
+"""Env flags accept 'on' as truthy consistently (salvage of #2863).
+
+Behavior contract: every env-driven enable flag in gateway config coerces
+through the shared TRUTHY_STRINGS set, so "on" behaves like "1"/"true"/"yes".
+"""
+
+import os
+from unittest.mock import patch
+
+from utils import TRUTHY_STRINGS, env_var_enabled
+
+
+def test_truthy_strings_include_on():
+    assert "on" in TRUTHY_STRINGS
+
+
+def test_env_var_enabled_accepts_on():
+    with patch.dict(os.environ, {"WHATSAPP_ENABLED": "on"}):
+        assert env_var_enabled("WHATSAPP_ENABLED") is True
+
+
+def test_env_var_enabled_default_respected():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("SIGNAL_IGNORE_STORIES", None)
+        assert env_var_enabled("SIGNAL_IGNORE_STORIES", "true") is True
+        assert env_var_enabled("SIGNAL_IGNORE_STORIES") is False
+
+
+def test_gateway_config_flags_use_shared_helper():
+    """Invariant: no env-flag site in gateway/config.py hand-rolls a truthy
+    set that omits 'on'."""
+    import inspect
+
+    import gateway.config as gc
+
+    src = inspect.getsource(gc)
+    for pattern in ('in {"true", "1", "yes"}', 'in ("true", "1", "yes")'):
+        assert pattern not in src, f"hand-rolled truthy set without 'on': {pattern}"
+
+
+def test_desktop_gate_accepts_on():
+    from tools.close_terminal_tool import check_close_terminal_requirements
+    from tools.read_terminal_tool import check_read_terminal_requirements
+
+    with patch.dict(os.environ, {"HERMES_DESKTOP": "on"}):
+        assert check_read_terminal_requirements() is True
+        assert check_close_terminal_requirements() is True
+    with patch.dict(os.environ, {"HERMES_DESKTOP": "off"}):
+        assert check_read_terminal_requirements() is False

--- a/tools/close_terminal_tool.py
+++ b/tools/close_terminal_tool.py
@@ -15,6 +15,8 @@ the GUI.
 import json
 import os
 
+from utils import env_var_enabled
+
 from tools.process_registry import process_registry
 from tools.registry import registry, tool_error
 
@@ -30,7 +32,7 @@ def close_terminal_tool(process_id: str) -> str:
 
 def check_close_terminal_requirements() -> bool:
     """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return (os.getenv("HERMES_DESKTOP") or "").strip().lower() in ("1", "true", "yes")
+    return env_var_enabled("HERMES_DESKTOP")
 
 
 CLOSE_TERMINAL_SCHEMA = {

--- a/tools/read_terminal_tool.py
+++ b/tools/read_terminal_tool.py
@@ -13,6 +13,7 @@ import os
 from typing import Callable, Optional
 
 from tools.registry import registry, tool_error
+from utils import env_var_enabled
 
 
 def read_terminal_tool(
@@ -50,7 +51,7 @@ def read_terminal_tool(
 
 def check_read_terminal_requirements() -> bool:
     """Desktop GUI only — HERMES_DESKTOP is set on the gateway the app spawns."""
-    return (os.getenv("HERMES_DESKTOP") or "").strip().lower() in ("1", "true", "yes")
+    return env_var_enabled("HERMES_DESKTOP")
 
 
 READ_TERMINAL_SCHEMA = {


### PR DESCRIPTION
## Summary
Every env-driven enable flag now accepts `on` as truthy — 7 sites in `gateway/config.py` (plus the `HERMES_DESKTOP` gates) still hand-rolled `{"true","1","yes"}` sets while the rest of the codebase already used the shared `TRUTHY_STRINGS` (which includes `on`).

Salvage of #2863 by @aydnOktay, reimplemented against current main: instead of the PR's per-site tuple edits, the sites now route through the existing `utils.env_var_enabled` helper so drift can't recur. The PR's `approval.py` HERMES_YOLO_MODE portion is already on main via `is_truthy_value`.

## Changes
- `gateway/config.py`: WHATSAPP_ENABLED, SIGNAL_IGNORE_STORIES, MATRIX_ENCRYPTION, API_SERVER_ENABLED, WEBHOOK_ENABLED, MSGRAPH_WEBHOOK_ENABLED, BLUEBUBBLES_SEND_READ_RECEIPTS → `env_var_enabled()`
- `tools/read_terminal_tool.py`, `tools/close_terminal_tool.py`: HERMES_DESKTOP gate → `env_var_enabled()`
- `tests/gateway/test_env_flag_truthy.py`: behavior contract incl. an invariant that no hand-rolled `'on'`-less truthy set reappears in gateway/config.py

## Validation
| | Result |
|---|---|
| tests/gateway/test_env_flag_truthy.py | 5/5 pass |
| tests/gateway/test_config.py + terminal tool tests | 78/78 pass |
| ruff on touched files | clean |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa09e45/El-yCIgB_MdH90f3XXnfe_NaDYlMVT.png)

Nous Research
