### PR TITLE
fix(cli): show exit code for silent post-setup failures

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -937,6 +937,20 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
         return False
 
 
+def _print_subprocess_failure_detail(
+    result: subprocess.CompletedProcess,
+    *,
+    max_chars: int = 200,
+) -> None:
+    detail = (result.stderr or result.stdout or "").strip()
+    if detail:
+        for line in detail.splitlines()[-3:]:
+            _print_info(f"      {line[:max_chars]}")
+        return
+
+    _print_info(f"      process exited with code {result.returncode}")
+
+
 def _run_post_setup(post_setup_key: str):
     """Run post-setup hooks for tools that need extra installation steps."""
     import shutil
@@ -964,8 +978,7 @@ def _run_post_setup(post_setup_key: str):
             else:
                 from hermes_constants import display_hermes_home
                 _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install --workspaces=false")
-                if result.stderr:
-                    _print_info(f"      {result.stderr.strip()[:200]}")
+                _print_subprocess_failure_detail(result)
         elif not node_modules.exists():
             _print_warning("    Node.js not found - browser tools require: npm install (in hermes-agent directory)")
             return
@@ -1069,6 +1082,7 @@ def _run_post_setup(post_setup_key: str):
                 _print_success("    Camofox installed")
             else:
                 _print_warning("    npm install failed - run manually: npm install --workspaces=false")
+                _print_subprocess_failure_detail(result)
         if camofox_dir.exists():
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camofox-browser")

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
 import logging
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -15,6 +16,7 @@ from hermes_cli.tools_config import (
     _reconfigure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
+    _print_subprocess_failure_detail,
     _reconfigure_tool,
     _run_post_setup,
     _save_platform_tools,
@@ -1098,6 +1100,68 @@ def test_computer_use_post_setup_missing_override_does_not_accept_default_binary
     run.assert_not_called()
     assert "custom-cua" in seen
     assert "curl" in seen
+
+
+@pytest.mark.parametrize(
+    "stdout,stderr,expected",
+    [
+        ("npm stdout detail", "npm stderr detail", "npm stderr detail"),
+        ("npm stdout detail", "", "npm stdout detail"),
+        ("", "", "process exited with code 127"),
+    ],
+)
+def test_subprocess_failure_detail_reports_available_diagnostic(
+    monkeypatch, stdout, stderr, expected
+):
+    messages = []
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._print_info",
+        messages.append,
+    )
+
+    _print_subprocess_failure_detail(
+        subprocess.CompletedProcess(
+            ["npm", "install"],
+            127,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    )
+
+    assert any(expected in message for message in messages)
+
+
+def test_camofox_post_setup_npm_failure_reports_exit_code_when_output_empty(
+    monkeypatch, tmp_path
+):
+    import hermes_cli.tools_config as tools_config
+
+    infos = []
+    warnings = []
+
+    monkeypatch.setattr(tools_config, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        tools_config.shutil,
+        "which",
+        lambda name: "/usr/bin/npm" if name == "npm" else None,
+    )
+    monkeypatch.setattr(tools_config, "_print_info", infos.append)
+    monkeypatch.setattr(tools_config, "_print_warning", warnings.append)
+    monkeypatch.setattr(
+        tools_config.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0],
+            127,
+            stdout="",
+            stderr="",
+        ),
+    )
+
+    _run_post_setup("camofox")
+
+    assert any("npm install failed" in warning for warning in warnings)
+    assert any("process exited with code 127" in info for info in infos)
 
 
 class TestImagegenBackendRegistry:


### PR DESCRIPTION
## What does this PR do?

Fixes opaque post-setup npm failures when the subprocess exits non-zero but produces no stdout or stderr. In that case, Hermes now prints the process exit code so users have a concrete diagnostic instead of only seeing the manual retry command.

This keeps the install commands and retry behavior unchanged; it only improves the failure detail shown for the existing post-setup paths.

## Related Issue

Fixes #56566

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a shared post-setup subprocess failure-detail helper in `hermes_cli/tools_config.py`.
- Reused it for browser-tool npm installs and Camofox npm installs.
- Added regression tests for stderr, stdout, and empty-output fallback behavior.
- Added a Camofox post-setup regression test proving empty subprocess output reports the exit code.

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_tools_config.py -q`
2. `.venv/bin/python -m ruff check hermes_cli/tools_config.py tests/hermes_cli/test_tools_config.py`
3. `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py -k "subprocess_failure_detail or camofox_post_setup_npm_failure_reports_exit_code" -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.13 venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
