### PR TITLE
fix(agent): pick up bare reasoning field in build_assistant_message (vLLM >=0.23)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -953,11 +953,12 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         "finish_reason": finish_reason,
     }
 
-    raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
+    raw_reasoning_content = getattr(assistant_message, "reasoning_content", None) or getattr(assistant_message, "reasoning", None)
     if raw_reasoning_content is None and hasattr(assistant_message, "model_extra"):
         model_extra = getattr(assistant_message, "model_extra", None) or {}
-        if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
-            raw_reasoning_content = model_extra["reasoning_content"]
+        if isinstance(model_extra, dict):
+            # vLLM 0.23+ renamed reasoning_content -> reasoning
+            raw_reasoning_content = model_extra.get("reasoning_content") or model_extra.get("reasoning")
     if raw_reasoning_content is not None:
         msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
     elif assistant_tool_calls and agent._needs_thinking_reasoning_pad():


### PR DESCRIPTION
vLLM 0.23 renamed the OpenAI-compat response field `reasoning_content` to `reasoning`. `build_assistant_message()` only looks for `reasoning_content` (both as a message attribute and in `model_extra`), so reasoning returned by vLLM >=0.23 backends is silently dropped when the assistant message is rebuilt for history/persistence.

This falls back to the new bare `reasoning` name in both lookups, keeping `reasoning_content` as the preferred key so older backends are unaffected.

Companion to #51530, which does the same on the `chat_completions` transport side — together they cover both places the old field name is read. Running both in production against a local vLLM 0.23 endpoint since 2026-06-23