### PR TITLE
fix(google-chat): reject unauthorized senders before attachment processing

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1270,6 +1270,12 @@ class GoogleChatAdapter(BasePlatformAdapter):
         Everything else flows to ``handle_message`` as normal.
         """
         try:
+            if not self._sender_authorized_before_side_effects(msg, envelope):
+                logger.info(
+                    "[GoogleChat] rejecting unauthorized sender before attachment/thread processing"
+                )
+                return
+
             event = await self._build_message_event(msg, envelope)
             if event is None:
                 return
@@ -1299,6 +1305,72 @@ class GoogleChatAdapter(BasePlatformAdapter):
             await self.handle_message(event)
         except Exception:
             logger.exception("[GoogleChat] _dispatch_message failed")
+
+    @staticmethod
+    def _google_chat_auth_env_configured() -> bool:
+        def _env_value(name: str) -> str:
+            try:
+                from hermes_cli.config import get_env_value
+                value = get_env_value(name)
+            except Exception:
+                value = None
+            if value is None:
+                value = os.getenv(name, "")
+            return str(value or "").strip()
+
+        if _env_value("GOOGLE_CHAT_ALLOW_ALL_USERS").lower() in {"1", "true", "yes"}:
+            return False
+        return bool(
+            _env_value("GOOGLE_CHAT_ALLOWED_USERS")
+            or _env_value("GATEWAY_ALLOWED_USERS")
+        )
+
+    def _sender_authorized_before_side_effects(
+        self,
+        msg: Dict[str, Any],
+        envelope: Dict[str, Any],
+    ) -> bool:
+        """Check configured allowlists before downloads or thread-state writes.
+
+        ``handle_message()`` performs the normal gateway authorization, but
+        Google Chat has to download attachments and update its persistent
+        thread-count heuristic while building ``MessageEvent``. When an
+        allowlist is configured, reject unauthorized senders before those
+        side effects happen.
+        """
+        if not self._google_chat_auth_env_configured():
+            return True
+
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if not callable(auth_fn):
+            return True
+
+        space = envelope.get("space") or msg.get("space") or {}
+        space_name = space.get("name") or ""
+        space_type = (space.get("type") or space.get("spaceType") or "").upper()
+        chat_type = "dm" if space_type in {"DIRECT_MESSAGE", "DM"} else "group"
+        sender = msg.get("sender") or {}
+        sender_name = sender.get("name") or ""
+        sender_email = sender.get("email") or ""
+        sender_display = sender.get("displayName") or sender_email or sender_name
+        source = self.build_source(
+            chat_id=space_name,
+            chat_name=space.get("displayName") or space.get("name") or "",
+            chat_type=chat_type,
+            user_id=(sender_email or sender_name),
+            user_name=sender_display,
+            user_id_alt=(sender_name or None),
+        )
+        try:
+            return bool(auth_fn(source))
+        except Exception:
+            logger.debug(
+                "[GoogleChat] early auth check raised for sender %s; preserving legacy flow",
+                sender_email or sender_name or "<unknown>",
+                exc_info=True,
+            )
+            return True
 
     async def _handle_setup_files_command(
         self,

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1455,6 +1455,66 @@ class TestNativeAttachmentDelivery:
 
 class TestSetupFilesSlashCommand:
     @pytest.mark.asyncio
+    async def test_allowlist_rejects_before_attachment_download(self, adapter, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CHAT_ALLOWED_USERS", "alice@example.com")
+        envelope = _make_chat_envelope(
+            text="",
+            sender_email="mallory@example.com",
+            attachments=[{
+                "contentType": "image/png",
+                "attachmentDataRef": {"resourceName": "spaces/S/messages/M/attachments/A"},
+            }],
+        )
+        msg = envelope["chat"]["messagePayload"]["message"]
+        env = envelope["chat"]["messagePayload"]
+
+        class FakeRunner:
+            def _is_user_authorized(self, source):
+                return False
+
+            async def handle(self, event):
+                return "should not run"
+
+        runner = FakeRunner()
+        adapter._message_handler = runner.handle
+        adapter._build_message_event = AsyncMock()
+        adapter._download_attachment = AsyncMock()
+
+        await adapter._dispatch_message(msg, env)
+
+        adapter._build_message_event.assert_not_called()
+        adapter._download_attachment.assert_not_called()
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_allowlist_preserves_legacy_dispatch(self, adapter, monkeypatch):
+        monkeypatch.delenv("GOOGLE_CHAT_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GOOGLE_CHAT_ALLOW_ALL_USERS", raising=False)
+        envelope = _make_chat_envelope(text="hi", sender_email="new@example.com")
+        msg = envelope["chat"]["messagePayload"]["message"]
+        env = envelope["chat"]["messagePayload"]
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source=adapter.build_source(
+                chat_id="spaces/S",
+                chat_name="DM",
+                chat_type="dm",
+                user_id="new@example.com",
+                user_name="New",
+            ),
+            raw_message=msg,
+            message_id="spaces/S/messages/M",
+        )
+        adapter._build_message_event = AsyncMock(return_value=event)
+
+        await adapter._dispatch_message(msg, env)
+
+        adapter._build_message_event.assert_awaited_once()
+        adapter.handle_message.assert_awaited_once_with(event)
+
+    @pytest.mark.asyncio
     async def test_slash_command_intercepted_before_agent(self, adapter):
         """/setup-files is bot-side admin, not agent input. The dispatch
         path must short-circuit and not call handle_message."""


### PR DESCRIPTION
## Summary

Reject unauthorized Google Chat senders before the adapter builds a `MessageEvent`.

## Why

Google Chat's `_dispatch_message()` previously called `_build_message_event()` before the normal gateway authorization path in `handle_message()`. Building the event is not side-effect free: it downloads inbound attachments through `media.download_media` / `downloadUri`, caches those bytes locally, records the sender email for later file delivery, and updates the persistent thread-count heuristic.

In deployments using `GOOGLE_CHAT_ALLOWED_USERS` or `GATEWAY_ALLOWED_USERS`, an unauthorized sender could therefore make Hermes perform Google Chat API/media work and mutate local routing state before being rejected by the runner.

This matches the pre-auth side-effect class fixed in other messaging adapters: authorization needs to happen before downloads or persistent message-routing side effects.

## Changes

- Add an early Google Chat sender authorization check before `_build_message_event()`.
- Reuse the runner's `_is_user_authorized()` decision by constructing the same minimal source identity the event builder would use.
- Only enable the early deny path when a real allowlist is configured, preserving the legacy/pairing flow for unconfigured installs.
- Keep `GOOGLE_CHAT_ALLOW_ALL_USERS` as an explicit bypass for the early allowlist gate.
- Add regression tests proving unauthorized senders do not trigger event building/attachment download, while no-allowlist deployments still dispatch normally.

## Tests

```text
python -m pytest tests/gateway/test_google_chat.py -k "allowlist_rejects_before_attachment_download or no_allowlist_preserves_legacy_dispatch" -q --timeout-method=thread
2 passed, 160 deselected

python -m ruff check plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py