### PR TITLE
fix(skills): persist only the platform delta of disabled skills, not the global union

### DIFF
--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -43,13 +43,23 @@ def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str
 
 
 def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[str] = None):
-    """Persist disabled skill names to config."""
+    """Persist disabled skill names to config.
+
+    ``platform_disabled[platform]`` is an *override* list that is unioned
+    with the global ``disabled`` list on read (see
+    :func:`get_disabled_skills`), so it must store only the platform-specific
+    delta. Callers pass the effective (unioned) set they read back, so the
+    globally-disabled skills are subtracted before writing — otherwise every
+    global disable would be copied into the platform list and stay pinned
+    there even after the user re-enables it globally.
+    """
     config.setdefault("skills", {})
     if platform is None:
         config["skills"]["disabled"] = sorted(disabled)
     else:
+        global_disabled = set(config["skills"].get("disabled", []))
         config["skills"].setdefault("platform_disabled", {})
-        config["skills"]["platform_disabled"][platform] = sorted(disabled)
+        config["skills"]["platform_disabled"][platform] = sorted(set(disabled) - global_disabled)
     save_config(config)
 
 

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -86,6 +86,30 @@ class TestSaveDisabledSkills:
         assert "skills" in config
         assert "disabled" in config["skills"]
 
+    @patch("hermes_cli.skills_config.save_config")
+    def test_platform_save_excludes_global_disabled(self, mock_save):
+        from hermes_cli.skills_config import save_disabled_skills
+        # skills_command reads the UNION (global | platform) and passes it back
+        # here. Only the platform-specific delta may be persisted — the global
+        # disable must NOT be copied into the platform_disabled list, or it
+        # stays pinned there even after a later global re-enable.
+        config = {"skills": {"disabled": ["global-skill"]}}
+        save_disabled_skills(config, {"global-skill", "tg-skill"}, platform="telegram")
+        assert config["skills"]["platform_disabled"]["telegram"] == ["tg-skill"]
+
+    @patch("hermes_cli.skills_config.save_config")
+    def test_platform_re_enable_after_global_reenable(self, mock_save):
+        from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
+        # Disable a skill globally, then configure telegram (which reads the
+        # union and saves it back).
+        config = {"skills": {"disabled": ["global-skill"]}}
+        union = get_disabled_skills(config, platform="telegram")  # {"global-skill"}
+        save_disabled_skills(config, union, platform="telegram")
+        # Now re-enable the skill globally. Because the platform list only holds
+        # its delta (empty here), the effective telegram set clears too.
+        config["skills"]["disabled"] = []
+        assert get_disabled_skills(config, platform="telegram") == set()
+
 
 # ---------------------------------------------------------------------------
 # _is_skill_disabled


### PR DESCRIPTION
## What does this PR do?

Stops `hermes skills` from silently pinning globally-disabled skills onto a platform.

`skills_command` reads the effective disabled set via `get_disabled_skills(config, platform)`, which returns the **union** of the global `skills.disabled` list and the per-platform `platform_disabled` override (the read semantics landed in `ce19fdb7c`, "apply global|platform disabled union to all resolution sites"). It derives the new set from that union and passes it back to `save_disabled_skills`, which wrote it **verbatim** into `platform_disabled[platform]` with no subtraction.

Net effect: every globally-disabled skill gets copied into the per-platform list whenever a user configures a platform. Because the read path unions global + platform, this stays invisible — until the user later re-enables that skill globally. The skill then stays stuck disabled on the platform (which never intentionally disabled it), and the per-platform lists bloat over time with global duplicates.

Reproduction (headless):

```
config = {"skills": {"disabled": ["skill-a"], "platform_disabled": {"telegram": ["tg-only"]}}}
# hermes skills → telegram → disable skill-b:
disabled = get_disabled_skills(config, "telegram")   # {"skill-a", "tg-only"}  (union)
new = disabled | {"skill-b"}
save_disabled_skills(config, new, platform="telegram")
# BEFORE: platform_disabled["telegram"] == ["skill-a", "skill-b", "tg-only"]  ← skill-a leaked in
# Now re-enable skill-a globally (skills.disabled -> []):
get_disabled_skills(config, "telegram")              # STILL contains skill-a  ← stuck disabled
```

The fix subtracts the current global set before writing the platform override, so only the genuine platform-specific delta is persisted. `platform_disabled` is defined as an override list unioned with global on read, so this matches the module's own data model. The union read path is unchanged (global disables still hold everywhere); only the leaky duplication is removed.

The global save branch (`platform is None`) and the two `web_server.py` callers (which always save globally, `platform=None`) are untouched.

## Related Issue

Self-found while auditing the skills save/read paths against the union read semantics introduced in `ce19fdb7c`. No separate filed issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/skills_config.py`: in `save_disabled_skills`, when a platform is given, subtract the current global `skills.disabled` set before writing `platform_disabled[platform]`.
- `tests/hermes_cli/test_skills_config.py`: add two cases to `TestSaveDisabledSkills` — the union save persists only the platform delta, and a later global re-enable clears the effective platform state.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_skills_config.py -q`
2. Before the fix, the two new tests fail: `platform_disabled["telegram"]` contains the leaked `global-skill`, and it stays disabled after a global re-enable.
3. After the fix, all 32 cases pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_skills_config.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
