### PR TITLE
feat(moa): per-slot reasoning_effort for reference advisors

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -270,11 +270,20 @@ def _run_reference(
         # (their caching is automatic; markers are ignored harmlessly, but we
         # only decorate when the policy says the route honors them).
         messages = _maybe_apply_moa_cache_control(messages, runtime)
+        # Optional per-slot reasoning effort (preset key ``reasoning_effort``
+        # on a reference slot, preserved by moa_config._clean_slot). References
+        # are advisors, so presets commonly dial their thinking down ("low")
+        # without touching the acting aggregator's reasoning config. Passed via
+        # extra_body so backends that don't support it simply reject/ignore it
+        # per their normal handling — and a rejected reference degrades to a
+        # labelled note, never aborting the MoA turn.
+        effort = str(slot.get("reasoning_effort") or "").strip().lower()
         response = call_llm(
             task="moa_reference",
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
+            extra_body={"reasoning_effort": effort} if effort else None,
             **runtime,
         )
         usage = CanonicalUsage()

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -87,7 +87,16 @@ def _clean_slot(slot: Any) -> dict[str, str] | None:
     # an invalid slot is dropped, falling back to the preset's defaults.
     if provider.lower() == "moa":
         return None
-    return {"provider": provider, "model": model}
+    cleaned = {"provider": provider, "model": model}
+    # Optional per-slot reasoning effort for models that accept it (gpt-oss,
+    # o-series-style backends). References are advisors — their long thinking
+    # chains are usually wasted spend, so presets often want e.g. "low" on a
+    # reference slot while the acting aggregator keeps its own default. Kept
+    # as an opaque lowercased string: backends validate the actual value.
+    effort = str(slot.get("reasoning_effort") or "").strip().lower()
+    if effort:
+        cleaned["reasoning_effort"] = effort
+    return cleaned
 
 
 def _default_preset() -> dict[str, Any]:

--- a/tests/agent/test_moa_reference_reasoning_effort.py
+++ b/tests/agent/test_moa_reference_reasoning_effort.py
@@ -1,0 +1,101 @@
+"""Per-slot ``reasoning_effort`` on MoA reference advisors.
+
+References are advisors: on reasoning models, most of an advisor's turn is
+private thinking the aggregator never sees. A preset can now set
+``reasoning_effort`` on a reference slot and have it forwarded to that slot's
+backend via ``extra_body``, without touching the acting aggregator's own
+reasoning configuration.
+
+Covers both halves: config normalization preserves the key on slots
+(``moa_config._clean_slot`` whitelists slot keys), and ``_run_reference``
+forwards it to ``call_llm``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from agent import moa_loop
+from hermes_cli.moa_config import normalize_moa_config
+
+
+# ------------------------------------------------------------ moa_config --
+
+def _preset_with_slot(slot: Dict[str, Any]) -> Dict[str, Any]:
+    return normalize_moa_config(
+        {"presets": {"default": {
+            "reference_models": [slot],
+            "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+        }}}
+    )["presets"]["default"]
+
+
+def test_normalize_preserves_slot_reasoning_effort():
+    preset = _preset_with_slot(
+        {"provider": "openrouter", "model": "openai/gpt-5.5", "reasoning_effort": "Low "}
+    )
+    assert preset["reference_models"] == [
+        {"provider": "openrouter", "model": "openai/gpt-5.5", "reasoning_effort": "low"}
+    ]
+
+
+def test_normalize_drops_empty_reasoning_effort():
+    preset = _preset_with_slot(
+        {"provider": "openrouter", "model": "openai/gpt-5.5", "reasoning_effort": "  "}
+    )
+    assert preset["reference_models"] == [
+        {"provider": "openrouter", "model": "openai/gpt-5.5"}
+    ]
+
+
+def test_normalize_without_key_is_unchanged():
+    preset = _preset_with_slot({"provider": "openrouter", "model": "openai/gpt-5.5"})
+    assert preset["reference_models"] == [
+        {"provider": "openrouter", "model": "openai/gpt-5.5"}
+    ]
+
+
+# -------------------------------------------------------------- moa_loop --
+
+class _FakeResponse:
+    class _Choice:
+        class _Msg:
+            content = "advice"
+        message = _Msg()
+    choices = [_Choice()]
+    usage = None
+
+
+def _run_reference_capturing(monkeypatch, slot):
+    captured: Dict[str, Any] = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _FakeResponse()
+
+    monkeypatch.setattr(moa_loop, "call_llm", fake_call_llm)
+    # Bypass provider resolution — the slot's endpoint doesn't exist in tests.
+    monkeypatch.setattr(moa_loop, "_slot_runtime",
+                        lambda s: {"provider": s["provider"], "model": s["model"]})
+    label, text, _usage = moa_loop._run_reference(
+        slot, [{"role": "user", "content": "q"}], temperature=0.3, max_tokens=None,
+    )
+    assert text == "advice"
+    return captured
+
+
+def test_run_reference_forwards_reasoning_effort(monkeypatch):
+    captured = _run_reference_capturing(
+        monkeypatch,
+        {"provider": "ref", "model": "gpt-oss-20b", "reasoning_effort": "low"},
+    )
+    assert captured["extra_body"] == {"reasoning_effort": "low"}
+    assert captured["task"] == "moa_reference"
+
+
+def test_run_reference_omits_extra_body_without_effort(monkeypatch):
+    captured = _run_reference_capturing(
+        monkeypatch, {"provider": "ref", "model": "gpt-oss-20b"},
+    )
+    assert captured.get("extra_body") is None

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -130,6 +130,33 @@ moa:
       reference_max_tokens: 600   # concise advice → faster turns
 ```
 
+### Dialing down advisor thinking with `reasoning_effort`
+
+Reasoning models spend most of their advisor turn *thinking* rather than
+writing. For models that accept a reasoning-effort parameter (gpt-oss,
+o-series-style backends), you can set `reasoning_effort` **per reference
+slot** to cap that spend without touching the acting aggregator's own
+reasoning configuration:
+
+```yaml
+moa:
+  presets:
+    fast:
+      reference_models:
+        - provider: openrouter
+          model: openai/gpt-5.5
+          reasoning_effort: low   # advisors think briefly; aggregator unaffected
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+```
+
+The value is passed through to the slot's backend as-is (`low` / `medium` /
+`high` on most providers). Backends that don't support the parameter reject or
+ignore it per their normal handling — a rejected reference degrades to a
+labelled note for the aggregator, never aborting the turn. Slots without the
+key behave exactly as before.
+
 Leave it unset (or `0`/blank) to keep the prior uncapped behavior.
 
 ## Terminal preset management


### PR DESCRIPTION
## What does this PR do?

MoA reference models are **advisors**: the aggregator only reads their final advice, but on reasoning models (gpt-oss, o-series-style backends) most of an advisor's turn is private thinking the aggregator never sees. That thinking dominates advisor latency and token spend — and today there is no way to dial it down for references without also changing the acting aggregator's reasoning configuration.

This PR adds an optional per-slot `reasoning_effort` key on MoA reference slots:

```yaml
moa:
  presets:
    fast:
      reference_models:
        - provider: openrouter
          model: openai/gpt-5.5
          reasoning_effort: low   # advisors think briefly; aggregator unaffected
```

The value is preserved through preset normalization and forwarded to the slot's backend via `extra_body={"reasoning_effort": ...}` on the reference call only. Backends that don't support the parameter reject or ignore it per their normal handling — and a rejected reference already degrades to a labelled note for the aggregator, never aborting the MoA turn. Slots without the key behave byte-identically to before. Complements `reference_max_tokens` (which caps advisor *output*; this caps advisor *thinking*).

## Related Issue

No existing issue — motivated by a local MoA deployment where a gpt-oss-20b advisor spent the bulk of each reference turn in its reasoning chain.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/moa_config.py` — `_clean_slot` preserves an optional `reasoning_effort` string on slots (stripped/lowercased; empty values dropped), so the key survives preset normalization instead of being whitelisted away.
- `agent/moa_loop.py` — `_run_reference` forwards the slot's value as `extra_body={"reasoning_effort": ...}`; omitted entirely when unset.
- `website/docs/user-guide/features/mixture-of-agents.md` — documented alongside the existing `reference_max_tokens` tuning section.
- `tests/agent/test_moa_reference_reasoning_effort.py` — 5 tests covering both halves (normalization preserve/strip/absent; call forwarding with and without the key).

## How to Test

1. `pytest tests/agent/test_moa_reference_reasoning_effort.py tests/hermes_cli/test_moa_config.py tests/agent/test_moa_slot_api_mode.py tests/run_agent/test_moa_loop_mode.py -q` → all pass (5 new + existing MoA suites).
2. Live: add `reasoning_effort: low` to a reference slot of a preset pointing at a gpt-oss-style backend, run a MoA turn, and observe the reference request carries `reasoning_effort` (backend log) and the advisor's reasoning shortens accordingly.
3. Remove the key → requests are byte-identical to current behavior (no `extra_body` sent).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(moa):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — new tests plus the adjacent MoA suites (`test_moa_config`, `test_moa_slot_api_mode`, `test_moa_loop_mode`) all pass; the full suite has a handful of pre-existing environment-dependent failures on this box that reproduce identically on clean `main`
- [x] I've added tests for my changes (5 new tests)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/mixture-of-agents.md`)
- [x] I've updated `cli-config.yaml.example` — N/A (MoA presets are documented in the MoA feature doc, not the example file, which has no `moa:` section)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure config/request plumbing, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A (no tool behavior change)
