### PR TITLE
fix(video-gen): skip unavailable fallback providers

### DIFF
--- a/agent/video_gen_registry.py
+++ b/agent/video_gen_registry.py
@@ -11,7 +11,7 @@ Active selection
 The active provider is chosen by ``video_gen.provider`` in ``config.yaml``.
 If unset, :func:`get_active_provider` applies fallback logic:
 
-1. If exactly one provider is registered, use it.
+1. If exactly one available provider is registered, use it.
 2. Otherwise return ``None`` (the tool surfaces a helpful error pointing
    the user at ``hermes tools``).
 
@@ -78,6 +78,10 @@ def get_active_provider() -> Optional[VideoGenProvider]:
 
     Reads ``video_gen.provider`` from config.yaml; falls back per the
     module docstring.
+
+    Explicit configuration wins even when the provider reports unavailable,
+    so the dispatcher can surface the provider's setup error. Unconfigured
+    fallback only auto-selects providers whose ``is_available()`` returns true.
     """
     configured: Optional[str] = None
     try:
@@ -95,6 +99,13 @@ def get_active_provider() -> Optional[VideoGenProvider]:
     with _lock:
         snapshot = dict(_providers)
 
+    def _is_available_safe(p: VideoGenProvider) -> bool:
+        try:
+            return bool(p.is_available())
+        except Exception as exc:
+            logger.debug("video_gen provider %s.is_available() raised %s", p.name, exc)
+            return False
+
     if configured:
         provider = snapshot.get(configured)
         if provider is not None:
@@ -104,9 +115,10 @@ def get_active_provider() -> Optional[VideoGenProvider]:
             configured,
         )
 
-    # Fallback: single-provider case
-    if len(snapshot) == 1:
-        return next(iter(snapshot.values()))
+    # Fallback: single available provider case
+    available = [p for p in snapshot.values() if _is_available_safe(p)]
+    if len(available) == 1:
+        return available[0]
 
     return None
 

--- a/tests/agent/test_video_gen_registry.py
+++ b/tests/agent/test_video_gen_registry.py
@@ -9,15 +9,18 @@ from agent.video_gen_provider import VideoGenProvider
 
 
 class _FakeProvider(VideoGenProvider):
-    def __init__(self, name: str, available: bool = True):
+    def __init__(self, name: str, available: bool = True, raises: bool = False):
         self._name = name
         self._available = available
+        self._raises = raises
 
     @property
     def name(self) -> str:
         return self._name
 
     def is_available(self) -> bool:
+        if self._raises:
+            raise RuntimeError("availability probe failed")
         return self._available
 
     def generate(self, prompt, **kw):
@@ -74,6 +77,16 @@ class TestGetActiveProvider:
         active = video_gen_registry.get_active_provider()
         assert active is not None and active.name == "solo"
 
+    def test_single_unavailable_provider_does_not_autoresolve(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        video_gen_registry.register_provider(_FakeProvider("solo", available=False))
+        assert video_gen_registry.get_active_provider() is None
+
+    def test_single_provider_availability_error_does_not_autoresolve(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        video_gen_registry.register_provider(_FakeProvider("solo", raises=True))
+        assert video_gen_registry.get_active_provider() is None
+
     def test_no_provider_returns_none(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         assert video_gen_registry.get_active_provider() is None
@@ -97,6 +110,17 @@ class TestGetActiveProvider:
         )
         video_gen_registry.register_provider(_FakeProvider("xai"))
         video_gen_registry.register_provider(_FakeProvider("fal"))
+        active = video_gen_registry.get_active_provider()
+        assert active is not None and active.name == "fal"
+
+    def test_config_selects_unavailable_provider(self, tmp_path, monkeypatch):
+        import yaml
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"video_gen": {"provider": "fal"}})
+        )
+        video_gen_registry.register_provider(_FakeProvider("fal", available=False))
         active = video_gen_registry.get_active_provider()
         assert active is not None and active.name == "fal"
 


### PR DESCRIPTION
## What does this PR do?

Fixes the video generation provider fallback so an unconfigured install only auto-selects a single registered provider when that provider is actually available.

Explicit `video_gen.provider` configuration still wins even when the provider reports unavailable, which lets the caller surface that provider's setup-specific error instead of hiding the configured choice.

## Related Issue

Fixes #56564

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Changes

- Updates `agent.video_gen_registry.get_active_provider()` to filter fallback candidates through `is_available()`.
- Treats provider availability probe exceptions as unavailable during fallback.
- Adds regression coverage for unavailable single providers, raising availability checks, and explicit config selecting an unavailable provider.

## How to Test

- [x] `.venv/bin/python -m pytest tests/agent/test_video_gen_registry.py -q`
- [x] `.venv/bin/python -m ruff check agent/video_gen_registry.py tests/agent/test_video_gen_registry.py`
- [x] `scripts/run_tests.sh tests/agent/test_video_gen_registry.py -q`
- [ ] `pytest tests/ -q`

Platform: macOS, Python 3.13, local `.venv`.
