### PR TITLE
fix(auxiliary): preserve OpenRouter max_tokens for title generation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5738,6 +5738,13 @@ def _build_call_kwargs(
         # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
         # there.
         #
+        # OpenRouter is another exception: omitting max_tokens makes OpenRouter
+        # apply its own route/output default (observed as 65536 on some routes),
+        # so small auxiliary calls such as title generation can trip free-tier
+        # output limits even though the caller explicitly requested a tiny cap.
+        # OpenRouter accepts the standard OpenAI-compatible max_tokens field, so
+        # preserve explicit auxiliary caps there.
+        #
         # NVIDIA NIM (integrate.api.nvidia.com and local NIM endpoints) is a
         # second exception: some models—notably minimaxai/minimax-m3—return HTTP
         # 200 with an empty choices[] payload when max_tokens is omitted. The main
@@ -5751,8 +5758,13 @@ def _build_call_kwargs(
             _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
+        _is_openrouter = (
+            _provider_norm == "openrouter"
+            or base_url_host_matches(_effective_base, "openrouter.ai")
+        )
         if (
             _is_anthropic_compat_endpoint(provider, _effective_base)
+            or _is_openrouter
             or _is_nvidia_nim
         ):
             kwargs["max_tokens"] = max_tokens

--- a/tests/agent/test_unsupported_temperature_retry.py
+++ b/tests/agent/test_unsupported_temperature_retry.py
@@ -30,6 +30,7 @@ import pytest
 from agent.auxiliary_client import (
     call_llm,
     async_call_llm,
+    _build_call_kwargs,
     _is_unsupported_temperature_error,
 )
 
@@ -72,6 +73,32 @@ def _dummy_response():
     # response.choices[0].message.  The tests here patch that out, so
     # any sentinel object is fine.
     return {"ok": True}
+
+
+def test_build_call_kwargs_preserves_openrouter_max_tokens():
+    """Explicit aux output caps must reach OpenRouter instead of using its route default."""
+
+    kwargs = _build_call_kwargs(
+        "openrouter",
+        "z-ai/glm-5.2",
+        [{"role": "user", "content": "title"}],
+        max_tokens=500,
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert kwargs["max_tokens"] == 500
+
+
+def test_build_call_kwargs_still_omits_generic_openai_compat_max_tokens():
+    kwargs = _build_call_kwargs(
+        "custom",
+        "local-model",
+        [{"role": "user", "content": "summarize"}],
+        max_tokens=500,
+        base_url="https://example.test/v1",
+    )
+
+    assert "max_tokens" not in kwargs
 
 
 class TestCallLlmUnsupportedTemperatureRetry:


### PR DESCRIPTION
Fixes #56901.\n\nWhen auxiliary calls fall back to OpenRouter, keep the caller's explicit max_tokens cap instead of omitting it and letting OpenRouter apply a large route default. This prevents small title-generation calls from failing free-tier output limits with an unexpected 65536-token request.\n\nTests: scripts/run_tests.sh tests/agent/test_unsupported_temperature_retry.py