### PR TITLE
fix(config): honor secret scope for env reads

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7245,6 +7245,18 @@ def reload_env() -> int:
 
 def get_env_value(key: str) -> Optional[str]:
     """Get a value from ~/.hermes/.env or environment."""
+    try:
+        from agent.secret_scope import (
+            current_secret_scope as _current_secret_scope,
+            get_secret as _get_secret,
+            is_multiplex_active as _is_multiplex_active,
+        )
+
+        if _is_multiplex_active() or _current_secret_scope() is not None:
+            return _get_secret(key)
+    except ImportError:
+        pass
+
     # Check environment first
     if key in os.environ:
         return os.environ[key]
@@ -7276,7 +7288,7 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
         from agent.secret_scope import get_secret as _get_secret
 
         return _get_secret(key)
-    except Exception:
+    except ImportError:
         return os.environ.get(key)
 
 

--- a/tests/hermes_cli/test_env_load_cache.py
+++ b/tests/hermes_cli/test_env_load_cache.py
@@ -14,6 +14,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 
 def _write_env(path: Path, contents: str) -> None:
     path.write_text(contents, encoding="utf-8")
@@ -190,4 +192,55 @@ def test_load_env_handles_missing_file():
             assert load_env() == {}
             assert load_env() == {}  # cached
     finally:
+        invalidate_env_cache()
+
+
+def test_get_env_value_uses_profile_secret_scope_before_environ(tmp_path, monkeypatch):
+    from agent import secret_scope
+    from hermes_cli.config import get_env_value, invalidate_env_cache
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("XAI_API_KEY", "foreign-xai-key")
+    invalidate_env_cache()
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({"XAI_API_KEY": "scoped-xai-key"})
+    try:
+        assert get_env_value("XAI_API_KEY") == "scoped-xai-key"
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(False)
+        invalidate_env_cache()
+
+
+def test_get_env_value_fails_closed_without_secret_scope(tmp_path, monkeypatch):
+    from agent import secret_scope
+    from hermes_cli.config import get_env_value, invalidate_env_cache
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("XAI_API_KEY", "foreign-xai-key")
+    invalidate_env_cache()
+    secret_scope.set_multiplex_active(True)
+    try:
+        with pytest.raises(secret_scope.UnscopedSecretError):
+            get_env_value("XAI_API_KEY")
+    finally:
+        secret_scope.set_multiplex_active(False)
+        invalidate_env_cache()
+
+
+def test_get_env_value_prefer_dotenv_preserves_unscoped_fail_closed(
+    tmp_path, monkeypatch
+):
+    from agent import secret_scope
+    from hermes_cli.config import get_env_value_prefer_dotenv, invalidate_env_cache
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("XAI_API_KEY", "foreign-xai-key")
+    invalidate_env_cache()
+    secret_scope.set_multiplex_active(True)
+    try:
+        with pytest.raises(secret_scope.UnscopedSecretError):
+            get_env_value_prefer_dotenv("XAI_API_KEY")
+    finally:
+        secret_scope.set_multiplex_active(False)
         invalidate_env_cache()

