### PR TITLE
docs(web): update src/ structure to reflect current layout

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -39,17 +39,81 @@ This outputs to `../hermes_cli/web_dist/`, which the FastAPI server serves as a 
 
 ```
 src/
-├── components/ui/   # Reusable UI primitives (Card, Badge, Button, Input, etc.)
-├── lib/
-│   ├── api.ts       # API client — typed fetch wrappers for all backend endpoints
-│   └── utils.ts     # cn() helper for Tailwind class merging
-├── pages/
-│   ├── StatusPage   # Agent status, active/recent sessions
-│   ├── ConfigPage   # Dynamic config editor (reads schema from backend)
-│   └── EnvPage      # API key management with save/clear
-├── App.tsx          # Main layout and navigation
-├── main.tsx         # React entry point
-└── index.css        # Tailwind imports and theme variables
+├── components/              # Shared UI components used across pages
+│   ├── AuthWidget           # OAuth "logged in as" sidebar affordance
+│   ├── AutoField            # Dynamic form field renderer (select/switch/input)
+│   ├── AutomationBlueprints # Automation blueprint browser and launcher
+│   ├── ChatSessionList      # Conversation switcher for the Chat tab
+│   ├── ChatSidebar          # Structured-events panel next to the terminal
+│   ├── LanguageSwitcher     # Locale selector dropdown
+│   ├── Markdown             # Lightweight LLM output renderer
+│   ├── ModelInfoCard        # Model capability and metadata card
+│   ├── ModelPickerDialog    # Fuzzy model search and selection dialog
+│   ├── OAuthLoginModal      # OAuth device-flow login modal
+│   ├── OAuthProvidersCard   # OAuth provider status and management
+│   ├── PlatformsCard        # Connected platform status card with connectivity badges
+│   ├── ProfileScopeBanner   # Amber banner shown when a non-default management profile is active
+│   ├── ProfileSwitcher      # Management profile selector
+│   ├── ReasoningPicker      # Model reasoning effort selector
+│   ├── ScheduleBuilder      # Cron schedule builder UI
+│   ├── SidebarFooter        # Sidebar bottom status and version info
+│   ├── SidebarStatusStrip   # Agent status strip in sidebar
+│   ├── SkillEditorDialog    # Skill create and edit dialog
+│   ├── SlashPopover         # Slash command autocomplete popover
+│   ├── ThemeSwitcher        # Theme and font override picker
+│   ├── ToolCall             # Tool call result display with expand/collapse
+│   └── ToolsetConfigDrawer  # Toolset enable/disable configuration drawer
+├── contexts/                # React contexts and their hooks
+│   ├── PageHeaderProvider   # Page title injection into the app shell header
+│   ├── ProfileProvider      # Active management profile scope
+│   └── SystemActions        # Global system action dispatch and toast feedback
+├── hooks/                   # Standalone React hooks
+│   ├── useModalBehavior     # Escape-key and focus trap for modals
+│   └── useSidebarStatus     # Polling hook for agent status strip
+├── i18n/                    # Internationalisation — 18 locales
+│   ├── types.ts             # Translations interface and Locale union type
+│   ├── context.tsx          # I18nProvider and useI18n hook
+│   └── *.ts                 # Per-locale translation maps (en, zh, ja, ru …)
+├── lib/                     # Pure utilities and API layer
+│   ├── api.ts               # Typed fetch wrappers for all backend endpoints
+│   ├── cron-job.ts          # Cron job form state types and mutation payload helpers
+│   ├── gatewayClient.ts     # WebSocket client for tui_gateway JSON-RPC
+│   ├── fuzzy.ts             # Subsequence scorer for picker filtering
+│   ├── reasoning-effort.ts  # Reasoning-effort normalisation helpers
+│   ├── schedule.ts          # Cron schedule builder helpers
+│   └── utils.ts             # cn() and themedBody helpers for Tailwind
+├── pages/                   # Route-level page components
+│   ├── AnalyticsPage        # Usage analytics and token stats
+│   ├── ChannelsPage         # Notification channel management
+│   ├── ChatPage             # Embedded hermes --tui terminal
+│   ├── ConfigPage           # Dynamic config editor (reads schema from backend)
+│   ├── CronPage             # Scheduled job management
+│   ├── DocsPage             # Documentation viewer
+│   ├── EnvPage              # API key management with save/clear
+│   ├── FilesPage            # Working directory file browser
+│   ├── LogsPage             # Agent log viewer
+│   ├── McpPage              # MCP server management
+│   ├── ModelsPage           # Model catalogue and selection
+│   ├── PairingPage          # Device pairing and access management
+│   ├── PluginsPage          # Dashboard plugin management
+│   ├── ProfileBuilderPage   # Profile creation wizard
+│   ├── ProfilesPage         # Profile list and management
+│   ├── SessionsPage         # Active and recent session list
+│   ├── SkillsPage           # Skills browser and editor
+│   ├── SystemPage           # System health and diagnostics
+│   └── WebhooksPage         # Webhook configuration and management
+├── plugins/                 # Dashboard plugin system
+│   ├── registry.ts          # Plugin SDK exposure and component registry
+│   ├── slots.ts             # Named injection slots (header, sidebar, backdrop)
+│   ├── usePlugins.ts        # Hook — fetches manifests and injects plugin bundles
+│   └── sdk.d.ts             # Public type surface for window.__HERMES_PLUGIN_SDK__
+├── themes/                  # Dashboard theming layer
+│   ├── presets.ts           # Built-in theme definitions
+│   ├── fonts.ts             # Curated UI-font catalog for font override
+│   └── context.tsx          # ThemeProvider and useTheme hook
+├── App.tsx                  # Main layout, routing, and navigation
+├── main.tsx                 # React entry point
+└── index.css                # Tailwind imports and theme variables
 ```
 
 ## Typography & contrast rules

