### PR TITLE
fix: preserve Slack media attachments in threaded replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1677,6 +1677,24 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
+
+
+def _split_response_attachments_for_direct_send(adapter: Any, response: str):
+    """Return cleaned text plus native attachments for an already-managed send.
+
+    Some gateway paths, notably the queued-follow-up fast path, send a response
+    directly with ``adapter.send()`` before returning to the normal
+    ``_handle_message`` post-processing block. Those paths must still strip
+    ``MEDIA:`` directives from visible text and dispatch the corresponding
+    attachments separately; otherwise users see either raw host paths or a claim
+    that a file was attached when no uploader ran.
+    """
+    from gateway.platforms.base import BasePlatformAdapter
+
+    media_files, cleaned = adapter.extract_media(response)
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    images, text_content = adapter.extract_images(cleaned)
+    return text_content, images, media_files
 from gateway.delivery import DeliveryRouter, looks_like_telegram_private_chat_id
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
@@ -18761,11 +18779,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
-                                source.chat_id,
+                            _first_text, _first_images, _first_media_files = _split_response_attachments_for_direct_send(
+                                adapter,
                                 first_response,
-                                metadata=_status_thread_metadata,
                             )
+                            if _first_text:
+                                await adapter.send(
+                                    source.chat_id,
+                                    _first_text,
+                                    metadata=_status_thread_metadata,
+                                )
+                            for _image_url, _alt_text in _first_images or []:
+                                await adapter.send_image(
+                                    chat_id=source.chat_id,
+                                    image_url=_image_url,
+                                    caption=_alt_text,
+                                    metadata=_status_thread_metadata,
+                                )
+                            if _first_media_files:
+                                for _media_path, _is_voice in _first_media_files:
+                                    await adapter.send_document(
+                                        chat_id=source.chat_id,
+                                        file_path=_media_path,
+                                        metadata=_status_thread_metadata,
+                                    )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                     elif first_response:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18783,26 +18783,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 adapter,
                                 first_response,
                             )
-                            if _first_text:
+                            _first_caption_used = False
+                            if _first_text and not _first_images and not _first_media_files:
                                 await adapter.send(
                                     source.chat_id,
                                     _first_text,
                                     metadata=_status_thread_metadata,
                                 )
                             for _image_url, _alt_text in _first_images or []:
+                                _caption = _alt_text
+                                if _first_text and not _first_caption_used:
+                                    _caption = f"{_first_text}\n{_alt_text}" if _alt_text else _first_text
+                                    _first_caption_used = True
                                 await adapter.send_image(
                                     chat_id=source.chat_id,
                                     image_url=_image_url,
-                                    caption=_alt_text,
+                                    caption=_caption,
                                     metadata=_status_thread_metadata,
                                 )
                             if _first_media_files:
+                                from gateway.platforms.base import should_send_media_as_audio as _should_send_media_as_audio
+                                _IMAGE_EXTS_DIRECT = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+                                _VIDEO_EXTS_DIRECT = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
                                 for _media_path, _is_voice in _first_media_files:
-                                    await adapter.send_document(
-                                        chat_id=source.chat_id,
-                                        file_path=_media_path,
-                                        metadata=_status_thread_metadata,
-                                    )
+                                    _caption = _first_text if (_first_text and not _first_caption_used) else None
+                                    if _caption:
+                                        _first_caption_used = True
+                                    _ext = os.path.splitext(_media_path)[1].lower()
+                                    if _should_send_media_as_audio(source.platform, _ext, _is_voice):
+                                        await adapter.send_voice(
+                                            chat_id=source.chat_id,
+                                            audio_path=_media_path,
+                                            caption=_caption,
+                                            metadata=_status_thread_metadata,
+                                        )
+                                    elif _ext in _VIDEO_EXTS_DIRECT:
+                                        await adapter.send_video(
+                                            chat_id=source.chat_id,
+                                            video_path=_media_path,
+                                            caption=_caption,
+                                            metadata=_status_thread_metadata,
+                                        )
+                                    elif _ext in _IMAGE_EXTS_DIRECT:
+                                        await adapter.send_image_file(
+                                            chat_id=source.chat_id,
+                                            image_path=_media_path,
+                                            caption=_caption,
+                                            metadata=_status_thread_metadata,
+                                        )
+                                    else:
+                                        await adapter.send_document(
+                                            chat_id=source.chat_id,
+                                            file_path=_media_path,
+                                            caption=_caption,
+                                            metadata=_status_thread_metadata,
+                                        )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                     elif first_response:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4338,7 +4338,36 @@ async def _standalone_send(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
         ) as session:
             last_result = None
