### PR TITLE
fix(auxiliary): strip api_key sentinels and add OpenRouter key fallback for custom endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -109,6 +109,13 @@ from utils import base_url_host_matches, base_url_hostname, env_float, model_for
 
 logger = logging.getLogger(__name__)
 
+# Config/api_key sentinel values that must be treated as *unset* rather than
+# sent verbatim as a bearer token. A literal ``api_key: none`` in config.yaml is
+# parsed by YAML as the string "none" (NOT null), and "no-key-required" is our
+# own local-server placeholder; neither is a real credential. When the resolved
+# api_key is one of these, an env-var fallback (e.g. OPENROUTER_API_KEY) wins.
+_CUSTOM_KEY_SENTINELS = {"none", "null", "no-key-required", "nokey", "no_key"}
+
 
 # ── resolve_provider_client fall-through dedup ───────────────────────────
 # Both fall-through warning sites in resolve_provider_client (the "unknown
@@ -4219,9 +4226,33 @@ def resolve_provider_client(
     if provider == "custom":
         if explicit_base_url:
             custom_base = _to_openai_base_url(explicit_base_url).strip()
+            # Treat config sentinels ("none"/"null"/"no-key-required") as
+            # *unset* so an env-var fallback can win. A literal ``api_key: none``
+            # in config.yaml (parsed by YAML as the string "none", NOT null)
+            # must never be sent as the bearer token — it 401s. See the OCR /
+            # describe OpenRouter auth defect: the OCR tool passes an explicit
+            # OpenRouter base_url with no key, and auxiliary.vision is
+            # configured with ``api_key: none``; both force provider="custom"
+            # and previously resolved to "none"/"no-key-required" instead of
+            # OPENROUTER_API_KEY.
+            _explicit_key = (explicit_api_key or "").strip()
+            if _explicit_key.lower() in _CUSTOM_KEY_SENTINELS:
+                _explicit_key = ""
+            # When the explicit endpoint is OpenRouter, fall back to
+            # OPENROUTER_API_KEY (not OPENAI_API_KEY) so OpenRouter-custom
+            # calls authenticate correctly. This fixes OCR + describe + any
+            # future openrouter-custom call in one place without changing
+            # behaviour for other providers (OPENAI_API_KEY still wins for
+            # non-OpenRouter custom hosts).
+            _is_openrouter_host = base_url_host_matches(custom_base, "openrouter.ai")
+            _env_key = ""
+            if _is_openrouter_host:
+                _env_key = os.getenv("OPENROUTER_API_KEY", "").strip()
+            if not _env_key:
+                _env_key = os.getenv("OPENAI_API_KEY", "").strip()
             custom_key = (
-                (explicit_api_key or "").strip()
-                or os.getenv("OPENAI_API_KEY", "").strip()
+                _explicit_key
+                or _env_key
                 or "no-key-required"  # local servers don't need auth
             )
             if not custom_base:
@@ -4301,9 +4332,24 @@ def resolve_provider_client(
         if custom_entry:
             custom_base = custom_entry.get("base_url", "").strip()
             custom_key = custom_entry.get("api_key", "").strip()
+            # Treat config sentinels ("none"/"null"/"no-key-required") as
+            # *unset* so the key_env / openrouter env-var fallbacks can win.
+            # A literal ``api_key: none`` in a named-provider config (parsed by
+            # YAML as the string "none", NOT null) must never be sent as the
+            # bearer token — it 401s. Mirrors the explicit_base_url branch.
+            if custom_key.lower() in _CUSTOM_KEY_SENTINELS:
+                custom_key = ""
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = os.getenv(custom_key_env, "").strip()
+            # Symmetry with the explicit_base_url branch: when the named
+            # provider points at OpenRouter and no key resolved (sentinel
+            # stripped, no key_env), fall back to OPENROUTER_API_KEY so
+            # OpenRouter-custom named providers authenticate correctly. Does
+            # NOT touch non-OpenRouter named providers or local/keyless
+            # servers (their key stays empty → "no-key-required").
+            if not custom_key and base_url_host_matches(custom_base, "openrouter.ai"):
+                custom_key = os.getenv("OPENROUTER_API_KEY", "").strip()
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible providers configured with a placeholder `api_key`
(e.g. `api_key: none` in `config.yaml`, which YAML parses as the **string**
`"none"`, or the `"no-key-required"` local-server placeholder) sent that literal
string as the bearer token, producing **401s** against real endpoints such as
OpenRouter.

## The bug / how it manifests

A tool passes an explicit OpenRouter `base_url` with no key while the provider
is configured with a sentinel `api_key` (observed with the OCR / vision-describe
path). `resolve_provider_client` previously resolved the key to
`"none"`/`"no-key-required"` and sent it verbatim as `Authorization: Bearer none`,
which OpenRouter rejects with 401.

## The fix

`agent/auxiliary_client.py`, both the `explicit_base_url` and named-provider
(`custom_entry`) branches of `resolve_provider_client`, fixed symmetrically:

1. **Sentinel stripping** — a shared `_CUSTOM_KEY_SENTINELS` set
   (`{"none", "null", "no-key-required", "nokey", "no_key"}`) is now treated as
   *unset*, so a real fallback can win instead of sending a bogus token.

2. **OpenRouter env fallback** — when the custom endpoint host is `openrouter.ai`
   and no real key resolved, fall back to `OPENROUTER_API_KEY` (not
   `OPENAI_API_KEY`).

## Notes

- Behaviour is unchanged for other providers: `OPENAI_API_KEY` still wins for
  non-OpenRouter custom hosts, and local/keyless servers still resolve to
  `"no-key-required"`.
- Config note: a literal `api_key: none` is now correctly treated as "no key
  configured" rather than a credential named "none".

🤖 Generated with [Claude Code](https://claude.com/claude-code)