### PR TITLE
fix(billing): improve model pricing coverage and cache token accounting

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -429,6 +429,28 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
         pricing_version="deepseek-pricing-2026-05-12",
     ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.07"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.006"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-05-12",
+    ),
+    # StepFun
+    (
+        "stepfun",
+        "step-3.7-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.20"),
+        output_cost_per_million=Decimal("0.80"),
+        source="official_docs_snapshot",
+        source_url="https://platform.stepfun.com/docs/pricing",
+        pricing_version="stepfun-pricing-2026-06",
+    ),
     # Google Gemini
     (
         "google",
@@ -606,6 +628,8 @@ def resolve_billing_route(
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "stepfun" or model.startswith("stepfun/"):
+        return BillingRoute(provider="stepfun", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     # Vertex AI hosts the same Gemini models as Google AI Studio; price them
     # off the gemini official-docs snapshot. Strip the "google/" vendor prefix
     # the OpenAI-compat endpoint requires so the pricing key matches.
@@ -650,6 +674,19 @@ def _normalize_anthropic_model_name(model: str) -> str:
     # Normalize dots to dashes in version numbers (e.g. 4.7 → 4-7, 4.6 → 4-6)
     # But preserve the rest of the name structure
     name = re.sub(r"(\d+)\.(\d+)", r"\1-\2", name)
+    return name
+
+
+def _normalize_stepfun_model_name(model: str) -> str:
+    """Normalize StepFun model name variants to canonical form.
+
+    Handles:
+      - Vendor prefix: stepfun/step-3.7-flash → step-3.7-flash
+      - Dot notation: step-3.7-flash → step-3.7-flash
+    """
+    name = model.lower().strip()
+    if "/" in name:
+        name = name.split("/", 1)[-1]
     return name
 
 
@@ -813,6 +850,10 @@ def normalize_usage(
         cache_write_tokens = _to_int(
             getattr(details, "cache_write_tokens", 0) if details else 0
         )
+        if not cache_write_tokens:
+            cache_write_tokens = _to_int(
+                getattr(details, "cache_creation_tokens", 0) if details else 0
+            )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
                 getattr(response_usage, "cache_creation_input_tokens", 0)

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -711,6 +711,14 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
             entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
             if entry:
                 return entry
+    # StepFun vendor-prefixed ids (stepfun/step-3.7-flash) must strip the
+    # prefix so they match the bare pricing-table key.
+    if route.provider == "stepfun":
+        normalized = _normalize_stepfun_model_name(model)
+        if normalized != model:
+            entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
+            if entry:
+                return entry
     return None
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -322,3 +322,88 @@ def test_bedrock_claude_cached_session_estimates_cost_not_unknown():
     )
     assert result.status == "estimated"
     assert result.amount_usd is not None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests added per PR #57113 (teknium1 review)
+# ---------------------------------------------------------------------------
+
+def test_normalize_usage_chat_completions_reads_cache_creation_tokens_fallback():
+    """When cache_write_tokens is 0 in prompt_tokens_details but
+    cache_creation_tokens is set, fall back to cache_creation_tokens.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        prompt_tokens_details=SimpleNamespace(
+            cached_tokens=500,
+            cache_write_tokens=0,
+            cache_creation_tokens=400,
+        ),
+    )
+    normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
+    assert normalized.cache_write_tokens == 400
+
+
+def test_normalize_usage_chat_completions_prefers_cache_write_tokens_over_cache_creation_tokens():
+    """When both cache_write_tokens and cache_creation_tokens are set in
+    prompt_tokens_details, prefer cache_write_tokens.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        prompt_tokens_details=SimpleNamespace(
+            cached_tokens=500,
+            cache_write_tokens=100,
+            cache_creation_tokens=999,
+        ),
+    )
+    normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
+    assert normalized.cache_write_tokens == 100
+
+
+def test_normalize_usage_chat_completions_reads_cache_creation_input_tokens_fallback():
+    """When neither cache_write_tokens nor cache_creation_tokens is set in
+    prompt_tokens_details, fall back to top-level cache_creation_input_tokens.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=500),
+        cache_creation_input_tokens=400,
+    )
+    normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
+    assert normalized.cache_write_tokens == 400
+
+
+def test_deepseek_v4_flash_pricing_entry_exists():
+    """Regression test: deepseek-v4-flash must have a pricing entry."""
+    entry = get_pricing_entry("deepseek-v4-flash", provider="deepseek")
+    assert entry is not None
+
+
+def test_stepfun_step_3_7_flash_pricing_resolves():
+    """Vendor-prefixed stepfun/step-3.7-flash must resolve to the bare
+    pricing-table key via _normalize_stepfun_model_name.
+    """
+    from agent.usage_pricing import BillingRoute
+
+    entry = get_pricing_entry("stepfun/step-3.7-flash", provider="stepfun")
+    assert entry is not None
+    route = BillingRoute(
+        provider="stepfun",
+        model="stepfun/step-3.7-flash",
+        base_url="",
+        billing_mode="official_docs_snapshot",
+    )
+    assert route.provider == "stepfun"
+
+
+def test_resolve_billing_route_stepfun_vendor_prefix():
+    """resolve_billing_route must detect the stepfun/ vendor prefix and set
+    provider to 'stepfun'.
+    """
+    from agent.usage_pricing import resolve_billing_route
+
+    route = resolve_billing_route("stepfun/step-3.7-flash")
+    assert route.provider == "stepfun"


### PR DESCRIPTION
## What

This PR fixes two related telemetry gaps observed in real session data:

1. **Missing pricing entries** for `deepseek-v4-flash` and `stepfun/step-3.7-flash` caused most sessions to price as `$0.00` even when thousands of input/output tokens were recorded.
2. **`cache_write_tokens` undercounted to 0** on some OpenAI-compatible backends because the normalizer only checked `prompt_tokens_details.cache_write_tokens`, while several providers expose the same value under `prompt_tokens_details.cache_creation_tokens`.

## Changes

- Add `deepseek-v4-flash` pricing snapshot
- Add `stepfun/step-3.7-flash` pricing snapshot
- Route `stepfun/` prefixed models to the `stepfun` billing bucket in `resolve_billing_route()`
- Add `_normalize_stepfun_model_name()`
- Add `cache_creation_tokens` fallback in `normalize_usage()` so cache writes are not silently dropped

## Reproduction

In `state.db` sessions, `estimated_cost_usd` stayed at `$0.00` for high-token `deepseek-v4-flash` and `stepfun/step-3.7-flash` sessions, and `cache_write_tokens` was always `0` across providers.

## Verification

- `usage_pricing.py`: new entries are lookup-stable; fallback does not change behavior when `cache_write_tokens` is already present.
- No schema changes; backward-compatible with existing sessions.

Closes none. Supersedes nothing.