-            if formatted:
+            media_files = media_files or []
+            if media_files:
+                if not SLACK_AVAILABLE or AsyncWebClient is Any:
+                    return {"error": "Slack media upload failed: slack_sdk not installed"}
+                client_kwargs = {"token": token}
+                if _proxy:
+                    client_kwargs["proxy"] = _proxy
+                client = AsyncWebClient(**client_kwargs)
+                for idx, (media_path, _is_voice) in enumerate(media_files):
+                    if not os.path.exists(str(media_path)):
+                        return {"error": f"Slack media upload failed: file not found: {os.path.basename(str(media_path))}"}
+                    upload = await client.files_upload_v2(
+                        channel=chat_id,
+                        file=str(media_path),
+                        filename=os.path.basename(str(media_path)),
+                        initial_comment=formatted if idx == 0 else "",
+                        thread_ts=thread_id,
+                    )
+                    if isinstance(upload, dict) and upload.get("ok") is False:
+                        return {"error": f"Slack media upload failed: {upload.get('error', 'unknown')}"}
+                    file_id = None
+                    if isinstance(upload, dict):
+                        file_id = upload.get("file", {}).get("id") or upload.get("ts")
+                    last_result = {
+                        "success": True,
+                        "platform": "slack",
+                        "chat_id": chat_id,
+                        "message_id": file_id,
+                    }
+            elif formatted:
                 payload = {"channel": chat_id, "text": formatted, "mrkdwn": True}
                 if thread_id:
                     payload["thread_ts"] = thread_id
@@ -4355,35 +4384,6 @@ async def _standalone_send(
                         }
                     else:
                         return {"error": f"Slack API error: {data.get('error', 'unknown')}"}
