### PR TITLE
fix(tui): let command aliases override TUI extras

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4242,6 +4242,23 @@ def test_commands_catalog_includes_tui_mouse_command():
     assert "/mouse" in tui_pairs
 
 
+def test_commands_catalog_registry_alias_wins_over_tui_extra():
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    pairs = dict(resp["result"]["pairs"])
+    tui_cat = next(c for c in resp["result"]["categories"] if c["name"] == "TUI")
+    tui_pairs = dict(tui_cat["pairs"])
+    canon = resp["result"]["canon"]
+
+    assert "/compress" in pairs
+    assert pairs["/compress"].startswith("Compress conversation context")
+    assert canon["/compact"] == "/compress"
+    assert "/compact" not in pairs
+    assert "/compact" not in tui_pairs
+
+
 def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11189,6 +11189,12 @@ def _(rid, params: dict) -> dict:
             cat_map[cat].append([c, desc])
 
         for name, desc, cat in _TUI_EXTRA:
+            # Registry aliases win over TUI-only extras.  This prevents a
+            # client palette/catalog collision when a global command later
+            # claims a name that used to be local to the TUI (e.g. /compact is
+            # now an alias for /compress, not the compact-display toggle).
+            if name.lower() in canon:
+                continue
             all_pairs.append([name, desc])
             if cat not in cat_map:
                 cat_map[cat] = []


### PR DESCRIPTION
Fixes #57070.

## Summary
- skip TUI-only extra catalog entries when a registry command or alias already claims that slash name
- add regression coverage proving `/compact` canonicalizes to `/compress` and is not also surfaced as the TUI compact-display toggle

## Tests
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -k "commands_catalog_registry_alias_wins_over_tui_extra or commands_catalog_includes_tui_mouse_command or commands_catalog_filters_gateway_only_commands_and_keeps_status_visible"`
- `scripts/run_tests.sh tests/test_tui_gateway_server.py` (303 passed, 1 pre-existing unrelated failure: `test_verification_status_outside_workspace_is_not_applicable`)
