### PR TITLE
feat(gateway): per-channel model and system prompt overrides (#1991 salvage, fixes #1955)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -325,13 +325,47 @@ class SessionResetPolicy:
 
 
 @dataclass
+class ChannelOverride:
+    """
+    Per-channel override for model, provider, and system prompt.
+
+    Used in config under platforms.<name>.channel_overrides[channel_id].
+    Enables different channels (e.g. Discord #daily vs #dev) to use different
+    models and personas without running separate gateway instances.
+    """
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        if self.model is not None:
+            out["model"] = self.model
+        if self.provider is not None:
+            out["provider"] = self.provider
+        if self.system_prompt is not None:
+            out["system_prompt"] = self.system_prompt
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ChannelOverride":
+        if not data:
+            return cls()
+        return cls(
+            model=data.get("model"),
+            provider=data.get("provider"),
+            system_prompt=data.get("system_prompt"),
+        )
+
+
+@dataclass
 class PlatformConfig:
     """Configuration for a single messaging platform."""
     enabled: bool = False
     token: Optional[str] = None  # Bot token (Telegram, Discord)
     api_key: Optional[str] = None  # API key if different from token
     home_channel: Optional[HomeChannel] = None
-    
+
     # Reply threading mode (Telegram/Slack)
     # - "off": Never thread replies to original message
     # - "first": Only first chunk threads to user's message (default)
@@ -345,7 +379,7 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
-    # Whether the gateway shows a "typing…" / "is thinking…" status indicator
+# Whether the gateway shows a "typing…" / "is thinking…" status indicator
     # while the agent processes a message on this platform. Default True
     # preserves prior behavior. Set False on platforms where the indicator is
     # unwanted (e.g. Slack's assistant.threads.setStatus "is thinking…", which
@@ -353,6 +387,9 @@ class PlatformConfig:
     # noisy). Drives the per-message _keep_typing refresh loop in
     # gateway/platforms/base.py.
     typing_indicator: bool = True
+
+    # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
+    channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
 
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
@@ -371,6 +408,10 @@ class PlatformConfig:
             result["api_key"] = self.api_key
         if self.home_channel:
             result["home_channel"] = self.home_channel.to_dict()
+        if self.channel_overrides:
+            result["channel_overrides"] = {
+                cid: ov.to_dict() for cid, ov in self.channel_overrides.items()
+            }
         return result
 
     @classmethod
@@ -379,7 +420,7 @@ class PlatformConfig:
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
-        # gateway_restart_notification may be bridged into extra via the
+# gateway_restart_notification may be bridged into extra via the
         # shared-key loop in load_gateway_config(); check both top-level
         # and extra so YAML ``discord: gateway_restart_notification: false``
         # works without needing a separate platforms: block.
@@ -394,14 +435,22 @@ class PlatformConfig:
         if _typing is None:
             _typing = data.get("extra", {}).get("typing_indicator")
 
+        channel_overrides: Dict[str, ChannelOverride] = {}
+        raw_overrides = data.get("channel_overrides") or {}
+        if isinstance(raw_overrides, dict):
+            for cid, ov_data in raw_overrides.items():
+                if isinstance(ov_data, dict):
+                    channel_overrides[str(cid)] = ChannelOverride.from_dict(ov_data)
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            gateway_restart_notification=_coerce_bool(_grn, True),
+gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
+            channel_overrides=channel_overrides,
             extra=data.get("extra", {}),
         )
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -379,7 +379,7 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
-# Whether the gateway shows a "typing…" / "is thinking…" status indicator
+    # Whether the gateway shows a "typing…" / "is thinking…" status indicator
     # while the agent processes a message on this platform. Default True
     # preserves prior behavior. Set False on platforms where the indicator is
     # unwanted (e.g. Slack's assistant.threads.setStatus "is thinking…", which
@@ -420,7 +420,7 @@ class PlatformConfig:
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
-# gateway_restart_notification may be bridged into extra via the
+        # gateway_restart_notification may be bridged into extra via the
         # shared-key loop in load_gateway_config(); check both top-level
         # and extra so YAML ``discord: gateway_restart_notification: false``
         # works without needing a separate platforms: block.
@@ -448,7 +448,7 @@ class PlatformConfig:
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-gateway_restart_notification=_coerce_bool(_grn, True),
+            gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
             channel_overrides=channel_overrides,
             extra=data.get("extra", {}),
