### PR TITLE
fix(config): stop _normalize_custom_provider_entry mutating the caller's dict

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4468,6 +4468,15 @@ def _normalize_custom_provider_entry(
     if not isinstance(entry, dict):
         return None
 
+    # Shallow-copy before the alias normalization below writes into the
+    # entry: callers (get_compatible_custom_providers,
+    # providers_dict_to_custom_providers) pass live sub-dicts from
+    # load_config_readonly()'s shared cache, and mutating those both
+    # violates the cache's no-mutation contract and leaks duplicated
+    # alias keys back into config.yaml through any later
+    # save_config(load_config()) round-trip.
+    entry = dict(entry)
+
     # Accept camelCase aliases commonly used in hand-written configs.
     _CAMEL_ALIASES: Dict[str, str] = {
         "apiKey": "api_key",

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -237,3 +237,56 @@ class TestNormalizeCustomProviderEntry:
         }
         result = _normalize_custom_provider_entry(entry, provider_key="bad")
         assert result is None
+
+
+class TestNormalizeDoesNotMutateInput:
+    """The normalizer must not write alias keys into the caller's dict.
+
+    get_compatible_custom_providers and providers_dict_to_custom_providers
+    pass live sub-dicts from load_config_readonly()'s shared cache; an
+    in-place write violates the cache's no-mutation contract and leaks
+    duplicated alias keys into config.yaml via save_config(load_config()).
+    """
+
+    def test_camel_case_entry_is_not_mutated(self):
+        entry = {
+            "name": "x",
+            "baseUrl": "https://api.example.com/v1",
+            "apiKeyEnv": "MY_KEY",
+        }
+        snapshot = dict(entry)
+        result = _normalize_custom_provider_entry(entry, provider_key="x")
+        assert result is not None
+        assert result["base_url"] == "https://api.example.com/v1"
+        assert entry == snapshot
+
+    def test_api_key_env_alias_entry_is_not_mutated(self):
+        entry = {
+            "name": "x",
+            "base_url": "https://api.example.com/v1",
+            "api_key_env": "MY_KEY",
+        }
+        snapshot = dict(entry)
+        result = _normalize_custom_provider_entry(entry, provider_key="x")
+        assert result is not None
+        assert result["key_env"] == "MY_KEY"
+        assert entry == snapshot
+
+    def test_get_compatible_custom_providers_does_not_mutate_config(self):
+        from hermes_cli.config import get_compatible_custom_providers
+
+        config = {
+            "custom_providers": [
+                {
+                    "name": "ollama",
+                    "baseUrl": "https://ollama.example.com/v1",
+                    "apiKeyEnv": "OLLAMA_KEY",
+                }
+            ]
+        }
+        import copy
+
+        snapshot = copy.deepcopy(config)
+        providers = get_compatible_custom_providers(config)
+        assert providers, "entry should normalize successfully"
+        assert config == snapshot


### PR DESCRIPTION
## What does this PR do?

Stops `_normalize_custom_provider_entry` (`hermes_cli/config.py`) from mutating the dict it is passed.

The normalizer builds and returns a fresh `normalized` dict, but on the way it writes alias keys into its input:

```python
if "api_key_env" in entry and "key_env" not in entry:
    entry["key_env"] = entry["api_key_env"]
...
for camel, snake in _CAMEL_ALIASES.items():
    if camel in entry and snake not in entry:
        entry[snake] = entry[camel]
```

Two of its three callers, `get_compatible_custom_providers` and `providers_dict_to_custom_providers`, pass live sub-dicts from `load_config_readonly()`'s shared cache, which has an explicit no-mutation contract. The third caller, `_custom_provider_entry_to_provider_config`, already copies with `dict(entry)`, so the hazard was known. These two paths were just missed.

Consequences for a config written with the documented camelCase / `api_key_env` aliases:

- the cached config gains injected duplicate keys (`baseUrl` and `base_url`, `apiKeyEnv` and `key_env`). Every later `load_config()` deepcopy inherits them, and any `save_config(load_config())` flow (setup wizard, dashboard config writes, model persist) writes the duplicates back to `config.yaml`;
- the recent custom-provider TLS work put this on a hot path: `_resolve_aux_verify` runs it on every auxiliary-client build (compression, vision, title-gen), which is an unlocked dict mutation on a shared object from worker threads;
- open PR #56085 (`load_config_readonly()` at 31 read-only call sites in `agent/`) widens the blast radius, since several of those sites reach this normalizer.

Repro on current main:

```python
cfg = {"custom_providers": [{"name": "x", "baseUrl": "https://a/v1", "apiKeyEnv": "K"}]}
get_compatible_custom_providers(cfg)
cfg["custom_providers"][0].keys()
# dict_keys(['name', 'baseUrl', 'apiKeyEnv', 'base_url', 'key_env'])  ← polluted
```

The fix is a shallow `entry = dict(entry)` at the top of the normalizer. The return value is a separately-built dict, so nothing else changes.

## Related Issue

None filed. Alias handling was introduced for #9332; the readonly-cache interaction is what makes it bite.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `hermes_cli/config.py`: shallow-copy the entry before alias normalization, plus a comment explaining why.
- `tests/hermes_cli/test_provider_config_validation.py`: 3 regression tests. One checks a camelCase entry is left unchanged, one checks an `api_key_env` entry is left unchanged, and one checks `get_compatible_custom_providers` leaves the whole config deep-equal to a snapshot.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_provider_config_validation.py
```

All 3 new tests fail on current main and pass with the fix. The file's other 21 tests pass on both. Also green: tests/hermes_cli/test_config.py, test_custom_provider_tls.py, test_runtime_provider_resolution.py, tests/agent/test_auxiliary_named_custom_providers.py (317 tests, macOS 15). `scripts/check-windows-footguns.py` is clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A, internal contract fix)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes