### PR TITLE
test(tools): add unit tests for has_binary_extension

### DIFF
--- a/tests/tools/test_binary_extensions.py
+++ b/tests/tools/test_binary_extensions.py
@@ -1,0 +1,45 @@
+"""Unit tests for has_binary_extension (tools/binary_extensions.py).
+
+has_binary_extension is a pure, I/O-free helper that file_tools uses to skip
+binary files during text-based operations. These tests pin its contract:
+case-insensitive extension matching against BINARY_EXTENSIONS, the deliberate
+.pdf exclusion, and correct handling of paths with no extension.
+"""
+
+import pytest
+
+from tools.binary_extensions import has_binary_extension
+
+
+class TestHasBinaryExtension:
+    @pytest.mark.parametrize("path", [
+        "photo.png", "archive.zip", "program.exe", "clip.mp4",
+        "song.mp3", "font.ttf", "lib.so", "data.sqlite",
+    ])
+    def test_known_binary_extensions_true(self, path):
+        assert has_binary_extension(path) is True
+
+    @pytest.mark.parametrize("path", ["IMAGE.PNG", "Clip.MP4", "Archive.ZiP"])
+    def test_matching_is_case_insensitive(self, path):
+        assert has_binary_extension(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "script.py", "notes.txt", "README.md", "config.json", "style.css",
+    ])
+    def test_text_extensions_false(self, path):
+        assert has_binary_extension(path) is False
+
+    def test_pdf_is_deliberately_excluded(self):
+        # .pdf is text-inspectable â€” intentionally NOT in BINARY_EXTENSIONS.
+        assert has_binary_extension("report.pdf") is False
+
+    @pytest.mark.parametrize("path", ["README", "Makefile", "LICENSE"])
+    def test_no_extension_false(self, path):
+        assert has_binary_extension(path) is False
+
+    def test_multiple_dots_uses_last_extension(self):
+        assert has_binary_extension("archive.tar.gz") is True
+
+    def test_dot_in_directory_not_treated_as_extension(self):
+        # Last dot is in the directory segment; the file itself has no extension.
+        assert has_binary_extension("my.dir/file") is False


### PR DESCRIPTION
﻿## What does this PR do?

Adds unit test coverage for `has_binary_extension` in `tools/binary_extensions.py`. This pure, I/O-free helper is used by `tools/file_tools.py` to skip binary files during text-based operations, but had no direct tests.

The tests pin the function's contract:
- Extensions in `BINARY_EXTENSIONS` return `True` (images, archives, executables, audio, fonts, databases)
- Matching is case-insensitive (`IMAGE.PNG` → `True`)
- Text extensions return `False` (`.py`, `.txt`, `.md`, `.json`, `.css`)
- `.pdf` is deliberately **not** treated as binary (it is text-inspectable — this is documented intent in the module)
- Paths with no extension return `False`
- Multi-dot paths use the last extension (`archive.tar.gz` → `.gz`)
- A dot in a directory segment is not mistaken for an extension (`my.dir/file` → `False`)

## Type of Change

- [x] Test coverage (no production code changed)

## Why

`has_binary_extension` gates real file operations. Without a test, a future edit to `BINARY_EXTENSIONS` — or an accidental change to the deliberate `.pdf` exclusion — would pass silently. These tests lock the behavior in place.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_binary_extensions.py -v
```

## Notes

- 1 new file, no production code touched. Pure input→output assertions — no mocks, no network, no filesystem.
- Follows the existing style of `tests/tools/test_ansi_strip.py`.