@@ -1103,8 +1103,20 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 if "typing_indicator" in platform_cfg:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
+                has_channel_overrides = "channel_overrides" in platform_cfg
+                if has_channel_overrides:
+                    raw_overrides = platform_cfg.get("channel_overrides")
+                    if isinstance(raw_overrides, dict):
+                        plat_data, _extra = _ensure_platform_extra_dict(
+                            platforms_data, plat.value
+                        )
+                        plat_data["channel_overrides"] = {
+                            str(cid): ov_data
+                            for cid, ov_data in raw_overrides.items()
+                            if isinstance(ov_data, dict)
+                        }
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
-                if not bridged and not enabled_was_explicit:
+                if not bridged and not enabled_was_explicit and not has_channel_overrides:
                     continue
                 plat_data, extra = _ensure_platform_extra_dict(platforms_data, plat.value)
                 if enabled_was_explicit:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1660,6 +1660,7 @@ if not _configured_cwd or _configured_cwd in {".", "auto", "cwd"}:
     os.environ["TERMINAL_CWD"] = _fallback
 
 from gateway.config import (
+    ChannelOverride,
     Platform,
     _BUILTIN_PLATFORM_VALUES,
     GatewayConfig,
@@ -1822,6 +1823,27 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
         "max_tokens": max_tokens,
+    }
+
+
+def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
+    """Resolve runtime credentials for a specific provider (e.g. from channel override)."""
+    from hermes_cli.runtime_provider import (
+        resolve_runtime_provider,
+        format_runtime_provider_error,
+    )
+    try:
+        runtime = resolve_runtime_provider(requested=provider)
+    except Exception as exc:
+        raise RuntimeError(format_runtime_provider_error(exc)) from exc
+    return {
+        "api_key": runtime.get("api_key"),
+        "base_url": runtime.get("base_url"),
+        "provider": runtime.get("provider"),
+        "api_mode": runtime.get("api_mode"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+        "credential_pool": runtime.get("credential_pool"),
     }
 
 
@@ -2282,6 +2304,20 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     elif isinstance(model_cfg, dict):
         return model_cfg.get("default") or model_cfg.get("model") or ""
     return ""
+
+
+def _get_channel_override(
+    config: GatewayConfig,
+    platform: Platform,
+    chat_id: str,
+) -> Optional[ChannelOverride]:
+    """Return per-channel override for this platform/chat_id, or None."""
+    if not chat_id:
+        return None
+    platform_config = config.platforms.get(platform)
+    if not platform_config or not platform_config.channel_overrides:
+        return None
+    return platform_config.channel_overrides.get(str(chat_id))
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -3601,6 +3637,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 resolved_session_key, model, runtime_kwargs
             )
 
+        cfg = getattr(self, "config", None)
+        if cfg and source is not None and source.chat_id:
+            ch = _get_channel_override(cfg, source.platform, str(source.chat_id))
+            if ch:
+                channel_touch = False
+                if ch.model and not (override and override.get("model")):
+                    model = ch.model
+                    channel_touch = True
+                if ch.provider and not (override and override.get("provider")):
+                    runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(ch.provider)
+                    runtime_model = runtime_kwargs.pop("model", None)
+                    if runtime_model:
+                        model = runtime_model or model
+                    channel_touch = True
+                if channel_touch and override and resolved_session_key:
+                    model, runtime_kwargs = self._apply_session_model_override(
+                        resolved_session_key, model, runtime_kwargs
+                    )
+
         # When the config has no model.default but a provider was resolved
         # (e.g. user ran `hermes auth add openai-codex` without `hermes model`),
         # fall back to the provider's first catalog model so the API call
@@ -4472,6 +4527,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return prompt
         cfg = _load_gateway_runtime_config()
         return str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+
+    def _resolve_model_for_channel(self, platform: Platform, chat_id: str) -> str:
+        """Resolve model for this channel: channel_overrides[channel_id] else global default."""
+        config = getattr(self, "config", None)
+        if config:
+            override = _get_channel_override(config, platform, chat_id)
+            if override and override.model:
+                return override.model
+        return _resolve_gateway_model()
+
+    def _get_system_prompt_for_channel(self, platform: Platform, chat_id: str) -> str:
+        """System prompt for this channel: channel override else global ephemeral."""
+        config = getattr(self, "config", None)
+        if config:
+            override = _get_channel_override(config, platform, chat_id)
+            if override and override.system_prompt:
+                return (override.system_prompt or "").strip()
+        return getattr(self, "_ephemeral_system_prompt", None) or ""
 
     @staticmethod
     def _load_reasoning_config() -> dict | None:
