### PR TITLE
feat(gateway): prompt prefix warmer for local backends

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6024,6 +6024,14 @@ def call_llm(
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         base_url=_base_info or resolved_base_url)
 
+    # Snapshot the outbound prefix for the gateway prefix warmer (local
+    # tool-carrying requests only; no-op otherwise, never raises). This covers
+    # model calls that bypass build_api_kwargs — e.g. the MoA acting call.
+    from agent.prefix_warm_registry import record_call_prefix
+
+    record_call_prefix(_base_info or resolved_base_url,
+                       getattr(client, "api_key", None), kwargs)
+
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     _client_base = str(getattr(client, "base_url", "") or "")
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -805,7 +805,11 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         # registered providers with profiles were bypassing the strip.
         api_messages = agent._prepare_messages_for_non_vision_model(api_messages)
 
-        return _ct.build_kwargs(
+        # record_local_prefix: snapshot the outbound prefix for the gateway
+        # prefix warmer (local endpoints only; no-op otherwise, never raises).
+        from agent.prefix_warm_registry import record_local_prefix
+
+        return record_local_prefix(agent, _ct.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
@@ -825,7 +829,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
-        )
+        ))
 
     # ── Legacy flag path ────────────────────────────────────────────
     # Reached only when get_provider_profile() returns None — i.e. a
@@ -837,7 +841,10 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
 
