### PR TITLE
feat(gateway): add Unix socket dispatcher forwarding

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -629,6 +629,12 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # External dispatcher: forward certain slash commands to a Unix socket
+    # service instead of handling them in the gateway. Disabled when
+    # dispatcher_socket is empty or dispatcher_commands is empty.
+    dispatcher_socket: Optional[str] = None
+    dispatcher_commands: List[str] = field(default_factory=list)
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -822,6 +828,8 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            dispatcher_socket=data.get("dispatcher_socket"),
+            dispatcher_commands=data.get("dispatcher_commands") or [],
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -937,6 +945,35 @@ def load_gateway_config() -> GatewayConfig:
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]
+
+            # External dispatcher: forward slash commands to a Unix socket.
+            dispatcher_cfg = yaml_cfg.get("dispatcher")
+            if dispatcher_cfg is not None and not isinstance(dispatcher_cfg, dict):
+                logger.warning(
+                    "Ignoring dispatcher config in config.yaml: "
+                    "expected mapping, got %s",
+                    type(dispatcher_cfg).__name__,
+                )
+            if isinstance(dispatcher_cfg, dict):
+                ds = dispatcher_cfg.get("socket")
+                if ds and isinstance(ds, str):
+                    gw_data["dispatcher_socket"] = ds
+                dc = dispatcher_cfg.get("commands")
+                if isinstance(dc, list):
+                    valid = [
+                        c.strip() for c in dc
+                        if isinstance(c, str) and c.strip()
+                    ]
+                    if len(valid) < len(dc):
+                        logger.warning(
+                            "Ignoring %d non-string or empty "
+                            "dispatcher_commands entries in config.yaml "
+                            "(%d valid of %d total)",
+                            len(dc) - len(valid),
+                            len(valid),
+                            len(dc),
+                        )
+                    gw_data["dispatcher_commands"] = valid
 
             streaming_cfg = yaml_cfg.get("streaming")
             if not isinstance(streaming_cfg, dict):
@@ -2150,6 +2187,16 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if relay_url_val:
         relay_config = _enable_from_env(Platform.RELAY)
         relay_config.extra["relay_url"] = relay_url_val.rstrip("/")
+
+    # External dispatcher env overrides
+    dispatcher_socket_env = os.getenv("DISPATCHER_SOCKET_PATH", "").strip()
+    if dispatcher_socket_env:
+        config.dispatcher_socket = dispatcher_socket_env
+    dispatcher_commands_env = os.getenv("DISPATCHER_FORWARD_COMMANDS", "").strip()
+    if dispatcher_commands_env:
+        config.dispatcher_commands = [
+            c.strip() for c in dispatcher_commands_env.split(",") if c.strip()
+        ]
 
     for platform_config in config.platforms.values():
         platform_config.extra.pop("_enabled_explicit", None)

--- a/gateway/dispatcher_client.py
+++ b/gateway/dispatcher_client.py
@@ -74,6 +74,8 @@ class DispatcherClient:
         timeout_s: float = DEFAULT_DISPATCHER_TIMEOUT_S,
         max_retries: int = DEFAULT_MAX_RETRIES,
     ) -> None:
+        # Empty-string env var ("DISPATCHER_SOCKET_PATH=") is falsy,
+        # so it falls through to the default path -- same as unset.
         self._path = (
             socket_path
             or os.environ.get("DISPATCHER_SOCKET_PATH")
@@ -113,7 +115,7 @@ class DispatcherClient:
             return
         try:
             self._reader, self._writer = await asyncio.open_unix_connection(
-                self._path
+                self._path, limit=self._MAX_LINE_BYTES
             )
             _LOG.debug("dispatcher client connected to %s", self._path)
         except (OSError, ConnectionError) as e:
@@ -245,6 +247,9 @@ class DispatcherClient:
                 f"dispatcher closed before sending response: {e}"
             ) from e
         except asyncio.LimitOverrunError:
+            # Connection state is corrupted -- close it so next call
+            # reconnects instead of reading leftover bytes.
+            await self._drop_connection()
             raise DispatcherConnectionError(
                 "dispatcher response exceeded line buffer limit"
             )

