### PR TITLE
fix(tui): refresh config cache on fast model switch

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16,6 +16,49 @@ from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
 
 
+def test_load_cfg_invalidates_same_mtime_config_size_change(tmp_path):
+    """Config edits from another process must be visible to the TUI gateway.
+
+    A fast ``hermes config set model.*`` can rewrite config.yaml inside the
+    same filesystem timestamp tick.  The TUI backend must still notice the
+    content changed before it builds model options or syncs an open session's
+    model from config.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text(
+        "model:\n  default: old\n  provider: old\n",
+        encoding="utf-8",
+    )
+    token = set_hermes_home_override(home)
+    try:
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+
+        assert server._load_cfg()["model"]["default"] == "old"
+        original_stat = config_path.stat()
+
+        config_path.write_text(
+            "model:\n  default: newer-model\n  provider: new\n",
+            encoding="utf-8",
+        )
+        # Preserve the timestamp value that the old cache key used.  The file
+        # size changes, so an mtime+size signature should still invalidate.
+        os.utime(
+            config_path,
+            ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+        )
+
+        assert server._load_cfg()["model"]["default"] == "newer-model"
+    finally:
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+        reset_hermes_home_override(token)
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -137,7 +137,7 @@ _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
-_cfg_mtime: float | None = None
+_cfg_mtime: tuple[int, int] | None = None
 _cfg_path = None
 _session_resume_lock = threading.Lock()
 try:
@@ -1753,9 +1753,13 @@ def _load_cfg() -> dict:
         override = get_hermes_home_override()
         home = override if isinstance(override, str) and override else _hermes_home
         p = Path(home) / "config.yaml"
-        mtime = p.stat().st_mtime if p.exists() else None
+        if p.exists():
+            st = p.stat()
+            signature = (st.st_mtime_ns, st.st_size)
+        else:
+            signature = None
         with _cfg_lock:
-            if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
+            if _cfg_cache is not None and _cfg_mtime == signature and _cfg_path == p:
                 return _apply_managed(copy.deepcopy(_cfg_cache))
         if p.exists():
             with open(p, encoding="utf-8") as f:
@@ -1768,7 +1772,7 @@ def _load_cfg() -> dict:
             # the user's file. The managed overlay is applied on every return
             # path instead (read-side only).
             _cfg_cache = copy.deepcopy(data)
-            _cfg_mtime = mtime
+            _cfg_mtime = signature
             _cfg_path = p
         return _apply_managed(data)
     except Exception:
@@ -1803,7 +1807,8 @@ def _save_cfg(cfg: dict):
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path
         try:
-            _cfg_mtime = path.stat().st_mtime
+            st = path.stat()
+            _cfg_mtime = (st.st_mtime_ns, st.st_size)
         except Exception:
             _cfg_mtime = None
 


### PR DESCRIPTION
## Summary
- Make the TUI/desktop backend config cache invalidate on `(mtime_ns, size)` instead of coarse `st_mtime`
- Keep `_save_cfg()` and `_load_cfg()` using the same signature so in-process and CLI-written config updates agree
- Add a regression test for a same-timestamp `config.yaml` rewrite changing `model.default`

## Why
`model.options` and new Desktop/TUI sessions read config through `tui_gateway.server._load_cfg()`. It cached by `Path.stat().st_mtime` only, so a fast `hermes config set model.*` or `hermes model-switch` rewrite from another process could land in the same timestamp tick and leave the backend serving stale provider/model data until a later edit or restart.

Fixes #56924.

## Tests
- RED first: `scripts/run_tests.sh tests/test_tui_gateway_server.py -k test_load_cfg_invalidates_same_mtime_config_size_change -v --tb=short` failed with cached `old` model
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'test_load_cfg_invalidates_same_mtime_config_size_change or model_options or config_model' -v --tb=short`
- `python3 -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`

## Note
A full local `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` run still has one unrelated environment-sensitive browser test failure: `test_browser_manage_connect_default_local_reports_launch_hint` expects no supported Chromium executable, but this machine has browser tooling available despite the patched candidate list. The focused model/config tests pass.
