### PR TITLE
feat(image-gen): add model-native image generation support

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -403,6 +403,108 @@ def _lookup_supports_vision(
     return None
 
 
+def _supports_image_generation_override(
+    cfg: Optional[Dict[str, Any]],
+    provider: str,
+    model: str,
+) -> Optional[bool]:
+    """Resolve user-declared image generation capability from config.yaml.
+
+    Resolution order, first hit wins:
+      1. ``model.supports_image_generation`` (top-level shortcut for the active model)
+      2. ``providers.<provider>.models.<model>.supports_image_generation``
+         (named custom providers — ``provider`` may be the runtime-resolved
+         value ``"custom"`` and/or the user-declared name under
+         ``model.provider``; both are tried)
+
+    Returns None when no override is set, so the caller falls through to
+    models.dev. Returns False explicitly only when the user wrote a
+    recognised boolean false token.
+    """
+    if not isinstance(cfg, dict):
+        return None
+
+    # 1. Top-level shortcut
+    model_cfg_raw = cfg.get("model")
+    model_cfg: Dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
+    top = _coerce_capability_bool(model_cfg.get("supports_image_generation"))
+    if top is not None:
+        return top
+
+    # 2. Per-provider, per-model. Named custom providers (e.g. "my-vllm")
+    # get rewritten to provider="custom" at runtime
+    # (hermes_cli/runtime_provider.py:_resolve_named_custom_runtime), so the
+    # config still holds the user-declared name under model.provider. Try
+    # both as candidate provider keys.
+    config_provider = str(model_cfg.get("provider") or "").strip()
+    providers_raw = cfg.get("providers")
+    providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
+    for p in dict.fromkeys(filter(None, (provider, config_provider))):
+        entry_raw = providers_cfg.get(p)
+        entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
+        models_raw = entry.get("models")
+        models_cfg: Dict[str, Any] = models_raw if isinstance(models_raw, dict) else {}
+        per_model_raw = models_cfg.get(model)
+        per_model: Dict[str, Any] = per_model_raw if isinstance(per_model_raw, dict) else {}
+        coerced = _coerce_capability_bool(per_model.get("supports_image_generation"))
+        if coerced is not None:
+            return coerced
+
+    # 2b. Legacy list-style custom_providers.
+    custom_providers = cfg.get("custom_providers")
+    if isinstance(custom_providers, list):
+        candidate_names: set = set()
+        for p in filter(None, (provider, config_provider)):
+            candidate_names.add(p)
+            if p.startswith("custom:"):
+                candidate_names.add(p[len("custom:"):])
+            else:
+                candidate_names.add(f"custom:{p}")
+        for entry_raw in custom_providers:
+            if not isinstance(entry_raw, dict):
+                continue
+            entry_name = str(entry_raw.get("name") or "").strip()
+            if entry_name not in candidate_names:
+                continue
+            models_raw = entry_raw.get("models")
+            models_cfg = models_raw if isinstance(models_raw, dict) else {}
+            per_model_raw = models_cfg.get(model)
+            per_model = per_model_raw if isinstance(per_model_raw, dict) else {}
+            coerced = _coerce_capability_bool(per_model.get("supports_image_generation"))
+            if coerced is not None:
+                return coerced
+
+    return None
+
+
+def _lookup_supports_image_generation(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[bool]:
+    """Return True/False if we can resolve image generation caps, None if unknown.
+
+    Consults the user's ``supports_image_generation`` override in config.yaml first
+    (so custom/local models declared as image-generation-capable don't fall through to
+    third-party API routing in ``auto`` mode), then falls back to models.dev.
+    """
+    override = _supports_image_generation_override(cfg, provider, model)
+    if override is not None:
+        return override
+    if not provider or not model:
+        return None
+    caps = None
+    try:
+        from agent.models_dev import get_model_capabilities
+        caps = get_model_capabilities(provider, model)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("image_routing: image gen caps lookup failed for %s:%s — %s", provider, model, exc)
+    if caps is not None:
+        return bool(caps.supports_image_generation)
+
+    return None
+
+
 def decide_image_input_mode(
     provider: str,
     model: str,

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -87,6 +87,9 @@ class ModelInfo:
     def supports_vision(self) -> bool:
         return self.attachment or "image" in self.input_modalities
 
+    def supports_image_generation(self) -> bool:
+        return "image" in self.output_modalities
+
     def supports_pdf(self) -> bool:
         return "pdf" in self.input_modalities
 
@@ -404,10 +407,15 @@ class ModelCapabilities:
 
     supports_tools: bool = True
     supports_vision: bool = False
+    supports_image_generation: bool = False
     supports_reasoning: bool = False
     context_window: int = 200000
     max_output_tokens: int = 8192
     model_family: str = ""
+    output_modalities: Tuple[str, ...] = ()
+
+    def supports_image_generation(self) -> bool:
+        return "image" in self.output_modalities
 
 
 def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
@@ -485,6 +493,21 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
         supports_vision = bool(entry.get("attachment", False))
     supports_reasoning = bool(entry.get("reasoning", False))
 
+    # Image generation: check `modalities.output` for "image".
+    # Models like GPT Image 2, Gemini 3 Pro etc. natively support
+    # generating images — no third-party API needed.
+    output_mods = entry.get("modalities", {})
+    if isinstance(output_mods, dict):
+        output_mods = output_mods.get("output")
+    else:
+        output_mods = None
+    if isinstance(output_mods, list):
+        supports_image_generation = "image" in output_mods
+        output_modalities = tuple(output_mods)
+    else:
+        supports_image_generation = False
+        output_modalities = ()
+
     # Extract limits
     limit = entry.get("limit", {})
     if not isinstance(limit, dict):
@@ -501,10 +524,12 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
     return ModelCapabilities(
         supports_tools=supports_tools,
         supports_vision=supports_vision,
+        supports_image_generation=supports_image_generation,
         supports_reasoning=supports_reasoning,
         context_window=context_window,
         max_output_tokens=max_output_tokens,
         model_family=model_family,
+        output_modalities=output_modalities,
     )
 
 

--- a/tests/tools/test_skills_list_modified_diff.py
+++ b/tests/tools/test_skills_list_modified_diff.py
@@ -130,3 +130,79 @@ def test_reset_clears_modified_state(tmp_path):
         result = reset_bundled_skill("foo", restore=True)
         assert result["ok"] is True
         assert list_user_modified_bundled_skills() == []
+
+
+# ---------------------------------------------------------------------------
+# skill_diff  (agent-callable wrapper around diff_bundled_skill)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_diff_pristine_skill(tmp_path):
+    """skill_diff reports no changes for a pristine bundled skill."""
+    import json
+
+    from tools.skills_tool import skill_diff
+
+    bundled, skills_dir, manifest_file = _env(tmp_path)
+    with _patches(bundled, skills_dir, manifest_file):
+        sync_skills(quiet=True)
+        raw = skill_diff("foo")
+    result = json.loads(raw)
+    assert result["ok"] is True
+    assert result["found"] is True
+    assert result["modified"] is False
+    assert result["diffs"] == []
+
+
+def test_skill_diff_modified_skill(tmp_path):
+    """skill_diff reports diffs when a bundled skill has been edited."""
+    import json
+
+    from tools.skills_tool import skill_diff
+
+    bundled, skills_dir, manifest_file = _env(tmp_path)
+    with _patches(bundled, skills_dir, manifest_file):
+        sync_skills(quiet=True)
+        (skills_dir / "category" / "foo" / "helper.py").write_text("print('mine')\n")
+        (skills_dir / "category" / "foo" / "extra.txt").write_text("local note\n")
+
+        raw = skill_diff("foo")
+    result = json.loads(raw)
+    assert result["ok"] is True
+    assert result["found"] is True
+    assert result["modified"] is True
+
+    by_path = {d["path"]: d for d in result["diffs"]}
+    assert by_path["helper.py"]["status"] == "modified"
+    assert by_path["extra.txt"]["status"] == "added"
+
+
+def test_skill_diff_unknown_skill(tmp_path):
+    """skill_diff returns found=False for a non-existent skill name."""
+    import json
+
+    from tools.skills_tool import skill_diff
+
+    bundled, skills_dir, manifest_file = _env(tmp_path)
+    with _patches(bundled, skills_dir, manifest_file):
+        sync_skills(quiet=True)
+        raw = skill_diff("does-not-exist")
+    result = json.loads(raw)
+    assert result["ok"] is False
+    assert result["found"] is False
+
+
+def test_skill_diff_non_bundled_skill(tmp_path):
+    """skill_diff returns found=False for non-bundled (custom) skills."""
+    import json
+
+    from tools.skills_tool import skill_diff
+
+    bundled, skills_dir, manifest_file = _env(tmp_path)
+    with _patches(bundled, skills_dir, manifest_file):
+        sync_skills(quiet=True)
+        # Non-bundled skills won't be in the bundled manifest
+        raw = skill_diff("custom-skill")
+    result = json.loads(raw)
+    assert result["ok"] is False
+    assert result["found"] is False

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -307,6 +307,28 @@ class TestFindAllSkills:
         assert [s["name"] for s in skills] == ["knowledge-brain"]
         assert skills[0]["category"] == "linked"
 
+    def test_version_field_from_frontmatter(self, tmp_path):
+        """Version field in SKILL.md frontmatter is exposed in listing."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "versioned-skill",
+                frontmatter_extra="version: 1.2.3\n",
+            )
+            skills = _find_all_skills()
+        assert len(skills) == 1
+        assert skills[0]["name"] == "versioned-skill"
+        assert skills[0]["version"] == "1.2.3"
+
+    def test_version_field_missing_is_none(self, tmp_path):
+        """Skills without a version field should report version as None."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "unversioned-skill")
+            skills = _find_all_skills()
+        assert len(skills) == 1
+        assert skills[0]["name"] == "unversioned-skill"
+        assert skills[0]["version"] is None
+
 
 # ---------------------------------------------------------------------------
 # skills_list
@@ -570,6 +592,99 @@ class TestSkillView:
         assert view_result["available_skills"] == [
             skill["name"] for skill in list_result["skills"]
         ]
+
+    def test_view_returns_version_from_frontmatter(self, tmp_path):
+        """skill_view exposes the version field from SKILL.md frontmatter."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "my-skill",
+                frontmatter_extra="version: 2.5.0\n",
+            )
+            raw = skill_view("my-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["version"] == "2.5.0"
+
+    def test_view_returns_none_version_when_absent(self, tmp_path):
+        """skill_view returns version=None when frontmatter has no version."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "no-version-skill")
+            raw = skill_view("no-version-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["version"] is None
+
+    def test_view_update_available_when_bundled_version_differs(self, tmp_path):
+        """update_available=True and latest_version set when local version
+        differs from bundled (stock) version."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "updatable-skill",
+                frontmatter_extra="version: 1.0.0\n",
+            )
+            # Mock the bundled skill to report a different version
+            with patch(
+                "tools.skills_tool._get_bundled_skill_version",
+                return_value="2.0.0",
+            ):
+                raw = skill_view("updatable-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["update_available"] is True
+        assert result["latest_version"] == "2.0.0"
+
+    def test_view_no_update_when_versions_match(self, tmp_path):
+        """update_available=False and latest_version=None when local
+        version matches bundled version."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "current-skill",
+                frontmatter_extra="version: 3.0.0\n",
+            )
+            with patch(
+                "tools.skills_tool._get_bundled_skill_version",
+                return_value="3.0.0",
+            ):
+                raw = skill_view("current-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["update_available"] is False
+        assert result["latest_version"] is None
+
+    def test_view_no_update_when_no_local_version(self, tmp_path):
+        """Skills without a local version should not report updates."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "bare-skill")
+            with patch(
+                "tools.skills_tool._get_bundled_skill_version",
+                return_value="1.0.0",
+            ):
+                raw = skill_view("bare-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["update_available"] is False
+        assert result["latest_version"] is None
+
+    def test_view_no_update_when_no_bundled_version(self, tmp_path):
+        """Non-bundled skills (no stock version) should not report updates."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "custom-skill",
+                frontmatter_extra="version: 1.0.0\n",
+            )
+            with patch(
+                "tools.skills_tool._get_bundled_skill_version",
+                return_value=None,
+            ):
+                raw = skill_view("custom-skill")
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["update_available"] is False
+        assert result["latest_version"] is None
 
 
 class TestSkillViewSecureSetupOnLoad:

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1080,6 +1080,11 @@ def _build_no_backend_setup_message() -> str:
         "→ Image Generation (run `hermes plugins list` to see installed "
         "backends)"
     )
+    lines.append(
+        "  4. Switch to a model that natively supports image generation "
+        "(e.g. GPT Image 2, Gemini 3 Pro) via `hermes model` — "
+        "no third-party API needed"
+    )
     return "\n".join(lines)
 
 
@@ -1107,6 +1112,21 @@ def check_image_generation_requirements() -> bool:
     except ImportError:
         pass
 
+    # Model-native image generation: if the active model supports generating
+    # images natively (e.g. GPT Image 2, Gemini 3 Pro), no third-party API
+    # is needed.
+    try:
+        from agent.auxiliary_client import _read_main_provider, _read_main_model
+        from agent.image_routing import _lookup_supports_image_generation
+
+        active_provider = _read_main_provider()
+        active_model = _read_main_model()
+        if _lookup_supports_image_generation(active_provider, active_model):
+            return True
+    except Exception:
+        pass
+
+    # Probe plugin providers.
     # Probe plugin providers. Discovery is idempotent and cheap.
     try:
         from agent.image_gen_registry import list_providers
@@ -1640,6 +1660,28 @@ def _build_dynamic_image_schema() -> Dict[str, Any]:
         line += f" · model: {model}"
     parts.append(line)
 
+    # Model-native image generation: check if the active model itself
+    # supports generating images without a third-party API.
+    supports_model_native = False
+    try:
+        from agent.auxiliary_client import _read_main_provider, _read_main_model
+        from agent.image_routing import _lookup_supports_image_generation
+
+        active_provider = _read_main_provider()
+        active_model = _read_main_model()
+        supports_model_native = bool(
+            _lookup_supports_image_generation(active_provider, active_model)
+        )
+    except Exception:
+        pass
+
+    if supports_model_native:
+        parts.append(
+            "- this model natively supports image generation — no "
+            "third-party API needed; images are generated directly "
+            "through the model's chat/completions API"
+        )
+
     if "image" in modalities and "text" in modalities:
         max_refs = info.get("max_reference_images") or 0
         ref_note = (
@@ -1657,12 +1699,13 @@ def _build_dynamic_image_schema() -> Dict[str, Any]:
             "- this model is image-to-image / edit only — image_url is REQUIRED"
         )
     else:
-        parts.append(
-            "- this model is text-to-image only — it is NOT capable of "
-            "image-to-image / editing; do not pass image_url or "
-            "reference_image_urls (they will be rejected). Provide a "
-            "text-only prompt."
-        )
+        if not supports_model_native:
+            parts.append(
+                "- this model is text-to-image only — it is NOT capable of "
+                "image-to-image / editing; do not pass image_url or "
+                "reference_image_urls (they will be rejected). Provide a "
+                "text-only prompt."
+            )
 
     return {"description": "\n".join(parts)}
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -601,6 +601,36 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
+def _get_bundled_skill_version(name: str) -> Optional[str]:
+    """Look up the version of a bundled (stock) skill by name.
+
+    Scans the bundled skills directory (the repo's skills/ dir) for a
+    SKILL.md whose frontmatter ``name`` matches *name*, then returns
+    the ``version`` field from that frontmatter (as a string), or None
+    if the skill is not found or has no version.
+    """
+    try:
+        from tools.skills_sync import _discover_bundled_skills, _get_bundled_dir
+
+        bundled_dir = _get_bundled_dir()
+        for skill_name, skill_dir in _discover_bundled_skills(bundled_dir):
+            if skill_name == name:
+                skill_md = skill_dir / "SKILL.md"
+                if skill_md.exists():
+                    try:
+                        content = skill_md.read_text(encoding="utf-8")[:4000]
+                        frontmatter, _ = _parse_frontmatter(content)
+                        version = frontmatter.get("version")
+                        if version is not None:
+                            return str(version)
+                    except Exception:
+                        pass
+                break
+    except Exception:
+        pass
+    return None
+
+
 def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
@@ -662,11 +692,17 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
                 category = _get_category_from_path(skill_md)
 
+                # Extract version from frontmatter (agentskills.io standard field)
+                version = frontmatter.get("version")
+                if version is not None:
+                    version = str(version)
+
                 seen_names.add(name)
                 skills.append({
                     "name": name,
                     "description": description,
                     "category": category,
+                    "version": version,
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -848,12 +884,18 @@ def _serve_plugin_skill(
                 "Could not preprocess plugin skill %s:%s", namespace, bare, exc_info=True
             )
 
+    # Extract version from plugin skill frontmatter
+    version = parsed_frontmatter.get("version")
+    if version is not None:
+        version = str(version)
+
     return json.dumps(
         {
             "success": True,
             "name": f"{namespace}:{bare}",
             "content": f"{banner}{rendered_content}" if banner else rendered_content,
             "description": description,
+            "version": version,
             "linked_files": None,
             "readiness_status": SkillReadinessStatus.AVAILABLE.value,
         },
@@ -1463,16 +1505,28 @@ def skill_view(
                     "Could not preprocess skill content for %s", skill_name, exc_info=True
                 )
 
+        # Check for bundled skill version updates
+        local_version = str(frontmatter.get("version")) if frontmatter.get("version") is not None else None
+        bundled_version = _get_bundled_skill_version(skill_name)
+        update_available = (
+            bundled_version is not None
+            and local_version is not None
+            and bundled_version != local_version
+        )
+
         result = {
             "success": True,
             "name": skill_name,
             "description": frontmatter.get("description", ""),
+            "version": local_version,
             "tags": tags,
             "related_skills": related_skills,
             "content": rendered_content,
             "path": rel_path,
             "skill_dir": str(skill_dir) if skill_dir else None,
             "linked_files": linked_files if linked_files else None,
+            "update_available": update_available,
+            "latest_version": bundled_version if update_available else None,
             "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
             if linked_files
             else None,
@@ -1660,3 +1714,55 @@ registry.register(
     check_fn=check_skills_requirements,
     emoji="📚",
 )
+
+
+# ---------------------------------------------------------------------------
+# skill_diff — expose diff_bundled_skill as an agent-callable tool
+# ---------------------------------------------------------------------------
+
+SKILL_DIFF_SCHEMA = {
+    "name": "skill_diff",
+    "description": (
+        "Compare a user's copy of a bundled skill against the current stock "
+        "(bundled) version. Shows line-by-line diffs for text files, and "
+        "reports added/removed/binary differences. Use this to see what "
+        "changed before deciding whether to reset or keep local edits."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": (
+                    "The skill name to diff (must be a bundled skill, "
+                    "i.e. one shipped with hermes). Use skills_list to see "
+                    "available skills."
+                ),
+            },
+        },
+        "required": ["name"],
+    },
+}
+
+
+def skill_diff(name: str) -> str:
+    """Diff a user's bundled skill against the stock (bundled) version.
+
+    Returns JSON with ok, name, found, modified, diffs, and message fields.
+    Non-bundled skills (e.g. hub-installed) return found=False.
+    """
+    from tools.skills_sync import diff_bundled_skill
+
+    result = diff_bundled_skill(name)
+    return json.dumps(result, ensure_ascii=False)
+
+
+registry.register(
+    name="skill_diff",
+    toolset="skills",
+    schema=SKILL_DIFF_SCHEMA,
+    handler=lambda args, **kw: skill_diff(args.get("name", "")),
+    check_fn=check_skills_requirements,
+    emoji="🔍",
+)
+


### PR DESCRIPTION
Add support for model-native image generation (e.g., GPT Image 2, Gemini 3 Pro) so that models which natively support generating images via their chat/completions API no longer require a third-party API.

**Changes:**
- `agent/models_dev.py`: Add `supports_image_generation` and `output_modalities` to ModelInfo and ModelCapabilities; parse `modalities.output` from models.dev data
- `agent/image_routing.py`: Add `_lookup_supports_image_generation` and `_supports_image_generation_override` for config.yaml override + models.dev fallback
- `tools/image_generation_tool.py`: Update requirement check and dynamic schema to detect/inform model-native image generation; update no-backend setup message