### PR TITLE
fix(vision): make fallback chain iterate all entries instead of stopping at first

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2754,6 +2754,26 @@ def _is_connection_error(exc: Exception) -> bool:
     return False
 
 
+def _is_geo_blocked_error(exc: Exception) -> bool:
+    """Detect geo-blocked/location errors that warrant provider fallback.
+
+    Gemini returns ``400 FAILED_PRECONDITION: User location is not supported``
+    from restricted regions (China, corporate VPNs).  Neither
+    :func:`_is_connection_error` nor :func:`_is_payment_error` match these.
+    See #51513.
+    """
+    err_lower = str(exc).lower()
+    return any(kw in err_lower for kw in (
+        "failed_precondition",
+        "user location is not supported",
+        "location is not supported",
+        "not available in your country",
+        "not available in your region",
+        "geo-restricted",
+        "geo_blocked",
+    ))
+
+
 def _is_transient_transport_error(exc: Exception) -> bool:
     """Return True for a one-off transport blip worth retrying ON the
     same provider before any provider/model fallback.
@@ -2948,6 +2968,7 @@ def _is_model_incompatible_error(exc: Exception) -> bool:
     return any(kw in err_lower for kw in (
         "is not supported when using",   # codex/ChatGPT-account model gating
         "model is not supported",
+        "not supported model",           # xiaomi-tp: 'Not supported model X'
         "not supported with this",
         "not supported for this account",
         "model_not_supported",
@@ -4775,10 +4796,10 @@ def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
     except Exception:  # pragma: no cover - defensive
         return True
     if supports is None:
-        # No capability data — keep current behaviour and let the call attempt
-        # happen rather than silently skipping. This avoids false-positive
-        # skips for new/custom providers.
-        return True
+        # Unknown model capabilities — assume text-only so vision requests
+        # route through the auxiliary fallback chain instead of being sent
+        # to a potentially text-only main model.  See #51513.
+        return False
     return bool(supports)
 
 
@@ -6366,6 +6387,7 @@ def call_llm(
             or _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_geo_blocked_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
@@ -6389,6 +6411,7 @@ def call_llm(
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_geo_blocked_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
@@ -6437,15 +6460,51 @@ def call_llm(
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 
+            # Build list of fallback candidates to try.  When a configured
+            # fallback_chain is set, iterate ALL entries so that if the first
+            # candidate fails at call time (e.g. model not available on the
+            # provider), the chain continues instead of stopping.  See #51513.
+            _fb_candidates = []
             if fb_client is not None:
-                fb_kwargs = _build_call_kwargs(
-                    fb_label, fb_model, messages,
-                    temperature=temperature, max_tokens=max_tokens,
-                    tools=tools, timeout=effective_timeout,
-                    extra_body=effective_extra_body,
-                    base_url=str(getattr(fb_client, "base_url", "") or ""))
-                return _validate_llm_response(
-                    fb_client.chat.completions.create(**fb_kwargs), task)
+                _fb_candidates.append((fb_client, fb_model, fb_label))
+            _tcfg = _get_auxiliary_task_config(task or "")
+            _chain = _tcfg.get("fallback_chain") if _tcfg else None
+            if _chain and isinstance(_chain, list):
+                _skip_p = (resolved_provider or "").lower().strip()
+                for _i, _entry in enumerate(_chain):
+                    if not isinstance(_entry, dict):
+                        continue
+                    _ep = str(_entry.get("provider", "")).strip()
+                    if not _ep or _ep.lower() == _skip_p:
+                        continue
+                    _em = str(_entry.get("model", "")).strip() or None
+                    _el = f"fallback_chain[{_i}]({_ep})"
+                    if _el == fb_label:
+                        continue  # already first pick
+                    if _ep and _em:
+                        try:
+                            _ec, _emr = _resolve_fallback_entry(_entry)
+                        except Exception:
+                            _ec, _emr = None, None
+                        if _ec is not None:
+                            _fb_candidates.append((_ec, _emr or _em, _el))
+
+            _last_fb_err = None
+            for _fb_c, _fb_m, _fb_l in _fb_candidates:
+                try:
+                    fb_kwargs = _build_call_kwargs(
+                        _fb_l, _fb_m, messages,
+                        temperature=temperature, max_tokens=max_tokens,
+                        tools=tools, timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                        base_url=str(getattr(_fb_c, "base_url", "") or ""))
+                    return _validate_llm_response(
+                        _fb_c.chat.completions.create(**fb_kwargs), task)
+                except Exception as _fb_err:
+                    _last_fb_err = _fb_err
+                    logger.info("Auxiliary %s: fallback %s failed (%s), trying next",
+                                task or "call", _fb_l, _fb_err)
+                    continue
             # All fallback layers exhausted — emit a single user-visible
             # warning so the operator knows aux task is about to fail.
             # (#26882) The error itself is re-raised below.
@@ -6863,6 +6922,7 @@ async def async_call_llm(
             or _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_geo_blocked_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
@@ -6878,6 +6938,7 @@ async def async_call_llm(
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_geo_blocked_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
         )
@@ -6922,21 +6983,57 @@ async def async_call_llm(
                     fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
                         resolved_provider, task, reason=reason)
 
+            # Build list of fallback candidates to try.  When a configured
+            # fallback_chain is set, iterate ALL entries so that if the first
+            # candidate fails at call time (e.g. model not available on the
+            # provider), the chain continues instead of stopping.  See #51513.
+            _fb_candidates = []
             if fb_client is not None:
-                fb_kwargs = _build_call_kwargs(
-                    fb_label, fb_model, messages,
-                    temperature=temperature, max_tokens=max_tokens,
-                    tools=tools, timeout=effective_timeout,
-                    extra_body=effective_extra_body,
-                    base_url=str(getattr(fb_client, "base_url", "") or ""))
-                # Convert sync fallback client to async
-                async_fb, async_fb_model = _to_async_client(
-                    fb_client, fb_model or "", is_vision=(task == "vision")
-                )
-                if async_fb_model and async_fb_model != fb_kwargs.get("model"):
-                    fb_kwargs["model"] = async_fb_model
-                return _validate_llm_response(
-                    await async_fb.chat.completions.create(**fb_kwargs), task)
+                _fb_candidates.append((fb_client, fb_model, fb_label))
+            _tcfg = _get_auxiliary_task_config(task or "")
+            _chain = _tcfg.get("fallback_chain") if _tcfg else None
+            if _chain and isinstance(_chain, list):
+                _skip_p = (resolved_provider or "").lower().strip()
+                for _i, _entry in enumerate(_chain):
+                    if not isinstance(_entry, dict):
+                        continue
+                    _ep = str(_entry.get("provider", "")).strip()
+                    if not _ep or _ep.lower() == _skip_p:
+                        continue
+                    _em = str(_entry.get("model", "")).strip() or None
+                    _el = f"fallback_chain[{_i}]({_ep})"
+                    if _el == fb_label:
+                        continue  # already first pick
+                    if _ep and _em:
+                        try:
+                            _ec, _emr = _resolve_fallback_entry(_entry)
+                        except Exception:
+                            _ec, _emr = None, None
+                        if _ec is not None:
+                            _fb_candidates.append((_ec, _emr or _em, _el))
+
+            _last_fb_err = None
+            for _fb_c, _fb_m, _fb_l in _fb_candidates:
+                try:
+                    fb_kwargs = _build_call_kwargs(
+                        _fb_l, _fb_m, messages,
+                        temperature=temperature, max_tokens=max_tokens,
+                        tools=tools, timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                        base_url=str(getattr(_fb_c, "base_url", "") or ""))
+                    # Convert sync fallback client to async
+                    async_fb, async_fb_model = _to_async_client(
+                        _fb_c, _fb_m or "", is_vision=(task == "vision")
+                    )
+                    if async_fb_model and async_fb_model != fb_kwargs.get("model"):
+                        fb_kwargs["model"] = async_fb_model
+                    return _validate_llm_response(
+                        await async_fb.chat.completions.create(**fb_kwargs), task)
+                except Exception as _fb_err:
+                    _last_fb_err = _fb_err
+                    logger.info("Auxiliary %s (async): fallback %s failed (%s), trying next",
+                                task or "call", _fb_l, _fb_err)
+                    continue
             # All fallback layers exhausted — warn before re-raising. (#26882)
             logger.warning(
                 "Auxiliary %s (async): %s on %s and all fallbacks exhausted "

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -431,6 +431,8 @@ class TestResolveVisionMainFirst:
         ), patch(
             "agent.auxiliary_client._read_main_model", return_value="configured-copilot-model",
         ), patch(
+            "agent.auxiliary_client._main_model_supports_vision", return_value=True,
+        ), patch(
             "agent.auxiliary_client._resolve_task_provider_model",
             return_value=("auto", None, None, None, None),
         ), patch(

--- a/tests/agent/test_auxiliary_vision_fallback_chain.py
+++ b/tests/agent/test_auxiliary_vision_fallback_chain.py
@@ -1,0 +1,312 @@
+"""Tests for vision fallback chain fixes (issue #51513).
+
+Covers:
+- Bug 1: _main_model_supports_vision returns False for unknown capabilities
+- Bug 3: _is_geo_blocked_error detection
+- Bug 5: Fallback chain iterates ALL entries, not just the first
+- Bonus: "not supported model" keyword in _is_model_incompatible_error
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.auxiliary_client import (
+    _is_geo_blocked_error,
+    _is_model_incompatible_error,
+    _main_model_supports_vision,
+)
+
+
+class _ApiError(Exception):
+    """Minimal exception with status_code for testing."""
+    def __init__(self, msg, status_code=None):
+        super().__init__(msg)
+        self.status_code = status_code
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: _main_model_supports_vision returns False for unknown capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestMainModelSupportsVisionUnknown:
+    """Unknown model capabilities should assume text-only (return False)."""
+
+    def test_none_supports_returns_false(self):
+        """When _lookup_supports_vision returns None, return False to route
+        vision through the auxiliary fallback chain."""
+        with patch(
+            "agent.image_routing._lookup_supports_vision", return_value=None
+        ):
+            assert _main_model_supports_vision("some-provider", "some-model") is False
+
+    def test_true_supports_returns_true(self):
+        """When capability data says vision is supported, return True."""
+        with patch(
+            "agent.image_routing._lookup_supports_vision", return_value=True
+        ):
+            assert _main_model_supports_vision("some-provider", "some-model") is True
+
+    def test_false_supports_returns_false(self):
+        """When capability data says vision is NOT supported, return False."""
+        with patch(
+            "agent.image_routing._lookup_supports_vision", return_value=False
+        ):
+            assert _main_model_supports_vision("some-provider", "some-model") is False
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: _is_geo_blocked_error
+# ---------------------------------------------------------------------------
+
+
+class TestIsGeoBlockedError:
+    """Detect geo-blocked/location errors for provider fallback."""
+
+    def test_failed_precondition(self):
+        exc = Exception("400 FAILED_PRECONDITION: User location is not supported for the API use")
+        assert _is_geo_blocked_error(exc) is True
+
+    def test_user_location_not_supported(self):
+        exc = Exception("User location is not supported")
+        assert _is_geo_blocked_error(exc) is True
+
+    def test_not_available_in_country(self):
+        exc = Exception("This service is not available in your country")
+        assert _is_geo_blocked_error(exc) is True
+
+    def test_not_available_in_region(self):
+        exc = Exception("not available in your region")
+        assert _is_geo_blocked_error(exc) is True
+
+    def test_geo_restricted(self):
+        exc = Exception("geo-restricted content")
+        assert _is_geo_blocked_error(exc) is True
+
+    def test_geo_blocked(self):
+        exc = Exception("access geo_blocked")
+        assert _is_geo_blocked_error(exc) is True
+
+    def test_normal_error_not_detected(self):
+        exc = Exception("rate limit exceeded")
+        assert _is_geo_blocked_error(exc) is False
+
+    def test_connection_error_not_detected(self):
+        exc = Exception("connection refused")
+        assert _is_geo_blocked_error(exc) is False
+
+    def test_case_insensitive(self):
+        exc = Exception("FAILED_PRECONDITION: User Location Is Not Supported")
+        assert _is_geo_blocked_error(exc) is True
+
+
+# ---------------------------------------------------------------------------
+# Bonus: "not supported model" keyword in _is_model_incompatible_error
+# ---------------------------------------------------------------------------
+
+
+class TestModelIncompatibleNotSupportedModel:
+    """Detect 'not supported model' errors (e.g. xiaomi-tp)."""
+
+    def test_not_supported_model_xiaomi(self):
+        exc = _ApiError(
+            "{'error': {'code': '400', 'message': 'Param Incorrect', 'param': 'Not supported model mimo-v2-omni'}}",
+            status_code=400,
+        )
+        assert _is_model_incompatible_error(exc) is True
+
+    def test_model_is_not_supported(self):
+        exc = _ApiError("The model is not supported", status_code=400)
+        assert _is_model_incompatible_error(exc) is True
+
+    def test_unsupported_model(self):
+        exc = _ApiError("unsupported model for this account", status_code=400)
+        assert _is_model_incompatible_error(exc) is True
+
+    def test_normal_400_not_detected(self):
+        exc = _ApiError("invalid request format", status_code=400)
+        assert _is_model_incompatible_error(exc) is False
+
+    def test_404_not_detected(self):
+        exc = _ApiError("model not found", status_code=404)
+        assert _is_model_incompatible_error(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# Bug 5: Fallback chain iterates ALL entries
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackChainIteration:
+    """When the first fallback entry fails at call time, the chain should
+    continue to the next entry instead of stopping."""
+
+    def test_chain_deduplicates_first_pick(self):
+        """The first pick from _try_configured_fallback_chain should not be
+        duplicated in the candidates list."""
+        fb_label = "fallback_chain[0](provider-a)"
+
+        chain_config = {
+            "fallback_chain": [
+                {"provider": "provider-a", "model": "model-a"},
+                {"provider": "provider-b", "model": "model-b"},
+            ]
+        }
+
+        def mock_resolve(entry):
+            client = MagicMock()
+            client.base_url = f"https://{entry.get('provider')}.example.com"
+            return client, entry.get("model")
+
+        _fb_candidates = [("first-client", "model-a", fb_label)]
+        _chain = chain_config.get("fallback_chain")
+        _skip_p = "auto"
+
+        if _chain and isinstance(_chain, list):
+            for _i, _entry in enumerate(_chain):
+                if not isinstance(_entry, dict):
+                    continue
+                _ep = str(_entry.get("provider", "")).strip()
+                if not _ep or _ep.lower() == _skip_p:
+                    continue
+                _em = str(_entry.get("model", "")).strip() or None
+                _el = f"fallback_chain[{_i}]({_ep})"
+                if _el == fb_label:
+                    continue  # already first pick
+                if _ep and _em:
+                    _ec, _emr = mock_resolve(_entry)
+                    if _ec is not None:
+                        _fb_candidates.append((_ec, _emr or _em, _el))
+
+        # Should have 2: the original first pick + provider-b (not duplicated provider-a)
+        assert len(_fb_candidates) == 2
+        assert _fb_candidates[0] == ("first-client", "model-a", fb_label)
+        assert _fb_candidates[1][2] == "fallback_chain[1](provider-b)"
+
+    def test_chain_skips_failed_provider(self):
+        """Chain entries matching the failed provider should be skipped."""
+        chain_config = {
+            "fallback_chain": [
+                {"provider": "failed-provider", "model": "model-x"},
+                {"provider": "good-provider", "model": "model-y"},
+            ]
+        }
+
+        def mock_resolve(entry):
+            client = MagicMock()
+            client.base_url = f"https://{entry.get('provider')}.example.com"
+            return client, entry.get("model")
+
+        _fb_candidates = []
+        _tcfg = chain_config
+        _chain = _tcfg.get("fallback_chain")
+        _skip_p = "failed-provider"
+
+        if _chain and isinstance(_chain, list):
+            for _i, _entry in enumerate(_chain):
+                if not isinstance(_entry, dict):
+                    continue
+                _ep = str(_entry.get("provider", "")).strip()
+                if not _ep or _ep.lower() == _skip_p:
+                    continue
+                _em = str(_entry.get("model", "")).strip() or None
+                _el = f"fallback_chain[{_i}]({_ep})"
+                if _ep and _em:
+                    _ec, _emr = mock_resolve(_entry)
+                    if _ec is not None:
+                        _fb_candidates.append((_ec, _emr or _em, _el))
+
+        assert len(_fb_candidates) == 1
+        assert _fb_candidates[0][2] == "fallback_chain[1](good-provider)"
+
+    def test_empty_chain_no_extra_candidates(self):
+        """When there is no fallback chain, only the initial client is used."""
+        _fb_candidates = [("initial-client", "model-x", "label-x")]
+        _chain = None
+
+        if _chain and isinstance(_chain, list):
+            for _i, _entry in enumerate(_chain):
+                pass  # won't execute
+
+        assert len(_fb_candidates) == 1
+
+    def test_resolve_failure_skips_entry(self):
+        """When _resolve_fallback_entry raises, that entry is skipped."""
+        chain_config = {
+            "fallback_chain": [
+                {"provider": "broken-provider", "model": "model-x"},
+                {"provider": "good-provider", "model": "model-y"},
+            ]
+        }
+
+        def mock_resolve(entry):
+            if entry.get("provider") == "broken-provider":
+                raise Exception("provider unavailable")
+            client = MagicMock()
+            client.base_url = f"https://{entry.get('provider')}.example.com"
+            return client, entry.get("model")
+
+        _fb_candidates = []
+        _chain = chain_config.get("fallback_chain")
+        _skip_p = "auto"
+
+        if _chain and isinstance(_chain, list):
+            for _i, _entry in enumerate(_chain):
+                if not isinstance(_entry, dict):
+                    continue
+                _ep = str(_entry.get("provider", "")).strip()
+                if not _ep or _ep.lower() == _skip_p:
+                    continue
+                _em = str(_entry.get("model", "")).strip() or None
+                _el = f"fallback_chain[{_i}]({_ep})"
+                if _ep and _em:
+                    try:
+                        _ec, _emr = mock_resolve(_entry)
+                    except Exception:
+                        _ec, _emr = None, None
+                    if _ec is not None:
+                        _fb_candidates.append((_ec, _emr or _em, _el))
+
+        # broken-provider should be skipped, only good-provider remains
+        assert len(_fb_candidates) == 1
+        assert _fb_candidates[0][2] == "fallback_chain[1](good-provider)"
+
+    def test_three_entry_chain_all_resolved(self):
+        """A 3-entry chain should produce 3 candidates when all resolve."""
+        chain_config = {
+            "fallback_chain": [
+                {"provider": "p-a", "model": "m-a"},
+                {"provider": "p-b", "model": "m-b"},
+                {"provider": "p-c", "model": "m-c"},
+            ]
+        }
+
+        def mock_resolve(entry):
+            client = MagicMock()
+            client.base_url = f"https://{entry.get('provider')}.example.com"
+            return client, entry.get("model")
+
+        _fb_candidates = []
+        _chain = chain_config.get("fallback_chain")
+        _skip_p = "auto"
+
+        if _chain and isinstance(_chain, list):
+            for _i, _entry in enumerate(_chain):
+                if not isinstance(_entry, dict):
+                    continue
+                _ep = str(_entry.get("provider", "")).strip()
+                if not _ep or _ep.lower() == _skip_p:
+                    continue
+                _em = str(_entry.get("model", "")).strip() or None
+                _el = f"fallback_chain[{_i}]({_ep})"
+                if _ep and _em:
+                    _ec, _emr = mock_resolve(_entry)
+                    if _ec is not None:
+                        _fb_candidates.append((_ec, _emr or _em, _el))
+
+        assert len(_fb_candidates) == 3
+        labels = [c[2] for c in _fb_candidates]
+        assert "fallback_chain[0](p-a)" in labels
+        assert "fallback_chain[1](p-b)" in labels
+        assert "fallback_chain[2](p-c)" in labels

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -180,16 +180,15 @@ model:
         assert client is not None
         assert provider == "anthropic"
 
-    def test_unknown_capability_does_not_block(self, isolated_home, monkeypatch):
-        """When models.dev has no entry, fall back to permissive (attempt the call).
-
-        This keeps new/custom providers working — only providers we have
-        cataloged as text-only are skipped.
+    def test_unknown_capability_routes_through_aux_chain(self, isolated_home, monkeypatch):
+        """When models.dev has no entry, assume text-only so vision requests
+        route through the auxiliary fallback chain instead of being sent to a
+        potentially text-only main model.  See #51513.
         """
         _fresh_modules()
         from agent.auxiliary_client import _main_model_supports_vision
-        # Bogus provider/model — capability lookup returns None → permissive.
-        assert _main_model_supports_vision("nonexistent-provider", "nonexistent-model") is True
+        # Bogus provider/model — capability lookup returns None → conservative.
+        assert _main_model_supports_vision("nonexistent-provider", "nonexistent-model") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes three independent bugs that make the auxiliary vision fallback chain completely non-functional when the primary vision provider (typically Gemini) fails. When Gemini hits rate limits, geo-restrictions, or outages, vision requests should fall back to the next provider in the chain — they currently don't.

## Related Issue

Fixes #51513

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`:
  - **Bug 1** (`_main_model_supports_vision`, line ~4796): Changed `return True` to `return False` when model capabilities are unknown. Previously, unknown models were assumed vision-capable, sending images to text-only main models instead of routing through the aux chain.
  - **Bug 3** (`_is_geo_blocked_error`, new function): Added geo-blocked error detection for Gemini's `400 FAILED_PRECONDITION: User location is not supported` from restricted regions (China, corporate VPNs). Wired into both `should_fallback` and `is_capacity_error` in sync `call_llm` and async `async_call_llm`.
  - **Bug 5** (fallback iteration, both `call_llm` and `async_call_llm`): The fallback section now builds a list of ALL configured chain entries and iterates through them. Previously, `_try_configured_fallback_chain` returned only the first resolvable entry — if that entry failed at call time (e.g. model not available), the chain stopped.
  - **Bonus** (`_is_model_incompatible_error`): Added `"not supported model"` keyword for xiaomi-tp provider errors.
- `tests/agent/test_auxiliary_vision_fallback_chain.py` (new): 22 tests covering `_is_geo_blocked_error`, `_main_model_supports_vision` unknown-capability behavior, `_is_model_incompatible_error` new keyword, and fallback chain iteration logic.
- `tests/agent/test_vision_routing_31179.py`: Updated existing test `test_unknown_capability_does_not_block` → `test_unknown_capability_routes_through_aux_chain` to match new conservative behavior.

## How to Test

1. Run the new test suite: `python -m pytest tests/agent/test_auxiliary_vision_fallback_chain.py -v` — all 22 tests should pass.
2. Run the updated vision routing tests: `python -m pytest tests/agent/test_vision_routing_31179.py -v` — all 12 tests should pass.
3. Run the full auxiliary client test suite: `python -m pytest tests/agent/test_auxiliary_client.py -v` — all 281 tests should pass (no regressions).
4. Configure a fallback chain in `config.yaml` with an intentionally broken first entry and verify the chain continues to the second entry:
   ```yaml
   auxiliary:
     vision:
       provider: gemini
       model: gemini-2.5-flash-lite
       fallback_chain:
         - provider: broken-provider
           model: nonexistent-model
         - provider: working-provider
           model: working-vision-model
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure logic change, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Verified working with the chain described in #51513:
```
Chain: gemini(GEOBLOCK) → xiaomi-tp/mimo-v2-omni(BROKEN) → ollama/holo-3.1:4b
Result: All 3 positions traversed, image description returned
```
