### PR TITLE
fix(desktop): show Hindsight local embedded mode

### DIFF
--- a/apps/desktop/src/app/settings/provider-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/provider-config-panel.test.tsx
@@ -28,7 +28,12 @@ function hindsightSchema(overrides: Partial<MemoryProviderConfig['fields'][numbe
       is_set: true,
       options: [
         { value: 'cloud', label: 'Cloud', description: 'Hindsight Cloud API (lightweight, just needs an API key)' },
-        { value: 'local_external', label: 'Local External', description: 'Connect to an existing Hindsight instance' }
+        { value: 'local_external', label: 'Local External', description: 'Connect to an existing Hindsight instance' },
+        {
+          value: 'local_embedded',
+          label: 'Local Embedded',
+          description: 'Run a managed local Hindsight daemon with embedded PostgreSQL'
+        }
       ]
     },
     {
@@ -135,6 +140,29 @@ describe('ProviderConfigPanel', () => {
         api_key: '',
         api_url: 'http://localhost:8888',
         bank_id: 'ben-bank',
+        recall_budget: 'mid'
+      })
+    )
+  })
+
+  it('preserves local embedded mode when it is already configured', async () => {
+    getMemoryProviderConfig.mockResolvedValue(hindsightSchema([{ value: 'local_embedded' }]))
+
+    await renderPanel()
+
+    expect(await screen.findByText('Local Embedded')).toBeTruthy()
+    expect(
+      screen.getAllByText('Run a managed local Hindsight daemon with embedded PostgreSQL').length
+    ).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(saveMemoryProviderConfig).toHaveBeenCalledWith('hindsight', {
+        mode: 'local_embedded',
+        api_key: '',
+        api_url: 'https://api.hindsight.vectorize.io',
+        bank_id: 'hermes',
         recall_budget: 'mid'
       })
     )

--- a/hermes_cli/memory_providers.py
+++ b/hermes_cli/memory_providers.py
@@ -95,6 +95,11 @@ HINDSIGHT = MemoryProvider(
                     "Local External",
                     "Connect to an existing Hindsight instance",
                 ),
+                ProviderFieldOption(
+                    "local_embedded",
+                    "Local Embedded",
+                    "Run a managed local Hindsight daemon with embedded PostgreSQL",
+                ),
             ),
         ),
         ProviderField(

--- a/tests/hermes_cli/test_memory_providers.py
+++ b/tests/hermes_cli/test_memory_providers.py
@@ -27,9 +27,7 @@ def test_hindsight_mode_gating_is_expressed_as_select_options():
 
     mode = next(field for field in provider.fields if field.key == "mode")
     assert mode.kind == KIND_SELECT
-    assert mode.allowed_values() == {"cloud", "local_external"}
-    # local_embedded is intentionally unsupported on desktop.
-    assert "local_embedded" not in mode.allowed_values()
+    assert mode.allowed_values() == {"cloud", "local_external", "local_embedded"}
 
 
 def test_api_key_is_a_secret_bound_to_env():

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -391,7 +391,11 @@ class TestWebServerEndpoints:
         fields = self._provider_field_map(data)
         assert fields["mode"]["kind"] == "select"
         assert fields["mode"]["value"] == "cloud"
-        assert {opt["value"] for opt in fields["mode"]["options"]} == {"cloud", "local_external"}
+        assert {opt["value"] for opt in fields["mode"]["options"]} == {
+            "cloud",
+            "local_external",
+            "local_embedded",
+        }
         assert fields["api_url"]["value"] == "https://api.hindsight.vectorize.io"
         assert fields["bank_id"]["value"] == "hermes"
         assert fields["recall_budget"]["value"] == "mid"
@@ -429,7 +433,9 @@ class TestWebServerEndpoints:
             "recall_budget": "high",
         }
 
-    def test_put_memory_provider_config_rejects_unsupported_select_value(self):
+    def test_put_memory_provider_config_accepts_local_embedded_mode(self):
+        from hermes_constants import get_hermes_home
+
         resp = self.client.put(
             "/api/memory/providers/hindsight/config",
             json={
@@ -442,7 +448,11 @@ class TestWebServerEndpoints:
             },
         )
 
-        assert resp.status_code == 400
+        assert resp.status_code == 200
+
+        config_path = get_hermes_home() / "hindsight" / "config.json"
+        provider_config = json.loads(config_path.read_text(encoding="utf-8"))
+        assert provider_config["mode"] == "local_embedded"
 
     def test_put_unknown_memory_provider_returns_404(self):
         resp = self.client.put(


### PR DESCRIPTION
## Summary
- Add `local_embedded` to the Hindsight mode options exposed by the desktop memory-provider settings schema.
- Update web-server and desktop panel regression tests so an existing `local_embedded` config is displayed and preserved instead of being coerced to `cloud`.

## Why
A valid Hindsight config can use `mode: local_embedded`, but the desktop config surface only allowed `cloud` and `local_external`. The web endpoint therefore treated `local_embedded` as an unsupported select value and fell back to the default `cloud`, making the settings panel misleading and risking an accidental save back to cloud mode.

There is a broader schema-driven memory-provider PR open (#48675). This is the small surgical fix for the current production bug, so users with local embedded Hindsight are not shown the wrong mode while that larger refactor is reviewed.

## Test Plan
- `python -m pytest tests/hermes_cli/test_memory_providers.py tests/hermes_cli/test_web_server.py -q` — 342 passed
- `python -m ruff check hermes_cli/memory_providers.py tests/hermes_cli/test_memory_providers.py tests/hermes_cli/test_web_server.py` — passed
- `npm run typecheck` from `apps/desktop` — passed
- `npx vitest run --environment jsdom src/app/settings/provider-config-panel.test.tsx` from `apps/desktop` — 5 passed
