### PR TITLE
docs(ollama): correct API-timeout guidance to include config.yaml key

### DIFF
--- a/website/docs/guides/local-ollama-setup.md
+++ b/website/docs/guides/local-ollama-setup.md
@@ -31,7 +31,7 @@ By the end, you'll have:
 | **GPU** | Not required | NVIDIA GPU with 8+ GB VRAM speeds things up significantly |
 
 :::tip CPU-only works, but expect slower responses
-Ollama runs on CPU-only servers. A 9B model on a modern 8-core CPU gives ~10 tokens/sec. A 31B model on CPU is slower (~2–5 tokens/sec) — each response takes 30–120 seconds, but it works. A GPU dramatically improves this. For CPU-only setups, widen the API timeout via the env var (it's not a `config.yaml` key):
+Ollama runs on CPU-only servers. A 9B model on a modern 8-core CPU gives ~10 tokens/sec. A 31B model on CPU is slower (~2–5 tokens/sec) — each response takes 30–120 seconds, but it works. A GPU dramatically improves this. For CPU-only setups, widen the API timeout via the `HERMES_API_TIMEOUT` env var (or set `providers.<id>.request_timeout_seconds` in `config.yaml`, which takes precedence):
 
 ```bash
 # ~/.hermes/.env

--- a/website/docs/guides/local-ollama-setup.md
+++ b/website/docs/guides/local-ollama-setup.md
@@ -31,7 +31,7 @@ By the end, you'll have:
 | **GPU** | Not required | NVIDIA GPU with 8+ GB VRAM speeds things up significantly |
 
 :::tip CPU-only works, but expect slower responses
-Ollama runs on CPU-only servers. A 9B model on a modern 8-core CPU gives ~10 tokens/sec. A 31B model on CPU is slower (~2–5 tokens/sec) — each response takes 30–120 seconds, but it works. A GPU dramatically improves this. For CPU-only setups, widen the API timeout via the `HERMES_API_TIMEOUT` env var (or set `providers.<id>.request_timeout_seconds` in `config.yaml`, which takes precedence):
+Ollama runs on CPU-only servers. A 9B model on a modern 8-core CPU gives ~10 tokens/sec. A 31B model on CPU is slower (~2–5 tokens/sec) — each response takes 30–120 seconds, but it works. A GPU dramatically improves this. For CPU-only setups, widen the API timeout via the `HERMES_API_TIMEOUT` env var (or set `providers.custom.request_timeout_seconds` in `config.yaml`, which takes precedence):
 
 ```bash
 # ~/.hermes/.env


### PR DESCRIPTION
﻿## What does this PR do?

Corrects outdated guidance in the local Ollama setup guide. The CPU-only tip currently tells users the API timeout **"is not a `config.yaml` key"** and steers them exclusively to the legacy `HERMES_API_TIMEOUT` env var:

> For CPU-only setups, widen the API timeout via the env var (it's not a `config.yaml` key):

That predates the `request_timeout_seconds` config feature. The API timeout **is** configurable from `config.yaml`, and the config value takes precedence over the legacy env var:

- `hermes_cli/timeouts.py` — reads `provider_config.get("request_timeout_seconds")`
- `run_agent.py` — documents the resolution order: `providers.<id>.request_timeout_seconds` (provider-wide) resolves **before** the `HERMES_API_TIMEOUT` env var
- `website/docs/reference/environment-variables.md` and `configuration.md` both state the configured value "wins over the legacy `HERMES_API_TIMEOUT` env var"

## The fix

One line, additive — keeps the existing env-var example valid while pointing at the preferred config key:

```diff
-For CPU-only setups, widen the API timeout via the env var (it's not a `config.yaml` key):
+For CPU-only setups, widen the API timeout via the `HERMES_API_TIMEOUT` env var (or set `providers.<id>.request_timeout_seconds` in `config.yaml`, which takes precedence):
```

## Type of Change

- [x] Documentation update

## Notes

- Docs-only. Zero runtime/behavior change.
- 1 file, 1 line changed.
- Provable by direct source comparison against `hermes_cli/timeouts.py` and the resolution chain documented in `run_agent.py`.
