### PR TITLE
[codex] Keep OpenRouter auxiliary token caps

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5733,7 +5733,12 @@ def _build_call_kwargs(
         # models reject it entirely with error 1210). Omitting it sidesteps all of
         # those wire-format quirks at once.
         #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
+        # OpenRouter is an exception: its fallback default can be the model's
+        # full output window, so explicit auxiliary caps (notably short title
+        # generation) must survive. Use the shared helper because OpenRouter can
+        # proxy models with different token-parameter spellings.
+        #
+        # Anthropic Messages wire (MiniMax and any
         # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
         # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
         # there.
@@ -5751,7 +5756,13 @@ def _build_call_kwargs(
             _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
-        if (
+        _is_openrouter = (
+            _provider_norm == "openrouter"
+            or base_url_host_matches(_effective_base, "openrouter.ai")
+        )
+        if _is_openrouter:
+            kwargs.update(auxiliary_max_tokens_param(max_tokens, model=model))
+        elif (
             _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim
         ):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -185,7 +185,6 @@ class TestBuildCallKwargsMaxTokens:
             ("copilot", "gpt-5.4", "https://api.githubcopilot.com"),
             ("copilot", "gpt-5.5", "https://api.githubcopilot.com"),
             ("custom", "gpt-5", "https://api.openai.com/v1"),
-            ("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1"),
             ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1"),
             ("custom", "qwen", "http://localhost:8080/v1"),
             ("zai", "glm-4v-flash", "https://open.bigmodel.cn/api/paas/v4"),
@@ -235,6 +234,39 @@ class TestBuildCallKwargsMaxTokens:
             base_url="https://integrate.api.nvidia.com/v1",
         )
         assert kwargs["max_tokens"] == 4096
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            ("openrouter", "google/gemini-3-flash-preview", "https://openrouter.ai/api/v1"),
+            ("custom", "google/gemini-3-flash-preview", "https://openrouter.ai/api/v1"),
+        ],
+    )
+    def test_keeps_explicit_max_tokens_for_openrouter(self, provider, model, base_url):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+            base_url=base_url,
+        )
+        assert kwargs["max_tokens"] == 500
+        assert "max_completion_tokens" not in kwargs
+
+    def test_openrouter_openai_family_uses_max_completion_tokens(self):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="openrouter",
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert kwargs["max_completion_tokens"] == 500
+        assert "max_tokens" not in kwargs
 
 
 class TestNousTagsScoping:


### PR DESCRIPTION
Fixes #56901.

## Summary
- preserve explicit auxiliary `max_tokens` caps for OpenRouter provider/base URL calls
- reuse `auxiliary_max_tokens_param()` so OpenRouter-hosted OpenAI-family models still use `max_completion_tokens`
- add regression coverage for named OpenRouter and custom OpenRouter base URLs

## Reproduction
Before this change, `_build_call_kwargs(provider="openrouter", model="google/gemini-3-flash-preview", max_tokens=500, base_url="https://openrouter.ai/api/v1")` omitted both token-limit kwargs.

## Tests
- `uv run --extra dev python -m pytest -q tests/agent/test_auxiliary_client.py::TestBuildCallKwargsMaxTokens -o addopts=`
- `uv run --extra dev ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q -o addopts=`