### PR TITLE
fix(stt): pass language to groq transcription

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -282,6 +282,43 @@ class TestTranscribeGroq:
         call_kwargs = mock_openai_cls.call_args
         assert call_kwargs.kwargs["base_url"] == GROQ_BASE_URL
 
+    def test_passes_groq_language_from_config(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "שלום"
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._load_stt_config", return_value={
+                 "groq": {"language": "he"},
+                 "local": {"language": "en"},
+             }), \
+             patch("openai.OpenAI", return_value=mock_client):
+            from tools.transcription_tools import _transcribe_groq
+            result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        call_kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert call_kwargs["language"] == "he"
+
+    def test_groq_language_falls_back_to_local_config(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "bonjour"
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._load_stt_config", return_value={
+                 "local": {"language": "fr"},
+             }), \
+             patch("openai.OpenAI", return_value=mock_client):
+            from tools.transcription_tools import _transcribe_groq
+            result = _transcribe_groq(sample_wav, "whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        call_kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+        assert call_kwargs["language"] == "fr"
+
     def test_api_error_returns_failure(self, monkeypatch, sample_wav):
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1289,16 +1289,29 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         logger.info("Model %s not available on Groq, using %s", model_name, DEFAULT_GROQ_STT_MODEL)
         model_name = DEFAULT_GROQ_STT_MODEL
 
+    stt_config = _load_stt_config()
+    groq_config = stt_config.get("groq", {}) if isinstance(stt_config, dict) else {}
+    local_config = stt_config.get("local", {}) if isinstance(stt_config, dict) else {}
+    language = (
+        (groq_config.get("language") if isinstance(groq_config, dict) else None)
+        or (local_config.get("language") if isinstance(local_config, dict) else None)
+        or os.getenv(LOCAL_STT_LANGUAGE_ENV)
+        or None
+    )
+
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
         client = OpenAI(api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0)
         try:
             with open(file_path, "rb") as audio_file:
-                transcription = client.audio.transcriptions.create(
-                    model=model_name,
-                    file=audio_file,
-                    response_format="text",
-                )
+                transcribe_kwargs = {
+                    "model": model_name,
+                    "file": audio_file,
+                    "response_format": "text",
+                }
+                if language:
+                    transcribe_kwargs["language"] = str(language)
+                transcription = client.audio.transcriptions.create(**transcribe_kwargs)
 
             transcript_text = str(transcription).strip()
             logger.info("Transcribed %s via Groq API (%s, %d chars)",


### PR DESCRIPTION
## Summary
- pass language to Groq Whisper transcription requests when configured
- prefer stt.groq.language, falling back to stt.local.language and the existing local STT language env
- add regression coverage for Groq-specific language and local fallback behavior

Fixes #55551

## Tests
- .venv/bin/python -m pytest tests/tools/test_transcription_tools.py -q -k "TranscribeGroq or groq_language"
- .venv/bin/python -m ruff check tools/transcription_tools.py tests/tools/test_transcription_tools.py
- .venv/bin/python -m pytest tests/tools/test_transcription_tools.py -q
- scripts/run_tests.sh tests/tools/test_transcription_tools.py -q