-    return _ct.build_kwargs(
+    # See profile path above — snapshot the outbound prefix for the warmer.
+    from agent.prefix_warm_registry import record_local_prefix
+
+    return record_local_prefix(agent, _ct.build_kwargs(
         model=agent.model,
         messages=_msgs_for_chat,
         tools=tools_for_api,
@@ -872,7 +879,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         lmstudio_reasoning_options=agent._lmstudio_reasoning_options_cached() if _is_lmstudio else None,
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
-    )
+    ))
 
 
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -886,6 +886,41 @@ def compress_context(
             except Exception as e:
                 logger.debug("event_callback error on session:compress: %s", e)
 
+        # Re-warm this session's local-endpoint prompt prefix in the
+        # background. Compaction just rewrote the transcript and system
+        # prompt, so the next turn's rendered prompt matches no cached state
+        # and would pay the full re-prefill at TTFT (seconds on a 20k+ prefix
+        # against a local backend). Replaying the new prefix now moves that
+        # cost off the user's next message. Gated on ``prefix_warmer.enabled``
+        # (same opt-in as the periodic warmer); fire-and-forget daemon thread
+        # so the compression return path never blocks on a prefill.
+        try:
+            from hermes_cli.config import load_config_readonly as _load_cfg_ro
+
+            _pw_raw = _load_cfg_ro().get("prefix_warmer") or {}
+            if _pw_raw.get("enabled"):
+                from gateway.config import PrefixWarmerConfig as _PWConfig
+                from gateway.prefix_warmer import warm_compacted_prefix as _warm_compacted
+
+                # Wire-clean copies taken synchronously: the warm thread must
+                # not race the caller's ownership of ``compressed``, and
+                # private bookkeeping keys must not reach the API server.
+                _wire_keys = ("role", "content", "name", "tool_calls", "tool_call_id")
+                _warm_msgs = [
+                    {k: m[k] for k in _wire_keys if k in m}
+                    for m in compressed
+                    if isinstance(m, dict)
+                ]
+                threading.Thread(
+                    target=_warm_compacted,
+                    args=(system_message, new_system_prompt, _warm_msgs,
+                          _PWConfig.from_dict(dict(_pw_raw))),
+                    name="post-compaction-prefix-warm",
+                    daemon=True,
+                ).start()
+        except Exception as _pw_err:
+            logger.debug("post-compaction prefix warm skipped: %s", _pw_err)
+
         # Surface the compaction mode to the caller (run_conversation / gateway)
         # via a rotation-independent flag. The gateway uses this — NOT an
         # id-change diff — to re-baseline transcript handling (history_offset=0 +

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -648,6 +648,13 @@ def compress_context(
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
 
+        # Preserve the exact system message that was used for the captured
+        # outbound prefix. ``system_message`` is normally None; the fully
+        # rendered prompt lives in this cache until invalidation below.
+        old_system_prompt = getattr(agent, "_cached_system_prompt", None)
+        if not old_system_prompt:
+            old_system_prompt = agent._build_system_prompt(system_message)
+
         agent._invalidate_system_prompt()
         new_system_prompt = agent._build_system_prompt(system_message)
         agent._cached_system_prompt = new_system_prompt
@@ -897,7 +904,11 @@ def compress_context(
         try:
             from hermes_cli.config import load_config_readonly as _load_cfg_ro
 
-            _pw_raw = _load_cfg_ro().get("prefix_warmer") or {}
+            _pw_cfg = _load_cfg_ro()
+            _pw_raw = _pw_cfg.get("prefix_warmer")
+            if not isinstance(_pw_raw, dict):
+                _gateway_cfg = _pw_cfg.get("gateway") or {}
+                _pw_raw = _gateway_cfg.get("prefix_warmer") or {}
             if _pw_raw.get("enabled"):
                 from gateway.config import PrefixWarmerConfig as _PWConfig
                 from gateway.prefix_warmer import warm_compacted_prefix as _warm_compacted
@@ -913,7 +924,7 @@ def compress_context(
                 ]
                 threading.Thread(
                     target=_warm_compacted,
-                    args=(system_message, new_system_prompt, _warm_msgs,
+                    args=(old_system_prompt, new_system_prompt, _warm_msgs,
                           _PWConfig.from_dict(dict(_pw_raw))),
                     name="post-compaction-prefix-warm",
                     daemon=True,

--- a/agent/prefix_warm_registry.py
+++ b/agent/prefix_warm_registry.py
@@ -1,0 +1,128 @@
+"""Registry of recent local-backend prompt prefixes for the gateway prefix warmer.
+
+Local llama.cpp-style servers reuse cached KV/recurrent state only when a new
+request's rendered prompt shares a byte-identical prefix with a cached state
+(and, on hybrid-SSM architectures, a state checkpoint exists at or before the
+divergence point). Hermes's system prompt is built once per session and is
+byte-stable across turns, so every fresh session on the same profile pays a
+full "entry tax" prefill of the same ~10-20k token prefix — unless some cached
+state still holds it.
+
+This module records, per (base_url, model), the most recent chat-completions
+request kwargs the agent actually sent to a *local* endpoint. The gateway's
+prefix-warmer watcher (see ``gateway/prefix_warmer.py``) periodically replays
+a tiny request built from that snapshot — the same ``tools`` and the same
+leading system message, a fixed one-character user turn, ``max_tokens=1`` — so
+the server keeps a warm state whose prefix exactly matches what the next fresh
+session will send. A warm request that hits its own cached state costs only a
+handful of prefill tokens.
+
+Capture happens in ``build_api_kwargs`` (agent/chat_completion_helpers.py) and
+must never affect the request path: ``record_local_prefix`` swallows all
+errors and stores only references plus a shallow copy of the kwargs dict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+# Newest-first cap on distinct (base_url, model, system-prompt) prefixes
+# retained. A gateway normally sends one or two distinct prefixes; the cap
+# bounds the warmer's worst-case work when auxiliary tasks (background
+# review, MoA) contribute additional tool-carrying prefixes.
+_MAX_ENTRIES = 4
+
+_lock = threading.Lock()
+# key: (base_url, model, system_hash) -> snapshot dict
+_entries: Dict[tuple, Dict[str, Any]] = {}
+
+
+def _record(base_url: str, api_key: Optional[str], kwargs: Dict[str, Any], *,
+            require_tools: bool) -> None:
+    """Core capture: store a snapshot if this is a warmable local prefix."""
+    if not base_url:
+        return
+    from agent.model_metadata import is_local_endpoint
+
+    if not is_local_endpoint(base_url):
+        return
+    messages = kwargs.get("messages") or []
+    if not messages or messages[0].get("role") != "system":
+        return
+    head = messages[0].get("content")
+    if not isinstance(head, str) or not head.strip():
+        return
+    if require_tools and not kwargs.get("tools"):
+        return
+    model = kwargs.get("model") or ""
+    key = (base_url, model, hashlib.sha256(head.encode("utf-8", "replace")).hexdigest()[:16])
+    snapshot = {
+        "base_url": base_url,
+        "api_key": api_key or "local",
+        "model": model,
+        "system_content": head,
+        # Reference, not a copy: tool schemas are large and effectively
+        # immutable for the life of the agent. The warmer serializes them
+        # only at send time.
+        "tools": kwargs.get("tools"),
+        "extra_body": kwargs.get("extra_body"),
+        "recorded_at": time.time(),
+    }
+    with _lock:
+        _entries[key] = snapshot
+        while len(_entries) > _MAX_ENTRIES:
+            oldest = min(_entries, key=lambda k: _entries[k]["recorded_at"])
+            del _entries[oldest]
+
+
+def record_local_prefix(agent: Any, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Record ``kwargs`` as the latest prompt prefix for the agent's endpoint.
+
+    Called on the hot request path (``build_api_kwargs``) — returns ``kwargs``
+    unchanged and never raises. Records only when the endpoint is local, the
+    api_mode is plain chat-completions, and the request opens with a system
+    message (the shared prefix the warmer exists to keep hot).
+    """
+    try:
+        if getattr(agent, "api_mode", None) not in (None, "chat_completions"):
+            return kwargs
+        _record(
+            getattr(agent, "base_url", None) or "",
+            getattr(agent, "api_key", None),
+            kwargs,
+            require_tools=False,
+        )
+    except Exception:
+        pass
+    return kwargs
+
+
+def record_call_prefix(base_url: Optional[str], api_key: Optional[str],
+                       kwargs: Dict[str, Any]) -> None:
+    """Record a ``call_llm`` request's prefix (never raises).
+
+    Covers model calls that bypass ``build_api_kwargs`` — most importantly
+    the MoA acting/aggregator call, which carries the agent's full system
+    prompt and tool schemas. ``tools`` is required here so tool-less
+    auxiliary calls (compression summaries, advisors, embeddings glue) don't
+    churn the registry with prefixes no fresh session will ever share.
+    """
+    try:
+        _record(str(base_url or ""), api_key, kwargs, require_tools=True)
+    except Exception:
+        pass
+
+
+def get_snapshots() -> List[Dict[str, Any]]:
+    """Return the current snapshots, newest first."""
+    with _lock:
+        return sorted(_entries.values(), key=lambda s: -s["recorded_at"])
+
+
+def clear() -> None:
+    """Drop all snapshots (test helper)."""
+    with _lock:
+        _entries.clear()

--- a/agent/prefix_warm_registry.py
+++ b/agent/prefix_warm_registry.py
@@ -19,11 +19,20 @@ handful of prefill tokens.
 
 Capture happens in ``build_api_kwargs`` (agent/chat_completion_helpers.py) and
 must never affect the request path: ``record_local_prefix`` swallows all
-errors and stores only references plus a shallow copy of the kwargs dict.
+errors, and both record hooks are dormant no-ops unless ``enable_capture()``
+has been called (the gateway calls it when the warmer starts), so processes
+that never enable the warmer — including plain CLI runs — pay nothing.
+
+Note the captured system message includes Hermes's volatile tail (memory
+block, user profile, session timestamp), so a fresh session's prompt matches
+the warm state up to that boundary rather than through the entire system
+block. The stable head — tool schemas plus the fixed system prose, which is
+the bulk of the prefix — is what the warmer keeps reusable.
 """
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import threading
 import time
@@ -38,6 +47,28 @@ _MAX_ENTRIES = 4
 _lock = threading.Lock()
 # key: (base_url, model, system_hash) -> snapshot dict
 _entries: Dict[tuple, Dict[str, Any]] = {}
+# base_url -> monotonic-ish wall time of the last real local request seen
+# (warmable or not). The warmer uses this to stand down while an endpoint
+# has live traffic — see ``last_traffic_at``.
+_last_traffic: Dict[str, float] = {}
+
+# Process-global gate, set by the gateway when the warmer starts. While
+# False (the default, and always in warmer-less processes such as plain CLI
+# runs) both record hooks return immediately, so the request path pays
+# nothing for a feature that isn't on.
+_capture_enabled = False
+
+
+def enable_capture() -> None:
+    """Turn on prefix capture (called once when the warmer watcher starts)."""
+    global _capture_enabled
+    _capture_enabled = True
+
+
+def disable_capture() -> None:
+    """Turn capture back off (test helper)."""
+    global _capture_enabled
+    _capture_enabled = False
 
 
 def _record(base_url: str, api_key: Optional[str], kwargs: Dict[str, Any], *,
@@ -49,6 +80,8 @@ def _record(base_url: str, api_key: Optional[str], kwargs: Dict[str, Any], *,
 
     if not is_local_endpoint(base_url):
         return
+    with _lock:
+        _last_traffic[base_url] = time.time()
     messages = kwargs.get("messages") or []
     if not messages or messages[0].get("role") != "system":
         return
@@ -64,11 +97,13 @@ def _record(base_url: str, api_key: Optional[str], kwargs: Dict[str, Any], *,
         "api_key": api_key or "local",
         "model": model,
         "system_content": head,
-        # Reference, not a copy: tool schemas are large and effectively
-        # immutable for the life of the agent. The warmer serializes them
-        # only at send time.
-        "tools": kwargs.get("tools"),
-        "extra_body": kwargs.get("extra_body"),
+        # Deep copies: the caller's objects can be mutated in place after
+        # build time (e.g. conversation_loop's _force_ascii_payload
+        # sanitization), which would silently corrupt a by-reference
+        # snapshot. Capture only runs when the warmer is enabled, so the
+        # copy cost is paid solely by users of the feature.
+        "tools": copy.deepcopy(kwargs.get("tools")),
+        "extra_body": copy.deepcopy(kwargs.get("extra_body")),
         "recorded_at": time.time(),
     }
     with _lock:
@@ -82,10 +117,13 @@ def record_local_prefix(agent: Any, kwargs: Dict[str, Any]) -> Dict[str, Any]:
     """Record ``kwargs`` as the latest prompt prefix for the agent's endpoint.
 
     Called on the hot request path (``build_api_kwargs``) — returns ``kwargs``
-    unchanged and never raises. Records only when the endpoint is local, the
-    api_mode is plain chat-completions, and the request opens with a system
-    message (the shared prefix the warmer exists to keep hot).
+    unchanged and never raises. A no-op unless ``enable_capture()`` has run.
+    Records only when the endpoint is local, the api_mode is plain
+    chat-completions, and the request opens with a system message (the shared
+    prefix the warmer exists to keep hot).
     """
+    if not _capture_enabled:
+        return kwargs
     try:
         if getattr(agent, "api_mode", None) not in (None, "chat_completions"):
             return kwargs
@@ -109,7 +147,10 @@ def record_call_prefix(base_url: Optional[str], api_key: Optional[str],
     prompt and tool schemas. ``tools`` is required here so tool-less
     auxiliary calls (compression summaries, advisors, embeddings glue) don't
     churn the registry with prefixes no fresh session will ever share.
+    A no-op unless ``enable_capture()`` has run.
     """
+    if not _capture_enabled:
+        return
     try:
         _record(str(base_url or ""), api_key, kwargs, require_tools=True)
     except Exception:
@@ -122,7 +163,19 @@ def get_snapshots() -> List[Dict[str, Any]]:
         return sorted(_entries.values(), key=lambda s: -s["recorded_at"])
 
 
+def last_traffic_at(base_url: str) -> float:
+    """Wall time of the last real local request seen for ``base_url``.
+
+    Returns 0.0 if none has been seen. Updated for every local-endpoint
+    request that reaches the capture hooks (warmable or not), so the warmer
+    can stand down while an endpoint is actively serving a session.
+    """
+    with _lock:
+        return _last_traffic.get(base_url, 0.0)
+
+
 def clear() -> None:
-    """Drop all snapshots (test helper)."""
+    """Drop all snapshots and traffic timestamps (test helper)."""
     with _lock:
         _entries.clear()
+        _last_traffic.clear()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -585,6 +585,20 @@ streaming:
   # buffer_threshold: 40      # chars before forcing an edit flush
   # cursor: " ▉"              # cursor shown during streaming
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Prompt Prefix Warmer (local backends)
+# ─────────────────────────────────────────────────────────────────────────────
+# Keep the shared prompt prefix (tool schemas + system prompt) hot in a LOCAL
+# llama.cpp-style server's cache so fresh sessions skip the 10-20k-token
+# "entry tax" prefill. The gateway periodically replays a tiny (max_tokens=1)
+# request carrying the same prefix bytes Hermes last sent to each local
+# endpoint. No effect on cloud providers (they manage their own prompt
+# caches), so this is off by default.
+prefix_warmer:
+  enabled: false
+  # interval_seconds: 240     # seconds between warm cycles
+  # timeout_seconds: 120      # per warm-request timeout (covers a cold prefill)
+
 # =============================================================================
 # Skills Configuration
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -594,10 +594,17 @@ streaming:
 # request carrying the same prefix bytes Hermes last sent to each local
 # endpoint. No effect on cloud providers (they manage their own prompt
 # caches), so this is off by default.
+#
+# Caveat: warm requests share the server's cache slots with real sessions.
+# Endpoints with recent real traffic are skipped (min_idle_seconds), but on a
+# server with a single parallel slot a warm request can still evict a live
+# session's cached state — prefer leaving this off unless the server runs
+# with 2+ slots (llama.cpp --parallel 2 or higher).
 prefix_warmer:
   enabled: false
   # interval_seconds: 240     # seconds between warm cycles
   # timeout_seconds: 120      # per warm-request timeout (covers a cold prefill)
+  # min_idle_seconds: 180     # skip endpoints with real traffic this recent
 
 # =============================================================================
 # Skills Configuration

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -528,6 +528,43 @@ class StreamingConfig:
         )
 
 
+@dataclass
+class PrefixWarmerConfig:
+    """Configuration for the local-backend prompt prefix warmer.
+
+    When enabled, the gateway periodically replays a tiny request carrying the
+    shared prompt prefix (tool schemas + system message) of the most recent
+    request sent to each *local* endpoint, so the server keeps a cached state
+    fresh sessions can reuse instead of re-prefilling the whole prefix. See
+    ``gateway/prefix_warmer.py`` for mechanics. Off by default: it only helps
+    llama.cpp-style local backends, and costs one 1-token request per interval.
+    """
+    enabled: bool = False
+    # Seconds between warm cycles. Local server caches are typically evicted
+    # by competing traffic rather than time, so a few minutes is plenty.
+    interval_seconds: int = 240
+    # Per-request timeout — generous enough to cover a full cold prefill of a
+    # large prefix on modest hardware.
+    timeout_seconds: float = 120.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "interval_seconds": self.interval_seconds,
+            "timeout_seconds": self.timeout_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PrefixWarmerConfig":
+        if not data:
+            return cls()
+        return cls(
+            enabled=_coerce_bool(data.get("enabled"), False),
+            interval_seconds=_coerce_int(data.get("interval_seconds"), 240),
+            timeout_seconds=_coerce_float(data.get("timeout_seconds"), 120.0),
+        )
+
+
 # -----------------------------------------------------------------------------
 # Built-in platform connection checkers
 # -----------------------------------------------------------------------------
@@ -621,6 +658,9 @@ class GatewayConfig:
 
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
+
+    # Local-backend prompt prefix warmer (see PrefixWarmerConfig)
+    prefix_warmer: PrefixWarmerConfig = field(default_factory=PrefixWarmerConfig)
 
     # Session store pruning: drop SessionEntry records older than this many
     # days from the in-memory dict and sessions.json.  Keeps the store from
@@ -732,6 +772,7 @@ class GatewayConfig:
             "multiplex_profiles": self.multiplex_profiles,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "prefix_warmer": self.prefix_warmer.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
         }
     
@@ -821,6 +862,7 @@ class GatewayConfig:
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            prefix_warmer=PrefixWarmerConfig.from_dict(data.get("prefix_warmer", {})),
             session_store_max_age_days=session_store_max_age_days,
         )
 
@@ -945,6 +987,14 @@ def load_gateway_config() -> GatewayConfig:
                 streaming_cfg = yaml_cfg.get("gateway", {}).get("streaming")
             if isinstance(streaming_cfg, dict):
                 gw_data["streaming"] = streaming_cfg
+
+            prefix_warmer_cfg = yaml_cfg.get("prefix_warmer")
+            if not isinstance(prefix_warmer_cfg, dict):
+                # Fall back to nested gateway.prefix_warmer written by
+                # ``hermes config set gateway.prefix_warmer.*``
+                prefix_warmer_cfg = yaml_cfg.get("gateway", {}).get("prefix_warmer")
+            if isinstance(prefix_warmer_cfg, dict):
+                gw_data["prefix_warmer"] = prefix_warmer_cfg
 
             if "reset_triggers" in yaml_cfg:
                 gw_data["reset_triggers"] = yaml_cfg["reset_triggers"]

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -546,12 +546,18 @@ class PrefixWarmerConfig:
     # Per-request timeout — generous enough to cover a full cold prefill of a
     # large prefix on modest hardware.
     timeout_seconds: float = 120.0
+    # Skip warming an endpoint that has seen real traffic this recently:
+    # recent traffic means the prefix is already hot, and on few-slot servers
+    # a warm request landing mid-conversation can evict a live session's
+    # cached state.
+    min_idle_seconds: float = 180.0
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "enabled": self.enabled,
             "interval_seconds": self.interval_seconds,
             "timeout_seconds": self.timeout_seconds,
+            "min_idle_seconds": self.min_idle_seconds,
         }
 
     @classmethod
