### PR TITLE
feat(desktop): add live tasks sidebar view

### DIFF
--- a/apps/desktop/src/app/chat/route-tile.test.ts
+++ b/apps/desktop/src/app/chat/route-tile.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { TASKS_ROUTE } from '../routes'
+
+import { hasBuiltinRoutePage } from './route-tile'
+
+describe('route tiles', () => {
+  it('supports Live Tasks as a built-in split page', () => {
+    expect(hasBuiltinRoutePage(TASKS_ROUTE)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/route-tile.tsx
+++ b/apps/desktop/src/app/chat/route-tile.tsx
@@ -13,19 +13,25 @@ import { ContribBoundary } from '@/contrib/react/boundary'
 import { useContributions } from '@/contrib/react/use-contributions'
 import { $routeTiles, closeRouteTile, type RouteTile } from '@/store/route-tiles'
 
-import { ARTIFACTS_ROUTE, contributedRoutes, MESSAGING_ROUTE, ROUTES_AREA, SKILLS_ROUTE } from '../routes'
+import { ARTIFACTS_ROUTE, contributedRoutes, MESSAGING_ROUTE, ROUTES_AREA, SKILLS_ROUTE, TASKS_ROUTE } from '../routes'
 
 import { paneMirror } from './pane-mirror'
 
 const SkillsView = lazy(async () => ({ default: (await import('../skills')).SkillsView }))
 const MessagingView = lazy(async () => ({ default: (await import('../messaging')).MessagingView }))
 const ArtifactsView = lazy(async () => ({ default: (await import('../artifacts')).ArtifactsView }))
+const TasksView = lazy(async () => ({ default: (await import('../tasks')).TasksView }))
 
 // Built-in page views + their pane titles, keyed by route.
 const BUILTIN_PAGES: Record<string, { render: () => ReactNode; title: string }> = {
   [ARTIFACTS_ROUTE]: { render: () => <ArtifactsView />, title: 'Artifacts' },
   [MESSAGING_ROUTE]: { render: () => <MessagingView />, title: 'Messaging' },
-  [SKILLS_ROUTE]: { render: () => <SkillsView />, title: 'Capabilities' }
+  [SKILLS_ROUTE]: { render: () => <SkillsView />, title: 'Capabilities' },
+  [TASKS_ROUTE]: { render: () => <TasksView />, title: 'Live tasks' }
+}
+
+export function hasBuiltinRoutePage(path: string): boolean {
+  return path in BUILTIN_PAGES
 }
 
 /** Humanize a route path into a tab title: `/my-atlas` → `My Atlas`. */

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -104,7 +104,8 @@ import {
   MESSAGING_ROUTE,
   SIDEBAR_NAV_AREA,
   type SidebarNavContribution,
-  SKILLS_ROUTE
+  SKILLS_ROUTE,
+  TASKS_ROUTE
 } from '../../routes'
 import type { SidebarNavItem } from '../../types'
 
@@ -153,6 +154,12 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     icon: props => <Codicon name="symbol-misc" {...props} />,
     route: SKILLS_ROUTE,
     keybindActionId: 'nav.skills'
+  },
+  {
+    id: 'tasks',
+    label: '',
+    icon: props => <Codicon name="checklist" {...props} />,
+    route: TASKS_ROUTE
   },
   {
     id: 'messaging',
@@ -1103,6 +1110,7 @@ export function ChatSidebar({
 
                 const active =
                   (item.id === 'skills' && currentView === 'skills') ||
+                  (item.id === 'tasks' && currentView === 'tasks') ||
                   (item.id === 'messaging' && currentView === 'messaging') ||
                   (item.id === 'artifacts' && currentView === 'artifacts') ||
                   // Contributed rows light up at their own route.

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -33,6 +33,7 @@ import type { SidebarActions, WiringActions } from './types'
 const ArtifactsView = lazy(async () => ({ default: (await import('../artifacts')).ArtifactsView }))
 const MessagingView = lazy(async () => ({ default: (await import('../messaging')).MessagingView }))
 const SkillsView = lazy(async () => ({ default: (await import('../skills')).SkillsView }))
+const TasksView = lazy(async () => ({ default: (await import('../tasks')).TasksView }))
 
 export function LegacySessionRedirect() {
   const { sessionId } = useParams()
@@ -178,6 +179,7 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
       <Route element={chatView} index />
       <Route element={chatView} path=":sessionId" />
       <Route element={page(<SkillsView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="skills" />
+      <Route element={page(<TasksView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="tasks" />
       <Route element={page(<MessagingView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="messaging" />
       <Route element={page(<ArtifactsView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="artifacts" />
       <Route element={null} path="agents" />

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -55,7 +55,7 @@ import {
   setCurrentProvider,
   setMessages
 } from '@/store/session'
-import { focusOpenSession } from '@/store/session-states'
+import { focusOpenSession, getSessionStateGeneration } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { isSecondaryWindow } from '@/store/windows'
 import { useSkinCommand } from '@/themes/use-skin-command'
@@ -266,15 +266,22 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       }
 
       const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
+      const stateGeneration = getSessionStateGeneration()
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
           const latest = await getSessionMessages(storedSessionId, storedProfile)
+
+          if (stateGeneration !== getSessionStateGeneration()) {
+            return
+          }
+
           const messages = toChatMessages(latest.messages)
           updateSessionState(
             runtimeSessionId,
             state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
-            storedSessionId
+            storedSessionId,
+            stateGeneration
           )
 
           const restored = todosForHydration(latestSessionTodos(messages))
@@ -310,6 +317,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
 
     const stored = $messagingSessions.get().find(s => sessionMatchesStoredId(s, storedSessionId))
+    const stateGeneration = getSessionStateGeneration()
 
     if (!stored || !isMessagingSource(stored.source)) {
       return
@@ -317,6 +325,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
     try {
       const latest = await getSessionMessages(storedSessionId, stored.profile)
+
+      if (stateGeneration !== getSessionStateGeneration()) {
+        return
+      }
+
       const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}`
       const sig = sessionMessagesSignature(latest.messages)
 
@@ -330,7 +343,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       updateSessionState(
         runtimeSessionId,
         state => ({ ...state, messages: preserveLocalAssistantErrors(messages, state.messages) }),
-        storedSessionId
+        storedSessionId,
+        stateGeneration
       )
     } catch {
       // Non-fatal: next poll or manual refresh can hydrate.

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -8,6 +8,7 @@ export const NEW_CHAT_ROUTE = '/'
 export const SETTINGS_ROUTE = '/settings'
 export const COMMAND_CENTER_ROUTE = '/command-center'
 export const SKILLS_ROUTE = '/skills'
+export const TASKS_ROUTE = '/tasks'
 export const MESSAGING_ROUTE = '/messaging'
 export const ARTIFACTS_ROUTE = '/artifacts'
 export const CRON_ROUTE = '/cron'
@@ -30,6 +31,7 @@ export type AppView =
   | 'profiles'
   | 'settings'
   | 'skills'
+  | 'tasks'
   | 'starmap'
 
 export type AppRouteId =
@@ -42,6 +44,7 @@ export type AppRouteId =
   | 'profiles'
   | 'settings'
   | 'skills'
+  | 'tasks'
   | 'starmap'
 
 export interface AppRoute {
@@ -55,6 +58,7 @@ export const APP_ROUTES = [
   { id: 'settings', path: SETTINGS_ROUTE, view: 'settings' },
   { id: 'command-center', path: COMMAND_CENTER_ROUTE, view: 'command-center' },
   { id: 'skills', path: SKILLS_ROUTE, view: 'skills' },
+  { id: 'tasks', path: TASKS_ROUTE, view: 'tasks' },
   { id: 'messaging', path: MESSAGING_ROUTE, view: 'messaging' },
   { id: 'artifacts', path: ARTIFACTS_ROUTE, view: 'artifacts' },
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -20,6 +20,7 @@ import {
   setResumeFailedSessionId,
   setSessions
 } from '@/store/session'
+import { clearAllSessionStates } from '@/store/session-states'
 
 import type { ClientSessionState } from '../../types'
 
@@ -217,7 +218,8 @@ function ResumeHarness({
   requestGateway,
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionId = null,
-  sessionStateByRuntimeIdRef
+  sessionStateByRuntimeIdRef,
+  updateSessionState
 }: {
   onStateUpdate?: (sessionId: string, state: ClientSessionState) => void
   onReady: (resume: (storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) => void
@@ -225,6 +227,12 @@ function ResumeHarness({
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
   selectedStoredSessionId?: string | null
   sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
+  updateSessionState?: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null,
+    expectedGeneration?: number
+  ) => ClientSessionState
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
 
@@ -243,12 +251,14 @@ function ResumeHarness({
     selectedStoredSessionIdRef: ref<string | null>(selectedStoredSessionId),
     sessionStateByRuntimeIdRef: sessionStateByRuntimeIdRef ?? ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
-    updateSessionState: (sessionId, updater) => {
-      const next = updater({} as ClientSessionState)
-      onStateUpdate?.(sessionId, next)
+    updateSessionState:
+      updateSessionState ??
+      ((sessionId, updater) => {
+        const next = updater({} as ClientSessionState)
+        onStateUpdate?.(sessionId, next)
 
-      return next
-    }
+        return next
+      })
   })
 
   useEffect(() => {
@@ -273,6 +283,12 @@ describe('resumeSession failure recovery', () => {
     options: {
       runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
       sessionStateByRuntimeIdRef?: MutableRefObject<Map<string, ClientSessionState>>
+      updateSessionState?: (
+        sessionId: string,
+        updater: (state: ClientSessionState) => ClientSessionState,
+        storedSessionId?: string | null,
+        expectedGeneration?: number
+      ) => ClientSessionState
     } = {}
   ): Promise<void> {
     let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
@@ -511,6 +527,41 @@ describe('resumeSession failure recovery', () => {
     await runResume(requestGateway)
 
     expect($resumeFailedSessionId.get()).toBeNull()
+  })
+
+  it('ignores a resume that resolves after the gateway generation is reset', async () => {
+    let resolvePrefetch!: (value: { messages: never[] }) => void
+    let resolveResume!: (value: { info: Record<string, never>; messages: never[]; session_id: string }) => void
+
+    const prefetch = new Promise<{ messages: never[] }>(resolve => (resolvePrefetch = resolve))
+
+    const resumed = new Promise<{ info: Record<string, never>; messages: never[]; session_id: string }>(
+      resolve => (resolveResume = resolve)
+    )
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return resumed as never
+      }
+
+      return {} as never
+    })
+
+    const updateSessionState = vi.fn((_sessionId, updater: (state: ClientSessionState) => ClientSessionState) =>
+      updater(createClientSessionState('stored-1'))
+    )
+
+    vi.mocked(getSessionMessages).mockReturnValue(prefetch as never)
+    const pending = runResume(requestGateway, { updateSessionState })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.resume', expect.any(Object)))
+
+    act(() => clearAllSessionStates())
+    resolvePrefetch({ messages: [] })
+    resolveResume({ info: {}, messages: [], session_id: 'runtime-stale' })
+    await pending
+
+    expect(updateSessionState).not.toHaveBeenCalled()
+    expect($messages.get()).toEqual([])
   })
 
   it('resumes via the gateway default (deferred build) — not lazy, no eager opt-out', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -50,6 +50,7 @@ import {
 import {
   closeSessionTile,
   dropSessionState,
+  getSessionStateGeneration,
   openSessionTile,
   patchSessionTile,
   publishSessionState,
@@ -98,7 +99,8 @@ interface SessionActionsOptions {
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
-    storedSessionId?: string | null
+    storedSessionId?: string | null,
+    expectedGeneration?: number
   ) => ClientSessionState
 }
 
@@ -307,8 +309,13 @@ export function useSessionActions({
               : $currentCwd.get().trim() || resolveNewSessionCwd()
 
         const params = await desktopSessionCreateParams(cwd)
+        const stateGeneration = getSessionStateGeneration()
         const created = await requestGateway<SessionCreateResponse>('session.create', params)
         const stored = created.stored_session_id ?? null
+
+        if (stateGeneration !== getSessionStateGeneration()) {
+          return null
+        }
 
         if (
           activeSessionIdRef.current !== startingActiveSessionId ||
@@ -347,7 +354,7 @@ export function useSessionActions({
         const runtimeInfo = applyRuntimeInfo(created.info)
 
         if (runtimeInfo) {
-          updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored)
+          updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored, stateGeneration)
         }
 
         // User may have armed YOLO on the new-chat draft before the runtime
@@ -356,7 +363,7 @@ export function useSessionActions({
           await setSessionYolo(requestGateway, created.session_id, true).catch(() => undefined)
         }
 
-        return created.session_id
+        return stateGeneration === getSessionStateGeneration() ? created.session_id : null
       } finally {
         window.setTimeout(() => {
           creatingSessionRef.current = false
@@ -400,8 +407,13 @@ export function useSessionActions({
         // Fresh tile → the resolved new-session cwd (project/default), not the
         // primary composer's live cwd.
         const params = await desktopSessionCreateParams(resolveNewSessionCwd().trim())
+        const stateGeneration = getSessionStateGeneration()
         const created = await requestGateway<SessionCreateResponse>('session.create', params)
         const stored = created.stored_session_id
+
+        if (stateGeneration !== getSessionStateGeneration()) {
+          return
+        }
 
         if (!stored) {
           await requestGateway('session.close', { session_id: created.session_id }).catch(() => undefined)
@@ -416,7 +428,12 @@ export function useSessionActions({
         // runtime so the tile skips a redundant resume.
         upsertOptimisticSession(created, stored, null, null)
         const runtimeInfo = applyRuntimeInfo(created.info)
-        updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
+        updateSessionState(
+          created.session_id,
+          state => (runtimeInfo ? { ...state, ...runtimeInfo } : state),
+          stored,
+          stateGeneration
+        )
 
         openSessionTile(stored, dir)
         patchSessionTile(stored, { runtimeId: created.session_id })
@@ -449,9 +466,12 @@ export function useSessionActions({
       resumeRequestRef.current = requestId
       const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
       const resumeStartMessages = resumedSameSelectedSession ? $messages.get() : []
+      let stateGeneration = getSessionStateGeneration()
 
       const isCurrentResume = () =>
-        resumeRequestRef.current === requestId && selectedStoredSessionIdRef.current === storedSessionId
+        resumeRequestRef.current === requestId &&
+        selectedStoredSessionIdRef.current === storedSessionId &&
+        stateGeneration === getSessionStateGeneration()
 
       // Paint the click before the profile-resolve / gateway-swap awaits below,
       // so there's zero dead air: highlight the row instantly (the sidebar reads
@@ -525,6 +545,14 @@ export function useSessionActions({
       }
 
       await ensureGatewayProfile(sessionProfile)
+
+      if (resumeRequestRef.current !== requestId || selectedStoredSessionIdRef.current !== storedSessionId) {
+        return
+      }
+
+      // This resume owns an intentional profile switch, so continue in the new
+      // generation. Any later reset invalidates the request through isCurrentResume.
+      stateGeneration = getSessionStateGeneration()
 
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and
@@ -666,7 +694,8 @@ export function useSessionActions({
                   busy: running,
                   awaitingResponse: running
                 }),
-                storedSessionId
+                storedSessionId,
+                stateGeneration
               )
 
               busyRef.current = running
@@ -860,7 +889,8 @@ export function useSessionActions({
             busy: resumedRunning,
             awaitingResponse: resumedRunning
           }),
-          storedSessionId
+          storedSessionId,
+          stateGeneration
         )
       } catch (err) {
         if (!isCurrentResume()) {
@@ -966,6 +996,8 @@ export function useSessionActions({
       creatingSessionRef.current = true
 
       try {
+        const stateGeneration = getSessionStateGeneration()
+
         // No title: the backend auto-names the branch from its parent's lineage.
         const branched = await requestGateway<SessionCreateResponse>('session.create', {
           cols: 96,
@@ -974,6 +1006,10 @@ export function useSessionActions({
           messages: branchMessages.map(({ content, role }) => ({ content, role })),
           ...(parentStoredId && { parent_session_id: parentStoredId })
         })
+
+        if (stateGeneration !== getSessionStateGeneration()) {
+          return false
+        }
 
         const routedSessionId = branched.stored_session_id ?? branched.session_id
         const preview = branchMessages.map(({ content }) => content).find(Boolean) ?? null
@@ -1007,7 +1043,8 @@ export function useSessionActions({
             busy: false,
             awaitingResponse: false
           }),
-          routedSessionId
+          routedSessionId,
+          stateGeneration
         )
         setSelectedStoredSessionId(routedSessionId)
         selectedStoredSessionIdRef.current = routedSessionId
@@ -1017,7 +1054,12 @@ export function useSessionActions({
         patchSessionWorkspace(routedSessionId, runtimeInfo?.cwd)
 
         if (runtimeInfo) {
-          updateSessionState(branched.session_id, state => ({ ...state, ...runtimeInfo }), routedSessionId)
+          updateSessionState(
+            branched.session_id,
+            state => ({ ...state, ...runtimeInfo }),
+            routedSessionId,
+            stateGeneration
+          )
         }
 
         return true

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache-reset.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache-reset.test.tsx
@@ -1,0 +1,66 @@
+import { act, cleanup, render } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { clearAllSessionStates, getSessionStateGeneration } from '@/store/session-states'
+
+import { useSessionStateCache } from './use-session-state-cache'
+
+type Cache = ReturnType<typeof useSessionStateCache>
+
+function Harness({ onReady }: { onReady: (cache: Cache) => void }) {
+  const busyRef: MutableRefObject<boolean> = { current: false }
+
+  const cache = useSessionStateCache({
+    activeSessionId: 'runtime',
+    busyRef,
+    selectedStoredSessionId: 'stored',
+    setAwaitingResponse: () => undefined,
+    setBusy: () => undefined,
+    setMessages: () => undefined
+  })
+
+  onReady(cache)
+
+  return null
+}
+
+describe('useSessionStateCache — gateway reset', () => {
+  afterEach(() => {
+    cleanup()
+    clearAllSessionStates()
+  })
+
+  it('drops hook-owned runtime and stored-id caches when all session states are cleared', () => {
+    let cache!: Cache
+    render(<Harness onReady={value => (cache = value)} />)
+
+    act(() => {
+      cache.updateSessionState('runtime', state => ({ ...state, busy: true }), 'stored')
+    })
+
+    expect(cache.sessionStateByRuntimeIdRef.current.has('runtime')).toBe(true)
+    expect(cache.runtimeIdByStoredSessionIdRef.current.get('stored')).toBe('runtime')
+
+    act(() => {
+      clearAllSessionStates()
+    })
+
+    expect(cache.sessionStateByRuntimeIdRef.current.size).toBe(0)
+    expect(cache.runtimeIdByStoredSessionIdRef.current.size).toBe(0)
+  })
+
+  it('rejects an async update captured before the reset', () => {
+    let cache!: Cache
+    render(<Harness onReady={value => (cache = value)} />)
+    const staleGeneration = getSessionStateGeneration()
+
+    act(() => {
+      clearAllSessionStates()
+      cache.updateSessionState('runtime', state => ({ ...state, busy: true }), 'stored', staleGeneration)
+    })
+
+    expect(cache.sessionStateByRuntimeIdRef.current.size).toBe(0)
+    expect(cache.runtimeIdByStoredSessionIdRef.current.size).toBe(0)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -17,7 +17,12 @@ import {
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
-import { publishSessionState, setWatchdogClearFn } from '@/store/session-states'
+import {
+  getSessionStateGeneration,
+  publishSessionState,
+  setSessionStateCacheClearFn,
+  setWatchdogClearFn
+} from '@/store/session-states'
 
 import type { ClientSessionState } from '../../types'
 
@@ -135,6 +140,18 @@ export function useSessionStateCache({
     }
   }, [])
 
+  const clearSessionStateCache = useCallback(() => {
+    resetViewSync()
+    sessionStateByRuntimeIdRef.current.clear()
+    runtimeIdByStoredSessionIdRef.current.clear()
+  }, [resetViewSync])
+
+  useEffect(() => {
+    setSessionStateCacheClearFn(clearSessionStateCache)
+
+    return () => setSessionStateCacheClearFn(null)
+  }, [clearSessionStateCache])
+
   const flushPendingViewState = useCallback(() => {
     const pending = pendingViewStateRef.current
     pendingViewStateRef.current = null
@@ -251,8 +268,13 @@ export function useSessionStateCache({
     (
       sessionId: string,
       updater: (state: ClientSessionState) => ClientSessionState,
-      storedSessionId?: string | null
+      storedSessionId?: string | null,
+      expectedGeneration?: number
     ) => {
+      if (expectedGeneration !== undefined && expectedGeneration !== getSessionStateGeneration()) {
+        return sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState(storedSessionId ?? null)
+      }
+
       const previous = ensureSessionState(sessionId, storedSessionId)
       const next = updater({ ...previous, messages: previous.messages })
       sessionStateByRuntimeIdRef.current.set(sessionId, next)

--- a/apps/desktop/src/app/tasks/aggregation.test.ts
+++ b/apps/desktop/src/app/tasks/aggregation.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { TodoItem } from '@/lib/todos'
+import type { SubagentProgress, SubagentStatus } from '@/store/subagents'
+import type { SessionInfo } from '@/types/hermes'
+
+import { aggregateLiveTaskSessions } from './aggregation'
+
+const session = (id: string, overrides: Partial<SessionInfo> = {}): SessionInfo =>
+  ({
+    archived: false,
+    cwd: '/tmp/project',
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: true,
+    last_active: 10,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: null,
+    started_at: 1,
+    title: 'Mapped session',
+    tool_call_count: 0,
+    ...overrides
+  }) as SessionInfo
+
+const pendingTodo = (id: string): TodoItem => ({ content: `task ${id}`, id, status: 'pending' })
+const completedTodo = (id: string): TodoItem => ({ content: `task ${id}`, id, status: 'completed' })
+
+const subagent = (id: string, status: SubagentStatus, updatedAt: number): SubagentProgress => ({
+  filesRead: [],
+  filesWritten: [],
+  goal: `subagent ${id}`,
+  id,
+  parentId: null,
+  startedAt: 1,
+  status,
+  stream: [],
+  taskCount: 1,
+  taskIndex: 0,
+  updatedAt
+})
+
+describe('aggregateLiveTaskSessions', () => {
+  it('normalizes a mapped runtime id to its stored session', () => {
+    const runtimeState = createClientSessionState('stored-1')
+
+    const rows = aggregateLiveTaskSessions({
+      sessions: [session('stored-1')],
+      sessionStates: { 'runtime-1': runtimeState },
+      subagentsBySession: {},
+      todosBySession: { 'runtime-1': [pendingTodo('mapped')] }
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      id: 'stored-1',
+      routeId: 'stored-1',
+      runtimeId: 'runtime-1',
+      title: 'Mapped session'
+    })
+    expect(rows[0]?.todos.map(todo => todo.id)).toEqual(['mapped'])
+  })
+
+  it('keeps an unmapped runtime id visible without inventing a stored route', () => {
+    const rows = aggregateLiveTaskSessions({
+      sessions: [],
+      sessionStates: {},
+      subagentsBySession: {},
+      todosBySession: { 'runtime-only': [pendingTodo('unmapped')] }
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      id: 'runtime-only',
+      routeId: null,
+      runtimeId: 'runtime-only',
+      title: 'Session runtime-'
+    })
+  })
+
+  it('keeps unmapped runtime state visible with its live status', () => {
+    const runtimeState = createClientSessionState(null)
+    runtimeState.busy = true
+    runtimeState.needsInput = true
+
+    const rows = aggregateLiveTaskSessions({
+      sessions: [],
+      sessionStates: { 'runtime-only': runtimeState },
+      subagentsBySession: {},
+      todosBySession: {}
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      busy: true,
+      id: 'runtime-only',
+      needsInput: true,
+      routeId: null,
+      runtimeId: 'runtime-only'
+    })
+  })
+
+  it('combines live data from multiple runtimes for one stored session', () => {
+    const first = createClientSessionState('stored-1')
+    first.busy = true
+    const second = createClientSessionState('stored-1')
+    second.needsInput = true
+
+    const rows = aggregateLiveTaskSessions({
+      sessions: [session('stored-1')],
+      sessionStates: { 'runtime-1': first, 'runtime-2': second },
+      subagentsBySession: {},
+      todosBySession: { 'runtime-1': [pendingTodo('first')], 'runtime-2': [pendingTodo('second')] }
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      busy: true,
+      id: 'stored-1',
+      needsInput: true,
+      routeId: 'stored-1'
+    })
+    expect(rows[0]?.todos.map(todo => todo.id)).toEqual(['first', 'second'])
+  })
+
+  it('deduplicates logical work across overlapping runtimes before counting', () => {
+    const oldRuntime = createClientSessionState('stored-1')
+    const newRuntime = createClientSessionState('stored-1')
+
+    const rows = aggregateLiveTaskSessions({
+      sessions: [session('stored-1')],
+      sessionStates: { old: oldRuntime, current: newRuntime },
+      subagentsBySession: {
+        old: [subagent('agent-1', 'running', 1)],
+        current: [subagent('agent-1', 'completed', 2)]
+      },
+      todosBySession: {
+        old: [pendingTodo('todo-1')],
+        current: [completedTodo('todo-1'), pendingTodo('todo-2')]
+      }
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.todos).toEqual([completedTodo('todo-1'), pendingTodo('todo-2')])
+    expect(rows[0]).toMatchObject({ activeSubagentCount: 0, activeTodoCount: 1, failedSubagentCount: 0 })
+  })
+
+  it('canonicalizes lineage roots and continuations into one conversation row', () => {
+    const rootRuntime = createClientSessionState('root')
+    const continuationRuntime = createClientSessionState('continuation')
+
+    const rows = aggregateLiveTaskSessions({
+      sessions: [session('root'), session('continuation', { _lineage_root_id: 'root', title: 'Continuation' })],
+      sessionStates: { rootRuntime, continuationRuntime },
+      subagentsBySession: {},
+      todosBySession: {
+        rootRuntime: [pendingTodo('root-task')],
+        continuationRuntime: [pendingTodo('continuation-task')]
+      }
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ id: 'continuation', routeId: 'continuation', title: 'Continuation' })
+    expect(rows[0]?.todos.map(todo => todo.id)).toEqual(['root-task', 'continuation-task'])
+  })
+})

--- a/apps/desktop/src/app/tasks/aggregation.ts
+++ b/apps/desktop/src/app/tasks/aggregation.ts
@@ -1,0 +1,155 @@
+import type { ClientSessionState } from '@/app/types'
+import { sessionTitle } from '@/lib/chat-runtime'
+import type { TodoItem } from '@/lib/todos'
+import {
+  activeSubagentCount,
+  buildSubagentTree,
+  failedSubagentCount,
+  type SubagentNode,
+  type SubagentProgress
+} from '@/store/subagents'
+import { todoListActive } from '@/store/todos'
+import type { SessionInfo } from '@/types/hermes'
+
+export type LiveTodoStatus = 'cancelled' | 'completed' | 'in_progress' | 'pending'
+
+export interface LiveTaskSession {
+  id: string
+  routeId: null | string
+  runtimeId: null | string
+  session: null | SessionInfo
+  title: string
+  busy: boolean
+  needsInput: boolean
+  todos: TodoItem[]
+  activeTodoCount: number
+  subagents: SubagentNode[]
+  activeSubagentCount: number
+  failedSubagentCount: number
+  updatedAt: number
+}
+
+interface AggregateLiveTaskSessionsOptions {
+  sessions: SessionInfo[]
+  sessionStates: Record<string, ClientSessionState>
+  subagentsBySession: Record<string, SubagentProgress[]>
+  todosBySession: Record<string, TodoItem[]>
+}
+
+const ACTIVE_TODO_STATUSES: ReadonlySet<LiveTodoStatus> = new Set(['pending', 'in_progress'])
+const RUNTIME_KEY_PREFIX = 'runtime:'
+
+function sessionLabel(session: null | SessionInfo, sessionId: string): string {
+  return session ? sessionTitle(session) : `Session ${sessionId.slice(0, 8)}`
+}
+
+function sessionTimestampMs(session: null | SessionInfo): number {
+  return session ? Math.max(session.last_active || 0, session.started_at || 0) * 1000 : 0
+}
+
+function uniqueById<T extends { id: string }>(items: readonly T[]): T[] {
+  return [...new Map(items.map(item => [item.id, item])).values()]
+}
+
+export function aggregateLiveTaskSessions({
+  sessions,
+  sessionStates,
+  subagentsBySession,
+  todosBySession
+}: AggregateLiveTaskSessionsOptions): LiveTaskSession[] {
+  const canonicalSessionByLineage = new Map<string, SessionInfo>()
+
+  for (const session of sessions) {
+    const lineageId = session._lineage_root_id || session.id
+    const current = canonicalSessionByLineage.get(lineageId)
+
+    if (!current || sessionTimestampMs(session) >= sessionTimestampMs(current)) {
+      canonicalSessionByLineage.set(lineageId, session)
+    }
+  }
+
+  const sessionsByStoredId = new Map<string, SessionInfo>()
+
+  for (const session of sessions) {
+    const canonical = canonicalSessionByLineage.get(session._lineage_root_id || session.id) ?? session
+
+    sessionsByStoredId.set(session.id, canonical)
+    sessionsByStoredId.set(session._lineage_root_id || session.id, canonical)
+  }
+
+  const runtimeIdsBySession = new Map<string, Set<string>>()
+
+  for (const runtimeId of new Set([
+    ...Object.keys(sessionStates),
+    ...Object.keys(todosBySession),
+    ...Object.keys(subagentsBySession)
+  ])) {
+    const storedId = sessionStates[runtimeId]?.storedSessionId
+    const canonicalStoredId = storedId ? (sessionsByStoredId.get(storedId)?.id ?? storedId) : null
+    const key = canonicalStoredId ?? `${RUNTIME_KEY_PREFIX}${runtimeId}`
+    const runtimeIds = runtimeIdsBySession.get(key) ?? new Set<string>()
+
+    runtimeIds.add(runtimeId)
+    runtimeIdsBySession.set(key, runtimeIds)
+  }
+
+  const rows: LiveTaskSession[] = []
+
+  for (const [key, runtimeIdSet] of runtimeIdsBySession) {
+    const runtimeOnly = key.startsWith(RUNTIME_KEY_PREFIX)
+    const runtimeIds = [...runtimeIdSet]
+
+    const runtimeId = runtimeIds.at(-1) ?? null
+    const storedId = runtimeOnly ? null : key
+    const session = storedId ? (sessionsByStoredId.get(storedId) ?? null) : null
+    const states = runtimeIds.flatMap(id => (sessionStates[id] ? [sessionStates[id]] : []))
+
+    const todos = uniqueById(
+      runtimeIds.flatMap(id => todosBySession[id] ?? []).filter(todo => todo.id && todo.content)
+    )
+
+    const subagents = uniqueById(
+      runtimeIds.flatMap(id => subagentsBySession[id] ?? []).sort((left, right) => left.updatedAt - right.updatedAt)
+    )
+
+    const activeTodos = todos.filter(todo => ACTIVE_TODO_STATUSES.has(todo.status))
+    const activeSubagents = activeSubagentCount(subagents)
+    const failedSubagents = failedSubagentCount(subagents)
+    const busy = states.some(state => state.busy)
+    const needsInput = states.some(state => state.needsInput)
+
+    if (!(busy || needsInput || todoListActive(todos) || activeSubagents > 0)) {
+      continue
+    }
+
+    rows.push({
+      id: storedId ?? runtimeId ?? key,
+      routeId: session?.id ?? storedId,
+      runtimeId,
+      session,
+      title: sessionLabel(session, storedId ?? runtimeId ?? key),
+      busy,
+      needsInput,
+      todos,
+      activeTodoCount: activeTodos.length,
+      subagents: buildSubagentTree(subagents),
+      activeSubagentCount: activeSubagents,
+      failedSubagentCount: failedSubagents,
+      updatedAt: Math.max(sessionTimestampMs(session), ...subagents.map(item => item.updatedAt), 0)
+    })
+  }
+
+  return rows.sort((left, right) => {
+    const leftScore =
+      Number(left.busy) * 4 +
+      Number(left.needsInput) * 2 +
+      Number(left.activeSubagentCount > 0 || left.activeTodoCount > 0)
+
+    const rightScore =
+      Number(right.busy) * 4 +
+      Number(right.needsInput) * 2 +
+      Number(right.activeSubagentCount > 0 || right.activeTodoCount > 0)
+
+    return rightScore - leftScore || right.updatedAt - left.updatedAt || left.title.localeCompare(right.title)
+  })
+}

--- a/apps/desktop/src/app/tasks/index.tsx
+++ b/apps/desktop/src/app/tasks/index.tsx
@@ -1,0 +1,368 @@
+import { useStore } from '@nanostores/react'
+import type * as React from 'react'
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { $sessions } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
+import { $subagentsBySession, type SubagentNode } from '@/store/subagents'
+import { $todosBySession } from '@/store/todos'
+
+import { PAGE_INSET_X } from '../layout-constants'
+import { PageSearchShell } from '../page-search-shell'
+import { sessionRoute } from '../routes'
+import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
+
+import { aggregateLiveTaskSessions, type LiveTaskSession, type LiveTodoStatus } from './aggregation'
+
+function includesQuery(value: null | string | undefined, query: string): boolean {
+  return (value || '').toLowerCase().includes(query)
+}
+
+function taskStatusTone(status: LiveTodoStatus): string {
+  switch (status) {
+    case 'completed':
+      return 'bg-emerald-500/12 text-emerald-300 border-emerald-500/20'
+
+    case 'cancelled':
+      return 'bg-slate-500/12 text-slate-300 border-slate-500/20'
+
+    case 'in_progress':
+      return 'bg-sky-500/12 text-sky-300 border-sky-500/20'
+
+    case 'pending':
+
+    default:
+      return 'bg-amber-500/12 text-amber-200 border-amber-500/20'
+  }
+}
+
+function taskStatusLabel(status: LiveTodoStatus): string {
+  switch (status) {
+    case 'completed':
+      return 'Done'
+
+    case 'cancelled':
+      return 'Cancelled'
+
+    case 'in_progress':
+      return 'In progress'
+
+    case 'pending':
+
+    default:
+      return 'Pending'
+  }
+}
+
+function subagentStatusTone(status: SubagentNode['status']): string {
+  switch (status) {
+    case 'completed':
+      return 'bg-emerald-500/12 text-emerald-300 border-emerald-500/20'
+
+    case 'failed':
+
+    case 'interrupted':
+      return 'bg-rose-500/12 text-rose-300 border-rose-500/20'
+
+    case 'queued':
+      return 'bg-violet-500/12 text-violet-200 border-violet-500/20'
+
+    case 'running':
+
+    default:
+      return 'bg-sky-500/12 text-sky-300 border-sky-500/20'
+  }
+}
+
+function subagentStatusLabel(status: SubagentNode['status']): string {
+  switch (status) {
+    case 'completed':
+      return 'Completed'
+
+    case 'failed':
+      return 'Failed'
+
+    case 'interrupted':
+      return 'Interrupted'
+
+    case 'queued':
+      return 'Queued'
+
+    case 'running':
+
+    default:
+      return 'Running'
+  }
+}
+
+function latestSubagentLine(node: SubagentNode): null | string {
+  return node.stream.at(-1)?.text?.trim() || node.summary?.trim() || null
+}
+
+function matchesSession(entry: LiveTaskSession, query: string): boolean {
+  if (!query) {
+    return true
+  }
+
+  if (includesQuery(entry.title, query) || includesQuery(entry.id, query) || includesQuery(entry.session?.cwd, query)) {
+    return true
+  }
+
+  if (entry.todos.some(todo => includesQuery(todo.content, query) || includesQuery(todo.status, query))) {
+    return true
+  }
+
+  const stack = [...entry.subagents]
+
+  while (stack.length > 0) {
+    const node = stack.pop()!
+
+    if (
+      includesQuery(node.goal, query) ||
+      includesQuery(node.currentTool, query) ||
+      includesQuery(node.summary, query) ||
+      includesQuery(latestSubagentLine(node), query)
+    ) {
+      return true
+    }
+
+    stack.push(...node.children)
+  }
+
+  return false
+}
+
+interface TasksViewProps extends React.ComponentProps<'section'> {
+  setStatusbarItemGroup?: SetStatusbarItemGroup
+}
+
+export function TasksView({ setStatusbarItemGroup: _setStatusbarItemGroup, ...props }: TasksViewProps) {
+  const navigate = useNavigate()
+  const sessions = useStore($sessions)
+  const sessionStates = useStore($sessionStates)
+  const todosBySession = useStore($todosBySession)
+  const subagentsBySession = useStore($subagentsBySession)
+  const [query, setQuery] = useState('')
+
+  const liveSessions = useMemo(
+    () => aggregateLiveTaskSessions({ sessions, sessionStates, subagentsBySession, todosBySession }),
+    [sessions, sessionStates, subagentsBySession, todosBySession]
+  )
+
+  const normalizedQuery = query.trim().toLowerCase()
+
+  const visibleSessions = useMemo(
+    () => liveSessions.filter(entry => matchesSession(entry, normalizedQuery)),
+    [liveSessions, normalizedQuery]
+  )
+
+  const totals = useMemo(() => {
+    let todoCount = 0
+    let subagentCount = 0
+    let blockedCount = 0
+    let busyCount = 0
+
+    for (const entry of liveSessions) {
+      todoCount += entry.activeTodoCount
+      subagentCount += entry.activeSubagentCount
+      blockedCount += Number(entry.needsInput)
+      busyCount += Number(entry.busy)
+    }
+
+    return {
+      sessions: liveSessions.length,
+      todos: todoCount,
+      subagents: subagentCount,
+      blocked: blockedCount,
+      busy: busyCount
+    }
+  }, [liveSessions])
+
+  return (
+    <PageSearchShell
+      {...props}
+      activeTab="live"
+      filters={
+        <>
+          <SummaryPill label="Live sessions" value={totals.sessions} />
+          <SummaryPill label="Busy now" value={totals.busy} />
+          <SummaryPill label="Todo items" value={totals.todos} />
+          <SummaryPill label="Subagents" value={totals.subagents} />
+          <SummaryPill label="Needs input" value={totals.blocked} />
+        </>
+      }
+      onSearchChange={setQuery}
+      searchHidden={liveSessions.length === 0}
+      searchPlaceholder="Search live tasks…"
+      searchValue={query}
+      tabs={[{ id: 'live', label: 'Live tasks' }]}
+    >
+      <div className={cn('h-full overflow-y-auto py-3', PAGE_INSET_X)}>
+        {visibleSessions.length === 0 ? (
+          <EmptyState hasQuery={normalizedQuery.length > 0} />
+        ) : (
+          <div className="space-y-3 pb-6">
+            {visibleSessions.map(entry => (
+              <section
+                className="rounded-xl border border-(--ui-stroke-secondary) bg-(--ui-sidebar-surface-background) p-4 shadow-sm"
+                key={entry.id}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="truncate text-sm font-semibold text-foreground">{entry.title}</h2>
+                      {entry.busy && <Pill className="bg-sky-500/12 text-sky-300 border-sky-500/20">Running</Pill>}
+                      {entry.needsInput && (
+                        <Pill className="bg-amber-500/12 text-amber-200 border-amber-500/20">Needs input</Pill>
+                      )}
+                      {entry.failedSubagentCount > 0 && (
+                        <Pill className="bg-rose-500/12 text-rose-300 border-rose-500/20">
+                          {entry.failedSubagentCount} issue{entry.failedSubagentCount === 1 ? '' : 's'}
+                        </Pill>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-2 text-xs text-(--ui-text-tertiary)">
+                      <span>{entry.activeTodoCount} active todo{entry.activeTodoCount === 1 ? '' : 's'}</span>
+                      <span>•</span>
+                      <span>{entry.activeSubagentCount} active subagent{entry.activeSubagentCount === 1 ? '' : 's'}</span>
+                      {entry.session?.cwd ? (
+                        <>
+                          <span>•</span>
+                          <span className="max-w-[48rem] truncate">{entry.session.cwd}</span>
+                        </>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <Button
+                    disabled={!entry.routeId}
+                    onClick={() => entry.routeId && navigate(sessionRoute(entry.routeId))}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    Open session
+                  </Button>
+                </div>
+
+                <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+                  <div className="space-y-2">
+                    <SectionTitle title="Todo list" />
+                    {entry.todos.length === 0 ? (
+                      <MutedPanel>No live todo items for this session yet.</MutedPanel>
+                    ) : (
+                      <ul className="space-y-2">
+                        {entry.todos.map(todo => (
+                          <li
+                            className="rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-chat-surface-background) px-3 py-2"
+                            key={todo.id}
+                          >
+                            <div className="flex items-start gap-2">
+                              <Badge className={cn('mt-0.5 shrink-0 border text-[10px] uppercase tracking-wide', taskStatusTone(todo.status))}>
+                                {taskStatusLabel(todo.status)}
+                              </Badge>
+                              <div className="min-w-0 flex-1 text-sm text-foreground">{todo.content}</div>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <SectionTitle title="Subagents" />
+                    {entry.subagents.length === 0 ? (
+                      <MutedPanel>No background subagents are running for this session.</MutedPanel>
+                    ) : (
+                      <div className="space-y-2">
+                        {entry.subagents.map(node => (
+                          <SubagentTree key={node.id} node={node} />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </PageSearchShell>
+  )
+}
+
+function SummaryPill({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-(--ui-stroke-secondary) bg-(--ui-chat-surface-background) px-3 py-1 text-xs text-(--ui-text-secondary)">
+      <span>{label}</span>
+      <span className="font-semibold text-foreground">{value}</span>
+    </div>
+  )
+}
+
+function Pill({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <span className={cn('rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide', className)}>{children}</span>
+}
+
+function SectionTitle({ title }: { title: string }) {
+  return <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-(--ui-text-tertiary)">{title}</div>
+}
+
+function MutedPanel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-dashed border-(--ui-stroke-secondary) bg-(--ui-chat-surface-background) px-3 py-3 text-sm text-(--ui-text-tertiary)">
+      {children}
+    </div>
+  )
+}
+
+function EmptyState({ hasQuery }: { hasQuery: boolean }) {
+  return (
+    <div className="grid min-h-[18rem] place-items-center rounded-xl border border-dashed border-(--ui-stroke-secondary) bg-(--ui-sidebar-surface-background) px-6 text-center">
+      <div className="max-w-md space-y-2">
+        <div className="text-base font-semibold text-foreground">{hasQuery ? 'No matching live tasks' : 'No live tasks right now'}</div>
+        <p className="text-sm text-(--ui-text-tertiary)">
+          {hasQuery
+            ? 'Try a different search term, or wait for Hermes to start work in another session.'
+            : 'This page lights up automatically when Hermes starts a session, creates todo items, or spins up subagents.'}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function SubagentTree({ node, depth = 0 }: { node: SubagentNode; depth?: number }) {
+  const latest = latestSubagentLine(node)
+
+  return (
+    <div className="space-y-2">
+      <div
+        className="rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-chat-surface-background) px-3 py-2"
+        style={{ marginLeft: depth > 0 ? `${depth * 14}px` : undefined }}
+      >
+        <div className="flex flex-wrap items-start gap-2">
+          <Badge className={cn('border text-[10px] uppercase tracking-wide', subagentStatusTone(node.status))}>
+            {subagentStatusLabel(node.status)}
+          </Badge>
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="text-sm font-medium text-foreground">{node.goal}</div>
+            {latest ? <div className="text-xs text-(--ui-text-secondary)">{latest}</div> : null}
+            <div className="flex flex-wrap gap-2 text-[11px] text-(--ui-text-tertiary)">
+              {node.currentTool ? <span>Tool: {node.currentTool}</span> : null}
+              {typeof node.toolCount === 'number' ? <span>Tools used: {node.toolCount}</span> : null}
+              {typeof node.durationSeconds === 'number' ? <span>{Math.round(node.durationSeconds)}s</span> : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {node.children.map(child => (
+        <SubagentTree depth={depth + 1} key={child.id} node={child} />
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -123,7 +123,7 @@ export type CommandDispatchResponse =
   | SendCommandDispatchResponse
   | PrefillCommandDispatchResponse
 
-export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
+export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills' | 'tasks'
 
 export interface SidebarNavItem {
   /** Built-in view id, or a contributed row's namespaced contribution id. */

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1553,6 +1553,7 @@ export const en: Translations = {
     nav: {
       'new-session': 'New session',
       skills: 'Capabilities',
+      tasks: 'Live tasks',
       messaging: 'Messaging',
       artifacts: 'Artifacts'
     },

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $sessionsLimit, resetSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import {
   $cronSessions,
@@ -15,6 +16,9 @@ import {
   setSessionsLoading,
   setSessionsTotal
 } from '@/store/session'
+import { $sessionStates, publishSessionState } from '@/store/session-states'
+import { $subagentsBySession, upsertSubagent } from '@/store/subagents'
+import { $todosBySession, setSessionTodos } from '@/store/todos'
 
 import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from './gateway-switch'
 
@@ -31,6 +35,11 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setMessagingSessions([{ id: 'm1', title: 'tg', profile: 'default' } as never])
     setSessionsLoading(false)
     setFreshDraftReady(false)
+    const runtimeState = createClientSessionState('s1')
+    runtimeState.busy = true
+    publishSessionState('runtime-s1', runtimeState)
+    setSessionTodos('runtime-s1', [{ id: 'todo-1', content: 'old task', status: 'pending' }])
+    upsertSubagent('runtime-s1', { goal: 'old subagent', status: 'running', subagent_id: 'subagent-1' })
     $sessionsLimit.set(SIDEBAR_SESSIONS_PAGE_SIZE * 3)
   })
 
@@ -39,6 +48,9 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setSessions([])
     setCronSessions([])
     setMessagingSessions([])
+    $sessionStates.set({})
+    $todosBySession.set({})
+    $subagentsBySession.set({})
     setSessionsLoading(true)
     $gatewaySwitching.set(false)
   })
@@ -53,5 +65,8 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     expect($sessionsLoading.get()).toBe(true)
     expect($sessionsLimit.get()).toBe(SIDEBAR_SESSIONS_PAGE_SIZE)
     expect($freshDraftReady.get()).toBe(true)
+    expect($sessionStates.get()).toEqual({})
+    expect($todosBySession.get()).toEqual({})
+    expect($subagentsBySession.get()).toEqual({})
   })
 })

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -18,6 +18,8 @@ import {
   setSessionsTotal
 } from '@/store/session'
 import { clearAllSessionStates } from '@/store/session-states'
+import { clearAllSessionSubagents } from '@/store/subagents'
+import { clearAllSessionTodos } from '@/store/todos'
 
 // True while a soft gateway-mode apply is mid-flight (wipe → re-dial). Lets the
 // boot hook suppress the backend-exit toast and keeps the cold-boot CONNECTING
@@ -48,6 +50,8 @@ export function wipeSessionListsForGatewaySwitch(): void {
   // $attentionSessionIds (they're computed from it). $unreadFinishedSessionIds
   // is separate (transient, not computable) so wipe it explicitly.
   clearAllSessionStates()
+  clearAllSessionTodos()
+  clearAllSessionSubagents()
   $unreadFinishedSessionIds.set([])
   setSessionsLoading(true)
   resetSessionsLimit()

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -50,9 +50,19 @@ const sessionWatchdogTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 type WatchdogClearFn = (runtimeId: string) => void
 let watchdogClearFn: WatchdogClearFn | null = null
+let sessionStateCacheClearFn: (() => void) | null = null
+let sessionStateGeneration = 0
+
+export function getSessionStateGeneration(): number {
+  return sessionStateGeneration
+}
 
 export function setWatchdogClearFn(fn: WatchdogClearFn | null) {
   watchdogClearFn = fn
+}
+
+export function setSessionStateCacheClearFn(fn: (() => void) | null) {
+  sessionStateCacheClearFn = fn
 }
 
 function armWatchdog(runtimeId: string) {
@@ -181,12 +191,15 @@ export function dropSessionState(runtimeId: string) {
  *  wiped gateway's sessions must not fire stale clears or linger in the
  *  sidebar merge keep-set after the switch. */
 export function clearAllSessionStates() {
+  sessionStateGeneration += 1
+
   for (const timer of sessionWatchdogTimers.values()) {
     clearTimeout(timer)
   }
 
   sessionWatchdogTimers.clear()
   settledExpiry.clear()
+  sessionStateCacheClearFn?.()
   $sessionStates.set({})
 }
 

--- a/apps/desktop/src/store/subagents.ts
+++ b/apps/desktop/src/store/subagents.ts
@@ -189,6 +189,10 @@ export function clearSessionSubagents(sid: string) {
   $subagentsBySession.set(rest)
 }
 
+export function clearAllSessionSubagents() {
+  $subagentsBySession.set({})
+}
+
 export function pruneDelegateFallbackSubagents(sid: string) {
   const map = $subagentsBySession.get()
   const list = map[sid]

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -74,6 +74,15 @@ export function clearSessionTodos(sid: string) {
   $todosBySession.set(rest)
 }
 
+export function clearAllSessionTodos() {
+  for (const timer of clearTimers.values()) {
+    clearTimeout(timer)
+  }
+
+  clearTimers.clear()
+  $todosBySession.set({})
+}
+
 // Drop a still-active todo list (any pending/in_progress item) — used at turn
 // end, when an unfinished list means the turn stopped without a final `todo`
 // update, so the "Tasks N/M" panel would otherwise stay pinned above the


### PR DESCRIPTION
## Summary
- add a new Live tasks entry to the Hermes Desktop left sidebar
- wire a `/tasks` route into the desktop router and lazy-load the new page
- surface live todo, session, and subagent state in a dedicated dashboard

## Testing
- npm run typecheck
- npx eslint src/app/tasks/index.tsx src/app/routes.ts src/app/types.ts src/app/chat/sidebar/index.tsx src/app/desktop-controller.tsx src/i18n/en.ts
- npm run build
