### PR TITLE
fix(prompt-size): honor effective Hermes toolsets

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -25,12 +25,31 @@ def _bytes(s: str) -> int:
     return len(s.encode("utf-8"))
 
 
+def _resolve_inspection_toolsets(cfg: Dict[str, Any], platform: str) -> List[str]:
+    """Resolve toolsets the inspected fresh session would receive."""
+    from hermes_cli.tools_config import _get_platform_tools
+
+    platform_key = (platform or "cli").lower().strip()
+    if platform_key in {"tui", "desktop", "gui"}:
+        try:
+            from agent.coding_context import coding_selection
+
+            coding_toolsets = coding_selection(platform="tui", config=cfg)
+        except Exception:
+            coding_toolsets = None
+        if coding_toolsets is not None:
+            return sorted({*coding_toolsets, "project"})
+        return sorted(_get_platform_tools(cfg, "cli") | {"project"})
+    return sorted(_get_platform_tools(cfg, platform_key))
+
+
 def _build_inspection_agent(platform: str) -> Any:
     """Construct an offline AIAgent for prompt inspection.
 
     Dummy ``api_key`` + ``base_url`` force the direct-construction path in
-    ``run_agent.py`` (no provider auto-detection, no network). Toolsets and
-    platform come from the caller so the breakdown matches a real session.
+    ``run_agent.py`` (no provider auto-detection, no network). Toolsets are
+    resolved through the same per-platform runtime path used by real sessions
+    so the breakdown matches what ships on the wire.
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
@@ -38,6 +57,8 @@ def _build_inspection_agent(platform: str) -> Any:
     cfg = load_config()
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
+    platform_key = (platform or "cli").lower().strip()
+    enabled_toolsets = _resolve_inspection_toolsets(cfg, platform_key)
 
     return AIAgent(
         model=model,
@@ -45,7 +66,8 @@ def _build_inspection_agent(platform: str) -> Any:
         base_url="https://openrouter.ai/api/v1",
         quiet_mode=True,
         save_trajectories=False,
-        platform=platform,
+        enabled_toolsets=enabled_toolsets,
+        platform=platform_key,
     )
 
 

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -70,6 +70,32 @@ def test_runs_offline_without_credentials(isolated_home, monkeypatch):
     assert data["system_prompt"]["bytes"] > 0
 
 
+def test_tool_schema_count_honors_platform_tool_config(isolated_home):
+    """``prompt-size`` must measure the same lean toolset a fresh session uses."""
+    config = isolated_home / "config.yaml"
+    config.write_text(
+        "platform_toolsets:\n"
+        "  cli:\n"
+        "    - file\n",
+        encoding="utf-8",
+    )
+    data = compute_prompt_breakdown("cli")
+    assert data["tools"]["count"] == 4
+
+
+def test_desktop_prompt_size_uses_cli_tool_config_plus_project_tools(isolated_home):
+    """Desktop/TUI sessions resolve via CLI tool config plus project controls."""
+    config = isolated_home / "config.yaml"
+    config.write_text(
+        "platform_toolsets:\n"
+        "  cli:\n"
+        "    - file\n",
+        encoding="utf-8",
+    )
+    data = compute_prompt_breakdown("desktop")
+    assert data["tools"]["count"] == 7
+
+
 def test_skills_index_reflects_installed_skills(isolated_home):
     """Installing a skill makes the skills-index block non-empty.
 


### PR DESCRIPTION
## Summary
- Make `hermes prompt-size` build its offline inspection agent with the same effective toolsets used by real sessions.
- Honor configured CLI toolsets and mirror TUI/Desktop runtime behavior by including the project toolset over the configured CLI profile.
- Add regressions for lean CLI tool config and Desktop/TUI project-tool behavior.

## Validation
- `venv/Scripts/python.exe -m pytest tests/hermes_cli/test_prompt_size.py -q -n 0` → `9 passed`
- Re-ran in isolated branch after rebasing onto current `origin/main`: `9 passed in 12.87s`
- Verified prompt-size output from the local install reports lean schemas instead of broad default schemas:
  - CLI: `31,733 B`, `15 tools`
  - TUI/Desktop: `32,984 B`, `18 tools`

## Notes
- This is an offline diagnostic fix only; it does not change runtime tool execution policy, provider configuration, MCP, gateway, secrets, or deployment behavior.