### PR TITLE
feat(gateway): inline shutdown-reason clause in the "Gateway shutting down" chat notification

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4996,6 +4996,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
 
+    def _shutdown_reason_hint(self) -> Optional[str]:
+        """One-line reason for the shutdown notification message.
+
+        Returns ``None`` for chat ``/restart``, ``SIGUSR1``, or any other
+        operator-planned stop — those cases already have a clear
+        "restarting" verb + resume-on-next-message hint on the notification,
+        so an added reason string would be redundant and slightly noisy.
+
+        Returns a short reason string for external / unplanned stops so the
+        user reading the WhatsApp / Discord / Slack message knows the
+        gateway didn't decide to restart itself. Common cases the operator
+        wants to distinguish:
+
+        * ``terminal interrupt (Ctrl+C)`` — SIGINT from a foreground shell.
+        * ``external stop from systemd`` — SIGTERM under a systemd unit
+          (covers ``systemctl stop/restart``, package-upgrade needrestart
+          hooks, container/pod terminations that route through systemd).
+        * ``external stop`` — SIGTERM outside systemd (bare kill, container
+          orchestrator that isn't systemd, ``pkill`` from an admin shell).
+
+        Draws on the ``_shutdown_ctx`` snapshot captured by the signal
+        handler (see ``gateway/shutdown_forensics.py``). Falls back to
+        ``None`` when the context isn't available so the caller renders
+        the original short message without an inline reason clause.
+        """
+        if self._restart_requested:
+            return None
+        ctx = getattr(self, "_shutdown_ctx", None)
+        if not isinstance(ctx, dict):
+            return None
+        sig = ctx.get("signal")
+        if sig == "SIGINT":
+            return "terminal interrupt (Ctrl+C)"
+        if sig == "SIGTERM":
+            if ctx.get("under_systemd"):
+                return "external stop from systemd"
+            return "external stop"
+        return None
+
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
 
@@ -5007,13 +5046,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         restart_source = self._restart_command_source if self._restart_requested else None
 
         action = "restarting" if self._restart_requested else "shutting down"
+        reason_hint = self._shutdown_reason_hint()
         hint = (
             "Your current task will be interrupted. "
             "Send any message after restart and I'll try to resume where you left off."
             if self._restart_requested
             else "Your current task will be interrupted."
         )
-        msg = f"⚠️ Gateway {action} — {hint}"
+        if reason_hint:
+            msg = f"⚠️ Gateway {action} — {reason_hint}. {hint}"
+        else:
+            msg = f"⚠️ Gateway {action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
@@ -18597,6 +18640,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         except Exception as _e:
             _shutdown_ctx = None
             logger.debug("snapshot_shutdown_context failed: %s", _e)
+
+        # Mirror onto the runner so _notify_active_sessions_of_shutdown can
+        # derive a human-readable reason string for the outbound "Gateway
+        # shutting down" message (SIGINT vs SIGTERM-under-systemd vs bare
+        # kill). Never fails: if snapshot failed and _shutdown_ctx is None,
+        # the notify helper falls back to the plain unreasoned message.
+        try:
+            runner._shutdown_ctx = _shutdown_ctx
+        except Exception as _e:
+            logger.debug("Failed to mirror _shutdown_ctx onto runner: %s", _e)
 
         if planned_takeover:
             logger.info(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5026,6 +5026,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ctx = getattr(self, "_shutdown_ctx", None)
         if not isinstance(ctx, dict):
             return None
+        # Suppress the reason clause for marker-confirmed planned SIGTERM
+        # paths — these are operator-initiated and already surface via
+        # the "restarting"/"planned stop" narrative on the notification.
+        # Emitting "external stop from systemd" for a `hermes gateway stop`
+        # or a `--replace` takeover would be misleading. The signal
+        # handler stamps these markers into `_shutdown_ctx`; see
+        # `gateway/shutdown_forensics.py` for the marker read logic and
+        # `gateway/status.py` (`_PLANNED_STOP_MARKER_FILENAME` /
+        # `_get_takeover_marker_path()`) for the write side.
+        if ctx.get("planned_stop_marker") is not None:
+            return None
+        if ctx.get("takeover_marker") is not None and ctx.get("takeover_marker_for_self"):
+            return None
         sig = ctx.get("signal")
         if sig == "SIGINT":
             return "terminal interrupt (Ctrl+C)"

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -688,3 +688,137 @@ async def test_restart_shutdown_notification_anchors_telegram_dm_topic():
         "direct_messages_topic_id": "20197",
         "telegram_reply_to_message_id": "462",
     }