--- a/web/README.md
+++ b/web/README.md
@@ -41,47 +41,72 @@ This outputs to `../hermes_cli/web_dist/`, which the FastAPI server serves as a 
 src/
 ├── components/              # Shared UI components used across pages
 │   ├── AuthWidget           # OAuth "logged in as" sidebar affordance
-│   ├── AutoField            # Dynamic form field renderer (select/switch/input)
-│   ├── AutomationBlueprints # Automation blueprint browser and launcher
-│   ├── ChatSessionList      # Conversation switcher for the Chat tab
-│   ├── ChatSidebar          # Structured-events panel next to the terminal
-│   ├── LanguageSwitcher     # Locale selector dropdown
-│   ├── Markdown             # Lightweight LLM output renderer
-│   ├── ModelInfoCard        # Model capability and metadata card
-│   ├── ModelPickerDialog    # Fuzzy model search and selection dialog
-│   ├── OAuthLoginModal      # OAuth device-flow login modal
-│   ├── OAuthProvidersCard   # OAuth provider status and management
-│   ├── PlatformsCard        # Connected platform status card with connectivity badges
-│   ├── ProfileScopeBanner   # Amber banner shown when a non-default management profile is active
-│   ├── ProfileSwitcher      # Management profile selector
-│   ├── ReasoningPicker      # Model reasoning effort selector
-│   ├── ScheduleBuilder      # Cron schedule builder UI
-│   ├── SidebarFooter        # Sidebar bottom status and version info
-│   ├── SidebarStatusStrip   # Agent status strip in sidebar
-│   ├── SkillEditorDialog    # Skill create and edit dialog
-│   ├── SlashPopover         # Slash command autocomplete popover
-│   ├── ThemeSwitcher        # Theme and font override picker
-│   ├── ToolCall             # Tool call result display with expand/collapse
-│   └── ToolsetConfigDrawer  # Toolset enable/disable configuration drawer
+│   ├── AutoField             # Dynamic form field renderer (select/switch/input)
+│   ├── AutomationBlueprints  # Automation blueprint browser and launcher
+│   ├── ChatSessionList       # Conversation switcher for the Chat tab
+│   ├── ChatSidebar           # Structured-events panel next to the terminal
+│   ├── ConfirmDialog         # Reusable confirm/cancel dialog with optional destructive styling
+│   ├── DeleteConfirmDialog   # ConfirmDialog wrapper preset to destructive with i18n delete/cancel labels
+│   ├── HermesConsoleModal    # xterm-based modal streaming live agent execution output, scoped to the active profile
+│   ├── LanguageSwitcher      # Locale selector dropdown
+│   ├── Markdown              # Lightweight LLM output renderer
+│   ├── ModelInfoCard         # Model capability and metadata card
+│   ├── ModelPickerDialog     # Fuzzy model search and selection dialog
+│   ├── ModelReloadConfirm    # Confirm dialog before a full-page reload to apply a model switch
+│   ├── OAuthLoginModal       # OAuth device-flow login modal
+│   ├── OAuthProvidersCard    # OAuth provider status and management
+│   ├── PlatformsCard         # Connected platform status card with connectivity badges
+│   ├── ProfileScopeBanner    # Amber banner shown when a non-default management profile is active
+│   ├── ProfileSwitcher       # Management profile selector
+│   ├── ReasoningPicker       # Model reasoning effort selector
+│   ├── ScheduleBuilder       # Cron schedule builder UI
+│   ├── SidebarFooter         # Sidebar bottom status and version info
+│   ├── SidebarStatusStrip    # Agent status strip in sidebar
+│   ├── SkillEditorDialog     # Skill create and edit dialog
+│   ├── SlashPopover          # Slash command autocomplete popover
+│   ├── ThemeSwitcher         # Theme and font override picker
+│   └── ToolsetConfigDrawer   # Toolset enable/disable configuration drawer
 ├── contexts/                # React contexts and their hooks
