### PR TITLE
fix(gateway): pass explicit .ogg output_path for Telegram auto-TTS

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -13,6 +13,7 @@ import os
 import random
 import re
 import socket as _socket
+import tempfile
 import subprocess
 import sys
 import time
@@ -4965,8 +4966,21 @@ class BasePlatformAdapter(ABC):
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
+                            # Pass an explicit output_path with the correct
+                            # extension for the current platform.  The
+                            # session contextvar (HERMES_SESSION_PLATFORM) is
+                            # not populated at this call site — it is set by
+                            # _set_session_env() inside _handle_message_with_agent
+                            # and cleared on return.  Without an explicit path
+                            # text_to_speech_tool falls back to .mp3, which
+                            # causes Telegram to render sendAudio instead of
+                            # sendVoice.
+                            _tts_ext = "ogg" if self.platform == Platform.TELEGRAM else "mp3"
+                            _ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                            _tts_out = Path(tempfile.gettempdir()) / f"auto_tts_{_ts}.{_tts_ext}"
                             tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                                text_to_speech_tool, text=speech_text,
+                                output_path=str(_tts_out),
                             )
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -353,3 +353,40 @@ class TestTelegramAutoTtsCaptionDelivery:
                 "metadata": {"thread_id": "17585", "notify": True},
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_telegram_auto_tts_passes_explicit_ogg_output_path(self, tmp_path):
+        """Auto-TTS must pass an explicit .ogg output_path on Telegram.
+
+        Regression test for #57049: the session contextvar
+        (HERMES_SESSION_PLATFORM) is not populated at the auto-TTS call
+        site in base.py, so text_to_speech_tool falls back to .mp3.
+        The fix passes an explicit output_path with the correct
+        extension based on self.platform.
+        """
+        adapter = DummyTelegramAdapter()
+        adapter._keep_typing = self._hold_typing()
+        adapter._should_auto_tts_for_chat = lambda _chat_id: True
+        adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="tts-1"))
+        adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="Short reply"))
+
+        tts_path = tmp_path / "reply.ogg"
+        tts_path.write_text("audio", encoding="utf-8")
+        event = self._make_voice_event()
+
+        captured_kwargs = {}
+
+        def capture_tts(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return json.dumps({"file_path": str(tts_path)})
+
+        with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+            "tools.tts_tool.text_to_speech_tool",
+            side_effect=capture_tts,
+        ):
+            await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert "output_path" in captured_kwargs, "text_to_speech_tool should receive explicit output_path"
+        assert captured_kwargs["output_path"].endswith(".ogg"), (
+            f"Telegram auto-TTS must use .ogg extension, got: {captured_kwargs['output_path']}"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the base platform adapter's auto-TTS path calls `text_to_speech_tool` without an explicit `output_path`, causing Telegram voice replies to be sent as regular audio attachments (`sendAudio`) instead of native voice bubbles (`sendVoice`).

The root cause: `text_to_speech_tool` uses `get_session_env("HERMES_SESSION_PLATFORM")` to detect the platform and choose the output format. The session contextvar is set by `_set_session_env()` inside `_handle_message_with_agent()` and cleared on return. The auto-TTS code in `base.py`'s `_process_message_background` runs *after* the agent returns, so the contextvar is empty — the tool defaults to `.mp3` regardless of platform.

The fix: pass an explicit `output_path` with the correct extension (`.ogg` for Telegram, `.mp3` otherwise) based on `self.platform`, which is always available on the adapter instance.

## Related Issue

Fixes #57049

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Build an explicit `output_path` with the correct extension based on `self.platform` before calling `text_to_speech_tool` in the auto-TTS block. Added `import tempfile`.
- `tests/gateway/test_base_topic_sessions.py`: Added regression test `test_telegram_auto_tts_passes_explicit_ogg_output_path` verifying that the TTS tool receives an `.ogg` output_path on Telegram.

## How to Test

1. Run `python -m pytest tests/gateway/test_base_topic_sessions.py -q` — all 11 tests should pass
2. The new test specifically validates: when `self.platform == Platform.TELEGRAM` and auto-TTS is enabled, `text_to_speech_tool` is called with `output_path` ending in `.ogg`
3. On a live Telegram gateway with `voice.auto_tts: true` and `tts.provider: edge`, voice replies should render as native voice bubbles (tap-to-play) instead of audio file attachments

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `python -m pytest tests/gateway/test_base_topic_sessions.py -q` and all 11 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (fix uses existing `self.platform` attribute)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — regression test validates the fix programmatically.
