### PR TITLE
fix(dashboard): keep password auth on login form

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,12 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers do not have an OAuth redirect flow. Let the
+    # normal /login page render its credential form instead of auto-bouncing
+    # to /auth/login, where BasicAuthProvider.start_login intentionally raises.
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -192,6 +192,19 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             status_code=404,
             detail=f"Provider does not support interactive login: {provider!r}",
         )
+    if getattr(p, "supports_password", False):
+        # Password providers use the credential form on /login, not an OAuth
+        # redirect. A direct /auth/login?provider=basic should therefore land
+        # on the form instead of surfacing BasicAuthProvider.start_login's
+        # intentional NotImplementedError as a 500.
+        from urllib.parse import quote
+        from hermes_cli.dashboard_auth.prefix import prefix_from_request
+
+        safe_next = _validate_post_login_target(next)
+        login_url = f"{prefix_from_request(request)}/login"
+        if safe_next:
+            login_url = f"{login_url}?next={quote(safe_next, safe='')}"
+        return RedirectResponse(url=login_url, status_code=302)
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -333,6 +333,23 @@ class TestPasswordLoginRoute:
         )
         assert resp.status_code == 200
 
+    def test_password_only_provider_does_not_auto_sso_to_oauth_route(self, gated_app):
+        # With exactly one OAuth provider, HTML loads may auto-bounce to
+        # /auth/login. A password-only provider has no OAuth start_login flow;
+        # it must render /login's credential form instead of raising a 500.
+        resp = gated_app.get("/sessions", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"].startswith("/login")
+        assert "/auth/login" not in resp.headers["location"]
+
+    def test_direct_oauth_login_for_password_provider_redirects_to_form(self, gated_app):
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=%2Fsessions",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2Fsessions"
+
 
 # ---------------------------------------------------------------------------
 # Transparent refresh — expired access token, live refresh token


### PR DESCRIPTION
## Summary
- Prevent password-only dashboard auth providers from being auto-routed through the OAuth `/auth/login` flow.
- Make direct `/auth/login?provider=<password-provider>` requests redirect back to `/login` instead of surfacing `NotImplementedError` as a 500.
- Adds regressions for both the unauthenticated HTML auto-SSO path and direct login URL path.

## Test plan
- `PYTHONPATH=. python -m pytest -q -o 'addopts=' tests/hermes_cli/test_dashboard_auth_password_login.py`
