### PR TITLE
fix(desktop): remember delegate parent sessions

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -11,6 +11,7 @@ import { Pane, PaneMain } from '@/components/pane-shell'
 import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { isFocusWithin } from '@/lib/keybinds/combo'
+import { rememberedSessionIdForRoute } from '@/lib/remembered-session'
 import { cn } from '@/lib/utils'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
@@ -164,6 +165,7 @@ export function DesktopController() {
   const filePreviewTarget = useStore($filePreviewTarget)
   const previewTarget = useStore($previewTarget)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const sessions = useStore($sessions)
   const terminalTakeover = useStore($terminalTakeover)
   const reviewOpen = useStore($reviewOpen)
   const fileBrowserOpen = useStore($fileBrowserOpen)
@@ -237,12 +239,16 @@ export function DesktopController() {
     }
   }, [])
 
-  // Remember the open chat so a relaunch reopens it instead of an empty new-chat.
+  // Remember the open parent chat so a relaunch reopens it instead of an empty
+  // new-chat. Delegate subagent sessions are implementation details: if a route
+  // briefly points at one (for example after a Ctrl+C restart), persist the
+  // parent id instead so the next boot resumes the visible conversation.
   useEffect(() => {
-    if (routedSessionId) {
-      setRememberedSessionId(routedSessionId)
+    const remembered = rememberedSessionIdForRoute(routedSessionId, sessions)
+    if (remembered) {
+      setRememberedSessionId(remembered)
     }
-  }, [routedSessionId])
+  }, [routedSessionId, sessions])
 
   // Restore that chat once, on cold start only (we're at the new-chat route and
   // haven't navigated yet). A dead/deleted id self-clears via the exhausted latch

--- a/apps/desktop/src/lib/remembered-session.test.ts
+++ b/apps/desktop/src/lib/remembered-session.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+import { rememberedSessionIdForRoute } from './remembered-session'
+
+function session(overrides: Partial<SessionInfo> & Pick<SessionInfo, 'id'>): SessionInfo {
+  return {
+    ended_at: null,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 0,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: null,
+    started_at: 0,
+    title: null,
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+describe('rememberedSessionIdForRoute', () => {
+  it('remembers ordinary routed sessions unchanged', () => {
+    expect(rememberedSessionIdForRoute('parent', [session({ id: 'parent', source: 'desktop' })])).toBe('parent')
+  })
+
+  it('maps delegate subagent routes back to the parent session', () => {
+    const sessions = [session({ id: 'child', source: 'subagent', _delegate_from: 'parent' })]
+
+    expect(rememberedSessionIdForRoute('child', sessions)).toBe('parent')
+  })
+
+  it('does not persist an orphan subagent as the remembered chat', () => {
+    const sessions = [session({ id: 'child', source: 'subagent' })]
+
+    expect(rememberedSessionIdForRoute('child', sessions)).toBeNull()
+  })
+
+  it('keeps unknown route ids so cold-start restore still works before the list loads', () => {
+    expect(rememberedSessionIdForRoute('late-session', [])).toBe('late-session')
+  })
+})

--- a/apps/desktop/src/lib/remembered-session.ts
+++ b/apps/desktop/src/lib/remembered-session.ts
@@ -1,0 +1,18 @@
+import type { SessionInfo } from '@/hermes'
+
+export function rememberedSessionIdForRoute(routedSessionId: string | null, sessions: SessionInfo[]): string | null {
+  if (!routedSessionId) {
+    return null
+  }
+
+  const routed = sessions.find(session => session.id === routedSessionId || session._lineage_root_id === routedSessionId)
+  if (!routed) {
+    return routedSessionId
+  }
+
+  if (routed.source === 'subagent') {
+    return routed._delegate_from || routed.parent_session_id || null
+  }
+
+  return routedSessionId
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -348,6 +348,8 @@ export interface SessionInfo {
   output_tokens: number
   /** Parent conversation when this row is a /branch fork. */
   parent_session_id?: null | string
+  /** Parent conversation that spawned this delegate subagent session. */
+  _delegate_from?: null | string
   preview: null | string
   source: null | string
   started_at: number


### PR DESCRIPTION
Fixes #56983.

Desktop now avoids persisting delegate subagent sessions as the cold-start remembered chat. When a routed session is a subagent, the remembered id is rewritten to its parent delegate session (or skipped if orphaned), so restarts resume the visible parent conversation.

Tests: npm exec vitest -- apps/desktop/src/lib/remembered-session.test.ts