### PR TITLE
fix(cli): skip TUI workspace check when bundled TUI exists (#57031)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1749,7 +1749,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         )
         sys.exit(1)
 
-    if not ext_dir:
+    if not ext_dir and not _find_bundled_tui():
         _ensure_tui_workspace(tui_dir)
 
     # 1. Prebuilt bundle (nix / packaged release): just run it.


### PR DESCRIPTION
## Problem

`_ensure_tui_workspace()` is called unconditionally when `HERMES_TUI_DIR` is not set (line 1752), even for **pip/homebrew installs** where a bundled `tui_dist/` exists in the wheel. The workspace check tries `git restore` (fails in non-git installs) and calls `sys.exit(1)`, blocking access to the bundled TUI fallback at `_find_bundled_tui()` (line 1764).

**Call chain for Homebrew:**
1. `PROJECT_ROOT` resolves to `site-packages/` (no `.git`)
2. `HERMES_TUI_DIR` is not set (homebrew formula doesn't set it)
3. `_ensure_tui_workspace(tui_dir)` → `ui-tui/` doesn't exist → tries `git restore` → no `.git` → `sys.exit(1)`
4. `_find_bundled_tui()` at line 1764 is **never reached**

## Fix

Add a guard: only call `_ensure_tui_workspace()` when no bundled TUI is found. This lets pip/homebrew installs fall through to the prebuilt bundle check.

```python
# Before:
if not ext_dir:
    _ensure_tui_workspace(tui_dir)

# After:
if not ext_dir and not _find_bundled_tui():
    _ensure_tui_workspace(tui_dir)
```

Fixes #57031