+
+
+# ── _shutdown_reason_hint + reason clause in notification ─────────────────
+
+
+class TestShutdownReasonHint:
+    def _fresh_runner(self):
+        runner, _adapter = make_restart_runner()
+        # make_restart_runner leaves _restart_requested = False; be explicit
+        # so test intent is clear at the call site.
+        runner._restart_requested = False
+        return runner
+
+    def test_no_hint_when_restart_requested(self):
+        # A chat /restart or SIGUSR1-initiated planned restart already has
+        # the "restarting" verb + resume-on-next-message hint; skip the
+        # inline reason so the message stays tight.
+        runner = self._fresh_runner()
+        runner._restart_requested = True
+        runner._shutdown_ctx = {"signal": "SIGTERM", "under_systemd": True}
+        assert runner._shutdown_reason_hint() is None
+
+    def test_no_hint_when_ctx_missing(self):
+        runner = self._fresh_runner()
+        # Attribute genuinely absent — mirrors runner state before the
+        # signal handler has fired (or the handler failed to snapshot).
+        assert runner._shutdown_reason_hint() is None
+
+    def test_no_hint_when_ctx_none(self):
+        runner = self._fresh_runner()
+        runner._shutdown_ctx = None
+        assert runner._shutdown_reason_hint() is None
+
+    def test_no_hint_for_unknown_signal(self):
+        runner = self._fresh_runner()
+        runner._shutdown_ctx = {"signal": "SIGKILL"}  # never reaches handler in practice
+        assert runner._shutdown_reason_hint() is None
+
+    def test_sigint_ctrl_c(self):
+        runner = self._fresh_runner()
+        runner._shutdown_ctx = {"signal": "SIGINT"}
+        assert runner._shutdown_reason_hint() == "terminal interrupt (Ctrl+C)"
+
+    def test_sigterm_under_systemd(self):
+        runner = self._fresh_runner()
+        runner._shutdown_ctx = {"signal": "SIGTERM", "under_systemd": True}
+        assert runner._shutdown_reason_hint() == "external stop from systemd"
+
+    def test_sigterm_not_under_systemd(self):
+        runner = self._fresh_runner()
+        runner._shutdown_ctx = {"signal": "SIGTERM", "under_systemd": False}
+        assert runner._shutdown_reason_hint() == "external stop"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_includes_reason_hint(tmp_path, monkeypatch):
+    """SIGTERM under systemd produces a notification with the reason clause."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM, chat_id="home-42", name="Ops",
+    )
+    # Simulate an unplanned SIGTERM from systemd (e.g. systemctl restart,
+    # apt-daily unattended-upgrade needrestart hook, etc.).
+    runner._restart_requested = False
+    runner._shutdown_ctx = {"signal": "SIGTERM", "under_systemd": True}
+
+    # Force one session into "active" so the active-chat path fires the
+    # message (independent of the home-channel path).
+    runner._snapshot_running_agents = lambda: ["agent:main:telegram:dm:home-42"]  # type: ignore[assignment]
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.send.called
+    sent_text = adapter.send.call_args[0][1] if len(adapter.send.call_args[0]) > 1 else adapter.send.call_args[1]["text"]
+    assert "external stop from systemd" in sent_text
+    assert "⚠️ Gateway shutting down" in sent_text
+    # The task-interrupted hint must still be there — the reason is
+    # additive, not a replacement.
+    assert "Your current task will be interrupted." in sent_text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_omits_reason_for_chat_restart(tmp_path, monkeypatch):
+    """A chat /restart falls into the planned-restart branch and keeps the
+    original resume-on-next-message message unchanged (no inline reason)."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM, chat_id="home-42", name="Ops",
+    )
+    runner._restart_requested = True
+    # Even if we had a shutdown ctx (SIGUSR1 via `hermes gateway restart`),
+    # the reason clause should be skipped for planned restarts.
+    runner._shutdown_ctx = {"signal": "SIGUSR1", "under_systemd": True}
+    runner._snapshot_running_agents = lambda: ["agent:main:telegram:dm:home-42"]  # type: ignore[assignment]
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.send.called
+    sent_text = adapter.send.call_args[0][1] if len(adapter.send.call_args[0]) > 1 else adapter.send.call_args[1]["text"]
+    # No reason clause interpolated between the em-dash and the hint.
+    assert "external stop" not in sent_text
+    assert "terminal interrupt" not in sent_text
+    assert "⚠️ Gateway restarting" in sent_text
+    assert "Send any message after restart" in sent_text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_omits_reason_when_ctx_absent(tmp_path, monkeypatch):
+    """No `_shutdown_ctx` on the runner → notification falls back to the
+    original short message. Preserves prior behavior for callers that don't
+    go through the signal handler (e.g. unit-under-test that calls
+    `_notify_active_sessions_of_shutdown` directly)."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM, chat_id="home-42", name="Ops",
+    )
+    runner._restart_requested = False
+    # Explicitly don't set _shutdown_ctx.
+    runner._snapshot_running_agents = lambda: ["agent:main:telegram:dm:home-42"]  # type: ignore[assignment]
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.send.called
+    sent_text = adapter.send.call_args[0][1] if len(adapter.send.call_args[0]) > 1 else adapter.send.call_args[1]["text"]
+    assert sent_text == "⚠️ Gateway shutting down — Your current task will be interrupted."

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -741,6 +741,46 @@ class TestShutdownReasonHint:
         runner._shutdown_ctx = {"signal": "SIGTERM", "under_systemd": False}
         assert runner._shutdown_reason_hint() == "external stop"
 
+    def test_sigterm_with_planned_stop_marker_suppresses_reason(self):
+        """A marker-confirmed `hermes gateway stop` is operator-initiated;
+        classifying it as `external stop from systemd` would misrepresent
+        the intent on the user-facing notification. Marker presence is the
+        authoritative signal — no reason clause should render."""
+        runner = self._fresh_runner()
+        runner._shutdown_ctx = {
+            "signal": "SIGTERM",
+            "under_systemd": True,
+            "planned_stop_marker": '{"written_at":"2026-07-19T12:00:00Z"}',
+        }
+        assert runner._shutdown_reason_hint() is None
+
+    def test_sigterm_with_takeover_marker_for_self_suppresses_reason(self):
+        """`hermes gateway restart --replace` writes a takeover marker
+        that names the target PID. When the marker names us, the SIGTERM
+        is a planned handoff — no external-stop reason."""
+        runner = self._fresh_runner()
+        runner._shutdown_ctx = {
+            "signal": "SIGTERM",
+            "under_systemd": True,
+            "takeover_marker": '{"target_pid":123}',
+            "takeover_marker_for_self": True,
+        }
+        assert runner._shutdown_reason_hint() is None
+
+    def test_sigterm_with_takeover_marker_for_other_still_reports_external(self):
+        """A takeover marker that DOESN'T name us is a smoking gun for
+        another --replace instance killing us — that IS an external
+        stop from the perspective of this runner, and the reason clause
+        should surface so the operator sees it."""
+        runner = self._fresh_runner()
+        runner._shutdown_ctx = {
+            "signal": "SIGTERM",
+            "under_systemd": True,
+            "takeover_marker": '{"target_pid":999}',
+            "takeover_marker_for_self": False,
+        }
+        assert runner._shutdown_reason_hint() == "external stop from systemd"
+
 
 @pytest.mark.asyncio
 async def test_shutdown_notification_includes_reason_hint(tmp_path, monkeypatch):
@@ -798,6 +838,69 @@ async def test_shutdown_notification_omits_reason_for_chat_restart(tmp_path, mon
     assert "terminal interrupt" not in sent_text
     assert "⚠️ Gateway restarting" in sent_text
     assert "Send any message after restart" in sent_text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_omits_reason_for_planned_stop_marker(tmp_path, monkeypatch):
+    """A `hermes gateway stop` writes a planned-stop marker. The runner
+    receives SIGTERM under systemd, but the marker classifies the stop
+    as operator-initiated. The user-facing notification must NOT include
+    the `external stop from systemd` reason clause."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM, chat_id="home-42", name="Ops",
+    )
+    runner._restart_requested = False
+    runner._shutdown_ctx = {
+        "signal": "SIGTERM",
+        "under_systemd": True,
+        "planned_stop_marker": '{"written_at":"2026-07-19T12:00:00Z"}',
+    }
+    runner._snapshot_running_agents = lambda: ["agent:main:telegram:dm:home-42"]  # type: ignore[assignment]
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.send.called
+    sent_text = adapter.send.call_args[0][1] if len(adapter.send.call_args[0]) > 1 else adapter.send.call_args[1]["text"]
+    assert "external stop" not in sent_text, (
+        "planned-stop marker must suppress the external-stop reason clause"
+    )
+    assert "⚠️ Gateway shutting down" in sent_text
+    assert "Your current task will be interrupted." in sent_text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_omits_reason_for_self_takeover_marker(tmp_path, monkeypatch):
+    """A `hermes gateway restart --replace` writes a takeover marker
+    naming the target PID. When the marker names us, the SIGTERM is a
+    planned handoff. The user-facing notification must NOT include the
+    external-stop reason clause."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM, chat_id="home-42", name="Ops",
+    )
+    runner._restart_requested = False
+    runner._shutdown_ctx = {
+        "signal": "SIGTERM",
+        "under_systemd": True,
+        "takeover_marker": '{"target_pid":123}',
+        "takeover_marker_for_self": True,
+    }
+    runner._snapshot_running_agents = lambda: ["agent:main:telegram:dm:home-42"]  # type: ignore[assignment]
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.send.called
+    sent_text = adapter.send.call_args[0][1] if len(adapter.send.call_args[0]) > 1 else adapter.send.call_args[1]["text"]
+    assert "external stop" not in sent_text, (
+        "self-takeover marker must suppress the external-stop reason clause"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Adds a short reason clause to the outbound shutdown notification so users can tell WHY the gateway is going down without cross-checking the operator's terminal. Uses the shutdown-forensics context that the signal handler already captures via `snapshot_shutdown_context()`.

## Why

Prior notification for external stops:

> ⚠️ Gateway shutting down — Your current task will be interrupted.

Users on WhatsApp / Discord / Slack can't tell whether the gateway restarted itself (chat `/restart` or `hermes gateway restart` — the "restarting" verb + resume-hint already communicate that) OR something else stopped it. In production, "something else" is most commonly `systemctl restart` from an admin, or a package upgrade that runs through `needrestart`, or an OS-level unattended-upgrades job that catches the gateway holding a stale `libsqlite3.so`. All are indistinguishable to the user reading the chat notification.

This PR distinguishes them.

## Message shape per scenario

| Scenario | New message |
|---|---|
| Chat `/restart` (unchanged) | `⚠️ Gateway restarting — Your current task will be interrupted. Send any message after restart and I'll try to resume where you left off.` |
| `systemctl restart` / apt unattended-upgrades / `needrestart` hook | `⚠️ Gateway shutting down — external stop from systemd. Your current task will be interrupted.` |
| Bare `kill` from an admin shell (no systemd context) | `⚠️ Gateway shutting down — external stop. Your current task will be interrupted.` |
| Foreground `Ctrl+C` (SIGINT) | `⚠️ Gateway shutting down — terminal interrupt (Ctrl+C). Your current task will be interrupted.` |
| No shutdown ctx captured (fallback, unchanged) | `⚠️ Gateway shutting down — Your current task will be interrupted.` |

Chat `/restart` already carries a "restarting" verb + resume-on-next-message hint, so the reason clause is intentionally suppressed for planned restarts — otherwise the message reads redundantly. The clause only fires for external / unplanned stops.

## What changes

- New `_shutdown_reason_hint()` method on `GatewayRunner` — reads `self._shutdown_ctx` + `self._restart_requested` and returns a short human-readable string (or `None` to fall through to the original message).
- `_notify_active_sessions_of_shutdown()` calls the helper and splices the reason between the em-dash and the task-interrupted hint.
- Signal handler now mirrors `_shutdown_ctx` onto the runner so the notify helper can read it. Best-effort; a snapshot failure falls through to the original reason-less message.

## Backward compatibility

- When `_shutdown_ctx` is absent (unit tests that call the notify helper directly, or environments where the forensics snapshot fails), the message is byte-identical to prior main.
- When `_restart_requested` is `True` (chat `/restart`, SIGUSR1 planned restart, `hermes gateway restart`), the message is byte-identical to prior main.
- All 27 pre-existing tests in `tests/gateway/test_restart_notification.py` pass unmodified.

## Tests

10 new tests, all passing on Python 3.12:

- **7 in `TestShutdownReasonHint`** — covers the helper's return value for each combination of `_restart_requested` × signal type × `under_systemd`, plus the fall-through cases (ctx missing, ctx `None`, unknown signal).
- **3 end-to-end message-shape tests** — assert `external stop from systemd` appears for SIGTERM under systemd, no reason clause for chat `/restart`, original short message when no ctx.

## Related

Sibling to two other open PRs from this contributor:

- #55008 — `home_channel_startup_notification` config (opt-in "gateway back online" ping on every startup)
- #55018 — `sd_notify` + `WatchdogSec` integration (opt-in `Type=notify` support for hang detection)

Together they give production single-VM deployments the standard three-part restart visibility: **you know WHY it went down, that it went down, and that it came back up.**

## Files

| File | Lines |
|---|---|
| `gateway/run.py` | +55 / -1 |
| `tests/gateway/test_restart_notification.py` | +134 / -0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)