### PR TITLE
fix(cli): bound local model detection responses

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import json
 import os
 import re
 from urllib.parse import urlparse
@@ -34,6 +35,8 @@ from hermes_cli.auth import (
 from hermes_cli.config import get_compatible_custom_providers, load_config
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_int
+
+_LOCAL_MODELS_MAX_BYTES = 1_000_000
 
 
 def _getenv(name: str, default: str = "") -> str:
@@ -254,9 +257,9 @@ def _auto_detect_local_model(base_url: str) -> str:
         url = base_url.rstrip("/")
         if not url.endswith("/v1"):
             url += "/v1"
-        resp = requests.get(url + "/models", timeout=5)
+        resp = requests.get(url + "/models", timeout=5, stream=True)
         if resp.ok:
-            models = resp.json().get("data", [])
+            models = _read_local_models_json(resp).get("data", [])
             if len(models) == 1:
                 model_id = models[0].get("id", "")
                 if model_id:
@@ -266,6 +269,46 @@ def _auto_detect_local_model(base_url: str) -> str:
         # local model auto-detection fails unexpectedly.
         logger.debug("Auto-detect model from %s failed: %s", base_url, exc)
     return ""
+
+
+def _read_local_models_json(resp: Any) -> Dict[str, Any]:
+    """Read a bounded OpenAI-compatible /models JSON response."""
+    content_length = resp.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > _LOCAL_MODELS_MAX_BYTES:
+                close = getattr(resp, "close", None)
+                if close:
+                    close()
+                raise RuntimeError(
+                    f"/models response too large ({content_length} bytes; "
+                    f"limit {_LOCAL_MODELS_MAX_BYTES})"
+                )
+        except ValueError:
+            pass
+
+    chunks = []
+    total = 0
+    try:
+        for chunk in resp.iter_content(chunk_size=64 * 1024):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > _LOCAL_MODELS_MAX_BYTES:
+                raise RuntimeError(f"/models response too large (>{_LOCAL_MODELS_MAX_BYTES} bytes)")
+            chunks.append(chunk)
+    finally:
+        close = getattr(resp, "close", None)
+        if close:
+            close()
+
+    raw = b"".join(chunks).decode(getattr(resp, "encoding", None) or "utf-8")
+    if not raw.strip():
+        return {}
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("/models response must be a JSON object")
+    return data
 
 
 def _get_model_config() -> Dict[str, Any]:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1,11 +1,24 @@
 import base64
 import json
 import time
+from unittest.mock import MagicMock
 from types import SimpleNamespace
 
 import pytest
 
 from hermes_cli import runtime_provider as rp
+
+
+def _streaming_response(payload: dict, *, ok: bool = True):
+    raw = json.dumps(payload).encode("utf-8")
+    resp = MagicMock()
+    resp.ok = ok
+    resp.headers = {"content-length": str(len(raw))}
+    resp.encoding = "utf-8"
+    resp.iter_content.return_value = [raw]
+    resp.json.side_effect = AssertionError("/models response must be streamed")
+    resp.close = MagicMock()
+    return resp
 
 
 def _fake_invoke_jwt(ttl_seconds=3600):
@@ -19,6 +32,41 @@ def _fake_invoke_jwt(ttl_seconds=3600):
         ).encode()
     ).decode().rstrip("=")
     return f"{header}.{payload}.sig"
+
+
+def test_auto_detect_local_model_streams_models_response(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return _streaming_response({"data": [{"id": "local-model"}]})
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert rp._auto_detect_local_model("http://localhost:11434") == "local-model"
+    assert calls == [
+        ("http://localhost:11434/v1/models", {"timeout": 5, "stream": True})
+    ]
+
+
+def test_auto_detect_local_model_returns_empty_for_oversized_response(monkeypatch):
+    resp = MagicMock()
+    resp.ok = True
+    resp.headers = {"content-length": str(rp._LOCAL_MODELS_MAX_BYTES + 1)}
+    resp.iter_content.side_effect = AssertionError("oversized body should not be read")
+    resp.json.side_effect = AssertionError("/models response must be streamed")
+    resp.close = MagicMock()
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", lambda *a, **k: resp)
+
+    assert rp._auto_detect_local_model("http://localhost:11434") == ""
+    resp.iter_content.assert_not_called()
+    resp.json.assert_not_called()
+    resp.close.assert_called_once()
 
 
 def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes unbounded buffering in local model auto-detection. When Hermes probes a local OpenAI-compatible `/v1/models` endpoint to infer the only loaded model, it now requests the response with `stream=True` and parses the body through a small bounded JSON reader.

Normal small `/models` responses still detect a single model. Oversized, malformed, or non-object responses fall back to no detected model, matching the existing failure behavior without buffering arbitrary response bodies.

## Related Issue

Fixes #56559

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a bounded `/models` JSON reader in `hermes_cli/runtime_provider.py`.
- Switched `_auto_detect_local_model()` to call local `/models` with `stream=True`.
- Added tests proving small streamed responses still detect the model.
- Added tests proving oversized responses return `""`, do not call `.json()`, do not iterate the body, and close the response.

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`
2. `.venv/bin/python -m ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py`
3. `scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.13 venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
