### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Problem

QQAdapter.connect() does not accept the `is_reconnect` keyword argument that the gateway passes on every reconnect attempt (see `gateway/run.py:3259`).

This causes QQBot to permanently stay in `retrying` state with:

```
QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

## Fix

Add `is_reconnect: bool = False` to `QQAdapter.connect()`, matching the `BasePlatformAdapter.connect` contract that every other adapter already follows (telegram, slack, signal, weixin, yuanbao, teams, etc.).

## Related

- `gateway/platforms/base.py:2864` — base class defines the contract
- `gateway/run.py:3259` — gateway calls `adapter.connect(is_reconnect=is_reconnect)`
- `gateway/relay/adapter.py:118` — relay adapter already fixed for the same issue (#52911)