### PR TITLE
fix(whatsapp): resolve LID sender IDs to phone numbers in bridge payload (#3219 salvage)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "ai-lab@foxmail.com": "CrazyBoyM",  # PR #55828 salvage (image_gen openai-codex: wire image-to-image / reference-image editing via Codex Responses input_image parts; magic-byte + read-guard + 25MB-cap + clamp-to-16 hardening)
+    "r0gersm1th@users.noreply.github.com": "r0gersm1th",  # PR #3219 salvage (whatsapp bridge: resolve LID sender IDs to phone numbers in the message payload so phone-based allowlists match; commit authored by collaborator r0gersm1th, PR by @ajmeese7)
     "tarunravi@gmail.com": "tarunravi",  # PR #2696 salvage (api-server: inline MEDIA:<path> image tags as base64 data URLs in final responses so remote OpenAI-compatible frontends can render server-local screenshots; the PR's tool-progress-streaming and SSE-sentinel pieces were independently superseded on main)
     "aqdrgg19@gmail.com": "VolodymyrBg",  # PR #2861 salvage (webhook: drop the unused full request payload from retained _delivery_info entries — up to ~1MB dead weight per delivery for the 1h idempotency TTL)
     "ohyes9711@gmail.com": "CharmingGroot",  # PR #2794 salvage (email: guard msg_data[0][1] against malformed IMAP fetch structures so one bad response can't abort the batch and permanently lose seen-marked messages; Message-ID domain falls back to localhost when EMAIL_ADDRESS lacks '@')

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -510,12 +510,19 @@ async function startSocket() {
         continue;
       }
 
+      // Resolve LID → phone for the senderId so the gateway can match
+      // against phone-based allowlists (WHATSAPP_ALLOWED_USERS).
+      const resolvedSenderId = lidToPhone[senderNumber]
+        ? (lidToPhone[senderNumber] + '@s.whatsapp.net')
+        : senderId;
+      const resolvedSenderNumber = lidToPhone[senderNumber] || senderNumber;
+
       const event = {
         messageId: msg.key.id,
         chatId,
-        senderId,
-        senderName: msg.pushName || senderNumber,
-        chatName: isGroup ? (chatId.split('@')[0]) : (msg.pushName || senderNumber),
+        senderId: resolvedSenderId,
+        senderName: msg.pushName || resolvedSenderNumber,
+        chatName: isGroup ? (chatId.split('@')[0]) : (msg.pushName || resolvedSenderNumber),
         isGroup,
         body,
         hasMedia,


### PR DESCRIPTION
## Summary
WhatsApp LID sender IDs (`@lid`) are now resolved to phone numbers in the bridge message payload, so phone-based allowlists (`WHATSAPP_ALLOWED_USERS`) match senders whose messages arrive under Meta's anonymized LID addressing.

Salvage of #3219 — commit authored by Roger Smith (@r0gersm1th), PR by @ajmeese7; cherry-picked onto current main with commit authorship preserved (the PR's two other commits were merge-from-main noise).

## Changes
- `scripts/whatsapp-bridge/bridge.js`: resolve `senderId`/`senderName`/`chatName` through the existing `lidToPhone` map before building the event payload
- `scripts/release.py`: AUTHOR_MAP entry

## Validation
| | Result |
|---|---|
| `node --check bridge.js` | syntax ok |
| lidToPhone map + rebuild-on-creds-update | already present on main; change slots into current `const event` block unchanged |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa0a095/dYLLuxk-32N2nB7IIsQaY_gvkfgFQY.png)

Nous Research
