### PR TITLE
fix(execute_code): clarify strict mode filesystem boundary

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -19,6 +19,7 @@ import json
 import os
 import socket
 import time
+from pathlib import Path
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -710,6 +711,12 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
         self.assertIn("shell_quote", desc)
         self.assertIn("retry", desc)
 
+    def test_strict_mode_description_mentions_host_filesystem_tool_boundary(self):
+        schema = build_execute_code_schema(mode="strict")
+        desc = schema["description"]
+        self.assertIn("temp-dir isolation only applies to the Python process cwd", desc)
+        self.assertIn("still operate on the host filesystem", desc)
+
     def test_none_defaults_to_all_tools(self):
         schema_none = build_execute_code_schema(None)
         schema_all = build_execute_code_schema(SANDBOX_ALLOWED_TOOLS)
@@ -817,6 +824,42 @@ class TestEnvVarFiltering(unittest.TestCase):
         finally:
             os.environ.clear()
             os.environ.update(env_backup)
+
+
+@unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
+def test_strict_mode_write_file_still_targets_host_filesystem():
+    scratch_dir = Path.cwd() / ".pytest-exec-code"
+    target = scratch_dir / "strict-host-write.txt"
+    code = (
+        "from hermes_tools import write_file, terminal\n"
+        f"print(write_file({str(target)!r}, 'hello from strict'))\n"
+        f"print(terminal({('test -f ' + str(target) + ' && echo exists || echo missing')!r})['output'])\n"
+    )
+
+    scratch_dir.mkdir(exist_ok=True)
+    if target.exists():
+        target.unlink()
+
+    try:
+        with patch(
+            "tools.code_execution_tool._load_config",
+            return_value={"timeout": 10, "max_tool_calls": 50, "mode": "strict"},
+        ):
+            raw = execute_code(
+                code,
+                task_id="test-strict-host-write",
+                enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+            )
+
+        result = json.loads(raw)
+        assert result["status"] == "success", result
+        assert target.read_text(encoding="utf-8") == "hello from strict"
+        assert "exists" in result["output"]
+    finally:
+        if target.exists():
+            target.unlink()
+        if scratch_dir.exists():
+            scratch_dir.rmdir()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1829,10 +1829,19 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
             "Scripts run in their own temp dir, not the session's CWD — use absolute paths "
             "(os.path.expanduser('~/.hermes/.env')) or terminal()/read_file() for user files."
         )
+        tool_fs_note = (
+            "The temp-dir isolation only applies to the Python process cwd. Hermes tool calls "
+            "(read_file, write_file, patch, search_files, terminal) still operate on the host "
+            "filesystem, using absolute paths or their normal path-resolution rules."
+        )
     else:
         cwd_note = (
             "Scripts run in the session's working directory with the active venv's python, "
             "so project deps (pandas, etc.) and relative paths work like in terminal()."
+        )
+        tool_fs_note = (
+            "Hermes tool calls (read_file, write_file, patch, search_files, terminal) operate "
+            "on the same host filesystem they use outside execute_code."
         )
 
     description = (
@@ -1849,6 +1858,7 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
         "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
         "terminal() is foreground-only (no background or pty).\n\n"
         f"{cwd_note}\n\n"
+        f"{tool_fs_note}\n\n"
         "Print your final result to stdout. Use Python stdlib (json, re, math, csv, "
         "datetime, collections, etc.) for processing between tool calls.\n\n"
         "Also available (no import needed — built into hermes_tools):\n"


### PR DESCRIPTION
## Summary
- clarify in `execute_code` schema text that strict mode only isolates the child Python process cwd
- state explicitly that Hermes tool calls like `write_file` and `terminal` still resolve against the host filesystem
- add schema and regression tests covering the documented behavior

## Why
Issue #57045 reports a mismatch between the strict-mode description and actual `write_file` behavior. Current `main` still routes Hermes tool calls to the host filesystem; the problem is that the schema text implies stronger isolation than the tool actually provides.

## Testing
- `UV_PYTHON=3.11 uv run --extra dev python -m pytest tests/tools/test_code_execution.py -q`