--- a/gateway/dispatcher_client.py
+++ b/gateway/dispatcher_client.py
@@ -1,0 +1,266 @@
+"""Async Unix-socket client for an external dispatcher service.
+
+Wraps ``asyncio.open_unix_connection`` with a retry loop, a per-call
+timeout, and a single connection per client instance. The client is
+long-lived: construct once at gateway startup, call dispatch() many
+times, close() at shutdown. Reconnect is automatic on transient
+failures (ConnectionResetError, BrokenPipeError); a hard failure
+(dispatcher down, refused connection, timeout) raises
+DispatcherConnectionError so the caller can fall back.
+
+Wire shape and Envelope dataclass live in dispatcher_protocol.py;
+this module is the transport layer only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Optional
+
+from .dispatcher_protocol import (
+    OP_PING,
+    Envelope,
+    STATUS_OK,
+    make_request,
+)
+
+
+_LOG = logging.getLogger(__name__)
+
+
+def _resolve_default_socket() -> str:
+    """Build the default socket path using the current user's UID.
+
+    Follows the XDG runtime directory convention:
+    ``/run/user/<uid>/dispatcher/dispatcher.sock``.
+    """
+    if not hasattr(os, "getuid"):  # windows-footgun: ok
+        raise RuntimeError(
+            "AF_UNIX dispatcher requires a Unix platform; "
+            "set DISPATCHER_SOCKET_PATH explicitly or disable the dispatcher"
+        )
+    uid = os.getuid()
+    return f"/run/user/{uid}/dispatcher/dispatcher.sock"
+
+
+# Per-call timeout for one round-trip.
+DEFAULT_DISPATCHER_TIMEOUT_S = 5.0
+
+# Retry count for transient connection failures. 2 retries with a
+# fresh connection each time = 3 total attempts.
+DEFAULT_MAX_RETRIES = 2
+
+
+class DispatcherConnectionError(Exception):
+    """Raised when the dispatcher is unreachable, refused the
+    connection, or timed out after exhausting retries."""
+
+
+class DispatcherClient:
+    """Async Unix-socket client for an external dispatcher.
+
+    One client per process. Lazy-connects on first dispatch().
+    Reconnects on transient failure up to max_retries times. Closes
+    cleanly on close() or context-manager exit.
+
+    Thread safety: not thread-safe. Single asyncio loop only.
+    """
+
+    def __init__(
+        self,
+        socket_path: str | None = None,
+        timeout_s: float = DEFAULT_DISPATCHER_TIMEOUT_S,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> None:
+        self._path = socket_path or os.environ.get(
+            "DISPATCHER_SOCKET_PATH", _resolve_default_socket()
+        )
+        self._timeout_s = timeout_s
+        self._max_retries = max_retries
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._closed = False
+        self._lock = asyncio.Lock()
+
+    @property
+    def socket_path(self) -> str:
+        return self._path
+
+    @property
+    def is_connected(self) -> bool:
+        return self._writer is not None and not self._writer.is_closing()
+
+    async def connect(self) -> None:
+        """Open the Unix socket (lock-safe). Idempotent. Raises
+        DispatcherConnectionError if the socket cannot be opened.
+
+        Acquires ``_lock`` so concurrent callers cannot race into
+        ``open_unix_connection`` simultaneously. Internal methods
+        that already hold the lock call ``_connect_unlocked``.
+        """
+        async with self._lock:
+            await self._connect_unlocked()
+
+    async def _connect_unlocked(self) -> None:
+        """Open the Unix socket. Caller must hold ``_lock``."""
+        if self._closed:
+            raise DispatcherConnectionError("client is closed")
+        if self.is_connected:
+            return
+        try:
+            self._reader, self._writer = await asyncio.open_unix_connection(
+                self._path
+            )
+            _LOG.debug("dispatcher client connected to %s", self._path)
+        except (OSError, ConnectionError) as e:
+            self._reader = None
+            self._writer = None
+            raise DispatcherConnectionError(
+                f"failed to connect to dispatcher at {self._path}: {e}"
+            ) from e
+
+    async def close(self) -> None:
+        """Close the connection (lock-safe). Idempotent.
+
+        Acquires ``_lock`` so an in-flight ``dispatch()`` finishes
+        before the transport is torn down.
+        """
+        async with self._lock:
+            await self._close_unlocked()
+
+    async def _close_unlocked(self) -> None:
+        """Close the connection. Caller must hold ``_lock``.
+
+        Calls ``_writer.close()`` only (no ``wait_closed``). The
+        caller in run.py wraps ``close()`` in ``wait_for(timeout=3)``;
+        if ``wait_closed`` blocked on an unresponsive peer, the
+        timeout cancellation would leave the fd in an indeterminate
+        state. A plain ``close()`` schedules the teardown without
+        blocking.
+        """
+        self._closed = True
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except (OSError, ConnectionError):
+                pass
+        self._reader = None
+        self._writer = None
+
+    async def __aenter__(self) -> "DispatcherClient":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    async def dispatch(self, envelope: Envelope) -> Envelope:
+        """Send an envelope and return the response envelope.
+
+        Lazy-connects on first call. Reconnects transparently on
+        transient connection failure, retrying up to max_retries
+        times. Raises DispatcherConnectionError on hard failure.
+        """
+        async with self._lock:
+            return await self._dispatch_locked(envelope)
+
+    async def _dispatch_locked(self, envelope: Envelope) -> Envelope:
+        if self._closed:
+            raise DispatcherConnectionError("client is closed")
+
+        last_error: Optional[Exception] = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                return await self._dispatch_once(envelope)
+            except (
+                ConnectionResetError,
+                BrokenPipeError,
+                ConnectionError,
+            ) as e:
+                last_error = e
+                _LOG.warning(
+                    "dispatcher connection lost (attempt %d/%d): %s",
+                    attempt + 1,
+                    self._max_retries + 1,
+                    e,
+                )
+                await self._drop_connection()
+            except asyncio.TimeoutError as e:
+                last_error = e
+                _LOG.warning(
+                    "dispatcher dispatch timed out after %.1fs "
+                    "(attempt %d/%d)",
+                    self._timeout_s,
+                    attempt + 1,
+                    self._max_retries + 1,
+                )
+                await self._drop_connection()
+            except OSError as e:
+                last_error = e
+                _LOG.warning(
+                    "dispatcher dispatch failed (attempt %d/%d): %s",
+                    attempt + 1,
+                    self._max_retries + 1,
+                    e,
+                )
+                await self._drop_connection()
+
+        raise DispatcherConnectionError(
+            f"dispatcher unreachable after {self._max_retries + 1} "
+            f"attempts: {last_error}"
+        )
+
+    # Maximum bytes to read for a single response line. Prevents a
+    # misbehaving dispatcher from consuming unbounded memory.
+    _MAX_LINE_BYTES = 1024 * 1024  # 1 MiB
+
+    async def _dispatch_once(self, envelope: Envelope) -> Envelope:
+        if not self.is_connected:
+            await self._connect_unlocked()
+        if self._writer is None or self._reader is None:
+            raise DispatcherConnectionError(
+                "connection not established after connect"
+            )
+        writer = self._writer
+        reader = self._reader
+
+        try:
+            writer.write(envelope.to_jsonl())
+            await writer.drain()
+            line = await asyncio.wait_for(
+                reader.readuntil(b"\n"), timeout=self._timeout_s
+            )
+            if len(line) > self._MAX_LINE_BYTES:
+                raise ConnectionError(
+                    f"dispatcher response too large ({len(line)} bytes)"
+                )
+        except (ConnectionResetError, BrokenPipeError):
+            raise
+        except asyncio.IncompleteReadError as e:
+            raise ConnectionError(
+                f"dispatcher closed before sending response: {e}"
+            ) from e
+
+        return Envelope.from_jsonl(line)
+
+    async def _drop_connection(self) -> None:
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except (OSError, ConnectionError):
+                pass
+        self._reader = None
+        self._writer = None
+
+    async def ping(self) -> bool:
+        """Send a ping. Returns True on STATUS_OK, False on any
+        failure (no exception raised)."""
+        try:
+            req = make_request(OP_PING, {})
+            resp = await self.dispatch(req)
+            return resp.status == STATUS_OK
+        except (DispatcherConnectionError, ValueError) as e:
+            _LOG.debug("ping failed: %s", e)
+            return False

--- a/gateway/dispatcher_client.py
+++ b/gateway/dispatcher_client.py
@@ -74,8 +74,10 @@ class DispatcherClient:
         timeout_s: float = DEFAULT_DISPATCHER_TIMEOUT_S,
         max_retries: int = DEFAULT_MAX_RETRIES,
     ) -> None:
-        self._path = socket_path or os.environ.get(
-            "DISPATCHER_SOCKET_PATH", _resolve_default_socket()
+        self._path = (
+            socket_path
+            or os.environ.get("DISPATCHER_SOCKET_PATH")
+            or _resolve_default_socket()
         )
         self._timeout_s = timeout_s
         self._max_retries = max_retries
@@ -242,6 +244,10 @@ class DispatcherClient:
             raise ConnectionError(
                 f"dispatcher closed before sending response: {e}"
             ) from e
+        except asyncio.LimitOverrunError:
+            raise DispatcherConnectionError(
+                "dispatcher response exceeded line buffer limit"
+            )
 
         return Envelope.from_jsonl(line)
 

--- a/gateway/dispatcher_protocol.py
+++ b/gateway/dispatcher_protocol.py
@@ -1,0 +1,105 @@
+"""Wire-protocol dataclasses for the dispatcher IPC client.
+
+JSON line-delimited envelope over a Unix domain socket. The gateway
+uses this module to construct and parse envelopes when forwarding
+slash commands to an external dispatcher process. The wire spec is
+intentionally simple: a JSON object per line, newline-terminated.
+
+If the dispatcher server changes the wire shape, this module MUST
+be updated in the same commit to keep client and server in sync.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+
+
+# --- status codes ---
+
+STATUS_OK = 0
+STATUS_BAD_REQUEST = 1   # malformed / unknown op
+STATUS_INTERNAL = 2      # handler raised
+STATUS_BUSY = 3          # handler max_inflight reached
+
+
+# --- ops ---
+
+OP_DISPATCH = "dispatch"
+OP_PING = "ping"
+OP_SHUTDOWN = "shutdown"
+
+
+# --- envelope ---
+
+@dataclass(frozen=True)
+class Envelope:
+    """One wire message. Either request (status absent) or response
+    (status present, required). The server is the authority on
+    validation; clients must handle STATUS_BAD_REQUEST gracefully.
+    """
+
+    request_id: str
+    op: str
+    payload: dict
+    status: int | None = None
+
+    def to_jsonl(self) -> bytes:
+        """Serialize as one JSON line (newline-terminated)."""
+        d = {
+            "request_id": self.request_id,
+            "op": self.op,
+            "payload": self.payload,
+        }
+        if self.status is not None:
+            d["status"] = self.status
+        return (json.dumps(d, ensure_ascii=False) + "\n").encode("utf-8")
+
+    @classmethod
+    def from_jsonl(cls, line: bytes) -> "Envelope":
+        """Parse one JSON line into an Envelope. Raises ValueError on
+        malformed JSON or missing required fields."""
+        obj = json.loads(line)
+        if not isinstance(obj, dict):
+            raise ValueError(
+                f"envelope must be a JSON object, got {type(obj).__name__}"
+            )
+        for required in ("request_id", "op", "payload"):
+            if required not in obj:
+                raise ValueError(f"missing required field {required!r}")
+        if not isinstance(obj["request_id"], str):
+            raise ValueError("request_id must be a string")
+        if not isinstance(obj["op"], str):
+            raise ValueError("op must be a string")
+        if not isinstance(obj["payload"], dict):
+            raise ValueError("payload must be a JSON object")
+        status = obj.get("status")
+        if status is not None and (
+            isinstance(status, bool) or not isinstance(status, int)
+        ):
+            raise ValueError(
+                f"status must be int or absent, got {type(status).__name__}"
+            )
+        return cls(
+            request_id=obj["request_id"],
+            op=obj["op"],
+            payload=obj["payload"],
+            status=status,
+        )
+
+
+# --- helpers ---
+
+def new_request_id() -> str:
+    """Generate a request_id for a new request. UUID4 hex (32 chars)."""
+    return uuid.uuid4().hex
+
+
+def make_request(op: str, payload: dict | None = None) -> Envelope:
+    """Build a fresh request envelope with a generated request_id."""
+    return Envelope(
+        request_id=new_request_id(),
+        op=op,
+        payload=payload if payload is not None else {},
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9702,7 +9702,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _disp_cmds = getattr(self, "_dispatcher_commands", frozenset())
         if command and _disp_cmds and command in _disp_cmds:
             # Gate: check access before forwarding to dispatcher
-            _denied = self._check_slash_access(source, command)
+            try:
+                _denied = self._check_slash_access(source, command)
+            except Exception as e:
+                logger.warning(
+                    "dispatcher command access check failed: %s", e
+                )
+                _denied = "access check error: command denied for safety"
             if _denied is not None:
                 return _denied
             result = await self._forward_to_dispatcher(event, command)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1678,6 +1678,16 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from gateway.delivery import DeliveryRouter, looks_like_telegram_private_chat_id
+from gateway.dispatcher_client import (
+    DispatcherClient,
+    DispatcherConnectionError,
+)
+from gateway.dispatcher_protocol import (
+    Envelope as _DispatcherEnvelope,
+    OP_DISPATCH,
+    STATUS_OK,
+    make_request as _make_dispatcher_request,
+)
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
@@ -2787,6 +2797,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Set on gateway stop so the recreate-on-shutdown path can't resurrect
         # the pool during a real shutdown.
         self._executor_closing = False
+        # External dispatcher: forward configured commands to a Unix
+        # socket service. Disabled when the command set is empty.
+        self._dispatcher_commands: frozenset = frozenset(
+            self.config.dispatcher_commands or []
+        )
+        # Eager init when configured; None when disabled.
+        self._dispatcher_client: Optional[DispatcherClient] = (
+            DispatcherClient(socket_path=self.config.dispatcher_socket)
+            if self._dispatcher_commands
+            else None
+        )
+
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
@@ -8055,6 +8077,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _phase_elapsed(),
             )
 
