### PR TITLE
docs(stt): document fully local STT (MLX + CUDA) and gateway PATH/ffmpeg

### DIFF
--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -477,6 +477,60 @@ stt:
 
 Hermes writes the incoming voice message to `{input_path}`, runs the command, and reads the `.txt` file produced under `{output_dir}`. Language is auto-detected by the Volcengine bigmodel endpoint.
 
+### Fully local STT (no API keys)
+
+If you don't want any audio leaving the machine, two zero-key setups cover most hardware. Both keep transcription entirely on-device.
+
+**CUDA / NVIDIA GPU — built-in `local` provider.** The default `local` provider already uses your GPU when it can. `faster-whisper` loads with `device="auto"` and `compute_type="auto"`, so it takes the CUDA path automatically when the `ctranslate2` wheel finds the NVIDIA runtime, and prints the model download on first use:
+
+```yaml
+# ~/.hermes/config.yaml
+stt:
+  provider: local
+  local:
+    model: large-v3          # GPUs handle the big models comfortably
+```
+
+No `device:` knob is needed — GPU is picked automatically. If the CUDA libraries (`libcublas`, `libcudnn`) aren't installed, `ctranslate2` sometimes reports the missing shared library only at load or at the first `transcribe()` call. Hermes catches those CUDA library-load errors and **falls back to CPU (`int8`)** rather than failing the voice message, logging a warning like:
+
+```
+faster-whisper CUDA load failed (…) — falling back to CPU (int8).
+Install the NVIDIA CUDA runtime (libcublas/libcudnn) to use GPU.
+```
+
+So a GPU box with a broken CUDA runtime still transcribes (just slower). To actually use the GPU, install the NVIDIA CUDA runtime that matches your `ctranslate2` build.
+
+**Apple Silicon (MLX / M-series) — command provider.** `faster-whisper` runs on CPU on macOS; for hardware-accelerated local STT on Apple Silicon use [`mlx-whisper`](https://pypi.org/project/mlx-whisper/) and wire its CLI in as a [command provider](#stt-custom-command-providers):
+
+```bash
+pip install mlx-whisper
+```
+
+```yaml
+# ~/.hermes/config.yaml
+stt:
+  provider: mlx
+  providers:
+    mlx:
+      type: command
+      command: "mlx_whisper {input_path} --model mlx-community/whisper-large-v3-mlx --output-dir {output_dir} --output-name transcript --output-format txt --language {language}"
+      format: txt
+      language: en
+```
+
+A command provider reads its transcript back from `{output_path}` (Hermes sets this to `{output_dir}/transcript.txt` for `format: txt`) or, failing that, from the command's stdout — it does **not** scan `{output_dir}` for arbitrary files. `mlx_whisper` writes `<output-dir>/<output-name>.<format>`, so `--output-dir {output_dir} --output-name transcript --output-format txt` lands exactly on `{output_path}`. See [STT placeholders](#stt-placeholders) for the full list Hermes substitutes.
+
+(The legacy `HERMES_LOCAL_STT_COMMAND` / `stt.provider: local_command` escape hatch is looser — it globs any `.txt` under `{output_dir}` — but the named `stt.providers.<name>` registry above is the recommended way to add a local engine.)
+
+#### Running under the gateway service: PATH and ffmpeg
+
+A long-running gateway (systemd unit, launchd agent, Docker) often starts with a **minimal `PATH`** that omits `/opt/homebrew/bin` and `/usr/local/bin`, so a `whisper`/`mlx_whisper`/`ffmpeg` that works in your shell can be invisible to the service. Hermes checks `/opt/homebrew/bin` and `/usr/local/bin` in addition to `PATH` when locating `whisper` and `ffmpeg`, which covers the common Homebrew case, but for anything installed elsewhere:
+
+- Give the local-command provider an **absolute path** (`command: "/full/path/to/mlx_whisper …"`), or
+- Add the install directory to the service's environment (e.g. systemd `Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"`).
+
+The local **CLI fallback** — the auto-detected `whisper` binary and the `HERMES_LOCAL_STT_COMMAND` / `stt.provider: local_command` path — also needs **`ffmpeg`** for non-WAV inputs: voice notes usually arrive as `.ogg`/`.m4a`, and that path converts them to WAV first. If `ffmpeg` isn't found you'll see `Local STT fallback requires ffmpeg for non-WAV inputs, but ffmpeg was not found` — install it (`brew install ffmpeg`, `apt install ffmpeg`) and make sure it's on the service's `PATH` too. (The built-in faster-whisper `local` provider decodes audio itself and doesn't shell out to `ffmpeg`; a named `stt.providers.<name>` command engine like `mlx_whisper` above handles its own decoding too.)
+
 ### Fallback Behavior
 
 If your configured provider isn't available, Hermes automatically falls back:


### PR DESCRIPTION
## What does this PR do?

Documents fully local, no-API-key STT for voice messages. The existing "Voice Message Transcription (STT)" section covers `faster-whisper`, the local `whisper` CLI, and `HERMES_LOCAL_STT_COMMAND` only generically, with no GPU/Apple-Silicon recipe and no guidance for running under the gateway service. This adds a focused "Fully local STT (no API keys)" subsection so users can get on-device transcription working on their hardware.

## Related Issue

Fixes #56989

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/tts.md`: new "Fully local STT (no API keys)" subsection covering:
  - **CUDA / NVIDIA GPU** via the built-in `local` provider — documents the `device="auto"` / `compute_type="auto"` behavior and the automatic CUDA→CPU (`int8`) fallback when the NVIDIA runtime is missing (`tools/transcription_tools.py` `_load_local_whisper_model`).
  - **Apple Silicon (MLX)** via an `mlx_whisper` command provider under `stt.providers.<name>`, using `--output-dir {output_dir} --output-name transcript --output-format txt` so the file lands on the registry's `{output_path}`.
  - A "Running under the gateway service" note: minimal-`PATH` services, the `/opt/homebrew/bin` + `/usr/local/bin` lookup, and the `ffmpeg` requirement of the local CLI fallback.

## How to Test

1. Build the docs site (or read the rendered `website/docs/user-guide/features/tts.md`) and confirm the new subsection renders, including the intra-page links (`#stt-custom-command-providers`, `#stt-placeholders`).
2. Follow the CUDA recipe on a GPU box, or the MLX recipe on Apple Silicon, and send a voice message — it transcribes with no API key.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant tests: `scripts/run_tests.sh tests/tools/test_transcription_command_providers.py -q` (50 passed) — docs-only change, no code touched
- [ ] I've added tests for my changes — N/A (docs only)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the subsection is explicitly split by platform (CUDA/Linux vs Apple Silicon) and service PATH/ffmpeg notes cover Homebrew/apt
- [x] I've updated tool descriptions/schemas — N/A (no tool behavior change)