-
-            if media_files:
-                if not SLACK_AVAILABLE or AsyncWebClient is Any:
-                    return {"error": "Slack media upload failed: slack_sdk not installed"}
-                client_kwargs = {"token": token}
-                if _proxy:
-                    client_kwargs["proxy"] = _proxy
-                client = AsyncWebClient(**client_kwargs)
-                for media_path, _is_voice in media_files or []:
-                    if not os.path.exists(str(media_path)):
-                        return {"error": f"Slack media upload failed: file not found: {os.path.basename(str(media_path))}"}
-                    upload = await client.files_upload_v2(
-                        channel=chat_id,
-                        file=str(media_path),
-                        filename=os.path.basename(str(media_path)),
-                        initial_comment="" if formatted else "",
-                        thread_ts=thread_id,
-                    )
-                    if isinstance(upload, dict) and upload.get("ok") is False:
-                        return {"error": f"Slack media upload failed: {upload.get('error', 'unknown')}"}
-                    file_id = None
-                    if isinstance(upload, dict):
-                        file_id = upload.get("file", {}).get("id") or upload.get("ts")
-                    last_result = {
-                        "success": True,
-                        "platform": "slack",
-                        "chat_id": chat_id,
-                        "message_id": file_id,
-                    }
 
             return last_result or {
                 "success": True,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4337,21 +4337,60 @@ async def _standalone_send(
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
         ) as session:
-            payload = {"channel": chat_id, "text": formatted, "mrkdwn": True}
-            if thread_id:
-                payload["thread_ts"] = thread_id
-            async with session.post(
-                url, headers=headers, json=payload, **_req_kw
-            ) as resp:
-                data = await resp.json()
-                if data.get("ok"):
-                    return {
+            last_result = None
+            if formatted:
+                payload = {"channel": chat_id, "text": formatted, "mrkdwn": True}
+                if thread_id:
+                    payload["thread_ts"] = thread_id
+                async with session.post(
+                    url, headers=headers, json=payload, **_req_kw
+                ) as resp:
+                    data = await resp.json()
+                    if data.get("ok"):
+                        last_result = {
+                            "success": True,
+                            "platform": "slack",
+                            "chat_id": chat_id,
+                            "message_id": data.get("ts"),
+                        }
+                    else:
+                        return {"error": f"Slack API error: {data.get('error', 'unknown')}"}
+
+            if media_files:
+                if not SLACK_AVAILABLE or AsyncWebClient is Any:
+                    return {"error": "Slack media upload failed: slack_sdk not installed"}
+                client_kwargs = {"token": token}
+                if _proxy:
+                    client_kwargs["proxy"] = _proxy
+                client = AsyncWebClient(**client_kwargs)
+                for media_path, _is_voice in media_files or []:
+                    if not os.path.exists(str(media_path)):
+                        return {"error": f"Slack media upload failed: file not found: {os.path.basename(str(media_path))}"}
+                    upload = await client.files_upload_v2(
+                        channel=chat_id,
+                        file=str(media_path),
+                        filename=os.path.basename(str(media_path)),
+                        initial_comment="" if formatted else "",
+                        thread_ts=thread_id,
+                    )
+                    if isinstance(upload, dict) and upload.get("ok") is False:
+                        return {"error": f"Slack media upload failed: {upload.get('error', 'unknown')}"}
+                    file_id = None
+                    if isinstance(upload, dict):
+                        file_id = upload.get("file", {}).get("id") or upload.get("ts")
+                    last_result = {
                         "success": True,
                         "platform": "slack",
                         "chat_id": chat_id,
-                        "message_id": data.get("ts"),
+                        "message_id": file_id,
                     }
-                return {"error": f"Slack API error: {data.get('error', 'unknown')}"}
+
+            return last_result or {
+                "success": True,
+                "platform": "slack",
+                "chat_id": chat_id,
+                "message_id": None,
+            }
     except Exception as e:
         return {"error": f"Slack send failed: {e}"}
 

--- a/tests/gateway/test_response_attachment_helpers.py
+++ b/tests/gateway/test_response_attachment_helpers.py
@@ -1,0 +1,32 @@
+class _Adapter:
+    @staticmethod
+    def extract_media(content):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        return BasePlatformAdapter.extract_media(content)
+
+    @staticmethod
+    def extract_images(content):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        return BasePlatformAdapter.extract_images(content)
+
+
+def test_split_response_attachments_strips_media_from_text(tmp_path, monkeypatch):
+    from gateway.run import _split_response_attachments_for_direct_send
+
+    monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "0")
+    report = tmp_path / "diameter.csv.gz"
+    report.write_text("rows\n", encoding="utf-8")
+
+    response = f"Attached file below\nMEDIA:{report}\nDone"
+
+    text, images, media_files = _split_response_attachments_for_direct_send(
+        _Adapter(), response
+    )
+
+    assert "MEDIA:" not in text
+    assert "Attached file below" in text
+    assert "Done" in text
+    assert images == []
+    assert media_files == [(str(report), False)]

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -404,6 +404,192 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_slack_media_delivery_uses_standalone_upload_path(self, tmp_path):
+        slack_cfg = SimpleNamespace(enabled=True, token="xoxb-test", extra={})
+        report = tmp_path / "diameter.csv.gz"
+        report.write_text("rows\n", encoding="utf-8")
+        send = AsyncMock(
+            return_value={"success": True, "platform": "slack", "message_id": "1"}
+        )
+
+        entry = _slack_entry()
+        assert entry is not None
+        original = entry.standalone_sender_fn
+
+        async def recorder(pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False):
+            return await send(
+                pconfig,
+                chat_id,
+                message,
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document,
+            )
+
+        entry.standalone_sender_fn = recorder
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    slack_cfg,
+                    "CLX6NJKB9",
+                    "Attached",
+                    thread_id="1782982014.696759",
+                    media_files=[(str(report), False)],
+                )
+            )
+        finally:
+            entry.standalone_sender_fn = original
+
+        assert result["success"] is True
+        assert "warnings" not in result
+        send.assert_awaited_once_with(
+            slack_cfg,
+            "CLX6NJKB9",
+            "Attached",
+            thread_id="1782982014.696759",
+            media_files=[(str(report), False)],
+            force_document=False,
+        )
+
+    def test_slack_media_only_delivery_still_uploads_file(self, tmp_path):
+        slack_cfg = SimpleNamespace(enabled=True, token="xoxb-test", extra={})
+        report = tmp_path / "diameter.csv.gz"
+        report.write_text("rows\n", encoding="utf-8")
+        send = AsyncMock(
+            return_value={"success": True, "platform": "slack", "message_id": "1"}
+        )
+        entry = _slack_entry()
+        assert entry is not None
+        original = entry.standalone_sender_fn
+
+        async def recorder(pconfig, chat_id, message, *, thread_id=None, media_files=None, force_document=False):
+            return await send(
+                pconfig,
+                chat_id,
+                message,
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document,
+            )
+
+        entry.standalone_sender_fn = recorder
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    slack_cfg,
+                    "CLX6NJKB9",
+                    "",
+                    thread_id="1782982014.696759",
+                    media_files=[(str(report), False)],
+                )
+            )
+        finally:
+            entry.standalone_sender_fn = original
+
+        assert result["success"] is True
+        assert "warnings" not in result
+        send.assert_awaited_once()
+        assert send.await_args.kwargs["media_files"] == [(str(report), False)]
+
+    def test_slack_standalone_send_uploads_media_in_thread(self, tmp_path, monkeypatch):
+        import plugins.platforms.slack.adapter as slack_mod
+
+        report = tmp_path / "diameter.csv.gz"
+        report.write_text("rows\n", encoding="utf-8")
+
+        class _Resp:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                return False
+
+            async def json(self):
+                return {"ok": True, "ts": "1782986634.727459"}
+
+        class _Session:
+            def __init__(self, *args, **kwargs):
+                self.posts = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                return False
+
+            def post(self, url, *, headers=None, json=None, **kwargs):
+                self.posts.append((url, json))
+                return _Resp()
+
+        upload_client = MagicMock()
+        upload_client.files_upload_v2 = AsyncMock(
+            return_value={"ok": True, "file": {"id": "F123"}}
+        )
+        client_cls = MagicMock(return_value=upload_client)
+
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+        monkeypatch.setattr(slack_mod, "AsyncWebClient", client_cls)
+        monkeypatch.setattr(slack_mod.aiohttp, "ClientSession", _Session)
+
+        result = asyncio.run(
+            slack_mod._standalone_send(
+                SimpleNamespace(token="xoxb-test", extra={}),
+                "CLX6NJKB9",
+                "Attached",
+                thread_id="1782982014.696759",
+                media_files=[(str(report), False)],
+            )
+        )
+
+        assert result["success"] is True
+        upload_client.files_upload_v2.assert_awaited_once_with(
+            channel="CLX6NJKB9",
+            file=str(report),
+            filename="diameter.csv.gz",
+            initial_comment="",
+            thread_ts="1782982014.696759",
+        )
+
+    def test_slack_standalone_upload_non_ok_returns_error(self, tmp_path, monkeypatch):
+        import plugins.platforms.slack.adapter as slack_mod
+
+        report = tmp_path / "diameter.csv.gz"
+        report.write_text("rows\n", encoding="utf-8")
+
+        class _Session:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                return False
+
+        upload_client = MagicMock()
+        upload_client.files_upload_v2 = AsyncMock(
+            return_value={"ok": False, "error": "not_in_channel"}
+        )
+        client_cls = MagicMock(return_value=upload_client)
+
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+        monkeypatch.setattr(slack_mod, "AsyncWebClient", client_cls)
+        monkeypatch.setattr(slack_mod.aiohttp, "ClientSession", _Session)
+
+        result = asyncio.run(
+            slack_mod._standalone_send(
+                SimpleNamespace(token="xoxb-test", extra={}),
+                "CLX6NJKB9",
+                "",
+                thread_id="1782982014.696759",
+                media_files=[(str(report), False)],
+            )
+        )
+
+        assert result == {"error": "Slack media upload failed: not_in_channel"}
+
     def test_resolved_matrix_thread_name_preserves_thread_id(self):
         matrix_cfg = SimpleNamespace(
             enabled=True,

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -510,8 +510,10 @@ class TestSendMessageTool:
                 return {"ok": True, "ts": "1782986634.727459"}
 
         class _Session:
+            posts = []
+
             def __init__(self, *args, **kwargs):
-                self.posts = []
+                type(self).posts = []
 
             async def __aenter__(self):
                 return self
@@ -520,7 +522,7 @@ class TestSendMessageTool:
                 return False
 
             def post(self, url, *, headers=None, json=None, **kwargs):
-                self.posts.append((url, json))
+                type(self).posts.append((url, json))
                 return _Resp()
 
         upload_client = MagicMock()
@@ -544,11 +546,12 @@ class TestSendMessageTool:
         )
 
         assert result["success"] is True
