### PR TITLE
fix(agent): apply reasoning stale-timeout floor to hyphenated Sonnet 4.x IDs

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -104,8 +104,7 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("claude-opus-4", 240),
     ("claude-opus-5", 240),
     ("claude-sonnet-5", 180),
-    ("claude-sonnet-4.5", 180),
-    ("claude-sonnet-4.6", 180),
+    ("claude-sonnet-4", 180),
     # Anthropic Mythos-class named reasoning models (claude-fable-5, …).
     # 1M context + 128K output — heavier thinking phase than the
     # numbered Claude line, so the floor is in the deep-reasoning tier

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -82,6 +82,12 @@ import pytest
     ("anthropic/claude-sonnet-4-20250514", 180.0),
     ("anthropic/claude-sonnet-4.5", 180.0),
     ("anthropic/claude-sonnet-4.6", 180.0),
+    # Bare canonical `claude-sonnet-4` (no trailing minor) — exercises the
+    # end-of-string branch `(?:$|[\-._])` of the compiled pattern, which the
+    # separator-suffixed cases above never reach.  This exact ID appears in
+    # repo examples/configs, so the floor must resolve for it too.
+    ("anthropic/claude-sonnet-4", 180.0),
+    ("claude-sonnet-4", 180.0),
     # Anthropic Mythos-class named reasoning models — deep-reasoning tier.
     ("anthropic/claude-fable-5", 600.0),
     ("claude-fable-5", 600.0),

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -69,9 +69,17 @@ import pytest
     ("openai/o3-pro", 600.0),
     ("openai/o3-mini", 300.0),
     ("openai/o4-mini", 300.0),
-    # Anthropic Claude 4.x thinking variants.
+    # Anthropic Claude 4.x thinking variants.  Canonical Sonnet IDs are
+    # hyphenated (claude-sonnet-4-5 / -4-6); the legacy dotted forms are
+    # kept for back-compat.  Both must resolve to the 180s floor — the
+    # dotted-only table entries used to miss the hyphenated canonical IDs
+    # because re.escape made the "." a literal dot.
     ("anthropic/claude-opus-4-6", 240.0),
     ("anthropic/claude-opus-4-20250514", 240.0),
+    ("anthropic/claude-sonnet-4-6", 180.0),
+    ("claude-sonnet-4-6", 180.0),
+    ("anthropic/claude-sonnet-4-5", 180.0),
+    ("anthropic/claude-sonnet-4-20250514", 180.0),
     ("anthropic/claude-sonnet-4.5", 180.0),
     ("anthropic/claude-sonnet-4.6", 180.0),
     # Anthropic Mythos-class named reasoning models — deep-reasoning tier.


### PR DESCRIPTION
## What does this PR do?

Fixes the Claude Sonnet 4.5/4.6 reasoning stale-timeout floor, which never applied to the canonical model IDs.

The floor table keyed the Sonnet entries on **dotted** slugs (`claude-sonnet-4.5`, `claude-sonnet-4.6`), but `_get_pattern` builds the matcher with `re.escape(slug)`, which turns the `.` into a **literal dot**. Canonical Sonnet IDs are **hyphenated** (`claude-sonnet-4-6`, exactly as used in `agent/usage_pricing.py`), so after `claude-sonnet-4` the real ID has `-6`, not `.6` — it matches neither dotted entry. `_match_any` then returns `None` and no floor is applied. Opus was unaffected because it was already keyed on the bare `claude-opus-4` family prefix (matches via the `-` separator).

Live repro on `main`:

```
get_reasoning_stale_timeout_floor("anthropic/claude-sonnet-4-6") -> None    # expected 180.0
get_reasoning_stale_timeout_floor("claude-sonnet-4-5")           -> None    # expected 180.0
get_reasoning_stale_timeout_floor("anthropic/claude-sonnet-4.6") -> 180.0   # only the dotted form worked
get_reasoning_stale_timeout_floor("anthropic/claude-opus-4-6")   -> 240.0   # opus fine
```

Consequence: Sonnet 4.5/4.6 extended-thinking runs fell back to the default 90s/180s stale detector instead of the 180s floor, so a long think tripped the stale killer and the connection was cut mid-think — the exact failure #52217 exists to prevent, silently un-applied to the most-used Claude tier.

The fix replaces the two dotted entries with the bare `claude-sonnet-4` family prefix, mirroring the opus convention. It matches every 4.x thinking variant (`-4-5`, `-4-6`, `-4-7`, and the legacy dotted `4.5`/`4.6` — since `.` is already in the `[\-._]` separator class) and does not match non-thinking Claude 3.x.

## Related Issue

Follow-up to the floor introduced in #52217; self-found while auditing the slug table against the canonical hyphenated IDs used elsewhere in the codebase. No separate filed issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/reasoning_timeouts.py`: replace the two dotted Sonnet entries (`claude-sonnet-4.5`, `claude-sonnet-4.6`) with the bare `claude-sonnet-4` family prefix.
- `tests/agent/test_reasoning_stale_timeout_floor.py`: add hyphenated positive cases (`claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-sonnet-4-20250514`, bare + aggregator-prefixed); retain the legacy dotted rows for back-compat.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/agent/test_reasoning_stale_timeout_floor.py -q`
2. Before the fix, the four new hyphenated positive cases fail (resolver returns `None`); the dotted back-compat rows still pass.
3. After the fix, all 55 cases pass. Opus (240s) and non-thinking Claude 3.x (`None`) are unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_reasoning_stale_timeout_floor.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A