### PR TITLE
fix(gateway/qqbot): add is_reconnect kwarg to QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,14 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        Args:
+            is_reconnect: True when reconnecting after a previous session
+                (e.g. WebSocket timeout).  The QQ adapter does not need to
+                differentiate, but the gateway always passes this keyword.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)


### PR DESCRIPTION
## Bug

The gateway's `_connect_adapter()` (`run.py` ~L3334) passes `is_reconnect=True` when reconnecting a platform after a WebSocket drop. The QQ adapter's `connect()` method does not accept this keyword, causing:

```
ERROR gateway.run: ✗ qqbot error: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

followed by persistent reconnect failures with exponential backoff (60s → 120s → 240s → …) until the gateway is manually restarted.

## Root Cause

`QQAdapter.connect()` signature:
```python
async def connect(self) -> bool:
```

Base class `BasePlatformAdapter.connect()`:
```python
async def connect(self, *, is_reconnect: bool = False) -> bool:
```

Most platform adapters (weixin, bluebubbles, signal, whatsapp_cloud, api_server, webhook, …) already accept `is_reconnect`. The QQ adapter was missed.

## Fix

Align `QQAdapter.connect()` with the base class signature by adding `*, is_reconnect: bool = False`. The QQ adapter does not need to differentiate between initial connect and reconnect, so the parameter is accepted but not used — consistent with other adapters.

## Testing

Verified on a live gateway (v0.18.0, pipx install) where QQ Bot was stuck in reconnect-loop with this exact error. After patching the pipx site-packages copy and restarting, QQ Bot reconnected successfully.