### PR TITLE
fix(tui): add approval full payload review

### DIFF
--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -166,6 +166,8 @@ Notes:
 | --------------------------- | ------------------- | ------------------------------------------------- |
 | approval prompt             | `Up/Down`, `Enter`  | Move and confirm the selected approval choice     |
 | approval prompt             | `o`, `s`, `a`, `d`  | Quick-pick `once`, `session`, `always`, `deny`    |
+| approval prompt             | `v`                 | Toggle a bounded full-payload review for truncated commands              |
+| full-payload review         | `j`/`k`               | Scroll the review without moving approval controls                     |
 | approval prompt             | `Esc`, `Ctrl+C`     | Deny                                              |
 | clarify prompt with choices | `Up/Down`, `Enter`  | Move and confirm the selected choice              |
 | clarify prompt with choices | single-digit number | Quick-pick the matching numbered choice           |

--- a/ui-tui/src/__tests__/approvalAction.test.ts
+++ b/ui-tui/src/__tests__/approvalAction.test.ts
@@ -1,6 +1,22 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { approvalAction, approvalOptions } from '../components/prompts.js'
+import {
+  approvalAction,
+  approvalFullReviewMessage,
+  approvalOptions,
+  approvalOverflowMessage,
+  ApprovalPanel,
+  approvalPayloadPage
+} from '../components/prompts.js'
+import { DARK_THEME } from '../theme.js'
+
+const theme = DARK_THEME
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
   it('maps Esc to deny — parity with global Ctrl+C cancellation', () => {
@@ -36,11 +52,106 @@ describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
     expect(approvalAction('', { downArrow: true }, 3)).toEqual({ kind: 'noop' })
   })
 
