### PR TITLE
fix(schema): inline $ref pointers to $defs for strict backend compat (#56979)

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -201,8 +201,12 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
-def test_ref_with_default_sibling_stripped():
-    """Strict backends reject ``default`` alongside ``$ref``."""
+def test_ref_with_default_sibling_inlined():
+    """Strict backends reject ``default`` alongside ``$ref``.
+
+    After inlining, the $ref is replaced with the definition and ``default``
+    is carried over as a sibling of the inlined schema (where it is legal).
+    """
     tools = [_tool("t", {
         "type": "object",
         "properties": {
@@ -217,11 +221,16 @@ def test_ref_with_default_sibling_stripped():
     })]
     out = sanitize_tool_schemas(tools)
     payload = out[0]["function"]["parameters"]["properties"]["payload"]
-    assert payload == {"$ref": "#/$defs/Payload"}
+    # $ref should be inlined — no more $ref pointer.
+    assert "$ref" not in payload
+    assert payload["type"] == "object"
+    assert "q" in payload["properties"]
+    # $defs should be removed after inlining.
+    assert "$defs" not in out[0]["function"]["parameters"]
 
 
-def test_nullable_union_collapse_does_not_leave_default_on_ref():
-    """Nullable anyOf collapse must not attach ``default`` to a ``$ref`` branch."""
+def test_nullable_union_collapse_inlines_ref():
+    """Nullable anyOf collapse + $ref inlining produces a self-contained schema."""
     tools = [_tool("t", {
         "type": "object",
         "properties": {
@@ -242,13 +251,16 @@ def test_nullable_union_collapse_does_not_leave_default_on_ref():
     })]
     out = sanitize_tool_schemas(tools)
     prop = out[0]["function"]["parameters"]["properties"]["input"]
-    assert prop["$ref"] == "#/$defs/Payload"
-    assert "default" not in prop
+    # After nullable collapse + inlining: no $ref, has the actual schema.
+    assert "$ref" not in prop
+    assert prop["type"] == "object"
+    assert "q" in prop["properties"]
     assert prop.get("nullable") is True
+    assert "$defs" not in out[0]["function"]["parameters"]
 
 
-def test_ref_description_preserved():
-    """Annotation siblings that strict backends allow should survive."""
+def test_ref_description_carried_to_inlined():
+    """Description on a $ref node is carried over to the inlined definition."""
     tools = [_tool("t", {
         "type": "object",
         "properties": {
@@ -264,7 +276,9 @@ def test_ref_description_preserved():
     out = sanitize_tool_schemas(tools)
     payload = out[0]["function"]["parameters"]["properties"]["payload"]
     assert payload["description"] == "The payload"
-    assert payload["$ref"] == "#/$defs/Payload"
+    assert "$ref" not in payload
+    assert payload["type"] == "object"
+    assert "$defs" not in out[0]["function"]["parameters"]
 
 
 def test_empty_tools_list_returns_empty():
@@ -700,3 +714,179 @@ def test_strip_slash_enum_ignores_non_string_enum_values():
     props = tools[0]["function"]["parameters"]["properties"]
     assert props["level"]["enum"] == [1, 2, 3]
     assert props["flag"]["enum"] == [True, False]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _inline_defs_refs — $ref inlining for strict backends (Fireworks, etc.)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_defs_ref_inlined_basic():
+    """$ref to $defs/X is replaced with the actual definition."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "cookie": {"$ref": "#/$defs/SetCookieParam"},
+        },
+        "$defs": {
+            "SetCookieParam": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "value": {"type": "string"},
+                },
+                "required": ["name", "value"],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]
+    cookie = params["properties"]["cookie"]
+    assert "$ref" not in cookie
+    assert cookie["type"] == "object"
+    assert "name" in cookie["properties"]
+    assert "value" in cookie["properties"]
+    assert cookie["required"] == ["name", "value"]
+    assert "$defs" not in params
+
+
+def test_defs_ref_inlined_nested():
+    """$ref nested inside properties is also inlined."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "request": {
+                "type": "object",
+                "properties": {
+                    "cookie": {"$ref": "#/$defs/Cookie"},
+                },
+            },
+        },
+        "$defs": {
+            "Cookie": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    inner = out[0]["function"]["parameters"]["properties"]["request"]["properties"]["cookie"]
+    assert "$ref" not in inner
+    assert inner["type"] == "object"
+    assert "name" in inner["properties"]
+
+
+def test_defs_ref_inlined_legacy_definitions():
+    """Legacy ``definitions`` key (draft-07) is also inlined."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "item": {"$ref": "#/definitions/Item"},
+        },
+        "definitions": {
+            "Item": {"type": "string"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]
+    item = params["properties"]["item"]
+    assert "$ref" not in item
+    assert item["type"] == "string"
+    assert "definitions" not in params
+
+
+def test_defs_ref_inlined_multiple_refs():
+    """Multiple distinct $ref pointers are all inlined."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "a": {"$ref": "#/$defs/A"},
+            "b": {"$ref": "#/$defs/B"},
+        },
+        "$defs": {
+            "A": {"type": "string"},
+            "B": {"type": "integer"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    props = out[0]["function"]["parameters"]["properties"]
+    assert props["a"] == {"type": "string"}
+    assert props["b"] == {"type": "integer"}
+    assert "$defs" not in out[0]["function"]["parameters"]
+
+
+def test_defs_ref_unknown_ref_preserved():
+    """$ref pointing to a non-existent definition is left as-is."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "x": {"$ref": "#/$defs/NonExistent"},
+        },
+        "$defs": {
+            "Real": {"type": "string"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    x = out[0]["function"]["parameters"]["properties"]["x"]
+    # Unknown ref preserved — can't inline what doesn't exist.
+    assert x["$ref"] == "#/$defs/NonExistent"
+
+
+def test_defs_ref_external_ref_preserved():
+    """$ref to an external schema (not #/$defs/) is left untouched."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "x": {"$ref": "https://json-schema.org/draft-07/schema"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    x = out[0]["function"]["parameters"]["properties"]["x"]
+    assert x["$ref"] == "https://json-schema.org/draft-07/schema"
+
+
+def test_no_defs_no_change():
+    """Schema without $defs is returned unchanged by inlining."""
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+    }
+    tools = [_tool("t", copy.deepcopy(schema))]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["properties"]["x"] == {"type": "string"}
+
+
+def test_defs_ref_fireworks_set_cookie_param():
+    """Regression test for #56979: Fireworks rejects $ref to $defs/SetCookieParam."""
+    tools = [_tool("browser_set_cookie", {
+        "type": "object",
+        "properties": {
+            "cookie": {"$ref": "#/$defs/SetCookieParam", "description": "The cookie to set"},
+        },
+        "$defs": {
+            "SetCookieParam": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Cookie name"},
+                    "value": {"type": "string", "description": "Cookie value"},
+                    "domain": {"type": "string", "description": "Cookie domain"},
+                    "path": {"type": "string", "description": "Cookie path"},
+                },
+                "required": ["name", "value"],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]
+    cookie = params["properties"]["cookie"]
+    # Fireworks can't resolve $ref — verify it's inlined.
+    assert "$ref" not in cookie
+    assert cookie["type"] == "object"
+    assert "name" in cookie["properties"]
+    assert "value" in cookie["properties"]
+    assert cookie["description"] == "The cookie to set"
+    assert cookie["required"] == ["name", "value"]
+    # $defs removed.
+    assert "$defs" not in params
+    # Input not mutated.
+    assert "SetCookieParam" in tools[0]["function"]["parameters"].get("$defs", {})

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -97,6 +97,7 @@ def _sanitize_single_tool(tool: dict) -> dict:
         fn["parameters"], path=fn.get("name", "<tool>")
     )
     fn["parameters"] = _strip_ref_siblings(fn["parameters"])
+    fn["parameters"] = _inline_defs_refs(fn["parameters"], path=fn.get("name", "<tool>"))
     return out
 
 
@@ -126,6 +127,99 @@ def _strip_ref_siblings(node: Any) -> Any:
             if key in out:
                 out.pop(key, None)
     return out
+
+
+def _inline_defs_refs(node: Any, *, path: str = "<tool>") -> Any:
+    """Inline ``$ref`` pointers into ``$defs`` / ``definitions``.
+
+    Strict OpenAI-compatible backends (Fireworks, some JSON-Schema draft-07
+    validators) fail tool requests when the schema contains ``$ref``::
+
+        Error resolving schema reference '#/$defs/SetCookieParam'
+
+    This function resolves every ``{"$ref": "#/$defs/X"}`` (and the legacy
+    ``#/definitions/X`` form) by replacing the ``$ref`` node with a copy of
+    the referenced definition.  After inlining, the now-unused ``$defs`` /
+    ``definitions`` block is removed from the top-level parameters object so
+    the emitted schema is fully self-contained.
+
+    Circular references are guarded by a depth limit (max 8 expansions of
+    the same ref path); tool schemas from MCP servers are tree-structured
+    in practice so this never fires on real input.
+    """
+    # Collect all $defs / definitions blocks reachable from the root.
+    defs: dict[str, Any] = {}
+    if isinstance(node, dict):
+        for defs_key in ("$defs", "definitions"):
+            block = node.get(defs_key)
+            if isinstance(block, dict):
+                defs.update(block)
+
+    if not defs:
+        return node
+
+    result = _do_inline_refs(node, defs, path=path, _seen=set())
+
+    # Strip the now-inlined $defs / definitions from the top level.
+    if isinstance(result, dict):
+        for defs_key in ("$defs", "definitions"):
+            if defs_key in result:
+                logger.debug(
+                    "schema_sanitizer[%s]: removed %s after inlining refs",
+                    path, defs_key,
+                )
+                result.pop(defs_key, None)
+
+    return result
+
+
+def _do_inline_refs(
+    node: Any,
+    defs: dict[str, Any],
+    *,
+    path: str,
+    _seen: set[str],
+    _depth: int = 0,
+) -> Any:
+    """Recursively walk *node*, replacing ``$ref`` with the definition."""
+    if _depth > 8:
+        return node
+
+    if isinstance(node, list):
+        return [_do_inline_refs(item, defs, path=f"{path}[{i}]", _seen=_seen, _depth=_depth)
+                for i, item in enumerate(node)]
+    if not isinstance(node, dict):
+        return node
+
+    ref = node.get("$ref")
+    if isinstance(ref, str) and ref.startswith("#/"):
+        # Accept both #/$defs/X and #/definitions/X
+        parts = ref.lstrip("#/").split("/", 1)
+        if len(parts) == 2 and parts[0] in ("$defs", "definitions") and parts[1] in defs:
+            ref_key = parts[1]
+            if ref_key in _seen:
+                # Circular — return the ref as-is rather than infinite loop.
+                return node
+            _seen.add(ref_key)
+            logger.debug(
+                "schema_sanitizer[%s]: inlining $ref %r", path, ref,
+            )
+            replacement = copy.deepcopy(defs[ref_key])
+            # Carry over sibling keywords (description, title, etc.) that
+            # were on the $ref node — but NOT $ref itself.
+            for k, v in node.items():
+                if k == "$ref":
+                    continue
+                if k not in replacement:
+                    replacement[k] = v
+            result = _do_inline_refs(replacement, defs, path=path, _seen=_seen, _depth=_depth + 1)
+            _seen.discard(ref_key)
+            return result
+
+    # Not a $ref — recurse into children.
+    return {k: _do_inline_refs(v, defs, path=f"{path}.{k}", _seen=_seen, _depth=_depth)
+            if isinstance(v, (dict, list)) else v
+            for k, v in node.items()}
 
 
 _TOP_LEVEL_FORBIDDEN_KEYS = ("allOf", "anyOf", "oneOf", "enum", "not")


### PR DESCRIPTION
## What does this PR do?

Inline `$ref` pointers into `$defs` / `definitions` in tool parameter schemas before sending them to LLM backends. Strict OpenAI-compatible providers like Fireworks reject schemas that contain `$ref` with HTTP 400:

```
Error resolving schema reference '#/$defs/SetCookieParam': AttributeError("'NoneType' object has no attribute 'lookup'")
```

The existing `schema_sanitizer.py` already recursed into `$defs` for type normalization but left `$ref` pointers intact. This PR adds a post-processing step that resolves every `#/$defs/X` (and legacy `#/definitions/X`) reference by replacing it with a deep copy of the definition, then removes the now-unused `$defs` block. The result is a fully self-contained schema that strict backends can validate.

## Related Issue

Fixes #56979

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py`: Added `_inline_defs_refs()` and `_do_inline_refs()` — walk the schema tree, resolve `$ref` → `$defs` pointers, carry over sibling keywords (description, title), strip `$defs` after inlining. Circular refs guarded by depth limit (8).
- `tests/tools/test_schema_sanitizer.py`: Updated 3 existing tests to expect inlined output instead of preserved `$ref`; added 8 new tests covering basic inlining, nested refs, legacy `definitions`, multiple refs, unknown refs, external refs, no-op on `$defs`-free schemas, and a regression test reproducing the exact #56979 `SetCookieParam` error.

## How to Test

1. `python -m pytest tests/tools/test_schema_sanitizer.py -q` — should pass (51 tests).
2. Regression test `test_defs_ref_fireworks_set_cookie_param` reproduces the exact schema shape from #56979.
3. Manual: configure a custom Fireworks provider with tools enabled and send a message — should no longer get HTTP 400 on `$ref` resolution.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_schema_sanitizer.py -q` and all 51 tests pass
- [x] I've added tests for my changes (8 new tests + 3 updated)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (code-only change)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A (schema behavior change is transparent)

## Screenshots / Logs

```
schema_sanitizer[browser_set_cookie]: inlining $ref '#/$defs/SetCookieParam'
schema_sanitizer[browser_set_cookie]: removed $defs after inlining refs
```
