### PR TITLE
fix(agent): make repair_message_sequence self-contained for orphaned assistant(tool_calls)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -511,8 +511,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             idx += 1
             continue
         call_ids = [
-            tc.get("id") for tc in (msg.get("tool_calls") or [])
-            if isinstance(tc, dict) and tc.get("id")
+            _ra().AIAgent._get_tool_call_id_static(tc)
+            for tc in (msg.get("tool_calls") or [])
+            if isinstance(tc, dict) and _ra().AIAgent._get_tool_call_id_static(tc)
         ]
         if not call_ids:
             idx += 1
@@ -524,12 +525,12 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             and isinstance(filtered[run_end], dict)
             and filtered[run_end].get("role") == "tool"
         ):
-            answered.add(filtered[run_end].get("tool_call_id"))
+            answered.add((filtered[run_end].get("tool_call_id") or "").strip())
             run_end += 1
         missing = [cid for cid in call_ids if cid not in answered]
         if missing:
             names = {
-                tc.get("id"): ((tc.get("function") or {}).get("name") or "unknown")
+                _ra().AIAgent._get_tool_call_id_static(tc): _ra().AIAgent._get_tool_call_name_static(tc)
                 for tc in (msg.get("tool_calls") or [])
                 if isinstance(tc, dict)
             }
@@ -537,7 +538,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 {
                     "role": "tool",
                     "tool_call_id": cid,
-                    "name": names.get(cid, "unknown"),
+                    "name": names.get(cid) or "unknown",
                     "content": "Tool execution was interrupted before a result was returned.",
                 }
                 for cid in missing

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -382,15 +382,22 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
          resumed histories. Refs #29148, #49147.
       1. Stray ``tool`` messages whose ``tool_call_id`` doesn't match
          any preceding assistant tool_call — dropped.
