### PR TITLE
fix(slack): preserve blank-separated ordered lists

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -63,6 +63,17 @@ def _indent_level(spaces: str) -> int:
     return min(width // 2, 5)  # Slack rich_text_list supports up to indent 5
 
 
+def _list_marker(line: str) -> Optional[Tuple[int, bool, str]]:
+    """Return ``(indent, ordered, text)`` for a markdown list item line."""
+    bm = _BULLET_RE.match(line)
+    if bm:
+        return (_indent_level(bm.group(1)), False, bm.group(2))
+    om = _ORDERED_RE.match(line)
+    if om:
+        return (_indent_level(om.group(1)), True, om.group(3))
+    return None
+
+
 # ----------------------------------------------------------------------------
 # Inline markdown → rich_text elements
 # ----------------------------------------------------------------------------
@@ -438,19 +449,28 @@ def render_blocks(
                 flush_para()
                 items: List[Tuple[int, bool, str]] = []
                 while i < n:
-                    bm = _BULLET_RE.match(lines[i])
-                    om = _ORDERED_RE.match(lines[i])
-                    if bm:
-                        items.append((_indent_level(bm.group(1)), False, bm.group(2)))
-                        i += 1
-                    elif om:
-                        items.append((_indent_level(om.group(1)), True, om.group(3)))
+                    marker = _list_marker(lines[i])
+                    if marker is not None:
+                        items.append(marker)
                         i += 1
                     elif lines[i].strip() and lines[i].startswith((" ", "\t")) and items:
                         # continuation line of the previous item
                         indent, ordered, txt = items[-1]
                         items[-1] = (indent, ordered, txt + " " + lines[i].strip())
                         i += 1
+                    elif not lines[i].strip() and items:
+                        j = i + 1
+                        while j < n and not lines[j].strip():
+                            j += 1
+                        next_marker = _list_marker(lines[j]) if j < n else None
+                        prev_indent, prev_ordered, _ = items[-1]
+                        if (
+                            next_marker is not None
+                            and (next_marker[0], next_marker[1]) == (prev_indent, prev_ordered)
+                        ):
+                            i = j
+                        else:
+                            break
                     else:
                         break
                 blocks.append(_list_block(items))

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -71,6 +71,18 @@ class TestNestedLists:
         assert "ordered" in styles
         assert "bullet" in styles
 
+    def test_blank_separated_ordered_items_stay_in_one_list(self):
+        blocks = render_blocks("1. alpha\n\n1. beta\n\n1. gamma")
+        lists = [
+            e
+            for b in blocks
+            for e in b.get("elements", [])
+            if e.get("type") == "rich_text_list"
+        ]
+        assert [(e["style"], e["indent"], len(e["elements"])) for e in lists] == [
+            ("ordered", 0, 3)
+        ]
+
 
 class TestInlineFormatting:
     def test_link_becomes_link_element(self):


### PR DESCRIPTION
## What does this PR do?

Fixes Slack rich Block Kit rendering for numbered lists whose items are separated by blank lines. The renderer now treats blank lines inside a list run as soft separators when the next non-blank line is another list item with the same indent and ordered/bullet style, so Slack receives one `rich_text_list` instead of several single-item ordered lists.

## Related Issue

Fixes #57076

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Changes

- Adds a small `_list_marker()` helper to avoid duplicating bullet/ordered list parsing.
- Keeps blank-separated ordered items in the same Slack `rich_text_list` when they belong to the same list run.
- Adds regression coverage for `1. alpha\n\n1. beta\n\n1. gamma` rendering as one ordered list with three elements.

## How to Test

- [x] `.venv/bin/python -m pytest tests/gateway/test_slack_block_kit.py -q`
- [x] `.venv/bin/python -m ruff check plugins/platforms/slack/block_kit.py tests/gateway/test_slack_block_kit.py`
- [x] `scripts/run_tests.sh tests/gateway/test_slack_block_kit.py -q`
- [ ] `pytest tests/ -q`

Platform: macOS, Python 3.13, local `.venv`.
