### PR TITLE
fix(photon): repair CLI and standalone delivery

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1677,6 +1677,7 @@ class PluginManager:
         loaded = LoadedPlugin(manifest=manifest, enabled=True)
         loaded.deferred = True
         self._plugins[lookup_key] = loaded
+        self._register_deferred_platform_cli(manifest)
 
         def _loader(_manifest: PluginManifest = manifest) -> None:
             self._load_plugin(_manifest)
@@ -1699,6 +1700,66 @@ class PluginManager:
                 exc_info=True,
             )
             self._load_plugin(manifest)
+
+    def _register_deferred_platform_cli(self, manifest: PluginManifest) -> None:
+        """Expose lightweight CLI commands shipped by deferred platform plugins.
+
+        Bundled platform adapters are lazy-loaded to keep ordinary `hermes`
+        startup fast, but some of them also ship small management CLIs
+        (`hermes photon ...`). Import only `<plugin>/cli.py` when present so
+        argparse can see the command without importing the heavy adapter SDKs.
+        """
+        plugin_dir = Path(manifest.path or "")
+        cli_file = plugin_dir / "cli.py"
+        if not cli_file.exists():
+            return
+        try:
+            if _NS_PARENT not in sys.modules:
+                ns_pkg = types.ModuleType(_NS_PARENT)
+                ns_pkg.__path__ = []  # type: ignore[attr-defined]
+                ns_pkg.__package__ = _NS_PARENT
+                sys.modules[_NS_PARENT] = ns_pkg
+
+            key = manifest.key or manifest.name
+            slug = key.replace("/", "__").replace("-", "_")
+            package_name = f"{_NS_PARENT}.{slug}"
+            if package_name not in sys.modules:
+                pkg = types.ModuleType(package_name)
+                pkg.__path__ = [str(plugin_dir)]  # type: ignore[attr-defined]
+                pkg.__package__ = package_name
+                sys.modules[package_name] = pkg
+
+            cli_module_name = f"{package_name}.cli"
+            spec = importlib.util.spec_from_file_location(cli_module_name, cli_file)
+            if spec is None or spec.loader is None:
+                return
+            module = importlib.util.module_from_spec(spec)
+            module.__package__ = package_name
+            sys.modules[cli_module_name] = module
+            spec.loader.exec_module(module)
+
+            setup_fn = getattr(module, "register_cli", None)
+            if setup_fn is None:
+                return
+            handler_fn = getattr(module, "dispatch", None)
+            command_name = self._platform_name_from_manifest(manifest)
+            self._cli_commands.setdefault(
+                command_name,
+                {
+                    "name": command_name,
+                    "help": f"Set up and manage {manifest.name}",
+                    "description": manifest.description or "",
+                    "setup_fn": setup_fn,
+                    "handler_fn": handler_fn,
+                    "plugin": manifest.name,
+                },
+            )
+        except Exception:
+            logger.debug(
+                "Deferred platform CLI registration failed for '%s'",
+                manifest.key or manifest.name,
+                exc_info=True,
+            )
 
     def _load_plugin(self, manifest: PluginManifest) -> None:
         """Import a plugin module and call its ``register(ctx)`` function."""

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -72,6 +72,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_SIDECAR_PORT = 8789
 _DEFAULT_SIDECAR_BIND = "127.0.0.1"
+_SIDECAR_TOKEN_STATE = "photon/sidecar-token.json"
 
 # Photon iMessage messages from the SDK side have no documented hard
 # limit, but the underlying iMessage protocol limits practical message
