### PR TITLE
fix(anthropic): harden keychain credential parsing

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -905,10 +905,13 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     raw = result.stdout.strip()
     if not raw:
         return None
+    if not isinstance(raw, (str, bytes, bytearray)):
+        logger.debug("Keychain: credentials payload has unexpected type %s", type(raw).__name__)
+        return None
 
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         logger.debug("Keychain: credentials payload is not valid JSON")
         return None
 

--- a/tests/agent/test_anthropic_keychain.py
+++ b/tests/agent/test_anthropic_keychain.py
@@ -49,6 +49,13 @@ class TestReadClaudeCodeCredentialsFromKeychain:
             mock_run.return_value = MagicMock(returncode=0, stdout="not valid json", stderr="")
             assert _read_claude_code_credentials_from_keychain() is None
 
+    def test_returns_none_for_unexpected_stdout_payload_type(self):
+        """Malformed mocked Keychain stdout must not crash credential fallback."""
+        with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
+             patch("agent.anthropic_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=MagicMock(), stderr="")
+            assert _read_claude_code_credentials_from_keychain() is None
+
     def test_returns_none_when_password_field_is_missing_claude_ai_oauth(self):
         with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
              patch("agent.anthropic_adapter.subprocess.run") as mock_run:


### PR DESCRIPTION
## What does this PR do?

Hardens the macOS Claude Code Keychain credential reader so malformed or unexpectedly mocked Keychain stdout payloads do not crash Anthropic OAuth fallback resolution.

On macOS, `_read_claude_code_credentials_from_keychain()` currently does:

```python
raw = result.stdout.strip()
data = json.loads(raw)
```

When tests patch `subprocess.run` broadly, `result.stdout.strip()` can be a `MagicMock`; `json.loads(raw)` then raises `TypeError` before credential-file/env fallback logic can run.

This PR treats unexpected stdout payload types like malformed Keychain payloads: return `None` and continue fallback credential resolution.

## Related Issue

Fixes #27003.

Related: #27065 has the same intent but is currently conflicting; this branch is the minimal fix rebased on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py`
  - Check that the stripped Keychain payload is `str | bytes | bytearray` before calling `json.loads()`.
  - Catch `TypeError` alongside `json.JSONDecodeError` for malformed credential payloads.
- `tests/agent/test_anthropic_keychain.py`
  - Add a regression test for a Darwin/macOS Keychain read where `stdout.strip()` returns a non-string mock payload.

## How to Test

1. Verified the new regression failed before the production fix:

   ```bash
   python -m pytest -q \
     tests/agent/test_anthropic_keychain.py::TestReadClaudeCodeCredentialsFromKeychain::test_returns_none_for_unexpected_stdout_payload_type
   ```

   Before the fix this failed with:

   ```text
   TypeError: the JSON object must be str, bytes or bytearray, not MagicMock
   ```

2. Verified the focused Keychain/OAuth setup tests pass after the fix:

   ```bash
   python -m pytest -q \
     tests/agent/test_anthropic_keychain.py \
     tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken
   ```

   Result:

   ```text
   24 passed in 0.22s
   ```

3. Verified syntax/diff hygiene:

   ```bash
   python -m py_compile agent/anthropic_adapter.py
   git diff --check
   ```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
