### PR TITLE
fix(web_extract): re-check provider final URLs before storing content

### DIFF
--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -129,6 +129,44 @@ class TestEndToEnd:
         assert "para 0 " in content
         assert "para 2999 " in content
 
+    def test_web_extract_blocks_private_final_url_before_store(self, monkeypatch):
+        class FakeProvider:
+            name = "fake"
+            display_name = "Fake"
+
+            def supports_extract(self):
+                return True
+
+            async def extract(self, urls, **kwargs):
+                return [{
+                    "url": "http://169.254.169.254/latest/meta-data/",
+                    "title": "metadata",
+                    "content": "instance secret",
+                    "raw_content": "instance secret",
+                    "metadata": {
+                        "sourceURL": "http://169.254.169.254/latest/meta-data/"
+                    },
+                }]
+
+        async def safety_check(url):
+            return "169.254.169.254" not in url
+
+        store_calls = []
+        with patch("tools.web_tools._ensure_web_plugins_loaded"), \
+             patch("tools.web_tools._get_extract_backend", return_value="fake"), \
+             patch("tools.web_tools.async_is_safe_url", new=safety_check), \
+             patch("tools.web_tools._store_full_text", side_effect=store_calls.append), \
+             patch("agent.web_search_registry.get_provider", return_value=FakeProvider()):
+            result = json.loads(asyncio.new_event_loop().run_until_complete(
+                wt.web_extract_tool(["https://example.com/redirect"])
+            ))
+
+        item = result["results"][0]
+        assert item["url"] == "http://169.254.169.254/latest/meta-data/"
+        assert item["content"] == ""
+        assert "private or internal" in item["error"]
+        assert store_calls == []
+
 
 def _make_awaitable(value):
     async def _coro(*a, **k):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -776,6 +776,38 @@ async def web_extract_tool(
         if ssrf_blocked:
             results = ssrf_blocked + results
 
+        # Provider-level extractors may report a final/result URL that differs
+        # from the URL we preflighted (for example after redirects or canonical
+        # URL normalization). Firecrawl has its own redirect re-check; keep the
+        # same invariant centrally so Exa/Tavily/Parallel cannot return and
+        # store content for a private/internal final URL.
+        safe_results: List[Dict[str, Any]] = []
+        for result in results:
+            if result.get("error"):
+                safe_results.append(result)
+                continue
+            result_url = result.get("url") or result.get("metadata", {}).get("sourceURL") or ""
+            if result_url and not await async_is_safe_url(result_url):
+                logger.info(
+                    "Blocked web_extract result for unsafe final URL: %s",
+                    result_url,
+                )
+                safe_results.append(
+                    {
+                        "url": result_url,
+                        "title": result.get("title", ""),
+                        "content": "",
+                        "raw_content": "",
+                        "error": (
+                            "Blocked: URL targets a private or internal "
+                            "network address"
+                        ),
+                    }
+                )
+                continue
+            safe_results.append(result)
+        results = safe_results
+
         response = {"results": results}
         
         pages_extracted = len(response.get('results', []))


### PR DESCRIPTION
## Summary

Re-check `web_extract` provider result URLs before returning or storing extracted content.

## Why

`web_extract_tool()` preflights the user-supplied URLs with `async_is_safe_url()` before dispatching to the configured extract backend. However, providers can return a different final/result URL after redirects or canonicalization.

Firecrawl already has a provider-local final URL SSRF re-check, but the central dispatcher did not enforce the same invariant for other extract providers such as Exa, Tavily, and Parallel. That meant a provider result whose final URL resolved to a private/internal address could still flow into the truncate-and-store path, including `cache/web` persistence and a `read_file` footer.

The dispatcher should treat the provider-reported final URL as the authoritative URL for post-fetch safety before content is exposed to the model or saved locally.

## Changes

- Add a central post-provider safety pass in `web_extract_tool()`.
- For every successful provider result, re-check `result["url"]` / `metadata.sourceURL` with `async_is_safe_url()`.
- Replace unsafe final URL results with a blocked error before truncate-and-store runs.
- Add a regression test proving a safe initial URL whose provider result points at `169.254.169.254` is blocked and never stored.

## Tests

```text
python -m pytest tests/tools/test_web_tools_truncate.py -q --timeout-method=thread
13 passed

python -m ruff check tools/web_tools.py tests/tools/test_web_tools_truncate.py