@@ -121,6 +122,85 @@ def _coerce_port(value: Any, default: int) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _sidecar_token_state_path() -> Path:
+    """Profile-local runtime token used by out-of-process Photon senders."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / _SIDECAR_TOKEN_STATE
+
+
+def _write_sidecar_token_state(*, bind: str, port: int, token: str, pid: int) -> None:
+    """Persist the live sidecar token for same-user helpers like `hermes send`.
+
+    The token is not a Photon credential; it only authenticates loopback HTTP
+    calls to the currently running sidecar. Store it under the active Hermes
+    profile with 0600 permissions so cron / `hermes send` processes can reuse
+    the gateway-owned sidecar without weakening the sidecar's auth boundary.
+    """
+    path = _sidecar_token_state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            path.parent.chmod(0o700)
+        except OSError:
+            pass
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        payload = {
+            "bind": bind,
+            "port": int(port),
+            "token": token,
+            "pid": int(pid),
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            pass
+        tmp.replace(path)
+    except Exception as exc:
+        logger.debug("[photon] could not write sidecar token state: %s", exc)
+
+
+def _read_sidecar_token_state(*, bind: str, port: int) -> Optional[str]:
+    """Read a live sidecar token written by the gateway, if it is still valid."""
+    try:
+        data = json.loads(_sidecar_token_state_path().read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if str(data.get("bind") or _DEFAULT_SIDECAR_BIND) != bind:
+        return None
+    try:
+        if int(data.get("port")) != int(port):
+            return None
+    except (TypeError, ValueError):
+        return None
+    token = data.get("token")
+    if not isinstance(token, str) or not token:
+        return None
+    # Avoid handing out a stale token from a dead/replaced sidecar. POSIX can
+    # verify the pid cheaply; other platforms fall back to the loopback request.
+    try:
+        pid = int(data.get("pid") or 0)
+    except (TypeError, ValueError):
+        pid = 0
+    if pid and sys.platform != "win32" and not PhotonAdapter._pid_is_sidecar(pid):
+        return None
+    return token
+
+
+def _clear_sidecar_token_state(token: str) -> None:
+    """Remove the runtime token state if it still belongs to this adapter."""
+    path = _sidecar_token_state_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("token") != token:
+            return
+        path.unlink(missing_ok=True)
+    except Exception:
+        pass
 
 
 def check_requirements() -> bool:
@@ -907,6 +987,12 @@ class PhotonAdapter(BasePlatformAdapter):
                         headers={"X-Hermes-Sidecar-Token": self._sidecar_token},
                     )
                     if resp.status_code == 200:
+                        _write_sidecar_token_state(
+                            bind=self._sidecar_bind,
+                            port=self._sidecar_port,
+                            token=self._sidecar_token,
+                            pid=self._sidecar_proc.pid,
+                        )
                         return
                 except httpx.RequestError as e:
                     last_err = e
@@ -983,6 +1069,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 except subprocess.TimeoutExpired:
                     proc.kill()
         finally:
+            _clear_sidecar_token_state(self._sidecar_token)
             self._sidecar_proc = None
             if self._sidecar_supervisor_task is not None:
                 self._sidecar_supervisor_task.cancel()
@@ -1584,13 +1671,16 @@ async def _standalone_send(
         (pconfig.extra or {}).get("sidecar_port") or os.getenv("PHOTON_SIDECAR_PORT"),
         _DEFAULT_SIDECAR_PORT,
     )
-    token = os.getenv("PHOTON_SIDECAR_TOKEN")
+    token = os.getenv("PHOTON_SIDECAR_TOKEN") or _read_sidecar_token_state(
+        bind=_DEFAULT_SIDECAR_BIND,
+        port=port,
+    )
     if not token:
         return {
             "error": (
-                "Photon standalone send requires a running sidecar with "
-                "PHOTON_SIDECAR_TOKEN set in the environment. Cron processes "
-                "cannot spawn the sidecar themselves."
+                "Photon standalone send requires a running gateway-owned "
+                "sidecar. Start or restart the gateway so it can publish "
+                "the local sidecar token for this Hermes profile."
             )
         }
     base = f"http://{_DEFAULT_SIDECAR_BIND}:{port}"

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -612,6 +612,36 @@ function ok(res, data) {
   res.end(JSON.stringify({ ok: true, ...data }));
 }
 
+function isTransientPhotonError(e) {
+  const text = (e && (e.stack || e.message) ? e.stack || e.message : String(e || "")).toLowerCase();
+  return (
+    text.includes("econnreset") ||
+    text.includes("connection dropped") ||
+    text.includes("unavailable") ||
+    text.includes("upstream") ||
+    text.includes("internalerror")
+  );
+}
+
+async function withTransientRetry(label, fn, attempts = 3) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastError = e;
+      if (attempt >= attempts || !isTransientPhotonError(e)) throw e;
+      const delay = 250 * 2 ** (attempt - 1);
+      console.error(
+        `photon-sidecar: transient ${label} failure (${attempt}/${attempts}); retrying in ${delay}ms: ` +
+          (e && e.message ? e.message : String(e))
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastError;
+}
+
 function handleInbound(req, res) {
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/x-ndjson");
@@ -732,7 +762,7 @@ const server = http.createServer(async (req, res) => {
       // readable plain text on platforms that don't.
       const builder =
         format === "markdown" ? spectrumMarkdown(text) : spectrumText(text);
-      const result = await space.send(builder);
+      const result = await withTransientRetry("send", () => space.send(builder));
       return ok(res, { messageId: result?.id || null });
     }
     if (req.url === "/send-attachment") {
@@ -835,7 +865,7 @@ const server = http.createServer(async (req, res) => {
         return badRequest(res, "state must be start or stop");
       }
       const space = await resolveSpace(spaceId);
-      await space.send(spectrumTyping(state));
+      await withTransientRetry("typing", () => space.send(spectrumTyping(state)), 2);
       return ok(res, {});
     }
     res.statusCode = 404;

--- a/tests/plugins/test_photon_platform_fixes.py
+++ b/tests/plugins/test_photon_platform_fixes.py
@@ -1,0 +1,71 @@
+import argparse
+import json
+
+from hermes_cli.plugins import PluginManager, PluginManifest
+from plugins.platforms.photon import adapter as photon_adapter
+
+
+def test_deferred_photon_platform_exposes_cli_command():
+    manifest = PluginManifest(
+        name="photon-platform",
+        version="0.3.0",
+        description="Photon Spectrum gateway adapter",
+        source="bundled",
+        path="plugins/platforms/photon",
+        kind="platform",
+        key="platforms/photon",
+    )
+    manager = PluginManager()
+
+    manager._register_deferred_platform_cli(manifest)
+
+    cmd = manager._cli_commands["photon"]
+    parser = argparse.ArgumentParser()
+    cmd["setup_fn"](parser)
+    args = parser.parse_args(["status"])
+    assert args.photon_command == "status"
+    assert callable(cmd["handler_fn"])
+
+
+def test_photon_sidecar_token_state_roundtrip(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(photon_adapter.PhotonAdapter, "_pid_is_sidecar", staticmethod(lambda pid: pid == 1234))
+
+    photon_adapter._write_sidecar_token_state(
+        bind="127.0.0.1",
+        port=8789,
+        token="secret-token",
+        pid=1234,
+    )
+
+    path = tmp_path / "photon" / "sidecar-token.json"
+    assert path.exists()
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    assert photon_adapter._read_sidecar_token_state(bind="127.0.0.1", port=8789) == "secret-token"
+    assert photon_adapter._read_sidecar_token_state(bind="127.0.0.1", port=8790) is None
+
+    data = json.loads(path.read_text())
+    data["pid"] = 9999
+    path.write_text(json.dumps(data))
+    assert photon_adapter._read_sidecar_token_state(bind="127.0.0.1", port=8789) is None
+
+
+def test_photon_sidecar_token_state_clear_only_matching_token(tmp_path, monkeypatch):
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    photon_adapter._write_sidecar_token_state(
+        bind="127.0.0.1",
+        port=8789,
+        token="current-token",
+        pid=0,
+    )
+
+    path = tmp_path / "photon" / "sidecar-token.json"
+    photon_adapter._clear_sidecar_token_state("other-token")
+    assert path.exists()
+
+    photon_adapter._clear_sidecar_token_state("current-token")
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- expose lightweight CLI commands for deferred bundled platform plugins so `hermes photon status` works
- persist the gateway-owned Photon sidecar loopback token in a 0600 profile-local runtime file for standalone/cron delivery
- retry transient Photon upstream send/typing failures from the sidecar

## Test Plan
- `scripts/run_tests.sh tests/plugins/test_photon_platform_fixes.py -v`
- `python3 -m py_compile hermes_cli/plugins.py plugins/platforms/photon/adapter.py`
- `node --check plugins/platforms/photon/sidecar/index.mjs`
- live checked `hermes photon status` and `hermes send --to photon ... --json` locally