### PR TITLE
fix(kanban): allow triage tasks without assignee

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1136,6 +1136,33 @@ def test_create_rejects_no_assignee(worker_env):
     assert json.loads(kt._handle_create({"title": "t"})).get("error")
 
 
+def test_create_allows_triage_without_assignee(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_create({
+        "title": "triage task",
+        "body": "route this later",
+        "triage": True,
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["status"] == "triage"
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, d["task_id"])
+        assert task.assignee is None
+        assert task.status == "triage"
+    finally:
+        conn.close()
+
+
+def test_create_schema_only_requires_title():
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    assert KANBAN_CREATE_SCHEMA["parameters"]["required"] == ["title"]
+
+
 def test_create_rejects_non_list_parents(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_create({"title": "t", "assignee": "a", "parents": 42})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -841,7 +841,10 @@ def _handle_create(args: dict, **kw) -> str:
     if not title or not str(title).strip():
         return tool_error("title is required")
     assignee = args.get("assignee")
-    if not assignee:
+    triage, bool_error = _parse_bool_arg(args, "triage")
+    if bool_error:
+        return tool_error(bool_error)
+    if not assignee and not triage:
         return tool_error(
             "assignee is required — name the profile that should execute this "
             "task (the dispatcher will only spawn tasks with an assignee)"
@@ -867,9 +870,6 @@ def _handle_create(args: dict, **kw) -> str:
     _inherit_workspace = workspace_kind is None and workspace_path is None
     if workspace_kind is None:
         workspace_kind = "scratch"
-    triage, bool_error = _parse_bool_arg(args, "triage")
-    if bool_error:
-        return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
@@ -912,7 +912,7 @@ def _handle_create(args: dict, **kw) -> str:
                 conn,
                 title=str(title).strip(),
                 body=body,
-                assignee=str(assignee),
+                assignee=str(assignee) if assignee else None,
                 parents=tuple(parents),
                 tenant=tenant,
                 priority=int(priority) if priority is not None else 0,
@@ -1409,8 +1409,8 @@ KANBAN_CREATE_SCHEMA = {
                 "description": (
                     "Profile name that should execute this task "
                     "(e.g. 'researcher-a', 'reviewer', 'writer'). "
-                    "Required — tasks without an assignee are never "
-                    "dispatched."
+                    "Required unless triage=true; non-triage tasks "
+                    "without an assignee are never dispatched."
                 ),
             },
             "body": {
@@ -1543,7 +1543,7 @@ KANBAN_CREATE_SCHEMA = {
             },
             "board": _board_schema_prop(),
         },
-        "required": ["title", "assignee"],
+        "required": ["title"],
     },
 }
 


### PR DESCRIPTION
## Summary
- parse triage before enforcing kanban_create assignee validation
- allow triage=true tasks to be created without an assignee so the decomposer can route them later
- update the tool schema so assignee is not declared as globally required

Fixes #54510

## Tests
- .venv/bin/python -m pytest tests/tools/test_kanban_tools.py -q -k "create_allows_triage_without_assignee or create_schema_only_requires_title or create_rejects_no_assignee or create_parses_triage"
- .venv/bin/python -m ruff check tools/kanban_tools.py tests/tools/test_kanban_tools.py
- .venv/bin/python -m pytest tests/tools/test_kanban_tools.py -q
- scripts/run_tests.sh tests/tools/test_kanban_tools.py -q