### PR TITLE
fix(cron): clean up HERMES_CRON_SESSION env var after each job run (#56771)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3031,6 +3031,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
+        # Remove the process-wide cron sentinel so it does not leak into
+        # interactive gateway sessions running in the same process (#56771).
+        os.environ.pop("HERMES_CRON_SESSION", None)
         # Release the cwd lock now that the env is restored, so a waiting
         # workdir job (or queued reader) can proceed without seeing the override.
         if _holds_cwd_write:


### PR DESCRIPTION
## Problem

When the cron scheduler runs in-process via `InProcessCronScheduler` (same Python process as the gateway), `run_job()` sets `os.environ["HERMES_CRON_SESSION"] = "1"` but never removes it in the `finally` block. Since `os.environ` is process-global and shared across all threads, this sentinel leaks into interactive gateway sessions.

**Impact:** After any cron job runs, `execute_code` and terminal commands in Telegram/gateway interactive sessions are blocked with the cron-deny approval error until the gateway process is restarted.

## Root Cause

- `cron/scheduler.py:2444` — sets `os.environ["HERMES_CRON_SESSION"] = "1"`
- `cron/scheduler.py:3025+` — `finally` block cleans up `TERMINAL_CWD`, ContextVars, session DB, agent resources — but **not** `HERMES_CRON_SESSION`
- `tools/approval.py:2655` — `check_code_execution_approval()` reads `HERMES_CRON_SESSION` from `os.getenv()` and blocks execution

The codebase already uses ContextVars for per-job session state to avoid exactly this class of cross-session pollution, but `HERMES_CRON_SESSION` was left as a raw `os.environ` write.

## Fix

Add `os.environ.pop("HERMES_CRON_SESSION", None)` to the `finally` block in `run_job()`, alongside the existing `TERMINAL_CWD` cleanup. This ensures the env var is only present while a cron job is actively running.

Fixes #56771
