### PR TITLE
fix(cli): add timeout to git stash during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6425,11 +6425,22 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         "hermes-update-autostash-%Y%m%d-%H%M%S"
     )
     print("→ Local changes detected — stashing before update...")
-    subprocess.run(
-        git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
-        cwd=cwd,
-        check=True,
-    )
+    try:
+        subprocess.run(
+            git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
+            cwd=cwd,
+            check=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            "  ⚠ git stash timed out after 120s — skipping auto-stash.\n"
+            "  Your local changes are NOT stashed.  The update will proceed\n"
+            "  without stashing; if git complains, manually stash or reset:\n"
+            "    git stash push --include-untracked\n"
+            "    git reset --hard HEAD"
+        )
+        return None
     stash_ref = subprocess.run(
         git_cmd + ["rev-parse", "--verify", "refs/stash"],
         cwd=cwd,

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -901,3 +901,23 @@ def test_bootstrap_marker_not_autostashed_by_update(tmp_path):
         ["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True
     ).stdout
     assert ".hermes-bootstrap-complete" not in status
+
+
+def test_stash_local_changes_if_needed_returns_none_on_timeout(monkeypatch, tmp_path):
+    """When git stash hangs (TimeoutExpired), skip stashing and return None."""
+    import subprocess
+    from types import SimpleNamespace
+
+    def fake_run(cmd, **kwargs):
+        if cmd[-2:] == ["status", "--porcelain"]:
+            return SimpleNamespace(stdout=" M hermes_cli/main.py\n", returncode=0)
+        if cmd[-2:] == ["ls-files", "--unmerged"]:
+            return SimpleNamespace(stdout="", returncode=0)
+        if cmd[1:4] == ["stash", "push", "--include-untracked"]:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=120)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    result = hermes_main._stash_local_changes_if_needed(["git"], Path(tmp_path))
+    assert result is None


### PR DESCRIPTION
## What does this PR do?

Add a 120-second timeout to `git stash push --include-untracked` in the update flow. On Windows, this command can hang indefinitely when files are locked by other processes (antivirus, gateway, etc.), causing `hermes update` to appear stuck for hours.

When the timeout is reached, the update proceeds without stashing and prints guidance for manual stash/reset.

## Related Issue

Fixes #57081

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Added `timeout=120` to the `git stash push --include-untracked` subprocess call in `_stash_local_changes_if_needed()`. Catches `subprocess.TimeoutExpired` and returns `None` (skip stashing) with actionable guidance.
- `tests/hermes_cli/test_update_autostash.py`: Added `test_stash_local_changes_if_needed_returns_none_on_timeout` verifying the timeout behavior.

## How to Test

1. Run `pytest tests/hermes_cli/test_update_autostash.py -q` — all 34 tests should pass.
2. On a system with locked files (e.g., Windows with antivirus scanning), `hermes update` should no longer hang indefinitely. After 120s, it prints a warning and proceeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
