### PR TITLE
fix(doctor): recognize Vertex provider profiles

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -754,6 +754,16 @@ def run_doctor(args):
                 _resolve_auth_provider = None
                 pass
             try:
+                from providers import list_providers as _list_provider_profiles
+
+                known_providers.update(
+                    str(profile.name).strip().lower()
+                    for profile in _list_provider_profiles()
+                    if str(getattr(profile, "name", "")).strip()
+                )
+            except Exception:
+                pass
+            try:
                 from hermes_cli.config import get_compatible_custom_providers as _compatible_custom_providers
                 from hermes_cli.providers import (
                     normalize_provider as _normalize_catalog_provider,
@@ -810,6 +820,12 @@ def run_doctor(args):
             ):
                 provider_def = _resolve_provider_full(provider, user_providers, custom_providers)
                 catalog_provider = provider_def.id if provider_def is not None else None
+                if catalog_provider is None and provider in known_providers:
+                    # Some runtime providers (for example Vertex) are registered
+                    # as ProviderProfile entries rather than model-catalog
+                    # providers. They are valid even when resolve_provider_full()
+                    # has no catalog object for them.
+                    catalog_provider = provider
                 if catalog_provider is not None:
                     provider_ids_to_accept.add(catalog_provider)
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -469,6 +469,44 @@ def test_run_doctor_accepts_bare_custom_provider(monkeypatch, tmp_path):
     assert "model.provider 'custom' is not a recognised provider" not in out
 
 
+def test_run_doctor_accepts_vertex_provider_profile(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: vertex\n"
+        "  default: google/gemini-3-flash-preview\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert "model.provider 'vertex' is not a recognised provider" not in out
+    assert "model.provider 'vertex' is unknown" not in out
+
+
 def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #56906.\n\n
┌─────────────────────────────────────────────────────────┐
│                 🩺 Hermes Doctor                        │
└─────────────────────────────────────────────────────────┘

◆ Security Advisories
  ✓ No active security advisories

◆ MCP Server Security
  ✓ No suspicious MCP stdio commands

◆ Python Environment
  ✓ Python 3.11.15
  ✓ Virtual environment active
  ✓ Version files consistent (0.18.0)

◆ SSL / CA Certificates
  ✓ SSL CA certificate bundle is valid

◆ Required Packages
  ✓ OpenAI SDK
  ✓ Rich (terminal UI)
  ✓ python-dotenv
  ✓ PyYAML
  ✓ HTTPX
  ✓ Croniter (cron expressions) (optional)
  ⚠ python-telegram-bot (optional, not installed)
  ✓ discord.py (optional)

◆ Configuration Files
  ✓ ~/.hermes/.env file exists
  ✓ API key or custom endpoint configured
  ✓ ~/.hermes/config.yaml exists
  ✓ Config version up to date (v32)

◆ xAI Model Retirement (May 15, 2026)
  ✓ No retired xAI models in config

◆ Auth Providers
  ⚠ Nous Portal auth (not logged in)
  ✓ OpenAI Codex auth (logged in)
  ⚠ MiniMax OAuth (not logged in)
  ⚠ xAI OAuth (not logged in)
    → No xAI OAuth credentials stored. Select xAI Grok OAuth (SuperGrok / Premium+) in `hermes model`.

◆ Directory Structure
  ✓ ~/.hermes directory exists
  ✓ ~/.hermes/cron/ exists
  ✓ ~/.hermes/sessions/ exists
  ✓ ~/.hermes/logs/ exists
  ✓ ~/.hermes/skills/ exists
  ✓ ~/.hermes/memories/ exists
  ✓ ~/.hermes/SOUL.md exists (persona configured)
  ✓ ~/.hermes/memories/ directory exists
  ✓ MEMORY.md exists (2110 chars)
  ✓ USER.md exists (1165 chars)
  ✓ ~/.hermes/state.db exists (93 sessions)

◆ Gateway Service
  ✓ Systemd linger enabled (gateway service survives logout)

◆ Command Installation
  ✓ Venv entry point exists (venv/bin/hermes)
  ✓ ~/.local/bin/hermes → correct target

◆ External Tools
  ✓ git
  ✓ ripgrep (rg) (faster file search)
    → Running inside a container — using local terminal backend (docker-in-docker is not configured by default)
  ✓ docker (optional)
  ✓ Node.js
  ⚠ agent-browser not installed (run: npm install)
  ✓ Browser tools (agent-browser) deps (no known vulnerabilities)
  ✓ web workspace deps (no known vulnerabilities)
  ✓ ui-tui workspace deps (no known vulnerabilities)

◆ API Connectivity
  Running 26 connectivity checks in parallel…                                                                        ✓ OpenRouter API
  ✓ OpenCode Zen        
  ✓ OpenCode Go          (key configured)

◆ Tool Availability
  ✓ browser
  ✓ clarify
  ✓ code_execution
  ✓ cronjob
  ✓ delegation
  ✓ discord
  ✓ discord_admin
  ✓ file
  ✓ image_gen
  ✓ memory
  ✓ project
  ✓ session_search
  ✓ skills
  ✓ terminal
  ✓ todo
  ✓ tts
  ✓ video
  ✓ vision
  ✓ web
  ✓ kanban (runtime-gated; loaded only for dispatcher-spawned workers)
  ⚠ browser-cdp (system dependency not met)
  ⚠ computer_use (system dependency not met)
  ⚠ feishu_doc (system dependency not met)
  ⚠ feishu_drive (system dependency not met)
  ⚠ hermes-yuanbao (system dependency not met)
  ⚠ homeassistant (system dependency not met)
  ⚠ spotify (system dependency not met)
  ⚠ video_gen (system dependency not met)
  ⚠ x_search (missing XAI_API_KEY)

◆ Skills Hub
  ⚠ Skills Hub directory not initialized (run: hermes skills list)
  ⚠ No GITHUB_TOKEN (60 req/hr rate limit — set in ~/.hermes/.env for better rates)

◆ Memory Provider
  ✓ ariadne provider active

────────────────────────────────────────────────────────────
  All checks passed! 🎉 built its valid-provider set from API-key auth providers plus model-catalog providers, which missed runtime-only ProviderProfile entries such as Vertex. This adds ProviderProfile names to the accepted set and treats profile-only providers as valid even when they have no model-catalog object.\n\nTests: scripts/run_tests.sh tests/hermes_cli/test_doctor.py tests/hermes_cli/test_vertex_provider.py