### PR TITLE
fix(browser): bound Camofox control JSON responses

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -3,8 +3,11 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 from tools.browser_camofox import (
+    _CONTROL_JSON_MAX_BYTES,
+    _read_control_json,
     camofox_back,
     camofox_click,
     camofox_close,
@@ -65,10 +68,33 @@ def _config_with_camofox(**camofox_config):
 def _mock_response(status=200, json_data=None):
     resp = MagicMock()
     resp.status_code = status
-    resp.json.return_value = json_data or {}
+    raw = json.dumps(json_data or {}).encode("utf-8")
+    resp.headers = {"content-length": str(len(raw))}
+    resp.encoding = "utf-8"
+    resp.iter_content.return_value = [raw]
+    resp.json.side_effect = AssertionError("Camofox control JSON must be streamed")
     resp.content = b"\x89PNG\r\n\x1a\nfake"
     resp.raise_for_status = MagicMock()
+    resp.close = MagicMock()
     return resp
+
+
+def test_control_json_reader_rejects_oversized_response_before_iterating():
+    resp = MagicMock()
+    resp.headers = {"content-length": str(_CONTROL_JSON_MAX_BYTES + 1)}
+    resp.iter_content.side_effect = AssertionError("oversized body should not be read")
+    resp.close = MagicMock()
+
+    with pytest.raises(RuntimeError, match="Camofox response too large"):
+        _read_control_json(resp)
+    resp.close.assert_called_once()
+
+
+def test_control_json_reader_streams_small_json_without_response_json():
+    resp = _mock_response(json_data={"ok": True})
+
+    assert _read_control_json(resp) == {"ok": True}
+    resp.json.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -455,5 +481,3 @@ class TestBrowserToolRouting:
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
         from tools.browser_tool import check_browser_requirements
         assert check_browser_requirements() is True
-
-

--- a/tests/tools/test_browser_camofox_auth.py
+++ b/tests/tools/test_browser_camofox_auth.py
@@ -24,9 +24,14 @@ from tools.browser_camofox import (
 def _mock_response(status=200, json_data=None):
     resp = MagicMock()
     resp.status_code = status
-    resp.json.return_value = json_data or {}
+    raw = json.dumps(json_data or {}).encode("utf-8")
+    resp.headers = {"content-length": str(len(raw))}
+    resp.encoding = "utf-8"
+    resp.iter_content.return_value = [raw]
+    resp.json.side_effect = AssertionError("Camofox control JSON must be streamed")
     resp.content = b"\x89PNG\r\n\x1a\nfake"
     resp.raise_for_status = MagicMock()
+    resp.close = MagicMock()
     return resp
 
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 30  # fallback when config is unreadable
 _SNAPSHOT_MAX_CHARS = 80_000  # camofox paginates at this limit
+_CONTROL_JSON_MAX_BYTES = 1_000_000
 _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
 
@@ -137,10 +138,10 @@ def check_camofox_available() -> bool:
     if not url:
         return False
     try:
-        resp = requests.get(f"{url}/health", timeout=5)
+        resp = requests.get(f"{url}/health", timeout=5, stream=True)
         if resp.status_code == 200 and not _vnc_url_checked:
             try:
-                data = resp.json()
+                data = _read_control_json(resp)
                 vnc_port = data.get("vncPort")
                 if isinstance(vnc_port, int) and 1 <= vnc_port <= 65535:
                     from urllib.parse import urlparse
@@ -410,9 +411,10 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
         },
         timeout=_get_command_timeout(),
         headers=_auth_headers(),
+        stream=True,
     )
     resp.raise_for_status()
-    data = resp.json()
+    data = _read_control_json(resp)
     session["tab_id"] = data.get("tabId")
     return session
 