--- a/tests/tools/test_xai_http_credentials.py
+++ b/tests/tools/test_xai_http_credentials.py
@@ -1,0 +1,57 @@
+import pytest
+
+
+def _set_xai_oauth_unavailable(monkeypatch):
+    from hermes_cli import auth
+
+    monkeypatch.setattr(auth, "resolve_xai_oauth_runtime_credentials", lambda **_: {})
+
+
+def test_xai_credentials_fail_closed_without_profile_scope(tmp_path, monkeypatch):
+    from agent import secret_scope
+    from hermes_cli.config import invalidate_env_cache
+    from tools.xai_http import resolve_xai_http_credentials
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("XAI_API_KEY", "foreign-xai-key")
+    monkeypatch.setenv("XAI_BASE_URL", "https://foreign.example/v1")
+    _set_xai_oauth_unavailable(monkeypatch)
+    invalidate_env_cache()
+    previous_multiplex = secret_scope.is_multiplex_active()
+    token = secret_scope.set_secret_scope(None)
+    secret_scope.set_multiplex_active(True)
+    try:
+        with pytest.raises(secret_scope.UnscopedSecretError):
+            resolve_xai_http_credentials(force_refresh=True)
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(previous_multiplex)
+        invalidate_env_cache()
+
+
+def test_xai_credentials_do_not_fall_back_to_environ_when_scope_has_no_key(
+    tmp_path, monkeypatch
+):
+    from agent import secret_scope
+    from hermes_cli.config import invalidate_env_cache
+    from tools.xai_http import resolve_xai_http_credentials
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("XAI_API_KEY", "foreign-xai-key")
+    monkeypatch.setenv("XAI_BASE_URL", "https://foreign.example/v1")
+    _set_xai_oauth_unavailable(monkeypatch)
+    invalidate_env_cache()
+    previous_multiplex = secret_scope.is_multiplex_active()
+    token = secret_scope.set_secret_scope({})
+    secret_scope.set_multiplex_active(True)
+    try:
+        credentials = resolve_xai_http_credentials(force_refresh=True)
+        assert credentials == {
+            "provider": "xai",
+            "api_key": "",
+            "base_url": "https://api.x.ai/v1",
+        }
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(previous_multiplex)
+        invalidate_env_cache()

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -60,13 +60,11 @@ def get_env_value(name: str, default=None):
     """
     try:
         from hermes_cli.config import get_env_value as _hermes_get_env_value
+    except ImportError:
+        return os.environ.get(name, default)
 
-        value = _hermes_get_env_value(name)
-        if value is not None:
-            return value
-    except Exception:
-        pass
-    return os.environ.get(name, default)
+    value = _hermes_get_env_value(name)
+    return value if value is not None else default
 
 
 def hermes_xai_user_agent() -> str:


### PR DESCRIPTION
## What does this PR do?

Routes `hermes_cli.config.get_env_value()` through the active profile secret scope when Hermes is running in multiplex mode, or when a secret scope is already installed.

Recent Vertex hardening (#56680) made provider-specific credential reads fail closed instead of falling back to another profile's process environment. The generic config env helper still had the older behavior: it checked `os.environ` first, so callers such as xAI credential resolution could read a foreign profile's `XAI_API_KEY` even when the current turn had its own scoped secret.

This keeps the legacy single-profile behavior unchanged while making multiplex/profile-scoped reads honor `agent.secret_scope`.

## Related Issue

Follow-up sibling hardening for #56680.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`
  - Makes `get_env_value()` call `agent.secret_scope.get_secret()` when multiplex mode is active or a secret scope is installed.
  - Preserves existing env-first behavior for ordinary single-profile callers.
  - Stops `get_env_value_prefer_dotenv()` from swallowing `UnscopedSecretError`; it only falls back to `os.environ` if `agent.secret_scope` cannot be imported.
- `tests/hermes_cli/test_env_load_cache.py`
  - Adds regression coverage that a scoped value wins over foreign `os.environ`.
  - Adds regression coverage that unscoped multiplex reads fail closed.
  - Adds regression coverage that `get_env_value_prefer_dotenv()` preserves the fail-closed behavior.

## How to Test

1. Run the focused regression tests:

   ```bash
   python -m pytest \
     tests/hermes_cli/test_env_load_cache.py::test_get_env_value_uses_profile_secret_scope_before_environ \
     tests/hermes_cli/test_env_load_cache.py::test_get_env_value_fails_closed_without_secret_scope \
     tests/hermes_cli/test_env_load_cache.py::test_get_env_value_prefer_dotenv_preserves_unscoped_fail_closed \
     -q
   ```

2. Run the related config/secret-scope suites:

   ```bash
   python -m pytest \
     tests/hermes_cli/test_env_load_cache.py \
     tests/agent/test_secret_scope.py \
     tests/agent/test_vertex_adapter.py \
     tests/agent/test_credential_pool.py \
     -q
   ```

3. Run lint on the changed files:

   ```bash
   python -m ruff check hermes_cli/config.py tests/hermes_cli/test_env_load_cache.py
   ```

Observed locally:

- Focused regression tests: 3 passed
- Related config/secret-scope suites: 120 passed
- Ruff: all checks passed

Manual sanity check:

```text
resolve_xai_http_credentials(force_refresh=True)
→ {'provider': 'xai', 'api_key': 'scoped-xai-key', 'base_url': 'https://scoped.example/v1'}
```

with foreign `XAI_API_KEY` / `XAI_BASE_URL` also present in `os.environ`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression tests:

```text
...                                                                      [100%]
3 passed in 0.21s
```

Related config/secret-scope suites:

```text
........................................................................ [ 60%]
................................................                         [100%]
120 passed in 2.45s
```

Ruff:

```text
All checks passed!
```
