### PR TITLE
Fix/lazy deps pip fallback env scrub

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1841,6 +1841,7 @@ AUTHOR_MAP = {
     "poli.koltsova@gmail.com": "wnuuee1",  # commit 9fd2b2cb PR author
     "yosapol@jitrak.dev": "Eji4h",  # direct email match
     "kiljadn@gmail.com": "designnotdrum",  # PR #56480 salvage (toolset static-inference fix)
+    "drexux0@gmail.com": "Drexuxux",
 }
 
 

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -147,6 +147,54 @@ class TestSecurityGating:
 
 
 # ---------------------------------------------------------------------------
+# credential scrubbing on the install ladder
+# ---------------------------------------------------------------------------
+
+
+class TestPipFallbackEnvScrub:
+    def test_pip_fallback_strips_provider_credentials(self, monkeypatch):
+        """The uv tier scrubs Hermes-managed secrets; the pip fallback tier must
+        too. On a host without uv, every lazy install goes through pip, and
+        without scrubbing the operator's provider keys leak into the pip
+        subprocess (and any package build hook it runs)."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-secret-should-not-leak")
+
+        calls: list = []
+
+        class _Done:
+            returncode = 0
+            stdout = "ok"
+            stderr = ""
+
+        def _fake_run(cmd, **kwargs):
+            calls.append((list(cmd), kwargs))
+            return _Done()
+
+        # No uv on PATH -> force the pip fallback tier.
+        _orig_which = ld.shutil.which
+        monkeypatch.setattr(
+            ld.shutil, "which",
+            lambda name: None if name == "uv" else _orig_which(name),
+        )
+        monkeypatch.setattr(ld.subprocess, "run", _fake_run)
+
+        ld._venv_pip_install(("harmless-pkg>=1.0",))
+
+        install = next(
+            c for c in calls
+            if "install" in c[0] and any("harmless-pkg" in a for a in c[0])
+        )
+        _cmd, kwargs = install
+        env = kwargs.get("env")
+        assert env is not None, (
+            "pip fallback must pass an explicit scrubbed env, not inherit os.environ"
+        )
+        assert "OPENROUTER_API_KEY" not in env, (
+            "provider credential leaked into the pip fallback subprocess env"
+        )
+
+
+# ---------------------------------------------------------------------------
 # ensure() happy/sad paths
 # ---------------------------------------------------------------------------
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -681,10 +681,17 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                                       f"pip not available and ensurepip failed: {e}")
 
         try:
+            # Scrub Hermes-managed credentials from the pip subprocess too, so
+            # the fallback tier matches the uv tier above. Without this, on any
+            # host without ``uv`` the pip child (and any package build hook it
+            # runs) inherits the operator's full environment — provider API
+            # keys, gateway tokens, GitHub auth — which #53937 set out to strip
+            # by default across the whole spawn surface.
             r = subprocess.run(
                 pip_cmd + ["install", *target_args, *constraint_args, *specs],
                 capture_output=True, text=True, timeout=timeout,
                 stdin=subprocess.DEVNULL,
+                env=uv_env,
             )
             if r.returncode == 0 and target is not None:
                 _activate_target_on_syspath(target)


### PR DESCRIPTION
While poking at on-demand dependency installs on a box that doesn't have `uv`
installed, I noticed the pip fallback in `_venv_pip_install` (`tools/lazy_deps.py`)
was handing the child process my entire environment — provider API keys and all.

The function tries `uv pip install` first and falls back to `python -m pip
install`. The uv branch is careful — it builds its environment with
`hermes_subprocess_env(inherit_credentials=False)`, so Hermes-managed secrets
are stripped before the subprocess ever sees them. The pip fallback right below
it just calls `subprocess.run([... "install", *specs])` with no `env=` at all,
which means the child inherits the parent process environment verbatim: OpenAI /
OpenRouter / Anthropic keys, gateway tokens, GitHub auth, the lot.

That matters because it's not a hypothetical path. Anywhere `uv` isn't on PATH,
*every* lazy install lands in this branch, and pip runs the target package's
build hooks (`setup.py`, PEP 517 backends) with those secrets sitting in
`os.environ` for the taking. #53937 (GHSA-m4m8-xjp4-5rmm) already made
strip-by-default the policy across the spawn surface; this one tier of the
install ladder just got missed.

The fix is a one-liner: pass the same already-scrubbed `uv_env` to the pip
fallback that the uv branch uses. No behaviour change for the uv path, and pip
still sees everything it legitimately needs (PATH, VIRTUAL_ENV, pip/index config
— none of which are on the credential blocklist).

Repro, before the fix:

```python
import os, tools.lazy_deps as ld
os.environ["OPENROUTER_API_KEY"] = "sk-secret"
ld.shutil.which = lambda n: None            # pretend uv isn't installed
ld.subprocess.run = lambda cmd, **kw: print(cmd[:3], "env passed:", kw.get("env") is not None)
ld._venv_pip_install(("harmless-pkg",))
# pip install ... -> env passed: False   (inherits os.environ, incl. the key)
```

Added a regression test (`TestPipFallbackEnvScrub`) that forces the pip tier and
asserts the credential never reaches the subprocess env. Mutation-checked:
reverting the one-line fix turns it red. Full `pytest tests/tools/test_lazy_deps.py`
is green at 62.

