### PR TITLE
fix(gateway): recognize whatsapp_cloud as a built-in delivery platform

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -205,7 +205,7 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
-    "qqbot", "yuanbao",
+    "qqbot", "yuanbao", "whatsapp_cloud",
 })
 
 # Platforms that support a configured cron/notification home target, mapped to

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -66,7 +66,7 @@ _BUILTIN_DELIVER_PLATFORMS = {
     "telegram", "discord", "slack", "signal", "sms", "whatsapp",
     "matrix", "mattermost", "homeassistant", "email", "dingtalk",
     "feishu", "wecom", "wecom_callback", "weixin", "bluebubbles",
-    "qqbot", "yuanbao",
+    "qqbot", "yuanbao", "whatsapp_cloud",
 }
 
 DEFAULT_HOST = "0.0.0.0"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -552,6 +552,33 @@ class TestRoutingIntents:
             assert platforms == ["discord", "telegram"], f"token={token!r} -> {platforms}"
 
 
+class TestBuiltinDeliveryPlatforms:
+    """Built-in platforms must pass the ``_KNOWN_DELIVERY_PLATFORMS`` gate."""
+
+    def test_whatsapp_cloud_home_channel_resolves(self, monkeypatch):
+        """whatsapp_cloud is a built-in adapter (never in the plugin
+        registry), so the hardcoded set is its only admission path; without
+        it the home-channel target silently vanishes from the resolution."""
+        from cron.scheduler import _resolve_delivery_targets
+
+        monkeypatch.setenv("WHATSAPP_CLOUD_HOME_CHANNEL", "15551234567")
+        targets = _resolve_delivery_targets(
+            {"deliver": "whatsapp_cloud", "origin": None}
+        )
+        assert targets == [
+            {"platform": "whatsapp_cloud", "chat_id": "15551234567", "thread_id": None}
+        ]
+
+    def test_every_home_target_platform_is_known(self):
+        """Anti-drift guard: every platform with a home-target env var must
+        be deliverable — a mismatch means cron delivery is silently dropped
+        (the resolver returns no target and records no delivery error)."""
+        from cron.scheduler import _HOME_TARGET_ENV_VARS, _is_known_delivery_platform
+
+        for platform in _HOME_TARGET_ENV_VARS:
+            assert _is_known_delivery_platform(platform), platform
+
+
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1009,6 +1009,35 @@ class TestDeliverCrossPlatformThreadId:
         )
 
 
+class TestBuiltinDeliverPlatforms:
+    """send()'s admission gate for built-in (non-plugin) platforms."""
+
+    @pytest.mark.asyncio
+    async def test_whatsapp_cloud_passes_the_builtin_gate(self):
+        """whatsapp_cloud is a built-in adapter (never in the plugin
+        registry), so ``_BUILTIN_DELIVER_PLATFORMS`` is its only admission
+        path through ``send()``; without it the identical route config
+        fails "Unknown deliver type" while ``deliver_only`` routes (which
+        skip the gate via ``_direct_deliver``) work."""
+        adapter = _make_adapter()
+        mock_target = AsyncMock()
+        mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_runner = MagicMock()
+        mock_runner.adapters = {Platform("whatsapp_cloud"): mock_target}
+        mock_runner.config.get_home_channel.return_value = None
+        adapter.gateway_runner = mock_runner
+
+        adapter._delivery_info["webhook:r:1"] = {
+            "deliver": "whatsapp_cloud",
+            "deliver_extra": {"chat_id": "15551234567"},
+        }
+        result = await adapter.send("webhook:r:1", "hello")
+        assert result.success is True
+        mock_target.send.assert_awaited_once_with(
+            "15551234567", "hello", metadata=None
+        )
+
+
 class TestInsecureNoAuthSafetyRail:
     """connect() refuses to start when INSECURE_NO_AUTH is combined with a
     non-loopback bind. Guards against accidentally exposing an unauthenticated


### PR DESCRIPTION
## What does this PR do?

Adds `whatsapp_cloud` to the two hand-maintained delivery-platform sets that predate it. This fixes cron-delivery drops and agent-mode webhook rejections for the WhatsApp Business Cloud adapter.

`whatsapp_cloud` shipped as a built-in platform (#43921/#44331): it has a `Platform` enum entry (`gateway/config.py`), a working `send()` (`gateway/platforms/whatsapp_cloud.py`), and the cron scheduler already maps it to `WHATSAPP_CLOUD_HOME_CHANNEL` in `_HOME_TARGET_ENV_VARS`. Both allow-lists were written before it landed, and the plugin-registry fallback can't rescue it because built-ins never register a `PlatformEntry`:

1. `cron/scheduler.py` `_KNOWN_DELIVERY_PLATFORMS`. A cron job with `deliver: whatsapp_cloud` runs and saves output locally, but the target is dropped in `_resolve_delivery_targets`. `_is_known_delivery_platform` returns `None`, so there is no delivery and no `delivery_errors` entry. The `all` routing token expands `whatsapp_cloud` from the home-target map and then drops it at the same gate. `cron_delivery_targets()` filters it out of the delivery-target picker even when connected. It was the only key in `_HOME_TARGET_ENV_VARS` absent from the set. Repro:

   ```python
   # WHATSAPP_CLOUD_HOME_CHANNEL=15551234567
   _resolve_delivery_targets({"deliver": "whatsapp_cloud", "origin": None})  # → []
   _resolve_delivery_targets({"deliver": "telegram", "origin": None})        # → [ok]
   ```

2. `gateway/platforms/webhook.py` `_BUILTIN_DELIVER_PLATFORMS`. An agent-mode webhook route with `deliver: whatsapp_cloud` fails with `"Unknown deliver type: whatsapp_cloud"`, while the identical config on a `deliver_only` route works (`_direct_deliver` calls `_deliver_cross_platform` without the gate). That asymmetry shows this is drift, not policy.

Downstream delivery is fully generic: `Platform(platform_name)` looks up the config and calls the live adapter's `send`. So the two one-word additions are the whole fix. The colon form `deliver: whatsapp_cloud:<chat_id>` already bypassed the cron gate and worked, which made the bare-form failure confusing.

Same drift family as #24987 (yuanbao missing from `_HOME_TARGET_ENV_VARS`, in the other direction). Adjacent but not overlapping: #51632 adds write-time deliver validation in `cron/jobs.py` and would reject `whatsapp_cloud` at create time for the same root cause. With this fix both layers agree.

## Related Issue

None filed; root cause traced to `whatsapp_cloud` landing after both sets were written (#43921/#44331).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `cron/scheduler.py`: add `"whatsapp_cloud"` to `_KNOWN_DELIVERY_PLATFORMS`.
- `gateway/platforms/webhook.py`: add `"whatsapp_cloud"` to `_BUILTIN_DELIVER_PLATFORMS`.
- `tests/cron/test_scheduler.py`: `deliver: whatsapp_cloud` resolves the home-channel target. Also adds an anti-drift guard asserting every platform in `_HOME_TARGET_ENV_VARS` passes `_is_known_delivery_platform`, so a future built-in platform can't repeat this.
- `tests/gateway/test_webhook_adapter.py`: agent-mode `send()` with `deliver: whatsapp_cloud` reaches the target adapter instead of "Unknown deliver type".

## How to Test

```bash
scripts/run_tests.sh tests/cron/test_scheduler.py tests/gateway/test_webhook_adapter.py
```

All 3 new tests fail on current main and pass with the fix; the full two files are green (278 tests, macOS 15). `scripts/check-windows-footguns.py` clean on all 4 files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A: no user-facing docs list the deliver platforms)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes