### PR TITLE
Align Codex cache affinity header

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -253,9 +253,10 @@ class ResponsesApiTransport(ProviderTransport):
         # prompt_cache_key is content-addressed from the static prefix
         # (instructions + tools), NOT session_id — recurring cron jobs carry a
         # per-fire timestamp in session_id (cron_<id>_<ts>) that made every run
-        # cache-cold. session_id is left untouched for transcript isolation and
-        # the cache-scope routing headers below. Falls back to session_id when
-        # there is no static content to hash.
+        # cache-cold. session_id is left untouched for transcript isolation;
+        # x-client-request-id below follows this cache key so the Codex backend
+        # routes stable prefixes to the same cache shard. Falls back to
+        # session_id when there is no static content to hash.
         cache_key = _content_cache_key(instructions, response_tools) or session_id
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
@@ -342,7 +343,9 @@ class ResponsesApiTransport(ProviderTransport):
                         }
                     )
                 merged_extra_headers["session_id"] = cache_scope_id
-                merged_extra_headers["x-client-request-id"] = cache_scope_id
+                merged_extra_headers["x-client-request-id"] = str(
+                    kwargs.get("prompt_cache_key") or cache_key or cache_scope_id
+                )
                 kwargs["extra_headers"] = merged_extra_headers
 
         max_tokens = params.get("max_tokens")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -195,8 +195,13 @@ class TestCodexBuildKwargs:
         )
 
         headers = kw.get("extra_headers", {})
+        # For ChatGPT/Codex, keep the raw session_id header for transcript
+        # identity, but route x-client-request-id to the same content-addressed
+        # value as prompt_cache_key so repeated stable prefixes get cache
+        # affinity across resumed turns and recurring jobs.
         assert headers.get("session_id") == "conv-codex-1"
-        assert headers.get("x-client-request-id") == "conv-codex-1"
+        assert headers.get("x-client-request-id") == kw["prompt_cache_key"]
+        assert headers.get("x-client-request-id") != "conv-codex-1"
 
     def test_codex_backend_no_headers_without_session_id(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
@@ -224,8 +229,30 @@ class TestCodexBuildKwargs:
 
         headers = kw.get("extra_headers", {})
         assert headers.get("x-test") == "1"
+        # For ChatGPT/Codex, keep the raw session_id header for transcript
+        # identity, but route x-client-request-id to the same content-addressed
+        # value as prompt_cache_key so repeated stable prefixes get cache
+        # affinity across resumed turns and recurring jobs.
         assert headers.get("session_id") == "conv-codex-1"
-        assert headers.get("x-client-request-id") == "conv-codex-1"
+        assert headers.get("x-client-request-id") == kw["prompt_cache_key"]
+        assert headers.get("x-client-request-id") != "conv-codex-1"
+
+    def test_codex_backend_x_client_request_id_follows_prompt_cache_override(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="conv-codex-1",
+            is_codex_backend=True,
+            request_overrides={"prompt_cache_key": "manual-cache-key"},
+        )
+
+        headers = kw.get("extra_headers", {})
+        assert kw["prompt_cache_key"] == "manual-cache-key"
+        assert headers.get("session_id") == "conv-codex-1"
+        assert headers.get("x-client-request-id") == "manual-cache-key"
 
     def test_non_codex_responses_preserves_caller_extra_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]


### PR DESCRIPTION
## Summary

Fix Codex prompt-cache affinity by aligning the cache-routing `x-client-request-id` header with the final `prompt_cache_key` for the ChatGPT/Codex backend.

Hermes already builds a stable, content-addressed `prompt_cache_key` from the static prefix (`instructions + tools`). That keeps recurring jobs and fresh Hermes sessions from going cache-cold when the visible Hermes `session_id` changes. But the Codex backend path still sent `x-client-request-id` as the raw Hermes session id, so the body cache key and request-affinity header could point at different cache namespaces.

This keeps the raw `session_id` header unchanged for transcript/session identity, and only changes `x-client-request-id` to follow the final `prompt_cache_key`.

Fixes #47126.

## What changed

- Preserve content-addressed `prompt_cache_key` behavior.
- Keep `session_id` header as the real Hermes session id.
- Set Codex `x-client-request-id` to the final `prompt_cache_key` value.
- Respect manual `request_overrides["prompt_cache_key"]` by making the header follow that final overridden key.
- Add regression coverage for Codex cache-routing headers and override behavior.

## Validation

Ran against a clean branch from `origin/main`:

```bash
pytest -q tests/agent/transports/test_codex_transport.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/agent/test_codex_responses_adapter.py \
  tests/agent/test_codex_cloudflare_headers.py
```

Result: `169 passed`.

Also verified locally in an isolated disposable `HERMES_HOME` sandbox that resumed `openai-codex / gpt-5.5` turns still reach high per-call cache reuse after warmup, while this patch keeps the existing content-addressed key behavior needed for timestamped recurring jobs.