+        assert _Session.posts == []
         upload_client.files_upload_v2.assert_awaited_once_with(
             channel="CLX6NJKB9",
             file=str(report),
             filename="diameter.csv.gz",
-            initial_comment="",
+            initial_comment="Attached",
             thread_ts="1782982014.696759",
         )
 
@@ -559,14 +562,20 @@ class TestSendMessageTool:
         report.write_text("rows\n", encoding="utf-8")
 
         class _Session:
+            posts = []
+
             def __init__(self, *args, **kwargs):
-                pass
+                type(self).posts = []
 
             async def __aenter__(self):
                 return self
 
             async def __aexit__(self, *_exc):
                 return False
+
+            def post(self, url, *, headers=None, json=None, **kwargs):
+                type(self).posts.append((url, json))
+                raise AssertionError("text post should not run before media upload")
 
         upload_client = MagicMock()
         upload_client.files_upload_v2 = AsyncMock(
@@ -589,6 +598,7 @@ class TestSendMessageTool:
         )
 
         assert result == {"error": "Slack media upload failed: not_in_channel"}
+        assert _Session.posts == []
 
     def test_resolved_matrix_thread_name_preserves_thread_id(self):
         matrix_cfg = SimpleNamespace(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -932,11 +932,34 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Slack: route through plugin standalone sender, including native file uploads. ---
+    if platform == Platform.SLACK:
+        from gateway.platform_registry import platform_registry
+        _slack_entry = platform_registry.get("slack")
+        if _slack_entry is None or _slack_entry.standalone_sender_fn is None:
+            return {"error": "Slack plugin not registered or missing standalone_sender_fn"}
+        last_result = None
+        slack_chunks = chunks or [""]
+        for i, chunk in enumerate(slack_chunks):
+            is_last = (i == len(slack_chunks) - 1)
+            result = await _slack_entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files if is_last else [],
+                force_document=force_document,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and whatsapp; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -944,24 +967,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and whatsapp"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
         )
 
     last_result = None
     for chunk in chunks:
