### PR TITLE
fix(slack): keep blank-line-separated ordered items in one rich_text_list

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -451,6 +451,10 @@ def render_blocks(
                         indent, ordered, txt = items[-1]
                         items[-1] = (indent, ordered, txt + " " + lines[i].strip())
                         i += 1
+                    elif not lines[i].strip():
+                        # blank line — soft separator within a list run;
+                        # skip so that ordered items stay in one rich_text_list.
+                        i += 1
                     else:
                         break
                 blocks.append(_list_block(items))

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -90,6 +90,22 @@ class TestInlineFormatting:
         ]
         assert styled, "expected a bold-styled text element in the list item"
 
+    def test_blank_line_separated_ordered_items_stay_in_one_list(self):
+        """Regression: blank lines between ordered items must not reset numbering.
+
+        Slack numbers each rich_text_list independently.  If blank lines break
+        the list run, N items produce N separate lists each starting at 1.
+        See: https://github.com/NousResearch/hermes-agent/issues/57076
+        """
+        md = "1. alpha\n\n1. beta\n\n1. gamma"
+        blocks = render_blocks(md)
+        rich = [b for b in blocks if b["type"] == "rich_text"][0]
+        lists = [e for e in rich["elements"] if e["type"] == "rich_text_list"]
+        # Must be ONE list with 3 items, not 3 separate single-item lists
+        assert len(lists) == 1
+        items = lists[0]["elements"]
+        assert len(items) == 3
+
 
 class TestTables:
     def test_pipe_table_renders_native_table_block(self):


### PR DESCRIPTION
## What does this PR do?

Fixes blank-line-separated ordered lists in Slack's rich_blocks renderer. When an ordered Markdown list has blank lines between items (the natural shape of LLM-authored content like scheduled briefings), the list run loop breaks on each blank line. Slack numbers each `rich_text_list` independently, so N blank-separated items produce N separate lists each starting at "1.".

The fix adds a blank-line skip condition inside the list run loop so that blank lines are treated as soft separators rather than run terminators.

## Related Issue

Fixes #57076

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/block_kit.py`: Added `elif not lines[i].strip()` branch in the list run loop to skip blank lines as soft separators, keeping ordered items in a single `rich_text_list`.
- `tests/gateway/test_slack_block_kit.py`: Added regression test `test_blank_line_separated_ordered_items_stay_in_one_list` that asserts 3 blank-line-separated ordered items produce one list with 3 items.

## How to Test

1. Run the regression test:
   ```bash
   python -m pytest tests/gateway/test_slack_block_kit.py -xvs -k "blank_line"
   ```
2. Run all block_kit tests to verify no regressions:
   ```bash
   python -m pytest tests/gateway/test_slack_block_kit.py -xvs
   ```
3. Smoke-test the renderer directly:
   ```python
   from plugins.platforms.slack.block_kit import render_blocks
   blocks = render_blocks("1. alpha\n\n1. beta\n\n1. gamma")
   rich = [b for b in blocks if b["type"] == "rich_text"][0]
   lists = [e for e in rich["elements"] if e["type"] == "rich_text_list"]
   assert len(lists) == 1  # one list, not three
   assert len(lists[0]["elements"]) == 3
   ```
   Observed result: one `rich_text_list` with 3 items (correct numbering in Slack).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
