### PR TITLE
fix(codex): extend stale timeout for gateway-scale tool payloads

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -128,6 +128,23 @@ def _is_openai_codex_backend(agent) -> bool:
     )
 
 
+def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
+    """Minimum wall-clock stale timeout for openai-codex by estimated context.
+
+    Gateway/Telegram sessions routinely ship ~15–25k tokens of tools +
+    instructions before the first user message. Subscription-backed Codex can
+    legitimately spend several minutes in backend admission/prefill at that
+    size; the generic 90s non-stream stale default aborts healthy calls.
+    """
+    if est_tokens > 100_000:
+        return 1200.0
+    if est_tokens > 50_000:
+        return 900.0
+    if est_tokens > 10_000:
+        return 600.0
+    return 0.0
+
+
 def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
     """Return a normalized OpenRouter provider.sort value or None."""
     if not isinstance(raw_sort, str):
@@ -316,12 +333,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
     _openai_codex_backend = _is_openai_codex_backend(agent)
     _est_tokens_for_codex_watchdog = estimate_request_context_tokens(api_kwargs)
     if _codex_watchdog_enabled and _openai_codex_backend:
-        if _est_tokens_for_codex_watchdog > 100_000:
-            _stale_timeout = max(_stale_timeout, 1200.0)
-        elif _est_tokens_for_codex_watchdog > 50_000:
-            _stale_timeout = max(_stale_timeout, 900.0)
-        elif _est_tokens_for_codex_watchdog > 25_000:
-            _stale_timeout = max(_stale_timeout, 600.0)
+        _codex_floor = openai_codex_stale_timeout_floor(_est_tokens_for_codex_watchdog)
+        if _codex_floor:
+            _stale_timeout = max(_stale_timeout, _codex_floor)
 
     if _est_tokens_for_codex_watchdog > 100_000:
         _codex_idle_timeout_default = 180.0
@@ -344,7 +358,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
     elif _openai_codex_backend:
-        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 25_000.0)
+        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 10_000.0)
         _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
             "1", "true", "yes", "on"
         }

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -380,7 +380,7 @@ def test_large_codex_request_waits_instead_of_ttfb_reconnect(tmp_path, monkeypat
 
     monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
 
-    large_input = "x" * 120_000  # ~30k estimated tokens, above large-request gate.
+    large_input = "x" * 44_000  # ~11k estimated tokens, above the 10k gate.
     resp = h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": large_input})
     assert resp is sentinel
     assert "codex_ttfb_kill" not in closes
@@ -415,7 +415,7 @@ def test_large_codex_request_strict_ttfb_env_still_reconnects(tmp_path, monkeypa
 
     monkeypatch.setattr(agent, "_run_codex_stream", fake_hang)
 
-    large_input = "x" * 120_000
+    large_input = "x" * 44_000
     try:
         with pytest.raises(TimeoutError) as excinfo:
             h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": large_input})

--- a/tests/agent/test_non_stream_stale_timeout.py
+++ b/tests/agent/test_non_stream_stale_timeout.py
@@ -188,3 +188,22 @@ providers:
 
     agent = _make_agent(tmp_path)
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 1800.0
+
+
+# ── openai-codex gateway-scale stale floor ────────────────────────────────
+
+
+def test_openai_codex_stale_floor_covers_gateway_tool_payload():
+    """Gateway/Telegram tool payloads (~20k tokens) need the 600s Codex floor."""
+    from agent.chat_completion_helpers import openai_codex_stale_timeout_floor
+
+    assert openai_codex_stale_timeout_floor(22_095) == 600.0
+    assert openai_codex_stale_timeout_floor(10_001) == 600.0
+    assert openai_codex_stale_timeout_floor(10_000) == 0.0
+
+
+def test_openai_codex_stale_floor_tiers():
+    from agent.chat_completion_helpers import openai_codex_stale_timeout_floor
+
+    assert openai_codex_stale_timeout_floor(55_000) == 900.0
+    assert openai_codex_stale_timeout_floor(120_000) == 1200.0


### PR DESCRIPTION
## Summary
- Lower the openai-codex wall-clock stale-timeout floor from 25k to 10k estimated tokens so Telegram/gateway sessions (~20k tools+instructions) are not killed at the generic 90s cutoff while Codex is still prefilling
- Align the no-byte TTFB disable gate to the same 10k threshold
- Add regression tests for the ~22k-token gateway case reported in Discord

## Context
User report: openai-codex/gpt-5.4 on Telegram gateway timed out at 90s with `context=~22,095 tokens`, but the orphaned request completed ~281s later. DeepSeek worked fine; Codex subscription was valid.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_non_stream_stale_timeout.py tests/agent/test_codex_ttfb_watchdog.py -q`