### PR TITLE
fix(agent): strip orphan tool_calls in repair_message_sequence (#56980)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -384,6 +384,14 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
          any preceding assistant tool_call — dropped.
       2. Consecutive ``user`` messages — merged with newline separator
          so no user input is lost.
+      3. ``assistant`` messages whose ``tool_calls`` are missing all
+         ``tool`` results (``tool_call_id`` never seen) — the orphan
+         calls are stripped, leaving the assistant text intact. This
+         occurs after context compaction, partial session resume, or
+         retry loops that drop tool results. Without this pass,
+         strict providers (DeepSeek v4, Kimi) return HTTP 400
+         "insufficient tool messages following tool_calls message".
+         Refs #56980.
 
     Deliberately does NOT rewind orphan ``assistant(tool_calls)+tool``
     pairs that precede a user message — that pattern IS valid when the
@@ -518,6 +526,36 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 repairs += 1
                 continue
         merged.append(msg)
+
+    # Pass 3: strip orphan tool_calls from assistant messages that have
+    # no matching tool results.  After Pass 1 dropped stray tool msgs,
+    # an ``assistant(tool_calls)`` that originally had results may now
+    # reference ids that were never seen — its tool calls are dangled.
+    # Strict providers (DeepSeek v4, Kimi) reject such histories with
+    # HTTP 400 "insufficient tool messages following tool_calls message".
+    # Fix: build a set of every tool_call_id actually present in tool
+    # messages, then strip tool_calls whose ids are absent.  Refs #56980.
+    seen_tool_ids: set = set()
+    for msg in merged:
+        if isinstance(msg, dict) and msg.get("role") == "tool":
+            tc_id = msg.get("tool_call_id")
+            if tc_id:
+                seen_tool_ids.add(tc_id)
+    for msg in merged:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        calls = msg.get("tool_calls")
+        if not calls:
+            continue
+        orphan_calls = [tc for tc in calls if not (isinstance(tc, dict) and tc.get("id") in seen_tool_ids)]
+        if not orphan_calls:
+            continue
+        kept = [tc for tc in calls if tc not in orphan_calls]
+        if kept:
+            msg["tool_calls"] = kept
+        else:
+            del msg["tool_calls"]
+        repairs += len(orphan_calls)
 
     if repairs > 0:
         # Rewrite in place so downstream paths (persistence, return

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -201,6 +201,79 @@ def test_repair_preserves_system_messages():
     assert messages == original
 
 
+def test_repair_strips_orphan_tool_calls_at_end():
+    """assistant(tool_calls) at end with no tool results → strip tool_calls."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "c1", "type": "function",
+                         "function": {"name": "read_file", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "file content"},
+        {"role": "assistant", "content": "checking more",
+         "tool_calls": [{"id": "c2", "type": "function",
+                         "function": {"name": "terminal", "arguments": "{}"}}]},
+        # c2 has no tool result — context compaction stripped it
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs >= 1
+    # The last assistant message must have its orphan tool_calls stripped
+    last = messages[-1]
+    assert last["role"] == "assistant"
+    assert "tool_calls" not in last
+    assert last["content"] == "checking more"
+
+
+def test_repair_strips_orphan_parallel_tool_calls():
+    """assistant with parallel tool_calls where some results are missing."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [
+             {"id": "c1", "type": "function",
+              "function": {"name": "read_file", "arguments": "{}"}},
+             {"id": "c2", "type": "function",
+              "function": {"name": "terminal", "arguments": "{}"}},
+         ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "file content"},
+        # c2 result is missing
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs >= 1
+    # c2 should be stripped, c1 kept
+    assistant = messages[1]
+    assert assistant["role"] == "assistant"
+    remaining_ids = [tc["id"] for tc in assistant.get("tool_calls", [])]
+    assert "c1" in remaining_ids
+    assert "c2" not in remaining_ids
+
+
+def test_repair_preserves_complete_tool_calls():
+    """Complete tool_calls with matching results must NOT be stripped."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "c1", "type": "function",
+                         "function": {"name": "read_file", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "file content"},
+        {"role": "assistant", "content": "done"},
+    ]
+    original = [dict(m) for m in messages]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    # No repairs expected — sequence is valid
+    assert repairs == 0
+    # tool_calls should be preserved
+    assert "tool_calls" in messages[1]
+
+
 # ── repair_message_sequence_with_cursor (#44837) ───────────────────────────
 
 from agent.agent_runtime_helpers import repair_message_sequence_with_cursor


### PR DESCRIPTION
## What does this PR do?

Adds Pass 3 to `repair_message_sequence` that strips orphan `tool_calls` from assistant messages whose `tool_call_id`s have no matching `tool` result messages in the sequence. This prevents HTTP 400 "insufficient tool messages following tool_calls message" from strict providers (DeepSeek v4, Kimi) when context compaction, partial session resume, or retry loops leave dangling tool-call references.

## Related Issue

Fixes #56980

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`: Added Pass 3 in `repair_message_sequence` — builds a set of all `tool_call_id`s present in `tool` messages, then strips `tool_calls` entries from assistant messages whose ids are absent. Keeps assistant text content intact; only removes the orphan calls.
- `tests/run_agent/test_message_sequence_repair.py`: Added 3 tests covering the new pass — orphan tool_calls at sequence end, parallel tool_calls with partial results missing, and no-op when all tool_calls have matching results.

## How to Test

1. Run `python -m pytest tests/run_agent/test_message_sequence_repair.py -v` — all 28 tests should pass, including the 3 new ones (`test_repair_strips_orphan_tool_calls_at_end`, `test_repair_strips_orphan_parallel_tool_calls`, `test_repair_preserves_complete_tool_calls`).
2. The fix is verified by the new test `test_repair_strips_orphan_tool_calls_at_end` which simulates the exact scenario from the issue: an assistant message with `tool_calls` at the end of the sequence with no matching tool result.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
