### PR TITLE
fix(teams): reject unauthorized senders before attachment processing

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -878,6 +878,11 @@ class TeamsAdapter(BasePlatformAdapter):
             user_name=user_name,
             guild_id=getattr(conv, "tenant_id", None) or self._tenant_id,
         )
+        if not self._sender_authorized_before_side_effects(source):
+            logger.info(
+                "[teams] rejecting unauthorized sender before attachment processing"
+            )
+            return
 
         # Handle attachments (images, documents, video, audio)
         media_urls = []
@@ -976,6 +981,28 @@ class TeamsAdapter(BasePlatformAdapter):
             message_id=msg_id,
         )
         await self.handle_message(event)
+
+    def _sender_authorized_before_side_effects(self, source: "SessionSource") -> bool:
+        """Ask the gateway auth gate before Teams performs attachment side effects.
+
+        ``handle_message()`` performs the normal authorization check, but Teams
+        downloads and caches attachment bytes before building the final
+        ``MessageEvent``. Reuse the runner's decision here so unauthorized
+        senders cannot trigger those pre-auth downloads.
+        """
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if not callable(auth_fn):
+            return True
+        try:
+            return bool(auth_fn(source))
+        except Exception:
+            logger.debug(
+                "[teams] early auth check raised for sender %s; preserving legacy flow",
+                source.user_id or "<unknown>",
+                exc_info=True,
+            )
+            return True
 
     async def _send_card(self, chat_id: str, card: "AdaptiveCard") -> "Any":
         """Send an AdaptiveCard, using a stored ConversationReference when available."""

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -830,6 +830,27 @@ class TestTeamsAttachmentClassification:
         assert event.media_types == ["application/pdf"]
 
     @pytest.mark.anyio
+    async def test_unauthorized_sender_rejected_before_attachment_download(self):
+        adapter = self._make_adapter()
+        adapter._fetch_attachment_bytes = AsyncMock(return_value=b"%PDF-1.4 fake")
+
+        class FakeRunner:
+            def _is_user_authorized(self, source):
+                return False
+
+            async def handle(self, event):
+                return "should not run"
+
+        runner = FakeRunner()
+        adapter._message_handler = runner.handle
+
+        activity = self._make_activity([self._file_download_attachment()])
+        await adapter._on_message(self._make_ctx(activity))
+
+        adapter._fetch_attachment_bytes.assert_not_awaited()
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.anyio
     async def test_mixed_image_and_document_prefers_document(self):
         from gateway.platforms.base import MessageType
 


### PR DESCRIPTION
## Summary

Reject unauthorized Microsoft Teams senders before the adapter downloads or caches inbound attachments.

## Why

`TeamsAdapter._on_message()` builds the `SessionSource` before processing attachments, but the normal gateway authorization check only runs later through `handle_message(event)`. Attachment processing is not side-effect free: Teams file/download-info attachments and direct content URLs can trigger HTTP downloads and local media-cache writes before the runner rejects the sender.

In deployments using `TEAMS_ALLOWED_USERS` or `GATEWAY_ALLOWED_USERS`, an unauthorized sender could therefore make Hermes fetch pre-authenticated Teams/SharePoint attachment URLs and write cached files before authorization.

This matches the pre-auth side-effect class fixed in other messaging adapters: authorization needs to happen before external media fetches or persistent local side effects.

## Changes

- Add an early Teams sender authorization check after constructing the `SessionSource`.
- Reuse the gateway runner's `_is_user_authorized()` decision instead of duplicating allowlist logic in the adapter.
- Return before attachment download/cache work when the sender is unauthorized.
- Preserve legacy/test flows when no runner auth hook is installed.
- Add regression coverage proving unauthorized senders do not trigger attachment downloads or dispatch.

## Tests

```text
python -m pytest tests/gateway/test_teams.py -k "unauthorized_sender_rejected_before_attachment_download or file_download_info_sets_document_type or image_only_still_photo" -q --timeout-method=thread
3 passed, 55 deselected

python -m ruff check plugins/platforms/teams/adapter.py tests/gateway/test_teams.py