### PR TITLE
fix(tui): avoid compact catalog alias collision

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4557,6 +4557,21 @@ def test_commands_catalog_includes_tui_mouse_command():
     assert "/mouse" in tui_pairs
 
 
+def test_commands_catalog_does_not_list_alias_collisions_as_pairs():
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    pairs = dict(resp["result"]["pairs"])
+    tui_cat = next(c for c in resp["result"]["categories"] if c["name"] == "TUI")
+    tui_pairs = dict(tui_cat["pairs"])
+    canon = resp["result"]["canon"]
+
+    assert canon["/compact"] == "/compress"
+    assert "/compact" not in pairs
+    assert "/compact" not in tui_pairs
+
+
 def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11782,6 +11782,12 @@ def _(rid, params: dict) -> dict:
             cat_map[cat].append([c, desc])
 
         for name, desc, cat in _TUI_EXTRA:
+            # ``pairs`` are concrete commands; aliases live only in ``canon``.
+            # If a registry alias now owns the same slash text (for example
+            # /compact -> /compress), emitting a TUI extra with that name makes
+            # the catalog internally inconsistent for clients that merge both.
+            if canon.get(name.lower(), name) != name:
+                continue
             all_pairs.append([name, desc])
             if cat not in cat_map:
                 cat_map[cat] = []


### PR DESCRIPTION
Summary
- Keep commands.catalog internally consistent when a TUI-only extra command name collides with a registry alias.
- Preserve /compact as the registry alias for /compress in canon while omitting the conflicting TUI extra from catalog pairs/categories.
- Add a regression test for the /compact collision.

Root Cause
- PR #57029 added compact as an alias for /compress, so commands.catalog now maps canon["/compact"] to "/compress". The same response still listed the legacy TUI-only /compact display toggle as a concrete pair, giving clients two meanings for the same slash text.

Tests
- python -m pytest tests/test_tui_gateway_server.py -q -k "commands_catalog or complete_slash"
- python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py
- git diff --check

Fixes #57070