### PR TITLE
fix(slack): avoid null table column settings

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1444,9 +1444,21 @@ class SlackAdapter(BasePlatformAdapter):
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                last_result = await self._get_client(
+                client = self._get_client(
                     chat_id, team_id=self._metadata_team_id(metadata)
-                ).chat_postMessage(**kwargs)
+                )
+                try:
+                    last_result = await client.chat_postMessage(**kwargs)
+                except Exception as exc:
+                    if "blocks" not in kwargs or not self._is_invalid_blocks_error(exc):
+                        raise
+                    logger.warning(
+                        "[Slack] Block Kit payload rejected; retrying without blocks: %s",
+                        exc,
+                    )
+                    fallback_kwargs = dict(kwargs)
+                    fallback_kwargs.pop("blocks", None)
+                    last_result = await client.chat_postMessage(**fallback_kwargs)
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -1542,9 +1554,26 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks = self._maybe_blocks(content)
                 if blocks:
                     update_kwargs["blocks"] = blocks
-            await self._get_client(
+            client = self._get_client(
                 chat_id, team_id=self._metadata_team_id(metadata)
-            ).chat_update(**update_kwargs)
+            )
+            try:
+                await client.chat_update(**update_kwargs)
+            except Exception as exc:
+                if "blocks" not in update_kwargs or not self._is_invalid_blocks_error(
+                    exc
+                ):
+                    raise
+                logger.warning(
+                    "[Slack] Final Block Kit edit rejected; clearing blocks and retrying: %s",
+                    exc,
+                )
+                fallback_kwargs = dict(update_kwargs)
+                # Omitting blocks on chat.update preserves the previous block
+                # layout. An explicit empty list clears it before plain-text
+                # fallback is applied.
+                fallback_kwargs["blocks"] = []
+                await client.chat_update(**fallback_kwargs)
             if finalize:
                 await self.stop_typing(chat_id, metadata=metadata)
             return SendResult(success=True, message_id=message_id)
@@ -2062,6 +2091,10 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception:  # pragma: no cover - renderer already guards itself
             logger.debug("[Slack] block render failed; using plain text", exc_info=True)
             return None
+
+    @staticmethod
+    def _is_invalid_blocks_error(exc: Exception) -> bool:
+        return "invalid_blocks" in str(exc)
 
     def format_message(self, content: str) -> str:
         """Convert standard markdown to Slack mrkdwn format.

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -285,18 +285,20 @@ def _table_block(rows: List[str], sep_line: str) -> Optional[Block]:
         return None
 
     aligns = _parse_alignment(sep_line)
-    column_settings: List[Optional[Dict[str, Any]]] = []
+    column_settings: List[Dict[str, Any]] = []
     for c in range(min(ncols, MAX_TABLE_COLS)):
         align = aligns[c] if c < len(aligns) else "left"
         # Only emit a setting when it differs from the default (left, no wrap);
-        # use null to skip a column, per the Slack schema.
-        column_settings.append({"align": align} if align != "left" else None)
+        # omitted trailing columns inherit Slack's defaults.
+        column_settings.append({"align": align} if align != "left" else {})
+    while column_settings and not column_settings[-1]:
+        column_settings.pop()
 
     block: Block = {
         "type": "table",
         "rows": [[_rich_text_cell(cell) for cell in row] for row in parsed],
     }
-    if any(cs is not None for cs in column_settings):
+    if column_settings:
         block["column_settings"] = column_settings
     return block
 

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -159,10 +159,21 @@ class TestTables:
         )
         blocks = render_blocks(md)
         cs = blocks[0]["column_settings"]
-        # left is default -> null; center/right emitted
-        assert cs[0] is None
+        # left is default -> empty object placeholder; center/right emitted
+        assert cs[0] == {}
         assert cs[1] == {"align": "center"}
         assert cs[2] == {"align": "right"}
+
+    def test_column_settings_omit_trailing_default_columns(self):
+        md = (
+            "| Item | Status | Note |\n"
+            "|---|---:|---|\n"
+            "| Hermes | ok | default-left trailing column |"
+        )
+        blocks = render_blocks(md)
+        cs = blocks[0]["column_settings"]
+        assert cs == [{}, {"align": "right"}]
+        assert all(isinstance(setting, dict) for setting in cs)
 
     def test_inline_formatting_inside_cells(self):
         md = (

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -53,6 +53,27 @@ class TestSendMessageBlocks:
         assert "divider" in types
 
     @pytest.mark.asyncio
+    async def test_invalid_blocks_retries_once_without_blocks(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_postMessage.side_effect = [
+            RuntimeError("invalid_blocks: must provide an object"),
+            {"ts": "111.333"},
+        ]
+
+        result = await adapter.send(
+            "C1", RICH_MD, metadata={"slack_team_id": "T_OTHER"}
+        )
+
+        assert result.success
+        assert client.chat_postMessage.await_count == 2
+        first = client.chat_postMessage.await_args_list[0].kwargs
+        second = client.chat_postMessage.await_args_list[1].kwargs
+        assert "blocks" in first
+        assert "blocks" not in second
+        assert second["text"]
+        adapter._get_client.assert_called_once_with("C1", team_id="T_OTHER")
+
+    @pytest.mark.asyncio
     async def test_enabled_but_unrenderable_falls_back_to_text(self):
         # 60 dividers -> renderer returns None -> no blocks kwarg, text stands
         adapter, client = _make_adapter({"rich_blocks": True})
@@ -115,6 +136,31 @@ class TestEditMessageBlocks:
         kwargs = client.chat_update.await_args.kwargs
         assert "blocks" in kwargs and kwargs["blocks"]
         assert kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_final_blocks_clear_layout_on_workspace_client(self):
+        adapter, client = _make_adapter({"rich_blocks": True})
+        client.chat_update.side_effect = [
+            RuntimeError("invalid_blocks: must provide an object"),
+            {"ts": "111.222"},
+        ]
+
+        result = await adapter.edit_message(
+            "C1",
+            "111.222",
+            RICH_MD,
+            finalize=True,
+            metadata={"slack_team_id": "T_OTHER"},
+        )
+
+        assert result.success
+        assert client.chat_update.await_count == 2
+        first = client.chat_update.await_args_list[0].kwargs
+        second = client.chat_update.await_args_list[1].kwargs
+        assert first["blocks"]
+        assert second["blocks"] == []
+        assert second["text"]
+        adapter._get_client.assert_called_once_with("C1", team_id="T_OTHER")
 
     @pytest.mark.asyncio
     async def test_finalize_edit_gets_feedback_buttons_when_enabled(self):


### PR DESCRIPTION
## Summary
- Replace invalid `null` Slack table `column_settings` entries with schema-valid objects and omit trailing default columns.
- If Slack rejects a rendered `chat.postMessage` payload with `invalid_blocks`, retry once as plain text.
- Apply the same fallback to finalized streaming `chat.update` calls, using `blocks=[]` so an existing block layout is cleared.
- Preserve workspace routing by resolving the metadata-selected client once and reusing it for both attempts.

## Tests
- Table settings contain only objects and omit trailing defaults.
- Post fallback retries without blocks on the same workspace client.
- Final edit fallback clears blocks on the same workspace client.
- `.venv/bin/python -m pytest tests/gateway/test_slack_block_kit.py tests/gateway/test_slack_block_kit_adapter.py tests/gateway/test_slack.py -q` (277 passed)
- `.venv/bin/python -m ruff check plugins/platforms/slack/adapter.py plugins/platforms/slack/block_kit.py tests/gateway/test_slack_block_kit.py tests/gateway/test_slack_block_kit_adapter.py`
- `git diff --check`