### PR TITLE
fix(tests): Windows-aware path-list split and UTF-8 progress output in parallel runner

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -32,7 +32,9 @@ Usage:
 
 Environment:
     HERMES_TEST_WORKERS  Override worker count (default: os.cpu_count())
-    HERMES_TEST_PATHS    Override discovery roots (colon-sep, default: 'tests')
+    HERMES_TEST_PATHS    Override discovery roots (colon-sep; on Windows
+                         ';' also works and drive letters are handled;
+                         default: 'tests')
 
 Exit code: 0 if every file's pytest exited 0; 1 otherwise.
 """
@@ -89,6 +91,41 @@ _DEFAULT_FILE_TIMEOUT_SECONDS = 300.0
 # wall-clock seconds. Used by ``--slice`` to distribute files across
 # CI jobs by estimated total time, so no one job gets all the slow files.
 _DURATIONS_FILE = "test_durations.json"
+
+
+def _split_pathspec(value: str) -> List[str]:
+    """Split a separator-joined path list (``--paths``/``--files``/
+    ``HERMES_TEST_PATHS``) into individual paths.
+
+    POSIX: ``:``-separated, as documented.
+
+    Windows: ``;`` (``os.pathsep``) and ``:`` are both accepted as
+    separators, but a ``:`` that forms a drive letter (``C:\\...`` or
+    ``C:/...``) stays glued to its path — a naive ``split(":")`` turns
+    ``C:\\repo\\tests`` into ``['C', '\\repo\\tests']``, where the bogus
+    ``C`` becomes a phantom discovery root and the rooted remainder only
+    resolves by accident of ``Path.__truediv__`` re-anchoring it onto
+    ``repo_root``'s drive.
+    """
+    if sys.platform != "win32":
+        return [p for p in value.split(":") if p.strip()]
+    parts: List[str] = []
+    for chunk in value.split(";"):
+        raw = chunk.split(":")
+        i = 0
+        while i < len(raw):
+            part = raw[i]
+            if (
+                len(part) == 1
+                and part.isalpha()
+                and i + 1 < len(raw)
+                and raw[i + 1][:1] in ("\\", "/")
+            ):
+                part = f"{part}:{raw[i + 1]}"
+                i += 1
+            parts.append(part)
+            i += 1
+    return [p for p in parts if p.strip()]
 
 
 def _approximately_count_tests(
@@ -592,6 +629,18 @@ def _slice_files(
 
 
 def main() -> int:
+    if sys.platform == "win32":
+        # When stdout/stderr are pipes (CI, subprocess capture, redirection),
+        # Windows defaults them to the legacy ANSI code page (e.g. cp1252),
+        # which cannot encode the ✓/✗ progress glyphs. The resulting
+        # UnicodeEncodeError fires inside the executor's done-callback, so
+        # per-file progress lines are silently swallowed. Force UTF-8.
+        for _stream in (sys.stdout, sys.stderr):
+            try:
+                _stream.reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, OSError):
+                pass
+
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -606,7 +655,11 @@ def main() -> int:
     parser.add_argument(
         "--paths",
         default=os.environ.get("HERMES_TEST_PATHS", ":".join(_DEFAULT_ROOTS)),
-        help="Colon-separated discovery roots (default: 'tests')",
+        help=(
+            "Colon-separated discovery roots (default: 'tests'). On "
+            "Windows, ';' also separates and drive letters (C:\\...) are "
+            "kept intact."
+        ),
     )
     parser.add_argument(
         "--include-integration",
@@ -652,9 +705,10 @@ def main() -> int:
         "--files",
         metavar="LIST",
         help=(
-            "Explicit colon-separated list of test files to run. Bypasses "
-            "discovery entirely — used by CI matrix jobs that receive their "
-            "file list from the generate job."
+            "Explicit colon-separated list of test files to run (on "
+            "Windows, ';' also separates and drive letters are kept "
+            "intact). Bypasses discovery entirely — used by CI matrix "
+            "jobs that receive their file list from the generate job."
         ),
     )
     parser.add_argument(
@@ -749,7 +803,7 @@ def main() -> int:
 
     # --files: explicit file list from the CI generate job — skip discovery.
     if args.files:
-        files = [repo_root / f for f in args.files.split(":") if f.strip()]
+        files = [repo_root / f for f in _split_pathspec(args.files)]
         roots = []
     else:
         # Resolve discovery roots: positional path args override --paths if any
@@ -757,7 +811,7 @@ def main() -> int:
         if args.paths_positional:
             roots = [repo_root / p for p in args.paths_positional]
         else:
-            roots = [repo_root / p for p in args.paths.split(":") if p]
+            roots = [repo_root / p for p in _split_pathspec(args.paths)]
 
         if args.include_integration:
             # Caller takes responsibility — typically used via explicit -k filter.

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -220,7 +220,11 @@ def _run_runner(probe_dir: Path, *extra: str) -> subprocess.CompletedProcess:
         cwd=repo_root,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        text=True,
+        # The runner emits UTF-8 (it reconfigures its own piped stdout on
+        # Windows, which would otherwise default to the ANSI code page and
+        # turn the ✓/✗ glyphs into mojibake on decode here).
+        encoding="utf-8",
+        errors="replace",
         timeout=60,
     )
 
@@ -271,9 +275,54 @@ def test_positional_path_not_treated_as_flag(tmp_path: Path) -> None:
         [sys.executable, str(runner), str(probe_dir), "-j", "1",
          "--file-timeout", "30", "-q"],
         cwd=repo_root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        text=True, timeout=60,
+        encoding="utf-8", errors="replace", timeout=60,
     )
     assert proc.returncode == 0, proc.stdout
     # Discovery found the probe file (2 tests), proving the positional path
     # was consumed as a root, not forwarded to pytest as a bad flag.
     assert "test_flagprobe.py" in proc.stdout, proc.stdout
+
+
+def test_multiple_absolute_paths_split_on_pathsep(tmp_path: Path) -> None:
+    """``--paths`` accepts ``os.pathsep``-joined absolute paths.
+
+    On Windows the absolute paths contain drive-letter colons, so a naive
+    ``split(":")`` shreds them into phantom roots and only one (or neither)
+    of the two probe dirs would be discovered.
+    """
+    dir_a = _make_probe_dir(tmp_path)
+    dir_b = tmp_path / "probe_b"
+    dir_b.mkdir()
+    (dir_b / "test_flagprobe_b.py").write_text(
+        "def test_gamma():\n    assert True\n"
+    )
+    repo_root = Path(__file__).resolve().parent.parent
+    runner = repo_root / "scripts" / "run_tests_parallel.py"
+    proc = subprocess.run(
+        [sys.executable, str(runner),
+         "--paths", os.pathsep.join([str(dir_a), str(dir_b)]),
+         "-j", "1", "--file-timeout", "30", "-q"],
+        cwd=repo_root, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        encoding="utf-8", errors="replace", timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout
+    assert "Discovered 2 test files" in proc.stdout, proc.stdout
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="drive-letter paths")
+def test_drive_letter_colon_is_not_a_path_separator(tmp_path: Path) -> None:
+    """An absolute ``--paths`` value stays one root on Windows.
+
+    The naive split used to produce a phantom relative root ``'C'`` (the
+    drive letter) alongside the real path; discovery only worked by the
+    accident of ``repo_root / '\\rooted\\rest'`` re-anchoring onto the
+    repo's drive.
+    """
+    probe_dir = _make_probe_dir(tmp_path)
+    proc = _run_runner(probe_dir, "-q")
+    assert proc.returncode == 0, proc.stdout
+    drive = str(probe_dir)[0]
+    assert f"['{drive}', " not in proc.stdout, (
+        f"drive letter split off as a phantom root:\n{proc.stdout}"
+    )
+    assert "Discovered 1 test files" in proc.stdout, proc.stdout


### PR DESCRIPTION
## What does this PR do?

Fixes two pre-existing Windows bugs in the parallel test runner (`scripts/run_tests_parallel.py`), both verified on `main` @ 30e947e0a on Windows 11:

1. **Drive-letter-safe path-list splitting.** `--files`, `--paths`, and `HERMES_TEST_PATHS` were split with a naive `.split(":")`, which shreds absolute Windows paths at the drive letter: `--paths C:\repo\tests` became `['C', '\repo\tests']`. The bogus `C` turned into a phantom discovery root (visible in the discovery banner), and the rooted remainder only resolved by accident of `WindowsPath.__truediv__` re-anchoring it onto `repo_root`'s drive — point it at another drive and discovery silently finds nothing. Two roots joined with `os.pathsep` (`;`) were shredded even worse. A new `_split_pathspec()` helper keeps `:` as the separator on POSIX and, on Windows, accepts both `;` (`os.pathsep`) and `:` while keeping drive-letter colons glued to their paths — so the `:`-joined repo-relative lists emitted by the CI generate job keep working unchanged on every platform.

2. **Per-file progress lines no longer vanish on piped Windows output** (this is what made `tests/test_run_tests_parallel.py::test_bare_value_flag_keeps_its_value` fail on win32). With stdout attached to a pipe (CI, subprocess capture, redirection), Windows encodes it with the legacy ANSI code page (cp1252), which cannot encode the `✓`/`✗` glyphs — every `_print_progress()` call raised `UnicodeEncodeError` inside the `ThreadPoolExecutor` done-callback, so all per-file progress lines were silently swallowed (with traceback spam on stderr). The failing test was a symptom: it asserts `"1✓" in stdout or "1 passed" in stdout`, but the `1✓` line never printed and the ASCII summary reads `1 tests passed`, which doesn't contain the substring `1 passed`. The runner now reconfigures its own stdout/stderr to UTF-8 (`errors="replace"`) on Windows at the top of `main()`, and the test helpers decode the captured output as UTF-8 explicitly so the glyphs round-trip instead of turning into mojibake.

The runner fix (not an assertion relaxation) was chosen for bug 2 because losing every per-file progress line under CI/redirection is a real product defect, not just a test-expectation mismatch.

## Related Issue

Fixes #57149

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/run_tests_parallel.py`
  - New `_split_pathspec()` — drive-letter-aware splitting for `--files` / `--paths` / `HERMES_TEST_PATHS`; both call sites switched to it; help text and module docstring updated.
  - `main()` reconfigures `sys.stdout`/`sys.stderr` to UTF-8 with `errors="replace"` on win32 (guarded, no-op elsewhere).
- `tests/test_run_tests_parallel.py`
  - `_run_runner()` and the inline `subprocess.run` capture the runner's output with `encoding="utf-8", errors="replace"` (previously locale-dependent `text=True`).
  - New regression test `test_multiple_absolute_paths_split_on_pathsep` (all platforms): two absolute roots joined with `os.pathsep` are both discovered.
  - New regression test `test_drive_letter_colon_is_not_a_path_separator` (win32-only): no phantom drive-letter root in the discovery banner.

## How to Test

1. On Windows, on `main` @ 30e947e0a: `python -m pytest tests/test_run_tests_parallel.py::test_bare_value_flag_keeps_its_value -x` → fails; the captured runner output shows the phantom `['C', 'C:\\...']` discovery root and a `UnicodeEncodeError` traceback from the progress callback.
2. On this branch: `python -m pytest tests/test_run_tests_parallel.py -q` → `6 passed, 1 skipped` (the skip is the POSIX-only zombie-cleanup verifier).
3. Manual: `python scripts/run_tests_parallel.py --paths C:\abs\path\to\tests -j 1 -q | more` → discovery banner shows a single intact root and the per-file `✓` progress line survives the pipe.
4. On POSIX nothing changes: `:`-joined lists (including CI's generate-job output) split exactly as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full `tests/test_run_tests_parallel.py` suite; runner also exercised end-to-end)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — runner docstring + `--paths`/`--files` help text
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — POSIX splitting behavior is byte-for-byte unchanged; UTF-8 reconfigure is win32-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (win32, piped stdout):

```
Discovered 1 test files (~2 tests) under ['C', 'C:\\Users\\...\\probe']; running with -j 1
exception calling callback for <Future at 0x25e25b00850 state=finished returned tuple>
  ...
  File "scripts\run_tests_parallel.py", line 437, in _print_progress
    print(msg, flush=True)
UnicodeEncodeError: 'charmap' codec can't encode character '✓' in position 21: character maps to <undefined>
=== Summary: 1 files, 1 tests passed, 0 failed (100% complete) in 2.4s (1 workers) ===
```

After (win32, piped stdout):

```
Discovered 1 test files (~11 tests) under ['tests\\test_run_tests_parallel.py']; running with -j 1
[100.0% |    11/~11 | ✓1 | ✗0] ✓ tests\test_run_tests_parallel.py (1✓, 22.9s)
=== Summary: 1 files, 1 tests passed, 0 failed (100% complete) in 22.9s (1 workers) ===
```

```
$ python -m pytest tests/test_run_tests_parallel.py -q
6 passed, 1 skipped in 69.75s (0:01:09)
```
