### PR TITLE
fix(agent): gate Telegram rich-Markdown hint on rich_messages config

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -655,19 +655,7 @@ PLATFORM_HINTS = {
         "Standard Markdown is automatically converted to Telegram formatting. "
         "Supported: **bold**, *italic*, ~~strikethrough~~, ||spoiler||, "
         "`inline code`, ```code blocks```, [links](url), and ## headers. "
-        "Telegram now supports rich Markdown, so lean into it: whenever it "
-        "makes the answer clearer or easier to scan, actively reach for real "
-        "Markdown tables (pipe `| col | col |` syntax), bullet and numbered "
-        "lists, task lists (`- [ ]` / `- [x]`), headings, nested blockquotes, "
-        "collapsible details, footnotes/references, math/formulas (`$...$`, "
-        "`$$...$$`), underline, subscript/superscript, marked (highlighted) "
-        "text, and anchors. Default to structured formatting over dense "
-        "paragraphs for any comparison, set of steps, key/value summary, or "
-        "tabular data. Prefer real Markdown tables and task lists over "
-        "hand-built bullet substitutes when presenting structured data; these "
-        "degrade gracefully (tables become readable bullet groups) when rich "
-        "rendering is unavailable, but advanced constructs like math and "
-        "collapsible details may render as plain source text in that case. "
+        "Prefer bullet lists and labeled key:value pairs for structured data. "
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
@@ -849,6 +837,27 @@ PLATFORM_HINTS = {
         "Use MEDIA:/absolute/path instead."
     ),
 }
+
+# Telegram rich-messages extension — only injected when the user has opted in
+# to ``platforms.telegram.extra.rich_messages: true``.  The base
+# PLATFORM_HINTS["telegram"] covers MarkdownV2-compatible constructs; this
+# extension adds the Bot API 10.1 rich-Markdown guidance (tables, task lists,
+# collapsible details, math, etc.).
+TELEGRAM_RICH_MESSAGES_HINT = (
+    "Telegram now supports rich Markdown, so lean into it: whenever it "
+    "makes the answer clearer or easier to scan, actively reach for real "
+    "Markdown tables (pipe `| col | col |` syntax), bullet and numbered "
+    "lists, task lists (`- [ ]` / `- [x]`), headings, nested blockquotes, "
+    "collapsible details, footnotes/references, math/formulas (`$...$`, "
+    "`$$...$$`), underline, subscript/superscript, marked (highlighted) "
+    "text, and anchors. Default to structured formatting over dense "
+    "paragraphs for any comparison, set of steps, key/value summary, or "
+    "tabular data. Prefer real Markdown tables and task lists over "
+    "hand-built bullet substitutes when presenting structured data; these "
+    "degrade gracefully (tables become readable bullet groups) when rich "
+    "rendering is unavailable, but advanced constructs like math and "
+    "collapsible details may render as plain source text in that case. "
+)
 
 # ---------------------------------------------------------------------------
 # Environment hints — execution-environment awareness for the agent.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -39,6 +39,7 @@ from agent.prompt_builder import (
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
+    TELEGRAM_RICH_MESSAGES_HINT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
@@ -396,6 +397,20 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
                 _default_hint = _entry.platform_hint
         except Exception:
             pass
+
+    # For Telegram: append the rich-messages extension only when the user has
+    # opted in to ``platforms.telegram.extra.rich_messages: true``.  The base
+    # hint covers MarkdownV2-compatible constructs; the extension adds Bot API
+    # 10.1 guidance (tables, task lists, math, collapsible details, etc.).
+    if platform_key == "telegram" and _default_hint:
+        try:
+            from hermes_cli.config import load_config_readonly
+            _cfg = load_config_readonly()
+            _tg_extra = ((_cfg.get("platforms") or {}).get("telegram") or {}).get("extra") or {}
+            if _tg_extra.get("rich_messages"):
+                _default_hint = _default_hint.rstrip() + " " + TELEGRAM_RICH_MESSAGES_HINT
+        except Exception:
+            pass  # Config read failure — fall back to base hint only
 
     _effective_hint = _resolve_platform_hint(agent, platform_key, _default_hint)
     if _effective_hint:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1092,15 +1092,22 @@ class TestPromptBuilderConstants:
         hint = PLATFORM_HINTS["telegram"]
         lowered = hint.lower()
         assert "Telegram has NO table syntax" not in hint