@@ -16791,14 +16864,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
             
-            # Combine platform context, per-channel context, and the user-configured
-            # ephemeral system prompt.
+            # Combine platform context, YAML channel_prompts hint for this chat,
+            # channel_overrides system_prompt (or global ephemeral), and gateway
+            # ephemeral prompt from _get_system_prompt_for_channel.
             combined_ephemeral = context_prompt or ""
             event_channel_prompt = (channel_prompt or "").strip()
             if event_channel_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
-            if self._ephemeral_system_prompt:
-                combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
+            cfg_channel_prompt = self._get_system_prompt_for_channel(
+                source.platform, source.chat_id or ""
+            )
+            if cfg_channel_prompt:
+                combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()
 
             max_iterations = _current_max_iterations()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2306,18 +2306,54 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _channel_override_lookup_keys(
+    chat_id: str,
+    *,
+    thread_id: Optional[str] = None,
+    parent_id: Optional[str] = None,
+) -> list[str]:
+    """Ordered, de-duplicated keys for ``channel_overrides`` lookup.
+
+    Matches ``resolve_channel_prompt`` semantics: exact thread/channel id first,
+    then parent channel/forum id (Discord threads inherit parent overrides).
+    """
+    keys: list[str] = []
+    seen: set[str] = set()
+    for key in (chat_id, thread_id, parent_id):
+        if not key:
+            continue
+        sk = str(key)
+        if sk in seen:
+            continue
+        seen.add(sk)
+        keys.append(sk)
+    return keys
+
+
 def _get_channel_override(
     config: GatewayConfig,
     platform: Platform,
     chat_id: str,
+    *,
+    thread_id: Optional[str] = None,
+    parent_id: Optional[str] = None,
 ) -> Optional[ChannelOverride]:
-    """Return per-channel override for this platform/chat_id, or None."""
-    if not chat_id:
-        return None
+    """Return per-channel override for this platform/chat_id, or None.
+
+    Looks up ``channel_overrides`` by ``chat_id``, then ``thread_id``, then
+    ``parent_id`` (forum threads / child channels inherit the parent entry).
+    """
     platform_config = config.platforms.get(platform)
     if not platform_config or not platform_config.channel_overrides:
         return None
-    return platform_config.channel_overrides.get(str(chat_id))
+    overrides = platform_config.channel_overrides
+    for key in _channel_override_lookup_keys(
+        chat_id, thread_id=thread_id, parent_id=parent_id
+    ):
+        ov = overrides.get(key)
+        if ov is not None:
+            return ov
+    return None
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -3579,11 +3615,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: Optional[str] = None,
         user_config: Optional[dict] = None,
     ) -> tuple[str, dict]:
-        """Resolve model/runtime for a session, honoring session-scoped /model overrides.
+        """Resolve model/runtime for a session.
 