-      2. Consecutive ``user`` messages — merged with newline separator
+      2. ``assistant`` messages carrying ``tool_calls`` whose ids are not
+         fully answered by the tool messages immediately following them
+         — a synthetic error result is inserted for each unanswered id.
+         Interruption (``/stop``, process kill, resume mid tool-loop) can
+         leave some or all of a turn's calls unanswered; strict
+         OpenAI-compatible providers (DeepSeek v4, Moonshot/Kimi) reject
+         that shape outright — "An assistant message with 'tool_calls'
+         must be followed by tool messages…" — rather than responding
+         with an empty completion. Inserting a stub result (instead of
+         stripping the ``tool_calls``) keeps the model's stated intent
+         visible in the transcript. No-op when every call already has a
+         matching result — the "ongoing dialog" pattern (a complete
+         assistant(tool_calls)+tool pair followed by a user redirect
+         before the model's continuation turn) is left untouched.
+      3. Consecutive ``user`` messages — merged with newline separator
          so no user input is lost.
-
-    Deliberately does NOT rewind orphan ``assistant(tool_calls)+tool``
-    pairs that precede a user message — that pattern IS valid when the
-    previous turn completed normally and the user jumped in to redirect
-    before the model got a continuation turn (the ongoing dialog
-    pattern). The empty-response scaffolding stripper handles the
-    genuinely-broken variant via its flag-gated rewind.
 
     Returns the number of repairs made (for logging/telemetry).
     """
@@ -492,7 +499,55 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 known_tool_ids = set()
             filtered.append(msg)
 
-    # Pass 2: merge consecutive user messages. Preserves all user input
+    # Pass 2: close assistant(tool_calls) turns whose ids are not fully
+    # answered by the tool messages immediately following them. Runs after
+    # Pass 1 so stray/unmatched tool results have already been dropped and
+    # can't be mistaken for a real answer. A no-op whenever every call
+    # already has a matching result.
+    idx = 0
+    while idx < len(filtered):
+        msg = filtered[idx]
+        if not (isinstance(msg, dict) and msg.get("role") == "assistant"):
+            idx += 1
+            continue
+        call_ids = [
+            tc.get("id") for tc in (msg.get("tool_calls") or [])
+            if isinstance(tc, dict) and tc.get("id")
+        ]
+        if not call_ids:
+            idx += 1
+            continue
+        run_end = idx + 1
+        answered: set = set()
+        while (
+            run_end < len(filtered)
+            and isinstance(filtered[run_end], dict)
+            and filtered[run_end].get("role") == "tool"
+        ):
+            answered.add(filtered[run_end].get("tool_call_id"))
+            run_end += 1
+        missing = [cid for cid in call_ids if cid not in answered]
+        if missing:
+            names = {
+                tc.get("id"): ((tc.get("function") or {}).get("name") or "unknown")
+                for tc in (msg.get("tool_calls") or [])
+                if isinstance(tc, dict)
+            }
+            stubs = [
+                {
+                    "role": "tool",
+                    "tool_call_id": cid,
+                    "name": names.get(cid, "unknown"),
+                    "content": "Tool execution was interrupted before a result was returned.",
+                }
+                for cid in missing
+            ]
+            filtered[run_end:run_end] = stubs
+            repairs += len(stubs)
+            run_end += len(stubs)
+        idx = run_end
+
+    # Pass 3: merge consecutive user messages. Preserves all user input
     # so nothing the user typed is lost.
     merged: List[Dict] = []
     for msg in filtered:

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -201,6 +201,115 @@ def test_repair_preserves_system_messages():
     assert messages == original
 
 
+# ── Pass 2: close orphaned assistant(tool_calls) turns ─────────────────────
+
+def test_repair_closes_fully_unanswered_trailing_tool_calls():
+    """assistant(tool_calls) as the last message, no tool response at all —
+    e.g. the turn was interrupted before any tool executed. DeepSeek v4 and
+    other strict OpenAI-compatible providers reject an assistant message
+    with 'tool_calls' that isn't immediately followed by its tool results.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "compile llama.cpp"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [
+             {"id": "t1", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+             {"id": "t2", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+         ]},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 2
+    assert [m["role"] for m in messages] == ["user", "assistant", "tool", "tool"]
+    assert {m["tool_call_id"] for m in messages[2:]} == {"t1", "t2"}
+
+
+def test_repair_closes_partially_answered_tool_calls():
+    """Some of an assistant turn's tool_calls have a matching result, some
+    don't — a stub is inserted only for the missing ids.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "compile llama.cpp"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [
+             {"id": "t1", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+             {"id": "t2", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+             {"id": "t3", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+         ]},
+        {"role": "tool", "tool_call_id": "t1", "content": "ok"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 2
+    tool_ids = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
+    assert tool_ids == ["t1", "t2", "t3"]
+
+
+def test_repair_closes_orphaned_tool_calls_before_wakeup_message():
+    """Interrupted mid tool-loop, then a wakeup/cron notification lands as a
+    fresh user turn — the orphan is no longer the literal tail, but must
+    still be closed so alternation stays valid for the next API call.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "compile llama.cpp"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "bash", "arguments": "{}"}}]},
+        {"role": "user", "content": "[wakeup notification] resuming previous task"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert [m["role"] for m in messages] == ["user", "assistant", "tool", "user"]
+    assert messages[2]["tool_call_id"] == "t1"
+
+
+def test_repair_orphan_close_is_idempotent():
+    """Running repair twice must not insert duplicate stubs."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "compile llama.cpp"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "bash", "arguments": "{}"}}]},
+    ]
+
+    first = AIAgent._repair_message_sequence(agent, messages)
+    second = AIAgent._repair_message_sequence(agent, messages)
+
+    assert first == 1
+    assert second == 0
+    assert [m["role"] for m in messages] == ["user", "assistant", "tool"]
+
+
+def test_repair_still_preserves_complete_pair_before_user_redirect():
+    """Non-regression: a fully-answered assistant(tool_calls)+tool pair
+    followed by a user redirect is the valid 'ongoing dialog' pattern and
+    must not gain any synthetic tool messages.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "out"},
+        {"role": "user", "content": "Q2"},
+    ]
+    original = [dict(m) for m in messages]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 0
+    assert messages == original
+
+
 # ── repair_message_sequence_with_cursor (#44837) ───────────────────────────
 
 from agent.agent_runtime_helpers import repair_message_sequence_with_cursor

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -288,6 +288,30 @@ def test_repair_orphan_close_is_idempotent():
     assert [m["role"] for m in messages] == ["user", "assistant", "tool"]
 
 
+def test_repair_closes_orphaned_tool_calls_using_call_id_field():
+    """Codex/Responses-style tool_calls key the id as ``call_id`` rather
+    than ``id``. The close pass must use the same call_id||id extractor
+    as sanitize_api_messages, or Codex-shaped orphans go undetected.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"call_id": "cx1", "type": "function",
+                         "function": {"name": "bash", "arguments": "{}"}}]},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "cx1",
+        "name": "bash",
+        "content": "Tool execution was interrupted before a result was returned.",
+    }
+
+
 def test_repair_still_preserves_complete_pair_before_user_redirect():
     """Non-regression: a fully-answered assistant(tool_calls)+tool pair
     followed by a user redirect is the valid 'ongoing dialog' pattern and


