### PR TITLE
Add WorkorAI to the optional-mcps catalog

### DIFF
--- a/optional-mcps/workorai/manifest.yaml
+++ b/optional-mcps/workorai/manifest.yaml
@@ -1,0 +1,62 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: workorai
+description: "WorkorAI talent marketplace MCP: candidate job search and employer hiring with explainable matching."
+source: https://github.com/work0r-ai/agent-kit
+
+# WorkorAI is a remote Streamable HTTP MCP server (MIT-licensed; also
+# published on the official MCP Registry as io.github.work0r-ai/workorai).
+# Nothing to install locally — Hermes's MCP client connects to the URL.
+transport:
+  type: http
+  url: https://workorai.com/mcp
+
+# The server accepts anonymous connections, but the anonymous tool surface
+# is a single onboarding tool (`request_access`). The full candidate/employer
+# toolset (~28 tools) is exposed only with a per-user API key sent as an
+# Authorization bearer header. Users obtain keys at https://workorai.com.
+#
+# The key is optional at install time: skipping it still installs a working
+# (onboarding-only) entry. Note that manifest v1 has no way to declare
+# request headers, so entering a key here stores it in ~/.hermes/.env and
+# the Authorization header is a documented one-line follow-up in
+# post_install (runtime `${VAR}` substitution in `headers` picks the value
+# up from .env).
+auth:
+  type: api_key
+  env:
+    - name: WORKORAI_MCP_API_KEY
+      prompt: "WorkorAI API key (optional — press Enter to skip; get one at https://workorai.com)"
+      required: false
+      secret: true
+
+# Tool selection at install time:
+# The install-time probe runs unauthenticated, so it only sees
+# `request_access`. Declaring the authenticated tool names in
+# `tools.default_enabled` would be useless here — the checklist drops names
+# the probe didn't return. Leave it unset; once the Authorization header is
+# configured (see post_install), re-run `hermes mcp configure workorai` to
+# see the full list and prune. The employer tools include real mutations
+# (create/publish/close/delete job posts, invite candidates, set review
+# status) and the candidate tools can apply to / withdraw from jobs — prune
+# per your threat model.
+
+post_install: |
+  Without an API key the server exposes a single onboarding tool
+  (request_access). To use the full candidate/employer toolset:
+
+    1. Get a per-user API key at https://workorai.com (or via the
+       request_access tool).
+    2. Make sure it is stored in ~/.hermes/.env as WORKORAI_MCP_API_KEY
+       (the install prompt already did this if you entered the key).
+    3. Add the auth header to mcp_servers.workorai in ~/.hermes/config.yaml:
+
+         headers:
+           Authorization: "Bearer ${WORKORAI_MCP_API_KEY}"
+
+    4. Re-run `hermes mcp configure workorai` to re-probe the authenticated
+       tool list and prune the mutating tools you don't want.
+
+  Start a new Hermes session to load the tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,6 +334,7 @@ locales = ["locales/*.yaml"]
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
+"optional-mcps/workorai" = ["optional-mcps/workorai/manifest.yaml"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]


### PR DESCRIPTION
Adds `optional-mcps/workorai/manifest.yaml` so the WorkorAI MCP server is installable via `hermes mcp install workorai`.

**What it is:** WorkorAI talent marketplace MCP — candidate job search and employer hiring with explainable matching. Remote Streamable HTTP endpoint at `https://workorai.com/mcp`, no local process. Canonical repo: https://github.com/work0r-ai/agent-kit (MIT); also on the official MCP Registry as `io.github.work0r-ai/workorai` (v0.4.3).

**Manifest decisions** (schema v1, following the linear/n8n/unreal-engine patterns):
- `auth: api_key` with a single optional (`required: false`) env var `WORKORAI_MCP_API_KEY`. The server accepts anonymous connections but then exposes only a `request_access` onboarding tool; the full candidate/employer toolset needs a per-user Authorization bearer key (obtained at https://workorai.com). Since manifest v1 has no headers field, `post_install` documents the one-line `headers:` block that the runtime's `${VAR}` substitution resolves from `~/.hermes/.env`.
- `tools.default_enabled` intentionally unset: the install-time probe runs unauthenticated, so declaring authenticated tool names would just be dropped from the checklist. `post_install` points users at `hermes mcp configure workorai` after auth to prune mutating tools (job create/publish/delete, applications, invitations).

**Verified:**
- Live endpoint: anonymous `initialize` + `tools/list` against `https://workorai.com/mcp` (200, `text/event-stream`, returns `request_access`).
- Manifest parses cleanly with `hermes_cli.mcp_catalog._parse_manifest` (the `TestShippedCatalog` contract).

Disclosure: I'm affiliated with WorkorAI. Happy to adjust the entry to whatever the catalog policy prefers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)