### PR TITLE
fix(cli): skip TUI workspace check for managed installs (Homebrew/NixOS)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1697,10 +1697,15 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
     if tui_dir.is_dir():
         return
 
-    # Managed installs (Homebrew, NixOS) ship the TUI prebuilt in
-    # ``hermes_cli/tui_dist/`` — there is no ``ui-tui/`` source tree to
-    # restore.  Let the caller fall through to ``_find_bundled_tui()``.
+    # Managed installs (Homebrew, NixOS) and pip-installed wheels ship the
+    # TUI prebuilt in ``hermes_cli/tui_dist/`` — there is no ``ui-tui/``
+    # source tree to restore.  Let the caller fall through to
+    # ``_find_bundled_tui()``.  We check for the bundled entry point
+    # directly so that package-shaped installs without ``HERMES_MANAGED``
+    # set also skip the git-restore gate (#57031).
     if os.environ.get("HERMES_MANAGED", "").strip():
+        return
+    if _find_bundled_tui() is not None:
         return
 
     if _restore_tui_workspace(tui_dir):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1697,6 +1697,12 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
     if tui_dir.is_dir():
         return
 
+    # Managed installs (Homebrew, NixOS) ship the TUI prebuilt in
+    # ``hermes_cli/tui_dist/`` — there is no ``ui-tui/`` source tree to
+    # restore.  Let the caller fall through to ``_find_bundled_tui()``.
+    if os.environ.get("HERMES_MANAGED", "").strip():
+        return
+
     if _restore_tui_workspace(tui_dir):
         if not os.environ.get("HERMES_QUIET"):
             print(f"Restored missing TUI workspace: {tui_dir}")

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -352,6 +352,30 @@ def test_make_tui_argv_exits_with_recovery_hint_when_workspace_unrecoverable(
     assert "hermes update --force" in err
 
 
+def test_make_tui_argv_skips_workspace_check_for_managed_install(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """Managed installs (Homebrew/NixOS) skip ui-tui check and use bundled TUI."""
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setenv("HERMES_MANAGED", "homebrew")
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+
+    # Create a bundled tui_dist so _find_bundled_tui succeeds.
+    hermes_cli_dir = Path(main_mod.__file__).parent
+    bundled = tmp_path / "bundled_tui_dist"
+    (bundled / "entry.js").parent.mkdir(parents=True)
+    (bundled / "entry.js").write_text("console.log('tui')")
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled / "entry.js")
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    # Should NOT raise SystemExit — managed mode skips the workspace gate.
+    argv, cwd = main_mod._make_tui_argv(tmp_path / "ui-tui", tui_dev=False)
+    assert "node" in argv[0]
+    assert str(bundled / "entry.js") in argv
+    err = capsys.readouterr().err
+    assert "TUI workspace is missing" not in err
+
+
 def test_make_tui_argv_restores_missing_workspace_from_git(
     tmp_path: Path, main_mod, monkeypatch, capsys
 ) -> None:

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -376,6 +376,29 @@ def test_make_tui_argv_skips_workspace_check_for_managed_install(
     assert "TUI workspace is missing" not in err
 
 
+def test_make_tui_argv_skips_workspace_check_for_bundled_wheel(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """Pip-installed wheels with bundled TUI skip workspace check without HERMES_MANAGED."""
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+
+    # Simulate a bundled tui_dist/entry.js (pip wheel layout).
+    bundled = tmp_path / "bundled_tui_dist"
+    (bundled / "entry.js").parent.mkdir(parents=True)
+    (bundled / "entry.js").write_text("console.log('tui')")
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda: bundled / "entry.js")
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    # Should NOT raise SystemExit — bundled fallback is checked before git-restore.
+    argv, cwd = main_mod._make_tui_argv(tmp_path / "ui-tui", tui_dev=False)
+    assert "node" in argv[0]
+    assert str(bundled / "entry.js") in argv
+    err = capsys.readouterr().err
+    assert "TUI workspace is missing" not in err
+
+
 def test_make_tui_argv_restores_missing_workspace_from_git(
     tmp_path: Path, main_mod, monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes --tui` crashing on Homebrew/Linuxbrew installs with "the TUI workspace is missing" error. The `_ensure_tui_workspace()` guard assumes a git checkout with `ui-tui/` source tree, but managed installs (Homebrew, NixOS) ship the TUI prebuilt in `hermes_cli/tui_dist/` — there is no `ui-tui/` directory to restore. The fix adds an early return when `HERMES_MANAGED` is set, letting the caller fall through to `_find_bundled_tui()` which already handles the prebuilt bundle path.

## Related Issue

Fixes #57031

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Added `HERMES_MANAGED` check in `_ensure_tui_workspace()` to skip the git-restore gate for managed installs (Homebrew, NixOS), allowing fallback to the bundled `tui_dist/` TUI.
- `tests/hermes_cli/test_tui_npm_install.py`: Added `test_make_tui_argv_skips_workspace_check_for_managed_install` covering the managed-install code path.

## How to Test

1. `python -m pytest tests/hermes_cli/test_tui_npm_install.py -q` — should pass (30/30 including the new test)
2. On a Homebrew install: `hermes --tui` should no longer crash with "TUI workspace is missing" (it will use the bundled `tui_dist/entry.js` instead)
3. On a dev checkout without `HERMES_MANAGED`: existing behavior is unchanged — `_ensure_tui_workspace` still attempts `git restore` and shows the recovery hint if that fails

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_tui_npm_install.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — N/A (HERMES_MANAGED is set by package managers on all platforms)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
