### PR TITLE
fix(agent): inline Fireworks local tool schema refs

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -706,6 +706,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     )
     _is_nous = "nousresearch" in agent._base_url_lower
     _is_nvidia = "integrate.api.nvidia.com" in agent._base_url_lower
+    _is_fireworks = base_url_host_matches(agent.base_url, "fireworks.ai")
     _is_kimi = (
         base_url_host_matches(agent.base_url, "api.kimi.com")
         or base_url_host_matches(agent.base_url, "moonshot.ai")
@@ -789,6 +790,16 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         # registered providers with profiles were bypassing the strip.
         api_messages = agent._prepare_messages_for_non_vision_model(api_messages)
 
+        if _is_fireworks:
+            try:
+                from tools.schema_sanitizer import inline_local_refs
+                tools_for_api = inline_local_refs(tools_for_api)
+            except Exception as exc:
+                logger.warning(
+                    "%s⚠️ Failed to inline local tool-schema refs for Fireworks: %s",
+                    getattr(agent, "log_prefix", ""), exc,
+                )
+
         return _ct.build_kwargs(
             model=agent.model,
             messages=api_messages,
@@ -820,6 +831,16 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
 
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
+
+    if _is_fireworks:
+        try:
+            from tools.schema_sanitizer import inline_local_refs
+            tools_for_api = inline_local_refs(tools_for_api)
+        except Exception as exc:
+            logger.warning(
+                "%s⚠️ Failed to inline local tool-schema refs for Fireworks: %s",
+                getattr(agent, "log_prefix", ""), exc,
+            )
 
     return _ct.build_kwargs(
         model=agent.model,

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 
 from tools.schema_sanitizer import (
+    inline_local_refs,
     sanitize_tool_schemas,
     strip_pattern_and_format,
     strip_slash_enum,
@@ -265,6 +266,41 @@ def test_ref_description_preserved():
     payload = out[0]["function"]["parameters"]["properties"]["payload"]
     assert payload["description"] == "The payload"
     assert payload["$ref"] == "#/$defs/Payload"
+
+
+def test_inline_local_refs_expands_defs_and_preserves_ref_annotations():
+    tools = [_tool("browser_like", {
+        "type": "object",
+        "properties": {
+            "cookies": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/$defs/SetCookieParam",
+                    "description": "Cookie to set",
+                },
+            },
+        },
+        "$defs": {
+            "SetCookieParam": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "value": {"type": "string"},
+                },
+                "required": ["name", "value"],
+            },
+        },
+    })]
+
+    out = inline_local_refs(tools)
+    params = out[0]["function"]["parameters"]
+    items = params["properties"]["cookies"]["items"]
+
+    assert "$ref" not in items
+    assert "$defs" not in params
+    assert items["type"] == "object"
+    assert items["description"] == "Cookie to set"
+    assert items["properties"]["name"] == {"type": "string"}
 
 
 def test_empty_tools_list_returns_empty():

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -61,6 +61,82 @@ def sanitize_tool_schemas(tools: list[dict]) -> list[dict]:
     return sanitized
 
 
+def inline_local_refs(tools: list[dict]) -> list[dict]:
+    """Return a copy of ``tools`` with local ``$defs`` / ``definitions`` refs inlined.
+
+    Some OpenAI-compatible backends accept JSON Schema but do not resolve local
+    references inside tool parameters. Fireworks rejects built-in browser schemas
+    with errors such as ``unresolved #/$defs/SetCookieParam``. Inlining keeps the
+    same accepted argument shape while sending a ref-free schema to those
+    backends. Annotation siblings on the reference node (for example
+    ``description`` or ``nullable``) are preserved over the referenced schema.
+    """
+    if not tools:
+        return tools
+
+    out = copy.deepcopy(tools)
+    for tool in out:
+        fn = tool.get("function") if isinstance(tool, dict) else None
+        params = fn.get("parameters") if isinstance(fn, dict) else None
+        if isinstance(params, dict):
+            fn["parameters"] = _inline_refs_in_schema(params)
+    return out
+
+
+def _inline_refs_in_schema(schema: dict) -> dict:
+    defs: dict[str, Any] = {}
+    raw_defs = schema.get("$defs")
+    if isinstance(raw_defs, dict):
+        defs.update(raw_defs)
+    raw_definitions = schema.get("definitions")
+    if isinstance(raw_definitions, dict):
+        defs.update(raw_definitions)
+    if not defs:
+        return schema
+
+    def resolve_ref(ref: str) -> Any | None:
+        prefix = None
+        if ref.startswith("#/$defs/"):
+            prefix = "#/$defs/"
+        elif ref.startswith("#/definitions/"):
+            prefix = "#/definitions/"
+        if prefix is None:
+            return None
+        name = ref[len(prefix):].replace("~1", "/").replace("~0", "~")
+        target = defs.get(name)
+        return copy.deepcopy(target) if target is not None else None
+
+    def walk(node: Any, stack: tuple[str, ...] = ()) -> Any:
+        if isinstance(node, list):
+            return [walk(item, stack) for item in node]
+        if not isinstance(node, dict):
+            return node
+
+        ref = node.get("$ref")
+        if isinstance(ref, str):
+            if ref in stack:
+                return {k: walk(v, stack) for k, v in node.items() if k != "$ref"}
+            target = resolve_ref(ref)
+            if isinstance(target, dict):
+                merged = walk(target, (*stack, ref))
+                if isinstance(merged, dict):
+                    for key, value in node.items():
+                        if key == "$ref":
+                            continue
+                        merged[key] = walk(value, stack)
+                    return merged
+
+        out: dict[str, Any] = {}
+        for key, value in node.items():
+            if key in {"$defs", "definitions"}:
+                continue
+            out[key] = walk(value, stack)
+        return out
+
+    inlined = walk(schema)
+    return inlined if isinstance(inlined, dict) else schema
+
+
 def _sanitize_single_tool(tool: dict) -> dict:
     """Deep-copy and sanitize a single OpenAI-format tool entry."""
     out = copy.deepcopy(tool)


### PR DESCRIPTION
Fixes #56979.

Fireworks' OpenAI-compatible endpoint rejects tool schemas that contain local JSON Schema refs such as #/$defs/SetCookieParam. This adds a provider-scoped schema transform that inlines local refs before sending tools to Fireworks, preserving annotations on the ref node while leaving other providers' schemas unchanged.

Tests: scripts/run_tests.sh tests/tools/test_schema_sanitizer.py