### PR TITLE
fix(telegram): render media captions with MarkdownV2

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -20,7 +20,7 @@ import threading
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Set, Any
+from typing import Any, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -278,6 +278,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     _TEXT_INJECT_EXTENSIONS,
+    _prefix_within_utf16_limit,
     utf16_len,
 )
 from plugins.platforms.telegram.telegram_ids import (
@@ -1275,6 +1276,44 @@ class TelegramAdapter(BasePlatformAdapter):
         except ImportError:
             return False
 
+    @staticmethod
+    def _looks_like_markdown_parse_error(error: Exception) -> bool:
+        return classify_send_error(error) == "bad_format"
+
+    def _caption_kwargs(self, caption: Optional[str]) -> Dict[str, Any]:
+        """Build a Telegram caption without splitting UTF-16 code points."""
+        if not caption:
+            return {"caption": None}
+        if ParseMode is not None:
+            try:
+                formatted = self.format_message(caption)
+                if utf16_len(formatted) <= 1024:
+                    return {
+                        "caption": formatted,
+                        "parse_mode": ParseMode.MARKDOWN_V2,
+                    }
+            except Exception:
+                logger.debug(
+                    "[%s] media caption MarkdownV2 formatting failed; "
+                    "sending plain caption",
+                    self.name,
+                    exc_info=True,
+                )
+        return {"caption": _prefix_within_utf16_limit(caption, 1024)}
+
+    @staticmethod
+    def _plain_caption_retry_kwargs(
+        send_kwargs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        retry_kwargs = dict(send_kwargs)
+        caption = retry_kwargs.get("caption")
+        if caption:
+            retry_kwargs["caption"] = _prefix_within_utf16_limit(
+                _strip_mdv2(str(caption)), 1024
+            )
+        retry_kwargs.pop("parse_mode", None)
+        return retry_kwargs
+
     @classmethod
     def _should_retry_without_dm_topic_reply_anchor(
         cls,
@@ -1327,15 +1366,57 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to_message_id: Optional[int],
         media_label: str,
         reset_media: Optional[Any] = None,
+        allow_plain_caption_retry: bool = True,
+        allow_topic_anchor_retry: bool = True,
+        plain_caption_retry_factory: Optional[
+            Callable[[Dict[str, Any]], Dict[str, Any]]
+        ] = None,
     ) -> Any:
-        """Retry stale private-topic media replies once without the topic anchor."""
+        """Retry media sends through bounded caption and topic fallbacks."""
         try:
             return await send_fn(**send_kwargs)
         except Exception as send_err:
-            if not self._should_retry_without_dm_topic_reply_anchor(
-                send_err,
-                metadata,
-                reply_to_message_id,
+            has_formatted_caption = bool(
+                send_kwargs.get("parse_mode") is not None
+                and send_kwargs.get("caption")
+            )
+            if (
+                allow_plain_caption_retry
+                and (plain_caption_retry_factory is not None or has_formatted_caption)
+                and self._looks_like_markdown_parse_error(send_err)
+            ):
+                logger.warning(
+                    "[%s] Telegram %s caption MarkdownV2 parse failed, "
+                    "retrying as plain text: %s",
+                    self.name,
+                    media_label,
+                    _redact_telegram_error_text(send_err),
+                )
+                if reset_media is not None:
+                    reset_media()
+                retry_kwargs = (
+                    plain_caption_retry_factory(send_kwargs)
+                    if plain_caption_retry_factory is not None
+                    else self._plain_caption_retry_kwargs(send_kwargs)
+                )
+                return await self._send_with_dm_topic_reply_anchor_retry(
+                    send_fn,
+                    retry_kwargs,
+                    metadata,
+                    reply_to_message_id,
+                    media_label,
+                    reset_media=reset_media,
+                    allow_plain_caption_retry=False,
+                    allow_topic_anchor_retry=allow_topic_anchor_retry,
+                    plain_caption_retry_factory=plain_caption_retry_factory,
+                )
+            if (
+                not allow_topic_anchor_retry
+                or not self._should_retry_without_dm_topic_reply_anchor(
+                    send_err,
+                    metadata,
+                    reply_to_message_id,
+                )
             ):
                 raise
             logger.warning(
@@ -1347,11 +1428,20 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             if reset_media is not None:
                 reset_media()
-            retry_kwargs = dict(send_kwargs)
-            retry_kwargs["reply_to_message_id"] = None
-            retry_kwargs.pop("message_thread_id", None)
-            retry_kwargs.pop("direct_messages_topic_id", None)
-            return await send_fn(**retry_kwargs)
+            send_kwargs["reply_to_message_id"] = None
+            send_kwargs.pop("message_thread_id", None)
+            send_kwargs.pop("direct_messages_topic_id", None)
+            return await self._send_with_dm_topic_reply_anchor_retry(
+                send_fn,
+                send_kwargs,
+                metadata,
+                reply_to_message_id,
+                media_label,
+                reset_media=reset_media,
+                allow_plain_caption_retry=allow_plain_caption_retry,
+                allow_topic_anchor_retry=False,
+                plain_caption_retry_factory=plain_caption_retry_factory,
+            )
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -6761,7 +6851,9 @@ class TelegramAdapter(BasePlatformAdapter):
                         "[%s] voice caption MarkdownV2 formatting failed; "
                         "sending plain caption", self.name, exc_info=True,
                     )
-                _caption_variants.append((caption[:1024], None))
+                _caption_variants.append(
+                    (_prefix_within_utf16_limit(caption, 1024), None)
+                )
             else:
                 _caption_variants.append((None, None))
 
@@ -6780,33 +6872,36 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                     msg = None
                     _last_parse_error: Optional[Exception] = None
+                    voice_send_kwargs = {
+                        "chat_id": normalize_telegram_chat_id(chat_id),
+                        "voice": audio_file,
+                        "reply_to_message_id": reply_to_id,
+                        "duration": _duration_secs,
+                        **voice_thread_kwargs,
+                        **self._notification_kwargs(metadata),
+                    }
                     for _cap_text, _cap_parse_mode in _caption_variants:
+                        voice_send_kwargs["caption"] = _cap_text
+                        voice_send_kwargs["parse_mode"] = _cap_parse_mode
                         try:
                             msg = await self._send_with_dm_topic_reply_anchor_retry(
                                 self._bot.send_voice,
-                                {
-                                    "chat_id": normalize_telegram_chat_id(chat_id),
-                                    "voice": audio_file,
-                                    "caption": _cap_text,
-                                    "parse_mode": _cap_parse_mode,
-                                    "reply_to_message_id": reply_to_id,
-                                    "duration": _duration_secs,
-                                    **voice_thread_kwargs,
-                                    **self._notification_kwargs(metadata),
-                                },
+                                voice_send_kwargs,
                                 metadata,
-                                reply_to_id,
+                                voice_send_kwargs.get("reply_to_message_id"),
                                 "voice",
                                 reset_media=lambda: audio_file.seek(0),
+                                allow_plain_caption_retry=False,
                             )
                             break
                         except Exception as _cap_error:
                             # Only retry the next (plain) variant on entity
                             # parse failures; anything else is a real send
                             # error for the outer handler.
-                            if (_cap_parse_mode is not None
-                                    and ("parse" in str(_cap_error).lower()
-                                         or "entit" in str(_cap_error).lower())):
+                            if (
+                                _cap_parse_mode is not None
+                                and self._looks_like_markdown_parse_error(_cap_error)
+                            ):
                                 logger.warning(
                                     "[%s] voice caption MarkdownV2 rejected, "
                                     "retrying plain: %s",
@@ -6837,7 +6932,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         {
                             "chat_id": normalize_telegram_chat_id(chat_id),
                             "audio": audio_file,
-                            "caption": caption[:1024] if caption else None,
+                            **self._caption_kwargs(caption),
                             "reply_to_message_id": reply_to_id,
                             "duration": _duration_secs,
                             **audio_thread_kwargs,
@@ -6932,22 +7027,51 @@ class TelegramAdapter(BasePlatformAdapter):
 
             media: List[Any] = []
             opened_files: List[Any] = []
-            try:
-                for image_url, alt_text in chunk:
-                    caption = alt_text[:1024] if alt_text else None
-                    if image_url.startswith("file://"):
-                        local_path = _unquote(image_url[7:])
-                        if not os.path.exists(local_path):
-                            logger.warning(
-                                "[%s] Skipping missing image in media group: %s",
-                                self.name, local_path,
+
+            def _close_opened_files(files: List[Any]) -> None:
+                for fh in files:
+                    try:
+                        fh.close()
+                    except Exception:
+                        pass
+
+            def _build_media_group(
+                plain_captions: bool = False,
+            ) -> tuple[List[Any], List[Any]]:
+                built_media: List[Any] = []
+                built_files: List[Any] = []
+                try:
+                    for image_url, alt_text in chunk:
+                        caption_kwargs = self._caption_kwargs(alt_text)
+                        if plain_captions:
+                            caption_kwargs = self._plain_caption_retry_kwargs(
+                                caption_kwargs
                             )
-                            continue
-                        fh = open(local_path, "rb")
-                        opened_files.append(fh)
-                        media.append(InputMediaPhoto(media=fh, caption=caption))
-                    else:
-                        media.append(InputMediaPhoto(media=image_url, caption=caption))
+                        if image_url.startswith("file://"):
+                            local_path = _unquote(image_url[7:])
+                            if not os.path.exists(local_path):
+                                logger.warning(
+                                    "[%s] Skipping missing image in media group: %s",
+                                    self.name,
+                                    local_path,
+                                )
+                                continue
+                            fh = open(local_path, "rb")
+                            built_files.append(fh)
+                            built_media.append(
+                                InputMediaPhoto(media=fh, **caption_kwargs)
+                            )
+                        else:
+                            built_media.append(
+                                InputMediaPhoto(media=image_url, **caption_kwargs)
+                            )
+                except Exception:
+                    _close_opened_files(built_files)
+                    raise
+                return built_media, built_files
+
+            try:
+                media, opened_files = _build_media_group()
 
                 if not media:
                     continue
@@ -6972,6 +7096,18 @@ class TelegramAdapter(BasePlatformAdapter):
                         except Exception:
                             pass
 
+                def _plain_media_group_retry_kwargs(
+                    current_kwargs: Dict[str, Any],
+                ) -> Dict[str, Any]:
+                    nonlocal media, opened_files
+                    _close_opened_files(opened_files)
+                    media, opened_files = _build_media_group(
+                        plain_captions=True
+                    )
+                    retry_kwargs = dict(current_kwargs)
+                    retry_kwargs["media"] = media
+                    return retry_kwargs
+
                 await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_media_group,
                     {
@@ -6985,6 +7121,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to_id,
                     "media group",
                     reset_media=_reset_opened_files,
+                    plain_caption_retry_factory=(
+                        _plain_media_group_retry_kwargs
+                        if any(alt_text for _, alt_text in chunk)
+                        else None
+                    ),
                 )
             except Exception as e:
                 logger.warning(
@@ -6997,11 +7138,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     chat_id, chunk, metadata, human_delay=human_delay,
                 )
             finally:
-                for fh in opened_files:
-                    try:
-                        fh.close()
-                    except Exception:
-                        pass
+                _close_opened_files(opened_files)
 
     async def send_image_file(
         self,
@@ -7035,7 +7172,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "photo": image_file,
-                        "caption": caption[:1024] if caption else None,
+                        **self._caption_kwargs(caption),
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -7132,7 +7269,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "document": f,
                         "filename": display_name,
-                        "caption": caption[:1024] if caption else None,
+                        **self._caption_kwargs(caption),
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -7182,7 +7319,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "video": f,
-                        "caption": caption[:1024] if caption else None,
+                        **self._caption_kwargs(caption),
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -7237,7 +7374,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 {
                     "chat_id": normalize_telegram_chat_id(chat_id),
                     "photo": image_url,
-                    "caption": caption[:1024] if caption else None,
+                    **self._caption_kwargs(caption),
                     "reply_to_message_id": reply_to_id,
                     **photo_thread_kwargs,
                     **self._notification_kwargs(metadata),
@@ -7279,7 +7416,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     {
                         "chat_id": normalize_telegram_chat_id(chat_id),
                         "photo": image_data,
-                        "caption": caption[:1024] if caption else None,
+                        **self._caption_kwargs(caption),
                         "reply_to_message_id": reply_to_id,
                         **upload_thread_kwargs,
                         **self._notification_kwargs(metadata),
@@ -7326,7 +7463,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 {
                     "chat_id": normalize_telegram_chat_id(chat_id),
                     "animation": animation_url,
-                    "caption": caption[:1024] if caption else None,
+                    **self._caption_kwargs(caption),
                     "reply_to_message_id": reply_to_id,
                     **animation_thread_kwargs,
                     **self._notification_kwargs(metadata),

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -116,6 +116,7 @@ def _ensure_telegram_mock():
 
 _ensure_telegram_mock()
 
+import telegram  # noqa: E402
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
 
@@ -130,10 +131,15 @@ class TestTelegramMultiImage:
 
     def test_single_batch_under_10_calls_send_media_group_once(self, adapter):
         """3 photos → one send_media_group call with 3 items."""
-        import telegram
         images = [(f"https://x.com/{i}.png", f"alt{i}") for i in range(3)]
         # Make InputMediaPhoto a concrete class that records its args
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media, "caption": caption})
+        telegram.InputMediaPhoto = MagicMock(
+            side_effect=lambda media, caption=None, **kwargs: {
+                "media": media,
+                "caption": caption,
+                **kwargs,
+            }
+        )
 
         _run(adapter.send_multiple_images("12345", images))
 
@@ -144,9 +150,10 @@ class TestTelegramMultiImage:
 
     def test_batch_over_10_chunks(self, adapter):
         """15 photos → two send_media_group calls (10 + 5)."""
-        import telegram
         images = [(f"https://x.com/{i}.png", "") for i in range(15)]
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media})
+        telegram.InputMediaPhoto = MagicMock(
+            side_effect=lambda media, caption=None, **_kwargs: {"media": media}
+        )
 
         _run(adapter.send_multiple_images("12345", images))
 
@@ -156,8 +163,9 @@ class TestTelegramMultiImage:
 
     def test_animations_routed_to_send_animation(self, adapter):
         """GIFs are peeled off and sent individually via send_animation."""
-        import telegram
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media})
+        telegram.InputMediaPhoto = MagicMock(
+            side_effect=lambda media, caption=None, **_kwargs: {"media": media}
+        )
         adapter.send_animation = AsyncMock()
         # 2 photos + 1 gif
         images = [
@@ -174,8 +182,9 @@ class TestTelegramMultiImage:
 
     def test_fallback_to_per_image_on_send_media_group_failure(self, adapter):
         """If send_media_group raises, each photo falls back to send_image."""
-        import telegram
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media})
+        telegram.InputMediaPhoto = MagicMock(
+            side_effect=lambda media, caption=None, **_kwargs: {"media": media}
+        )
         adapter._bot.send_media_group = AsyncMock(side_effect=Exception("boom"))
         adapter.send_image = AsyncMock(return_value=MagicMock(success=True))
         adapter.send_animation = AsyncMock(return_value=MagicMock(success=True))
@@ -186,6 +195,71 @@ class TestTelegramMultiImage:
 
         # Three per-image fallback calls
         assert adapter.send_image.await_count == 3
+
+    def test_media_group_markdown_parse_failure_retries_plain_captions(
+        self, adapter, tmp_path
+    ):
+
+        image_path = tmp_path / "photo.png"
+        image_path.write_bytes(b"png-data")
+        telegram.InputMediaPhoto = MagicMock(
+            side_effect=lambda media, caption=None, **kwargs: {
+                "media": media,
+                "caption": caption,
+                **kwargs,
+            }
+        )
+        adapter._bot.send_media_group = AsyncMock(
+            side_effect=[
+                RuntimeError("can't parse entities: can't find end of Bold entity"),
+                [MagicMock(message_id=1)],
+            ]
+        )
+        adapter.send_image = AsyncMock(return_value=MagicMock(success=True))
+
+        images = [(f"file://{image_path}", "**Important:** caption")]
+        _run(adapter.send_multiple_images("12345", images))
+
+        assert adapter._bot.send_media_group.await_count == 2
+        assert adapter.send_image.await_count == 0
+        first_media = adapter._bot.send_media_group.await_args_list[0].kwargs["media"][0]
+        retry_media = adapter._bot.send_media_group.await_args_list[1].kwargs["media"][0]
+        assert first_media["parse_mode"] is not None
+        assert "parse_mode" not in retry_media
+        assert "**" not in retry_media["caption"]
+
+    @pytest.mark.asyncio
+    async def test_media_group_build_failure_closes_open_files(
+        self, adapter, tmp_path
+    ):
+        first = tmp_path / "first.jpg"
+        second = tmp_path / "second.jpg"
+        first.write_bytes(b"first")
+        second.write_bytes(b"second")
+
+        opened = []
+
+        def build_media(media, caption=None, **kwargs):
+            opened.append(media)
+            if len(opened) == 2:
+                raise ValueError("media construction failed")
+            return {"media": media, "caption": caption, **kwargs}
+
+        telegram.InputMediaPhoto = MagicMock(side_effect=build_media)
+        adapter._bot.send_media_group = AsyncMock()
+        adapter.send_image = AsyncMock(return_value=None)
+
+        await adapter.send_multiple_images(
+            "123",
+            [
+                (f"file://{first}", "one"),
+                (f"file://{second}", "two"),
+            ],
+        )
+
+        assert len(opened) == 2
+        assert all(file_handle.closed for file_handle in opened)
+        adapter._bot.send_media_group.assert_not_awaited()
 
     def test_empty_noop(self, adapter):
         _run(adapter.send_multiple_images("12345", []))

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -22,6 +22,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     SUPPORTED_VIDEO_TYPES,
+    utf16_len,
 )
 
 
@@ -51,6 +52,7 @@ def _ensure_telegram_mock():
 _ensure_telegram_mock()
 
 # Now we can safely import
+from plugins.platforms.telegram import adapter as telegram_adapter_mod  # noqa: E402
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 
 
@@ -696,6 +698,61 @@ class TestSendVoice:
         connected_adapter._bot.send_audio.assert_awaited_once()
         connected_adapter._bot.send_document.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_mp3_caption_uses_markdownv2_parse_mode(
+        self, connected_adapter, tmp_path
+    ):
+        audio_file = tmp_path / "clip.mp3"
+        audio_file.write_bytes(b"ID3" + b"\x00" * 32)
+        connected_adapter._bot.send_audio = AsyncMock(
+            return_value=MagicMock(message_id=104)
+        )
+        caption = "## Solar\n**Charge from grid** is enabled."
+
+        result = await connected_adapter.send_voice(
+            chat_id="12345",
+            audio_path=str(audio_file),
+            caption=caption,
+        )
+
+        assert result.success is True
+        call_kwargs = connected_adapter._bot.send_audio.await_args.kwargs
+        assert call_kwargs["caption"] == connected_adapter.format_message(caption)
+        assert call_kwargs["parse_mode"] == telegram_adapter_mod.ParseMode.MARKDOWN_V2
+
+    @pytest.mark.asyncio
+    async def test_mp3_caption_parse_failure_retries_plain_caption(
+        self, connected_adapter, tmp_path
+    ):
+        audio_file = tmp_path / "clip.mp3"
+        audio_file.write_bytes(b"ID3" + b"\x00" * 32)
+        positions = []
+
+        async def mock_send_audio(**kwargs):
+            stream = kwargs["audio"]
+            positions.append(stream.tell())
+            if len(positions) == 1:
+                stream.read()
+                raise RuntimeError(
+                    "can't parse entities: can't find end of Bold entity"
+                )
+            return MagicMock(message_id=105)
+
+        connected_adapter._bot.send_audio = AsyncMock(side_effect=mock_send_audio)
+
+        result = await connected_adapter.send_voice(
+            chat_id="12345",
+            audio_path=str(audio_file),
+            caption="**Important:** caption",
+        )
+
+        assert result.success is True
+        assert connected_adapter._bot.send_audio.await_count == 2
+        assert positions == [0, 0]
+        retry_kwargs = connected_adapter._bot.send_audio.await_args_list[1].kwargs
+        assert "parse_mode" not in retry_kwargs
+        assert retry_kwargs["caption"] == "Important: caption"
+
 
 # ---------------------------------------------------------------------------
 # TestSendDocument — outbound file attachment delivery
@@ -735,6 +792,73 @@ class TestSendDocument:
         assert call_kwargs["chat_id"] == 12345
         assert call_kwargs["filename"] == "report.pdf"
         assert call_kwargs["caption"] == "Here's the report"
+        assert call_kwargs["parse_mode"] == telegram_adapter_mod.ParseMode.MARKDOWN_V2
+
+    @pytest.mark.asyncio
+    async def test_send_document_caption_uses_markdownv2_parse_mode(
+        self, connected_adapter, tmp_path
+    ):
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+        connected_adapter._bot.send_document = AsyncMock(
+            return_value=MagicMock(message_id=99)
+        )
+        caption = "**Important:** see `report.pdf`."
+
+        result = await connected_adapter.send_document(
+            chat_id="12345", file_path=str(test_file), caption=caption
+        )
+
+        assert result.success is True
+        call_kwargs = connected_adapter._bot.send_document.await_args.kwargs
+        assert call_kwargs["caption"] == connected_adapter.format_message(caption)
+        assert call_kwargs["parse_mode"] == telegram_adapter_mod.ParseMode.MARKDOWN_V2
+
+    @pytest.mark.asyncio
+    async def test_send_document_formatter_failure_uses_plain_caption(
+        self, connected_adapter, tmp_path, monkeypatch
+    ):
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+        connected_adapter._bot.send_document = AsyncMock(
+            return_value=MagicMock(message_id=100)
+        )
+        monkeypatch.setattr(
+            connected_adapter,
+            "format_message",
+            MagicMock(side_effect=ValueError("format failed")),
+        )
+
+        result = await connected_adapter.send_document(
+            chat_id="12345",
+            file_path=str(test_file),
+            caption="**Important:** see report.",
+        )
+
+        assert result.success is True
+        call_kwargs = connected_adapter._bot.send_document.call_args[1]
+        assert call_kwargs["caption"] == "**Important:** see report."
+        assert "parse_mode" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_send_document_caption_uses_utf16_safe_prefix(
+        self, connected_adapter, tmp_path
+    ):
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+        connected_adapter._bot.send_document = AsyncMock(
+            return_value=MagicMock(message_id=100)
+        )
+
+        await connected_adapter.send_document(
+            chat_id="12345",
+            file_path=str(test_file),
+            caption="😀" * 513,
+        )
+
+        call_kwargs = connected_adapter._bot.send_document.await_args.kwargs
+        assert call_kwargs["caption"] == "😀" * 512
+        assert utf16_len(call_kwargs["caption"]) == 1024
 
     @pytest.mark.asyncio
     async def test_send_document_custom_filename(self, connected_adapter, tmp_path):
@@ -832,7 +956,7 @@ class TestSendDocument:
         test_file.write_bytes(b"data")
 
         connected_adapter._bot.send_document = AsyncMock(
-            side_effect=RuntimeError("Telegram API error")
+            side_effect=RuntimeError("markdown transport unavailable")
         )
 
         # The base fallback calls self.send() which is also on _bot, so mock it
@@ -844,8 +968,11 @@ class TestSendDocument:
         result = await connected_adapter.send_document(
             chat_id="12345",
             file_path=str(test_file),
+            caption="**Important:** report",
         )
 
+        # A non-parse failure must not trigger the plain-caption retry.
+        connected_adapter._bot.send_document.assert_awaited_once()
         # Should have fallen back to base class
         assert result.success is True
         assert result.message_id == "fallback"

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -939,6 +939,7 @@ async def test_native_media_dm_topic_reply_not_found_retry_drops_thread_id(
     result = await getattr(adapter, method_name)(
         chat_id="123",
         **{path_kw: str(media_path)},
+        caption="**Important:** caption",
         metadata={
             "thread_id": "20197",
             "telegram_dm_topic_reply_fallback": True,
@@ -949,9 +950,99 @@ async def test_native_media_dm_topic_reply_not_found_retry_drops_thread_id(
     assert result.success is True
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["parse_mode"] is not None
     assert call_log[1]["reply_to_message_id"] is None
     assert "message_thread_id" not in call_log[1]
     assert "direct_messages_topic_id" not in call_log[1]
+    assert call_log[1]["parse_mode"] is not None
+
+
+@pytest.mark.asyncio
+async def test_native_media_dm_topic_retry_can_then_retry_plain_caption(tmp_path):
+    """Stale topic fallback remains eligible for Markdown caption fallback."""
+    adapter = _make_adapter()
+    media_path = tmp_path / "clip.mp3"
+    media_path.write_bytes(b"mp3-data")
+    call_log = []
+
+    async def mock_send_audio(**kwargs):
+        call_log.append(dict(kwargs))
+        if len(call_log) == 1:
+            raise FakeBadRequest("Message to be replied not found")
+        if len(call_log) == 2:
+            raise FakeBadRequest("can't parse entities: can't find end of Bold entity")
+        return SimpleNamespace(message_id=787)
+
+    adapter._bot = SimpleNamespace(send_audio=mock_send_audio)
+
+    result = await adapter.send_voice(
+        chat_id="123",
+        audio_path=str(media_path),
+        caption="**Important:** caption",
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+        },
+    )
+
+    assert result.success is True
+    assert len(call_log) == 3
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["parse_mode"] is not None
+    assert call_log[1]["reply_to_message_id"] is None
+    assert "message_thread_id" not in call_log[1]
+    assert call_log[1]["parse_mode"] is not None
+    assert call_log[2]["reply_to_message_id"] is None
+    assert "message_thread_id" not in call_log[2]
+    assert "parse_mode" not in call_log[2]
+    assert "**" not in call_log[2]["caption"]
+
+
+@pytest.mark.asyncio
+async def test_voice_dm_topic_retry_preserves_stripped_routing_for_plain_caption(
+    tmp_path,
+):
+    adapter = _make_adapter()
+    media_path = tmp_path / "clip.ogg"
+    media_path.write_bytes(b"ogg-data")
+    call_log = []
+
+    async def mock_send_voice(**kwargs):
+        call_log.append(dict(kwargs))
+        if len(call_log) == 1:
+            raise FakeBadRequest("Message to be replied not found")
+        if len(call_log) == 2:
+            raise FakeBadRequest(
+                "can't parse entities: can't find end of Bold entity"
+            )
+        return SimpleNamespace(message_id=788)
+
+    adapter._bot = SimpleNamespace(send_voice=mock_send_voice)
+
+    result = await adapter.send_voice(
+        chat_id="123",
+        audio_path=str(media_path),
+        caption="**Important:** caption",
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+        },
+    )
+
+    assert result.success is True
+    assert len(call_log) == 3
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["parse_mode"] is not None
+    assert call_log[1]["reply_to_message_id"] is None
+    assert "message_thread_id" not in call_log[1]
+    assert call_log[1]["parse_mode"] is not None
+    assert call_log[2]["reply_to_message_id"] is None
+    assert "message_thread_id" not in call_log[2]
+    assert call_log[2]["parse_mode"] is None
 
 
 @pytest.mark.asyncio
@@ -970,6 +1061,7 @@ async def test_animation_dm_topic_reply_not_found_retry_drops_thread_id():
     result = await adapter.send_animation(
         chat_id="123",
         animation_url="https://example.com/anim.gif",
+        caption="**Important:** caption",
         metadata={
             "thread_id": "20197",
             "telegram_dm_topic_reply_fallback": True,
@@ -980,9 +1072,11 @@ async def test_animation_dm_topic_reply_not_found_retry_drops_thread_id():
     assert result.success is True
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["parse_mode"] is not None
     assert call_log[1]["reply_to_message_id"] is None
     assert "message_thread_id" not in call_log[1]
     assert "direct_messages_topic_id" not in call_log[1]
+    assert call_log[1]["parse_mode"] is not None
 
 
 @pytest.mark.asyncio
@@ -1036,6 +1130,7 @@ async def test_send_image_url_dm_topic_reply_not_found_retry_drops_thread_id(mon
     result = await adapter.send_image(
         chat_id="123",
         image_url="https://example.com/photo.png",
+        caption="**Important:** caption",
         metadata={
             "thread_id": "20197",
             "telegram_dm_topic_reply_fallback": True,
@@ -1046,7 +1141,9 @@ async def test_send_image_url_dm_topic_reply_not_found_retry_drops_thread_id(mon
     assert result.success is True
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["parse_mode"] is not None
     assert call_log[1]["reply_to_message_id"] is None
+    assert call_log[1]["parse_mode"] is not None
     assert "message_thread_id" not in call_log[1]
     assert "direct_messages_topic_id" not in call_log[1]
 
@@ -1096,6 +1193,7 @@ async def test_send_image_upload_dm_topic_reply_not_found_retry_drops_thread_id(
     result = await adapter.send_image(
         chat_id="123",
         image_url="https://example.com/photo.png",
+        caption="**Important:** caption",
         metadata={
             "thread_id": "20197",
             "telegram_dm_topic_reply_fallback": True,
@@ -1106,9 +1204,12 @@ async def test_send_image_upload_dm_topic_reply_not_found_retry_drops_thread_id(
     assert result.success is True
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
+    assert call_log[0]["parse_mode"] is not None
     assert call_log[1]["reply_to_message_id"] == 462
     assert call_log[1]["message_thread_id"] == 20197
+    assert call_log[1]["parse_mode"] is not None
     assert call_log[2]["reply_to_message_id"] is None
+    assert call_log[2]["parse_mode"] is not None
     assert "message_thread_id" not in call_log[2]
     assert "direct_messages_topic_id" not in call_log[2]
 

--- a/tests/gateway/test_telegram_voice_caption_markdown.py
+++ b/tests/gateway/test_telegram_voice_caption_markdown.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import utf16_len
 
 
 def _ensure_telegram_mock():
@@ -113,6 +114,26 @@ async def test_voice_caption_overflow_skips_formatting(monkeypatch, tmp_path):
     kwargs = adapter._bot.send_voice.await_args.kwargs
     assert kwargs["parse_mode"] is None
     assert kwargs["caption"] == caption[:1024]
+
+
+@pytest.mark.asyncio
+async def test_voice_plain_caption_fallback_uses_utf16_limit(monkeypatch, tmp_path):
+    """Plain caption fallback must respect Telegram's UTF-16 unit limit."""
+    monkeypatch.setattr(
+        telegram_mod, "_probe_voice_duration_seconds", lambda _p: 3
+    )
+    adapter = _make_adapter()
+    caption = "😀" * 513
+
+    result = await adapter.send_voice(
+        "123", str(_write_ogg(tmp_path)), caption=caption
+    )
+
+    assert result.success is True
+    kwargs = adapter._bot.send_voice.await_args.kwargs
+    assert kwargs["parse_mode"] is None
+    assert kwargs["caption"] == "😀" * 512
+    assert utf16_len(kwargs["caption"]) == 1024
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Telegram gateway media replies now render captions as MarkdownV2 for photos, documents, videos, audio files, animations, and albums instead of exposing raw Markdown syntax. This follows the native voice-caption fix merged in #73508 while retaining the remaining cross-media behaviour from this PR.

Caption parse failures retry once with plain text, and that fallback composes with private-topic reply-anchor recovery without demoting native media delivery. Caption limits are enforced in UTF-16 units, including the existing voice overflow fallback.

## Related Issue

Related: #32029, #32839, #32118, #32893, #73508

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: format captions for MP3/M4A audio, photos, documents, videos, URL and uploaded-image sends, animations, and media groups.
- `plugins/platforms/telegram/adapter.py`: retry MarkdownV2 parse failures once with a plain UTF-16-safe caption while preserving the existing private-topic fallback.
- `plugins/platforms/telegram/adapter.py`: retain #73508's native voice retry loop and make its plain overflow fallback UTF-16 safe.
- `plugins/platforms/telegram/adapter.py`: rebuild album media safely for plain-caption retries and close local file handles on every path.
- `tests/gateway/`: cover formatted captions, plain fallback, UTF-16 limits, albums, file cleanup, and topic-fallback composition.

## How to Test

1. Send an MP3/M4A file, photo, document, video, animation, or album with a caption such as `**Important:** caption`; Telegram should render the formatting instead of showing raw syntax.
2. Force a Telegram caption parse error; the adapter should retry the same native media send once without `parse_mode` and with a plain caption.
3. Combine a stale private-topic reply anchor with a later caption parse error; the adapter should remove routing and still complete the bounded plain-caption retry.
4. Send a caption containing 513 supplementary-plane emoji; the plain fallback must remain within Telegram's 1,024 UTF-16-unit limit.
5. Run:
   - `HERMES_PYTHON=/usr/bin/python3 scripts/run_tests.sh -j 4 tests/gateway/test_telegram_voice_caption_markdown.py tests/gateway/test_telegram_documents.py tests/gateway/test_send_multiple_images.py tests/gateway/test_telegram_thread_fallback.py -q`
   - `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_voice_caption_markdown.py tests/gateway/test_telegram_documents.py tests/gateway/test_send_multiple_images.py tests/gateway/test_telegram_thread_fallback.py`
   - `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass. The full isolated Telegram gateway suite and refreshed GitHub CI passed.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux VPS checkout, Python test environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - N/A, Telegram adapter logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool schema changed

## Screenshots / Logs

Local verification:

- Canonical isolated Telegram gateway suite: 1,587 passed, 0 failed across 53 files
- Repository-wide Ruff check: passed
- `git diff --check`: passed
- GitHub CI run `30396374771`: passed for head `02d92af8673e57a7bcd9a5f9a0c13fff0d1e97a0`
