### PR TITLE
fix(tui): prefer bundled dist before workspace check

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1749,10 +1749,9 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         )
         sys.exit(1)
 
-    if not ext_dir:
-        _ensure_tui_workspace(tui_dir)
-
-    # 1. Prebuilt bundle (nix / packaged release): just run it.
+    # 1. Prebuilt bundle (nix / packaged release): just run it.  Check this
+    # before requiring the source workspace so wheels/Homebrew formulae that
+    # ship hermes_cli/tui_dist but not ui-tui/ can launch normally.
     if not tui_dev:
         if ext_dir:
             p = Path(ext_dir)
@@ -1765,6 +1764,9 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if bundled is not None:
             node = _node_bin("node")
             return [node, "--expose-gc", str(bundled)], bundled.parent
+
+    if not ext_dir:
+        _ensure_tui_workspace(tui_dir)
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.

--- a/tests/hermes_cli/test_tui_bundled.py
+++ b/tests/hermes_cli/test_tui_bundled.py
@@ -18,3 +18,29 @@ def test_tui_returns_none_when_no_bundle(tmp_path):
     from hermes_cli.main import _find_bundled_tui
     result = _find_bundled_tui(hermes_cli_dir=tmp_path / "hermes_cli")
     assert result is None
+
+
+def test_tui_uses_bundled_dist_without_source_workspace(tmp_path, monkeypatch):
+    """Packaged installs may ship hermes_cli/tui_dist but not ui-tui/."""
+    from hermes_cli import main
+
+    bundled = tmp_path / "hermes_cli" / "tui_dist" / "entry.js"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("// bundled TUI", encoding="utf-8")
+    project_root = tmp_path / "site-packages"
+    project_root.mkdir()
+
+    def fail_if_workspace_required(_tui_dir):
+        raise AssertionError("source ui-tui workspace should not be required")
+
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setattr(main, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(main, "_find_bundled_tui", lambda: bundled)
+    monkeypatch.setattr(main, "_ensure_tui_workspace", fail_if_workspace_required)
+    monkeypatch.setattr(main, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main.shutil, "which", lambda name: "/usr/bin/node" if name == "node" else None)
+
+    argv, cwd = main._make_tui_argv(project_root / "ui-tui", tui_dev=False)
+
+    assert argv == ["/usr/bin/node", "--expose-gc", str(bundled)]
+    assert cwd == bundled.parent


### PR DESCRIPTION
Fixes #57031.

## Summary
- let packaged installs launch the bundled `hermes_cli/tui_dist/entry.js` before requiring a source `ui-tui/` workspace
- keep checkout/dev fallback behavior unchanged when no bundled dist exists
- add regression coverage for a package-like layout with no `ui-tui/` directory

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_tui_bundled.py`
