### PR TITLE
fix(tui_gateway): register config shell hooks on the desktop surface

### DIFF
--- a/tests/test_tui_gateway_shell_hooks.py
+++ b/tests/test_tui_gateway_shell_hooks.py
@@ -1,0 +1,120 @@
+"""Desktop surface shell-hook registration.
+
+``hermes serve`` (the desktop backend) never passes through
+``hermes_cli.main._prepare_agent_startup`` — ``"serve"`` is not in
+``_AGENT_COMMANDS`` — so config-declared shell hooks (``hooks:`` in
+config.yaml) were never registered in the process that actually runs the
+agent turn.  The ``pre_llm_call`` dispatch itself is present and correct
+(agent/turn_context.py) but iterated an empty hook table: every lifecycle
+shell hook silently no-opped on the desktop surface while the identical
+profile worked under ``hermes chat``.
+
+These tests pin the fix: ``tui_gateway._make_agent`` — the shared
+agent-build chokepoint for BOTH desktop sub-paths (serve's in-memory
+gateway and the spawned ``tui_gateway.entry`` profile child) — must wire
+shell hooks from the loaded config via the idempotent
+``agent.shell_hooks.register_from_config``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+
+
+@pytest.fixture()
+def clean_hook_state():
+    """Isolate the shell-hook idempotence set + plugin-manager hook table."""
+    from agent import shell_hooks
+    from hermes_cli.plugins import get_plugin_manager
+
+    shell_hooks.reset_for_tests()
+    manager = get_plugin_manager()
+    saved = dict(manager._hooks)
+    manager._hooks.clear()
+    yield manager
+    manager._hooks.clear()
+    manager._hooks.update(saved)
+    shell_hooks.reset_for_tests()
+
+
+def _cfg():
+    return {
+        "hooks_auto_accept": True,
+        "hooks": {
+            "pre_llm_call": [
+                {"command": "echo desktop-hook-test", "timeout": 5},
+            ],
+        },
+    }
+
+
+def test_ensure_shell_hooks_registers_pre_llm_call(server, clean_hook_state):
+    """The desktop registration helper wires config hooks onto the manager."""
+    manager = clean_hook_state
+    server._ensure_shell_hooks(_cfg())
+    assert manager._hooks.get("pre_llm_call"), (
+        "desktop agent build must register config shell hooks on the plugin "
+        "manager — pre_llm_call context injection is dead on this surface "
+        "otherwise"
+    )
+
+
+def test_ensure_shell_hooks_swallows_failures(server, clean_hook_state):
+    """A broken hooks block must never take down agent construction."""
+    server._ensure_shell_hooks(None)          # not a dict
+    server._ensure_shell_hooks({"hooks": 42})  # malformed block
+    # reaching here without an exception is the assertion
+
+
+def test_make_agent_wires_shell_hooks(server, clean_hook_state, monkeypatch):
+    """_make_agent passes the loaded cfg through shell-hook registration."""
+    calls = []
+    monkeypatch.setattr(server, "_ensure_shell_hooks", lambda cfg: calls.append(cfg))
+    monkeypatch.setattr(server, "_load_cfg", lambda: _cfg())
+    monkeypatch.setattr(
+        server, "_resolve_startup_runtime", lambda: ("test-model", None)
+    )
+    monkeypatch.setattr(
+        server, "_resolve_runtime_with_fallback", lambda kw: {"provider": "openai"}
+    )
+    monkeypatch.setattr(server, "_load_provider_routing", lambda: {})
+    with patch.dict(
+        "sys.modules",
+        {
+            "run_agent": MagicMock(),
+            "hermes_cli.mcp_startup": MagicMock(),
+            "tui_gateway.entry": MagicMock(),
+        },
+    ):
+        server._make_agent("sid-shell-hook-test", "key-shell-hook-test")
+    assert calls, "_make_agent never invoked shell-hook registration"
+    assert calls[0].get("hooks"), (
+        "_make_agent must pass the loaded config (with its hooks block) to "
+        "shell-hook registration"
+    )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4203,6 +4203,34 @@ def _resolve_runtime_with_fallback(
         raise
 
 
+def _ensure_shell_hooks(cfg) -> None:
+    """Wire config-declared shell hooks into the plugin manager.
+
+    The desktop backend (``hermes serve`` and the spawned
+    ``tui_gateway.entry`` profile children) never passes through
+    ``hermes_cli.main._prepare_agent_startup`` — ``"serve"`` is not in
+    ``_AGENT_COMMANDS`` — so ``hooks:`` entries from config.yaml were never
+    registered on this surface and every lifecycle shell hook
+    (``pre_llm_call`` context injection, ``post_tool_call``, ...) silently
+    no-opped while the identical profile worked under ``hermes chat``.
+
+    Register at the shared agent-build chokepoint instead.
+    ``register_from_config`` is idempotent (keyed on event/matcher/command),
+    so per-build calls are safe and cheap; consent is resolved inside it via
+    the allowlist, ``hooks_auto_accept: true``, or ``HERMES_ACCEPT_HOOKS=1``
+    — never a TTY prompt on this headless path.
+    """
+    try:
+        from agent.shell_hooks import register_from_config
+
+        register_from_config(cfg)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed in tui_gateway._make_agent",
+            exc_info=True,
+        )
+
+
 def _make_agent(
     sid: str,
     key: str,
@@ -4235,6 +4263,9 @@ def _make_agent(
         pass
 
     cfg = _load_cfg()
+    # Desktop surface fix: hooks: from config are registered here because no
+    # hermes_cli.main startup path runs for `hermes serve` / entry children.
+    _ensure_shell_hooks(cfg)
     agent_cfg = cfg.get("agent") or {}
     system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
     startup_skills = _parse_tui_skills_env()


### PR DESCRIPTION
## Problem

Shell hooks declared under `hooks:` in config.yaml never fire on the desktop surface (`hermes serve`, including the spawned `tui_gateway.entry` profile children), while the identical profile works under `hermes chat`.

`register_from_config` (agent/shell_hooks.py) has exactly three runtime callers:
- `cli.py` — Termux deferred-startup path
- `gateway/run.py` — messaging gateway
- `hermes_cli/main.py` — guarded by `_prepare_agent_startup`, which returns early unless `args.command` is in `_AGENT_COMMANDS = {None, "chat", "acp", "rl"}` (or a matching subcommand). `"serve"` is in none of them, and the `tui_gateway` process never imports `register_from_config` at all.

So on desktop the `pre_llm_call` dispatch in `agent/turn_context.py` (and the context injection in `conversation_loop.py`) runs correctly against an **empty hook table** — every lifecycle shell hook (`pre_llm_call` context injection, `on_session_start`, `post_tool_call`) silently no-ops. `hermes hooks doctor` reports healthy because it exercises the script directly rather than the live registration path, which makes this gap unusually hard for users to self-diagnose ("config lies").

## Fix

Register at the shared agent-build chokepoint: `_make_agent` (tui_gateway/server.py) now calls `agent.shell_hooks.register_from_config(cfg)` via a defensive `_ensure_shell_hooks` helper.

- One spot covers **both** desktop sub-paths (serve's in-memory gateway and the spawned `entry` child).
- `register_from_config` is idempotent (keyed on event/matcher/command), so per-build calls are safe and cheap.
- Consent resolves inside it via the allowlist / `hooks_auto_accept: true` / `HERMES_ACCEPT_HOOKS=1` — no TTY prompt on this headless path; non-consented hooks are skipped with the existing warning, exactly as on the CLI path.
- Registration failures are swallowed with a debug log — a broken `hooks:` block can't take down agent construction.

Adding `serve`/`dashboard` to `_AGENT_COMMANDS` alone was considered and rejected: it misses profile-scoped chats that run in the spawned `tui_gateway.entry` child process.

## Tests

`tests/test_tui_gateway_shell_hooks.py` (new):
- `_ensure_shell_hooks` registers a `pre_llm_call` config hook onto the plugin manager
- malformed / non-dict hook config never raises out of agent construction
- `_make_agent` passes the loaded cfg through shell-hook registration

```
tests/test_tui_gateway_shell_hooks.py .. 3 passed
tests/test_tui_gateway_plugin_dispatch.py + _e2e + loop_noise .. 14 passed
```

`tests/agent/test_shell_hooks*.py`: 9 pre-existing Windows-runner failures (bare `.sh` subprocess exec, mtime semantics) are byte-identical with and without this diff (verified via stash on the same machine).

## Repro / verification

1. Profile config.yaml with a matcher-less `pre_llm_call` hook emitting `{"context": "..."}`, `hooks_auto_accept: true`, script allowlisted and healthy per `hermes hooks doctor`.
2. `hermes chat` → hook fires, context injected. Desktop app → hook never fires (instrumented fire-log stays empty).
3. With this fix, the desktop path registers on agent build and the same hook fires per turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQTVTNYTXV7pTsN9zGbFkL