### PR TITLE
fix(streaming): scrub leaked partial tool-call opener fragments per-delta

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -35,7 +35,13 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
 )
 from tools.terminal_tool import is_persistent_env
-from utils import base_url_host_matches, base_url_hostname, env_float, env_int
+from utils import (
+    base_url_host_matches,
+    base_url_hostname,
+    env_float,
+    env_int,
+    strip_partial_toolcall_fragments,
+)
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
@@ -2167,8 +2173,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # box is already closed (tool boundary flush).
                 elif agent.stream_delta_callback:
                     try:
-                        agent.stream_delta_callback(delta.content)
-                        agent._record_streamed_assistant_text(delta.content)
+                        # This branch bypasses _fire_stream_delta, so it must
+                        # replicate that path's partial tool-call opener scrub:
+                        # Qwen3-class models can leak an "<tool_call>" opener as
+                        # suppressed content (e.g. "ool_call>") before switching
+                        # to native tool_calls.  Guard on the scrubbed result so
+                        # a pure-fragment delta fires no callback.  Live per-delta
+                        # follow-up to #14251.
+                        _scrubbed = strip_partial_toolcall_fragments(delta.content)
+                        if _scrubbed:
+                            agent.stream_delta_callback(_scrubbed)
+                            agent._record_streamed_assistant_text(_scrubbed)
                     except Exception:
                         pass
 

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ import errno
 import json
 import logging
 import os
+import re
 import shutil
 import stat
 import tempfile
@@ -507,3 +508,39 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+# ─── Streaming Text Helpers ───────────────────────────────────────────────────
+
+
+# Matches the tail of a partial <tool_call>/<function_call> XML opener that a
+# model emitted as text content (e.g. "ool_call>", "ol_call>", "unction_call>")
+# before switching to native tool_calls.  The alternation is deliberately
+# permissive about how much of the opener leaked:
+#   - o{1,2}l_calls?>  →  "ool_call>", "ol_call>", "ool_calls>" …
+#   - unction_calls?>  →  "unction_call>", "unction_calls>"
+# A single compiled pattern is used for both search and substitution so there
+# is no search/sub asymmetry (the live follow-up to GitHub #14251).
+_TOOLCALL_FRAGMENT_RE = re.compile(
+    r"(?:o{1,2}l_calls?|unction_calls?|unction_call)>",
+    re.IGNORECASE,
+)
+
+
+def strip_partial_toolcall_fragments(text: str) -> str:
+    """Strip leaked partial ``<tool_call>``/``<function_call>`` opener fragments.
+
+    Qwen3-class models sometimes begin emitting an XML tool-call opener as
+    ordinary content (``<tool_call>``) and then switch to native ``tool_calls``
+    mid-token, leaving a stray content delta such as ``"ool_call>"`` that leaks
+    to user-facing output.  These tails are never valid prose, so they are
+    removed unconditionally.
+
+    This is the live per-delta scrub that GitHub #14251 explicitly deferred as
+    a follow-up; that PR only scrubbed the post-streaming final-text path.
+    """
+    if not text:
+        return text
+    if _TOOLCALL_FRAGMENT_RE.search(text):
+        return _TOOLCALL_FRAGMENT_RE.sub("", text)
+    return text


### PR DESCRIPTION
## Summary

Follow-up to #14251 (strip standalone tool-call XML from visible text), which
handled the post-streaming final-text path but **explicitly deferred the live
per-delta scrub**. This adds that per-delta scrub so partial tool-call opener
fragments never reach user-facing streamed output.

## The bug / how it manifests

Qwen3-class models sometimes begin emitting an XML tool-call opener as ordinary
content (`<tool_call>`) and then switch to native `tool_calls` mid-token,
leaving a stray content delta such as `"ool_call>"` that streams straight to
user-facing output. These tails are never valid prose.

## The fix

- `utils.py`: add `strip_partial_toolcall_fragments()`, using a single compiled
  regex for both search and substitution (no search/sub asymmetry) that matches
  the leaked tails of `<tool_call>` / `<function_call>` openers.
- `agent/chat_completion_helpers.py`: wire it into the `stream_delta_callback`
  branch of `interruptible_streaming_api_call`. That branch bypasses
  `_fire_stream_delta` and therefore did not previously get the scrub. The
  callback and text-record now guard on the scrubbed result, so a pure-fragment
  delta fires no callback and records no text.

## Notes

- Directly continues the deferred follow-up called out in #14251.
- No behaviour change for well-formed deltas: only leaked partial-opener tails
  are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)