### PR TITLE
fix(agent): re-apply custom-provider TLS settings on fallback activation

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1427,6 +1427,30 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 "base_url": fb_base_url,
                 **({"default_headers": dict(fb_headers)} if fb_headers else {}),
             }
+            try:
+                from hermes_cli.config import (
+                    apply_custom_provider_tls_to_client_kwargs,
+                    get_compatible_custom_providers,
+                    load_config_readonly,
+                )
+
+                # Mirror agent_init / switch_model: every request-scoped
+                # client is rebuilt from _client_kwargs, so without the
+                # fallback provider's ssl_ca_cert / ssl_verify here, a
+                # custom HTTPS endpoint signed by a private CA fails
+                # APIConnectionError on the first request after fallback
+                # activates (the initial fb_client resolves TLS via the
+                # auxiliary path, masking the gap until the rebuild).
+                apply_custom_provider_tls_to_client_kwargs(
+                    agent._client_kwargs,
+                    str(fb_base_url or ""),
+                    get_compatible_custom_providers(load_config_readonly()),
+                )
+            except Exception:
+                logger.debug(
+                    "custom-provider TLS resolution skipped on fallback activation",
+                    exc_info=True,
+                )
             if _fb_timeout is not None:
                 agent._client_kwargs["timeout"] = _fb_timeout
                 # Rebuild the shared OpenAI client so the configured

--- a/tests/agent/test_fallback_custom_provider_tls.py
+++ b/tests/agent/test_fallback_custom_provider_tls.py
@@ -1,0 +1,117 @@
+"""Regression: fallback activation must re-apply per-provider TLS settings.
+
+``agent_init`` and ``switch_model`` both call
+``apply_custom_provider_tls_to_client_kwargs`` when they (re)build
+``agent._client_kwargs``, because every request-scoped client is rebuilt from
+that dict and ``create_openai_client`` resolves ``ssl_ca_cert`` /
+``ssl_verify`` out of it. ``try_activate_fallback`` is the third place that
+rebuilds ``_client_kwargs``; without the same re-apply, falling back to a
+custom HTTPS endpoint signed by a private CA works for the very first
+request (the initial fb_client resolves TLS via the auxiliary path) and then
+fails ``APIConnectionError`` on every rebuilt client.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.chat_completion_helpers import try_activate_fallback
+
+_FB_BASE_URL = "https://ollama.internal.example/v1"
+_CA_PATH = "/etc/ssl/mkcert-root.pem"
+
+
+def _make_agent():
+    agent = MagicMock()
+    agent.provider = "openrouter"
+    agent.model = "openrouter/auto"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.api_mode = "chat_completions"
+    agent.api_key = "primary-key"
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = [
+        {"provider": "my-ollama", "model": "llama4", "base_url": _FB_BASE_URL},
+    ]
+    agent._primary_runtime = {
+        "provider": "openrouter",
+        "model": "openrouter/auto",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+        "api_key": "primary-key",
+        "client_kwargs": {
+            "api_key": "primary-key",
+            "base_url": "https://openrouter.ai/api/v1",
+        },
+        "use_prompt_caching": False,
+        "use_native_cache_layout": False,
+        "anthropic_api_key": "",
+        "anthropic_base_url": "",
+    }
+    agent._config_context_length = None
+    agent._credential_pool = None
+    agent._rate_limited_until = 0
+    agent._transport_cache = {}
+    agent._client_kwargs = {
+        "api_key": "primary-key",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+    agent._buffer_status = MagicMock()
+    agent._is_azure_openai_url.return_value = False
+    agent._is_direct_openai_url.return_value = False
+    agent._provider_model_requires_responses_api.return_value = False
+    agent._anthropic_prompt_cache_policy.return_value = (False, False)
+    agent._ensure_lmstudio_runtime_loaded = MagicMock()
+    agent._replace_primary_openai_client = MagicMock()
+    agent.context_compressor = None
+    return agent
+
+
+def _activate(agent, config):
+    fallback_client = SimpleNamespace(
+        api_key="fb-key",
+        base_url=_FB_BASE_URL,
+        _custom_headers={},
+    )
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(fallback_client, "llama4"),
+    ), patch(
+        "agent.credential_pool.load_pool",
+        return_value=None,
+    ), patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value=config,
+    ):
+        assert try_activate_fallback(agent) is True
+
+
+def test_fallback_applies_per_provider_ssl_ca_cert():
+    agent = _make_agent()
+    _activate(agent, {
+        "custom_providers": [
+            {"name": "my-ollama", "base_url": _FB_BASE_URL, "ssl_ca_cert": _CA_PATH},
+        ],
+    })
+    assert agent.base_url == _FB_BASE_URL
+    assert agent._client_kwargs.get("ssl_ca_cert") == _CA_PATH
+
+
+def test_fallback_applies_per_provider_ssl_verify_false():
+    agent = _make_agent()
+    _activate(agent, {
+        "custom_providers": [
+            {"name": "my-ollama", "base_url": _FB_BASE_URL, "ssl_verify": False},
+        ],
+    })
+    assert agent._client_kwargs.get("ssl_verify") is False
+
+
+def test_fallback_without_tls_settings_leaves_kwargs_clean():
+    agent = _make_agent()
+    _activate(agent, {
+        "custom_providers": [
+            {"name": "my-ollama", "base_url": _FB_BASE_URL},
+        ],
+    })
+    assert "ssl_ca_cert" not in agent._client_kwargs
+    assert "ssl_verify" not in agent._client_kwargs


### PR DESCRIPTION
## What does this PR do?

Makes mid-session fallback activation honor per-provider TLS settings (`ssl_ca_cert` / `ssl_verify` from `custom_providers` / `providers`), the same way init and `/model` switching already do.

`agent._client_kwargs` is rebuilt in three places, and every request-scoped client is rebuilt from that dict (`create_openai_client` pops `ssl_ca_cert`/`ssl_verify` into `resolve_httpx_verify`). The three places:

- `agent/agent_init.py` applies TLS via `apply_custom_provider_tls_to_client_kwargs`.
- `switch_model` in `agent/agent_runtime_helpers.py` applies TLS from live config.
- `try_activate_fallback` in `agent/chat_completion_helpers.py` rebuilds `_client_kwargs` from scratch with no TLS re-apply. That is the bug.

The fallback chain explicitly supports custom endpoints (`base_url` hint, "e.g. Ollama Cloud" comment). With `fallback_model` pointing at a custom HTTPS endpoint signed by a private CA:

1. The primary 429s and the fallback activates.
2. The initial `fb_client` works, because it resolves TLS through the auxiliary-client path.
3. The next request-scoped rebuild from `_client_kwargs` drops the CA, so every subsequent request raises `APIConnectionError`. The same endpoint configured as the primary provider works fine.

The fix mirrors the `switch_model` block: read `custom_providers` from live config (`load_config_readonly`) and re-apply `ssl_ca_cert`/`ssl_verify` to the rebuilt kwargs, wrapped in the same fail-open `try/except` with a debug log.

## Related Issue

Same bug class as the recently merged custom-provider TLS work (#56681 follow-up surface). Related environment class: #28260.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: in the chat-completions branch of `try_activate_fallback`, apply `apply_custom_provider_tls_to_client_kwargs(agent._client_kwargs, fb_base_url, get_compatible_custom_providers(load_config_readonly()))` right after `_client_kwargs` is rebuilt (before the timeout-triggered `_replace_primary_openai_client`, so the rebuilt client already carries TLS).
- `tests/agent/test_fallback_custom_provider_tls.py`: 3 tests driving the real `try_activate_fallback` with a stubbed provider client (same harness style as `tests/run_agent/test_fallback_credential_isolation.py`). They cover `ssl_ca_cert` applied, `ssl_verify: false` applied, and a control asserting no TLS keys leak when the entry has none.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_fallback_custom_provider_tls.py
```

The two TLS tests fail on current main (`_client_kwargs` has no `ssl_ca_cert`/`ssl_verify` after activation) and pass with the fix. The control passes on both. Also green: tests/run_agent/test_fallback_credential_isolation.py, tests/agent/test_failover_identity.py, tests/hermes_cli/test_custom_provider_tls.py, tests/agent/test_auxiliary_named_custom_providers.py, tests/hermes_cli/test_ollama_cloud_auth.py (macOS 15). Note: `tests/agent/test_credential_pool_routing.py::TestCliTurnRoutePool::test_resolve_turn_includes_pool` fails identically on clean main. It is pre-existing and unrelated. `scripts/check-windows-footguns.py` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A, internal fix)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes