### PR TITLE
fix(model-switch): prefer authenticated provider for ambiguous models

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -744,6 +744,59 @@ def _configured_provider_matches(
     return matches
 
 
+def _authenticated_exact_catalog_match(
+    model_name: str,
+    current_provider: str,
+    user_providers: Optional[dict],
+    custom_providers: Optional[list],
+) -> Optional[tuple[str, str]]:
+    """Prefer a single authenticated exact match over static provider guesses."""
+    name = (model_name or "").strip()
+    if not name:
+        return None
+
+    try:
+        from hermes_cli.models import _PROVIDER_MODELS
+    except Exception:
+        return None
+
+    target = name.lower()
+    static_matches: dict[str, str] = {}
+    for provider, catalog in _PROVIDER_MODELS.items():
+        for candidate in catalog:
+            if candidate.lower() == target:
+                static_matches[provider] = candidate
+                break
+
+    if len(static_matches) < 2:
+        return None
+
+    authed = get_authenticated_provider_slugs(
+        current_provider=current_provider,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    if not authed:
+        return None
+
+    matches = [
+        (provider, static_matches[provider])
+        for provider in authed
+        if provider in static_matches
+    ]
+    if not matches:
+        return None
+
+    current = (current_provider or "").strip().lower()
+    for provider, candidate in matches:
+        if provider == current:
+            return provider, candidate
+
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Core model-switching pipeline
 # ---------------------------------------------------------------------------
@@ -1097,7 +1150,14 @@ def switch_model(
             and not resolved_in_current_catalog
             and not config_routed
         ):
-            detected = detect_provider_for_model(new_model, current_provider)
+            detected = _authenticated_exact_catalog_match(
+                new_model,
+                current_provider,
+                user_providers,
+                custom_providers,
+            )
+            if not detected:
+                detected = detect_provider_for_model(new_model, current_provider)
             if detected:
                 target_provider, new_model = detected
 

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -38,6 +38,12 @@ _CODEX_SOFT_ACCEPT = {
     ),
 }
 
+_AMBIGUOUS_BUILTIN_MODEL = "gpt-test-collision"
+_AMBIGUOUS_PROVIDER_CATALOG = {
+    "openai-api": [_AMBIGUOUS_BUILTIN_MODEL],
+    "openai-codex": [_AMBIGUOUS_BUILTIN_MODEL],
+}
+
 
 def _run_switch(
     *,
@@ -110,34 +116,44 @@ def test_typed_configured_model_routes_away_from_openai_codex():
 
 def test_ambiguous_builtin_model_prefers_authenticated_codex_before_static_detector():
     """Bare ids can exist in several static catalogs. If the user is
-    authenticated for Codex, ``/model gpt-5.5`` should not be hijacked by the
+    authenticated for Codex, a colliding bare id should not be hijacked by the
     direct OpenAI API catalog just because it appears earlier in the static
     provider scan."""
-    result = _run_switch(
-        raw_input="gpt-5.5",
-        current_provider="zai",
-        current_model="glm-5.2",
-        detected_provider=("openai-api", "gpt-5.5"),
-        authenticated_providers=["openai-codex"],
-    )
+    with patch.dict(
+        "hermes_cli.models._PROVIDER_MODELS",
+        _AMBIGUOUS_PROVIDER_CATALOG,
+        clear=True,
+    ):
+        result = _run_switch(
+            raw_input=_AMBIGUOUS_BUILTIN_MODEL,
+            current_provider="zai",
+            current_model="glm-5.2",
+            detected_provider=("openai-api", _AMBIGUOUS_BUILTIN_MODEL),
+            authenticated_providers=["openai-codex"],
+        )
     assert result.success is True, result.error_message
     assert result.target_provider == "openai-codex"
-    assert result.new_model == "gpt-5.5"
+    assert result.new_model == _AMBIGUOUS_BUILTIN_MODEL
 
 
 def test_explicit_provider_still_wins_for_ambiguous_builtin_model():
     """The authenticated-provider preference only applies to bare model
     auto-detection. An explicit provider flag remains authoritative."""
-    result = _run_switch(
-        raw_input="gpt-5.5",
-        current_provider="zai",
-        current_model="glm-5.2",
-        explicit_provider="openai-api",
-        authenticated_providers=["openai-codex", "openai-api"],
-    )
+    with patch.dict(
+        "hermes_cli.models._PROVIDER_MODELS",
+        _AMBIGUOUS_PROVIDER_CATALOG,
+        clear=True,
+    ):
+        result = _run_switch(
+            raw_input=_AMBIGUOUS_BUILTIN_MODEL,
+            current_provider="zai",
+            current_model="glm-5.2",
+            explicit_provider="openai-api",
+            authenticated_providers=["openai-codex", "openai-api"],
+        )
     assert result.success is True, result.error_message
     assert result.target_provider == "openai-api"
-    assert result.new_model == "gpt-5.5"
+    assert result.new_model == _AMBIGUOUS_BUILTIN_MODEL
 
 
 def test_typed_configured_model_routes_to_custom_provider():

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -46,6 +46,9 @@ def _run_switch(
     user_providers=None,
     custom_providers=None,
     validation=_ACCEPTED,
+    detected_provider=None,
+    authenticated_providers=None,
+    explicit_provider="",
     current_model="old-model",
     current_base_url="",
 ):
@@ -61,7 +64,8 @@ def _run_switch(
          patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
          patch("hermes_cli.model_switch.normalize_model_for_provider", side_effect=lambda model, provider: model), \
          patch("hermes_cli.models.validate_requested_model", return_value=validation), \
-         patch("hermes_cli.models.detect_provider_for_model", return_value=None), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=detected_provider), \
+         patch("hermes_cli.model_switch.get_authenticated_provider_slugs", return_value=authenticated_providers or []), \
          patch("hermes_cli.model_switch.get_model_info", return_value=None), \
          patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
          patch(
@@ -79,6 +83,7 @@ def _run_switch(
             current_base_url=current_base_url,
             user_providers=user_providers or {},
             custom_providers=custom_providers or [],
+            explicit_provider=explicit_provider,
         )
 
 
@@ -101,6 +106,38 @@ def test_typed_configured_model_routes_away_from_openai_codex():
     assert result.success is True, result.error_message
     assert result.target_provider == "local-ollama"
     assert result.new_model == "qwen3.5-4b"
+
+
+def test_ambiguous_builtin_model_prefers_authenticated_codex_before_static_detector():
+    """Bare ids can exist in several static catalogs. If the user is
+    authenticated for Codex, ``/model gpt-5.5`` should not be hijacked by the
+    direct OpenAI API catalog just because it appears earlier in the static
+    provider scan."""
+    result = _run_switch(
+        raw_input="gpt-5.5",
+        current_provider="zai",
+        current_model="glm-5.2",
+        detected_provider=("openai-api", "gpt-5.5"),
+        authenticated_providers=["openai-codex"],
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openai-codex"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_explicit_provider_still_wins_for_ambiguous_builtin_model():
+    """The authenticated-provider preference only applies to bare model
+    auto-detection. An explicit provider flag remains authoritative."""
+    result = _run_switch(
+        raw_input="gpt-5.5",
+        current_provider="zai",
+        current_model="glm-5.2",
+        explicit_provider="openai-api",
+        authenticated_providers=["openai-codex", "openai-api"],
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openai-api"
+    assert result.new_model == "gpt-5.5"
 
 
 def test_typed_configured_model_routes_to_custom_provider():


### PR DESCRIPTION
## Summary
- Prefer a single authenticated exact catalog match before falling back to static provider detection for ambiguous bare model IDs.
- Keep explicit `--provider` authoritative and leave multi-auth ambiguity on the existing static detection path.
- Add hermetic regression coverage with a test-controlled `openai-api` / `openai-codex` catalog collision.

## Test plan
- `python -m pytest -o 'addopts=' -q tests/hermes_cli/test_model_switch_configured_provider_routing.py tests/hermes_cli/test_models.py::TestDetectProviderForModel tests/gateway/test_session_model_override_routing.py::test_run_agent_prefers_session_override_over_global_runtime`
- `python -m ruff check hermes_cli/model_switch.py tests/hermes_cli/test_model_switch_configured_provider_routing.py`

## Results
- 24 tests passed
- Ruff passed
