### PR TITLE
fix(photon): launch the iMessage sidecar node processes headless on Windows

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -865,6 +865,12 @@ class PhotonAdapter(BasePlatformAdapter):
                 text=True,
                 timeout=10,
                 check=False,
+                # Windows: node.exe is a console-subsystem binary, so spawning
+                # it from the windowless gateway (pythonw) allocates a console
+                # that flashes on every sidecar start. Suppress it.
+                creationflags=(
+                    subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
+                ),
             )
             if patch.returncode != 0:
                 raise RuntimeError((patch.stderr or patch.stdout or "").strip())
@@ -883,6 +889,12 @@ class PhotonAdapter(BasePlatformAdapter):
             stderr=subprocess.STDOUT,
             env=env,
             start_new_session=(sys.platform != "win32"),
+            # Windows: run the persistent sidecar headless — without this it
+            # keeps a visible console window open for the sidecar's lifetime
+            # (or flashes one if it exits early).
+            creationflags=(
+                subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
+            ),
         )
 
         # Pump sidecar stderr/stdout into our logger so users see crashes.

--- a/tests/plugins/platforms/photon/test_sidecar_headless_windows.py
+++ b/tests/plugins/platforms/photon/test_sidecar_headless_windows.py
@@ -1,0 +1,70 @@
+"""The sidecar's node processes must be spawned headless on Windows.
+
+``node.exe`` is a console-subsystem binary. When the gateway runs windowless
+(``pythonw`` — the normal Windows service setup), every ``subprocess`` spawn of
+node without ``CREATE_NO_WINDOW`` allocates a fresh console: the short-lived
+Spectrum patch run flashes a window on every sidecar start, and the persistent
+sidecar keeps one open for its whole lifetime.
+
+These are AST invariants pinning ``creationflags=CREATE_NO_WINDOW`` (win32-
+gated) onto both spawn sites in ``_start_sidecar`` — they fail if the flag is
+dropped from either call.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+
+from plugins.platforms.photon import adapter as photon_adapter
+
+
+def _start_sidecar_ast() -> ast.AST:
+    src = inspect.getsource(photon_adapter.PhotonAdapter._start_sidecar)
+    return ast.parse("class _W:\n" + "\n".join("    " + line for line in src.splitlines()))
+
+
+def _subprocess_calls(tree: ast.AST, attr: str) -> list[ast.Call]:
+    """All ``subprocess.<attr>(...)`` calls under ``tree``."""
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == attr
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "subprocess"
+    ]
+
+
+def _passes_no_window_creationflags(call: ast.Call) -> bool:
+    """True if the call passes a ``creationflags=`` kwarg referencing
+    ``CREATE_NO_WINDOW`` somewhere in its value expression."""
+    for kw in call.keywords:
+        if kw.arg != "creationflags":
+            continue
+        return any(
+            isinstance(node, ast.Attribute) and node.attr == "CREATE_NO_WINDOW"
+            for node in ast.walk(kw.value)
+        )
+    return False
+
+
+def test_patch_script_run_is_headless_on_windows():
+    tree = _start_sidecar_ast()
+    runs = _subprocess_calls(tree, "run")
+    assert runs, "expected the Spectrum patch subprocess.run in _start_sidecar"
+    assert all(_passes_no_window_creationflags(c) for c in runs), (
+        "subprocess.run in _start_sidecar must pass creationflags="
+        "CREATE_NO_WINDOW (win32-gated) or it flashes a console window"
+    )
+
+
+def test_persistent_sidecar_popen_is_headless_on_windows():
+    tree = _start_sidecar_ast()
+    popens = _subprocess_calls(tree, "Popen")
+    assert popens, "expected the sidecar subprocess.Popen in _start_sidecar"
+    assert all(_passes_no_window_creationflags(c) for c in popens), (
+        "subprocess.Popen in _start_sidecar must pass creationflags="
+        "CREATE_NO_WINDOW (win32-gated) or it keeps a console window open "
+        "for the sidecar's lifetime"
+    )


### PR DESCRIPTION
## What does this PR do?

On Windows, the Photon iMessage sidecar spawns `node.exe` twice in `_start_sidecar`: once for the short-lived Spectrum mixed-attachments patch script, and once for the persistent sidecar itself. `node.exe` is a console-subsystem binary, so when the gateway runs windowless (`pythonw` — the normal Windows service/autostart setup), each spawn allocates a fresh console: the patch run **flashes a console window on every sidecar start**, and the persistent sidecar **keeps a visible console window open for its entire lifetime**.

Fix: pass `creationflags=subprocess.CREATE_NO_WINDOW` (win32-gated, `0` elsewhere) on both spawn sites. No behavior change on macOS/Linux — the flag evaluates to `0` off Windows, and `CREATE_NO_WINDOW` is only referenced behind the platform check.

## Related Issue

No existing issue — found running the gateway as a hidden autostart on Windows 11, where the sidecar's console windows flash/persist on the user's desktop.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/adapter.py` — `creationflags=CREATE_NO_WINDOW` (win32-gated) on the Spectrum patch `subprocess.run` and the persistent sidecar `subprocess.Popen` in `_start_sidecar`.
- `tests/plugins/platforms/photon/test_sidecar_headless_windows.py` — AST invariants pinning the flag onto both spawn sites (mirrors the repo's existing AST-pin test style), so the fix can't silently regress.

## How to Test

1. `pytest tests/plugins/platforms/photon/test_sidecar_headless_windows.py -q` → 2 passed.
2. Repro (before): on Windows, run the gateway via `pythonw` with Photon configured — a console window flashes when the sidecar starts and a second one stays open while it runs.
3. After: sidecar starts and runs with no visible windows; `hermes photon` messaging works unchanged (verified on a live Windows 11 gateway).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(photon):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — the new tests and the photon suite pass; `test_sidecar_lifecycle.py` has 3 pre-existing failures on Windows (they exercise the POSIX `lsof`/`ps` reap path) that reproduce identically on clean `main`
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (live gateway with Photon/iMessage sidecar)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior-invisible fix; inline comments explain the win32 gating)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the flag is win32-gated and evaluates to `0` on macOS/Linux; POSIX behavior byte-identical
- [x] I've updated tool descriptions/schemas — N/A
