### PR TITLE
feat(memory/supermemory): support self-hosted server via SUPERMEMORY_BASE_URL

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -31,8 +31,26 @@ _VALID_SEARCH_MODES = ("hybrid", "memories", "documents")
 _DEFAULT_API_TIMEOUT = 5.0
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
-_CONVERSATIONS_URL = "https://api.supermemory.ai/v4/conversations"
+_DEFAULT_BASE_URL = "https://api.supermemory.ai"
+_CONVERSATIONS_PATH = "/v4/conversations"
 _API_KEY_URL = "http://app.supermemory.ai/integrations?connect=hermes"
+
+
+def _supermemory_base_url() -> str:
+    """Base URL for the Supermemory API.
+
+    Defaults to Supermemory Cloud. Set SUPERMEMORY_BASE_URL to point Hermes at a
+    self-hosted Supermemory server (https://supermemory.ai/docs/self-hosting),
+    e.g. ``http://localhost:6767``. Applied to both the conversation-ingest
+    endpoint and the Supermemory SDK client.
+    """
+    return (os.environ.get("SUPERMEMORY_BASE_URL", "").strip() or _DEFAULT_BASE_URL).rstrip("/")
+
+
+def _conversations_url() -> str:
+    return f"{_supermemory_base_url()}{_CONVERSATIONS_PATH}"
+
+
 _TRIVIAL_RE = re.compile(
     r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
     re.IGNORECASE,
@@ -285,6 +303,7 @@ class _SupermemoryClient:
         self._timeout = timeout
         self._client = Supermemory(
             api_key=api_key,
+            base_url=_supermemory_base_url(),
             timeout=timeout,
             max_retries=0,
             default_headers={"x-sm-source": "hermes"},
@@ -388,7 +407,7 @@ class _SupermemoryClient:
             payload["metadata"] = self._merge_metadata(metadata)
 
         req = urllib.request.Request(
-            _CONVERSATIONS_URL,
+            _conversations_url(),
             data=json.dumps(payload).encode("utf-8"),
             headers={
                 "Authorization": f"Bearer {self._api_key}",

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -1,18 +1,22 @@
 import json
 import os
 import stat
+import sys
 import threading
+import types
 
 import pytest
 
 from plugins.memory.supermemory import (
     SupermemoryMemoryProvider,
     _clean_text_for_capture,
+    _conversations_url,
     _format_connection_summary,
     _format_prefetch_context,
     _load_supermemory_config,
     _probe_supermemory_connection,
     _save_supermemory_config,
+    _supermemory_base_url,
 )
 
 
@@ -623,3 +627,41 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+def test_base_url_defaults_to_cloud(monkeypatch):
+    monkeypatch.delenv("SUPERMEMORY_BASE_URL", raising=False)
+    assert _supermemory_base_url() == "https://api.supermemory.ai"
+    assert _conversations_url() == "https://api.supermemory.ai/v4/conversations"
+
+
+def test_base_url_honors_env_override(monkeypatch):
+    monkeypatch.setenv("SUPERMEMORY_BASE_URL", "http://localhost:6767/")  # trailing slash trimmed
+    assert _supermemory_base_url() == "http://localhost:6767"
+    assert _conversations_url() == "http://localhost:6767/v4/conversations"
+
+
+def test_blank_base_url_falls_back_to_cloud(monkeypatch):
+    monkeypatch.setenv("SUPERMEMORY_BASE_URL", "   ")
+    assert _supermemory_base_url() == "https://api.supermemory.ai"
+
+
+def test_sdk_client_receives_base_url(monkeypatch):
+    """_SupermemoryClient must forward the resolved base URL to the Supermemory SDK."""
+    monkeypatch.setenv("SUPERMEMORY_BASE_URL", "http://localhost:6767")
+    captured = {}
+
+    fake_mod = types.ModuleType("supermemory")
+
+    class _FakeSupermemory:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    fake_mod.Supermemory = _FakeSupermemory
+    monkeypatch.setitem(sys.modules, "supermemory", fake_mod)
+
+    from plugins.memory.supermemory import _SupermemoryClient
+
+    _SupermemoryClient(api_key="k", timeout=5.0, container_tag="hermes")
+    assert captured["base_url"] == "http://localhost:6767"
+    assert captured["api_key"] == "k"


### PR DESCRIPTION
## What & why

The `supermemory` memory provider hardcodes the Supermemory **Cloud** host in two places, with no override, making it impossible to point Hermes at a **self-hosted** Supermemory server:

- `_CONVERSATIONS_URL = "https://api.supermemory.ai/v4/conversations"` (raw `urllib` conversation ingest)
- the `Supermemory(...)` SDK client (recall / search / profile / forget) is constructed without a `base_url`

The docs expose only `SUPERMEMORY_API_KEY` / `SUPERMEMORY_CONTAINER_TAG`, so there is currently no supported way to use the official self-hosted `supermemory-server`.

Fixes #57061.

## Change

Add **`SUPERMEMORY_BASE_URL`** (default `https://api.supermemory.ai`), resolved via a small helper and applied to **both** paths:

```python
def _supermemory_base_url() -> str:
    return (os.environ.get("SUPERMEMORY_BASE_URL", "").strip() or _DEFAULT_BASE_URL).rstrip("/")
```

- Blank/unset → falls back to cloud, so **existing setups are unaffected**.
- Trailing slashes are trimmed.
- The SDK client now receives `base_url=_supermemory_base_url()`.

## Tests

Added 4 unit tests (`tests/plugins/memory/test_supermemory_provider.py`):
- default → cloud
- env override (trailing slash trimmed)
- blank env → cloud fallback
- `_SupermemoryClient` forwards `base_url` to the SDK

```
43 passed in 0.43s        # full provider suite
ruff check … All checks passed!
```

## Live verification against a self-hosted server

Ran the **patched** code against an official `supermemory-server` **v0.0.3** (linux-arm64) with `SUPERMEMORY_BASE_URL=http://<host>:6767`:

- **urllib ingest path** — `_conversations_url()` resolved to `http://<host>:6767/v4/conversations`; `ingest_conversation(...)` posted successfully and the server logged extraction of the conversation.
- **SDK path** — `Supermemory(base_url=…).documents.add(...)` returned an id and `search.memories(...)` returned the doc. The server accepted the **local** API key (a cloud endpoint would have rejected it), confirming requests routed to the self-hosted box, not cloud.

Happy to adjust naming (e.g. also reading a `base_url` key from `supermemory.json`) if preferred.
