### PR TITLE
fix(tts): convert explicit Edge OGG output

### DIFF
--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -26,6 +26,19 @@ async def _write_edge_output(_text: str, output_path: str, _tts_config: dict) ->
     return output_path
 
 
+class _FakeEdgeTTS:
+    saved_paths: list[str] = []
+
+    class Communicate:
+        def __init__(self, text: str, **kwargs):
+            self.text = text
+            self.kwargs = kwargs
+
+        async def save(self, output_path: str) -> None:
+            _FakeEdgeTTS.saved_paths.append(output_path)
+            Path(output_path).write_bytes(b"mp3")
+
+
 def test_edge_cli_preserves_native_mp3(tmp_path, monkeypatch):
     out = tmp_path / "speech.mp3"
     convert = Mock()
@@ -68,3 +81,48 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+@pytest.mark.asyncio
+async def test_edge_explicit_ogg_writes_real_opus_not_mp3_bytes(tmp_path, monkeypatch):
+    out = tmp_path / "speech.ogg"
+    mp3 = tmp_path / "speech.mp3"
+    _FakeEdgeTTS.saved_paths = []
+
+    def fake_convert(path: str) -> str:
+        assert path == str(mp3)
+        assert mp3.read_bytes() == b"mp3"
+        out.write_bytes(b"ogg")
+        return str(out)
+
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: _FakeEdgeTTS)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", fake_convert)
+
+    result = await tts_tool._generate_edge_tts("hello", str(out), {})
+
+    assert result == str(out)
+    assert out.read_bytes() == b"ogg"
+    assert not mp3.exists()
+    assert _FakeEdgeTTS.saved_paths == [str(mp3)]
+
+
+def test_edge_explicit_ogg_is_voice_compatible(tmp_path, monkeypatch):
+    out = tmp_path / "speech.ogg"
+
+    async def write_ogg(_text: str, output_path: str, _tts_config: dict) -> str:
+        Path(output_path).write_bytes(b"ogg")
+        return output_path
+
+    convert = Mock()
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", write_ogg)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{out}"
+    convert.assert_not_called()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -953,8 +953,29 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
         pct = round((speed - 1.0) * 100)
         kwargs["rate"] = f"{pct:+d}%"
 
+    save_path = output_path
+    explicit_opus = output_path.lower().endswith(".ogg")
+    if explicit_opus:
+        # edge-tts always writes MP3 bytes regardless of the filename. Do not
+        # save those bytes directly under a .ogg extension; write a neighboring
+        # MP3 first, then convert to real Ogg/Opus for Telegram voice delivery.
+        save_path = str(Path(output_path).with_suffix(".mp3"))
+
     communicate = _edge_tts.Communicate(text, **kwargs)
-    await communicate.save(output_path)
+    await communicate.save(save_path)
+
+    if explicit_opus:
+        converted = _convert_to_opus(save_path)
+        if not converted:
+            raise RuntimeError(
+                "Edge TTS requires ffmpeg to write Ogg/Opus output for .ogg paths"
+            )
+        if converted != output_path:
+            os.replace(converted, output_path)
+        try:
+            os.remove(save_path)
+        except OSError:
+            pass
     return output_path
 
 
@@ -2406,6 +2427,11 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
+        elif provider == "edge" and file_str.endswith(".ogg"):
+            # _generate_edge_tts only leaves an .ogg here after converting the
+            # MP3 stream to real Ogg/Opus, so an explicit .ogg path is safe to
+            # route as a native voice bubble even outside a session context.
+            voice_compatible = True
         elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 


### PR DESCRIPTION
Fixes #57048.

## Summary
- make Edge TTS write MP3 to a temporary neighboring path when the caller requests `.ogg`
- convert that MP3 to real Ogg/Opus before returning the requested path
- mark explicit Edge `.ogg` outputs as voice-compatible once conversion has succeeded

## Tests
- `scripts/run_tests.sh tests/tools/test_tts_opus_routing.py`
