### PR TITLE
fix(discord): warn when auth policy is missing

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -328,6 +328,11 @@ def _build_allowed_mentions():
     )
 
 
+def _discord_env_truthy(name: str) -> bool:
+    """Return True for common opt-in boolean env-var spellings."""
+    return os.getenv(name, "").strip().lower() in {"true", "1", "yes", "on"}
+
+
 def _discord_ready_timeout_seconds() -> float:
     """Return the Discord ready wait timeout during gateway startup."""
     raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
@@ -955,6 +960,20 @@ class DiscordAdapter(BasePlatformAdapter):
                     int(rid.strip()) for rid in roles_env.split(",")
                     if rid.strip().isdigit()
                 }
+
+            if (
+                not self._allowed_user_ids
+                and not self._allowed_role_ids
+                and not os.getenv("DISCORD_ALLOWED_CHANNELS", "").strip()
+                and not _discord_env_truthy("DISCORD_ALLOW_ALL_USERS")
+                and not _discord_env_truthy("GATEWAY_ALLOW_ALL_USERS")
+            ):
+                logger.warning(
+                    "[%s] No Discord access policy configured; inbound Discord messages will be denied by default. "
+                    "Set DISCORD_ALLOWED_USERS or DISCORD_ALLOWED_ROLES, or explicitly opt in with "
+                    "DISCORD_ALLOW_ALL_USERS=true / GATEWAY_ALLOW_ALL_USERS=true, then restart the gateway.",
+                    self.name,
+                )
 
             # Set up intents.
             # Message Content is required for normal text replies.
@@ -3150,9 +3169,9 @@ class DiscordAdapter(BasePlatformAdapter):
         has_users = bool(allowed_users)
         has_roles = bool(allowed_roles)
         if not has_users and not has_roles:
-            if os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+            if _discord_env_truthy("DISCORD_ALLOW_ALL_USERS"):
                 return True
-            if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+            if _discord_env_truthy("GATEWAY_ALLOW_ALL_USERS"):
                 return True
             # Channel-scoped guild access requires validated channel context.
             # Do not treat DISCORD_ALLOWED_CHANNELS alone as a user-wide bypass
@@ -6341,9 +6360,9 @@ def _component_check_auth(
     if user is None or getattr(user, "id", None) is None:
         return False
 
-    if os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+    if _discord_env_truthy("DISCORD_ALLOW_ALL_USERS"):
         return True
-    if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+    if _discord_env_truthy("GATEWAY_ALLOW_ALL_USERS"):
         return True
 
     user_set = {str(uid).strip() for uid in (allowed_user_ids or set()) if str(uid).strip()}

--- a/plugins/platforms/discord/plugin.yaml
+++ b/plugins/platforms/discord/plugin.yaml
@@ -21,8 +21,8 @@ optional_env:
     prompt: "Allowed users (comma-separated)"
     password: false
   - name: DISCORD_ALLOW_ALL_USERS
-    description: "Allow any Discord user to trigger the bot (dev only)"
-    prompt: "Allow all users? (true/false)"
+    description: "Explicitly allow any Discord user to trigger the bot (trusted/private guilds only)"
+    prompt: "Allow all Discord users? (true/false)"
     password: false
   - name: DISCORD_HOME_CHANNEL
     description: "Default channel ID for cron / notification delivery"

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -191,6 +191,86 @@ async def test_connect_only_requests_members_intent_when_needed(monkeypatch, all
 
 
 @pytest.mark.asyncio
+async def test_connect_warns_when_discord_access_policy_missing(monkeypatch, caplog):
+    """A fail-closed Discord bot should not look healthy-but-silent in logs."""
+    for name in (
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOWED_ROLES",
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False))
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda *, command_prefix, intents, proxy=None, allowed_mentions=None, **_: FakeBot(
+            intents=intents,
+            allowed_mentions=allowed_mentions,
+        ),
+    )
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    caplog.set_level("WARNING")
+    assert await adapter.connect() is True
+    assert "No Discord access policy configured" in caplog.text
+    assert "DISCORD_ALLOW_ALL_USERS=true" in caplog.text
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("DISCORD_ALLOWED_USERS", "769524422783664158"),
+        ("DISCORD_ALLOWED_ROLES", "123456789012345678"),
+        ("DISCORD_ALLOWED_CHANNELS", "987654321098765432"),
+        ("DISCORD_ALLOW_ALL_USERS", "true"),
+        ("GATEWAY_ALLOW_ALL_USERS", "yes"),
+    ],
+)
+async def test_connect_no_missing_policy_warning_when_discord_policy_configured(
+    monkeypatch,
+    caplog,
+    env_name,
+    env_value,
+):
+    for name in (
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOWED_ROLES",
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(env_name, env_value)
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False))
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda *, command_prefix, intents, proxy=None, allowed_mentions=None, **_: FakeBot(
+            intents=intents,
+            allowed_mentions=allowed_mentions,
+        ),
+    )
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    caplog.set_level("WARNING")
+    assert await adapter.connect() is True
+    assert "No Discord access policy configured" not in caplog.text
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "initial_allowed",
     [

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -271,8 +271,10 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DISCORD_BOT_TOKEN` | **Yes** | — | Bot token from the [Discord Developer Portal](https://discord.com/developers/applications). |
-| `DISCORD_ALLOWED_USERS` | **Yes** | — | Comma-separated Discord user IDs allowed to interact with the bot. Without this **or** `DISCORD_ALLOWED_ROLES`, the gateway denies all users. |
+| `DISCORD_ALLOWED_USERS` | Conditional | — | Comma-separated Discord user IDs allowed to interact with the bot. Without this **or** `DISCORD_ALLOWED_ROLES`, the gateway denies all users unless `DISCORD_ALLOW_ALL_USERS=true`, `GATEWAY_ALLOW_ALL_USERS=true`, or `DISCORD_ALLOWED_CHANNELS` explicitly scopes guild access. |
 | `DISCORD_ALLOWED_ROLES` | No | — | Comma-separated Discord role IDs. Any member with one of these roles is authorized — OR semantics with `DISCORD_ALLOWED_USERS`. Auto-enables the **Server Members Intent** on connect. Useful when moderation teams churn: new mods get access as soon as the role is granted, no config push needed. |
+| `DISCORD_ALLOW_ALL_USERS` | No | `false` | Explicit opt-in to allow every Discord user who can reach the bot. This restores the pre-0.18 open behavior for Discord only; use only for trusted/private guilds or development. |
+| `GATEWAY_ALLOW_ALL_USERS` | No | `false` | Global allow-all opt-in for every gateway platform. Prefer the platform-specific `DISCORD_ALLOW_ALL_USERS` unless you intentionally want all connected platforms open. |
 | `DISCORD_HOME_CHANNEL` | No | — | Channel ID where the bot sends proactive messages (cron output, reminders, notifications). |
 | `DISCORD_HOME_CHANNEL_NAME` | No | `"Home"` | Display name for the home channel in logs and status output. |
 | `DISCORD_COMMAND_SYNC_POLICY` | No | `"safe"` | Controls native slash-command startup sync. `"safe"` diffs existing global commands and only updates what changed, recreating commands when Discord metadata changes cannot be applied via patch. `"bulk"` preserves the old `tree.sync()` behavior. `"off"` skips startup sync entirely. |
@@ -736,9 +738,34 @@ Refreshing the directory (`/channels refresh` on platforms that expose it, or a 
 
 ### Bot is online but not responding to messages
 
-**Cause**: Message Content Intent is disabled.
+**Cause**: Either Message Content Intent is disabled, or Discord auth is failing closed because no access policy is configured.
 
-**Fix**: Go to [Developer Portal](https://discord.com/developers/applications) → your app → Bot → Privileged Gateway Intents → enable **Message Content Intent** → Save Changes. Restart the gateway.
+**Fix**:
+
+1. Go to [Developer Portal](https://discord.com/developers/applications) → your app → Bot → Privileged Gateway Intents → enable **Message Content Intent** → Save Changes.
+2. Verify that at least one Discord access policy is configured:
+
+   ```bash
+   # recommended: allow specific users
+   DISCORD_ALLOWED_USERS=284102345871466496
+
+   # or allow a trusted guild/dev bot to behave like pre-0.18 Discord
+   DISCORD_ALLOW_ALL_USERS=true
+   ```
+
+3. Restart the gateway:
+
+   ```bash
+   hermes gateway restart
+   ```
+
+If the gateway log says Discord is connected and REST API checks work, but every inbound message is silent, look for this warning in `~/.hermes/logs/gateway.log`:
+
+```text
+No Discord access policy configured; inbound Discord messages will be denied by default.
+```
+
+Hermes 0.18 intentionally fails closed on externally reachable adapters. A Discord bot with no `DISCORD_ALLOWED_USERS`, no `DISCORD_ALLOWED_ROLES`, no `DISCORD_ALLOWED_CHANNELS`, and no explicit allow-all flag will connect successfully but deny inbound users before normal message handling.
 
 ### "Disallowed Intents" error on startup
 


### PR DESCRIPTION
> Related: #52065. This PR is intentionally not a duplicate: #52065 fixes misleading setup-wizard copy around empty allowlists, while this PR adds runtime diagnostics and Discord troubleshooting docs for already-configured bots that appear connected but deny all inbound messages after the 0.18 fail-closed auth change.

## What does this PR do?

Makes the Discord 0.18 fail-closed authorization change diagnosable instead of looking like a healthy-but-silent bot.

The fail-closed behavior is kept: if no Discord access policy is configured, inbound users are still denied by default. The fix is to surface that state clearly at startup and document the safe recovery paths.

## Related Issue

No tracked issue. This addresses a user-reported regression after the 0.18 Discord auth hardening.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py`
  - Logs a startup warning when Discord has no access policy configured and will deny inbound messages by default.
  - Reuses a small truthy-env helper for Discord/global allow-all checks.
- `website/docs/user-guide/messaging/discord.md`
  - Adds `DISCORD_ALLOW_ALL_USERS` and `GATEWAY_ALLOW_ALL_USERS` to the Discord env var table.
  - Updates the "bot online but not responding" troubleshooting section to cover both Message Content Intent and fail-closed auth.
- `plugins/platforms/discord/plugin.yaml`
  - Clarifies that Discord allow-all is an explicit trusted/private-guild opt-in.
- `tests/gateway/test_discord_connect.py`
  - Adds regression coverage for the missing-policy warning and for configured policy paths that should not warn.

## How to Test

1. Start Discord with only `DISCORD_BOT_TOKEN` configured and no `DISCORD_ALLOWED_USERS`, `DISCORD_ALLOWED_ROLES`, `DISCORD_ALLOWED_CHANNELS`, `DISCORD_ALLOW_ALL_USERS`, or `GATEWAY_ALLOW_ALL_USERS`.
2. Confirm the gateway log contains:

   ```text
   No Discord access policy configured; inbound Discord messages will be denied by default.
   ```

3. Configure one of the documented policies, then restart:

   ```bash
   DISCORD_ALLOWED_USERS=<your-discord-user-id>
   # or, for trusted/private guilds only:
   DISCORD_ALLOW_ALL_USERS=true
   hermes gateway restart
   ```

4. Confirm the warning is gone and Discord messages pass the intended auth policy.

Verified locally:

```bash
python3 -m pytest tests/gateway/test_discord_connect.py tests/gateway/test_discord_component_auth.py tests/gateway/test_discord_roles_dm_scope.py tests/gateway/test_discord_slash_auth.py tests/hermes_cli/test_web_server.py -k 'platform_scoped_messaging_env_vars_are_channel_managed or discord' -q -o 'addopts='
# 117 passed, 337 deselected

python3 -m py_compile plugins/platforms/discord/adapter.py hermes_cli/config.py
git diff --check
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, Discord gateway auth/logging only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