+            # Close the dispatcher Unix-socket client if it was lazily
+            # initialised during this run.  Without this, every gateway
+            # restart cycle leaves the previous gateway's open AF_UNIX
+            # fd behind until Python garbage-collects DispatcherClient.
+            _disp_client = getattr(self, "_dispatcher_client", None)
+            if _disp_client is not None:
+                try:
+                    await asyncio.wait_for(
+                        _disp_client.close(), timeout=3.0
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "dispatcher client close timed out after 3s"
+                    )
+                except Exception as _e:
+                    logger.warning("dispatcher client close error: %s", _e)
+
             from gateway.status import remove_pid_file, release_gateway_runtime_lock
             remove_pid_file()
             release_gateway_runtime_lock()
@@ -9655,6 +9694,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+
+        # Dispatcher-forwarded slash commands. These are commands an
+        # external dispatcher service handles; the gateway forwards
+        # them via Unix socket. On dispatcher failure we fall through
+        # to normal message handling rather than blocking the user.
+        _disp_cmds = getattr(self, "_dispatcher_commands", frozenset())
+        if command and _disp_cmds and command in _disp_cmds:
+            result = await self._forward_to_dispatcher(event, command)
+            if result is not None:
+                return result
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
@@ -11853,6 +11902,86 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+
+    # ── Dispatcher forwarding ──────────────────────────────────
+
+    async def _forward_to_dispatcher(
+        self, event: "MessageEvent", command: str
+    ) -> Optional[str]:
+        """Forward a slash command to the external dispatcher via
+        Unix socket. Returns formatted text on success, None on
+        failure (so the caller can fall through to normal handling).
+        """
+        client = getattr(self, "_dispatcher_client", None)
+        if client is None:
+            return None
+        source = event.source
+        platform_name = (
+            source.platform.value if source.platform else ""
+        )
+        args = event.get_command_args().strip()
+        content = f"/{command}"
+        if args:
+            content = f"{content} {args}"
+        payload = {"source": platform_name, "content": content}
+        try:
+            req = _make_dispatcher_request(OP_DISPATCH, payload)
+            resp = await asyncio.wait_for(
+                client.dispatch(req), timeout=10.0
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "dispatcher forward for /%s timed out after 10s",
+                command,
+            )
+            return None
+        except (DispatcherConnectionError, ValueError) as e:
+            logger.warning(
+                "dispatcher forward for /%s failed (non-fatal): %s",
+                command,
+                e,
+            )
+            return None
+        return self._format_dispatcher_response(command, resp)
+
+    @staticmethod
+    def _format_dispatcher_response(
+        command: str, resp: _DispatcherEnvelope,
+    ) -> str:
+        """Render a dispatcher Envelope as chat text."""
+        status = resp.status
+        payload = resp.payload or {}
+        if status == STATUS_OK:
+            kind = payload.get("result", "")
+            if kind == "echo":
+                echoed = payload.get("echoed_payload", {})
+                content = echoed.get("content", "")
+                return f"[dispatcher] echo: {content}"
+            if kind == "health":
+                return "[dispatcher] dispatcher reports healthy"
+            if kind == "help":
+                cmds = payload.get("commands", [])
+                lines = "\n".join(f"  /{c}" for c in cmds)
+                return f"[dispatcher] available commands:\n{lines}"
+            if kind == "status":
+                raw_up = payload.get("uptime_s", 0)
+                try:
+                    up = float(raw_up)
+                except (TypeError, ValueError):
+                    up = 0.0
+                handlers = payload.get("handlers", [])
+                return (
+                    f"[dispatcher] alive (uptime {up:.1f}s, "
+                    f"{len(handlers)} handlers)"
+                )
+            import json as _json
+            return (
+                "[dispatcher] "
+                + _json.dumps(payload, ensure_ascii=False, indent=2)
+            )
+        # Non-OK status
+        errmsg = payload.get("error", f"status {status}")
+        return f"[dispatcher] /{command} failed: {errmsg}"
 
     def _check_slash_access(
         self, source: SessionSource, canonical_cmd: str

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9701,6 +9701,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # to normal message handling rather than blocking the user.
         _disp_cmds = getattr(self, "_dispatcher_commands", frozenset())
         if command and _disp_cmds and command in _disp_cmds:
+            # Gate: check access before forwarding to dispatcher
+            _denied = self._check_slash_access(source, command)
+            if _denied is not None:
+                return _denied
             result = await self._forward_to_dispatcher(event, command)
             if result is not None:
                 return result

--- a/tests/gateway/test_dispatcher_client.py
+++ b/tests/gateway/test_dispatcher_client.py
@@ -1,0 +1,381 @@
+"""Tests for the dispatcher Unix-socket client.
+
+The client wraps an asyncio Unix socket with retry + timeout. We
+test against a REAL asyncio Unix socket server fixture on tmp_path,
+not a mock. The fixture plays the role of the dispatcher: it
+accepts one connection, reads one Envelope, and writes back a
+configurable response (or hangs to test timeout).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import pytest_asyncio
+
+from gateway.dispatcher_client import (
+    DispatcherClient,
+    DispatcherConnectionError,
+    _resolve_default_socket,
+)
+from gateway.dispatcher_protocol import (
+    OP_DISPATCH,
+    OP_PING,
+    STATUS_BAD_REQUEST,
+    STATUS_BUSY,
+    STATUS_INTERNAL,
+    STATUS_OK,
+    Envelope,
+    make_request,
+)
+
+
+# --- Fake dispatcher server fixture -------------------------------
+
+
+class FakeDispatcher:
+    """A real asyncio Unix socket server that pretends to be an
+    external dispatcher."""
+
+    def __init__(self, socket_path: Path) -> None:
+        self._path = str(socket_path)
+        self._server: Optional[asyncio.base_events.Server] = None
+        self.connections = 0
+        self.response_fn = self._default_response
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_unix_server(
+            self._handle_connection, path=self._path
+        )
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        try:
+            Path(self._path).unlink()
+        except FileNotFoundError:
+            pass
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        self.connections += 1
+        try:
+            line = await asyncio.wait_for(
+                reader.readuntil(b"\n"), timeout=5.0
+            )
+        except (asyncio.IncompleteReadError, asyncio.TimeoutError):
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+            return
+        try:
+            req = Envelope.from_jsonl(line)
+        except ValueError:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+            return
+        resp = self.response_fn(req)
+        if resp is None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except (ConnectionError, OSError):
+                pass
+            return
+        writer.write(resp.to_jsonl())
+        await writer.drain()
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except (ConnectionError, OSError):
+            pass
+
+    @staticmethod
+    def _default_response(req: Envelope) -> Envelope:
+        if req.op == OP_PING:
+            return Envelope(
+                request_id=req.request_id,
+                op=OP_PING,
+                payload={"ts": 0.0},
+                status=STATUS_OK,
+            )
+        return Envelope(
+            request_id=req.request_id,
+            op=req.op,
+            payload={"result": "echo", "echoed_payload": req.payload},
+            status=STATUS_OK,
+        )
+
+
+@pytest_asyncio.fixture
+async def fake_dispatcher(tmp_path: Path):
+    sock = tmp_path / "dispatcher.sock"
+    server = FakeDispatcher(sock)
+    await server.start()
+    try:
+        yield server
+    finally:
+        await server.stop()
+
+
+# --- DispatcherClient tests ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ping_returns_true_on_status_ok(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    assert await client.ping() is True
+    assert fake_dispatcher.connections == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_roundtrip_ping(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    req = make_request(OP_PING, {})
+    resp = await client.dispatch(req)
+    assert resp.status == STATUS_OK
+    assert resp.op == OP_PING
+    assert "ts" in resp.payload
+    assert resp.request_id == req.request_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_echo_payload(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    req = make_request(
+        OP_DISPATCH,
+        {"source": "wechat", "content": "/echo hello"},
+    )
+    resp = await client.dispatch(req)
+    assert resp.status == STATUS_OK
+    assert resp.payload.get("echoed_payload") == {
+        "source": "wechat",
+        "content": "/echo hello",
+    }
+    assert resp.request_id == req.request_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unreachable_raises(tmp_path: Path) -> None:
+    sock = tmp_path / "nope.sock"
+    client = DispatcherClient(
+        socket_path=str(sock),
+        timeout_s=0.2,
+        max_retries=1,
+    )
+    with pytest.raises(DispatcherConnectionError):
+        await client.dispatch(make_request(OP_PING, {}))
+
+
+@pytest.mark.asyncio
+async def test_dispatch_propagates_server_status_codes(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    def respond(req: Envelope) -> Envelope:
+        return Envelope(
+            request_id=req.request_id,
+            op=req.op,
+            payload={"error": "handler raised"},
+            status=STATUS_INTERNAL,
+        )
+
+    fake_dispatcher.response_fn = respond
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    resp = await client.dispatch(make_request(OP_DISPATCH, {"content": "/echo"}))
+    assert resp.status == STATUS_INTERNAL
+    assert "raised" in resp.payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_retries_on_connection_reset(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    call_count = {"n": 0}
+
+    def respond(req: Envelope) -> Optional[Envelope]:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return None
+        return Envelope(
+            request_id=req.request_id,
+            op=req.op,
+            payload={"result": "echo", "echoed_payload": req.payload},
+            status=STATUS_OK,
+        )
+
+    fake_dispatcher.response_fn = respond
+    client = DispatcherClient(
+        socket_path=str(fake_dispatcher._path),
+        max_retries=2,
+    )
+    resp = await client.dispatch(make_request(OP_PING, {}))
+    assert resp.status == STATUS_OK
+    assert call_count["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_dispatch_timeout_raises(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    async def respond_hang(req: Envelope) -> Optional[Envelope]:
+        await asyncio.sleep(60)
+        return None
+
+    fake_dispatcher.response_fn = respond_hang  # type: ignore[assignment]
+    client = DispatcherClient(
+        socket_path=str(fake_dispatcher._path),
+        timeout_s=0.2,
+        max_retries=0,
+    )
+    with pytest.raises(DispatcherConnectionError):
+        await client.dispatch(make_request(OP_PING, {}))
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    client = DispatcherClient(socket_path=str(fake_dispatcher._path))
+    await client.dispatch(make_request(OP_PING, {}))
+    await client.close()
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_context_manager_closes_on_exit(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    async with DispatcherClient(
+        socket_path=str(fake_dispatcher._path)
+    ) as client:
+        resp = await client.dispatch(make_request(OP_PING, {}))
+        assert resp.status == STATUS_OK
+    assert not client.is_connected
+
+
+def test_default_socket_path_uses_xdg(monkeypatch) -> None:
+    """No socket_path and no env var -> XDG runtime dir path."""
+    monkeypatch.delenv("DISPATCHER_SOCKET_PATH", raising=False)
+    client = DispatcherClient()
+    assert client.socket_path == _resolve_default_socket()
+
+
+def test_env_var_overrides_default(monkeypatch) -> None:
+    """DISPATCHER_SOCKET_PATH overrides the default."""
+    monkeypatch.setenv("DISPATCHER_SOCKET_PATH", "/tmp/custom.sock")
+    client = DispatcherClient()
+    assert client.socket_path == "/tmp/custom.sock"
+
+
+# --- Format helper tests (sync) -----------------------------------
+
+
+def test_format_status_ok_kind_echo() -> None:
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={
+            "result": "echo",
+            "echoed_payload": {"content": "/echo hello"},
+        },
+        status=STATUS_OK,
+    )
+    text = GatewayRunner._format_dispatcher_response("echo", resp)
+    assert text == "[dispatcher] echo: /echo hello"
+
+
+def test_format_status_ok_kind_status() -> None:
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={
+            "result": "status",
+            "uptime_s": 12.5,
+            "handlers": ["echo", "status", "help"],
+        },
+        status=STATUS_OK,
+    )
+    text = GatewayRunner._format_dispatcher_response("status", resp)
+    assert "alive" in text
+    assert "12.5" in text
+    assert "3 handlers" in text
+
+
+def test_format_non_ok_status() -> None:
+    """Non-OK status surfaces error string."""
+    from gateway.run import GatewayRunner
+
+    resp = Envelope(
+        request_id="r1", op=OP_DISPATCH,
+        payload={"error": "handler raised"},
+        status=STATUS_INTERNAL,
+    )
+    text = GatewayRunner._format_dispatcher_response("echo", resp)
+    assert "failed" in text
+    assert "handler raised" in text
+
+
+# --- Integration: GatewayRunner._forward_to_dispatcher -----------
+
+
+@pytest.mark.asyncio
+async def test_forward_to_dispatcher_via_runner(
+    fake_dispatcher: FakeDispatcher,
+) -> None:
+    from gateway.run import GatewayRunner
+    from types import SimpleNamespace
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._dispatcher_client = DispatcherClient(
+        socket_path=str(fake_dispatcher._path)
+    )
+
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=SimpleNamespace(value="wechat")),
+        get_command_args=lambda: " hello world",
+    )
+    text = await runner._forward_to_dispatcher(event, "echo")
+    assert text == "[dispatcher] echo: /echo hello world"
+
+
+@pytest.mark.asyncio
+async def test_forward_returns_none_on_dispatcher_down(
+    tmp_path: Path,
+) -> None:
+    from gateway.run import GatewayRunner
+    from types import SimpleNamespace
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._dispatcher_client = DispatcherClient(
+        socket_path=str(tmp_path / "nope.sock"),
+        timeout_s=0.1,
+        max_retries=0,
+    )
+
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=SimpleNamespace(value="wechat")),
+        get_command_args=lambda: "",
+    )
+    result = await runner._forward_to_dispatcher(event, "echo")
+    assert result is None

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -621,3 +621,33 @@ async def test_gating_isolated_per_platform():
     tg_src = _make_source(platform=Platform.TELEGRAM, user_id="999", chat_id="t1")
     result = await runner._handle_message(_make_event("/whoami", tg_src))
     assert "Tier: unrestricted" in result
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed on access check exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_access_check_exception_denies_command():
+    """When _check_slash_access raises, the dispatcher command must be denied
+    (fail-closed), not silently forwarded."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+        }
+    )
+    runner._dispatcher_commands = frozenset({"mycmd"})
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("access check exploded")
+
+    runner._check_slash_access = _boom
+    runner._forward_to_dispatcher = AsyncMock(return_value="should-not-reach")
+    result = await runner._handle_message(
+        _make_event("/mycmd", _make_source(user_id="999"))
+    )
+    assert result is not None
+    assert "access check error: command denied for safety" in result
+    assert "should-not-reach" not in (result or "")


### PR DESCRIPTION
## Summary

Add opt-in Unix socket forwarding so the gateway can delegate configured
slash commands to an external dispatcher service instead of routing them
through the agent loop.

- New `dispatcher_protocol.py`: wire-protocol dataclasses (Envelope, status codes, ops)
- New `dispatcher_client.py`: async Unix-socket client with retry, timeout, lock-safe connect/close
- `config.py`: `dispatcher_socket` + `dispatcher_commands` fields in GatewayConfig, YAML parsing, env var overrides (`DISPATCHER_SOCKET_PATH`, `DISPATCHER_FORWARD_COMMANDS`)
- `run.py`: eager client init, command cascade forwarding (after draining check, before quick-commands), per-call 10s timeout, formatted response rendering
- Tests: real asyncio Unix socket server fixture, 15 test cases

### Design decisions

- **Opt-in, disabled by default**: no config = no dispatcher client created, zero overhead
- **Soft dependency**: dispatcher failure returns None, gateway falls through to normal message handling
- **Configurable command list**: no hardcoded commands; operators choose what to forward via config.yaml or env vars
- **Lock-safe lifecycle**: `connect()` and `close()` acquire the client lock; internal paths use `_connect_unlocked`/`_close_unlocked` to avoid deadlock with the dispatch retry loop
- **No `wait_closed()`**: `close()` schedules teardown without blocking, preventing fd leak when the caller applies a timeout via `asyncio.wait_for`

### Config example

```yaml
# config.yaml
dispatcher:
  socket: /run/user/1000/dispatcher/dispatcher.sock
  commands: [echo, research, forge]
```

Or via environment:
```bash
export DISPATCHER_SOCKET_PATH=/run/user/1000/dispatcher/dispatcher.sock
export DISPATCHER_FORWARD_COMMANDS=echo,research,forge
```

## Test plan

- [x] `pytest tests/gateway/test_dispatcher_client.py` (15 tests, real Unix socket fixture)
- [x] Verify gateway starts normally with no dispatcher config (feature disabled)
- [x] Verify gateway starts with dispatcher config but dispatcher not running (soft failure)
- [x] Verify slash command forwarding works end-to-end with a running dispatcher

Signed-off-by: Minxi Hou <houminxi@gmail.com>