-        If the session override already contains a complete provider bundle
-        (provider/api_key/base_url/api_mode), prefer it directly instead of
-        resolving fresh global runtime state first.
+        Priority (highest first): session ``/model`` → ``channel_overrides`` →
+        global config/env (``_resolve_gateway_model(user_config)`` and default
+        provider resolution).
         """
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
@@ -3632,29 +3668,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 runtime_model,
             )
             model = runtime_model
+
+        cfg = getattr(self, "config", None)
+        if cfg and source is not None:
+            chat_id = str(source.chat_id) if source.chat_id else ""
+            thread_id = (
+                str(source.thread_id) if getattr(source, "thread_id", None) else None
+            )
+            parent_id = (
+                str(source.parent_chat_id)
+                if getattr(source, "parent_chat_id", None)
+                else None
+            )
+            ch = _get_channel_override(
+                cfg,
+                source.platform,
+                chat_id,
+                thread_id=thread_id,
+                parent_id=parent_id,
+            )
+            if ch:
+                if ch.model:
+                    model = ch.model
+                if ch.provider:
+                    runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(
+                        ch.provider
+                    )
+                    ch_runtime_model = runtime_kwargs.pop("model", None)
+                    # Only adopt the provider's bundled model when the override
+                    # did not specify an explicit model.
+                    if ch_runtime_model and not ch.model:
+                        model = ch_runtime_model
+
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs
             )
-
-        cfg = getattr(self, "config", None)
-        if cfg and source is not None and source.chat_id:
-            ch = _get_channel_override(cfg, source.platform, str(source.chat_id))
-            if ch:
-                channel_touch = False
-                if ch.model and not (override and override.get("model")):
-                    model = ch.model
-                    channel_touch = True
-                if ch.provider and not (override and override.get("provider")):
-                    runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(ch.provider)
-                    runtime_model = runtime_kwargs.pop("model", None)
-                    if runtime_model:
-                        model = runtime_model or model
-                    channel_touch = True
-                if channel_touch and override and resolved_session_key:
-                    model, runtime_kwargs = self._apply_session_model_override(
-                        resolved_session_key, model, runtime_kwargs
-                    )
 
         # When the config has no model.default but a provider was resolved
         # (e.g. user ran `hermes auth add openai-codex` without `hermes model`),
@@ -4528,20 +4577,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         cfg = _load_gateway_runtime_config()
         return str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
 
-    def _resolve_model_for_channel(self, platform: Platform, chat_id: str) -> str:
-        """Resolve model for this channel: channel_overrides[channel_id] else global default."""
+    def _resolve_model_for_channel(
+        self,
+        platform: Platform,
+        chat_id: str,
+        *,
+        user_config: Optional[dict] = None,
+        thread_id: Optional[str] = None,
+        parent_id: Optional[str] = None,
+    ) -> str:
+        """Resolve model for this channel: channel_overrides else global default."""
         config = getattr(self, "config", None)
         if config:
-            override = _get_channel_override(config, platform, chat_id)
+            override = _get_channel_override(
+                config,
+                platform,
+                chat_id,
+                thread_id=thread_id,
+                parent_id=parent_id,
+            )
             if override and override.model:
                 return override.model
-        return _resolve_gateway_model()
+        return _resolve_gateway_model(user_config)
 
-    def _get_system_prompt_for_channel(self, platform: Platform, chat_id: str) -> str:
-        """System prompt for this channel: channel override else global ephemeral."""
+    def _get_system_prompt_for_channel(
+        self,
+        platform: Platform,
+        chat_id: str,
+        *,
+        thread_id: Optional[str] = None,
+        parent_id: Optional[str] = None,
+    ) -> str:
+        """Ephemeral system prompt for this channel/thread.
+
+        Uses ``channel_overrides`` when set, else the global gateway prompt.
+        Legacy ``channel_prompts`` are applied separately via ``event.channel_prompt``
+        in ``run_sync`` (adapter ``resolve_channel_prompt``), so they are not
+        duplicated here.
+        """
         config = getattr(self, "config", None)
         if config:
-            override = _get_channel_override(config, platform, chat_id)
+            override = _get_channel_override(
+                config,
+                platform,
+                chat_id,
+                thread_id=thread_id,
+                parent_id=parent_id,
+            )
             if override and override.system_prompt:
                 return (override.system_prompt or "").strip()
         return getattr(self, "_ephemeral_system_prompt", None) or ""
@@ -16872,7 +16954,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if event_channel_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
             cfg_channel_prompt = self._get_system_prompt_for_channel(
-                source.platform, source.chat_id or ""
+                source.platform,
+                source.chat_id or "",
+                thread_id=getattr(source, "thread_id", None),
+                parent_id=getattr(source, "parent_chat_id", None),
             )
             if cfg_channel_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2343,7 +2343,10 @@ def _get_channel_override(
     Looks up ``channel_overrides`` by ``chat_id``, then ``thread_id``, then
     ``parent_id`` (forum threads / child channels inherit the parent entry).
     """