-        assert "rich markdown" in lowered
-        assert "table" in lowered
-        assert "task list" in lowered
-        assert "math" in lowered
+        # Base hint covers MarkdownV2-compatible constructs.
+        assert "MEDIA:" in hint
+        # Rich-messages extension (TELEGRAM_RICH_MESSAGES_HINT) covers the
+        # Bot API 10.1 guidance; it is injected conditionally in
+        # system_prompt.py when rich_messages: true.
+        from agent.prompt_builder import TELEGRAM_RICH_MESSAGES_HINT
+        rich_lowered = TELEGRAM_RICH_MESSAGES_HINT.lower()
+        assert "rich markdown" in rich_lowered
+        assert "table" in rich_lowered
+        assert "task list" in rich_lowered
+        assert "math" in rich_lowered
         # Hint should proactively steer toward structured formatting, not just
         # permit it: bullet + numbered lists for scannable, structured output.
-        assert "bullet" in lowered
-        assert "numbered" in lowered
-        # Local media delivery guidance must remain intact.
+        assert "bullet" in rich_lowered
+        assert "numbered" in rich_lowered
+        # Local media delivery guidance must remain intact in the base hint.
         assert "include MEDIA:" in hint
 
     def test_platform_hints_mattermost(self):

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -99,3 +99,46 @@ class TestCodingContextBlock:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         agent = _make_agent(valid_tool_names=[], platform="cli")
         assert "coding agent" not in _stable_prompt(agent)
+
+
+class TestTelegramRichMessagesHint:
+    """Verify that TELEGRAM_RICH_MESSAGES_HINT is conditionally included."""
+
+    def test_base_hint_without_rich_messages(self, monkeypatch):
+        """When rich_messages is False (default), only the base hint is used."""
+        agent = _make_agent(platform="telegram")
+        # Mock config to return rich_messages: false (default)
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "platforms": {"telegram": {"extra": {"rich_messages": False}}}
+            }
+            stable = _stable_prompt(agent)
+        # Base hint should be present
+        assert "Standard Markdown is automatically converted" in stable
+        # Rich-messages extension should NOT be present
+        assert "lean into it" not in stable
+        assert "task lists" not in stable
+
+    def test_rich_hint_with_rich_messages_enabled(self, monkeypatch):
+        """When rich_messages is True, the rich-messages extension is appended."""
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {
+                "platforms": {"telegram": {"extra": {"rich_messages": True}}}
+            }
+            stable = _stable_prompt(agent)
+        # Base hint should be present
+        assert "Standard Markdown is automatically converted" in stable
+        # Rich-messages extension should be present
+        assert "lean into it" in stable
+        assert "task lists" in stable
+        assert "math/formulas" in stable
+
+    def test_base_hint_without_config(self, monkeypatch):
+        """When config has no telegram section, only base hint is used."""
+        agent = _make_agent(platform="telegram")
+        with patch("hermes_cli.config.load_config_readonly") as mock_cfg:
+            mock_cfg.return_value = {}
+            stable = _stable_prompt(agent)
+        assert "Standard Markdown is automatically converted" in stable
+        assert "lean into it" not in stable


### PR DESCRIPTION
## What does this PR do?

Gate the Telegram platform hint's rich-Markdown encouragement on the `rich_messages` config setting. When `rich_messages: false` (the default), the system prompt now only includes MarkdownV2-compatible formatting guidance. The Bot API 10.1 rich-Markdown extension (tables, task lists, math, collapsible details, etc.) is only injected when the user explicitly opts in via `platforms.telegram.extra.rich_messages: true`.

Previously, the platform hint always told the agent to "lean into" rich Markdown constructs regardless of the config, causing the agent to produce formatting that MarkdownV2 cannot render — especially broken on Telegram Web.

## Related Issue

Fixes #57122

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`: Split `PLATFORM_HINTS["telegram"]` into a base hint (MarkdownV2-compatible constructs only) and a new `TELEGRAM_RICH_MESSAGES_HINT` constant containing the Bot API 10.1 rich-Markdown guidance.
- `agent/system_prompt.py`: Added conditional logic to append `TELEGRAM_RICH_MESSAGES_HINT` only when `platforms.telegram.extra.rich_messages` is `true` in config. Uses `load_config_readonly()` for efficient cached reads.
- `tests/agent/test_prompt_builder.py`: Updated `test_telegram_hint_encourages_rich_markdown` to verify both the base hint and the separate rich-messages extension constant.
- `tests/agent/test_system_prompt.py`: Added `TestTelegramRichMessagesHint` class with 3 tests verifying conditional hint inclusion based on config.

## How to Test

1. Run `pytest tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -q` — all 168 tests should pass.
2. With default config (`rich_messages: false`), the Telegram platform hint should only list MarkdownV2-compatible constructs (bold, italic, strikethrough, spoiler, inline code, code blocks, links, headers).
3. With `platforms.telegram.extra.rich_messages: true`, the hint should additionally include rich-Markdown guidance (tables, task lists, math, collapsible details, etc.).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