-        if platform == Platform.SLACK:
-            # Slack migrated to a bundled plugin (#41112); delivery flows
-            # through the registry's standalone_sender_fn, which applies
-            # mrkdwn formatting and posts via the Slack Web API.
-            from gateway.platform_registry import platform_registry
-            _slack_entry = platform_registry.get("slack")
-            if _slack_entry is None or _slack_entry.standalone_sender_fn is None:
-                result = {"error": "Slack plugin not registered or missing standalone_sender_fn"}
-            else:
-                result = await _slack_entry.standalone_sender_fn(
-                    pconfig, chat_id, chunk, thread_id=thread_id
-                )
-        elif platform == Platform.WHATSAPP:
+        if platform == Platform.WHATSAPP:
             result = await _registry_standalone_send("whatsapp", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)


### PR DESCRIPTION
## Summary
- Route Slack send_message MEDIA attachments through the Slack standalone sender instead of silently warning and omitting them.
- Add Slack standalone file uploads via files_upload_v2, preserving thread_ts for threaded help-channel replies.
- Make Slack text+MEDIA sends atomic from the user perspective: the first file upload carries the formatted text as its initial_comment instead of posting text first and uploading the file second. This prevents retry/manual recovery paths from leaving a standalone “attached” text message or duplicating the artifact.
- Strip MEDIA directives before queued-followup first-response sends and dispatch the attachments, so direct-send fast paths do not claim an attachment without delivering it.
- Route queued-followup direct-send MEDIA by type and attach the response text as the first attachment caption when possible, instead of sending text separately then a generic document.
- Add regression coverage for .csv.gz attachments, Slack media-only sends, Slack upload failures, no pre-upload Slack text post, and queued-response media text cleanup.

## Test plan
- pytest -q tests/tools/test_send_message_tool.py tests/gateway/test_response_attachment_helpers.py tests/gateway/test_media_extraction.py
- python -m py_compile gateway/run.py tools/send_message_tool.py plugins/platforms/slack/adapter.py tests/tools/test_send_message_tool.py tests/gateway/test_response_attachment_helpers.py
- git diff --check

## Operational note
This prevents the failure mode where a Slack reply says a CSV or pcap artifact is attached while the file never uploads, keeps Slack file uploads in the target thread, and avoids split text/file sends that make duplicate-attachment recovery likely.
