### PR TITLE
Add Synthesis to optional-mcps (commerce intelligence, remote OAuth MCP)

### DIFF
--- a/optional-mcps/synthesis/manifest.yaml
+++ b/optional-mcps/synthesis/manifest.yaml
@@ -1,0 +1,30 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: synthesis
+description: Query your commerce data — Amazon, Shopify, Meta, NetSuite, Klaviyo and more — grounded in your real numbers, with a judgment layer that verifies its own answers.
+source: https://synthesisintelligence.ai/integrations
+
+# Synthesis ships a remote MCP server with native OAuth 2.1 + Dynamic Client
+# Registration over Streamable HTTP. Hermes's MCP client + mcp_oauth_manager
+# handle discovery, PKCE, token exchange, and refresh — nothing to install
+# locally.
+transport:
+  type: http
+  url: https://synthesisintelligence.ai/mcp
+
+auth:
+  type: oauth
+  # Native MCP OAuth (case 1) — the MCP client triggers the browser flow on
+  # the first probe / first connect. Sign in with your Synthesis access key.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with
+  Synthesis. Paste your Synthesis access key — generate one at
+  https://synthesisintelligence.ai/connections ("Connect to Claude, ChatGPT &
+  more" -> Generate access key). After auth, restart your Hermes session so
+  the Synthesis tools are loaded.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure synthesis


### PR DESCRIPTION
Adds **Synthesis** to `optional-mcps/`.

Synthesis is the commerce-intelligence layer for consumer brands: it connects a brand's Amazon, Shopify, Meta, NetSuite, Klaviyo, Recharge (and 20+ more) into one model and answers strategic questions grounded in the brand's real numbers — with a judgment layer that verifies its own claims before answering.

**Technical shape** (same profile as the `linear` entry):
- Remote MCP server over **Streamable HTTP** at `https://synthesisintelligence.ai/mcp`
- Native **OAuth 2.1 + Dynamic Client Registration** (RFC 9728 protected-resource metadata, RFC 8414 auth-server metadata, PKCE S256) — Hermes's MCP client + `mcp_oauth_manager` handle discovery, PKCE, token exchange, and refresh; nothing to install locally.
- Read-only, brand-scoped to the user's access key. Tools carry `title` + `readOnlyHint` annotations.

Users can already add the server manually by URL; this entry lists it in the catalog for discovery. On first connect, Hermes opens the browser auth flow and the user pastes their Synthesis access key (generated at https://synthesisintelligence.ai/connections).

Manifest follows the schema of the existing `linear`/`n8n` entries (`manifest_version: 1`, `transport.type: http`, `auth.type: oauth`, `post_install`).