@@ -562,6 +568,7 @@ class PrefixWarmerConfig:
             enabled=_coerce_bool(data.get("enabled"), False),
             interval_seconds=_coerce_int(data.get("interval_seconds"), 240),
             timeout_seconds=_coerce_float(data.get("timeout_seconds"), 120.0),
+            min_idle_seconds=_coerce_float(data.get("min_idle_seconds"), 180.0),
         )
 
 

--- a/gateway/prefix_warmer.py
+++ b/gateway/prefix_warmer.py
@@ -1,0 +1,132 @@
+"""Prompt prefix warmer for local backends.
+
+Local llama.cpp-style servers only reuse cached state when a new request's
+rendered prompt shares a byte-identical prefix with a state they still hold —
+and on hybrid-SSM models (Qwen3-Next/AgentWorld-class), only when a recurrent
+state checkpoint exists at or before the divergence point. In practice this
+means the first session after an idle stretch (or after other traffic rotated
+the cache) pays a full prefill of the shared prompt prefix — tool schemas plus
+the stable system prompt, often 10-20k tokens — even though every session on
+that profile sends the identical bytes.
+
+This watcher keeps that shared prefix hot. ``build_api_kwargs`` records the
+most recent request the agent sent to each local endpoint (see
+``agent/prefix_warm_registry.py``); every ``interval_seconds`` the watcher
+replays a minimal request per endpoint:
+
+    messages   = [the captured system message, one fixed "." user turn]
+    tools      = the captured tool schemas (rendered into the prompt by the
+                 server's chat template, so they must match byte-for-byte)
+    extra_body = the captured extra_body (may carry template-affecting
+                 options such as chat_template_kwargs)
+    max_tokens = 1, temperature = 0
+
+The server therefore keeps a cached state whose prompt is exactly the shared
+prefix plus a tiny tail. A fresh session diverges from it only at its own
+user turn, rolls back to the warm state's checkpoint, and prefills just its
+volatile tail instead of the whole prefix. Re-warming a state that is still
+cached costs only a few prefill tokens plus one generated token, so the
+steady-state overhead is negligible.
+
+Opt-in via config.yaml (the warmer is pointless for cloud providers, which
+manage their own prompt caches):
+
+    prefix_warmer:
+      enabled: true
+      interval_seconds: 240
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Fixed one-character user turn. Content is irrelevant — it just has to be
+# constant so consecutive warm requests hit their own cached state.
+_WARM_USER_CONTENT = "."
+
+
+def warm_once(config: Any) -> int:
+    """Send one warm request per recorded local prefix. Returns count warmed.
+
+    Synchronous (called via ``asyncio.to_thread``): the OpenAI client is
+    blocking, and a cache-hitting warm request completes in well under a
+    second. Errors are logged at debug and never propagate — a local server
+    that is restarting or busy simply misses one warm cycle.
+    """
+    from agent.prefix_warm_registry import get_snapshots
+
+    warmed = 0
+    for snap in get_snapshots():
+        try:
+            kwargs: Dict[str, Any] = {
+                "model": snap["model"],
+                "messages": [
+                    {"role": "system", "content": snap["system_content"]},
+                    {"role": "user", "content": _WARM_USER_CONTENT},
+                ],
+                "max_tokens": 1,
+                "temperature": 0,
+            }
+            if snap.get("tools"):
+                kwargs["tools"] = snap["tools"]
+            if snap.get("extra_body"):
+                kwargs["extra_body"] = snap["extra_body"]
+            t0 = time.time()
+            _send_warm_request(snap["base_url"], snap["api_key"], config, kwargs)
+            warmed += 1
+            logger.debug(
+                "prefix_warmer: warmed %s @ %s in %.2fs",
+                snap["model"], snap["base_url"], time.time() - t0,
+            )
+        except Exception as exc:
+            logger.debug(
+                "prefix_warmer: warm failed for %s @ %s: %s",
+                snap.get("model"), snap.get("base_url"), exc,
+            )
+    return warmed
+
+
+def _send_warm_request(base_url: str, api_key: str, config: Any, kwargs: Dict[str, Any]) -> None:
+    """One blocking chat-completions call to the local server."""
+    from openai import OpenAI
+
+    client = OpenAI(
+        base_url=base_url,
+        api_key=api_key or "local",
+        timeout=float(getattr(config, "timeout_seconds", 120.0)),
+        max_retries=0,
+    )
+    try:
+        client.chat.completions.create(**kwargs)
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+async def prefix_warmer_watcher(runner: Any, config: Any) -> None:
+    """Background loop: keep recorded local prompt prefixes warm.
+
+    Follows the gateway watcher conventions (initial settle delay,
+    ``runner._running`` loop condition, exceptions confined to one tick).
+    The loop also fires one immediate warm after the settle delay so a
+    gateway restart re-establishes the warm state without waiting a full
+    interval.
+    """
+    interval = max(30, int(getattr(config, "interval_seconds", 240)))
+    await asyncio.sleep(60)  # initial delay — let the gateway fully start
+    logger.info("prefix_warmer: watching (interval %ds)", interval)
+    while getattr(runner, "_running", False):
+        try:
+            warmed = await asyncio.to_thread(warm_once, config)
+            if warmed:
+                logger.debug("prefix_warmer: %d prefix(es) warm", warmed)
+        except Exception as exc:
+            logger.debug("prefix_warmer: tick error: %s", exc)
+        await asyncio.sleep(interval)

--- a/gateway/prefix_warmer.py
+++ b/gateway/prefix_warmer.py
@@ -119,6 +119,69 @@ def warm_once(config: Any) -> int:
     return warmed
 
 
+def warm_compacted_prefix(
+    old_system: str,
+    new_system: str,
+    compacted_messages: list,
+    config: Any,
+) -> int:
+    """Re-warm a session's local endpoints right after context compaction.
+
+    Compaction rewrites the transcript (summary + surviving tail) and appends
+    a compaction note to the system prompt, so the next turn's rendered
+    prompt shares no usable prefix with any cached state — the session pays
+    the full re-prefill at TTFT (seconds on a 20k+ prefix). This replays the
+    *post-compaction* prefix once, so the re-prefill happens now, in the
+    background, instead of in front of the user's next message.
+
+    Endpoint selection reuses the warm registry: a snapshot whose recorded
+    system content equals the *pre-compaction* system prompt belongs to this
+    session's request path (the direct provider, or the MoA acting/aggregator
+    call — both record). Only local endpoints are ever recorded, so cloud
+    providers are excluded by construction. Returns count warmed.
+    """
+    from agent.prefix_warm_registry import get_snapshots
+
+    warmed = 0
+    messages = [{"role": "system", "content": new_system}]
+    messages.extend(compacted_messages)
+    for snap in get_snapshots():
+        if snap.get("system_content") != old_system:
+            continue
+        try:
+            kwargs: Dict[str, Any] = {
+                "model": snap["model"],
+                "messages": messages,
+                "max_tokens": 1,
+                "temperature": 0,
+            }
+            if snap.get("tools"):
+                kwargs["tools"] = snap["tools"]
+            if snap.get("extra_body"):
+                kwargs["extra_body"] = snap["extra_body"]
+            t0 = time.time()
+            _send_warm_request(snap["base_url"], snap["api_key"], config, kwargs)
+            warmed += 1
+            logger.debug(
+                "prefix_warmer: post-compaction warm %s @ %s in %.2fs",
+                snap["model"], snap["base_url"], time.time() - t0,
+            )
+        except Exception as exc:
+            logger.debug(
+                "prefix_warmer: post-compaction warm failed for %s @ %s: %s",
+                snap.get("model"), snap.get("base_url"), exc,
+            )
+    if not warmed:
+        # Either no local endpoint is recorded yet, or the recorded system
+        # content didn't byte-match the pre-compaction prompt (a divergence
+        # in the request path worth knowing about when debugging TTFT).
+        logger.debug(
+            "prefix_warmer: post-compaction warm matched no snapshots (%d recorded)",
+            len(get_snapshots()),
+        )
+    return warmed
+
+
 def _send_warm_request(base_url: str, api_key: str, config: Any, kwargs: Dict[str, Any]) -> None:
     """One blocking chat-completions call to the local server."""
     from openai import OpenAI

--- a/gateway/prefix_warmer.py
+++ b/gateway/prefix_warmer.py
@@ -22,11 +22,25 @@ replays a minimal request per endpoint:
     max_tokens = 1, temperature = 0
 
 The server therefore keeps a cached state whose prompt is exactly the shared
-prefix plus a tiny tail. A fresh session diverges from it only at its own
-user turn, rolls back to the warm state's checkpoint, and prefills just its
-volatile tail instead of the whole prefix. Re-warming a state that is still
-cached costs only a few prefill tokens plus one generated token, so the
+prefix plus a tiny tail. A fresh session reuses that state up to the point
+where its prompt diverges — in practice somewhere inside the system block,
+because Hermes appends a volatile tail (memory block, user profile, session
+timestamp) after the stable head. The stable head (tool schemas + fixed
+system prose) is the bulk of the prefix, so realized reuse is typically most
+of the entry tax, not all of it; a memory write or date rollover between
+warm and reuse shortens it further. Re-warming a state that is still cached
+costs only a few prefill tokens plus one generated token, so the
 steady-state overhead is negligible.
+
+To avoid competing with live sessions for cache slots, a warm cycle skips
+any endpoint that has seen real traffic within ``min_idle_seconds``: recent
+traffic means the prefix is already hot, and on few-slot servers a warm
+request landing mid-conversation could otherwise evict an active session's
+state (llama.cpp assigns requests to slots by longest-common-prefix, so a
+warm request can select — and truncate — a slot holding a live session's
+KV). The guard keys off request-build times, so a single generation that
+runs longer than ``min_idle_seconds`` can still collide; on servers with a
+single parallel slot, prefer leaving the warmer off.
 
 Opt-in via config.yaml (the warmer is pointless for cloud providers, which
 manage their own prompt caches):
@@ -34,6 +48,7 @@ manage their own prompt caches):
     prefix_warmer:
       enabled: true
       interval_seconds: 240
+      min_idle_seconds: 180
 """
 
 from __future__ import annotations
