### PR TITLE
fix(logging): stop pytest runs from writing to the live agent.log

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -702,8 +702,14 @@ def init_agent(
     # Centralized logging — agent.log (INFO+) and errors.log (WARNING+)
     # both live under ~/.hermes/logs/.  Idempotent, so gateway mode
     # (which creates a new AIAgent per message) won't duplicate handlers.
+    # No hermes_home= override: ``run_agent._hermes_home`` is frozen at
+    # import time, so passing it here pins the log files to whatever
+    # HERMES_HOME resolved to when run_agent was first imported — under
+    # pytest that is the developer's real Hermes home, not the per-test
+    # sandbox. ``setup_logging()`` defaults to ``get_hermes_home()``,
+    # which reads the env var live.
     from hermes_logging import setup_logging, setup_verbose_logging
-    setup_logging(hermes_home=_ra()._hermes_home)
+    setup_logging()
 
     if agent.verbose_logging:
         setup_verbose_logging()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ test runner at ``scripts/run_tests.sh``.
 import asyncio
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,24 @@ import pytest
 PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# ── Import-time HERMES_HOME sandbox ─────────────────────────────────────────
+# The per-test fixture below redirects HERMES_HOME, but it runs AFTER test
+# modules are imported. Several modules resolve ``get_hermes_home()`` at
+# import time (``run_agent._hermes_home``, ``cli._hermes_home``, dotenv
+# loading) and anything derived from those frozen paths — most visibly the
+# root-logger file handlers that ``setup_logging()`` attaches — then points
+# at the developer's REAL Hermes home for the rest of the process. On
+# native Windows that meant ``pytest tests/`` appended mock-provider
+# records to the live ``%LOCALAPPDATA%\hermes\logs\agent.log``.
+#
+# Point HERMES_HOME at a session tempdir HERE, before pytest imports any
+# test module, so import-time consumers freeze a sandbox path instead.
+# Deliberately unconditional: a HERMES_HOME inherited from a developer
+# shell or Docker deployment must not leak into tests either.
+_IMPORT_TIME_HERMES_HOME = tempfile.mkdtemp(prefix="hermes-test-home-")
+os.environ["HERMES_HOME"] = _IMPORT_TIME_HERMES_HOME
 
 
 # ── Per-file process isolation ──────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -412,6 +412,17 @@ def _hermetic_environment(tmp_path, monkeypatch):
     monkeypatch.delenv("GMI_API_KEY", raising=False)
     monkeypatch.delenv("GMI_BASE_URL", raising=False)
 
+    yield
+
+    # setup_logging routes file handlers through a process-global
+    # QueueListener. HERMES_HOME changes for every test, so retaining those
+    # handlers would keep prior tmpdirs open and fan later records into stale
+    # homes. Tear the queue down before monkeypatch restores the environment.
+    logging_mod = sys.modules.get("hermes_logging")
+    if logging_mod is not None:
+        logging_mod._reset_queued_handlers()
+        logging_mod._logging_initialized = False
+
 
 # Backward-compat alias — old tests reference this fixture name. Keep it
 # as a no-op wrapper so imports don't break.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,8 +419,9 @@ def _hermetic_environment(tmp_path, monkeypatch):
     # handlers would keep prior tmpdirs open and fan later records into stale
     # homes. Tear the queue down before monkeypatch restores the environment.
     logging_mod = sys.modules.get("hermes_logging")
-    if logging_mod is not None:
-        logging_mod._reset_queued_handlers()
+    reset_queued_handlers = getattr(logging_mod, "_reset_queued_handlers", None)
+    if callable(reset_queued_handlers):
+        reset_queued_handlers()
         logging_mod._logging_initialized = False
 
 

--- a/tests/run_agent/test_logging_home_isolation.py
+++ b/tests/run_agent/test_logging_home_isolation.py
@@ -1,0 +1,118 @@
+"""Regression tests: agent logging must follow the LIVE ``HERMES_HOME``.
+
+``run_agent._hermes_home`` is resolved once at import time. Under pytest,
+test modules import ``run_agent`` during collection — BEFORE the per-test
+conftest fixture redirects ``HERMES_HOME`` — so that frozen path points at
+the developer's real Hermes home. ``agent_init`` used to pass it to
+``setup_logging()``, attaching root-logger file handlers to the real
+``~/.hermes/logs/agent.log`` (``%LOCALAPPDATA%\\hermes\\logs\\agent.log``
+on native Windows). Every mock-provider test in the process then appended
+records to the live install's log — which reads like the agent silently
+calling real provider APIs during a test run.
+
+The fix is twofold:
+  * ``agent_init`` calls ``setup_logging()`` with no override, so the log
+    directory is resolved from the environment at call time.
+  * ``tests/conftest.py`` sandboxes ``HERMES_HOME`` at import time as
+    defense-in-depth for other import-time consumers.
+"""
+
+import logging
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import run_agent
+from run_agent import AIAgent
+
+
+def _root_file_handler_paths() -> set:
+    return {
+        Path(h.baseFilename).resolve()
+        for h in logging.getLogger().handlers
+        if getattr(h, "baseFilename", None)
+    }
+
+
+def _make_tool_defs(*names: str) -> list:
+    """Build minimal tool definition list accepted by AIAgent.__init__."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def test_agent_logging_ignores_import_time_frozen_home(tmp_path, monkeypatch):
+    """setup_logging() must use the current HERMES_HOME, not the value
+    ``run_agent._hermes_home`` froze at import time."""
+    stale_home = tmp_path / "stale_import_time_home"
+    stale_home.mkdir()
+    live_home = Path(os.environ["HERMES_HOME"])  # per-test sandbox
+
+    # Simulate the original failure mode: run_agent was imported while
+    # HERMES_HOME pointed somewhere else (the real install).
+    monkeypatch.setattr(run_agent, "_hermes_home", stale_home)
+
+    handlers_before = list(logging.getLogger().handlers)
+    try:
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        paths = _root_file_handler_paths()
+        live_agent_log = (live_home / "logs" / "agent.log").resolve()
+        stale_resolved = stale_home.resolve()
+
+        assert live_agent_log in paths, (
+            f"agent.log handler not attached under live HERMES_HOME; "
+            f"handlers: {sorted(str(p) for p in paths)}"
+        )
+        offenders = [p for p in paths if stale_resolved in p.parents]
+        assert not offenders, (
+            "log handlers attached under the import-time frozen home "
+            f"instead of the live HERMES_HOME: {offenders}"
+        )
+    finally:
+        # Detach handlers this test added so the per-test tmp dir can be
+        # reclaimed and later tests in this process start clean.
+        root = logging.getLogger()
+        for h in root.handlers[:]:
+            if h not in handlers_before:
+                root.removeHandler(h)
+                try:
+                    h.close()
+                except Exception:
+                    pass
+
+
+def test_conftest_sandboxes_hermes_home_at_import_time():
+    """The import-time HERMES_HOME sandbox in tests/conftest.py must keep
+    module-level ``get_hermes_home()`` callers away from the real install."""
+    from hermes_constants import _get_platform_default_hermes_home
+
+    real_home = _get_platform_default_hermes_home().resolve()
+    frozen = Path(run_agent._hermes_home).resolve()
+    assert frozen != real_home and real_home not in frozen.parents, (
+        f"run_agent._hermes_home froze the REAL Hermes home ({frozen}); "
+        "tests/conftest.py must export a sandbox HERMES_HOME before any "
+        "test module is imported"
+    )

--- a/tests/run_agent/test_logging_home_isolation.py
+++ b/tests/run_agent/test_logging_home_isolation.py
@@ -17,7 +17,6 @@ The fix is twofold:
     defense-in-depth for other import-time consumers.
 """
 
-import logging
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -26,10 +25,12 @@ import run_agent
 from run_agent import AIAgent
 
 
-def _root_file_handler_paths() -> set:
+def _queued_file_handler_paths() -> set:
+    from hermes_logging import rotating_file_handlers
+
     return {
         Path(h.baseFilename).resolve()
-        for h in logging.getLogger().handlers
+        for h in rotating_file_handlers()
         if getattr(h, "baseFilename", None)
     }
 
@@ -60,48 +61,59 @@ def test_agent_logging_ignores_import_time_frozen_home(tmp_path, monkeypatch):
     # HERMES_HOME pointed somewhere else (the real install).
     monkeypatch.setattr(run_agent, "_hermes_home", stale_home)
 
-    handlers_before = list(logging.getLogger().handlers)
-    try:
-        with (
-            patch(
-                "run_agent.get_tool_definitions",
-                return_value=_make_tool_defs("web_search"),
-            ),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
-        ):
-            AIAgent(
-                api_key="test-key-1234567890",
-                base_url="https://openrouter.ai/api/v1",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
-
-        paths = _root_file_handler_paths()
-        live_agent_log = (live_home / "logs" / "agent.log").resolve()
-        stale_resolved = stale_home.resolve()
-
-        assert live_agent_log in paths, (
-            f"agent.log handler not attached under live HERMES_HOME; "
-            f"handlers: {sorted(str(p) for p in paths)}"
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
         )
-        offenders = [p for p in paths if stale_resolved in p.parents]
-        assert not offenders, (
-            "log handlers attached under the import-time frozen home "
-            f"instead of the live HERMES_HOME: {offenders}"
-        )
-    finally:
-        # Detach handlers this test added so the per-test tmp dir can be
-        # reclaimed and later tests in this process start clean.
-        root = logging.getLogger()
-        for h in root.handlers[:]:
-            if h not in handlers_before:
-                root.removeHandler(h)
-                try:
-                    h.close()
-                except Exception:
-                    pass
+
+    paths = _queued_file_handler_paths()
+    live_agent_log = (live_home / "logs" / "agent.log").resolve()
+    stale_resolved = stale_home.resolve()
+
+    assert live_agent_log in paths, (
+        f"agent.log handler not attached under live HERMES_HOME; "
+        f"handlers: {sorted(str(p) for p in paths)}"
+    )
+    offenders = [p for p in paths if stale_resolved in p.parents]
+    assert not offenders, (
+        "log handlers attached under the import-time frozen home "
+        f"instead of the live HERMES_HOME: {offenders}"
+    )
+
+
+def test_logging_queue_does_not_retain_previous_test_home(tmp_path, monkeypatch):
+    import hermes_logging
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(first))
+    hermes_logging.setup_logging()
+    assert all(first.resolve() in p.parents for p in _queued_file_handler_paths())
+
+    # This is the same lifecycle boundary used by the per-test fixture.
+    hermes_logging._reset_queued_handlers()
+    hermes_logging._logging_initialized = False
+    monkeypatch.setenv("HERMES_HOME", str(second))
+    hermes_logging.setup_logging()
+
+    paths = _queued_file_handler_paths()
+    assert paths
+    assert all(second.resolve() in p.parents for p in paths)
+    assert not any(first.resolve() in p.parents for p in paths)
 
 
 def test_conftest_sandboxes_hermes_home_at_import_time():


### PR DESCRIPTION
## What does this PR do?

Stops `pytest tests/` from appending mock-provider log records to the **real user's** `agent.log` (`%LOCALAPPDATA%\hermes\logs\agent.log` on native Windows, `~/.hermes/logs/agent.log` on POSIX).

`run_agent._hermes_home` is resolved once at import time. Under pytest, test modules are imported during collection — before the per-test `_hermetic_environment` fixture redirects `HERMES_HOME` — so `agent_init`'s `setup_logging(hermes_home=_ra()._hermes_home)` attached root-logger file handlers to the real install's `logs/agent.log`. Every mock-provider test in the process then wrote to the live log, producing entries like `provider=xai-oauth base_url=https://api.x.ai/v1 model=grok-4.3 ... msg='Say OK'` that look exactly like the agent silently calling real provider APIs.

The fix is at the callsite (per the guidance already in the `tests/conftest.py` docstring) plus defense-in-depth in the conftest itself:

1. `agent_init` now calls `setup_logging()` with no `hermes_home=` override — the default resolves `get_hermes_home()` at call time, which reads the env var live. Behavior for real CLI/gateway runs is unchanged (env doesn't change between import and agent init there).
2. `tests/conftest.py` exports a sandbox `HERMES_HOME` at conftest **import** time, before pytest imports any test module, so every other import-time `get_hermes_home()` consumer (`cli._hermes_home`, dotenv loading) freezes a sandbox path instead of the real install.

## Related Issue

Fixes #57118

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py` — drop the `hermes_home=_ra()._hermes_home` override on the `setup_logging()` call; resolve the log directory from the live environment instead of run_agent's import-time frozen path.
- `tests/conftest.py` — set `HERMES_HOME` to a session tempdir at module import time (unconditionally, so a `HERMES_HOME` inherited from a developer shell or Docker deployment can't leak into tests either). The existing per-test fixture still re-points it per test.
- `tests/run_agent/test_logging_home_isolation.py` (new) — two regression tests:
  - `test_agent_logging_ignores_import_time_frozen_home`: simulates a stale `run_agent._hermes_home` and asserts `AIAgent.__init__` attaches `agent.log` under the live `HERMES_HOME`, with nothing under the stale path. Fails if the `agent_init` fix is reverted.
  - `test_conftest_sandboxes_hermes_home_at_import_time`: asserts `run_agent._hermes_home` did not freeze the platform-default (real) home. Fails if the conftest sandbox is reverted.

## How to Test

1. On a machine with a live Hermes install, note the line count of `<hermes-home>/logs/agent.log`.
2. On `main`, run `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q` — `grep 'api.x.ai' <hermes-home>/logs/agent.log` shows new mock records (13 new lines in my repro, Windows 11 native).
3. On this branch, repeat — the live log gains zero test records (verified: 93 tests across `test_run_agent_codex_responses.py` + `test_auxiliary_client_xai_oauth_recovery.py`, live-log signature count unchanged).
4. `python -m pytest tests/run_agent/test_logging_home_isolation.py -q` — both regression tests pass; each fails with its half of the fix reverted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#57016 touches `tests/cli/conftest.py` reload pollution but not this)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (per-file runs of the affected areas: `tests/run_agent/test_run_agent.py` 414 passed, `tests/run_agent/test_run_agent_codex_responses.py` + xai recovery 93 passed, `tests/cron/test_cron_profile_isolation.py`, `tests/cron/test_cron_no_agent.py`, `tests/cli/test_cli_approval_ui.py`, `tests/agent/test_auxiliary_client.py` all green; `tests/test_hermes_logging.py` / `tests/test_hermes_constants.py` have pre-existing Windows-native chmod/symlink failures identical on unmodified `main`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 native (Python 3.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — comments at both changed sites explain the import-time-freeze trap
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the mechanism is platform-independent (POSIX `pytest tests/` wrote to the real `~/.hermes/logs/agent.log` the same way); fix uses only `tempfile`/env, no platform branches
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Pollution on `main` (live `%LOCALAPPDATA%\hermes\logs\agent.log` after running one test file):

```
2026-07-02 09:59:12,610 INFO [...] run_agent: OpenAI client created (agent_init, shared=True) thread=MainThread:11288 provider=xai-oauth base_url=https://api.x.ai/v1 model=grok-4.3
2026-07-02 09:59:13,113 INFO [...] agent.turn_context: conversation turn: session=... model=gpt-5.4 provider=copilot platform=unknown history=0 msg='Say OK'
```

After this branch: same run adds zero records to the live log.
