### PR TITLE
fix(tui-gateway): claim active-session leases lazily and release them when idle

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -563,6 +563,11 @@ session_reset:
 # top-level key takes precedence over gateway.max_concurrent_sessions. The cap
 # is a best-effort single-host/profile runtime guard; Hermes fails open if the
 # local runtime lease registry cannot be read or locked.
+# Counting is surface-aware: CLI processes count while open, messaging turns
+# count while in flight, and TUI/desktop tabs count from their first message
+# until they go idle (30 min default; HERMES_TUI_LEASE_IDLE_S overrides,
+# 0 = hold until the tab closes) — idle tabs release their slot and re-acquire
+# it on the next message.
 max_concurrent_sessions: null
 
 # When true, group/channel chats use one session per participant when the platform

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -1,8 +1,13 @@
 """Cross-process active chat session leases.
 
 The session database records persisted conversations.  This module records
-currently open chat surfaces, including idle CLI/TUI sessions that have not
-written a transcript row yet.
+currently active chat surfaces, including CLI sessions that have not written
+a transcript row yet.  What "active" means is surface-specific: the CLI
+holds a lease for the life of the interactive process, the messaging
+gateway claims per in-flight turn, and the TUI/desktop gateway claims on a
+tab's first turn and hands the slot back after an idle window (so open but
+quiet tabs don't pin ``max_concurrent_sessions``; see
+``tui_gateway.server._ensure_turn_lease`` / ``_release_idle_session_leases``).
 """
 
 from __future__ import annotations

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12,11 +12,18 @@ from unittest.mock import patch
 import pytest
 
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
-from hermes_cli.active_sessions import active_session_registry_snapshot
+from hermes_cli.active_sessions import (
+    active_session_registry_snapshot,
+    try_acquire_active_session,
+)
 from tui_gateway import server
 
 
-def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
+def test_session_create_claims_lazily_and_first_turn_hits_the_cap(monkeypatch, tmp_path):
+    """Opening a tab is free: the active-session slot is claimed lazily on the
+    tab's FIRST TURN (_ensure_turn_lease), not at session.create — so idle
+    tabs can't pin max_concurrent_sessions. The cap is enforced when the tab
+    actually speaks."""
     home = tmp_path / ".hermes"
     home.mkdir()
     (home / "config.yaml").write_text("max_concurrent_sessions: 1\n", encoding="utf-8")
@@ -35,23 +42,47 @@ def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
         monkeypatch.setattr(server, "_start_agent_build", lambda *args, **kwargs: None)
         monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
 
+        # Another surface holds the only slot.
+        blocker, message = try_acquire_active_session(
+            session_id="other-surface",
+            surface="cli",
+            config={"max_concurrent_sessions": 1},
+        )
+        assert message is None
+        assert blocker is not None
+
+        # Opening tabs still succeeds and claims nothing.
         first = server._methods["session.create"]("r1", {"cols": 80})
         assert "result" in first
         sid = first["result"]["session_id"]
-
         second = server._methods["session.create"]("r2", {"cols": 80})