@@ -57,11 +72,24 @@ def warm_once(config: Any) -> int:
     blocking, and a cache-hitting warm request completes in well under a
     second. Errors are logged at debug and never propagate — a local server
     that is restarting or busy simply misses one warm cycle.
-    """
-    from agent.prefix_warm_registry import get_snapshots
 
+    Endpoints with real traffic within ``config.min_idle_seconds`` are
+    skipped: their prefix is already hot, and warming a busy few-slot server
+    risks evicting a live session's cached state (see module docstring).
+    """
+    from agent.prefix_warm_registry import get_snapshots, last_traffic_at
+
+    min_idle = float(getattr(config, "min_idle_seconds", 180.0))
     warmed = 0
     for snap in get_snapshots():
+        base_url = snap["base_url"]
+        idle = time.time() - last_traffic_at(base_url)
+        if idle < min_idle:
+            logger.debug(
+                "prefix_warmer: skipping %s — active %.0fs ago (< %.0fs idle gate)",
+                base_url, idle, min_idle,
+            )
+            continue
         try:
             kwargs: Dict[str, Any] = {
                 "model": snap["model"],

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7120,6 +7120,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # engages drain on the first tick.
         asyncio.create_task(self._drain_control_watcher())
 
+        # Start the local-backend prompt prefix warmer — keeps the shared
+        # prompt prefix (tool schemas + system prompt) hot in local llama.cpp
+        # caches so fresh sessions skip the entry-tax prefill. Opt-in via
+        # ``prefix_warmer.enabled`` in config.yaml (no-op for cloud providers,
+        # so it stays off unless the user turns it on).
+        try:
+            _pw_cfg = getattr(self.config, "prefix_warmer", None)
+            if _pw_cfg is not None and _pw_cfg.enabled:
+                from gateway.prefix_warmer import prefix_warmer_watcher
+
+                asyncio.create_task(prefix_warmer_watcher(self, _pw_cfg))
+        except Exception:  # noqa: BLE001 - warmer must never block startup
+            logger.debug("prefix_warmer: failed to start", exc_info=True)
+
         logger.info("Press Ctrl+C to stop")
         
         return True

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7128,8 +7128,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             _pw_cfg = getattr(self.config, "prefix_warmer", None)
             if _pw_cfg is not None and _pw_cfg.enabled:
+                from agent.prefix_warm_registry import enable_capture
                 from gateway.prefix_warmer import prefix_warmer_watcher
 
+                # Capture hooks on the request path are dormant until this —
+                # processes that never start the warmer pay nothing.
+                enable_capture()
                 asyncio.create_task(prefix_warmer_watcher(self, _pw_cfg))
         except Exception:  # noqa: BLE001 - warmer must never block startup
             logger.debug("prefix_warmer: failed to start", exc_info=True)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -901,6 +901,12 @@ DEFAULT_CONFIG = {
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,
+    "prefix_warmer": {
+        "enabled": False,
+        "interval_seconds": 240,
+        "timeout_seconds": 120.0,
+        "min_idle_seconds": 180.0,
+    },
     # Soft LRU cap on in-memory TUI/desktop/dashboard sessions. When more than
     # this many are live, the gateway evicts the least-recently-active DETACHED
     # sessions (no live client) so accumulated agents don't pile up under memory

--- a/tests/agent/test_compression_postwarm.py
+++ b/tests/agent/test_compression_postwarm.py
@@ -1,0 +1,108 @@
+"""Post-compaction prefix warm: compress_context must fire a background
+re-warm of the session's local-endpoint prefix.
+
+Compaction rewrites the transcript and system prompt, so the next turn's
+rendered prompt matches no cached server state and pays the full re-prefill
+at TTFT. ``compress_context`` therefore hands the *post-compaction* prefix to
+``gateway.prefix_warmer.warm_compacted_prefix`` on a fire-and-forget thread,
+gated on the same ``prefix_warmer.enabled`` opt-in as the periodic warmer.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+
+
+def _build_agent_with_db(db: SessionDB, session_id: str):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary", "_db_persisted": True},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    return agent
+
+
+def _run_compress(agent, monkeypatch, *, warmer_enabled: bool):
+    import gateway.prefix_warmer as pw
+    import hermes_cli.config as hcfg
+
+    monkeypatch.setattr(
+        hcfg, "load_config_readonly",
+        lambda: {"prefix_warmer": {"enabled": warmer_enabled}},
+    )
+    calls = []
+    monkeypatch.setattr(
+        pw, "warm_compacted_prefix",
+        lambda old, new, msgs, cfg: calls.append((old, new, msgs, cfg)),
+    )
+
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    agent._compress_context(messages, "OLD SYSTEM PROMPT")
+
+    # The warm fires on a daemon thread; give it a moment.
+    deadline = time.time() + 5.0
+    while not calls and time.time() < deadline:
+        time.sleep(0.02)
+    return calls
+
+
+def test_compress_fires_background_warm_with_new_prefix(tmp_path: Path, monkeypatch) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "POSTWARM_1"
+    db.create_session(sid, source="cli")
+    agent = _build_agent_with_db(db, sid)
+
+    calls = _run_compress(agent, monkeypatch, warmer_enabled=True)
+
+    assert len(calls) == 1
+    old_system, new_system, warm_msgs, cfg = calls[0]
+    assert old_system == "OLD SYSTEM PROMPT"
+    # The new prefix is the rebuilt (non-empty) system prompt.
+    assert isinstance(new_system, str) and new_system.strip()
+    # The compacted transcript is replayed wire-clean: private bookkeeping
+    # keys (e.g. _db_persisted) must not reach the API server.
+    assert [m["content"] for m in warm_msgs][0].startswith("[CONTEXT COMPACTION]")
+    assert all("_db_persisted" not in m for m in warm_msgs)
+    assert cfg.enabled is True
+
+
+def test_compress_skips_warm_when_disabled(tmp_path: Path, monkeypatch) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "POSTWARM_2"
+    db.create_session(sid, source="cli")
+    agent = _build_agent_with_db(db, sid)
+
+    calls = _run_compress(agent, monkeypatch, warmer_enabled=False)
+    assert calls == []

--- a/tests/agent/test_compression_postwarm.py
+++ b/tests/agent/test_compression_postwarm.py
@@ -49,14 +49,13 @@ def _build_agent_with_db(db: SessionDB, session_id: str):
     return agent
 
 
-def _run_compress(agent, monkeypatch, *, warmer_enabled: bool):
+def _run_compress(agent, monkeypatch, *, warmer_enabled: bool, nested: bool = False):
     import gateway.prefix_warmer as pw
     import hermes_cli.config as hcfg
 
-    monkeypatch.setattr(
-        hcfg, "load_config_readonly",
-        lambda: {"prefix_warmer": {"enabled": warmer_enabled}},
-    )
+    warmer = {"enabled": warmer_enabled}
+    config = {"gateway": {"prefix_warmer": warmer}} if nested else {"prefix_warmer": warmer}
+    monkeypatch.setattr(hcfg, "load_config_readonly", lambda: config)
     calls = []
     monkeypatch.setattr(
         pw, "warm_compacted_prefix",
@@ -69,7 +68,7 @@ def _run_compress(agent, monkeypatch, *, warmer_enabled: bool):
         {"role": "user", "content": "q2"},
         {"role": "assistant", "content": "a2"},
     ]
-    agent._compress_context(messages, "OLD SYSTEM PROMPT")
+    agent._compress_context(messages, None)
 
     # The warm fires on a daemon thread; give it a moment.
     deadline = time.time() + 5.0
@@ -83,12 +82,13 @@ def test_compress_fires_background_warm_with_new_prefix(tmp_path: Path, monkeypa
     sid = "POSTWARM_1"
     db.create_session(sid, source="cli")
     agent = _build_agent_with_db(db, sid)
+    agent._cached_system_prompt = "EXACT OUTBOUND SYSTEM PROMPT"
 
     calls = _run_compress(agent, monkeypatch, warmer_enabled=True)
 
     assert len(calls) == 1
     old_system, new_system, warm_msgs, cfg = calls[0]
-    assert old_system == "OLD SYSTEM PROMPT"
+    assert old_system == "EXACT OUTBOUND SYSTEM PROMPT"
     # The new prefix is the rebuilt (non-empty) system prompt.
     assert isinstance(new_system, str) and new_system.strip()
     # The compacted transcript is replayed wire-clean: private bookkeeping
@@ -106,3 +106,16 @@ def test_compress_skips_warm_when_disabled(tmp_path: Path, monkeypatch) -> None:
 
     calls = _run_compress(agent, monkeypatch, warmer_enabled=False)
     assert calls == []
+
+
+def test_compress_accepts_nested_gateway_config(tmp_path: Path, monkeypatch) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "POSTWARM_3"
+    db.create_session(sid, source="cli")
+    agent = _build_agent_with_db(db, sid)
+    agent._cached_system_prompt = "CAPTURED PREFIX"
+
+    calls = _run_compress(agent, monkeypatch, warmer_enabled=True, nested=True)
+
+    assert len(calls) == 1
+    assert calls[0][0] == "CAPTURED PREFIX"

--- a/tests/gateway/test_prefix_warmer.py
+++ b/tests/gateway/test_prefix_warmer.py
@@ -1,0 +1,190 @@
+"""Tests for the local-backend prompt prefix warmer.
+
+Covers the three pieces:
+- ``agent/prefix_warm_registry.py`` — capture rules (local-only, system-head
+  only, chat-completions only), keying, and LRU cap.
+- ``gateway/prefix_warmer.py`` — warm_once builds the minimal replay request
+  from a snapshot and survives per-endpoint failures.
+- ``gateway/config.py`` — PrefixWarmerConfig defaults, coercion, roundtrip,
+  and the default-off gate.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+from agent import prefix_warm_registry as registry
+from gateway import prefix_warmer
+from gateway.config import GatewayConfig, PrefixWarmerConfig
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    registry.clear()
+    yield
+    registry.clear()
+
+
+def _agent(base_url="http://127.0.0.1:8001/v1", api_mode="chat_completions"):
+    return SimpleNamespace(
+        base_url=base_url, api_mode=api_mode, model="m", api_key="local"
+    )
+
+
+def _kwargs(system="SYSTEM PROMPT", model="agentworld-35b", tools=None):
+    messages: List[Dict[str, Any]] = []
+    if system is not None:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": "hi"})
+    kw: Dict[str, Any] = {"model": model, "messages": messages}
+    if tools is not None:
+        kw["tools"] = tools
+    return kw
+
+
+# ---------------------------------------------------------------- registry --
+
+def test_records_local_system_headed_request():
+    kw = _kwargs(tools=[{"function": {"name": "t"}}])
+    out = registry.record_local_prefix(_agent(), kw)
+    assert out is kw  # passthrough, same object
+    snaps = registry.get_snapshots()
+    assert len(snaps) == 1
+    assert snaps[0]["system_content"] == "SYSTEM PROMPT"
+    assert snaps[0]["model"] == "agentworld-35b"
+    assert snaps[0]["tools"] == [{"function": {"name": "t"}}]
+
+
+def test_skips_non_local_endpoint():
+    registry.record_local_prefix(
+        _agent(base_url="https://openrouter.ai/api/v1"), _kwargs()
+    )
+    assert registry.get_snapshots() == []
+
+
+def test_skips_non_chat_completions_api_mode():
+    registry.record_local_prefix(_agent(api_mode="anthropic_messages"), _kwargs())
+    assert registry.get_snapshots() == []
+
+
+def test_skips_request_without_system_head():
+    registry.record_local_prefix(_agent(), _kwargs(system=None))
+    assert registry.get_snapshots() == []
+
+
+def test_same_prefix_rerecord_updates_not_duplicates():
+    registry.record_local_prefix(_agent(), _kwargs(tools=[{"function": {"name": "a"}}]))
+    registry.record_local_prefix(_agent(), _kwargs(tools=[{"function": {"name": "b"}}]))
+    snaps = registry.get_snapshots()
+    assert len(snaps) == 1  # same (endpoint, model, system) -> one entry
+    assert snaps[0]["tools"] == [{"function": {"name": "b"}}]  # newest wins
+
+
+def test_entry_cap_evicts_oldest():
+    for i in range(6):
+        registry.record_local_prefix(
+            _agent(base_url=f"http://127.0.0.1:{8000 + i}/v1"), _kwargs()
+        )
+    snaps = registry.get_snapshots()
+    assert len(snaps) == registry._MAX_ENTRIES
+    urls = {s["base_url"] for s in snaps}
+    assert "http://127.0.0.1:8000/v1" not in urls  # oldest evicted
+    assert "http://127.0.0.1:8005/v1" in urls
+
+
+def test_never_raises_on_garbage(monkeypatch):
+    # A hostile agent object must not break the request path.
+    out = registry.record_local_prefix(object(), {"messages": None})
+    assert out == {"messages": None}
+
+
+def test_record_call_prefix_requires_tools():
+    # call_llm path: tool-less auxiliary calls (compression, advisors) must
+    # not churn the registry...
+    registry.record_call_prefix("http://127.0.0.1:8001/v1", "local", _kwargs())
+    assert registry.get_snapshots() == []
+    # ...but tool-carrying calls (e.g. the MoA acting call) are captured.
+    registry.record_call_prefix(
+        "http://127.0.0.1:8001/v1", "local", _kwargs(tools=[{"function": {"name": "t"}}])
+    )
+    assert len(registry.get_snapshots()) == 1
+
+
+def test_distinct_system_prompts_coexist_per_endpoint():
+    tools = [{"function": {"name": "t"}}]
+    registry.record_call_prefix("http://127.0.0.1:8001/v1", "local", _kwargs(system="MAIN", tools=tools))
+    registry.record_call_prefix("http://127.0.0.1:8001/v1", "local", _kwargs(system="REVIEW", tools=tools))
+    heads = {s["system_content"] for s in registry.get_snapshots()}
+    assert heads == {"MAIN", "REVIEW"}
+
+
+# --------------------------------------------------------------- warm_once --
+
+def test_warm_once_replays_minimal_request(monkeypatch):
+    tools = [{"function": {"name": "t"}}]
+    registry.record_local_prefix(
+        _agent(), _kwargs(tools=tools) | {"extra_body": {"chat_template_kwargs": {"x": 1}}}
+    )
+    sent = []
+
+    def fake_send(base_url, api_key, config, kwargs):
+        sent.append((base_url, api_key, kwargs))
+
+    monkeypatch.setattr(prefix_warmer, "_send_warm_request", fake_send)
+    assert prefix_warmer.warm_once(PrefixWarmerConfig()) == 1
+
+    base_url, api_key, kwargs = sent[0]
+    assert base_url == "http://127.0.0.1:8001/v1"
+    assert kwargs["max_tokens"] == 1
+    assert kwargs["messages"][0] == {"role": "system", "content": "SYSTEM PROMPT"}
+    assert kwargs["messages"][1]["role"] == "user"
+    assert kwargs["messages"][1]["content"] == prefix_warmer._WARM_USER_CONTENT
+    assert kwargs["tools"] == tools
+    assert kwargs["extra_body"] == {"chat_template_kwargs": {"x": 1}}
+
+
+def test_warm_once_continues_past_failures(monkeypatch):
+    registry.record_local_prefix(_agent(base_url="http://127.0.0.1:8001/v1"), _kwargs())
+    registry.record_local_prefix(_agent(base_url="http://127.0.0.1:8002/v1"), _kwargs())
+    calls = []
+
+    def flaky(base_url, api_key, config, kwargs):
+        calls.append(base_url)
+        if base_url.endswith("8002/v1"):
+            raise ConnectionError("server restarting")
+
+    monkeypatch.setattr(prefix_warmer, "_send_warm_request", flaky)
+    # One endpoint fails, the other still warms; no exception escapes.
+    assert prefix_warmer.warm_once(PrefixWarmerConfig()) == 1
+    assert len(calls) == 2
+
+
+def test_warm_once_no_snapshots_is_noop():
+    assert prefix_warmer.warm_once(PrefixWarmerConfig()) == 0
+
+
+# ------------------------------------------------------------------ config --
+
+def test_config_defaults_off():
+    cfg = PrefixWarmerConfig.from_dict({})
+    assert cfg.enabled is False
+    assert cfg.interval_seconds == 240
+    assert GatewayConfig.from_dict({}).prefix_warmer.enabled is False
+
+
+def test_config_roundtrip_and_coercion():
+    cfg = PrefixWarmerConfig.from_dict(
+        {"enabled": "true", "interval_seconds": "300", "timeout_seconds": "60"}
+    )
+    assert cfg.enabled is True
+    assert cfg.interval_seconds == 300
+    assert cfg.timeout_seconds == 60.0
+    assert PrefixWarmerConfig.from_dict(cfg.to_dict()) == cfg
+
+
+def test_gateway_config_roundtrip_includes_prefix_warmer():
+    gw = GatewayConfig.from_dict({"prefix_warmer": {"enabled": True}})
+    assert gw.prefix_warmer.enabled is True
+    assert gw.to_dict()["prefix_warmer"]["enabled"] is True

--- a/tests/gateway/test_prefix_warmer.py
+++ b/tests/gateway/test_prefix_warmer.py
@@ -332,6 +332,85 @@ def test_watcher_enforces_minimum_interval(monkeypatch):
     assert delays[1:] == [30]  # clamped to the 30s floor
 
 
+# ------------------------------------------------- warm_compacted_prefix --
+
+def test_compacted_warm_replays_new_prefix_to_matching_endpoint(monkeypatch):
+    tools = [{"function": {"name": "t"}}]
+    registry.record_local_prefix(_agent(), _kwargs(system="OLD SYSTEM", tools=tools))
+    sent = []
+    monkeypatch.setattr(
+        prefix_warmer, "_send_warm_request",
+        lambda base_url, api_key, config, kwargs: sent.append((base_url, kwargs)),
+    )
+
+    compacted = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "assistant", "content": "tail answer"},
+        {"role": "user", "content": "tail question"},
+    ]
+    warmed = prefix_warmer.warm_compacted_prefix(
+        "OLD SYSTEM", "NEW SYSTEM + note", compacted, PrefixWarmerConfig()
+    )
+    assert warmed == 1
+
+    base_url, kwargs = sent[0]
+    assert base_url == "http://127.0.0.1:8001/v1"
+    assert kwargs["max_tokens"] == 1
+    # The warm carries the POST-compaction prefix: new system + full
+    # compacted transcript (not the registry's stale system + "." tail).
+    assert kwargs["messages"][0] == {"role": "system", "content": "NEW SYSTEM + note"}
+    assert kwargs["messages"][1:] == compacted
+    assert kwargs["tools"] == tools
+
+
+def test_compacted_warm_skips_non_matching_system(monkeypatch):
+    registry.record_local_prefix(_agent(), _kwargs(system="SOME OTHER SESSION"))
+    sent = []
+    monkeypatch.setattr(
+        prefix_warmer, "_send_warm_request",
+        lambda *a: sent.append(a),
+    )
+    warmed = prefix_warmer.warm_compacted_prefix(
+        "OLD SYSTEM", "NEW SYSTEM", [{"role": "user", "content": "x"}], PrefixWarmerConfig()
+    )
+    assert warmed == 0
+    assert sent == []
+
+
+def test_compacted_warm_hits_every_matching_endpoint(monkeypatch):
+    # A MoA session records the same system prompt against two endpoints
+    # (direct provider + acting/aggregator); both must re-warm.
+    tools = [{"function": {"name": "t"}}]
+    registry.record_call_prefix("http://127.0.0.1:8011/v1", "local", _kwargs(system="OLD", tools=tools))
+    registry.record_call_prefix("http://127.0.0.1:8020/v1", "local", _kwargs(system="OLD", tools=tools))
+    sent = []
+    monkeypatch.setattr(
+        prefix_warmer, "_send_warm_request",
+        lambda base_url, api_key, config, kwargs: sent.append(base_url),
+    )
+    warmed = prefix_warmer.warm_compacted_prefix(
+        "OLD", "NEW", [{"role": "user", "content": "x"}], PrefixWarmerConfig()
+    )
+    assert warmed == 2
+    assert set(sent) == {"http://127.0.0.1:8011/v1", "http://127.0.0.1:8020/v1"}
+
+
+def test_compacted_warm_survives_endpoint_failure(monkeypatch):
+    tools = [{"function": {"name": "t"}}]
+    registry.record_call_prefix("http://127.0.0.1:8011/v1", "local", _kwargs(system="OLD", tools=tools))
+    registry.record_call_prefix("http://127.0.0.1:8020/v1", "local", _kwargs(system="OLD", tools=tools))
+
+    def flaky(base_url, api_key, config, kwargs):
+        if "8011" in base_url:
+            raise ConnectionError("server restarting")
+
+    monkeypatch.setattr(prefix_warmer, "_send_warm_request", flaky)
+    warmed = prefix_warmer.warm_compacted_prefix(
+        "OLD", "NEW", [{"role": "user", "content": "x"}], PrefixWarmerConfig()
+    )
+    assert warmed == 1  # one failed, one warmed, no exception escaped
+
+
 # ------------------------------------------------------------------ config --
 
 def test_config_defaults_off():

