### PR TITLE
fix(doctor): recognize vertex provider config

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -754,6 +754,11 @@ def run_doctor(args):
                 _resolve_auth_provider = None
                 pass
             try:
+                from hermes_cli.models import _KNOWN_PROVIDER_NAMES as _MODEL_KNOWN_PROVIDER_NAMES
+                known_providers.update(_MODEL_KNOWN_PROVIDER_NAMES)
+            except Exception:
+                pass
+            try:
                 from hermes_cli.config import get_compatible_custom_providers as _compatible_custom_providers
                 from hermes_cli.providers import (
                     normalize_provider as _normalize_catalog_provider,
@@ -814,10 +819,8 @@ def run_doctor(args):
                     provider_ids_to_accept.add(catalog_provider)
 
             if provider and provider != "auto":
-                if catalog_provider is None or (
-                    known_providers
-                    and not (provider_ids_to_accept & valid_provider_ids)
-                ):
+                known_match = bool(provider_ids_to_accept & valid_provider_ids)
+                if not known_match and catalog_provider is None:
                     known_list = ", ".join(sorted(known_providers)) if known_providers else "(unavailable)"
                     _fail_and_issue(
                         f"model.provider '{provider_raw}' is not a recognised provider",
@@ -845,6 +848,7 @@ def run_doctor(args):
                 "lmstudio",
                 "nous",
                 "nvidia",
+                "vertex",
             }
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -517,6 +517,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("kilocode", "anthropic/claude-sonnet-4.6"),
         ("kimi-coding", "kimi-k2"),
         ("nvidia", "qwen/qwen3.5-122b-a10b"),
+        ("vertex", "google/gemini-3-flash-preview"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
@@ -557,7 +558,7 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
     out = buf.getvalue()
     assert f"model.provider '{provider}' is not a recognised provider" not in out
     assert f"model.provider '{provider}' is unknown" not in out
-    if provider in {"opencode-zen", "kilocode", "nvidia"}:
+    if provider in {"opencode-zen", "kilocode", "nvidia", "vertex"}:
         assert (
             f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider}'"
             not in out


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes doctor` diagnostics for the Vertex provider. Doctor now recognizes provider IDs from the model/provider catalog in addition to API-key auth providers, so `model.provider: vertex` is not reported as unknown.

It also allows Vertex's recommended `google/gemini-*` model IDs through the vendor-slug check, matching the Vertex setup flow and runtime path.

## Related Issue

Fixes #56906

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Changes

- Extends doctor provider validation with `hermes_cli.models._KNOWN_PROVIDER_NAMES`.
- Treats catalog-known provider IDs as valid even when `resolve_provider_full()` has no catalog object for them.
- Adds `vertex` to the vendor-slug-accepting provider policy.
- Adds a regression case for `provider: vertex` with `default: google/gemini-3-flash-preview`.

## How to Test

- [x] `.venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -q -k "provider_ids_that_catalog_aliases or vertex"`
- [x] `.venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -q`
- [x] `.venv/bin/python -m ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q`
- [ ] `pytest tests/ -q`

Platform: macOS, Python 3.13, local `.venv`.
