### PR TITLE
fix(config): accept provider default_headers alias

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -39,6 +39,24 @@ logger = logging.getLogger(__name__)
 _CONFIG_PARSE_WARNED: set = set()
 
 
+def _coerce_provider_extra_headers(entry: Dict[str, Any]) -> Dict[str, str]:
+    """Return provider HTTP headers, accepting ``default_headers`` as an alias.
+
+    ``extra_headers`` is the canonical config key for provider-level request
+    headers.  ``default_headers`` appeared in older examples because it mirrors
+    the OpenAI client kwarg name, so keep it as a compatibility alias while
+    letting the canonical key win on collisions.
+    """
+    merged: Dict[str, str] = {}
+    for key in ("default_headers", "extra_headers"):
+        headers = entry.get(key)
+        if isinstance(headers, dict) and headers:
+            merged.update({
+                str(k): str(v) for k, v in headers.items() if v is not None
+            })
+    return merged
+
+
 def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
     """Preserve a corrupted ``config.yaml`` by copying it to a timestamped ``.bak``.
 
@@ -4489,7 +4507,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body", "extra_headers",
+        "discover_models", "extra_body", "extra_headers", "default_headers",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -4598,13 +4616,12 @@ def _normalize_custom_provider_entry(
         normalized["extra_body"] = dict(extra_body)
 
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).
-    # Values may carry credentials (e.g. CF-Access-Client-Secret) — never
-    # log them anywhere downstream.
-    extra_headers = entry.get("extra_headers")
-    if isinstance(extra_headers, dict) and extra_headers:
-        normalized["extra_headers"] = {
-            str(k): str(v) for k, v in extra_headers.items() if v is not None
-        }
+    # ``extra_headers`` is canonical; ``default_headers`` is a compatibility
+    # alias matching the OpenAI client kwarg name. Values may carry credentials
+    # (e.g. CF-Access-Client-Secret) — never log them anywhere downstream.
+    extra_headers = _coerce_provider_extra_headers(entry)
+    if extra_headers:
+        normalized["extra_headers"] = extra_headers
 
     ssl_ca_cert = entry.get("ssl_ca_cert")
     if isinstance(ssl_ca_cert, str) and ssl_ca_cert.strip():
@@ -4792,12 +4809,13 @@ def get_custom_provider_extra_headers(
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, str]:
-    """Return ``extra_headers`` from a matching ``providers`` / ``custom_providers`` entry.
+    """Return provider headers from a matching ``providers`` / ``custom_providers`` entry.
 
     Matches the entry whose ``base_url`` equals *base_url* (trailing-slash and
     case insensitive, mirroring :func:`get_custom_provider_tls_settings`) and
-    returns its ``extra_headers`` dict, or ``{}`` when no entry matches or the
-    entry declares none.
+    returns its ``extra_headers`` dict. ``default_headers`` is accepted as a
+    compatibility alias and normalized into the same return shape. Returns
+    ``{}`` when no entry matches or the entry declares none.
 
     SECURITY: header values routinely carry credentials (Cloudflare Access
     service tokens, proxy auth, custom bearer schemes). Callers must never
@@ -4818,12 +4836,7 @@ def get_custom_provider_extra_headers(
         entry_url = (entry.get("base_url") or "").rstrip("/").lower()
         if not entry_url or entry_url != target_url:
             continue
-        extra_headers = entry.get("extra_headers")
-        if isinstance(extra_headers, dict) and extra_headers:
-            return {
-                str(k): str(v) for k, v in extra_headers.items() if v is not None
-            }
-        return {}
+        return _coerce_provider_extra_headers(entry)
     return {}
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -31,7 +31,11 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import get_compatible_custom_providers, load_config
+from hermes_cli.config import (
+    _coerce_provider_extra_headers,
+    get_compatible_custom_providers,
+    load_config,
+)
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_int
 
@@ -592,16 +596,17 @@ def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> No
 
 
 def _lift_extra_headers(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
-    """Copy a validated ``extra_headers`` dict from a provider entry.
+    """Copy provider HTTP headers from a provider entry.
+
+    ``extra_headers`` is canonical; ``default_headers`` is accepted as a
+    compatibility alias matching the OpenAI client kwarg name.
 
     SECURITY: header values routinely carry credentials (Cloudflare Access
     service tokens, proxy auth, custom bearer schemes). Never log them.
     """
-    extra_headers = entry.get("extra_headers")
-    if isinstance(extra_headers, dict) and extra_headers:
-        result["extra_headers"] = {
-            str(k): str(v) for k, v in extra_headers.items() if v is not None
-        }
+    extra_headers = _coerce_provider_extra_headers(entry)
+    if extra_headers:
+        result["extra_headers"] = extra_headers
 
 
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -26,6 +26,38 @@ def test_normalize_entry_keeps_extra_headers():
     }
 
 
