### PR TITLE
fix(auth): surface real upstream 429 when all pool entries exhausted (#40960)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -601,6 +601,28 @@ def _resolve_api_key_provider_secret(
                 key = str(key).strip()
                 if has_usable_secret(key):
                     return key, f"credential_pool:{provider_id}"
+            # fix(#40960): when all entries are in exhaustion cooldown,
+            # return any usable (even exhausted) key so the upstream API
+            # returns its real 429 with the quota-reset timestamp instead
+            # of a misleading 401 from sending an empty Authorization header.
+            try:
+                for exhausted_entry in pool._entries:
+                    ex_key = (
+                        getattr(exhausted_entry, "access_token", "")
+                        or getattr(exhausted_entry, "runtime_api_key", "")
+                        or ""
+                    )
+                    ex_key = str(ex_key).strip()
+                    if has_usable_secret(ex_key):
+                        logger.warning(
+                            "credential_pool: all entries for %s are exhausted; "
+                            "returning an exhausted key to surface the real upstream error",
+                            provider_id,
+                        )
+                        return ex_key, f"credential_pool:{provider_id}:exhausted"
+            except Exception:
+                # best-effort: if introspection fails, fall through to the empty return
+                pass
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
Fix [issue #40960](https://github.com/NousResearch/hermes-agent/issues/40960): when all credential pool entries are in exhaustion cooldown (e.g. after a 429 quota-exhausted response), `_resolve_api_key_provider_secret()` silently returned an empty `api_key`. This caused the API request to fail with a misleading **401 Unauthorized**, hiding the real cause (a 429 quota message from the provider).

## Root Cause
`hermes_cli/auth.py` L593-605: when `pool.peek()` returns `None` (all entries in cooldown), the code returns an empty string for `api_key` instead of falling back to an exhausted entry.

## Fix
After `peek()` returns `None`, iterate `pool._entries` and return the first usable key with a warning log. The upstream API then returns its real 429 with the quota-reset timestamp, giving users actionable information.

## Test Plan
- [x] Syntax check: `ast.parse()` passes
- [x] Locally verified pool returns 401-masked-error before fix
- [ ] CI passes (GitHub Actions)
- [ ] Maintainer review

## Related
- Closes #40960
- See also #52727 (related short-term fix proposal)