### PR DESCRIPTION
## Summary

`repair_message_sequence` (`agent/agent_runtime_helpers.py`) sanitizes the persisted message history before every LLM call. It already handled 3 classes of malformed history — stray `tool` messages, consecutive-assistant merges, consecutive-user merges — but had no pass for the inverse case: an `assistant` message carrying `tool_calls` whose `tool_call_id`s are **not** answered by the `tool` messages that immediately follow it.

This PR adds that pass, makes the function self-contained, and fixes an id-extraction gap discovered during review.

## Background — how we got here

1. **#56980** reported this as a live HTTP 400 from DeepSeek v4 in production, with a specific repro (30+ message session, `/local-github-update` + `/local-llamacpp-compile`, build `c43aa6301`).
2. **The symptom class itself checks out.** The 400 in question — *"An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'..."* — is a general OpenAI-compatible-API requirement, not a DeepSeek-specific quirk, and it's well documented hitting DeepSeek from unrelated codebases:
   - Portkey's error library, verbatim match: https://portkey.ai/error-library/tool-call-response-error-10067
   - `charmbracelet/crush` against DeepSeek v3.1, with `tool_call_id`s named in the error: https://github.com/charmbracelet/crush/issues/862
   - `zed-industries/zed` against DeepSeek Reasoner during multi-tool-call prompts: https://github.com/zed-industries/zed/issues/51854
   - DeepSeek's own docs show the required shape (assistant `tool_calls` → matching `tool` message before the next request): https://api-docs.deepseek.com/guides/tool_calls

   So the *class* of failure #56980 named is real and independently reproduced elsewhere against the same provider — not invented.
3. Investigating the code independently (before even finding the issue) confirmed the underlying gap is real: `repair_message_sequence`'s own docstring said, verbatim, *"Deliberately does NOT rewind orphan `assistant(tool_calls)+tool` pairs..."* — an admitted, intentional omission.
4. Cross-checking #56980's own "Related Issues" list against the tracker confirmed 6/6 are real (#55442, #53716, #49147, #55603, #51727, #48879), two of them merged fixes from a maintainer for adjacent alternation bugs — so this repo has a real, well-documented history of shipping and fixing this bug class.
5. But **#56980's specific incident** doesn't hold up, checked directly against this repo:
   - The cited commit `c43aa6301` / `v2026.7.1-46-gc43aa6301` does not exist anywhere in the repo's full history (`git rev-list --all | grep c43aa6301` — zero hits, unshallowed). `git describe` on `main` at the time was `v2026.7.1-17-g88d1d6206` — 17 commits past the tag, not 46. Not a typo-level discrepancy — the cited point is 29 commits past where history actually ends.
   - The two cited slash commands, `/local-github-update` and `/local-llamacpp-compile`, don't exist anywhere in the tracked codebase (`git grep`, zero matches).
6. Running the real `repair_message_sequence -> sanitize_api_messages` pipeline against every orphan shape #56980 described — trailing unanswered `tool_calls`, partial parallel results, all-orphan after a merge, Codex `call_id`-format, orphan-then-user-injection — none of them reproduced a 400. `sanitize_api_messages` is called unconditionally right after `repair_message_sequence` in both production call sites (`conversation_loop.py:894`, `chat_completion_helpers.py:1536`), and `AIAgent.run_conversation` (used by CLI, `gateway/run.py`, and `tui_gateway/server.py` alike — there is no other entry point) always routes through `agent/conversation_loop.py`, so this is the single pipeline every client shares. It already injects a stub tool result for every orphaned `tool_call_id` before the request reaches the provider.
7. A maintainer-side close of #56980 reached the same empirical conclusion independently (matching finding, same broken commit citation carried over from the report without being caught) and asked for a raw rejected-payload artifact to proceed — which nobody has produced, because the described incident doesn't reproduce against `main`.
8. **Verdict: the DeepSeek 400 class is real and documented; #56980's specific incident, as filed, is not reproducible.** The design gap it pointed at is real regardless — see next section — so this work continues as a fresh issue (#57053) that documents the verified problem on its own terms instead of resting on a fabricated incident report.

