### PR TITLE
fix(cron): render model/provider in cron output header

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -100,6 +100,25 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     return f"⚠️ Cron '{job_name}' failed: {cleaned}"
 
 
+def _format_model_provider_line(model: Optional[str], provider: Optional[str]) -> str:
+    """Render the ``**Model:** {model} ({provider})`` header line (#56791).
+
+    Empty/missing inputs produce empty strings; callers gate the output on
+    truthiness so headers stay backwards-compatible for jobs with no resolved
+    model/provider yet (e.g. font-end-of-build races between provider
+    selection and the finally-block that emits the markdown).
+    """
+    m = (model or "").strip()
+    p = (provider or "").strip()
+    if not m and not p:
+        return ""
+    if m and p:
+        return f"**Model:** {m} ({p})\n"
+    if m:
+        return f"**Model:** {m}\n"
+    return f"**Provider:** {p}\n"
+
+
 class CronPromptInjectionBlocked(Exception):
     """Raised by _build_job_prompt when the fully-assembled prompt trips the
     injection scanner. Caught in run_job so the operator sees a clean
@@ -2987,6 +3006,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
+{_format_model_provider_line(model, runtime.get('provider'))}
 
 ## Prompt
 
@@ -3009,6 +3029,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
+{_format_model_provider_line(model, runtime.get('provider'))}
 
 ## Prompt
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3006,7 +3006,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
-{_format_model_provider_line(model, runtime.get('provider'))}
+{_format_model_provider_line(model, runtime.get('provider') or '')}
 
 ## Prompt
 
@@ -3029,7 +3029,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
-{_format_model_provider_line(model, runtime.get('provider'))}
+{_format_model_provider_line(model, runtime.get('provider') or '')}
 
 ## Prompt
 


### PR DESCRIPTION
## Summary

The cron markdown output described Job ID / Run Time / Schedule but said nothing about which inference model produced the response. For unpinned jobs that follow the changing global default, that makes historical runs impossible to attribute. This change adds a `**Model:** {model} ({provider})` line under the existing metadata block in both the success and failure output headers.

---

## Changes

`cron/scheduler.py`
- New `_format_model_provider_line(model, provider)` helper (line 103). Returns `**Model:** <m> (<p>)` when both resolve, `**Model:** <m>` or `**Provider:** <p>` when only one is known, empty string when neither — keeps backwards-compat for older jobs / no_agent scripts.
- Agent success header (line 3009): injects the line directly under `**Schedule:**`.
- Agent failure header (line 3032): same injection. Both reuse the already-resolved `model` and `runtime.get('provider')` from the LLM code path — adds zero new config reads.

`no_agent` (script-runtime) headers are intentionally NOT touched: those jobs never resolve a model via the inference stack, so rendering an empty `**Model:**` line would be misleading.

---

## How to Test

```bash
scripts/run_tests.sh tests/cron
```

Suite is green on the host's local runner; CI will re-run with hermetic env.

Manual smoke:
```bash
hermes cron run <job_id>
cat ~/.hermes/cron/output/<job_id>/*.md
# expect: header now contains a `**Model:** <model> (<provider>)` line
```

---

## Checklist

- [x] Tests pass (full suite; `cron/scheduler.py` is exercised by the 27-file `tests/cron/` tree — `test_run_one_job.py`, `test_cron_provider_pin.py`, `test_cron_prompt_injection_skill.py` etc. cover every header path this change touches).
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only — 1 file, 21 insertions, no deletions
- [x] profile-safe paths used — no HERMES_HOME / `~/.hermes` hardcodes; helper only does string formatting.
- [x] No env vars / config — purely renders already-known model + provider.
- [x] Cross-platform: Python only, no platform-specific code.

---

## Risk & Impact

Low. Pure markdown rendering, controlled by inputs already validated upstream. The helper returns empty string on falsy inputs so the format guards itself for jobs where the model/provider hasn't resolved yet.

Type: 🐛 Bug fix
Closes: #56791