### PR TITLE
fix(tui): route runtime check off read loop

### DIFF
--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -65,6 +65,7 @@ def capture(server):
 
 FRONTEND_POLLED_RPCS = [
     "session.list",   # loads session list — SQLite query
+    "setup.runtime_check",  # readiness probe — config/auth/provider checks
     "pet.info",       # petdex poll — file/network read
     "process.list",   # background process status — process registry scan
 ]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -216,6 +216,7 @@ _LONG_HANDLERS = frozenset(
         "session.compress",
         "session.list",
         "session.resume",
+        "setup.runtime_check",
         "shell.exec",
         "skills.manage",
         "slash.exec",


### PR DESCRIPTION
## What does this PR do?

Routes the desktop/TUI `setup.runtime_check` readiness probe through the existing `_LONG_HANDLERS` RPC pool instead of running it inline on the websocket reader path.

`setup.runtime_check` is polled by the frontend and performs config/auth/provider runtime checks. On current `main`, it is registered as a method but absent from `_LONG_HANDLERS`, so `dispatch()` can run it synchronously and block the read loop under GIL pressure. This is the residual failure described in #56888.

This PR keeps the fix intentionally narrow: add `setup.runtime_check` to `_LONG_HANDLERS` and extend the existing frontend-polled RPC regression list so it cannot regress.

## Related Issue

Fixes #56888

Related overlap: #56084 covers the broader `setup.runtime_check` + `setup.status` readiness-poll routing class. This PR is the minimal #56888-specific fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/server.py`: add `setup.runtime_check` to `_LONG_HANDLERS`.
- `tests/tui_gateway/test_inline_rpc_gil_starvation.py`: include `setup.runtime_check` in `FRONTEND_POLLED_RPCS`.

## How to Test

1. Verify current-main source behavior: `setup.runtime_check` is registered but absent from `_LONG_HANDLERS`.
2. Apply this PR.
3. Run:

```bash
git diff --check
scripts/run_tests.sh tests/tui_gateway/test_inline_rpc_gil_starvation.py
```

Result: `7 tests passed`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS / local Hermes worktree

### Documentation & Housekeeping

- [x] N/A — no documentation changes needed
- [x] N/A — no `cli-config.yaml.example` changes
- [x] N/A — no `CONTRIBUTING.md` or `AGENTS.md` changes
- [x] Cross-platform impact considered: this changes TUI gateway RPC dispatch only and should benefit Windows/macOS/Linux Desktop/TUI clients
- [x] N/A — no tool descriptions/schemas changed

## Screenshots / Logs

```text
▶ running per-file parallel test suite via run_tests_parallel.py
Discovered 1 test files (~4 tests) under ['tests/tui_gateway/test_inline_rpc_gil_starvation.py']; running with -j 20
[100.0% |     4/~4 | ✓7 | ✗0] ✓ tests/tui_gateway/test_inline_rpc_gil_starvation.py (7✓, 1.3s)

=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) in 1.3s (20 workers) ===
```