### PR TITLE
fix(google-chat): preserve quoted reply context

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1549,6 +1549,29 @@ class GoogleChatAdapter(BasePlatformAdapter):
         text = msg.get("argumentText") or msg.get("text") or ""
         text = text.strip()
 
+        quoted = msg.get("quotedMessageMetadata") or {}
+        quoted_snapshot = quoted.get("quotedMessageSnapshot") or {}
+        reply_to_text = (quoted_snapshot.get("text") or "").strip() or None
+        reply_to_message_id = (
+            quoted.get("name")
+            or quoted.get("quotedMessage")
+            or quoted.get("quotedMessageName")
+            or None
+        )
+        quoted_sender = quoted_snapshot.get("sender") or {}
+        reply_to_author_id = quoted_sender.get("name") or None
+        reply_to_author_name = (
+            quoted_sender.get("displayName")
+            or quoted_sender.get("email")
+            or reply_to_author_id
+            or None
+        )
+        reply_to_is_own = bool(
+            reply_to_author_id
+            and self._bot_user_id
+            and reply_to_author_id == self._bot_user_id
+        )
+
         # Slash command: emit MessageType.COMMAND with normalized text.
         slash = msg.get("slashCommand") or {}
         is_slash = bool(slash)
@@ -1648,6 +1671,11 @@ class GoogleChatAdapter(BasePlatformAdapter):
             message_id=msg.get("name") or None,
             media_urls=media_urls,
             media_types=media_types,
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            reply_to_author_id=reply_to_author_id,
+            reply_to_author_name=reply_to_author_name,
+            reply_to_is_own_message=reply_to_is_own,
         )
 
     async def _download_attachment(

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -197,7 +197,7 @@ def _make_pubsub_message(data: dict, *, attributes=None):
 
 def _make_chat_envelope(text="hello", sender_email="u@example.com", sender_type="HUMAN",
                        msg_name=None, thread_name=None, attachments=None,
-                       slash_command=None):
+                       slash_command=None, quoted_message_metadata=None):
     """Build a realistic Google Chat CloudEvents-style envelope body."""
     msg = {
         "name": msg_name or "spaces/S/messages/M.M",
@@ -216,6 +216,8 @@ def _make_chat_envelope(text="hello", sender_email="u@example.com", sender_type=
         msg["attachment"] = attachments
     if slash_command is not None:
         msg["slashCommand"] = slash_command
+    if quoted_message_metadata is not None:
+        msg["quotedMessageMetadata"] = quoted_message_metadata
 
     return {
         "chat": {
@@ -784,6 +786,59 @@ class TestBuildMessageEvent:
         event2 = await adapter._build_message_event(msg2, env2)
         # Second time same thread = user re-engaged → isolated session.
         assert event2.source.thread_id == "spaces/S/threads/T1"
+
+    @pytest.mark.asyncio
+    async def test_quoted_message_metadata_populates_reply_context(self, adapter):
+        env = _make_chat_envelope(
+            text="what did you mean?",
+            quoted_message_metadata={
+                "name": "spaces/S/messages/quoted-1",
+                "quotedMessageSnapshot": {
+                    "text": "Original answer",
+                    "sender": {
+                        "name": "users/other",
+                        "email": "other@example.com",
+                        "displayName": "Other User",
+                    },
+                },
+            },
+        )
+        msg = env["chat"]["messagePayload"]["message"]
+
+        event = await adapter._build_message_event(msg, env)
+
+        assert event.reply_to_message_id == "spaces/S/messages/quoted-1"
+        assert event.reply_to_text == "Original answer"
+        assert event.reply_to_author_id == "users/other"
+        assert event.reply_to_author_name == "Other User"
+        assert event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_quoted_bot_message_marks_own_reply_context(self, adapter):
+        adapter._bot_user_id = "users/BOT_ID"
+        env = _make_chat_envelope(
+            text="explain this",
+            quoted_message_metadata={
+                "name": "spaces/S/messages/bot-msg",
+                "quotedMessageSnapshot": {
+                    "text": "Bot answer",
+                    "sender": {
+                        "name": "users/BOT_ID",
+                        "displayName": "Hermes",
+                        "type": "BOT",
+                    },
+                },
+            },
+        )
+        msg = env["chat"]["messagePayload"]["message"]
+
+        event = await adapter._build_message_event(msg, env)
+
+        assert event.reply_to_message_id == "spaces/S/messages/bot-msg"
+        assert event.reply_to_text == "Bot answer"
+        assert event.reply_to_author_id == "users/BOT_ID"
+        assert event.reply_to_author_name == "Hermes"
+        assert event.reply_to_is_own_message is True
 
     @pytest.mark.asyncio
     async def test_dm_side_thread_caches_thread_for_outbound(self, adapter):


### PR DESCRIPTION
## Summary
- read Google Chat quotedMessageMetadata when building inbound MessageEvent objects
- populate generic reply_to_* fields so gateway/run.py can inject reply context consistently
- mark replies to the bot's own quoted messages via reply_to_is_own_message

Fixes #56607

## Tests
- .venv/bin/python -m pytest tests/gateway/test_google_chat.py -q -k "quoted_message_metadata or quoted_bot_message"
- .venv/bin/python -m ruff check plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py
- .venv/bin/python -m pytest tests/gateway/test_google_chat.py -q
- scripts/run_tests.sh tests/gateway/test_google_chat.py -q