## The actual, verified gap

`repair_message_sequence` runs on the canonical, persisted `messages` list (session state). `sanitize_api_messages` only patches the **ephemeral per-call `api_messages` copy** rebuilt fresh on every request — it never writes back to the persisted session.

Consequence: any caller that invokes `repair_message_sequence` without a *following* `sanitize_api_messages` call stays exposed to exactly the HTTP 400 #56980 described, and even in the covered path, the persisted session itself never actually heals — the same repair gets silently redone on every single call instead of converging once. Known/plausible callers in this position: sub-agent spawns, MoA reference-model calls, plugins, and the `run_agent.py:_repair_message_sequence` forwarder (currently exercised only by tests, but public API surface).

This PR closes that gap at the source — `repair_message_sequence` itself — instead of continuing to depend on a second, separately-invoked function to catch it downstream on every call.

## What changed

**`agent/agent_runtime_helpers.py`** — new Pass 2 inserted between the existing stray-tool-drop pass and the consecutive-user-merge pass (renumbered to Pass 3):

```python
# Pass 2: close assistant(tool_calls) turns whose ids are not fully
# answered by the tool messages immediately following them.
idx = 0
while idx < len(filtered):
    msg = filtered[idx]
    if not (isinstance(msg, dict) and msg.get("role") == "assistant"):
        idx += 1
        continue
    call_ids = [
        _ra().AIAgent._get_tool_call_id_static(tc)
        for tc in (msg.get("tool_calls") or [])
        if isinstance(tc, dict) and _ra().AIAgent._get_tool_call_id_static(tc)
    ]
    if not call_ids:
        idx += 1
        continue
    run_end = idx + 1
    answered: set = set()
    while (run_end < len(filtered) and isinstance(filtered[run_end], dict)
           and filtered[run_end].get("role") == "tool"):
        answered.add((filtered[run_end].get("tool_call_id") or "").strip())
        run_end += 1
    missing = [cid for cid in call_ids if cid not in answered]
    if missing:
        names = {
            _ra().AIAgent._get_tool_call_id_static(tc): _ra().AIAgent._get_tool_call_name_static(tc)
            for tc in (msg.get("tool_calls") or []) if isinstance(tc, dict)
        }
        stubs = [{
            "role": "tool", "tool_call_id": cid,
            "name": names.get(cid) or "unknown",
            "content": "Tool execution was interrupted before a result was returned.",
        } for cid in missing]
        filtered[run_end:run_end] = stubs
        repairs += len(stubs)
        run_end += len(stubs)
    idx = run_end
```

