### PR TITLE
fix(telegram): gate rich markdown prompt hint

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -617,6 +617,36 @@ STEER_CHANNEL_NOTE = (
 # message representation stays consistent ("system" everywhere).
 DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 
+TELEGRAM_MARKDOWNV2_HINT = (
+    "You are on a text messaging communication platform, Telegram. "
+    "Standard Markdown is automatically converted to Telegram MarkdownV2 "
+    "formatting. Supported: **bold**, *italic*, ~~strikethrough~~, "
+    "||spoiler||, `inline code`, ```code blocks```, [links](url), "
+    "## headers, bullet lists, and numbered lists. Avoid rich-only "
+    "constructs such as Markdown tables, task lists, collapsible details, "
+    "footnotes/references, math/formulas, underline, subscript/superscript, "
+    "marked text, and anchors unless rich Telegram messages are explicitly "
+    "enabled; they may render as raw text or fail in Telegram Web. Prefer "
+    "plain bullet lists or labeled key:value pairs for structured data. "
+    "You can send media files natively: to deliver a file to the user, "
+    "include MEDIA:/absolute/path/to/file in your response. Images "
+    "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
+    "bubbles, and videos (.mp4) play inline. You can also include image "
+    "URLs in markdown format ![alt](url) and they will be sent as native photos."
+)
+
+TELEGRAM_RICH_MARKDOWN_EXTENSION = (
+    "Telegram rich messages are enabled for this chat, so lean into rich "
+    "Markdown when it makes the answer clearer or easier to scan: actively "
+    "reach for real Markdown tables (pipe `| col | col |` syntax), bullet "
+    "and numbered lists, task lists (`- [ ]` / `- [x]`), headings, nested "
+    "blockquotes, collapsible details, footnotes/references, math/formulas "
+    "(`$...$`, `$$...$$`), underline, subscript/superscript, marked "
+    "(highlighted) text, and anchors. Default to structured formatting over "
+    "dense paragraphs for any comparison, set of steps, key/value summary, "
+    "or tabular data."
+)
+
 PLATFORM_HINTS = {
     "whatsapp": (
         "You are on a text messaging communication platform, WhatsApp. "
@@ -650,30 +680,7 @@ PLATFORM_HINTS = {
         "(error 131047). This rarely matters for live chat, but is worth "
         "knowing if you're scheduling a delayed message."
     ),
-    "telegram": (
-        "You are on a text messaging communication platform, Telegram. "
-        "Standard Markdown is automatically converted to Telegram formatting. "
-        "Supported: **bold**, *italic*, ~~strikethrough~~, ||spoiler||, "
-        "`inline code`, ```code blocks```, [links](url), and ## headers. "
-        "Telegram now supports rich Markdown, so lean into it: whenever it "
-        "makes the answer clearer or easier to scan, actively reach for real "
-        "Markdown tables (pipe `| col | col |` syntax), bullet and numbered "
-        "lists, task lists (`- [ ]` / `- [x]`), headings, nested blockquotes, "
-        "collapsible details, footnotes/references, math/formulas (`$...$`, "
-        "`$$...$$`), underline, subscript/superscript, marked (highlighted) "
-        "text, and anchors. Default to structured formatting over dense "
-        "paragraphs for any comparison, set of steps, key/value summary, or "
-        "tabular data. Prefer real Markdown tables and task lists over "
-        "hand-built bullet substitutes when presenting structured data; these "
-        "degrade gracefully (tables become readable bullet groups) when rich "
-        "rendering is unavailable, but advanced constructs like math and "
-        "collapsible details may render as plain source text in that case. "
-        "You can send media files natively: to deliver a file to the user, "
-        "include MEDIA:/absolute/path/to/file in your response. Images "
-        "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "
-        "bubbles, and videos (.mp4) play inline. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as native photos."
-    ),
+    "telegram": TELEGRAM_MARKDOWNV2_HINT,
     "discord": (
         "You are in a Discord server or group chat communicating with your user. "
         "You can send media files natively: include MEDIA:/absolute/path/to/file "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -39,6 +39,8 @@ from agent.prompt_builder import (
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
     TASK_COMPLETION_GUIDANCE,
+    TELEGRAM_MARKDOWNV2_HINT,
+    TELEGRAM_RICH_MARKDOWN_EXTENSION,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
@@ -108,6 +110,54 @@ def _resolve_platform_hint(agent: Any, platform_key: str, default_hint: str) -> 
     if isinstance(append_text, str) and append_text.strip():
         return f"{base}\n\n{append_text.strip()}".strip()
     return base
+
+
+def _coerce_config_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if text in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def _telegram_rich_messages_enabled() -> bool:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+    except Exception:
+        return False
+
+    platforms = cfg.get("platforms") if isinstance(cfg, dict) else None
+    telegram = platforms.get("telegram") if isinstance(platforms, dict) else None
+    if isinstance(telegram, dict):
+        extra = telegram.get("extra")
+        if isinstance(extra, dict) and "rich_messages" in extra:
+            return _coerce_config_bool(extra.get("rich_messages"), False)
+
+    top_level = cfg.get("telegram") if isinstance(cfg, dict) else None
+    if isinstance(top_level, dict):
+        extra = top_level.get("extra")
+        if isinstance(extra, dict) and "rich_messages" in extra:
+            return _coerce_config_bool(extra.get("rich_messages"), False)
+    return False
+
+
+def _default_platform_hint(platform_key: str) -> str:
+    if platform_key == "telegram":
+        hint = TELEGRAM_MARKDOWNV2_HINT
+        if _telegram_rich_messages_enabled():
+            hint = f"{hint}\n\n{TELEGRAM_RICH_MARKDOWN_EXTENSION}"
+        return hint
+    return PLATFORM_HINTS.get(platform_key, "")
 
 
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
@@ -386,7 +436,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # any per-platform override from config (platform_hints.<platform>).
     _default_hint = ""
     if platform_key in PLATFORM_HINTS:
-        _default_hint = PLATFORM_HINTS[platform_key]
+        _default_hint = _default_platform_hint(platform_key)
     elif platform_key:
         # Check plugin registry for platform-specific LLM guidance
         try:

--- a/tests/agent/test_platform_hint_overrides.py
+++ b/tests/agent/test_platform_hint_overrides.py
@@ -8,7 +8,7 @@ platforms). See HA Core ticket: configurable per-platform prompt hints.
 
 import types
 
-from agent.system_prompt import _resolve_platform_hint
+from agent.system_prompt import _default_platform_hint, _resolve_platform_hint
 
 
 def _agent(overrides):
@@ -99,3 +99,38 @@ class TestResolvePlatformHint:
         """append on a platform with no default just yields the extra text."""
         a = _agent({"customplat": {"append": "Only this."}})
         assert _resolve_platform_hint(a, "customplat", "") == "Only this."
+
+
+class TestTelegramDefaultHint:
+    def test_default_telegram_hint_is_markdownv2_safe(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        out = _default_platform_hint("telegram")
+        lowered = out.lower()
+        assert "avoid rich-only" in lowered
+        assert "rich messages are enabled" not in lowered
+
+    def test_telegram_rich_messages_opt_in_appends_rich_hint(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "telegram:\n"
+            "  extra:\n"
+            "    rich_messages: true\n",
+            encoding="utf-8",
+        )
+        out = _default_platform_hint("telegram")
+        lowered = out.lower()
+        assert "avoid rich-only" in lowered
+        assert "rich messages are enabled" in lowered
+        assert "markdown tables" in lowered
+
+    def test_telegram_rich_messages_opt_in_via_platforms_section(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    extra:\n"
+            "      rich_messages: true\n",
+            encoding="utf-8",
+        )
+        out = _default_platform_hint("telegram")
+        assert "rich messages are enabled" in out.lower()

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -32,6 +32,7 @@ from agent.prompt_builder import (
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
+    TELEGRAM_RICH_MARKDOWN_EXTENSION,
     WSL_ENVIRONMENT_HINT,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
@@ -1086,22 +1087,27 @@ class TestPromptBuilderConstants:
         # check that this test is calibrated correctly).
         assert "include MEDIA:" in PLATFORM_HINTS["telegram"]
 
-    def test_telegram_hint_encourages_rich_markdown(self):
-        # Telegram Bot API 10.1 rich messages are default-on, so the hint must
-        # encourage native structured markdown instead of forbidding tables.
+    def test_telegram_hint_defaults_to_markdownv2_safe_formatting(self):
         hint = PLATFORM_HINTS["telegram"]
         lowered = hint.lower()
-        assert "Telegram has NO table syntax" not in hint
-        assert "rich markdown" in lowered
-        assert "table" in lowered
-        assert "task list" in lowered
-        assert "math" in lowered
-        # Hint should proactively steer toward structured formatting, not just
-        # permit it: bullet + numbered lists for scannable, structured output.
+        assert "rich markdown" not in lowered
+        assert "avoid rich-only" in lowered
+        assert "markdown tables" in lowered
+        assert "task lists" in lowered
+        assert "math/formulas" in lowered
+        # Legacy MarkdownV2-safe structured formatting should still be allowed.
         assert "bullet" in lowered
         assert "numbered" in lowered
         # Local media delivery guidance must remain intact.
         assert "include MEDIA:" in hint
+
+    def test_telegram_rich_markdown_extension_mentions_rich_constructs(self):
+        hint = TELEGRAM_RICH_MARKDOWN_EXTENSION
+        lowered = hint.lower()
+        assert "rich messages are enabled" in lowered
+        assert "markdown tables" in lowered
+        assert "task lists" in lowered
+        assert "math/formulas" in lowered
 
     def test_platform_hints_mattermost(self):
         hint = PLATFORM_HINTS["mattermost"]
@@ -1644,5 +1650,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram platform hint so the default system prompt only encourages MarkdownV2-safe formatting when Telegram rich messages are disabled, which is the default adapter path.

When `telegram.extra.rich_messages: true` or `platforms.telegram.extra.rich_messages: true` is configured, Hermes appends the rich Markdown encouragement for tables, task lists, math, details, and related constructs.

## Related Issue

Fixes #57122

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Changes

- Splits the Telegram platform hint into a MarkdownV2-safe base hint and a rich-message extension.
- Reads the merged config when building the platform hint and only appends the rich extension when `rich_messages` is enabled.
- Supports both the existing top-level `telegram.extra.rich_messages` shape and a normalized `platforms.telegram.extra.rich_messages` shape.
- Updates prompt-builder and platform-hint tests for default-safe and opt-in-rich behavior.

## How to Test

- [x] `.venv/bin/python -m pytest tests/agent/test_platform_hint_overrides.py tests/agent/test_prompt_builder.py -q`
- [x] `.venv/bin/python -m ruff check agent/prompt_builder.py agent/system_prompt.py tests/agent/test_platform_hint_overrides.py tests/agent/test_prompt_builder.py`
- [x] `scripts/run_tests.sh tests/agent/test_platform_hint_overrides.py tests/agent/test_prompt_builder.py -q`
- [ ] `pytest tests/ -q`

Platform: macOS, Python 3.13, local `.venv`.
