### PR TITLE
fix(config): prevent YAML None→0 serialization in credential clearing

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4375,12 +4375,12 @@ def clear_model_endpoint_credentials(
     if not isinstance(model_cfg, dict):
         return model_cfg
     if clear_api_key:
-        model_cfg.pop("api_key", None)
-        model_cfg.pop("api", None)
+        model_cfg["api_key"] = ""
+        model_cfg["api"] = ""
     if clear_api_mode:
-        model_cfg.pop("api_mode", None)
+        model_cfg["api_mode"] = ""
     if clear_base_url:
-        model_cfg.pop("base_url", None)
+        model_cfg["base_url"] = ""
     return model_cfg
 
 


### PR DESCRIPTION
## Problem

When `clear_model_endpoint_credentials()` removes stale credentials (`api_key`, `api_mode`, `base_url`), it uses `.pop(key, None)`, which leaves the dict without those keys. However, PyYAML's serialization behavior serializes `None` values as integer `0` when the config is saved back to `config.yaml`.

This causes:
- `api_key: 0` in YAML (integer, not string)
- `Authorization: Bearer 0` sent to API endpoints
- All model API calls fail with 401 Unauthorized
- Affects **all profiles** using `custom:` providers

## Root Cause

```python
# Before (line 4378-4383)
model_cfg.pop("api_key", None)  # Returns None, key removed
# PyYAML dump sees None somewhere → serializes as 0
```

## Solution

Replace `.pop()` with explicit empty string assignment:

```python
# After
model_cfg["api_key"] = ""  # YAML serializes as empty string, not 0
```

This ensures PyYAML always sees string values and serializes them correctly as `""`, not `0`.

## Testing

- Manual: Configure custom provider → clear credentials → check `config.yaml` for `api_key: ""` (not `api_key: 0`)
- Verified on v0.17.0 (upstream 184c10cf)
- All 4 fields (`api_key`, `api`, `api_mode`, `base_url`) now handle consistently

## Impact

Fixes auth failures for all custom provider users. Previously required manual `hermes config set model.api_key ""` workaround.

Fixes #56535