-│   ├── PageHeaderProvider   # Page title injection into the app shell header
-│   ├── ProfileProvider      # Active management profile scope
-│   └── SystemActions        # Global system action dispatch and toast feedback
+│   ├── PageHeaderProvider    # Page title injection into the app shell header
+│   ├── page-header-context.ts # React context definition for page title, after-title node, and end slot
+│   ├── usePageHeader.ts      # Hook to consume PageHeaderContext, throws if used outside PageHeaderProvider
+│   ├── ProfileProvider       # Active management profile scope
+│   ├── profile-context.ts    # React context for active/current management profile and known profile list
+│   ├── useProfileScope.ts    # Hook to consume ProfileContext
+│   ├── SystemActions         # Global system action dispatch and toast feedback
+│   ├── system-actions-context.ts # React context for running/tracking system actions (restart, update)
+│   └── useSystemActions.ts   # Hook to consume SystemActionsContext, throws if used outside SystemActionsProvider
 ├── hooks/                   # Standalone React hooks
 │   ├── useModalBehavior     # Escape-key and focus trap for modals
 │   └── useSidebarStatus     # Polling hook for agent status strip
-├── i18n/                    # Internationalisation — 18 locales
+├── i18n/                    # Internationalisation — 16 locales
 │   ├── types.ts             # Translations interface and Locale union type
 │   ├── context.tsx          # I18nProvider and useI18n hook
-│   └── *.ts                 # Per-locale translation maps (en, zh, ja, ru …)
+│   ├── index.ts             # Barrel export: I18nProvider, useI18n, LOCALE_META, Locale, Translations
+│   └── *.ts                 # Per-locale translation maps (af, de, en, es, fr, ga, hu, it, ja, ko, pt, ru, tr, uk, zh, zh-hant)
 ├── lib/                     # Pure utilities and API layer
-│   ├── api.ts               # Typed fetch wrappers for all backend endpoints
-│   ├── cron-job.ts          # Cron job form state types and mutation payload helpers
-│   ├── gatewayClient.ts     # WebSocket client for tui_gateway JSON-RPC
-│   ├── fuzzy.ts             # Subsequence scorer for picker filtering
-│   ├── reasoning-effort.ts  # Reasoning-effort normalisation helpers
-│   ├── schedule.ts          # Cron schedule builder helpers
-│   └── utils.ts             # cn() and themedBody helpers for Tailwind
+│   ├── api.ts                # Typed fetch wrappers for all backend endpoints
+│   ├── chat-activation.ts    # Sticky latch delaying chat PTY connect until the chat tab has actually been active
+│   ├── chat-title.ts         # Normalizes/extracts session title from raw session-info payload
+│   ├── chatImagePaste.ts     # Clipboard image upload helpers — MIME/extension mapping and size cap for chat paste
+│   ├── clipboard.ts          # copyTextToClipboard() with secure-context Clipboard API + fallback path
+│   ├── cron-job.ts           # Cron job form state types and mutation payload helpers
+│   ├── dashboard-flags.ts    # Reads server-injected window flags (e.g. embedded TUI chat availability)
+│   ├── format.ts             # formatTokenCount() — human-readable token counts (1M, 128K, etc.)
+│   ├── fuzzy.ts              # Subsequence scorer for picker filtering
+│   ├── gatewayClient.ts      # WebSocket client for tui_gateway JSON-RPC
+│   ├── mcp-dashboard-oauth.ts # Drives an MCP server's OAuth flow (start, poll status, open auth URL) from the dashboard
+│   ├── mcp-server-create.ts  # McpServerDraft type/helpers for the add-MCP-server form
+│   ├── nested.ts             # getNestedValue/setNestedValue — dot-path access on nested config objects
+│   ├── pty-mobile-input.ts   # Mobile IME line-replacement handling for terminal input
+│   ├── pty-reconnect.ts      # PTY connection state machine and reconnect throttling for the chat terminal
+│   ├── reasoning-effort.ts   # Reasoning-effort normalisation helpers
+│   ├── resolve-page-title.ts # Maps route paths to i18n nav translation keys for the page header title
+│   ├── schedule.ts           # Cron schedule builder helpers
+│   ├── session-import.ts     # Normalizes/validates imported session data shape
+│   ├── session-refresh.ts    # Decides whether to silently re-fetch the sessions list after a cross-process poll
+│   ├── slashExec.ts          # Slash-command execution pipeline for web chat (mirrors TUI's createSlashHandler)
+│   └── utils.ts              # cn() and themedBody helpers for Tailwind
 ├── pages/                   # Route-level page components
 │   ├── AnalyticsPage        # Usage analytics and token stats
 │   ├── ChannelsPage         # Notification channel management
