### PR TITLE
fix(feishu): use interactive cards for full markdown rendering

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -152,12 +152,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^\n]+`)|(\*\*[^\n].+?\*\*)|(~~[^\n].+?~~)|(<u>.+?</u>)|(\*[^\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)|(^\|.+\|$)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -547,6 +544,34 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # ---------------------------------------------------------------------------
 # Post payload builders and parsers
 # ---------------------------------------------------------------------------
+
+
+def _build_interactive_card_payload(content: str) -> str:
+    """Wrap content in an interactive card for full markdown rendering.
+
+    Interactive cards support: bold, italic, strikethrough, code blocks with
+    copy button, tables, lists, links, images, and @mentions — everything
+    the ``post`` + ``md`` tag combo fails to render.
+    """
+    elements = [{"tag": "markdown", "content": content or "…"}]
+    title_text = "thinking…"
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped:
+            title_text = stripped.lstrip("#").strip()
+            title_text = title_text.replace("**", "").replace("*", "").replace("__", "")
+            if len(title_text) > 50:
+                title_text = title_text[:50] + "…"
+            break
+    card = {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "title": {"tag": "plain_text", "content": title_text},
+            "template": "blue",
+        },
+        "elements": elements,
+    }
+    return json.dumps(card, ensure_ascii=False)
 
 
 def _build_markdown_post_payload(content: str) -> str:
@@ -1859,9 +1884,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type != "interactive" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning("[Feishu] Invalid interactive card payload rejected by API; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1870,11 +1895,11 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 if (
-                    msg_type == "post"
+                    msg_type == "interactive"
                     and not self._response_succeeded(response)
                     and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    logger.warning("[Feishu] Interactive card payload rejected by API response; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1908,8 +1933,8 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await self._run_blocking(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+            if not result.success and msg_type == "interactive" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                logger.warning("[Feishu] Invalid interactive card update payload rejected by API; falling back to plain text")
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -4468,16 +4493,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
-        text_payload = {"text": content}
-        return "text", json.dumps(text_payload, ensure_ascii=False)
+        return "interactive", _build_interactive_card_payload(content)
 
     async def _send_uploaded_file_message(
         self,
@@ -4762,7 +4778,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return response
             except Exception as exc:
                 last_error = exc
-                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                if msg_type in ("post", "interactive") and _POST_CONTENT_INVALID_RE.search(str(exc)):
                     raise
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise


### PR DESCRIPTION
## Problem

Feishu adapter has two issues:

1. **Tables force plain-text downgrade**: `_MARKDOWN_TABLE_RE` detects markdown tables and forces the *entire message* to `msg_type=text`, stripping bold/links/lists/code blocks.
2. **`post` + `md` tag has limited rendering**: Lists, tables, and code blocks don't render. Only inline styles work.

## Fix

Switch all text messages from `post` + `md` to `interactive` card format with `markdown` elements. Interactive cards support the full Markdown feature set:

| Feature | post+md (old) | interactive card (new) |
|---------|--------------|----------------------|
| Bold/italic | ✅ | ✅ |
| Links | ✅ | ✅ |
| Lists | ❌ | ✅ |
| Tables | ❌ | ✅ |
| Code blocks + copy | ❌ | ✅ |
| Emoji | ✅ | ✅ |

### Changes
- Add `_build_interactive_card_payload()` — wraps content in a card with auto-derived header
- Simplify `_build_outbound_payload()` to always return interactive
- Remove `_MARKDOWN_TABLE_RE` regex
- Update fallback logic for interactive errors
- File+caption messages still use `post` (required by Feishu API)