### PR TITLE
fix(bluebubbles): preserve trailing (N/M) fraction in single-chunk replies

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -496,6 +496,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # Use the base splitter but skip pagination indicators — iMessage
         # bubbles flow naturally without "(1/3)" suffixes.
         chunks = BasePlatformAdapter.truncate_message(content, max_length)
+        # The base only appends a "(i/total)" indicator when it actually splits
+        # into multiple chunks; a message that fits in one chunk is returned
+        # verbatim. Only strip when there's an indicator to strip, so a
+        # single-chunk reply that legitimately ends in a "(N/M)" fraction
+        # (scores, page refs, ratios) keeps its final token.
+        if len(chunks) <= 1:
+            return chunks
         return [re.sub(r"\s*\(\d+/\d+\)$", "", c) for c in chunks]
 
     async def send(

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -84,6 +84,18 @@ class TestBlueBubblesHelpers:
         assert "".join(chunks) == "abcdefghij"
         assert all("(" not in chunk for chunk in chunks)
 
+    def test_truncate_message_preserves_trailing_fraction_in_single_chunk(self, monkeypatch):
+        # The base splitter only appends a "(i/total)" indicator when it splits
+        # into multiple chunks; a single-chunk reply is returned verbatim. So a
+        # short reply that genuinely ends in a "(N/M)" fraction must keep it —
+        # the pagination-suffix strip only applies to multi-chunk output.
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.truncate_message("The deal closed (5/10)") == ["The deal closed (5/10)"]
+        assert adapter.truncate_message("Progress (1/1)") == ["Progress (1/1)"]
+        assert adapter.truncate_message("Meeting notes\nAgenda item (2/3)") == [
+            "Meeting notes\nAgenda item (2/3)"
+        ]
+
     @pytest.mark.asyncio
     async def test_send_splits_paragraphs_into_multiple_bubbles(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

Stops the BlueBubbles adapter from silently deleting a real trailing `(N/M)` fraction from single-chunk replies.

`BlueBubblesAdapter.truncate_message` runs a `\s*\(\d+/\d+\)$` strip over **every** chunk to drop the base splitter's `(i/total)` pagination indicators (iMessage bubbles read fine without them). But `BasePlatformAdapter.truncate_message` only appends that indicator when it actually splits into multiple chunks — a message that fits in one chunk (`_len(content) <= max_length`) is returned **verbatim**, with no indicator. `MAX_TEXT_LENGTH` is 4000, so most agent replies are a single chunk — exactly the case where the strip has no legitimate indicator to remove and instead deletes real trailing user content.

Reproduction (single chunk, verified):

```
"The deal closed (5/10)"           -> "The deal closed"            (WRONG)
"Meeting notes\nAgenda item (2/3)" -> "Meeting notes\nAgenda item" (WRONG)
"Progress (1/1)"                   -> "Progress"                   (WRONG)
"Recipe step 1 (1/2) cup"          -> unchanged                    (correct — not $-anchored)
```

Any iMessage/BlueBubbles reply ending in a parenthesized fraction — scores, page/section refs, ratios, music notation, `(1/1)` — loses its final token before `send()`.

The fix guards the strip on multi-chunk output (`len(chunks) > 1`). Multi-chunk behavior is unchanged: the base appends the indicator **last**, so the end-anchored regex still removes only the appended ` (i/total)` and leaves a real trailing fraction inside a chunk body intact.

## Related Issue

Self-found while auditing the platform truncation overrides against the base splitter's indicator semantics. No separate filed issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py`: in `truncate_message`, return single-chunk output as-is and only run the pagination-suffix strip when there is more than one chunk.
- `tests/gateway/test_bluebubbles.py`: add `test_truncate_message_preserves_trailing_fraction_in_single_chunk`; the existing multi-chunk omit-suffix test is retained.

## How to Test

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/gateway/test_bluebubbles.py -q`
2. Before the fix, the new single-chunk test fails (`(5/10)` is stripped to `The deal closed`).
3. After the fix, all 61 cases pass, including the sibling multi-chunk test that still asserts the `(i/total)` indicator is dropped when the message is actually split.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_bluebubbles.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
