### PR TITLE
fix(gateway): request OGG for Telegram auto TTS

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -816,6 +816,15 @@ def cleanup_image_cache(max_age_hours: int = 24) -> int:
 AUDIO_CACHE_DIR = get_hermes_dir("cache/audio", "audio_cache")
 
 
+def _auto_tts_tool_kwargs(platform, speech_text: str) -> dict:
+    """Build kwargs for auto-TTS generation in the base adapter."""
+    kwargs = {"text": speech_text}
+    if _platform_name(platform) == "telegram":
+        AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        kwargs["output_path"] = str(AUDIO_CACHE_DIR / f"auto_tts_{uuid.uuid4().hex}.ogg")
+    return kwargs
+
+
 def get_audio_cache_dir() -> Path:
     """Return the audio cache directory, creating it if it doesn't exist."""
     d = _resolve_cache_dir("AUDIO_CACHE_DIR", "cache/audio", "audio_cache")
@@ -4965,8 +4974,9 @@ class BasePlatformAdapter(ABC):
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
+                            tts_kwargs = _auto_tts_tool_kwargs(self.platform, speech_text)
                             tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                                text_to_speech_tool, **tts_kwargs
                             )
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -6,10 +6,12 @@ from unittest.mock import patch
 
 import pytest
 
+from gateway.config import Platform
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
+    _auto_tts_tool_kwargs,
     cache_audio_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
@@ -19,6 +21,18 @@ from gateway.platforms.base import (
     _log_safe_path,
     _prefix_within_utf16_limit,
 )
+
+
+class TestAutoTTSOutputPath:
+    def test_telegram_requests_ogg_for_voice_bubble(self):
+        kwargs = _auto_tts_tool_kwargs(Platform.TELEGRAM, "hello")
+
+        assert kwargs["text"] == "hello"
+        assert kwargs["output_path"].endswith(".ogg")
+        assert "auto_tts_" in kwargs["output_path"]
+
+    def test_non_telegram_uses_tts_tool_default(self):
+        assert _auto_tts_tool_kwargs(Platform.DISCORD, "hello") == {"text": "hello"}
 
 
 class TestInboundMediaSizeCap:


### PR DESCRIPTION
Fixes #57049.

## Summary
- make the base adapter auto-TTS path pass an explicit `.ogg` output path for Telegram replies
- keep non-Telegram auto-TTS on the existing default path behavior
- add focused coverage for the auto-TTS kwargs selection

## Tests
- `scripts/run_tests.sh tests/gateway/test_platform_base.py -k "AutoTTSOutputPath"`

Note: Edge-backed `.ogg` conversion itself is handled by #57080 / issue #57048; this PR fixes the gateway path selection that previously never requested Telegram-compatible output.
