### PR TITLE
fix(vision): allow aggregator fallback when main provider model is text-only (#56995)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4942,9 +4942,13 @@ def resolve_vision_provider_client(
 
         # Fall back through aggregators (uses their dedicated vision model,
         # not the user's main model) when main provider has no client.
+        # Do NOT skip when candidate == main_provider: the main-provider
+        # block above tried the *main chat model* on that provider (which
+        # may be text-only), while _resolve_strict_vision_backend uses the
+        # provider's *dedicated vision model* (e.g. gemini-3-flash-preview
+        # for OpenRouter).  If the main provider was actually resolved we
+        # already returned; reaching here means it was skipped or failed.
         for candidate in _VISION_AUTO_PROVIDER_ORDER:
-            if candidate == main_provider:
-                continue  # already tried above
             sync_client, default_model = _resolve_strict_vision_backend(candidate)
             if sync_client is not None:
                 return _finalize(candidate, sync_client, default_model)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3854,6 +3854,56 @@ class TestVisionAutoSkipsKimiCoding:
         })
 
 
+class TestVisionAutoFallbackForTextOnlyAggregatorMain:
+    """When the main provider IS an aggregator (e.g. OpenRouter) and the
+    main model is text-only, the aggregator fallback loop must still try
+    the provider's dedicated vision model (#56995).
+
+    Previously the ``candidate == main_provider`` skip in the aggregator
+    loop prevented this, causing ``resolve_vision_provider_client`` to
+    return None even when OPENROUTER_API_KEY was set.
+    """
+
+    def test_text_only_openrouter_main_falls_through_to_openrouter_vision(
+        self, monkeypatch,
+    ):
+        """OpenRouter main + text-only model → OpenRouter vision model."""
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        fake_or_client = MagicMock(name="openrouter_vision_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: "openrouter",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model",
+            lambda: "zhipu/glm-5.2",
+        )
+        # Text-only: _main_model_supports_vision returns False
+        monkeypatch.setattr(
+            "agent.auxiliary_client._main_model_supports_vision",
+            lambda _p, _m: False,
+        )
+
+        def fake_strict(provider, model=None):
+            if provider == "openrouter":
+                return fake_or_client, "google/gemini-3-flash-preview"
+            return None, None
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            fake_strict,
+        )
+
+        provider, client, model = resolve_vision_provider_client()
+        assert provider == "openrouter", (
+            "text-only OpenRouter main should still resolve via OpenRouter "
+            "vision backend"
+        )
+        assert client is fake_or_client
+        assert model == "google/gemini-3-flash-preview"
+
+
 class TestCodexAuxiliaryAdapterTimeout:
     def test_forwards_timeout_to_responses_create(self):
         message_item = SimpleNamespace(


### PR DESCRIPTION
## What does this PR do?

Fixes the vision auto-detection fallback chain when the main provider is an aggregator (e.g. OpenRouter) and the main model is text-only (e.g. GLM 5.2). Previously, the aggregator loop skipped the provider because `candidate == main_provider`, even though the provider was never tried with its dedicated vision model — only the text-only chat model was tested. This caused `resolve_vision_provider_client()` to return `None` even when `OPENROUTER_API_KEY` was set.

## Related Issue

Fixes #56995

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Remove the `candidate == main_provider` skip in the vision aggregator fallback loop. If the main provider was successfully resolved, we already returned before reaching the loop; reaching it means the provider was skipped (text-only) or failed, so its dedicated vision model should still be tried.
- `tests/agent/test_auxiliary_client.py`: Add `TestVisionAutoFallbackForTextOnlyAggregatorMain` with a regression test for the OpenRouter + text-only model scenario.

## How to Test

1. Set main model to a text-only model on OpenRouter (e.g. `model.provider: openrouter`, `model.default: zhipu/glm-5.2`)
2. Ensure `OPENROUTER_API_KEY` is set in `.env`
3. Attach an image and ask "what's in this image"
4. Before fix: vision fails with "no LLM provider is configured for vision"
5. After fix: OpenRouter's vision model (gemini-3-flash-preview) resolves and describes the image
6. Run `pytest tests/agent/test_auxiliary_client.py::TestVisionAutoFallbackForTextOnlyAggregatorMain -xvs` — should pass
7. Run `pytest tests/agent/test_auxiliary_client.py::TestVisionAutoSkipsKimiCoding -xvs` — existing tests still pass (kimi-coding skip unaffected)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific changes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The bug manifests as `resolve_vision_provider_client()` returning `None` when:
- Main provider is an aggregator (e.g. "openrouter")  
- Main model is text-only (e.g. GLM 5.2)
- Aggregator has valid credentials (OPENROUTER_API_KEY set)

The root cause: the aggregator fallback loop at line 4946 had `if candidate == main_provider: continue` which skipped OpenRouter even though it was never tried with its dedicated vision model (gemini-3-flash-preview). The main-provider block only tested the text-only chat model.
