### PR TITLE
fix(api): persist compressed responses history

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2518,6 +2518,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response_text = ""
         agent_error: Optional[str] = None
+        agent_result: Optional[Dict[str, Any]] = None
+        effective_session_id = session_id
         usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
         terminal_snapshot_persisted = False
 
@@ -2525,6 +2527,7 @@ class APIServerAdapter(BasePlatformAdapter):
             response_env: Dict[str, Any],
             *,
             conversation_history_snapshot: Optional[List[Dict[str, Any]]] = None,
+            snapshot_session_id: Optional[str] = None,
         ) -> None:
             if not store:
                 return
@@ -2535,7 +2538,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "response": response_env,
                 "conversation_history": conversation_history_snapshot,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": snapshot_session_id if snapshot_session_id is not None else session_id,
             })
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
@@ -2819,18 +2822,20 @@ class APIServerAdapter(BasePlatformAdapter):
             # Pick up agent result + usage from the completed task
             try:
                 result, agent_usage = await agent_task
+                agent_result = result if isinstance(result, dict) else None
+                effective_session_id = self._result_effective_session_id(agent_result, session_id)
                 usage = agent_usage or usage
                 # If the agent produced a final_response but no text
                 # deltas were streamed (e.g. some providers only emit
                 # the full response at the end), emit a single fallback
                 # delta so Responses clients still receive a live text part.
-                agent_final = result.get("final_response", "") if isinstance(result, dict) else ""
+                agent_final = agent_result.get("final_response", "") if agent_result else ""
                 if agent_final and not final_text_parts:
                     await _emit_text_delta(agent_final)
                 if agent_final and not final_response_text:
                     final_response_text = agent_final
-                if isinstance(result, dict) and result.get("error") and not final_response_text:
-                    agent_error = _redact_api_error_text(result["error"])
+                if agent_result and agent_result.get("error") and not final_response_text:
+                    agent_error = _redact_api_error_text(agent_result["error"])
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = _redact_api_error_text(e)
@@ -2918,6 +2923,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 _persist_response_snapshot(
                     failed_env,
                     conversation_history_snapshot=_failed_history,
+                    snapshot_session_id=effective_session_id,
                 )
                 terminal_snapshot_persisted = True
                 await _write_event("response.failed", {
@@ -2935,12 +2941,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 full_history = self._build_response_conversation_history(
                     conversation_history,
                     user_message,
-                    result,
+                    agent_result or {},
                     final_response_text,
+                    prefer_result_messages=effective_session_id != session_id,
                 )
                 _persist_response_snapshot(
                     completed_env,
                     conversation_history_snapshot=full_history,
+                    snapshot_session_id=effective_session_id,
                 )
                 terminal_snapshot_persisted = True
                 await _write_event("response.completed", {
@@ -3238,6 +3246,7 @@ class APIServerAdapter(BasePlatformAdapter):
         final_response = _resolve_media_to_data_urls(result.get("final_response", ""))
         if not final_response:
             final_response = _redact_api_error_text(result.get("error", "(No response generated)"))
+        effective_session_id = self._result_effective_session_id(result, session_id)
 
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
         created_at = int(time.time())
@@ -3249,6 +3258,7 @@ class APIServerAdapter(BasePlatformAdapter):
             user_message,
             result,
             final_response,
+            prefer_result_messages=effective_session_id != session_id,
         )
 
         # Build output items from the current turn only.  AIAgent returns a
@@ -3281,14 +3291,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "response": response_data,
                 "conversation_history": full_history,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": effective_session_id,
             })
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
 
-        response_headers = {"X-Hermes-Session-Id": session_id}
+        response_headers = {"X-Hermes-Session-Id": effective_session_id}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(response_data, headers=response_headers)
@@ -3633,6 +3643,8 @@ class APIServerAdapter(BasePlatformAdapter):
         user_message: Any,
         result: Dict[str, Any],
         final_response: Any,
+        *,
+        prefer_result_messages: bool = False,
     ) -> List[Dict[str, Any]]:
         """Build the stored Responses transcript without duplicating history."""
         prior = list(conversation_history)
@@ -3645,7 +3657,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 user_message,
                 result,
             )
-            if turn_start:
+            if turn_start or prefer_result_messages:
                 return list(agent_messages)
 
             full_history = prior
@@ -3676,7 +3688,26 @@ class APIServerAdapter(BasePlatformAdapter):
             return len(expected_prefix)
         if prior and agent_messages[:len(prior)] == prior:
             return len(prior)
+        for idx in range(len(agent_messages) - 1, -1, -1):
+            msg = agent_messages[idx]
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == current_user["role"]
+                and msg.get("content") == current_user["content"]
+            ):
+                return idx + 1
         return 0
