### PR TITLE
fix: prevent orphaned session creation on /resume by clearing parent_session_id in memory manager switch (#57106)

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -804,7 +804,7 @@ class CLICommandsMixin:
                 if _mm is not None:
                     _mm.on_session_switch(
                         target_id,
-                        parent_session_id=old_session_id or "",
+                        parent_session_id="",
                         reset=False,
                         reason="resume",
                     )


### PR DESCRIPTION
Fixes #57106: When resuming a session by name, Hermes was incorrectly passing the old session ID as parent_session_id to the memory manager's on_session_switch hook, causing memory providers to treat the resumed session as a branch and create orphaned/forked sessions. The fix clears parent_session_id (sets to empty string) during resume operations to indicate continuation rather than branching.