-    platform_config = config.platforms.get(platform)
+    platforms = getattr(config, "platforms", None)
+    if not platforms:
+        return None
+    platform_config = platforms.get(platform)
     if not platform_config or not platform_config.channel_overrides:
         return None
     overrides = platform_config.channel_overrides

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -917,6 +917,7 @@ AUTHOR_MAP = {
     "fr@tecompanytea.com": "ifrederico",
     "cdanis@gmail.com": "cdanis",
     "samherring99@gmail.com": "samherring99",
+    "sampiyonyus@gmail.com": "crazywriter1",
     "desaiaum08@gmail.com": "Aum08Desai",
     "shannon.sands.1979@gmail.com": "shannonsands",
     "shannon@nousresearch.com": "shannonsands",

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -1,0 +1,128 @@
+"""Tests for per-channel model and system prompt overrides (Fixes #1955)."""
+
+import pytest
+
+from gateway.config import (
+    ChannelOverride,
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+)
+from gateway.run import _get_channel_override, GatewayRunner
+
+
+class TestGetChannelOverride:
+    def test_no_override_when_empty_config(self):
+        config = GatewayConfig()
+        assert _get_channel_override(config, Platform.DISCORD, "123") is None
+
+    def test_no_override_when_platform_not_configured(self):
+        config = GatewayConfig(platforms={})
+        assert _get_channel_override(config, Platform.DISCORD, "123") is None
+
+    def test_no_override_when_channel_not_in_overrides(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "999": ChannelOverride(model="openrouter/healer-alpha"),
+                    },
+                ),
+            },
+        )
+        assert _get_channel_override(config, Platform.DISCORD, "123") is None
+
+    def test_returns_override_when_channel_matches(self):
+        ov = ChannelOverride(
+            model="openrouter/healer-alpha",
+            provider="openrouter",
+            system_prompt="You are a summarizer.",
+        )
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={"1234567890": ov},
+                ),
+            },
+        )
+        result = _get_channel_override(config, Platform.DISCORD, "1234567890")
+        assert result is not None
+        assert result.model == "openrouter/healer-alpha"
+        assert result.provider == "openrouter"
+        assert result.system_prompt == "You are a summarizer."
+
+    def test_returns_override_when_chat_id_is_int_like(self):
+        """Caller may pass str(chat_id); override keys are normalized to str."""
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={"123": ChannelOverride(model="gpt-4")},
+                ),
+            },
+        )
+        assert _get_channel_override(config, Platform.DISCORD, "123").model == "gpt-4"
+
+
+class TestResolveModelForChannel:
+    def test_uses_channel_override_when_present(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(model="anthropic/claude-opus-4.6"),
+                    },
+                ),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        model = runner._resolve_model_for_channel(Platform.DISCORD, "chan_1")
+        assert model == "anthropic/claude-opus-4.6"
+
+    def test_falls_back_to_global_when_no_override(self, monkeypatch):
+        monkeypatch.setattr(
+            "gateway.run._resolve_gateway_model",
+            lambda: "global-model/default",
+        )
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(enabled=True, channel_overrides={}),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        model = runner._resolve_model_for_channel(Platform.DISCORD, "unknown_channel")
+        assert model == "global-model/default"
+
+
+class TestGetSystemPromptForChannel:
+    def test_uses_channel_override_when_present(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(system_prompt="You are a coding assistant."),
+                    },
+                ),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner._ephemeral_system_prompt = "Global prompt"
+        prompt = runner._get_system_prompt_for_channel(Platform.DISCORD, "chan_1")
+        assert prompt == "You are a coding assistant."
+
+    def test_falls_back_to_global_when_no_override(self):
+        config = GatewayConfig(
+            platforms={Platform.DISCORD: PlatformConfig(enabled=True)},
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner._ephemeral_system_prompt = "Global prompt"
+        prompt = runner._get_system_prompt_for_channel(Platform.DISCORD, "other")
+        assert prompt == "Global prompt"

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -1,5 +1,7 @@
 """Tests for per-channel model and system prompt overrides (Fixes #1955)."""
 
+from unittest.mock import patch
+
 import pytest
 
 from gateway.config import (
@@ -9,6 +11,7 @@ from gateway.config import (
     PlatformConfig,
 )
 from gateway.run import _get_channel_override, GatewayRunner
+from gateway.session import SessionSource
 
 
 class TestGetChannelOverride:
@@ -65,6 +68,60 @@ class TestGetChannelOverride:
         )
         assert _get_channel_override(config, Platform.DISCORD, "123").model == "gpt-4"
 
+    def test_thread_id_lookup_when_chat_id_misses(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "thread_99": ChannelOverride(model="topic-model"),
+                    },
+                ),
+            },
+        )
+        result = _get_channel_override(
+            config, Platform.DISCORD, "parent_chan", thread_id="thread_99"
+        )
+        assert result is not None
+        assert result.model == "topic-model"
+
+    def test_parent_id_fallback_when_thread_has_no_entry(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "parent_chan": ChannelOverride(model="parent-model"),
+                    },
+                ),
+            },
+        )
+        result = _get_channel_override(
+            config,
+            Platform.DISCORD,
+            "thread_only",
+            parent_id="parent_chan",
+        )
+        assert result is not None
+        assert result.model == "parent-model"
+
+    def test_exact_thread_overrides_parent(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "thread_1": ChannelOverride(model="thread-model"),
+                        "parent_chan": ChannelOverride(model="parent-model"),
+                    },
+                ),
+            },
+        )
+        result = _get_channel_override(
+            config, Platform.DISCORD, "thread_1", parent_id="parent_chan"
+        )
+        assert result.model == "thread-model"
+
 
 class TestResolveModelForChannel:
     def test_uses_channel_override_when_present(self):
