### PR TITLE
fix(cli): honor an explicit /journey --reveal 0 instead of rendering 100%

### DIFF
--- a/hermes_cli/journey.py
+++ b/hermes_cli/journey.py
@@ -206,7 +206,10 @@ def _cmd_show(args: argparse.Namespace) -> int:
     if getattr(args, "play", False):
         return _play(console, payload, cols=cols, rows=rows, color=color, fps=getattr(args, "fps", 12))
 
-    reveal = _clamp(float(getattr(args, "reveal", 1.0) or 1.0), 0.0, 1.0)
+    # NOT ``or 1.0``: an explicit ``--reveal 0`` ("0=oldest" per the help
+    # text) is falsy and would silently render the fully-revealed frame.
+    reveal_arg = getattr(args, "reveal", None)
+    reveal = _clamp(1.0 if reveal_arg is None else float(reveal_arg), 0.0, 1.0)
     console.print(_frame_renderable(payload, cols=cols, rows=rows, reveal=reveal, color=color))
     return 0
 

--- a/tests/hermes_cli/test_journey_render.py
+++ b/tests/hermes_cli/test_journey_render.py
@@ -36,3 +36,46 @@ def test_default_capture_is_plain_for_chat_bubbles():
     # Rich auto-detects the StringIO as non-tty → no color, no raw escapes.
     assert "\x1b[" not in _capture([], force=False)
     assert "\x1b[" not in _capture(["list"], force=False)
+
+
+# ---------------------------------------------------------------------------
+# --reveal parsing contract
+# ---------------------------------------------------------------------------
+
+def _reveal_reaching_renderer(argv: list[str], monkeypatch) -> float:
+    """Run the real ``args.func`` path and report the ``reveal`` value that
+    reaches the frame renderer."""
+    import hermes_cli.journey as journey
+    from rich.text import Text
+
+    seen: dict[str, float] = {}
+
+    def fake_frame(payload, *, cols, rows, reveal, color):
+        seen["reveal"] = reveal
+        return Text("frame")
+
+    monkeypatch.setattr(journey, "_frame_renderable", fake_frame)
+    # A non-empty payload so _cmd_show reaches the render call.
+    monkeypatch.setattr(journey, "_build_payload", lambda: {"nodes": [{"kind": "skill"}]})
+
+    parser = argparse.ArgumentParser(add_help=False)
+    journey.register_cli(parser)
+    args = parser.parse_args(argv)
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        args.func(args)
+    return seen["reveal"]
+
+
+def test_reveal_zero_renders_oldest_frame(monkeypatch):
+    # "0=oldest" per the --reveal help text; 0.0 is falsy and must not be
+    # swallowed into the fully-revealed default.
+    assert _reveal_reaching_renderer(["--reveal", "0"], monkeypatch) == 0.0
+
+
+def test_reveal_defaults_to_fully_revealed(monkeypatch):
+    assert _reveal_reaching_renderer([], monkeypatch) == 1.0
+
+
+def test_reveal_fraction_passes_through(monkeypatch):
+    assert _reveal_reaching_renderer(["--reveal", "0.25"], monkeypatch) == 0.25


### PR DESCRIPTION
## What does this PR do?

Makes an explicit `/journey --reveal 0` render the oldest (0%) frame instead of the fully-revealed (100%) one.

`_cmd_show` (`hermes_cli/journey.py`) coerces the flag with:

```python
reveal = _clamp(float(getattr(args, "reveal", 1.0) or 1.0), 0.0, 1.0)
```

`--reveal 0` parses (argparse `type=float`) to `0.0`. That's falsy, so `or 1.0` swaps it for the default. This is the opposite of what the flag's own help text documents (`"0=oldest, 1=now"`). It's reachable from both `hermes journey --reveal 0` and the interactive `/journey --reveal 0`. Every other value (0.25, 0.5, …) works, so the failure at the endpoint looks like a rendering bug rather than an argument-parsing one.

The fix treats only a missing value as the fully-revealed default. `0.0` clamps through unchanged.

## Related Issue

None filed; introduced with the /journey feature (#55555).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `hermes_cli/journey.py`: replace the falsy-swallowing `or 1.0` with an explicit None-check (plus a comment).
- `tests/hermes_cli/test_journey_render.py`: 3 contract tests that run the real `args.func` path and assert the `reveal` value that reaches the frame renderer. `--reveal 0` gives `0.0`, no flag gives `1.0`, and `--reveal 0.25` passes through.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_journey_render.py
```

`test_reveal_zero_renders_oldest_frame` fails on current main (renderer receives `1.0`) and passes with the fix. The other 4 tests, including the two pre-existing ANSI-routing contracts, pass on both. macOS 15. `scripts/check-windows-footguns.py` clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A, behavior now matches the existing help text)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes