### PR TITLE
fix: preserve user-defined providers when assigning model via GUI/API

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1000,11 +1000,19 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
         # against the user's current provider when it's an aggregator that
         # serves vendor-prefixed slugs; otherwise default to openrouter.
         try:
-            cur_cfg = load_config().get("model", {})
+            cfg = load_config()
+            cur_cfg = cfg.get("model", {})
             cur_provider = (
                 str(cur_cfg.get("provider", "") or "").strip().lower()
                 if isinstance(cur_cfg, dict) else ""
             )
+            # User-defined providers (config.yaml providers: section) are NOT
+            # in _KNOWN_PROVIDER_NAMES but are real providers — preserve them
+            # instead of falling back to openrouter. This fixes the desktop GUI
+            # where model selection overwrites a custom provider with openrouter.
+            user_provs = cfg.get("providers", {})
+            if isinstance(user_provs, dict) and canonical in user_provs:
+                return prov_in, model_in
         except Exception:
             cur_provider = ""
         from hermes_cli.models import _AGGREGATOR_PROVIDERS


### PR DESCRIPTION
## Summary

`_normalize_main_model_assignment()` in `hermes_cli/web_server.py` had a blind spot: when a user-defined provider (configured via `config.yaml -> providers:`) was used to assign a model through the desktop GUI or `/api/model/set`, the function checked only built-in `_KNOWN_PROVIDER_NAMES` and `_AGGREGATOR_PROVIDERS`. Custom providers like `open.cherryin.net` matched neither, so the code unconditionally fell back to `openrouter`, silently overwriting the user configured provider.

## Root cause

https://github.com/NousResearch/hermes-agent/blob/30e947e0a/hermes_cli/web_server.py#L998-L1016

The fallback logic at line 998 only handled two cases:
- Provider is in `_KNOWN_PROVIDER_NAMES` (built-in) → proceed to model normalization
- Provider is an aggregator (`_AGGREGATOR_PROVIDERS`) → keep current provider
- Everything else → **fallback to openrouter** ← the bug

## Fix

Before falling back to openrouter, check whether the provider slug exists in `config.yaml -> providers:` (the user-defined provider registry). If it does, return immediately — custom provider namespaces are opaque to the built-in normalizer and should be preserved verbatim.

This aligns the HTTP API behavior with what the CLI `hermes model` picker already does (which skips `_normalize_main_model_assignment` entirely for user-defined providers).

## Test plan

1. Set up a custom provider in `config.yaml -> providers:` (e.g. `open.cherryin.net` with its own `api` endpoint)
2. Open Desktop GUI → Model Settings → Select a model under the custom provider → Apply
3. Before fix: `config.yaml -> model.provider` is overwritten to `openrouter`
4. After fix: `config.yaml -> model.provider` correctly stays as the custom provider slug

## Related

Fixes an issue where Desktop GUI model selection silently breaks custom providers.