Behavior, precisely:
- Scoped **per assistant turn**, looking only at the run of `tool` messages *immediately* following it — mirrors how the existing Pass 1 (`known_tool_ids`) already reasons about adjacency, so a `system` message interleaved between an `assistant(tool_calls)` and its real `tool` answer still lets that answer count (matches pre-existing Pass 1 semantics; a naive merge of the two passes into one loop was tried and rejected in review because it broke exactly this case — see "Alternatives considered" below).
- **Stubs, does not strip.** If a turn's calls are fully orphaned, a strip approach (`del msg["tool_calls"]`) would leave `{"role": "assistant", "content": None}` — a contentless turn with no fallback text. Stubbing avoids that failure mode entirely and keeps the model's stated intent (what it tried to call) visible in the transcript, which also gives the model useful signal on its next turn ("execution was interrupted" vs. silence).
- Uses `AIAgent._get_tool_call_id_static` / `_get_tool_call_name_static` — `call_id || id` — the exact extractor `sanitize_api_messages` (`agent_runtime_helpers.py:2393`) and `context_compressor._sanitize_tool_pairs` already use. An earlier version of this pass read `tc.get("id")` directly; that missed Codex/Responses-API-shaped tool_calls, which key the id as `call_id`. Not a corruption risk (missing id just made the entry a silent no-op), but inconsistent with the rest of the file and inert exactly where the rest of the codebase already guards against this shape. Fixed and covered by a dedicated test.
- Idempotent: once a stub is inserted, that `tool_call_id` is answered, so a second call reports `repairs == 0` for the same input.
- No-op on the existing "ongoing dialog" pattern: a **complete** `assistant(tool_calls)+tool` pair followed by a user redirect (valid when the previous turn finished normally and the user jumped in before the model's continuation turn) is untouched, because every id in that turn already has a matching result.

Docstring updated to describe this as pass "2." and drop the now-inaccurate "Deliberately does NOT rewind..." paragraph; renumbered the user-merge pass to "3."

## Alternatives considered

| | This PR (stub, separate pass) | Merge into Pass 1 (rejected) | Strip tool_calls (rejected) |
|---|---|---|---|
| Detects orphan | Per-turn, contiguous `tool` run after assistant | Would require single "run closes" definition shared with Pass 1 | Global set of every `tool_call_id` seen anywhere |
| System message between assistant and its real tool answer | Still counts (scoped correctly) | Breaks — the merged pass would prematurely close the run and later **duplicate** the real answer against an already-inserted stub, reintroducing the #55442 duplicate-tool-response class | N/A (doesn't insert anything) |
| All calls in a turn orphaned | Inserts stub per id, assistant content untouched | — | `del msg["tool_calls"]` with no content fallback -> `{"content": None}`, no `tool_calls` — second schema violation risk, confirmed by reproducing that exact code path locally |
| Consistent with existing extractor convention | Yes (`call_id||id`, post-fix) | — | No (used `tc.get("id")` only) |
| Data loss | None — `tool_calls` preserved | — | Yes — erases that the model attempted a call |

Merging into Pass 1 would have saved ~25 lines but requires collapsing two genuinely different "when does a run close" definitions into one, which is exactly the kind of premature abstraction that trades a small line-count win for cross-cutting coupling and a real regression risk. Kept as two small, single-responsibility passes instead.

## Testing

`tests/run_agent/test_message_sequence_repair.py` — 6 new tests:

| Test | Covers |
|---|---|
| `test_repair_closes_fully_unanswered_trailing_tool_calls` | Trailing `assistant(tool_calls)` with zero tool results |
| `test_repair_closes_partially_answered_tool_calls` | Parallel `tool_calls`, some ids answered, some missing |
| `test_repair_closes_orphaned_tool_calls_before_wakeup_message` | Orphaned `tool_calls` immediately followed by an injected `user` (wakeup/background-notification) message — the #56980 trigger pattern |
| `test_repair_orphan_close_is_idempotent` | Running the repair twice does not insert duplicate stubs |
| `test_repair_closes_orphaned_tool_calls_using_call_id_field` | Codex/Responses-style tool_calls keyed by `call_id` instead of `id` |
| `test_repair_still_preserves_complete_pair_before_user_redirect` | Non-regression: complete pair + user redirect stays untouched |

Results:
- `python -m pytest tests/run_agent/test_message_sequence_repair.py -v` — **31/31 passing**
- `python -m pytest tests/agent/test_context_compressor.py tests/agent/test_replay_cleanup.py tests/agent/test_close_interrupted_tool_sequence.py -q` — **159/159 passing** (adjacent sanitizers, no regression)
- `python -m pytest tests/run_agent/test_run_agent.py -q` — **414/414 passing** (full suite touching this module)

### Suggested differential testing (not included in this PR, follow-up)

To validate no regression across long/real sessions and catch the N+1 issue class:
1. Fuzz synthetic message histories (random mix of assistant/tool/user, random orphan gaps, random `id`/`call_id` key choice) through `repair_message_sequence` then `sanitize_api_messages` together, asserting: every `assistant(tool_calls)` is immediately followed by a `tool` for every one of its ids (well-formedness invariant), and a second pass over the result reports 0 repairs (idempotency invariant).
2. Replay real 50+ message session dumps (with interruption points) through the full pipeline and assert the same two invariants, to catch any non-contiguous or multi-turn interleaving the unit tests don't construct.
3. Assert message count monotonicity bounds (repairs only ever insert stubs or merge, never duplicate an existing `tool_call_id`) to guard against the exact #55442 duplicate-response class this design explicitly avoids.

## Related

Continuation of #56980 (original report, not reproducible as filed; see proof below). Fixes #57053. Refs #57036 (extractor fix, folded in). Supersedes #57039, #57013, #57041 (all closed, redone as this issue/PR).

## Type of Change

- [x] Bug fix / hardening (non-breaking)

## Checklist

- [x] No new dependencies
- [x] No changes to message serialization format
- [x] No breaking changes to OpenAI/Anthropic provider compatibility
- [x] Existing "ongoing dialog" pattern (complete pair + user redirect) covered by a regression test
- [x] Uses the same `call_id||id` extractor as the rest of the file