+
+    @staticmethod
+    def _result_effective_session_id(
+        result: Optional[Dict[str, Any]],
+        fallback: Optional[str],
+    ) -> Optional[str]:
+        if isinstance(result, dict):
+            session_id = result.get("session_id")
+            if isinstance(session_id, str) and session_id:
+                return session_id
+        return fallback
 
     @classmethod
     def _turn_transcript_messages(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2068,6 +2068,171 @@ class TestResponsesEndpoint:
             assert first_session_id == second_session_id
 
     @pytest.mark.asyncio
+    async def test_previous_response_id_advances_to_compressed_session_and_history(self, adapter):
+        """Compression-rotated Responses chains must not reload stale parent history."""
+        stale_history = [
+            {"role": "user", "content": "old oversized prompt"},
+            {"role": "assistant", "content": "old oversized answer"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(stale_history),
+                "session_id": "pre-compression-session",
+            },
+        )
+
+        compacted_history = [
+            {"role": "assistant", "content": "Compaction handoff summary"},
+            {"role": "user", "content": "next turn"},
+            {"role": "assistant", "content": "compressed ok"},
+        ]
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "compressed ok",
+                        "messages": list(compacted_history),
+                        "session_id": "compressed-session",
+                        "api_calls": 1,
+                    },
+                    usage,
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "next turn",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+
+            assert resp.status == 200
+            assert resp.headers["X-Hermes-Session-Id"] == "compressed-session"
+            data = await resp.json()
+            stored = adapter._response_store.get(data["id"])
+            assert stored["session_id"] == "compressed-session"
+            assert stored["conversation_history"] == compacted_history
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "continued",
+                        "messages": compacted_history + [
+                            {"role": "user", "content": "after compression"},
+                            {"role": "assistant", "content": "continued"},
+                        ],
+                        "session_id": "compressed-session",
+                        "api_calls": 1,
+                    },
+                    usage,
+                )
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "after compression",
+                        "previous_response_id": data["id"],
+                    },
+                )
+
+            assert resp2.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["session_id"] == "compressed-session"
+            assert call_kwargs["conversation_history"] == compacted_history
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_advances_to_in_place_compressed_history(self, adapter):
+        """Same-session compression returns persisted metadata on messages."""
+        stale_history = [
+            {"role": "user", "content": f"old oversized prompt {idx}", "_db_persisted": True}
+            for idx in range(100)
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(stale_history),
+                "session_id": "same-session",
+            },
+        )
+
+        compacted_history = [
+            {
+                "role": "assistant",
+                "content": "[CONTEXT COMPACTION - REFERENCE ONLY] summary",
+                "_compressed_summary": True,
+                "_db_persisted": True,
+            },
+            {"role": "user", "content": "next turn", "_db_persisted": True},
+            {
+                "role": "assistant",
+                "content": "compressed ok",
+                "finish_reason": "stop",
+                "_db_persisted": True,
+            },
+        ]
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "compressed ok",
+                        "messages": list(compacted_history),
+                        "session_id": "same-session",
+                        "api_calls": 1,
+                    },
+                    usage,
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "next turn",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            stored = adapter._response_store.get(data["id"])
+            assert stored["session_id"] == "same-session"
+            assert stored["conversation_history"] == compacted_history
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "continued",
+                        "messages": compacted_history + [
+                            {"role": "user", "content": "after compression", "_db_persisted": True},
+                            {"role": "assistant", "content": "continued", "_db_persisted": True},
+                        ],
+                        "session_id": "same-session",
+                        "api_calls": 1,
+                    },
+                    usage,
+                )
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "after compression",
+                        "previous_response_id": data["id"],
+                    },
+                )
+
+            assert resp2.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["session_id"] == "same-session"
+            assert call_kwargs["conversation_history"] == compacted_history
+
+    @pytest.mark.asyncio
     async def test_invalid_previous_response_id_returns_404(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -2486,6 +2651,72 @@ class TestResponsesStreaming:
         assert stored_history == expected_history
         assert stored_history.count(prior_history[0]) == 1
         assert stored_history.count({"role": "user", "content": "Now add 1 more"}) == 1
+
+    @pytest.mark.asyncio
+    async def test_streamed_previous_response_id_advances_to_compressed_session_and_history(self, adapter):
+        stale_history = [
+            {"role": "user", "content": "old oversized prompt"},
+            {"role": "assistant", "content": "old oversized answer"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(stale_history),
+                "session_id": "pre-compression-session",
+            },
+        )
+
+        compacted_history = [
+            {"role": "assistant", "content": "Compaction handoff summary"},
+            {"role": "user", "content": "next turn"},
+            {"role": "assistant", "content": "compressed ok"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("compressed ok")
+                return (
+                    {
+                        "final_response": "compressed ok",
+                        "messages": list(compacted_history),
+                        "session_id": "compressed-session",
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "next turn",
+                        "previous_response_id": "resp_prev",
+                        "stream": True,
+                    },
+                )
+                body = await resp.text()
+
+        assert resp.status == 200
+        response_id = None
+        for line in body.splitlines():
+            if line.startswith("data: "):
+                try:
+                    payload = json.loads(line[len("data: "):])
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("type") == "response.completed":
+                    response_id = payload["response"]["id"]
+                    break
+
+        assert response_id
+        stored = adapter._response_store.get(response_id)
+        assert stored["session_id"] == "compressed-session"
+        assert stored["conversation_history"] == compacted_history
 
     @pytest.mark.asyncio
     async def test_stream_cancelled_persists_incomplete_snapshot(self, adapter):


### PR DESCRIPTION
## What does this PR do?

This PR fixes repeated context compression in the `/v1/responses` `previous_response_id` chain after Hermes compacts an agent transcript.

The Responses endpoint stores snapshots in `response_store.db` so later requests can continue from a previous response. When the agent compressed context, it returned a compacted `result["messages"]` transcript, but the API server could fail to recognize that transcript as the current turn's canonical history. In same-session compression, returned messages may include internal metadata such as `_db_persisted` or `_compressed_summary`, so full dict equality against the current user message failed.

When that boundary detection failed, the snapshot builder reattached the old oversized parent history in front of the compacted transcript. The next `previous_response_id` request therefore loaded stale history again and triggered compression repeatedly.

This fix:

- Stores the effective agent `session_id` returned by `_run_agent`, so chains follow compression-rotated sessions.
- Persists the compacted `result["messages"]` transcript after compression instead of rebuilding from stale parent history.
- Detects same-session compressed transcripts by matching the current user boundary on only `role` and `content`, ignoring internal persistence metadata.
- Applies the behavior to both non-streaming and streaming `/v1/responses` paths.
- Adds regression coverage for rotated-session compression, same-session compression with metadata, and streaming compression snapshots.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/56895

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - Persist the effective session id returned by the agent result for Responses snapshots and response headers.
  - Prefer the agent-returned compacted transcript when compression changes the effective session.
  - Detect same-session compacted transcripts by scanning for the current user message using only `role` and `content`.
  - Apply snapshot persistence changes to both streaming and non-streaming Responses flows.

- `tests/gateway/test_api_server.py`
  - Added a regression test for `previous_response_id` chaining after compression rotates to a new session.
  - Added a regression test for same-session compression where messages contain `_db_persisted` / `_compressed_summary` metadata.
  - Added streaming Responses coverage to ensure compressed session/history snapshots are persisted correctly.

## How to Test

1. Run syntax compilation:

   ```bash
   python -m compileall -q gateway\platforms\api_server.py tests\gateway\test_api_server.py
   ```

2. Run targeted Responses regression coverage:

   ```bash
   python -m pytest tests/gateway/test_api_server.py::TestResponsesEndpoint::test_previous_response_id_advances_to_in_place_compressed_history tests/gateway/test_api_server.py::TestResponsesEndpoint::test_previous_response_id_advances_to_compressed_session_and_history tests/gateway/test_api_server.py::TestResponsesStreaming::test_streamed_previous_response_id_advances_to_compressed_session_and_history tests/gateway/test_api_server.py::TestResponsesEndpoint::test_previous_response_id_chaining tests/gateway/test_api_server.py::TestResponsesEndpoint::test_previous_response_id_outputs_only_current_turn_items
   ```

3. Run the same async test methods through a focused manual runner:

   ```bash
   python - <<'PY'
   import asyncio
   from tests.gateway.test_api_server import _make_adapter, TestResponsesEndpoint, TestResponsesStreaming

   CASES = [
       (TestResponsesEndpoint(), "test_previous_response_id_advances_to_in_place_compressed_history"),
       (TestResponsesEndpoint(), "test_previous_response_id_advances_to_compressed_session_and_history"),
       (TestResponsesStreaming(), "test_streamed_previous_response_id_advances_to_compressed_session_and_history"),
       (TestResponsesEndpoint(), "test_previous_response_id_chaining"),
       (TestResponsesEndpoint(), "test_previous_response_id_outputs_only_current_turn_items"),
   ]

   async def main():
       for instance, name in CASES:
           adapter = _make_adapter()
           await getattr(instance, name)(adapter)
           print(f"PASS {name}")

   asyncio.run(main())
   PY
   ```

Expected result:

```text
PASS test_previous_response_id_advances_to_in_place_compressed_history
PASS test_previous_response_id_advances_to_compressed_session_and_history
PASS test_streamed_previous_response_id_advances_to_compressed_session_and_history
PASS test_previous_response_id_chaining
PASS test_previous_response_id_outputs_only_current_turn_items
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Targeted verification on Windows:

```text
PASS test_previous_response_id_advances_to_in_place_compressed_history
PASS test_previous_response_id_advances_to_compressed_session_and_history
PASS test_streamed_previous_response_id_advances_to_compressed_session_and_history
PASS test_previous_response_id_chaining
PASS test_previous_response_id_outputs_only_current_turn_items
```