+  it('offers a full-payload review row only when the command preview overflows', () => {
+    expect(approvalAction('v', {}, 0)).toEqual({ kind: 'noop' })
+    expect(approvalAction('5', {}, 0)).toEqual({ kind: 'noop' })
+    expect(approvalAction('', { downArrow: true }, 3)).toEqual({ kind: 'noop' })
+
+    expect(approvalAction('v', {}, 0, undefined, true)).toEqual({ kind: 'toggleFull' })
+    expect(approvalAction('V', {}, 0, undefined, true)).toEqual({ kind: 'toggleFull' })
+    expect(approvalAction('5', {}, 0, undefined, true)).toEqual({ kind: 'toggleFull' })
+    expect(approvalAction('', { return: true }, 4, undefined, true)).toEqual({ kind: 'toggleFull' })
+    expect(approvalAction('', { downArrow: true }, 3, undefined, true)).toEqual({ kind: 'move', delta: 1 })
+    expect(approvalAction('', { downArrow: true }, 4, undefined, true)).toEqual({ kind: 'noop' })
+  })
+
+  it('uses approval-local overflow copy instead of the old scrollback fallback', () => {
+    expect(approvalOverflowMessage(1)).toBe('… +1 more line hidden - select View full payload to review here')
+    expect(approvalOverflowMessage(3)).toBe('… +3 more lines hidden - select View full payload to review here')
+    expect(approvalOverflowMessage(3)).not.toContain('full text above')
+    expect(approvalFullReviewMessage(0, 10, 23)).toBe('Reviewing full payload: lines 1-10 of 23 (j/k scroll)')
+  })
+
+  it('pages the full payload with reversible j/k page indexes', () => {
+    const lines = Array.from({ length: 23 }, (_, index) => `line ${index + 1}`)
+
+    expect(approvalPayloadPage(lines, 0)).toEqual({ end: 10, index: 0, lines: lines.slice(0, 10), start: 0 })
+    expect(approvalPayloadPage(lines, 1)).toEqual({ end: 20, index: 1, lines: lines.slice(10, 20), start: 10 })
+    expect(approvalPayloadPage(lines, 2)).toEqual({ end: 23, index: 2, lines: lines.slice(20), start: 20 })
+    expect(approvalPayloadPage(lines, 3)).toEqual({ end: 23, index: 2, lines: lines.slice(20), start: 20 })
+
+    const lastPage = approvalPayloadPage(lines, 2)
+    const previousPage = approvalPayloadPage(lines, lastPage.index - 1)
+
+    expect(previousPage.start).toBe(10)
+    expect(approvalPayloadPage(lines, previousPage.index + 1)).toEqual(lastPage)
+
+    expect(approvalAction('j', {}, 0, undefined, true, true)).toEqual({ kind: 'pagePayload', delta: 1 })
+    expect(approvalAction('k', {}, 0, undefined, true, true)).toEqual({ kind: 'pagePayload', delta: -1 })
+    expect(approvalAction('', { pageDown: true }, 0, undefined, true, true)).toEqual({ kind: 'noop' })
+    expect(approvalAction('', { pageUp: true }, 0, undefined, true, true)).toEqual({ kind: 'noop' })
+  })
+
+  it('renders a bounded full-payload review with approval controls in a compact viewport', async () => {
+    const rawLines = Array.from({ length: 40 }, (_, index) => `payload line ${index + 1}`)
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdout, { columns: 80, isTTY: false, rows: 21 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const instance = renderSync(
+      React.createElement(ApprovalPanel, {
+        description: 'review this command',
+        opts: approvalOptions({ allowPermanent: true, command: 'ignored', description: 'review this command' }),
+        rawLines,
+        reviewPageIndex: 3,
+        sel: 0,
+        showFull: true,
+        t: theme
+      }),
+      {
+        patchConsole: false,
+        stderr: stderr as NodeJS.WriteStream,
+        stdin: stdin as NodeJS.ReadStream,
+        stdout: stdout as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await delay(20)
+
+      // Strip ANSI so assertions operate on the 21-row terminal frame.
+      // eslint-disable-next-line no-control-regex
+      const frame = output.replace(/\u001b\[[0-9;]*m/g, '')
+
+      expect(frame).toContain('payload line 31')
+      expect(frame).toContain('payload line 40')
+      expect(frame).not.toContain('payload line 30')
+      expect(frame).toContain('1. Allow once')
+      expect(frame).toContain('4. Deny')
+      expect(frame).toContain('5. Return to preview')
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
   it('Esc beats numeric/return — denying is always the first interpretation', () => {
     // If a terminal somehow delivers Esc + a digit in the same event, deny
     // wins.  Documents the precedence so a future refactor doesn't flip it.
-    expect(approvalAction('1', { escape: true }, 0)).toEqual({ kind: 'choose', choice: 'deny' })
-    expect(approvalAction('', { escape: true, return: true }, 1)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('1', { escape: true }, 0, undefined, true)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('v', { escape: true }, 0, undefined, true)).toEqual({ kind: 'choose', choice: 'deny' })
+    expect(approvalAction('', { escape: true, return: true }, 1, undefined, true)).toEqual({
+      kind: 'choose',
+      choice: 'deny'
+    })
   })
 
   it('returns noop for unrelated keystrokes (printable letters etc.)', () => {
@@ -57,6 +168,9 @@ describe('approvalAction — pure key dispatch for ApprovalPrompt', () => {
     expect(approvalAction('4', {}, 0, opts)).toEqual({ kind: 'noop' })
     expect(approvalAction('', { downArrow: true }, 2, opts)).toEqual({ kind: 'noop' })
     expect(approvalAction('', { return: true }, 2, opts)).toEqual({ kind: 'choose', choice: 'deny' })
+
+    expect(approvalAction('4', {}, 0, opts, true)).toEqual({ kind: 'toggleFull' })
+    expect(approvalAction('', { return: true }, 3, opts, true)).toEqual({ kind: 'toggleFull' })
   })
 
   it('offers only once and deny for Smart DENY owner override', () => {

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -31,11 +31,36 @@ export function approvalOptions(req: ApprovalReq): readonly ApprovalChoice[] {
 type ApprovalKey = {
   downArrow?: boolean
   escape?: boolean
+  pageDown?: boolean
+  pageUp?: boolean
   return?: boolean
   upArrow?: boolean
 }
 
-type ApprovalAction = { kind: 'choose'; choice: ApprovalChoice } | { kind: 'move'; delta: -1 | 1 } | { kind: 'noop' }
+type ApprovalAction =
+  | { kind: 'choose'; choice: ApprovalChoice }
+  | { kind: 'move'; delta: -1 | 1 }
+  | { kind: 'noop' }
+  | { kind: 'pagePayload'; delta: -1 | 1 }
+  | { kind: 'toggleFull' }
+
+export function approvalOverflowMessage(overflow: number) {
+  return `… +${overflow} more line${overflow === 1 ? '' : 's'} hidden - select View full payload to review here`
+}
+
+export function approvalFullReviewMessage(start: number, end: number, total: number) {
+  return `Reviewing full payload: lines ${start + 1}-${end} of ${total} (j/k scroll)`
+}
+
+export function approvalPayloadPage(lines: readonly string[], pageIndex: number, pageSize = CMD_PREVIEW_LINES) {
+  const size = Math.max(1, pageSize)
+  const pages = Math.max(1, Math.ceil(lines.length / size))
+  const index = Math.min(Math.max(0, pageIndex), pages - 1)
+  const start = index * size
+  const end = Math.min(start + size, lines.length)
+
+  return { end, index, lines: lines.slice(start, end), start }
+}
 
 /**
  * Pure key-dispatch for the approval prompt — exported so the regression
@@ -52,10 +77,24 @@ export function approvalAction(
   ch: string,
   key: ApprovalKey,
   sel: number,
-  opts: readonly ApprovalChoice[] = APPROVAL_OPTS
+  opts: readonly ApprovalChoice[] = APPROVAL_OPTS,
+  hasFullReview = false,
+  showingFullPayload = false
 ): ApprovalAction {
   if (key.escape) {
     return { kind: 'choose', choice: 'deny' }
+  }
+
+  if (hasFullReview && ch.toLowerCase() === 'v') {
+    return { kind: 'toggleFull' }
+  }
+
+  if (hasFullReview && showingFullPayload && ch === 'k') {
+    return { kind: 'pagePayload', delta: -1 }
+  }
+
+  if (hasFullReview && showingFullPayload && ch === 'j') {
+    return { kind: 'pagePayload', delta: 1 }
   }
 
   const n = parseInt(ch, 10)
@@ -64,15 +103,25 @@ export function approvalAction(
     return { kind: 'choose', choice: opts[n - 1]! }
   }
 
-  if (key.return) {
-    return { kind: 'choose', choice: opts[sel]! }
+  if (hasFullReview && n === opts.length + 1) {
+    return { kind: 'toggleFull' }
   }
+
+  if (key.return) {
+    if (hasFullReview && sel === opts.length) {
+      return { kind: 'toggleFull' }
+    }
+
+    return { kind: 'choose', choice: opts[Math.min(sel, opts.length - 1)]! }
+  }
+
+  const rowCount = opts.length + (hasFullReview ? 1 : 0)
 
   if (key.upArrow && sel > 0) {
     return { kind: 'move', delta: -1 }
   }
 
-  if (key.downArrow && sel < opts.length - 1) {
+  if (key.downArrow && sel < rowCount - 1) {
     return { kind: 'move', delta: 1 }
   }
 
@@ -81,17 +130,9 @@ export function approvalAction(
 
 export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
+  const [showFull, setShowFull] = useState(false)
+  const [reviewPageIndex, setReviewPageIndex] = useState(0)
   const opts = approvalOptions(req)
-
-  useInput((ch, key) => {
-    const action = approvalAction(ch, key, sel, opts)
-
-    if (action.kind === 'choose') {
-      onChoice(action.choice)
-    } else if (action.kind === 'move') {
-      setSel(s => s + action.delta)
-    }
-  })
 
   // Wrap long single-line commands to the panel width instead of clipping the
   // tail (mirrors the CLI approval panel fix — the full command must be
@@ -102,13 +143,46 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
     .split('\n')
     .flatMap(line => wrapAnsi(line, innerWidth, { hard: true, trim: false }).split('\n'))
 
-  const shown = rawLines.slice(0, CMD_PREVIEW_LINES)
-  const overflow = rawLines.length - shown.length
+  const hasFullReview = rawLines.length > CMD_PREVIEW_LINES
+
+  useInput((ch, key) => {
+    const action = approvalAction(ch, key, sel, opts, hasFullReview, showFull)
+
+    if (action.kind === 'choose') {
+      onChoice(action.choice)
+    } else if (action.kind === 'move') {
+      setSel(s => s + action.delta)
+    } else if (action.kind === 'pagePayload') {
+      setReviewPageIndex(index => approvalPayloadPage(rawLines, index + action.delta).index)
+    } else if (action.kind === 'toggleFull') {
+      setShowFull(v => !v)
+    }
+  })
+
+  return (
+    <ApprovalPanel
+      description={req.description}
+      opts={opts}
+      rawLines={rawLines}
+      reviewPageIndex={reviewPageIndex}
+      sel={sel}
+      showFull={showFull}
+      t={t}
+    />
+  )
+}
+
+export function ApprovalPanel({ description, opts, rawLines, reviewPageIndex, sel, showFull, t }: ApprovalPanelProps) {
+  const previewLines = rawLines.slice(0, CMD_PREVIEW_LINES)
+  const overflow = rawLines.length - previewLines.length
+  const hasFullReview = overflow > 0
+  const reviewPage = approvalPayloadPage(rawLines, reviewPageIndex)
+  const shown = showFull && hasFullReview ? reviewPage.lines : previewLines
 
   return (
     <Box borderColor={t.color.warn} borderStyle="double" flexDirection="column" paddingX={1}>
       <Text bold color={t.color.warn}>
-        ⚠ approval required · {req.description}
+        ⚠ approval required · {description}
       </Text>
 
       <Box flexDirection="column" paddingLeft={1}>
@@ -118,10 +192,12 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
           </Text>
         ))}
 
-        {overflow > 0 ? (
-          <Text color={t.color.muted}>
-            … +{overflow} more line{overflow === 1 ? '' : 's'} (full text above)
-          </Text>
+        {hasFullReview && !showFull ? (
+          <Text color={t.color.muted}>{approvalOverflowMessage(overflow)}</Text>
+        ) : null}
+
+        {hasFullReview && showFull ? (
+          <Text color={t.color.muted}>{approvalFullReviewMessage(reviewPage.start, reviewPage.end, rawLines.length)}</Text>
         ) : null}
       </Box>
 
@@ -136,7 +212,23 @@ export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptPr
         </Text>
       ))}
 
-      <Text color={t.color.muted}>↑/↓ select · Enter confirm · 1-{opts.length} quick pick · Esc/Ctrl+C deny</Text>
+      {hasFullReview ? (
+        <Text>
+          <Text
+            bold={sel === opts.length}
+            color={sel === opts.length ? t.color.warn : t.color.muted}
+            inverse={sel === opts.length}
+          >
+            {sel === opts.length ? '▸ ' : '  '}
+            {opts.length + 1}. {showFull ? 'Return to preview' : 'View full payload'}
+          </Text>
+        </Text>
+      ) : null}
+
+      <Text color={t.color.muted}>
+        ↑/↓ select · Enter confirm · 1-{opts.length + (hasFullReview ? 1 : 0)} quick pick
+        {hasFullReview ? ` · v ${showFull ? 'preview' : 'view'}` : ''} · Esc/Ctrl+C deny
+      </Text>
     </Box>
   )
 }
@@ -286,6 +378,16 @@ interface ApprovalPromptProps {
   cols?: number
   onChoice: (s: string) => void
   req: ApprovalReq
+  t: Theme
+}
+
+interface ApprovalPanelProps {
+  description: string
+  opts: readonly ApprovalChoice[]
+  rawLines: readonly string[]
+  reviewPageIndex: number
+  sel: number
+  showFull: boolean
   t: Theme
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds an in-prompt full payload review action to the TUI approval prompt so long commands/scripts can be reviewed before approval without relying on terminal scrollback or a vague "full text above" fallback.

## Shared root cause

- The TUI approval prompt wraps approval commands but caps the preview at 10 rendered lines, then points users to "full text above" instead of providing an approval-local review affordance.
- That shared prompt behavior makes hidden approval payload lines ambiguous (#38582) and leaves the TUI without classic CLI-style full-command review parity (#38583).

## How this fixes each issue

- #38582: replaces the ambiguous overflow copy with explicit wording that hidden lines can be reviewed inside the current prompt via `View full payload`.
- #38583: adds a selectable `View full payload` approval row and `v` shortcut that toggles the complete wrapped payload before choosing allow/deny.

## Related Issue

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [x] Tests (adding or improving test coverage)

## Changes Made

- `ui-tui/src/components/prompts.tsx`: adds overflow-aware approval key handling, a full-payload review toggle, and approval-local overflow/status copy.
- `ui-tui/src/__tests__/approvalAction.test.ts`: covers the new review row, `v`/number/Enter dispatch, reduced approval option sets, and the replacement overflow wording.
- `ui-tui/README.md`: documents the new approval prompt `v` shortcut.

## How to Test

1. Run `npm test --workspace ui-tui -- approvalAction.test.ts`.
2. Run `npm run typecheck --workspace ui-tui`.
3. Run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`.

Local notes: the Node checks could not start in this worktree because `vitest` and `tsc` are not installed. The required Python suite was attempted and aborted during collection before this change was exercised because `hermes_cli.web_server` tried to lazy-install missing `fastapi` into an externally managed Python environment. `git diff --check`, changed-Python lint discovery (no changed Python files), and `scripts/check-windows-footguns.py --diff origin/main` passed.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix/feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've considered cross-platform impact

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #38582
Refs #38583

<!-- autocontrib:worker-id=pr-spanning-ddba5cad kind=pr-open -->