+def test_normalize_entry_accepts_default_headers_alias():
+    normalized = _normalize_custom_provider_entry(
+        {
+            "name": "coreweave",
+            "base_url": "https://api.inference.wandb.ai/v1",
+            "default_headers": {"OpenAI-Project": "team/project"},
+        }
+    )
+    assert normalized is not None
+    assert normalized["extra_headers"] == {"OpenAI-Project": "team/project"}
+    assert "default_headers" not in normalized
+
+
+def test_normalize_entry_extra_headers_wins_over_default_headers_alias():
+    normalized = _normalize_custom_provider_entry(
+        {
+            "name": "coreweave",
+            "base_url": "https://api.inference.wandb.ai/v1",
+            "default_headers": {
+                "OpenAI-Project": "team/default-project",
+                "X-Default-Only": "kept",
+            },
+            "extra_headers": {"OpenAI-Project": "team/explicit-project"},
+        }
+    )
+    assert normalized is not None
+    assert normalized["extra_headers"] == {
+        "OpenAI-Project": "team/explicit-project",
+        "X-Default-Only": "kept",
+    }
+
+
 def test_normalize_entry_drops_invalid_extra_headers():
     for bad in ("not-a-dict", {}, 42, ["a"]):
         normalized = _normalize_custom_provider_entry(
@@ -65,6 +97,21 @@ def test_get_custom_provider_extra_headers_matches_base_url():
         custom_providers=providers,
     )
     assert headers == {"CF-Access-Client-Id": "xxxx.access"}
+
+
+def test_get_custom_provider_extra_headers_accepts_default_headers_alias():
+    providers = [
+        {
+            "name": "coreweave",
+            "base_url": "https://api.inference.wandb.ai/v1",
+            "default_headers": {"OpenAI-Project": "team/project"},
+        }
+    ]
+    headers = get_custom_provider_extra_headers(
+        "https://api.inference.wandb.ai/v1",
+        custom_providers=providers,
+    )
+    assert headers == {"OpenAI-Project": "team/project"}
 
 
 def test_get_custom_provider_extra_headers_no_match_returns_empty():

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3286,6 +3286,33 @@ def test_providers_dict_entry_surfaces_extra_headers(monkeypatch):
     assert resolved["extra_headers"] == {"CF-Access-Client-Id": "xxxx.access"}
 
 
+def test_providers_dict_entry_surfaces_default_headers_alias(monkeypatch):
+    """providers.<name>.default_headers feeds the same runtime path."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "coreweave": {
+                    "base_url": "https://api.inference.wandb.ai/v1",
+                    "api_key": "wandb-key",
+                    "default_headers": {"OpenAI-Project": "team/project"},
+                }
+            }
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="coreweave")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://api.inference.wandb.ai/v1"
+    assert resolved["api_key"] == "wandb-key"
+    assert resolved["extra_headers"] == {"OpenAI-Project": "team/project"}
+    assert "default_headers" not in resolved
+
+
 def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeypatch):
     """extra_headers must survive the credential-pool path too."""
     pool_return_value = {


### PR DESCRIPTION
## Summary
- accept provider-level `default_headers` as a compatibility alias for `extra_headers` on `providers` and `custom_providers`
- normalize aliases into the existing `extra_headers` runtime path, with `extra_headers` winning on collisions
- add regression coverage for W&B/CoreWeave `OpenAI-Project` headers on named providers

## Why
Hermes v0.18 added provider-level `extra_headers`, which covers project-scoped W&B/CoreWeave Serverless Inference requests. Earlier config examples and issue discussion used `default_headers`, matching the OpenAI client kwarg. Those configs are currently treated as unknown/ignored, so the project header is not passed through.

Fixes #52686

## Testing
- `uv run --extra dev python -m pytest tests/hermes_cli/test_custom_provider_extra_headers.py tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_with_extra_headers tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_without_extra_headers_omits_key tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_non_dict_extra_headers_ignored tests/hermes_cli/test_runtime_provider_resolution.py::test_providers_dict_entry_surfaces_extra_headers tests/hermes_cli/test_runtime_provider_resolution.py::test_providers_dict_entry_surfaces_default_headers_alias tests/hermes_cli/test_runtime_provider_resolution.py::test_resolve_named_custom_runtime_pool_result_includes_extra_headers tests/run_agent/test_custom_provider_extra_headers_client.py`
- `uv run --extra dev ruff check hermes_cli/config.py hermes_cli/runtime_provider.py tests/hermes_cli/test_custom_provider_extra_headers.py tests/hermes_cli/test_runtime_provider_resolution.py`
