### PR TITLE
fix(desktop): add styled tooltips to user message action buttons

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -54,6 +54,7 @@ import {
   USER_BUBBLE_BASE_CLASS
 } from '@/components/assistant-ui/thread/user-message'
 import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { attachmentDisplayText, attachmentId, pathLabel } from '@/lib/chat-runtime'
@@ -677,22 +678,23 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
                 {copy.attachingFile}
               </span>
             )}
-            <button
-              aria-label={copy.sendEdited}
-              className={cn('absolute right-2 bottom-2 size-5', USER_ACTION_ICON_BUTTON_CLASS)}
-              disabled={!canSubmit || submitting || staging}
-              onClick={() => {
-                const editor = editorRef.current
+            <Tip label={copy.sendEdited} side="top">
+              <button
+                aria-label={copy.sendEdited}
+                className={cn('absolute right-2 bottom-2 size-5', USER_ACTION_ICON_BUTTON_CLASS)}
+                disabled={!canSubmit || submitting || staging}
+                onClick={() => {
+                  const editor = editorRef.current
 
-                if (editor) {
-                  submitEdit(editor)
-                }
-              }}
-              title={copy.sendEdited}
-              type="button"
-            >
-              {submitting ? StopGlyph : <Codicon name="arrow-up" size={USER_ACTION_ICON_SIZE} />}
-            </button>
+                  if (editor) {
+                    submitEdit(editor)
+                  }
+                }}
+                type="button"
+              >
+                {submitting ? StopGlyph : <Codicon name="arrow-up" size={USER_ACTION_ICON_SIZE} />}
+              </button>
+            </Tip>
           </div>
         </div>
       </StickyHumanMessageContainer>

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -6,6 +6,7 @@ import { messageAttachmentRefs, messageContentText } from '@/components/assistan
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { UserMessageText } from '@/components/assistant-ui/thread/user-message-text'
 import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -280,57 +281,60 @@ export const UserMessage: FC<{
               ) : (
                 // Always editable — clicking opens the edit composer even while a
                 // turn streams; sending the edit reverts (interrupt + rewind).
-                <ActionBarPrimitive.Edit asChild>
-                  <button
-                    aria-label={copy.editMessage}
-                    className={bubbleClassName}
-                    onClick={() => triggerHaptic('selection')}
-                    onPointerDown={() => notifyThreadEditOpen()}
-                    title={copy.editMessage}
-                    type="button"
-                  >
-                    {bubbleContent}
-                  </button>
-                </ActionBarPrimitive.Edit>
+                <Tip label={copy.editMessage} side="bottom">
+                  <ActionBarPrimitive.Edit asChild>
+                    <button
+                      aria-label={copy.editMessage}
+                      className={bubbleClassName}
+                      onClick={() => triggerHaptic('selection')}
+                      onPointerDown={() => notifyThreadEditOpen()}
+                      type="button"
+                    >
+                      {bubbleContent}
+                    </button>
+                  </ActionBarPrimitive.Edit>
+                </Tip>
               )}
               {(showStop || showRestore) && (
                 <div className="pointer-events-none absolute right-2 bottom-2 z-10 flex items-center justify-center opacity-0 transition-opacity group-hover/user-message:opacity-100 group-focus-within/user-message:opacity-100">
                   {showStop ? (
-                    <button
-                      aria-label={copy.stop}
-                      className={cn('pointer-events-auto size-5', USER_ACTION_ICON_BUTTON_CLASS)}
-                      onClick={event => {
-                        event.preventDefault()
-                        event.stopPropagation()
-                        void onCancel?.()
-                      }}
-                      title={copy.stop}
-                      type="button"
-                    >
-                      {StopGlyph}
-                    </button>
+                    <Tip label={copy.stop} side="top">
+                      <button
+                        aria-label={copy.stop}
+                        className={cn('pointer-events-auto size-5', USER_ACTION_ICON_BUTTON_CLASS)}
+                        onClick={event => {
+                          event.preventDefault()
+                          event.stopPropagation()
+                          void onCancel?.()
+                        }}
+                        type="button"
+                      >
+                        {StopGlyph}
+                      </button>
+                    </Tip>
                   ) : (
-                    <button
-                      aria-label={copy.restoreCheckpoint}
-                      className={cn('pointer-events-auto size-6', USER_ACTION_ICON_BUTTON_CLASS)}
-                      onClick={event => {
-                        event.preventDefault()
-                        event.stopPropagation()
-                        triggerHaptic('selection')
-                        onRequestRestoreConfirm?.(messageId, {
-                          text: messageText,
-                          userOrdinal: runtimeUserOrdinal
-                        })
-                      }}
-                      onPointerDown={event => {
-                        event.preventDefault()
-                        event.stopPropagation()
-                      }}
-                      title={copy.restoreFromHere}
-                      type="button"
-                    >
-                      <Codicon name="discard" size="0.875rem" />
-                    </button>
+                    <Tip label={copy.restoreFromHere} side="top">
+                      <button
+                        aria-label={copy.restoreCheckpoint}
+                        className={cn('pointer-events-auto size-6', USER_ACTION_ICON_BUTTON_CLASS)}
+                        onClick={event => {
+                          event.preventDefault()
+                          event.stopPropagation()
+                          triggerHaptic('selection')
+                          onRequestRestoreConfirm?.(messageId, {
+                            text: messageText,
+                            userOrdinal: runtimeUserOrdinal
+                          })
+                        }}
+                        onPointerDown={event => {
+                          event.preventDefault()
+                          event.stopPropagation()
+                        }}
+                        type="button"
+                      >
+                        <Codicon name="discard" size="0.875rem" />
+                      </button>
+                    </Tip>
                   )}
                 </div>
               )}


### PR DESCRIPTION
## What does this PR do?
Replaces native browser `title=` tooltips with the app's styled `<Tip>` component on the user message bubble's action buttons, Edit message, Stop, and Restore checkpoint, as well as the Send edited message button in the inline edit composer. Same fix pattern as #56520, applied here to the remaining native tooltips in the user message thread.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/src/components/assistant-ui/thread/user-message.tsx` - replaced native `title=` with `<Tip label={...} side="bottom">` on the Edit message button (whole bubble), and `<Tip label={...} side="top">` on the Stop and Restore checkpoint icon buttons
- `apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx` - replaced native `title=` with `<Tip label={copy.sendEdited} side="top">` on the Send edited message button

## How to Test
1. Launch the desktop app and open any session with at least one user message
2. Hover over a sent user message bubble — verify a styled dark tooltip reading "Edit message" appears below the bubble (not the native browser tooltip)
3. While a response is streaming, hover the Stop icon on the latest user message — verify a styled tooltip appears above it
4. On an older user message (not currently streaming), hover the Restore checkpoint icon — verify a styled tooltip appears above it
5. Click a user message to open the inline edit composer, hover the send (arrow-up) button — verify a styled tooltip reading "Send edited message" appears above it
6. Verify clicking each button still triggers its existing behavior (edit opens, stop cancels the run, restore prompts confirmation, send submits the edit) — no functional regressions, tooltip-only change

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills
N/A

## Screenshots / Logs

<img width="640" height="128" alt="user-message 1" src="https://github.com/user-attachments/assets/3e8314b1-9e4e-45bf-acb8-1b795815705f" />

<img width="640" height="144" alt="user-message 2" src="https://github.com/user-attachments/assets/638542cf-1842-470f-9dfe-2b19a04def71" />
