### PR TITLE
fix(tui): reset terminal modes before Ink unmount to prevent kitty keyboard leak (#56759)

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -28,6 +28,7 @@ import { createResizeCoalescer } from '../lib/resizeCoalescer.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
 import { buildToolTrailLine, formatAbandonedClarify, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
+import { resetTerminalModes } from '../lib/terminalModes.js'
 import { estimatedMsgHeight, messageHeightKey } from '../lib/virtualHeights.js'
 import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
@@ -476,6 +477,15 @@ export function useMainApp(gw: GatewayClient) {
   const gateway = useMemo(() => ({ gw, rpc }), [gw, rpc])
 
   const die = useCallback(() => {
+    // Reset terminal modes BEFORE Ink's exit()/unmount to prevent a race:
+    // unmount may trigger a final reassert (POP+PUSH kitty keyboard) via
+    // stdout.write (async/buffered), and if process.exit fires the
+    // process.on('exit') handler before that buffer flushes, the PUSH lands
+    // AFTER our POP, leaving the terminal in kitty keyboard mode.
+    // Calling resetTerminalModes() here (with writeSync) guarantees the
+    // reset escape sequences are flushed to the terminal while we still
+    // control the event loop.  See #56759.
+    resetTerminalModes()
     gw.kill('app.die')
     exit()
     // Ink's exit() calls unmount() which resets terminal modes but does NOT
@@ -489,6 +499,7 @@ export function useMainApp(gw: GatewayClient) {
 
   const dieWithCode = useCallback(
     (code: number) => {
+      resetTerminalModes()
       gw.kill(`app.dieWithCode:${code}`)
       exit()
       process.exit(code)


### PR DESCRIPTION
## Problem

On `/quit`, the TUI leaves the terminal in a corrupted state where the kitty keyboard protocol remains active. Subsequent programs (e.g. `nano`) receive raw escape fragments like `0;133u` as literal text input.

**Root cause:** `die()` calls `exit()` (Ink unmount) then `process.exit(0)`. Ink's unmount can trigger a final reassert cycle that writes `DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD` via `stdout.write()` (async/buffered). When `process.exit()` fires the `process.on('exit')` handler, `writeSync` sends the POP sequence, but the buffered PUSH from the reassert hasn't flushed yet. After the process terminates, the kernel flushes all remaining buffers — the PUSH lands **after** the POP, leaving the terminal in kitty keyboard mode.

## Fix

Call `resetTerminalModes()` (via `writeSync`) **before** `exit()` in both `die()` and `dieWithCode()`, guaranteeing the reset escape sequences are flushed to the terminal while we still control the event loop.

This is safe because `resetTerminalModes()` is idempotent — the `process.on('exit')` handler will call it again on process termination, which is a harmless no-op.

Fixes #56759