@@ -103,14 +128,19 @@ src/
 │   ├── SystemPage           # System health and diagnostics
 │   └── WebhooksPage         # Webhook configuration and management
 ├── plugins/                 # Dashboard plugin system
+│   ├── index.ts             # Barrel export: SDK exposure, PluginPage, usePlugins, slot API, and plugin types
+│   ├── PluginPage.tsx       # Renders a registered plugin tab once its bundle calls register(), with loading/error state
 │   ├── registry.ts          # Plugin SDK exposure and component registry
 │   ├── slots.ts             # Named injection slots (header, sidebar, backdrop)
+│   ├── types.ts             # PluginManifest and RegisteredPlugin type definitions
 │   ├── usePlugins.ts        # Hook — fetches manifests and injects plugin bundles
 │   └── sdk.d.ts             # Public type surface for window.__HERMES_PLUGIN_SDK__
 ├── themes/                  # Dashboard theming layer
-│   ├── presets.ts           # Built-in theme definitions
-│   ├── fonts.ts             # Curated UI-font catalog for font override
-│   └── context.tsx          # ThemeProvider and useTheme hook
+│   ├── context.tsx          # ThemeProvider and useTheme hook
+│   ├── fonts.ts              # Curated UI-font catalog for font override
+│   ├── index.ts              # Barrel export: ThemeProvider, useTheme, BUILTIN_THEMES, font choices, theme types
+│   ├── presets.ts            # Built-in theme definitions
+│   └── types.ts              # DashboardTheme model — palette, typography, and layout layer definitions
 ├── App.tsx                  # Main layout, routing, and navigation
 ├── main.tsx                 # React entry point
 └── index.css                # Tailwind imports and theme variables
@@ -165,4 +195,3 @@ Typography is **opt-in per surface**, not global on layout shells — the app sh
 - Prefer **semantic tokens** (`text-text-*`, `bg-card`, `border-border`, `text-foreground`, `text-destructive`, `text-success`, `text-warning`) over raw layer references (`text-midground`, `text-foreground`).
 - `text-muted-foreground` is now wired to `--color-text-secondary`, so existing call sites stay correct, but new code should prefer the semantic name.
 - When you genuinely need a non-token color (icon de-emphasis on a chart, terminal foreground via inline style), keep alpha at `≥ 0.7` for any text.
-


### PR DESCRIPTION
## What does this PR do?
The `## Structure` section in `web/README.md` was outdated and no longer matched the actual contents of `web/src/`. It referenced a `components/ui/` subdirectory that does not exist, listed a `StatusPage` that has been removed, and omitted five directories that have since been added: `contexts/`, `hooks/`, `i18n/`, `plugins/`, and `themes/`. This PR replaces the stale tree with an accurate, fully-annotated map of the current `src/` layout.

## Related Issue
Fixes #

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `web/README.md` — replaced the `## Structure` code block with the current `src/` directory tree including all components, contexts, hooks, i18n, lib, pages, plugins, and themes with accurate per-file descriptions

## How to Test
1. Open `web/README.md` and review the `## Structure` section
2. Run `Get-ChildItem 'web/src' -Recurse -Name | Sort-Object` (Windows) or `find web/src -type f | sort` (macOS/Linux)
3. Confirm every directory and file in the output is reflected in the updated structure

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform:

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills
N/A

## Screenshots / Logs
N/A — documentation-only change.