### PR TITLE
feat(skills): add config-driven prompt tiering

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,6 +24,7 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_skill_tiers,
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_environment,
@@ -1491,6 +1492,13 @@ def build_skills_system_prompt(
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
+    skill_tiers = get_skill_tiers()
+    tier_key = (
+        bool(skill_tiers.get("enabled")),
+        tuple(sorted(skill_tiers.get("hot", set()))),
+        tuple(sorted(skill_tiers.get("warm", set()))),
+        tuple(sorted(skill_tiers.get("cold", set()))),
+    )
     cache_key = (
         str(skills_dir),
         tuple(str(d) for d in external_dirs),
@@ -1499,6 +1507,7 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        tier_key,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1657,57 +1666,133 @@ def build_skills_system_prompt(
     if not skills_by_category:
         result = ""
     else:
+        tiers_enabled = bool(skill_tiers.get("enabled"))
+        hot_names = set(skill_tiers.get("hot", set()))
+        cold_names = set(skill_tiers.get("cold", set()))
+
+        def _tier_for_skill(name: str) -> str:
+            if not tiers_enabled:
+                return "hot"
+            if name in hot_names:
+                return "hot"
+            if name in cold_names:
+                return "cold"
+            # Unknown or explicitly warm skills default to warm so tiering
+            # cannot silently hide newly-created skills from the prompt.
+            return "warm"
+
         index_lines = []
+        warm_lines = []
+        cold_skill_names = []
         for category in sorted(skills_by_category.keys()):
-            # Deduplicate and sort skills within each category
+            # Deduplicate and sort skills within each category.
             seen = set()
+            category_entries = []
+            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
+                if name in seen:
+                    continue
+                seen.add(name)
+                category_entries.append((name, desc))
+
+            # Compact-category rendering is the stronger contract: every skill
+            # in a demoted category stays visible by name, regardless of tier,
+            # and no description leaks back in through the warm bucket.
             if category in demoted:
-                names = sorted({name for name, _ in skills_by_category[category]})
+                names = [name for name, _ in category_entries]
                 index_lines.append(f"  {category} [names only]: {', '.join(names)}")
                 continue
+
+            category_skills = []
+            for name, desc in category_entries:
+                tier = _tier_for_skill(name)
+                if tier == "cold":
+                    cold_skill_names.append(name)
+                elif tier == "warm":
+                    warm_lines.append(f"- {name}: {desc}" if desc else f"- {name}")
+                else:
+                    category_skills.append((name, desc))
+
+            if tiers_enabled and not category_skills:
+                continue
+
             cat_desc = category_descriptions.get(category, "")
             if cat_desc:
                 index_lines.append(f"  {category}: {cat_desc}")
             else:
                 index_lines.append(f"  {category}:")
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
-                    continue
-                seen.add(name)
+            for name, desc in category_skills:
                 if desc:
                     index_lines.append(f"    - {name}: {desc}")
                 else:
                     index_lines.append(f"    - {name}")
 
-        result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
-            "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
-            + hidden_note
-        )
+        if tiers_enabled:
+            warm_block = ""
+            if warm_lines:
+                warm_block = (
+                    "\n<warm_skills>\n"
+                    "Warm skills are available by name. Load one with skill_view(name) "
+                    "only when the current task explicitly matches its trigger.\n"
+                    + "\n".join(sorted(warm_lines)) + "\n"
+                    "</warm_skills>\n"
+                )
+            cold_block = ""
+            if cold_skill_names:
+                cold_block = (
+                    "\n<cold_skills>\n"
+                    "Cold skills are listed by name only to preserve discoverability. "
+                    "Load one with skill_view(name) when the task explicitly calls for it.\n"
+                    + "\n".join(f"- {name}" for name in sorted(cold_skill_names)) + "\n"
+                    "</cold_skills>\n"
+                )
+            result = (
+                "## Skills (tiered)\n"
+                "Hot skills below include descriptions. Warm skills are compact reminders; "
+                "load one only when the task explicitly matches its trigger. "
+                "Cold skills remain visible by name only.\n"
+                "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
+                "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
+                "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill first.\n"
+                "If a skill has issues, fix it with skill_manage(action='patch'). "
+                "After difficult/iterative tasks, offer to save as a skill.\n"
+                "\n"
+                "<available_skills>\n"
+                + ("\n".join(index_lines) + "\n" if index_lines else "")
+                + "</available_skills>\n"
+                + warm_block
+                + cold_block
+                + hidden_note
+            )
+        else:
+            result = (
+                "## Skills (mandatory)\n"
+                "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+                "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+                "Err on the side of loading — it is always better to have context you don't need "
+                "than to miss critical steps, pitfalls, or established workflows. "
+                "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
+                "and proven workflows that outperform general-purpose approaches. Load the skill "
+                "even if you think you could handle the task with basic tools like web_search or terminal. "
+                "Skills also encode the user's preferred approach, conventions, and quality standards "
+                "for tasks like code review, planning, and testing — load them even for tasks you "
+                "already know how to do, because the skill defines how it should be done here.\n"
+                "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
+                "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
+                "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
+                "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
+                "`hermes setup`) so you don't have to guess or invent workarounds.\n"
+                "If a skill has issues, fix it with skill_manage(action='patch').\n"
+                "After difficult/iterative tasks, offer to save as a skill. "
+                "If a skill you loaded was missing steps, had wrong commands, or needed "
+                "pitfalls you discovered, update it before finishing.\n"
+                "\n"
+                "<available_skills>\n"
+                + "\n".join(index_lines) + "\n"
+                "</available_skills>\n"
+                "\n"
+                "Only proceed without loading a skill if genuinely none are relevant to the task."
+                + hidden_note
+            )
 
     # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -392,6 +392,50 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     return global_disabled
 
 
+def get_skill_tiers() -> Dict[str, Any]:
+    """Read optional skill-tier rendering config from config.yaml.
+
+    ``skills.tiers`` is a prompt-rendering hint, not an access-control
+    mechanism. It only changes how the default skills index is displayed;
+    ``skill_view`` / ``skills_list`` stay able to reach every enabled skill.
+
+    Shape::
+
+        skills:
+          tiers:
+            enabled: true
+            hot: [hermes-agent]
+            warm: [writing-plans]
+            cold: [godmode]
+
+    Missing or malformed config returns the safe disabled default.
+    """
+    parsed = _load_raw_config()
+    if not parsed:
+        return {"enabled": False, "hot": set(), "warm": set(), "cold": set()}
+
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return {"enabled": False, "hot": set(), "warm": set(), "cold": set()}
+
+    tiers_cfg = skills_cfg.get("tiers")
+    if not isinstance(tiers_cfg, dict):
+        return {"enabled": False, "hot": set(), "warm": set(), "cold": set()}
+
+    enabled_raw = tiers_cfg.get("enabled", False)
+    if isinstance(enabled_raw, str):
+        enabled = enabled_raw.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        enabled = bool(enabled_raw)
+
+    return {
+        "enabled": enabled,
+        "hot": _normalize_string_set(tiers_cfg.get("hot")),
+        "warm": _normalize_string_set(tiers_cfg.get("warm")),
+        "cold": _normalize_string_set(tiers_cfg.get("cold")),
+    }
+
+
 def _normalize_string_set(values) -> Set[str]:
     if values is None:
         return set()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -683,6 +683,25 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Optional prompt-rendering tiers. This only changes the default skills index
+  # injected into the system prompt; it does not disable skills. skills_list and
+  # skill_view can still load every enabled skill, including cold skills.
+  #
+  # enabled: false keeps the classic full skills index.
+  # hot: shown normally in the system prompt.
+  # warm: listed as compact reminders; unknown skills also default to warm when
+  #       tiers are enabled, so new skills are not silently hidden.
+  # cold: names remain visible, but descriptions are omitted to save context.
+  # tiers:
+  #   enabled: false
+  #   hot:
+  #     - hermes-agent
+  #   warm:
+  #     - github-operations
+  #     - writing-plans
+  #   cold:
+  #     - pixel-art
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -474,6 +474,151 @@ class TestBuildSkillsSystemPrompt:
         full = build_skills_system_prompt()
         assert "Write threads" in full
 
+    def test_tiered_skills_render_hot_warm_and_cold_names_only(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from agent import skill_utils
+        skill_utils._external_dirs_cache_clear()
+
+        (tmp_path / "config.yaml").write_text(
+            """
+skills:
+  tiers:
+    enabled: true
+    hot:
+      - hermes-agent
+    warm:
+      - obsidian-memory-graph-protocol
+    cold:
+      - godmode
+""".strip(),
+            encoding="utf-8",
+        )
+        specs = [
+            ("autonomous-ai-agents", "hermes-agent", "Hermes config help"),
+            ("note-taking", "obsidian-memory-graph-protocol", "Graph receipts"),
+            ("red-teaming", "godmode", "Red team prompts"),
+            ("creative", "pixel-art", "Pixel art workflows"),
+        ]
+        for cat, name, desc in specs:
+            d = tmp_path / "skills" / cat / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n",
+                encoding="utf-8",
+            )
+
+        result = build_skills_system_prompt()
+
+        assert "## Skills (tiered)" in result
+        assert "hermes-agent: Hermes config help" in result
+        assert "<warm_skills>" in result
+        assert "obsidian-memory-graph-protocol: Graph receipts" in result
+        # Unknown/unlisted enabled skills default warm, not cold.
+        assert "pixel-art: Pixel art workflows" in result
+        # Cold skills keep their names in the index but lose descriptions.
+        assert "<cold_skills>" in result
+        assert "godmode" in result
+        assert "Red team prompts" not in result
+        assert "Cold skills remain visible by name only" in result
+        assert "skill_view" in result
+
+    def test_tiered_skills_preserve_compact_category_contract(self, monkeypatch, tmp_path):
+        """Tiering must not undo names-only compaction for any tier."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from agent import skill_utils
+        skill_utils._external_dirs_cache_clear()
+
+        (tmp_path / "config.yaml").write_text(
+            """
+skills:
+  tiers:
+    enabled: true
+    hot: [hot-skill]
+    warm: [warm-skill]
+    cold: [cold-skill]
+""".strip(),
+            encoding="utf-8",
+        )
+        specs = [
+            ("hot-skill", "Hot description"),
+            ("warm-skill", "Warm description"),
+            ("cold-skill", "Cold description"),
+        ]
+        for name, desc in specs:
+            d = tmp_path / "skills" / "social-media" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n",
+                encoding="utf-8",
+            )
+
+        result = build_skills_system_prompt(
+            compact_categories=frozenset({"social-media"})
+        )
+
+        assert "social-media [names only]: cold-skill, hot-skill, warm-skill" in result
+        for name, desc in specs:
+            assert name in result
+            assert desc not in result
+        # Demoted entries are rendered once through the compact path, not
+        # duplicated into the warm/cold tier blocks.
+        assert "<warm_skills>" not in result
+        assert "<cold_skills>" not in result
+
+    def test_skill_tiers_disabled_preserves_full_index(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from agent import skill_utils
+        skill_utils._external_dirs_cache_clear()
+
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  tiers:\n    enabled: false\n    cold: [godmode]\n",
+            encoding="utf-8",
+        )
+        d = tmp_path / "skills" / "red-teaming" / "godmode"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: godmode\ndescription: Red team prompts\n---\n",
+            encoding="utf-8",
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "## Skills (mandatory)" in result
+        assert "godmode: Red team prompts" in result
+        assert "## Skills (tiered)" not in result
+
+    def test_skill_tier_config_is_part_of_prompt_cache_key(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from agent import skill_utils
+        skill_utils._external_dirs_cache_clear()
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "skills:\n  tiers:\n    enabled: true\n    hot: [hermes-agent]\n",
+            encoding="utf-8",
+        )
+        d = tmp_path / "skills" / "autonomous-ai-agents" / "hermes-agent"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: hermes-agent\ndescription: Hermes config help\n---\n",
+            encoding="utf-8",
+        )
+
+        hot = build_skills_system_prompt()
+        assert "hermes-agent: Hermes config help" in hot
+        assert "<warm_skills>" not in hot
+
+        config_path.write_text(
+            "skills:\n  tiers:\n    enabled: true\n    warm: [hermes-agent]\n",
+            encoding="utf-8",
+        )
+        import os
+        os.utime(config_path, None)
+
+        warm = build_skills_system_prompt()
+        assert "<warm_skills>" in warm
+        assert "- hermes-agent: Hermes config help" in warm
+
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -6,6 +6,7 @@ from agent.skill_utils import (
     extract_skill_conditions,
     get_disabled_skill_names,
     get_external_skills_dirs,
+    get_skill_tiers,
     is_excluded_skill_path,
     is_external_skill_path,
     is_skill_support_path,
@@ -237,6 +238,77 @@ def test_iter_skill_index_files_keeps_support_named_categories(tmp_path):
     assert found == [scripts_skill / "SKILL.md", templates_skill / "SKILL.md"]
     assert is_skill_support_path(scripts_skill / "SKILL.md") is False
     assert is_excluded_skill_path(scripts_skill / "SKILL.md") is False
+
+
+def test_get_skill_tiers_defaults_disabled(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+
+    assert get_skill_tiers() == {
+        "enabled": False,
+        "hot": set(),
+        "warm": set(),
+        "cold": set(),
+    }
+
+
+def test_get_skill_tiers_normalizes_config_values(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """
+skills:
+  tiers:
+    enabled: "true"
+    hot: hermes-agent
+    warm:
+      - writing-plans
+      - bounded-build-loop
+    cold:
+      - godmode
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+
+    assert get_skill_tiers() == {
+        "enabled": True,
+        "hot": {"hermes-agent"},
+        "warm": {"writing-plans", "bounded-build-loop"},
+        "cold": {"godmode"},
+    }
+
+
+def test_get_skill_tiers_cache_invalidates_on_config_edit(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "skills:\n  tiers:\n    enabled: true\n    hot: [old-hot]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skill_utils._external_dirs_cache_clear()
+
+    assert get_skill_tiers()["hot"] == {"old-hot"}
+
+    config_path.write_text(
+        "skills:\n  tiers:\n    enabled: true\n    hot: [new-hot]\n",
+        encoding="utf-8",
+    )
+    import os
+    os.utime(config_path, None)
+
+    assert get_skill_tiers()["hot"] == {"new-hot"}
 
 
 # ── skill_matches_platform on Termux ──────────────────────────────────────

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -63,6 +63,35 @@ Settings are resolved in this order (highest priority first):
 Secrets (API keys, bot tokens, passwords) go in `.env`. Everything else (model, terminal backend, compression settings, memory limits, toolsets) goes in `config.yaml`. When both are set, `config.yaml` wins for non-secret settings.
 :::
 
+## Skill Prompt Tiers
+
+Large skill libraries can make the default system prompt noisy. `skills.tiers`
+lets you keep skills installed and discoverable while rendering a smaller skills
+index in new sessions:
+
+```yaml
+skills:
+  tiers:
+    enabled: true
+    hot:
+      - hermes-agent       # shown normally in the system prompt
+    warm:
+      - github-operations  # compact reminder; load only on explicit match
+      - writing-plans
+    cold:
+      - pixel-art          # name shown; description omitted
+```
+
+Skill tiers are **prompt-rendering hints, not access control**. Cold skill names
+remain in the system-prompt index so the model can recall them, but their
+descriptions are omitted. They remain available through `skills_list`,
+`skill_view`, and explicit skill loads. When tiers are enabled, skills not named
+in `hot` or `cold` default to warm so newly-created skills keep a compact
+description instead of being silently demoted.
+
+Leave `skills.tiers.enabled: false` or omit the block to keep the classic full
+skills index.
+
 :::tip Org deployments
 An administrator can pin specific config and secret values that a standard user
 cannot override, via a system-level managed directory. See


### PR DESCRIPTION
## Summary
- add optional skills.tiers config for hot/warm/cold skill prompt rendering
- keep skill access semantics unchanged: cold skills remain discoverable/loadable through skills_list and skill_view
- document the config shape in cli-config.yaml.example and the configuration guide

## Verification
- pytest -q tests/agent/test_skill_utils.py tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py
- hermes prompt-size --platform telegram --json

## Notes
- Defaults are backward-compatible: omitting skills.tiers or setting enabled: false keeps the classic full skills index.
- Tiers are prompt-rendering hints, not an access-control mechanism.