-        assert second["error"]["message"] == (
+        assert "result" in second
+        assert [entry["session_id"] for entry in active_session_registry_snapshot()] == [
+            "other-surface"
+        ]
+
+        # The tab's first turn is what hits the cap...
+        session = server._sessions[sid]
+        limit = server._ensure_turn_lease(sid, session)
+        assert limit == (
             "Hermes is at the active session limit (1/1). "
             "Try again when another session finishes."
         )
-        assert list(server._sessions) == [sid]
+        assert session.get("active_session_lease") is None
 
+        # ...and claims (then reuses) the slot once it frees up.
+        blocker.release()
+        assert server._ensure_turn_lease(sid, session) is None
+        lease = session.get("active_session_lease")
+        assert lease is not None
+        assert server._ensure_turn_lease(sid, session) is None
+        assert session.get("active_session_lease") is lease
+        assert len(active_session_registry_snapshot()) == 1
+
+        # Closing the tab returns the slot.
         closed = server._methods["session.close"]("r3", {"session_id": sid})
         assert closed["result"]["closed"] is True
         assert active_session_registry_snapshot() == []
-
-        third = server._methods["session.create"]("r4", {"cols": 80})
-        assert "result" in third
     finally:
         _clear_server_sessions()
         server._cfg_cache = None

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -973,6 +973,162 @@ def test_sync_session_key_after_compress_reanchors_active_session_lease(
     lease.release()
 
 
+# ── Lazy turn leases + idle release ──────────────────────────────────
+
+
+def _lease_test_session(key: str = "session-1", **overrides) -> dict:
+    session = {
+        "active_session_lease": None,
+        "agent_ready": None,
+        "created_at": time.time(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "last_active": time.time(),
+        "running": False,
+        "session_key": key,
+    }
+    session.update(overrides)
+    return session
+
+
+def test_ensure_turn_lease_claims_once_and_reuses(server, monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_concurrent_sessions": 1})
+    from hermes_cli.active_sessions import active_session_registry_snapshot
+
+    session = _lease_test_session()
+    assert server._ensure_turn_lease("ui-1", session) is None
+    lease = session["active_session_lease"]
+    assert lease is not None
+    assert [e["session_id"] for e in active_session_registry_snapshot()] == ["session-1"]
+
+    # A held lease is reused, not re-claimed.
+    assert server._ensure_turn_lease("ui-1", session) is None
+    assert session["active_session_lease"] is lease
+    assert len(active_session_registry_snapshot()) == 1
+    lease.release()
+
+
+def test_ensure_turn_lease_surfaces_limit_message_at_cap(server, monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_concurrent_sessions": 1})
+    from hermes_cli.active_sessions import try_acquire_active_session
+
+    blocker, message = try_acquire_active_session(
+        session_id="other-surface",
+        surface="gateway:telegram",
+        config={"max_concurrent_sessions": 1},
+    )
+    assert message is None
+
+    session = _lease_test_session()
+    limit = server._ensure_turn_lease("ui-1", session)
+    assert limit == (
+        "Hermes is at the active session limit (1/1). "
+        "Try again when another session finishes."
+    )
+    assert session["active_session_lease"] is None
+
+    blocker.release()
+    assert server._ensure_turn_lease("ui-1", session) is None
+    assert session["active_session_lease"] is not None
+    session["active_session_lease"].release()
+
+
+def test_ensure_turn_lease_does_not_store_into_finalized_session(
+    server, monkeypatch, tmp_path
+):
+    """A tab closed between claim and store must not strand a registry entry:
+    the freshly claimed lease is handed straight back."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_concurrent_sessions": 1})
+    from hermes_cli.active_sessions import active_session_registry_snapshot
+
+    session = _lease_test_session(_finalized=True)
+    assert server._ensure_turn_lease("ui-1", session) is None
+    assert session["active_session_lease"] is None
+    assert active_session_registry_snapshot() == []
+
+
+def test_idle_lease_release_frees_slot_and_next_turn_reacquires(
+    server, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_concurrent_sessions": 1})
+    from hermes_cli.active_sessions import active_session_registry_snapshot
+
+    now = time.time()
+    stale = now - server._LEASE_IDLE_RELEASE_S - 60
+    session = _lease_test_session(last_active=stale, created_at=stale)
+    assert server._ensure_turn_lease("ui-1", session) is None
+    assert session["active_session_lease"] is not None
+    server._sessions["ui-1"] = session
+
+    # Idle past the window: the LEASE goes back, the session stays live.
+    server._release_idle_session_leases(now)
+    assert session.get("active_session_lease") is None
+    assert active_session_registry_snapshot() == []
+    assert server._sessions["ui-1"] is session
+
+    # The next turn transparently re-acquires.
+    assert server._ensure_turn_lease("ui-1", session) is None
+    assert session["active_session_lease"] is not None
+    assert len(active_session_registry_snapshot()) == 1
+    session["active_session_lease"].release()
+
+
+def test_idle_lease_release_skips_busy_recent_and_pending_sessions(
+    server, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(server, "_load_cfg", lambda: None)
+    now = time.time()
+    stale = now - server._LEASE_IDLE_RELEASE_S - 60
+
+    running = _lease_test_session(
+        "session-running", last_active=stale, created_at=stale, running=True
+    )
+    recent = _lease_test_session("session-recent")
+    queued = _lease_test_session(
+        "session-queued",
+        last_active=stale,
+        created_at=stale,
+        queued_prompt={"text": "next turn"},
+    )
+    pending = _lease_test_session("session-pending", last_active=stale, created_at=stale)
+    for sid, session in (
+        ("ui-running", running),
+        ("ui-recent", recent),
+        ("ui-queued", queued),
+        ("ui-pending", pending),
+    ):
+        session["active_session_lease"] = object.__new__(type("_Sentinel", (), {}))
+        server._sessions[sid] = session
+    # An unanswered gateway prompt marks ui-pending as awaiting input.
+    server._pending["rid-pending"] = ("ui-pending", None)
+
+    try:
+        server._release_idle_session_leases(now)
+        assert running["active_session_lease"] is not None
+        assert recent["active_session_lease"] is not None
+        assert queued["active_session_lease"] is not None
+        assert pending["active_session_lease"] is not None
+    finally:
+        server._pending.pop("rid-pending", None)
+
+
+def test_idle_lease_release_disabled_with_zero_window(server, monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(server, "_LEASE_IDLE_RELEASE_S", 0.0)
+    now = time.time()
+    session = _lease_test_session(last_active=now - 999999, created_at=now - 999999)
+    session["active_session_lease"] = object.__new__(type("_Sentinel", (), {}))
+    server._sessions["ui-1"] = session
+
+    server._release_idle_session_leases(now)
+    assert session["active_session_lease"] is not None
+
+
 def test_session_resume_live_payload_uses_current_history_with_ancestors(server, monkeypatch):
     """Live resume should not reuse a stale ancestor-inclusive snapshot."""
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -429,6 +429,52 @@ def _release_active_session_slot(session: dict | None) -> None:
         logger.debug("Failed to release active session slot", exc_info=True)
 
 
+def _ensure_turn_lease(sid: str, session: dict) -> str | None:
+    """Claim the cross-process active-session slot for this session's turn,
+    unless the session already holds one.
+
+    TUI/desktop sessions acquire their registry lease lazily on the first
+    turn (not at session.create/resume, which fire for every composer paint
+    and sidebar switch) and keep it across turns; the idle reaper hands the
+    slot back after ``_LEASE_IDLE_RELEASE_S`` without conversational
+    activity (see ``_release_idle_session_leases``). This is the re-acquire
+    half: mirrors the platform gateway's claim-per-turn in
+    ``gateway/run.py`` handle_message.
+
+    Returns the limit message when the cap is reached (the caller surfaces
+    it as the turn's error), None on success or fail-open.
+    """
+    with session["history_lock"]:
+        if session.get("active_session_lease") is not None:
+            return None
+    lease, limit_message = _claim_active_session_slot(
+        str(session.get("session_key") or ""),
+        live_session_id=sid,
+    )
+    if limit_message is not None:
+        return limit_message
+    if lease is None:
+        # Fail-open (registry unreadable/locked) — proceed uncounted, same as
+        # every other surface. The next turn retries the claim.
+        return None
+    # Store under the same lock turn-start uses, re-checking both the slot (a
+    # concurrent claimer may have won — e.g. a stuck-`running` overlap) and
+    # finalize (the tab may have closed between claim and store; a lease
+    # stored into a finalized session would leak until process exit).
+    with session["history_lock"]:
+        if (
+            session.get("active_session_lease") is None
+            and not session.get("_finalized")
+        ):
+            session["active_session_lease"] = lease
+            return None
+    try:
+        lease.release()
+    except Exception:
+        logger.debug("Failed to release turn lease after lost store race", exc_info=True)
+    return None
+
+
 def _transfer_active_session_slot(
     sid: str,
     session: dict,
@@ -771,12 +817,73 @@ def _session_is_evictable(sid: str, session: dict, now: float) -> bool:
     return (now - last_active) > _SESSION_TTL_S and (now - created_at) > _SESSION_TTL_S
 
 
+# How long a session may sit without conversational activity before its
+# cross-process active-session lease (max_concurrent_sessions slot) is handed
+# back. The lease only — the session, its agent, and its transcript stay live;
+# the next turn re-acquires through _ensure_turn_lease. Without this, tabs
+# sitting open in a CONNECTED desktop app hold their slot forever: the TTL
+# reaper above requires a dead transport, so N idle overnight tabs pin the cap
+# at N and lock out every other surface. 0 disables idle release.
+try:
+    _LEASE_IDLE_RELEASE_S = float(os.environ.get("HERMES_TUI_LEASE_IDLE_S") or 1800.0)
+except (TypeError, ValueError):
+    _LEASE_IDLE_RELEASE_S = 1800.0
+_LEASE_IDLE_RELEASE_S = max(0.0, _LEASE_IDLE_RELEASE_S)
+
+
+def _release_idle_session_leases(now: float) -> None:
+    """Release the active-session LEASE (not the session) for idle sessions.
+
+    Runs on the reaper cadence. Applies to live-transport sessions too — that
+    is the point: connected-but-idle tabs are exactly the ones the TTL reaper
+    can never free. Skips anything mid-turn, awaiting an input/approval
+    prompt, holding a queued next-turn prompt, or still building its agent
+    (imminent turn). The `running` check happens under history_lock, the same
+    lock every turn-start path sets it under, so a lease can't be pulled out
+    from under a turn that is about to reuse it.
+    """
+    if _LEASE_IDLE_RELEASE_S <= 0:
+        return
+    with _sessions_lock:
+        candidates = list(_sessions.items())
+    for sid, session in candidates:
+        if session.get("active_session_lease") is None or session.get("_finalized"):
+            continue
+        lock = session.get("history_lock")
+        if lock is None:
+            continue
+        with lock:
+            if session.get("running") or session.get("queued_prompt"):
+                continue
+            if _session_pending_kind(sid):
+                continue
+            ready = session.get("agent_ready")
+            if ready is not None and not ready.is_set() and not session.get("lazy"):
+                continue
+            last_active = float(session.get("last_active") or 0.0)
+            created_at = float(session.get("created_at") or 0.0)
+            reference = max(last_active, created_at)
+            if (now - reference) <= _LEASE_IDLE_RELEASE_S:
+                continue
+            lease = session.pop("active_session_lease", None)
+        if lease is None:
+            continue
+        try:
+            lease.release()
+        except Exception:
+            logger.debug("Failed to release idle active session lease", exc_info=True)
+
+
 def _reap_idle_sessions() -> None:
     now = time.time()
     with _sessions_lock:
         victims = [sid for sid, s in _sessions.items() if _session_is_evictable(sid, s, now)]
     for sid in victims:
         _close_session_by_id(sid, end_reason="idle_timeout")
+    try:
+        _release_idle_session_leases(now)
+    except Exception:
+        logger.debug("idle lease release sweep failed", exc_info=True)
     _enforce_session_cap()
 
 
@@ -4939,10 +5046,13 @@ def _(rid, params: dict) -> dict:
 
     ready = threading.Event()
     now = time.time()
-    lease, limit_message = _claim_active_session_slot(key, live_session_id=sid)
-    if limit_message is not None:
-        return _err(rid, 4090, limit_message)
 
+    # No active-session slot is claimed here. Every TUI/desktop launch (and
+    # every "New agent" / draft) opens a session just to paint the composer —
+    # like the DB row (see the NOTE below), the cross-process lease is claimed
+    # lazily on the first turn (_ensure_turn_lease), and idle tabs hand it
+    # back (_release_idle_session_leases) so open-but-quiet tabs don't pin
+    # max_concurrent_sessions.
     with _sessions_lock:
         _sessions[sid] = {
             "agent": None,
@@ -4950,7 +5060,7 @@ def _(rid, params: dict) -> dict:
             "agent_ready": ready,
             "attached_images": [],
             "close_on_disconnect": is_truthy_value(params.get("close_on_disconnect", False)),
-            "active_session_lease": lease,
+            "active_session_lease": None,
             "cols": cols,
             "created_at": now,
             "edit_snapshots": {},
@@ -5365,17 +5475,16 @@ def _(rid, params: dict) -> dict:
     # (resume_session_id keeps the upgrade on the stored conversation).
     if is_truthy_value(params.get("lazy", False)):
         sid = uuid.uuid4().hex[:8]
-        lease, limit_message = _claim_active_session_slot(target, live_session_id=sid)
-        if limit_message is not None:
-            return _err(rid, 4090, limit_message)
+        # Active-session lease is claimed lazily on the first turn (see
+        # _ensure_turn_lease) — reopening a tab never counts against
+        # max_concurrent_sessions by itself.
+        lease = None
         try:
             db.reopen_session(target)
             # The child's OWN conversation only — include_ancestors would prepend
             # the parent's transcript onto the subagent's branch.
             history = db.get_messages_as_conversation(target)
         except Exception as e:
-            if lease is not None:
-                lease.release()
             return _err(rid, 5000, f"resume failed: {e}")
         cwd = profile_resume_cwd or os.getenv("TERMINAL_CWD", os.getcwd())
         record = _deferred_session_record(
@@ -5426,9 +5535,8 @@ def _(rid, params: dict) -> dict:
     # session's persisted runtime identity, and is a real (upgradable) session.
     if not is_truthy_value(params.get("eager_build", False)):
         sid = uuid.uuid4().hex[:8]
-        lease, limit_message = _claim_active_session_slot(target, live_session_id=sid)
-        if limit_message is not None:
-            return _err(rid, 4090, limit_message)
+        # Lease claimed lazily on the first turn (_ensure_turn_lease).
+        lease = None
         # Interactive resume routes approvals/clarify through gateway prompts;
         # the deferred build wires the remaining per-session callbacks.
         _enable_gateway_prompts()
@@ -5437,8 +5545,6 @@ def _(rid, params: dict) -> dict:
             raw_history = db.get_messages_as_conversation(target)
             display_history = db.get_messages_as_conversation(target, include_ancestors=True)
         except Exception as e:
-            if lease is not None:
-                lease.release()
             return _err(rid, 5000, f"resume failed: {e}")
         # Display keeps the full transcript; the model-fed history drops a
         # dangling/interrupted tool-call tail so a session killed mid-loop does
@@ -5496,9 +5602,7 @@ def _(rid, params: dict) -> dict:
     # _session_resume_lock across it would stall session.close on the main
     # dispatch thread (it's not a _LONG_HANDLER), blocking fast-path RPCs.
     sid = uuid.uuid4().hex[:8]
-    lease, limit_message = _claim_active_session_slot(target, live_session_id=sid)
-    if limit_message is not None:
-        return _err(rid, 4090, limit_message)
+    # Active-session lease is claimed lazily on the first turn (_ensure_turn_lease).
     _enable_gateway_prompts()
     home_token = (
         set_hermes_home_override(str(profile_home)) if profile_home is not None else None
@@ -5539,8 +5643,6 @@ def _(rid, params: dict) -> dict:
         finally:
             _clear_session_context(tokens)
     except Exception as e:
-        if lease is not None:
-            lease.release()
         return _err(rid, 5000, f"resume failed: {e}")
     finally:
         if home_token is not None:
@@ -5557,8 +5659,6 @@ def _(rid, params: dict) -> dict:
                     agent.close()
             except Exception:
                 pass
-            if lease is not None:
-                lease.release()
             other_sid, other_session = live
             payload = _live_session_payload(
                 other_sid,
@@ -5599,10 +5699,7 @@ def _(rid, params: dict) -> dict:
                 # skills — must resolve to the resumed profile too).
                 if profile_home is not None:
                     _sessions[sid]["profile_home"] = str(profile_home)
-                _sessions[sid]["active_session_lease"] = lease
         except Exception as e:
-            if lease is not None:
-                lease.release()
             return _err(rid, 5000, f"resume failed: {e}")
         session = _sessions.get(sid) or {}
     return _ok(
@@ -7754,9 +7851,8 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4008, "nothing to branch — send a message first")
     new_key = _new_session_key()
     new_sid = uuid.uuid4().hex[:8]
-    lease, limit_message = _claim_active_session_slot(new_key, live_session_id=new_sid)
-    if limit_message is not None:
-        return _err(rid, 4090, limit_message)
+    # Active-session lease is claimed lazily on the branch's first turn
+    # (_ensure_turn_lease) — opening the branch tab doesn't consume a slot.
     branch_name = params.get("name", "")
     try:
         if branch_name:
@@ -7789,8 +7885,6 @@ def _(rid, params: dict) -> dict:
             )
         db.set_session_title(new_key, title)
     except Exception as e:
-        if lease is not None:
-            lease.release()
         return _err(rid, 5008, f"branch failed: {e}")
     try:
         tokens = _set_session_context(new_key)
@@ -7801,11 +7895,7 @@ def _(rid, params: dict) -> dict:
         _init_session(
             new_sid, new_key, agent, list(history), cols=session.get("cols", 80)
         )
-        if new_sid in _sessions:
-            _sessions[new_sid]["active_session_lease"] = lease
     except Exception as e:
-        if lease is not None:
-            lease.release()
         return _err(rid, 5000, f"agent init failed on branch: {e}")
     return _ok(rid, {"session_id": new_sid, "title": title, "parent": old_key})
 
@@ -8471,6 +8561,19 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         goal_followup = None  # set by the post-turn goal hook below
         try:
+            # Claim (or reuse) the cross-process active-session slot before any
+            # model work. First turn of a tab and first turn after an idle
+            # release both land here; every turn entry point (prompt.submit,
+            # queued drain, goal continuation, notification turns) funnels
+            # through this body. At cap, surface the standard limit message as
+            # this turn's error — same message.start→error shape as the
+            # ctx.blocked path below; the finally clears running/inflight so
+            # the client returns to idle.
+            limit_message = _ensure_turn_lease(sid, session)
+            if limit_message is not None:
+                _emit("error", sid, {"message": limit_message})
+                return
+
             from tools.approval import (
                 reset_current_session_key,
                 set_current_session_key,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1622,7 +1622,7 @@ The master `streaming.enabled` switch is `false` by default — nothing streams 
 
 ## Group Chat Session Isolation
 
-Limit how many chat sessions can actively be open across CLI, TUI/dashboard,
+Limit how many chat sessions can be active at once across CLI, TUI/dashboard,
 and messaging gateway:
 
 ```yaml
@@ -1631,6 +1631,21 @@ max_concurrent_sessions: null  # null/0 = unlimited; positive integer = active s
 
 When the cap is reached, Hermes returns a direct limit message for new sessions.
 Existing active sessions keep their normal behavior.
+
+What counts as "active" is surface-specific:
+
+- **CLI**: an interactive `hermes` process holds a slot for its lifetime.
+- **Messaging gateway** (Telegram, Discord, …): a slot is held per in-flight
+  turn and released when the turn finishes.
+- **TUI / desktop / dashboard**: a tab claims its slot on its first message
+  (opening tabs or switching sessions is free) and keeps it while the
+  conversation is active. A tab with no activity for 30 minutes hands its
+  slot back automatically and transparently re-acquires it on the next
+  message — so open-but-idle tabs don't pin the cap overnight. If the cap is
+  full at re-acquire time, that message fails with the standard limit
+  message; retry when a slot frees up. Tune the idle window with the
+  `HERMES_TUI_LEASE_IDLE_S` environment variable (seconds; `0` keeps slots
+  held until the tab closes).
 
 The canonical key is top-level `max_concurrent_sessions`. Hermes also accepts
 `gateway.max_concurrent_sessions` as a fallback, but the top-level key wins when


### PR DESCRIPTION
## Problem

`max_concurrent_sessions` slots leak to idle desktop/TUI tabs until the tab closes. Two release-path bugs compound:

1. **The lease is claimed at composer-paint time, before any user input.** Every TUI/desktop launch, "New agent", and draft calls `session.create`, which claimed a registry slot immediately (`tui_gateway/server.py`). Note the asymmetry with the gateway's own persistence policy: the DB row is deliberately created *lazily on the first prompt* to avoid ghost "Untitled" sessions for every composer paint — but the lease was eager. At the cap, even *launching the desktop app* failed with the session-limit error.
2. **A lease held by a connected client can never be released.** The only release path was `_finalize_session` (tab close / WS-orphan reap / process exit), and the idle reaper requires a **dead transport** plus a 6h TTL. Tabs sitting open in a healthy connected desktop app hold their slot forever.

Net effect: N idle overnight tabs pin the cap at N/N, and every new session on *any* surface (messaging gateway, CLI, new tabs) is rejected with "Hermes is at the active session limit" — even though nothing is running.

## Fix

Keep the cap's semantics ("recently active surfaces"); fix when the TUI gateway claims and releases:

- **Lazy claim on the first turn** (`_ensure_turn_lease`, at the top of the `_run_prompt_submit` run body — the chokepoint every turn entry funnels through: `prompt.submit`, queued-prompt drain, goal continuation, notification turns). Opening tabs and switching sessions no longer consumes a slot.
- **Idle release** via the existing reaper scan (`_release_idle_session_leases`): a session with no conversational activity for 30 minutes hands back the *lease only* — the session, its agent, and its transcript stay live. Skips anything mid-turn, awaiting an input/approval prompt, holding a queued prompt, or still building its agent. `HERMES_TUI_LEASE_IDLE_S` overrides the window (`0` = hold until tab close, i.e. today's behavior after first prompt).
- **Transparent re-acquire** on the next turn. If the cap is genuinely full at that moment, the turn surfaces the standard limit message as its error event — the same `message.start` → `error` shape as the existing context-injection-refused path, which both the Ink TUI and the desktop client already render as a failed turn (not a hung spinner).
- The lease is deliberately **kept across turns** (no per-turn churn): chained turns (queued prompts, goal continuations) can never lose their slot mid-run, and the compression re-anchor (`_transfer_active_session_slot`, #49041 fallback included) works unchanged on the same session slot.

Races covered: the claim's store is re-checked under `history_lock` (the same lock every turn-start path sets `running` under), a lease claimed for a tab that finalized in the claim window is handed straight back, and the idle sweep checks `running`/pending/queued state under that same lock so it can't pull a lease out from under a starting turn.

Why this shape instead of per-turn claim/release (what the messaging gateway does): releasing after every turn opens a window where a chained turn's re-claim loses to a concurrent surface — and the queued user prompt or notification event dispatched into that turn would be dropped. Holding across turns with an idle-window release avoids that class of bug entirely while still freeing idle tabs.

Per-surface semantics are now spelled out in the docs (`configuration.md`) and the `active_sessions.py` module docstring: CLI counts per open interactive process, messaging gateway per in-flight turn, TUI/desktop per recently-active tab.

## Tests

- `tests/tui_gateway/test_protocol.py`: new coverage for lazy claim + reuse, at-cap limit message, no-store-into-finalized-session, idle release + re-acquire, idle-release exemptions (running / recent / queued / pending), and `HERMES_TUI_LEASE_IDLE_S=0` disable. Existing compression lease re-anchor test unchanged and passing.
- `tests/test_tui_gateway_server.py`: `test_session_create_rejects_at_active_session_limit` reworked to pin the new contract (create claims nothing; the first turn hits the cap; close returns the slot).
- Green: `tests/hermes_cli/test_active_sessions.py`, `tests/gateway/test_max_concurrent_sessions.py`, `tests/tui_gateway/test_protocol.py`, `tests/hermes_cli/test_cli_active_session_limit.py` (96), `tests/test_tui_gateway_server.py` (303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
