### PR TITLE
fix(agent): honor resolved TLS verify on proxied keepalive clients

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -160,8 +160,10 @@ def build_keepalive_http_client(
     vision, web_extract, title generation, etc.) honor the same per-provider
     ``ssl_ca_cert`` / ``ssl_verify`` and ``HERMES_CA_BUNDLE`` settings the main
     client uses. It is passed on the ``HTTPTransport`` (which owns the SSL
-    context when a custom transport is supplied) and, for the copilot branch
-    that has no custom transport, on the client itself.
+    context for direct traffic when a custom transport is supplied) AND on
+    the client itself — httpx builds the proxy transport for proxied URLs
+    from the client-level ``verify``, and the copilot branch has no custom
+    transport at all.
     """
     try:
         import httpx
@@ -182,11 +184,16 @@ def build_keepalive_http_client(
         proxy = _get_proxy_for_base_url(base_url)
         transport_cls = httpx.AsyncHTTPTransport if async_mode else httpx.HTTPTransport
         client_cls = httpx.AsyncClient if async_mode else httpx.Client
-        # verify lives on the transport: httpx ignores the client-level
-        # ``verify`` when a custom ``transport=`` is supplied.
+        # verify must live in BOTH places: the custom transport carries it
+        # for direct traffic (httpx ignores client-level ``verify`` when a
+        # custom ``transport=`` is supplied), while proxied traffic goes
+        # through a separate proxy transport that httpx builds internally
+        # from the client-level ``verify`` — the custom transport is never
+        # consulted for proxied URLs.
         return client_cls(
             transport=transport_cls(socket_options=sock_opts, verify=verify),
             proxy=proxy,
+            verify=verify,
         )
     except Exception:
         return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -3904,11 +3904,16 @@ class AIAgent:
             # Explicitly read proxy settings while still honoring NO_PROXY for
             # loopback / local endpoints such as a locally hosted sub2api.
             _proxy = _get_proxy_for_base_url(base_url)
-            # verify lives on the transport: httpx ignores the client-level
-            # ``verify`` when a custom ``transport=`` is supplied.
+            # verify must live in BOTH places: the custom transport carries
+            # it for direct traffic (httpx ignores client-level ``verify``
+            # when a custom ``transport=`` is supplied), while proxied
+            # traffic goes through a separate proxy transport that httpx
+            # builds internally from the client-level ``verify`` — the
+            # custom transport is never consulted for proxied URLs.
             return _httpx.Client(
                 transport=_httpx.HTTPTransport(socket_options=_sock_opts, verify=verify),
                 proxy=_proxy,
+                verify=verify,
             )
         except Exception:
             return None

--- a/tests/agent/test_auxiliary_client_ssl_verify.py
+++ b/tests/agent/test_auxiliary_client_ssl_verify.py
@@ -16,7 +16,13 @@ import pytest
 
 from agent.process_bootstrap import build_keepalive_http_client
 
-_CA_ENV_VARS = ("HERMES_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "HTTPS_PROXY")
+_CA_ENV_VARS = (
+    "HERMES_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "HTTPS_PROXY",
+)
 
 
 @pytest.fixture
@@ -41,6 +47,35 @@ def test_build_keepalive_http_client_verify_false_disables_hostname_check(clean_
 def test_build_keepalive_http_client_default_verify_true(clean_tls_env):
     client = build_keepalive_http_client("https://ollama.example.com/v1")
     assert isinstance(client, httpx.Client)
+
+
+def test_build_keepalive_http_client_proxied_traffic_honors_verify(clean_tls_env, monkeypatch):
+    """Behind HTTPS_PROXY, httpx routes matching URLs through an internally
+    built proxy transport (the custom keepalive transport is never consulted
+    for proxied URLs), so the resolved verify must reach that transport too."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    ctx = ssl.create_default_context(cafile=certifi.where())
+    client = build_keepalive_http_client("https://ollama.example.com/v1", verify=ctx)
+    transport = client._transport_for_url(httpx.URL("https://ollama.example.com/v1"))
+    assert transport._pool._ssl_context is ctx
+
+
+def test_build_keepalive_http_client_proxied_verify_false(clean_tls_env, monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    client = build_keepalive_http_client("https://ollama.example.com/v1", verify=False)
+    transport = client._transport_for_url(httpx.URL("https://ollama.example.com/v1"))
+    assert transport._pool._ssl_context.check_hostname is False
+
+
+def test_build_keepalive_async_client_proxied_traffic_honors_verify(clean_tls_env, monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    ctx = ssl.create_default_context(cafile=certifi.where())
+    client = build_keepalive_http_client(
+        "https://ollama.example.com/v1", verify=ctx, async_mode=True,
+    )
+    assert isinstance(client, httpx.AsyncClient)
+    transport = client._transport_for_url(httpx.URL("https://ollama.example.com/v1"))
+    assert transport._pool._ssl_context is ctx
 
 
 def test_resolve_aux_verify_uses_per_provider_ssl_ca_cert(clean_tls_env, monkeypatch):

--- a/tests/run_agent/test_create_openai_client_ssl_verify.py
+++ b/tests/run_agent/test_create_openai_client_ssl_verify.py
@@ -9,7 +9,13 @@ import pytest
 from agent.ssl_verify import resolve_httpx_verify
 from run_agent import AIAgent
 
-_CA_ENV_VARS = ("HERMES_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "HTTPS_PROXY")
+_CA_ENV_VARS = (
+    "HERMES_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "HTTPS_PROXY",
+)
 
 
 @pytest.fixture
@@ -44,3 +50,26 @@ def test_build_keepalive_http_client_ssl_verify_false(clean_tls_env):
     )
     assert isinstance(client, httpx.Client)
     assert client._transport._pool._ssl_context.check_hostname is False
+
+
+def test_build_keepalive_http_client_proxied_traffic_honors_verify(clean_tls_env, monkeypatch):
+    """Behind HTTPS_PROXY, httpx routes matching URLs through an internally
+    built proxy transport (the custom keepalive transport is never consulted
+    for proxied URLs), so the resolved verify must reach that transport too."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    verify = resolve_httpx_verify(ca_bundle=certifi.where())
+    client = AIAgent._build_keepalive_http_client(
+        "https://ollama.example.com/v1", verify=verify,
+    )
+    transport = client._transport_for_url(httpx.URL("https://ollama.example.com/v1"))
+    assert transport._pool._ssl_context is verify
+
+
+def test_build_keepalive_http_client_proxied_ssl_verify_false(clean_tls_env, monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    verify = resolve_httpx_verify(ssl_verify=False)
+    client = AIAgent._build_keepalive_http_client(
+        "https://ollama.example.com/v1", verify=verify,
+    )
+    transport = client._transport_for_url(httpx.URL("https://ollama.example.com/v1"))
+    assert transport._pool._ssl_context.check_hostname is False


### PR DESCRIPTION
## What does this PR do?

Makes the resolved TLS `verify` (per-provider `ssl_ca_cert` / `ssl_verify`, `HERMES_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`) actually apply to proxied traffic in both keepalive client builders (`AIAgent._build_keepalive_http_client` and `agent.process_bootstrap.build_keepalive_http_client`).

Both builders currently pass `verify` only on the custom `HTTPTransport`, with a comment saying "httpx ignores the client-level `verify` when a custom `transport=` is supplied". That is only true for direct traffic. When `proxy=` is set (httpx 0.28.1, the pinned version), `Client.__init__` builds a separate proxy transport via `_init_proxy_transport(proxy, verify=<client-level verify>, ...)` and mounts it. `_transport_for_url()` prefers the mount, so the custom transport (the only place `verify` lived) is never consulted for proxied URLs.

Net effect: behind `HTTP(S)_PROXY`, every main-client request and every auxiliary call (compression, vision, title generation, and so on) ignored the resolved verify:
- a custom CA bundle fails closed with `CERTIFICATE_VERIFY_FAILED`,
- `ssl_verify: false` is not honored.

So the TLS settings were broken exactly for the users they target: corporate users behind SSL-decrypting proxies (the same environment class as #28260). `SSL_CERT_FILE` alone kept working by accident, because httpx's default `verify=True` context reads it, which masks the bug in some setups.

The fix passes `verify` at the client level too, so httpx's internally built proxy transport carries the same SSL context as the custom transport. The comments and the builder docstring are corrected to describe the real httpx behavior.

Note for reviewers: open PR #54550 rewrites this same builder (it pre-dates the `verify` parameter) and would need rebasing over this either way. It does not address the proxied-verify loss.

## Related Issue

Related context: #28260 (custom_providers with self-signed HTTPS endpoints).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `run_agent.py` (`AIAgent._build_keepalive_http_client`): pass `verify=verify` at client level alongside the custom transport, and correct the comment.
- `agent/process_bootstrap.py` (`build_keepalive_http_client`, sync and async): same fix, plus correct the comment and docstring.
- `tests/run_agent/test_create_openai_client_ssl_verify.py`: 2 regression tests asserting the transport selected for a proxied URL carries the resolved SSL context or disabled hostname check. Also adds `CURL_CA_BUNDLE` to the env-cleanup fixture (it is part of the resolution chain but was not cleared, which made the existing tests environment-sensitive).
- `tests/agent/test_auxiliary_client_ssl_verify.py`: 3 regression tests (sync ctx, `verify=False`, async ctx), same fixture hardening.

## How to Test

```bash
scripts/run_tests.sh tests/run_agent/test_create_openai_client_ssl_verify.py tests/agent/test_auxiliary_client_ssl_verify.py
```

All 5 new tests fail on current main (the proxied transport's `_ssl_context` is a default-verify context, not the resolved one) and pass with the fix. Full `tests/run_agent/` (126 files, 1872 tests) green on macOS 15. `scripts/check-windows-footguns.py` clean on all 4 files.

Standalone demonstration against httpx 0.28.1:

```python
import ssl, certifi, httpx
ctx = ssl.create_default_context(cafile=certifi.where())
c = httpx.Client(transport=httpx.HTTPTransport(verify=ctx), proxy="http://proxy.example:3128")
t = c._transport_for_url(httpx.URL("https://ollama.example.com/v1"))
assert t._pool._ssl_context is not ctx   # main: custom CA silently dropped
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docstring/comments updated; no user-facing docs affected)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes