### PR TITLE
fix(security): block credential files in context git refs

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -6,6 +6,7 @@ import json
 import mimetypes
 import os
 import re
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -321,7 +322,66 @@ def _expand_git_reference(
     content = result.stdout.strip()
     if not content:
         content = "(no output)"
+    denied_path = _git_patch_denied_path(content, cwd)
+    if denied_path is not None:
+        return (
+            f"{ref.raw}: git patch touches a sensitive credential path "
+            f"({denied_path}) and cannot be attached",
+            None,
+        )
     return None, f"🧾 {label} ({estimate_tokens_rough(content)} tokens)\n```diff\n{content}\n```"
+
+
+def _git_patch_denied_path(content: str, cwd: Path) -> str | None:
+    """Return the first credential-denied path referenced by a git patch."""
+    if not content or content == "(no output)":
+        return None
+    try:
+        from agent.file_safety import get_read_block_error
+    except Exception:
+        return "<unverified git patch path>"
+
+    for raw_path in _iter_git_patch_paths(content):
+        if raw_path is None:
+            continue
+        try:
+            candidate = (cwd / raw_path).resolve()
+            blocked = get_read_block_error(str(candidate))
+        except Exception:
+            return raw_path
+        if blocked is not None:
+            return raw_path
+    return None
+
+
+def _iter_git_patch_paths(content: str) -> list[str | None]:
+    paths: list[str | None] = []
+    for line in content.splitlines():
+        if line.startswith("diff --git "):
+            parts = _split_git_header(line)
+            if len(parts) >= 4:
+                paths.append(_normalize_git_patch_path(parts[2]))
+                paths.append(_normalize_git_patch_path(parts[3]))
+            continue
+        if line.startswith("--- ") or line.startswith("+++ "):
+            paths.append(_normalize_git_patch_path(line[4:]))
+    return paths
+
+
+def _split_git_header(line: str) -> list[str]:
+    try:
+        return shlex.split(line)
+    except ValueError:
+        return line.split()
+
+
+def _normalize_git_patch_path(raw: str) -> str | None:
+    path = raw.strip()
+    if not path or path == "/dev/null":
+        return None
+    if path.startswith(("a/", "b/")):
+        path = path[2:]
+    return path or None
 
 
 async def _fetch_url_content(

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -192,6 +192,40 @@ def test_expand_git_diff_staged_and_log(sample_repo: Path):
     assert "VALUE = 2" in result.message
 
 
+def test_staged_diff_refuses_credential_env_patch(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    secret_file = sample_repo / ".env"
+    secret_file.write_text("OPENAI_API_KEY=sk-test-secret-1234567890\n", encoding="utf-8")
+    _git(sample_repo, "add", ".env")
+
+    result = preprocess_context_references(
+        "Inspect @staged",
+        cwd=sample_repo,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "sensitive credential path" in result.message
+    assert "sk-test-secret" not in result.message
+    assert "OPENAI_API_KEY" not in result.message
+
+
+def test_staged_diff_allows_normal_source_patch(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    result = preprocess_context_references(
+        "Inspect @staged",
+        cwd=sample_repo,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "git diff --staged" in result.message
+    assert "VALUE = 2" in result.message
+    assert not result.warnings
+
+
 def test_missing_file_becomes_warning(sample_repo: Path):
     from agent.context_references import preprocess_context_references
 


### PR DESCRIPTION
## Summary

`@diff`, `@staged`, and `@git:N` context references attach raw git patch output without checking whether the patch touches credential-denied files. That means a staged or committed `.env` / Hermes auth file can be injected into model context even though direct `@file:.env` expansion is blocked by the canonical read deny-list.

## Why

The `@file` path now routes through `agent.file_safety.get_read_block_error()`, but git references bypass that path entirely:

- `@staged` runs `git diff --staged`
- `@diff` runs `git diff`
- `@git:N` runs `git log -N -p`

If the patch includes a secret-bearing file such as `.env`, the secret-bearing lines are returned inside the diff block.

Minimal repro before the fix:

```text
git init
echo hello > README.md
git add README.md && git commit -m init
echo OPENAI_API_KEY=sk-test-secret-1234567890 > .env
git add .env