### PR TITLE
fix(moa): skip aggregator when all references fail

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -524,6 +524,29 @@ def aggregate_moa_context(
         f"Reference {idx} — {label}:\n{text}"
         for idx, (label, text, _usage) in enumerate(reference_outputs, start=1)
     )
+
+    # Skip the aggregator call when every reference failed or was skipped —
+    # synthesising a wall of "[failed: …]" messages wastes tokens and can
+    # block for the full provider timeout (observed: ~6 min on SenseNova).
+    _FAILED_PREFIXES = ("[failed:", "[skipped:")
+    all_failed = reference_outputs and all(
+        text.startswith(_FAILED_PREFIXES)
+        for _label, text, _usage in reference_outputs
+    )
+    if all_failed:
+        logger.warning(
+            "MoA: all %d reference(s) failed — skipping aggregator, "
+            "falling back to single-model mode",
+            len(reference_outputs),
+        )
+        return (
+            "[Mixture of Agents context — all reference models failed. "
+            "Proceeding without aggregated guidance.]\n"
+            f"References: {', '.join(_slot_label(slot) for slot in reference_models)}\n\n"
+            f"{joined}"
+        )
+
+    agg_label = _slot_label(aggregator)
     synth_prompt = (
         "You are the aggregator in a Mixture of Agents process. Synthesize the "
         "reference responses into concise, actionable guidance for the main "
@@ -534,7 +557,6 @@ def aggregate_moa_context(
         f"Reference responses:\n{joined}"
     )
 
-    agg_label = _slot_label(aggregator)
     try:
         response = call_llm(
             task="moa_aggregator",

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1059,3 +1059,59 @@ def test_reference_guidance_merges_into_trailing_user_in_plain_chat():
     assert len(messages) == 2
     assert messages[-1]["role"] == "user"
     assert messages[-1]["content"] == "hello\n\nREFERENCE BLOCK"
+
+
+def test_aggregate_skips_aggregator_when_all_references_failed(monkeypatch):
+    """When every reference returns [failed: …], the aggregator is skipped entirely."""
+    from agent.moa_loop import aggregate_moa_context
+
+    call_count = {"n": 0}
+
+    def fake_call_llm(**kwargs):
+        call_count["n"] += 1
+        if kwargs["task"] == "moa_reference":
+            raise RuntimeError("provider down")
+        raise AssertionError("aggregator should not be called when all references fail")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    result = aggregate_moa_context(
+        user_prompt="do something",
+        api_messages=[{"role": "user", "content": "do something"}],
+        reference_models=[
+            {"provider": "openai", "model": "gpt-4"},
+            {"provider": "anthropic", "model": "claude-opus"},
+        ],
+        aggregator={"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+    )
+
+    # The aggregator LLM call was never made.
+    assert call_count["n"] == 2  # only the two reference calls
+    # The result still carries the failure notes so the main agent can act.
+    assert "[failed:" in result
+    assert "all reference models failed" in result
+
+
+def test_aggregate_skips_aggregator_when_all_references_skipped(monkeypatch):
+    """References that are skipped (MoA recursion guard) also trigger the early return."""
+    from agent.moa_loop import aggregate_moa_context
+
+    def fake_call_llm(**kwargs):
+        raise AssertionError("aggregator should not be called when all references are skipped")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    # Both reference models are "moa" — they hit the recursion guard and are
+    # returned as "[skipped: …]" without calling call_llm at all.
+    result = aggregate_moa_context(
+        user_prompt="do something",
+        api_messages=[{"role": "user", "content": "do something"}],
+        reference_models=[
+            {"provider": "moa", "model": "preset-a"},
+            {"provider": "moa", "model": "preset-b"},
+        ],
+        aggregator={"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+    )
+
+    assert "[skipped:" in result
+    assert "all reference models failed" in result


### PR DESCRIPTION
## What does this PR do?

Skips the MoA aggregator LLM call when **all** reference models fail or are skipped. Previously, the aggregator would attempt to synthesise a wall of `[failed: …]` messages, which could block for the full provider timeout (observed ~6 min on SenseNova) and then surface a non-retryable `BadRequestError` that left the session hanging with no response.

The early return carries the failure notes so the main agent loop can still act in single-model mode.

## Related Issue

Fixes #56878

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moa_loop.py` — In `aggregate_moa_context()`, added a guard after `_run_references_parallel()` that checks whether all outputs start with `[failed:` or `[skipped:`. When true, logs a warning and returns immediately with the joined failure notes, skipping the aggregator `call_llm` entirely.
- `tests/run_agent/test_moa_loop_mode.py` — Added two regression tests:
  - `test_aggregate_skips_aggregator_when_all_references_failed` — verifies the aggregator is not called when all references raise exceptions
  - `test_aggregate_skips_aggregator_when_all_references_skipped` — verifies the same for MoA recursion-guard skips

## How to Test

1. Run `python -m pytest tests/run_agent/test_moa_loop_mode.py -v` — all 29 tests should pass, including the two new ones
2. In a live MoA session where all reference providers are unreachable, the agent should now respond (possibly with reduced quality) instead of hanging for minutes and then failing with a non-retryable error
3. Normal MoA sessions with healthy references are unaffected — the guard only fires when every reference output begins with `[failed:` or `[skipped:`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/run_agent/test_moa_loop_mode.py -q` and all 29 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — N/A (pure Python logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
