### PR TITLE
fix(codex): extend stale timeout for gateway-scale tool payloads

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -134,7 +134,9 @@ def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
     Gateway/Telegram sessions routinely ship ~15–25k tokens of tools +
     instructions before the first user message. Subscription-backed Codex can
     legitimately spend several minutes in backend admission/prefill at that
-    size; the generic 90s non-stream stale default aborts healthy calls.
+    size; the generic 90s non-stream stale default aborts healthy calls. The
+    floor engages above 10k estimated tokens so those gateway-scale payloads
+    are covered; smaller requests keep the generic default.
     """
     if est_tokens > 100_000:
         return 1200.0

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -128,6 +128,23 @@ def _is_openai_codex_backend(agent) -> bool:
     )
 
 
+def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
+    """Minimum wall-clock stale timeout for openai-codex by estimated context.
+
+    Gateway/Telegram sessions routinely ship ~15–25k tokens of tools +
+    instructions before the first user message. Subscription-backed Codex can
+    legitimately spend several minutes in backend admission/prefill at that
+    size; the generic 90s non-stream stale default aborts healthy calls.
+    """
+    if est_tokens > 100_000:
+        return 1200.0
+    if est_tokens > 50_000:
+        return 900.0
+    if est_tokens > 10_000:
+        return 600.0
+    return 0.0
+
+
 def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
     """Return a normalized OpenRouter provider.sort value or None."""
     if not isinstance(raw_sort, str):
@@ -316,12 +333,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
     _openai_codex_backend = _is_openai_codex_backend(agent)
     _est_tokens_for_codex_watchdog = estimate_request_context_tokens(api_kwargs)
     if _codex_watchdog_enabled and _openai_codex_backend:
-        if _est_tokens_for_codex_watchdog > 100_000:
-            _stale_timeout = max(_stale_timeout, 1200.0)
-        elif _est_tokens_for_codex_watchdog > 50_000:
-            _stale_timeout = max(_stale_timeout, 900.0)
-        elif _est_tokens_for_codex_watchdog > 25_000:
-            _stale_timeout = max(_stale_timeout, 600.0)
+        _codex_floor = openai_codex_stale_timeout_floor(_est_tokens_for_codex_watchdog)
+        if _codex_floor:
+            _stale_timeout = max(_stale_timeout, _codex_floor)
 
     if _est_tokens_for_codex_watchdog > 100_000:
         _codex_idle_timeout_default = 180.0
@@ -344,7 +358,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
     elif _openai_codex_backend:
-        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 25_000.0)
+        _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 10_000.0)
         _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
             "1", "true", "yes", "on"
         }

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -380,7 +380,7 @@ def test_large_codex_request_waits_instead_of_ttfb_reconnect(tmp_path, monkeypat
 
     monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
 
-    large_input = "x" * 120_000  # ~30k estimated tokens, above large-request gate.
+    large_input = "x" * 44_000  # ~11k estimated tokens, above the 10k gate.
     resp = h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": large_input})
     assert resp is sentinel
     assert "codex_ttfb_kill" not in closes
@@ -415,7 +415,7 @@ def test_large_codex_request_strict_ttfb_env_still_reconnects(tmp_path, monkeypa
 
     monkeypatch.setattr(agent, "_run_codex_stream", fake_hang)
 
-    large_input = "x" * 120_000
+    large_input = "x" * 44_000
     try:
         with pytest.raises(TimeoutError) as excinfo:
             h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": large_input})

--- a/tests/agent/test_non_stream_stale_timeout.py
+++ b/tests/agent/test_non_stream_stale_timeout.py
@@ -188,3 +188,22 @@ providers:
 
     agent = _make_agent(tmp_path)
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 1800.0
+
+
+# ── openai-codex gateway-scale stale floor ────────────────────────────────
+
+
+def test_openai_codex_stale_floor_covers_gateway_tool_payload():
+    """Gateway/Telegram tool payloads (~20k tokens) need the 600s Codex floor."""
+    from agent.chat_completion_helpers import openai_codex_stale_timeout_floor
+
+    assert openai_codex_stale_timeout_floor(22_095) == 600.0
+    assert openai_codex_stale_timeout_floor(10_001) == 600.0
+    assert openai_codex_stale_timeout_floor(10_000) == 0.0
+
+
+def test_openai_codex_stale_floor_tiers():
+    from agent.chat_completion_helpers import openai_codex_stale_timeout_floor
+
+    assert openai_codex_stale_timeout_floor(55_000) == 900.0
+    assert openai_codex_stale_timeout_floor(120_000) == 1200.0


### PR DESCRIPTION
## Summary
Codex requests carrying ~10–25k tokens of tools + instructions (the normal shape of any Telegram/gateway session before the first user message) now get the 600s stale-timeout floor instead of being killed by the generic 90s non-stream cutoff while the ChatGPT Codex backend is still prefilling.

Root cause: the openai-codex stale-floor only engaged above 25k estimated tokens, but a gateway session ships ~15–25k tokens of baseline tools/instructions — landing exactly in the 10k–25k dead zone that fell through to the 90s default.

## Changes
- `agent/chat_completion_helpers.py`: lower the codex stale-floor gate from `>25k` to `>10k` tokens (via new `openai_codex_stale_timeout_floor()` helper); align the no-byte TTFB-disable default from 25k to 10k so the aggressive TTFB watchdog also relaxes for gateway-scale requests.
- Tests: regression coverage for the ~22k-token gateway case + tier boundaries.

## Validation
| est_tokens | Before (floor) | After (floor) |
|---|---|---|
| 22,095 (reported) | none → 90s stale death | 600s |
| 10,001 | none | 600s |
| 10,000 | none | none |
| 55,000 | 900s | 900s |
| 120,000 | 1200s | 1200s |

Reported symptom: openai-codex/gpt-5.4 on Telegram, `context=~22,095 tokens`, killed at 90s; orphaned request completed ~281s later. Reproduced on `main` and confirmed fixed.

Targeted tests: `tests/agent/test_non_stream_stale_timeout.py` + `tests/agent/test_codex_ttfb_watchdog.py` — 23 passed.

Salvage of #56985. Original commits cherry-picked with @HexLab98's authorship preserved.

Closes #56985
