### PR TITLE
fix(security): strip Azure Entra credentials from subprocess env

### DIFF
--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -35,6 +35,13 @@ _PROVIDER_SAMPLE = {
     "OPENROUTER_API_KEY": "or-fake",
 }
 
+_AZURE_ENTRA_SAMPLE = {
+    "AZURE_CLIENT_SECRET": "azure-client-secret",
+    "AZURE_FEDERATED_TOKEN_FILE": "/var/secrets/azure/federated-token",
+    "AZURE_CLIENT_ID": "client-id",
+    "AZURE_TENANT_ID": "tenant-id",
+}
+
 _SAFE_SAMPLE = {
     "PATH": "/usr/bin:/bin",
     "HOME": "/home/user",
@@ -149,6 +156,27 @@ class TestBrowserPassthroughPattern:
         # Provider + gateway secrets must NOT come back.
         assert "ANTHROPIC_API_KEY" not in env
         assert "TELEGRAM_BOT_TOKEN" not in env
+
+
+class TestAzureEntraCredentials:
+    def test_stripped_by_default(self):
+        result = _build(_AZURE_ENTRA_SAMPLE)
+        assert "AZURE_CLIENT_SECRET" not in result
+        assert "AZURE_FEDERATED_TOKEN_FILE" not in result
+        assert result["AZURE_CLIENT_ID"] == "client-id"
+        assert result["AZURE_TENANT_ID"] == "tenant-id"
+
+    def test_stripped_even_when_inheriting(self):
+        result = _build(
+            {**_PROVIDER_SAMPLE, **_AZURE_ENTRA_SAMPLE},
+            inherit_credentials=True,
+        )
+        assert "AZURE_CLIENT_SECRET" not in result
+        assert "AZURE_FEDERATED_TOKEN_FILE" not in result
+        assert result["AZURE_CLIENT_ID"] == "client-id"
+        assert result["AZURE_TENANT_ID"] == "tenant-id"
+        for var in _PROVIDER_SAMPLE:
+            assert var in result
 
 
 _INTERNAL_DYNAMIC_SAMPLE = {

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -136,6 +136,22 @@ class TestProviderEnvBlocklist:
         assert "VERTEX_CREDENTIALS_PATH" not in result_env
         assert "GOOGLE_APPLICATION_CREDENTIALS" not in result_env
 
+    def test_azure_entra_credentials_are_stripped(self):
+        """Azure Foundry Entra ID credentials must not leak to terminal subprocesses."""
+        result_env = _run_with_env(extra_os_env={
+            "AZURE_CLIENT_SECRET": "azure-client-secret",
+            "AZURE_FEDERATED_TOKEN_FILE": "/var/secrets/azure/federated-token",
+            "AZURE_CLIENT_ID": "client-id",
+            "AZURE_TENANT_ID": "tenant-id",
+        })
+
+        assert "AZURE_CLIENT_SECRET" not in result_env
+        assert "AZURE_FEDERATED_TOKEN_FILE" not in result_env
+        # Non-secret routing metadata remains available for ordinary Azure CLI
+        # / SDK workflows in the user's terminal.
+        assert result_env["AZURE_CLIENT_ID"] == "client-id"
+        assert result_env["AZURE_TENANT_ID"] == "tenant-id"
+
     def test_general_aws_credential_chain_is_preserved(self):
         """The GENERAL AWS credential chain must STILL pass through to
         subprocesses — this is the no-regression guard for #32314.
@@ -687,6 +703,13 @@ class TestHermesInternalDynamicSecrets:
         assert _is_hermes_internal_secret("GATEWAY_RELAY_SECRET")
         assert _is_hermes_internal_secret("GATEWAY_RELAY_DELIVERY_KEY")
         assert _is_hermes_internal_secret("GATEWAY_RELAY_SESSION_TOKEN")
+
+    def test_predicate_matches_azure_entra_secret_inputs(self):
+        from tools.environments.local import _is_hermes_internal_secret
+        assert _is_hermes_internal_secret("AZURE_CLIENT_SECRET")
+        assert _is_hermes_internal_secret("AZURE_FEDERATED_TOKEN_FILE")
+        assert not _is_hermes_internal_secret("AZURE_CLIENT_ID")
+        assert not _is_hermes_internal_secret("AZURE_TENANT_ID")
 
     def test_predicate_allows_auxiliary_non_secrets(self):
         """AUXILIARY_*_PROVIDER / _MODEL and GATEWAY_RELAY_* routing hints are

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -158,6 +158,11 @@ def _build_provider_env_blocklist() -> frozenset:
         # OPTIONAL_ENV_VARS marks it password=False and the loop above skips it.
         "VERTEX_CREDENTIALS_PATH",
         "GOOGLE_APPLICATION_CREDENTIALS",
+        # Azure Foundry Entra ID can authenticate through DefaultAzureCredential
+        # using a service-principal secret or workload-identity token file.
+        # Those are model-provider credentials, not terminal/tool credentials.
+        "AZURE_CLIENT_SECRET",
+        "AZURE_FEDERATED_TOKEN_FILE",
         "DEEPSEEK_API_KEY",
         "MISTRAL_API_KEY",
         "GROQ_API_KEY",
@@ -280,6 +285,8 @@ def _is_hermes_internal_secret(key: str) -> bool:
     if upper.startswith("GATEWAY_RELAY_") and (
         upper.endswith("_SECRET") or upper.endswith("_KEY") or upper.endswith("_TOKEN")
     ):
+        return True
+    if upper in {"AZURE_CLIENT_SECRET", "AZURE_FEDERATED_TOKEN_FILE"}:
         return True
     return False
 


### PR DESCRIPTION
## Summary

Azure Foundry's `model.auth_mode: entra_id` path can authenticate through Azure SDK environment credentials such as `AZURE_CLIENT_SECRET` or `AZURE_FEDERATED_TOKEN_FILE`. Those values were not included in Hermes subprocess env stripping, so they could be inherited by spawned terminal commands and non-terminal child processes.

This is the same credential-exposure class as the recent Vertex credential path fix: the provider does not use a normal static API key in `PROVIDER_REGISTRY`, so the env sanitizer did not recognize all provider-auth material.

## Why

`AZURE_CLIENT_SECRET` is a service-principal secret, and `AZURE_FEDERATED_TOKEN_FILE` points at a workload identity token file. Neither is needed by model-authored shell commands, browser workers, app-server helpers, or model-driving child CLIs.

Leaking them into subprocess environments gives arbitrary child processes access to Azure provider authentication material.

## Changes

- Add `AZURE_CLIENT_SECRET` and `AZURE_FEDERATED_TOKEN_FILE` to the provider env blocklist.
- Treat those two values as always-stripped internal/provider secret inputs so they are removed even when `hermes_subprocess_env(inherit_credentials=True)` preserves normal provider API keys.
- Keep non-secret Azure routing metadata such as `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` available.

## Tests

```text
python -m pytest tests/tools/test_local_env_blocklist.py -k "azure_entra or internal_secret or vertex_credentials_path or general_aws" -q --timeout-method=thread
6 passed, 47 deselected

python -m pytest tests/tools/test_hermes_subprocess_env.py -k "AzureEntra or InheritCredentials or InternalDynamicSecrets or TierInvariants" -q --timeout-method=thread
14 passed, 6 deselected

python -m pytest tests/tools/test_hermes_subprocess_env.py::TestAzureEntraCredentials tests/tools/test_local_env_blocklist.py::TestProviderEnvBlocklist::test_azure_entra_credentials_are_stripped tests/tools/test_local_env_blocklist.py::TestHermesInternalDynamicSecrets::test_predicate_matches_azure_entra_secret_inputs -q --timeout-method=thread
4 passed

python -m ruff check tools/environments/local.py tests/tools/test_local_env_blocklist.py tests/tools/test_hermes_subprocess_env.py