@@ -86,7 +143,7 @@ class TestResolveModelForChannel:
     def test_falls_back_to_global_when_no_override(self, monkeypatch):
         monkeypatch.setattr(
             "gateway.run._resolve_gateway_model",
-            lambda: "global-model/default",
+            lambda _cfg=None: "global-model/default",
         )
         config = GatewayConfig(
             platforms={
@@ -126,3 +183,120 @@ class TestGetSystemPromptForChannel:
         runner._ephemeral_system_prompt = "Global prompt"
         prompt = runner._get_system_prompt_for_channel(Platform.DISCORD, "other")
         assert prompt == "Global prompt"
+
+
+class TestResolveSessionAgentRuntimePriority:
+    """Model/runtime priority: session /model → channel_overrides → global."""
+
+    def test_channel_override_beats_global(self):
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {}
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(
+                            model="channel/model",
+                            provider="openrouter",
+                        ),
+                    },
+                ),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chan_1",
+            user_id="u1",
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={
+                 "provider": "anthropic",
+                 "api_key": "k",
+                 "base_url": "https://api.anthropic.com",
+                 "api_mode": "chat_completions",
+             }), \
+             patch(
+                 "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+                 return_value={
+                     "provider": "openrouter",
+                     "api_key": "k2",
+                     "base_url": "https://openrouter.ai/api/v1",
+                     "api_mode": "chat_completions",
+                 },
+             ):
+            model, runtime = runner._resolve_session_agent_runtime(
+                source=source,
+                user_config={"model": {"default": "global/model"}},
+            )
+        assert model == "channel/model"
+        assert runtime["provider"] == "openrouter"
+
+    def test_session_model_beats_channel_override(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(model="channel/model"),
+                    },
+                ),
+            },
+        )
+        session_key = "agent:main:discord:channel:chan_1"
+        runner._session_model_overrides = {
+            session_key: {
+                "model": "session/model",
+                "provider": "anthropic",
+            },
+        }
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chan_1",
+            chat_type="channel",
+            user_id="u1",
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={
+                 "provider": "openrouter",
+                 "api_key": "k",
+                 "base_url": "https://openrouter.ai/api/v1",
+                 "api_mode": "chat_completions",
+             }):
+            model, runtime = runner._resolve_session_agent_runtime(
+                source=source,
+                session_key=session_key,
+            )
+        assert model == "session/model"
+        assert runtime["provider"] == "anthropic"
+
+    def test_parent_channel_model_inherited_in_thread(self):
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {}
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "parent_chan": ChannelOverride(model="parent/model"),
+                    },
+                ),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="thread_1",
+            chat_type="thread",
+            parent_chat_id="parent_chan",
+            user_id="u1",
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={
+                 "provider": "anthropic",
+                 "api_key": "k",
+                 "base_url": "https://api.anthropic.com",
+                 "api_mode": "chat_completions",
+             }):
+            model, _runtime = runner._resolve_session_agent_runtime(source=source)
+        assert model == "parent/model"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -5,6 +5,7 @@ import os
 from unittest.mock import patch
 
 from gateway.config import (
+    ChannelOverride,
     GatewayConfig,
     HomeChannel,
     Platform,
@@ -89,6 +90,54 @@ class TestPlatformConfigRoundtrip:
         # extra; from_dict must honor it there too (mirrors _grn fallback).
         restored = PlatformConfig.from_dict({"extra": {"typing_indicator": False}})
         assert restored.typing_indicator is False
+    def test_channel_overrides_roundtrip(self):
+        pc = PlatformConfig(
+            enabled=True,
+            channel_overrides={
+                "1234567890": ChannelOverride(
+                    model="openrouter/healer-alpha",
+                    provider="openrouter",
+                    system_prompt="You are a daily news summarizer.",
+                ),
+                "9876543210": ChannelOverride(
+                    model="anthropic/claude-opus-4.6",
+                    provider="anthropic",
+                    system_prompt="You are a coding assistant.",
+                ),
+            },
+        )
+        d = pc.to_dict()
+        assert "channel_overrides" in d
+        assert d["channel_overrides"]["1234567890"]["model"] == "openrouter/healer-alpha"
+        assert d["channel_overrides"]["9876543210"]["system_prompt"] == "You are a coding assistant."
+        restored = PlatformConfig.from_dict(d)
+        assert restored.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
+        assert restored.channel_overrides["9876543210"].provider == "anthropic"
+
+    def test_channel_overrides_from_dict_normalizes_channel_id_to_str(self):
+        """YAML may have numeric channel IDs; we store as str."""
+        data = {
+            "enabled": True,
+            "channel_overrides": {
+                1234567890: {"model": "openrouter/healer-alpha"},
+            },
+        }
+        pc = PlatformConfig.from_dict(data)
+        assert "1234567890" in pc.channel_overrides
+        assert pc.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
+
+
+class TestChannelOverride:
+    def test_from_dict_empty(self):
+        assert ChannelOverride.from_dict({}).model is None
+        assert ChannelOverride.from_dict(None).model is None
+
+    def test_to_dict_omits_none(self):
+        ov = ChannelOverride(model="gpt-4", provider=None, system_prompt="Hi")
+        d = ov.to_dict()
+        assert d["model"] == "gpt-4"
+        assert "provider" not in d
+        assert d["system_prompt"] == "Hi"
 
 
 class TestGetConnectedPlatforms:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -831,6 +831,31 @@ class TestLoadGatewayConfig:
 
         assert config.always_log_local is False
 
+    def test_bridges_discord_channel_overrides_from_top_level_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_overrides:\n"
+            '    "1234567890":\n'
+            "      model: openrouter/healer-alpha\n"
+            "      provider: openrouter\n"
+            "      system_prompt: Daily news summarizer\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        discord = config.platforms[Platform.DISCORD]
+        assert "1234567890" in discord.channel_overrides
+        ov = discord.channel_overrides["1234567890"]
+        assert ov.model == "openrouter/healer-alpha"
+        assert ov.provider == "openrouter"
+        assert ov.system_prompt == "Daily news summarizer"
+
     def test_bridges_discord_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
Gateway platforms now support per-channel model, provider, and system-prompt overrides via `channel_overrides` in config.yaml — e.g. a Discord #news channel can run a cheap flash model while #coding runs opus, without touching the global default. Fixes #1955.

Salvage of #1991 by @crazywriter1 (stale branch, 3 commits cherry-picked with authorship preserved; conflicts re-anchored against the current mixin-based `gateway/run.py` and the typing_indicator/config changes that landed since).

Priority chain: session `/model` override > channel override > global default. The override prompt is resolved from static config keyed by chat_id, so it's byte-stable for a conversation's lifetime — no prompt-cache invalidation (same mechanism as the existing `channel_prompts`).

## Changes
- `gateway/config.py`: `ChannelOverride` dataclass, `PlatformConfig.channel_overrides`, YAML bridge (`discord: channel_overrides: {chat_id: {model, provider, system_prompt}}`), numeric chat_id normalization
- `gateway/run.py`: `_get_channel_override()`, `_resolve_runtime_agent_kwargs_for_provider()`, channel layer in `_resolve_session_agent_runtime` (session /model wins), channel system prompt joined into `combined_ephemeral`
- `tests/gateway/test_channel_overrides.py` (302 lines) + `test_config.py` additions
- `scripts/release.py`: AUTHOR_MAP entry for @crazywriter1

## Validation
| | Result |
|---|---|
| tests/gateway/test_channel_overrides.py + test_config.py | 98/98 pass |
| model-switch regression suites (48031, persistence, async offload) | 97/97 pass |
| E2E (real temp HERMES_HOME, real YAML load) | override resolves for str+int chat_ids, absent channels fall through |
| ruff | clean |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa09ef6/bMVtStYlzzasv_PPTXnxw_ppp23qkP.png)

Nous Research