--- a/tests/gateway/test_prefix_warmer.py
+++ b/tests/gateway/test_prefix_warmer.py
@@ -414,10 +414,13 @@ def test_compacted_warm_survives_endpoint_failure(monkeypatch):
 # ------------------------------------------------------------------ config --
 
 def test_config_defaults_off():
+    from hermes_cli.config import DEFAULT_CONFIG
+
     cfg = PrefixWarmerConfig.from_dict({})
     assert cfg.enabled is False
     assert cfg.interval_seconds == 240
     assert GatewayConfig.from_dict({}).prefix_warmer.enabled is False
+    assert DEFAULT_CONFIG["prefix_warmer"] == cfg.to_dict()
 
 
 def test_config_roundtrip_and_coercion():

--- a/tests/gateway/test_prefix_warmer.py
+++ b/tests/gateway/test_prefix_warmer.py
@@ -23,8 +23,16 @@ from gateway.config import GatewayConfig, PrefixWarmerConfig
 @pytest.fixture(autouse=True)
 def _clean_registry():
     registry.clear()
+    registry.enable_capture()
     yield
+    registry.disable_capture()
     registry.clear()
+
+
+# warm_once config with the idle gate disarmed — most tests record a prefix
+# and warm immediately, which the traffic-recency guard would otherwise skip.
+def _warm_cfg(**overrides):
+    return PrefixWarmerConfig(min_idle_seconds=0.0, **overrides)
 
 
 def _agent(base_url="http://127.0.0.1:8001/v1", api_mode="chat_completions"):
