### PR TITLE
[codex] Treat leaked Codex shell JSON as incomplete

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -71,6 +71,38 @@ _TOOL_CALL_LEAK_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Codex can also leak its CLI shell-call serialization as assistant text, e.g.
+# ``{"cmd": "mkdir -p /c/Temp && ..."}``, instead of emitting a structured
+# Responses ``function_call`` item.  Keep this strict: the JSON object must sit
+# at a line boundary and run to the end of the assistant text.
+_CODEX_SHELL_JSON_LEAK_PATTERN = re.compile(
+    r'(?:^|\n)\s*\{\s*"cmd"\s*:\s*"(?:\\.|[^"\\])*"'
+    r'(?:\s*,\s*"[A-Za-z_][\w-]*"\s*:\s*(?:"(?:\\.|[^"\\])*"|true|false|null|-?\d+(?:\.\d+)?))*'
+    r'\s*\}\s*$',
+    re.DOTALL,
+)
+_CODEX_SHELL_JSON_LEAK_LEADIN_PATTERN = re.compile(
+    r"^(?:sure,\s*)?(?:(?:now\s+)?"
+    r"(?:creating|writing|running|executing|checking|verifying|updating|installing|editing|making)\b|"
+    r"let\s+me\s+(?:create|write|run|execute|check|verify|update|install|edit|make)\b|"
+    r"i(?:'|’)?ll\s+(?:create|write|run|execute|check|verify|update|install|edit|make)\b|"
+    r"i\s+will\s+(?:create|write|run|execute|check|verify|update|install|edit|make)\b|"
+    r"i(?:'|’)?m\s+(?:creating|writing|running|executing|checking|verifying|updating|installing|editing|making)\b|"
+    r"i\s+am\s+(?:creating|writing|running|executing|checking|verifying|updating|installing|editing|making)\b)",
+    re.IGNORECASE,
+)
+
+
+def _has_codex_shell_json_leak(text: str) -> bool:
+    match = _CODEX_SHELL_JSON_LEAK_PATTERN.search(text)
+    if not match:
+        return False
+    lead_in = text[:match.start()].strip()
+    if not lead_in:
+        return False
+    previous_line = lead_in.splitlines()[-1].strip()
+    return bool(_CODEX_SHELL_JSON_LEAK_LEADIN_PATTERN.search(previous_line))
+
 
 # ---------------------------------------------------------------------------
 # Multimodal content helpers
@@ -1292,7 +1324,10 @@ def _normalize_codex_response(
     # ``function_call`` item. The existing loop already handles message
     # append, dedup, and retry budget.
     leaked_tool_call_text = False
-    if final_text and not tool_calls and _TOOL_CALL_LEAK_PATTERN.search(final_text):
+    if final_text and not tool_calls and (
+        _TOOL_CALL_LEAK_PATTERN.search(final_text)
+        or _has_codex_shell_json_leak(final_text)
+    ):
         leaked_tool_call_text = True
         logger.warning(
             "Codex response contains leaked tool-call text in assistant content "
@@ -1301,9 +1336,11 @@ def _normalize_codex_response(
             final_text[:300],
         )
         # Clear the text so downstream code doesn't surface the garbage as
-        # a summary. The encrypted reasoning items (if any) are preserved
-        # so the model keeps its chain-of-thought on the retry.
+        # a summary or replay it as a completed assistant message. The
+        # encrypted reasoning items (if any) are preserved so the model keeps
+        # its chain-of-thought on the retry.
         final_text = ""
+        message_items_raw = []
 
     assistant_message = SimpleNamespace(
         content=final_text,

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -139,6 +139,154 @@ def test_normalize_codex_response_in_progress_message_still_incomplete():
     assert finish_reason == "incomplete"
 
 
+def test_normalize_codex_response_treats_codex_shell_json_leak_as_incomplete():
+    """Codex occasionally leaks CLI-style shell JSON as assistant text.
+
+    That text is not a final answer and no tool has run, so the adapter must
+    route it through the incomplete continuation path instead of displaying the
+    JSON to the user as if it executed.
+    """
+    response = SimpleNamespace(
+        status="completed",
+        incomplete_details=None,
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(
+                    type="output_text",
+                    text='Creating the file now.\n{"cmd": "mkdir -p /c/Temp && echo hi > /c/Temp/x.txt"}',
+                )],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+    assert assistant_message.content == ""
+    assert assistant_message.tool_calls == []
+    assert assistant_message.codex_message_items is None
+
+
+def test_normalize_codex_response_treats_polite_action_shell_json_as_incomplete():
+    response = SimpleNamespace(
+        status="completed",
+        incomplete_details=None,
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(
+                    type="output_text",
+                    text='Sure, creating the file now.\n{"cmd": "mkdir -p /c/Temp"}',
+                )],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+    assert assistant_message.content == ""
+    assert assistant_message.codex_message_items is None
+
+
+def test_normalize_codex_response_drops_harmony_leak_from_replay_items():
+    response = SimpleNamespace(
+        status="completed",
+        incomplete_details=None,
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(
+                    type="output_text",
+                    text='assistant to=functions.terminal {"command": "echo hi"}',
+                )],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+    assert assistant_message.content == ""
+    assert assistant_message.codex_message_items is None
+
+
+def test_normalize_codex_response_allows_explicit_cmd_json_answer():
+    response = SimpleNamespace(
+        status="completed",
+        incomplete_details=None,
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(
+                    type="output_text",
+                    text='{"cmd": "npm test"}',
+                )],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == '{"cmd": "npm test"}'
+
+
+def test_normalize_codex_response_allows_documented_cmd_json_payload():
+    response = SimpleNamespace(
+        status="completed",
+        incomplete_details=None,
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(
+                    type="output_text",
+                    text='Use this payload when creating the job:\n{"cmd": "npm test"}',
+                )],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == 'Use this payload when creating the job:\n{"cmd": "npm test"}'
+
+
+def test_normalize_codex_response_allows_explanatory_im_returning_cmd_json():
+    response = SimpleNamespace(
+        status="completed",
+        incomplete_details=None,
+        output=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(
+                    type="output_text",
+                    text='I\'m returning the payload you asked for:\n{"cmd": "npm test"}',
+                )],
+            ),
+        ],
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == 'I\'m returning the payload you asked for:\n{"cmd": "npm test"}'
+
+
 # ---------------------------------------------------------------------------
 # _preflight_codex_api_kwargs — built-in (provider-executed) tools must pass
 # through validation.  Regression guard for the xAI native web_search


### PR DESCRIPTION
Fixes #56920.

## Summary
- detect Codex CLI-style shell JSON leaked as assistant text after an action lead-in
- route that response through the existing incomplete/continuation path instead of showing the JSON as a final answer
- clear replay message items for leaked tool-call text, while preserving false-positive cases where `{"cmd": ...}` is the requested answer payload

## Provenance
This is cherry-picked from minhngoc25a/hermes-agent `fix/codex-shell-json-tool-leak` (commit `30c7efbc2311a6bcf4d80ac5bf6a5ba645ce1ce4`) so the original author is preserved.

## Tests
- `uv run --extra dev python -m pytest -q tests/agent/test_codex_responses_adapter.py -o addopts=`
- `uv run --extra dev ruff check agent/codex_responses_adapter.py tests/agent/test_codex_responses_adapter.py`
- `scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py -q -o addopts=`