@@ -445,14 +447,62 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
+def _read_control_json(resp: requests.Response) -> dict:
+    """Read a bounded Camofox control-plane JSON response."""
+    content_length = resp.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > _CONTROL_JSON_MAX_BYTES:
+                close = getattr(resp, "close", None)
+                if close:
+                    close()
+                raise RuntimeError(
+                    f"Camofox response too large ({content_length} bytes; "
+                    f"limit {_CONTROL_JSON_MAX_BYTES})"
+                )
+        except ValueError:
+            pass
+
+    chunks = []
+    total = 0
+    try:
+        for chunk in resp.iter_content(chunk_size=64 * 1024):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > _CONTROL_JSON_MAX_BYTES:
+                raise RuntimeError(
+                    f"Camofox response too large (>{_CONTROL_JSON_MAX_BYTES} bytes)"
+                )
+            chunks.append(chunk)
+    finally:
+        close = getattr(resp, "close", None)
+        if close:
+            close()
+
+    raw = b"".join(chunks).decode(resp.encoding or "utf-8")
+    if not raw.strip():
+        return {}
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("Camofox control response must be a JSON object")
+    return data
+
+
 def _post(path: str, body: dict, timeout: Optional[int] = None) -> dict:
     """POST JSON to camofox and return parsed response."""
     if timeout is None:
         timeout = _get_command_timeout()
     url = f"{get_camofox_url()}{path}"
-    resp = requests.post(url, json=body, timeout=timeout, headers=_auth_headers())
+    resp = requests.post(
+        url,
+        json=body,
+        timeout=timeout,
+        headers=_auth_headers(),
+        stream=True,
+    )
     resp.raise_for_status()
-    return resp.json()
+    return _read_control_json(resp)
 
 
 def _get(path: str, params: dict = None, timeout: Optional[int] = None) -> dict:
@@ -460,9 +510,15 @@ def _get(path: str, params: dict = None, timeout: Optional[int] = None) -> dict:
     if timeout is None:
         timeout = _get_command_timeout()
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout, headers=_auth_headers())
+    resp = requests.get(
+        url,
+        params=params,
+        timeout=timeout,
+        headers=_auth_headers(),
+        stream=True,
+    )
     resp.raise_for_status()
-    return resp.json()
+    return _read_control_json(resp)
 
 
 def _get_raw(path: str, params: dict = None, timeout: Optional[int] = None) -> requests.Response:
@@ -480,9 +536,15 @@ def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict
     if timeout is None:
         timeout = _get_command_timeout()
     url = f"{get_camofox_url()}{path}"
-    resp = requests.delete(url, json=body, timeout=timeout, headers=_auth_headers())
+    resp = requests.delete(
+        url,
+        json=body,
+        timeout=timeout,
+        headers=_auth_headers(),
+        stream=True,
+    )
     resp.raise_for_status()
-    return resp.json()
+    return _read_control_json(resp)
 
 
 # ---------------------------------------------------------------------------
@@ -932,6 +994,4 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
         "note": "Console log capture is not available with the Camofox backend. "
                 "Use browser_snapshot or browser_vision to inspect page state.",
     })
-
-
 


### PR DESCRIPTION
## What does this PR do?

Fixes unbounded buffering of Camofox control-plane JSON responses. The Camofox backend now requests small JSON control responses with `stream=True` and parses them through a bounded reader before returning the fields Hermes needs.

Normal small Camofox responses keep working, while oversized control responses fail with a Camofox-specific error before Hermes buffers arbitrary response bodies.

## Related Issue

Fixes #56568

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a bounded Camofox control JSON reader in `tools/browser_camofox.py`.
- Switched `/health`, `/tabs`, and JSON helper requests (`_post`, `_get`, `_delete`) to `stream=True`.
- Kept `_get_raw` unchanged for binary responses such as screenshots.
- Updated Camofox fake responses so tests fail if control paths call `resp.json()` directly.
- Added regression tests for small streamed JSON and oversized `Content-Length` rejection.

## How to Test

1. `.venv/bin/python -m pytest tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_auth.py -q`
2. `.venv/bin/python -m ruff check tools/browser_camofox.py tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_auth.py`
3. `scripts/run_tests.sh tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_auth.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.13 venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