@@ -133,7 +141,7 @@ def test_warm_once_replays_minimal_request(monkeypatch):
         sent.append((base_url, api_key, kwargs))
 
     monkeypatch.setattr(prefix_warmer, "_send_warm_request", fake_send)
-    assert prefix_warmer.warm_once(PrefixWarmerConfig()) == 1
+    assert prefix_warmer.warm_once(_warm_cfg()) == 1
 
     base_url, api_key, kwargs = sent[0]
     assert base_url == "http://127.0.0.1:8001/v1"
@@ -157,12 +165,171 @@ def test_warm_once_continues_past_failures(monkeypatch):
 
     monkeypatch.setattr(prefix_warmer, "_send_warm_request", flaky)
     # One endpoint fails, the other still warms; no exception escapes.
-    assert prefix_warmer.warm_once(PrefixWarmerConfig()) == 1
+    assert prefix_warmer.warm_once(_warm_cfg()) == 1
     assert len(calls) == 2
 
 
 def test_warm_once_no_snapshots_is_noop():
-    assert prefix_warmer.warm_once(PrefixWarmerConfig()) == 0
+    assert prefix_warmer.warm_once(_warm_cfg()) == 0
+
+
+# ------------------------------------------------------- capture enablement --
+
+def test_capture_disabled_by_default_records_nothing():
+    # Simulates a warmer-less process (plain CLI run): with capture off, the
+    # hooks must be inert — no snapshots, no traffic timestamps.
+    registry.disable_capture()
+    kw = _kwargs(tools=[{"function": {"name": "t"}}])
+    out = registry.record_local_prefix(_agent(), kw)
+    assert out is kw
+    registry.record_call_prefix("http://127.0.0.1:8001/v1", "local", kw)
+    assert registry.get_snapshots() == []
+    assert registry.last_traffic_at("http://127.0.0.1:8001/v1") == 0.0
+
+
+# ---------------------------------------------------------- snapshot copies --
+
+def test_snapshot_survives_in_place_mutation_of_tools_and_extra_body():
+    # conversation_loop can sanitize the built kwargs in place after capture
+    # (_force_ascii_payload); the snapshot must not alias those objects.
+    tools = [{"function": {"name": "t", "description": "café"}}]
+    extra_body = {"chat_template_kwargs": {"x": "café"}}
+    registry.record_local_prefix(_agent(), _kwargs(tools=tools) | {"extra_body": extra_body})
+
+    tools[0]["function"]["description"] = "cafe"  # in-place ASCII sanitize
+    extra_body["chat_template_kwargs"]["x"] = "cafe"
+
+    snap = registry.get_snapshots()[0]
+    assert snap["tools"] is not tools
+    assert snap["tools"][0]["function"]["description"] == "café"
+    assert snap["extra_body"]["chat_template_kwargs"]["x"] == "café"
+
+
+# ------------------------------------------------------------- idle gating --
+
+def test_warm_once_skips_endpoint_with_recent_traffic(monkeypatch):
+    # Recording a prefix marks the endpoint as actively trafficked, so an
+    # immediate warm cycle must stand down (few-slot eviction guard).
+    registry.record_local_prefix(_agent(), _kwargs())
+    sent = []
+    monkeypatch.setattr(
+        prefix_warmer, "_send_warm_request", lambda *a: sent.append(a)
+    )
+    assert prefix_warmer.warm_once(PrefixWarmerConfig()) == 0  # default gate
+    assert sent == []
+    # Once the endpoint has been idle past the gate, warming resumes.
+    assert prefix_warmer.warm_once(_warm_cfg()) == 1
+    assert len(sent) == 1
+
+
+# -------------------------------------------------- real-prefix round trip --
+
+def test_warm_request_reproduces_real_build_kwargs_prefix(monkeypatch):
+    """The core contract: the warm request's prefix fields are byte-identical
+    to what the real chat-completions transport produced."""
+    import json
+
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file — supports UTF-8 content: café",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+    }]
+    built = ChatCompletionsTransport().build_kwargs(
+        model="agentworld-35b",
+        messages=[
+            {"role": "system", "content": "SYSTEM HEAD\n\nvolatile tail"},
+            {"role": "user", "content": "hello"},
+        ],
+        tools=tools,
+        extra_body_additions={"chat_template_kwargs": {"enable_thinking": False}},
+    )
+    out = registry.record_local_prefix(_agent(), built)
+    assert out is built
+
+    sent = []
+    monkeypatch.setattr(
+        prefix_warmer, "_send_warm_request",
+        lambda base_url, api_key, config, kwargs: sent.append(kwargs),
+    )
+    assert prefix_warmer.warm_once(_warm_cfg()) == 1
+
+    warm = sent[0]
+
+    def dumps(obj):
+        return json.dumps(obj, sort_keys=True, ensure_ascii=False)
+
+    # The prefix a llama.cpp chat template renders ahead of the user turn:
+    # leading system message + tool schemas + template-affecting extra_body.
+    assert dumps(warm["messages"][0]) == dumps(built["messages"][0])
+    assert dumps(warm["tools"]) == dumps(built["tools"])
+    assert dumps(warm["extra_body"]) == dumps(built["extra_body"])
+
+
+# ------------------------------------------------------------ watcher loop --
+
+def _run_watcher(monkeypatch, *, warm_side_effect, ticks, interval_seconds=240):
+    """Drive prefix_warmer_watcher with instant sleeps; returns (delays, warms)."""
+    import asyncio
+
+    runner = SimpleNamespace(_running=True)
+    delays: List[float] = []
+    warms: List[int] = []
+
+    def fake_warm(config):
+        warms.append(1)
+        if len(warms) >= ticks:
+            runner._running = False
+        return warm_side_effect()
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(delay):
+        delays.append(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr(prefix_warmer.asyncio, "sleep", fast_sleep)
+    monkeypatch.setattr(prefix_warmer, "warm_once", fake_warm)
+    cfg = PrefixWarmerConfig(interval_seconds=interval_seconds)
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(prefix_warmer.prefix_warmer_watcher(runner, cfg))
+    finally:
+        loop.close()
+    return delays, warms
+
+
+def test_watcher_settles_warms_on_interval_and_stops(monkeypatch):
+    delays, warms = _run_watcher(
+        monkeypatch, warm_side_effect=lambda: 1, ticks=2, interval_seconds=300
+    )
+    assert delays[0] == 60          # initial settle delay
+    assert delays[1:] == [300, 300]  # one interval sleep per tick
+    assert len(warms) == 2           # loop exited once _running went False
+
+
+def test_watcher_confines_tick_exceptions(monkeypatch):
+    def boom():
+        raise RuntimeError("endpoint exploded")
+
+    # Every tick raises; the watcher must keep ticking and exit cleanly.
+    delays, warms = _run_watcher(monkeypatch, warm_side_effect=boom, ticks=3)
+    assert len(warms) == 3
+
+
+def test_watcher_enforces_minimum_interval(monkeypatch):
+    delays, _ = _run_watcher(
+        monkeypatch, warm_side_effect=lambda: 0, ticks=1, interval_seconds=5
+    )
+    assert delays[1:] == [30]  # clamped to the 30s floor
 
 
 # ------------------------------------------------------------------ config --
@@ -176,11 +343,13 @@ def test_config_defaults_off():
 
 def test_config_roundtrip_and_coercion():
     cfg = PrefixWarmerConfig.from_dict(
-        {"enabled": "true", "interval_seconds": "300", "timeout_seconds": "60"}
+        {"enabled": "true", "interval_seconds": "300", "timeout_seconds": "60",
+         "min_idle_seconds": "90"}
     )
     assert cfg.enabled is True
     assert cfg.interval_seconds == 300
     assert cfg.timeout_seconds == 60.0
+    assert cfg.min_idle_seconds == 90.0
     assert PrefixWarmerConfig.from_dict(cfg.to_dict()) == cfg
 
 


### PR DESCRIPTION
## What does this PR do?

Local llama.cpp-style servers only reuse cached KV/recurrent state when a new request shares a byte-identical prompt prefix with a state they still hold â€” and on hybrid-SSM models (Qwen3-Next-class), only when a recurrent checkpoint exists at or before the divergence point. Every fresh session therefore pays a full prefill of the shared prefix (tool schemas + stable system prompt, typically 10â€“20k tokens) unless something keeps a matching state warm.

This PR adds an opt-in gateway watcher that keeps that prefix hot. Every `interval_seconds` it replays a minimal request per local endpoint (the captured system head + tools + a fixed 1-char user turn, `max_tokens=1`). The warm request is byte-identical to real traffic by construction because it snapshots the most recent kwargs actually sent to that endpoint. A warm request that hits its own cached state costs a few prefill tokens; fresh sessions then diverge only at their user turn and skip the entry-tax prefill. In practice this took a fresh-session prefill from ~17.3k tokens to ~350 on a local Qwen3-Next-class deployment.

**Follow-up included in this PR: the same warm, applied after context compaction.** Compaction rewrites the transcript (summary + surviving tail) and appends a note to the system prompt, so the next turn shares no usable prefix with any cached state and pays the full re-prefill right at the user's next message (~7s on a 20k+ prefix in local testing). `compress_context` now fires a background re-warm of the *post-compaction* prefix the moment compaction completes, moving that prefill off the critical path. It reuses the same registry and warm machinery, targets only the local endpoints this session actually talked to (matched by the pre-compaction system prompt, which naturally covers both the direct provider and the MoA aggregator call), stays behind the same `prefix_warmer.enabled` opt-in, and never blocks the compression return path.

Cloud providers manage their own prompt caches, so the warmer only ever targets local endpoints and is off by default.

## Related Issue

No existing issue â€” this came out of profiling session-start latency on local backends.

## Type of Change

- [x] âœ¨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/prefix_warm_registry.py` (new): `build_api_kwargs` snapshots the most recent chat-completions kwargs sent to each local endpoint (system head + tools + extra_body). Errors never touch the hot path.
- `gateway/prefix_warmer.py`: the warm loop â€” per-endpoint minimal replay request on an interval, with a per-request timeout sized to cover a cold prefill.
- `gateway/prefix_warmer.py`: `warm_compacted_prefix()` — replays the *post-compaction* prefix (new system prompt + compacted transcript, `max_tokens=1`) to each recorded local endpoint whose snapshot matches the pre-compaction system prompt.
- `agent/conversation_compression.py`: after compaction completes, fires `warm_compacted_prefix()` on a fire-and-forget daemon thread (gated on `prefix_warmer.enabled`, wire-clean message copies, errors confined to debug logs) so the re-prefill happens before the user's next turn.
- `gateway/config.py`: new `prefix_warmer` config section (`enabled` â€” default off, `interval_seconds`, `timeout_seconds`), wired through config.yaml like the `streaming` section.
- `gateway/run.py`: start/stop the warmer with the gateway lifecycle.
- `agent/chat_completion_helpers.py`, `agent/auxiliary_client.py`: registry capture hooks at the request-build sites.
- `cli-config.yaml.example`: documented the new section.
- `tests/gateway/test_prefix_warmer.py` (new): 26 tests covering registry capture, warm-request construction (byte-identical prefix), interval/timeout behavior, local-endpoint gating, error isolation, and the post-compaction re-warm (endpoint match, multi-endpoint fan-out, failure isolation).
- `tests/agent/test_compression_postwarm.py` (new): 2 tests that `compress_context` fires the background warm with the rebuilt prefix and honours the opt-in.

## How to Test

1. `pytest tests/gateway/test_prefix_warmer.py -q` â€” 28 tests across both files, all passing.
2. Point Hermes at a local llama.cpp-style server, enable in `cli-config.yaml`:
   ```yaml
   prefix_warmer:
     enabled: true
   ```
3. Run one session so the registry captures the endpoint's prefix, wait past `interval_seconds`, then start a fresh session â€” the server log shows the prefill hitting cache (prompt-token reuse) instead of reprocessing the full shared prefix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (native, no WSL), plus a live local llama.cpp deployment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) â€” docstrings + `cli-config.yaml.example`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys â€” or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows â€” N/A (additive, opt-in)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) â€” developed and tested on Windows; pure-Python async, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior â€” N/A (no tool changes)
