### PR TITLE
fix(browser): omit Browserbase warnings for local mode

### DIFF
--- a/tests/tools/test_browser_open_timeout.py
+++ b/tests/tools/test_browser_open_timeout.py
@@ -1,5 +1,6 @@
 """Tests for browser first-open timeout and timeout diagnostics."""
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -90,6 +91,28 @@ class TestReadCommandOutputFiles:
 
 
 class TestBrowserNavigateOpenTimeout:
+    def _patch_navigation(self, monkeypatch, *, title="t", features=None, is_local=True):
+        features = features if features is not None else {}
+
+        def fake_run(task_id, command, args, timeout=None):
+            if command == "snapshot":
+                return {"success": False, "error": "no snapshot"}
+            return {
+                "success": True,
+                "data": {"title": title, "url": args[0] if args else ""},
+            }
+
+        monkeypatch.setattr(bt, "_get_open_command_timeout", lambda first_open=False: 120 if first_open else 60)
+        monkeypatch.setattr(bt, "_run_browser_command", fake_run)
+        monkeypatch.setattr(bt, "_get_session_info", lambda key: {"_first_nav": True, "features": features})
+        monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(bt, "_is_local_backend", lambda: is_local)
+        monkeypatch.setattr(bt, "_is_local_sidecar_key", lambda key: False)
+        monkeypatch.setattr(bt, "_navigation_session_key", lambda task_id, url: task_id)
+        monkeypatch.setattr(bt, "_maybe_start_recording", lambda *a, **kw: None)
+        monkeypatch.setattr(bt, "check_website_access", lambda url: None)
+        monkeypatch.setattr(bt, "_is_safe_url", lambda url: True)
+
     def test_first_navigation_uses_first_open_timeout(self, monkeypatch):
         captured: dict = {}
 
@@ -110,3 +133,36 @@ class TestBrowserNavigateOpenTimeout:
 
         bt.browser_navigate("https://example.com", task_id="task-1")
         assert captured["timeout"] == 120
+
+    def test_local_first_navigation_omits_browserbase_proxy_warning(self, monkeypatch):
+        self._patch_navigation(monkeypatch, features={"local": True}, is_local=True)
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert result["stealth_features"] == ["local"]
+        assert "stealth_warning" not in result
+
+    def test_local_bot_detection_warning_omits_browserbase_upsell(self, monkeypatch):
+        self._patch_navigation(
+            monkeypatch,
+            title="Just a moment",
+            features={"local": True},
+            is_local=True,
+        )
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert "bot_detection_warning" in result
+        assert "BROWSERBASE_ADVANCED_STEALTH" not in result["bot_detection_warning"]
+        assert "Scale plan" not in result["bot_detection_warning"]
+
+    def test_cloud_first_navigation_keeps_browserbase_proxy_warning(self, monkeypatch):
+        self._patch_navigation(monkeypatch, features={"proxies": False}, is_local=False)
+
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="task-1"))
+
+        assert result["success"] is True
+        assert "stealth_warning" in result
+        assert "Browserbase" in result["stealth_warning"]

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2874,18 +2874,29 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         title_lower = title.lower()
 
         if any(pattern in title_lower for pattern in blocked_patterns):
+            if _is_local_backend():
+                warning_options = (
+                    "Options: 1) Try adding delays between actions, "
+                    "2) Access different pages first, "
+                    "3) Some sites have very aggressive bot detection that may be unavoidable."
+                )
+            else:
+                warning_options = (
+                    "Options: 1) Try adding delays between actions, "
+                    "2) Access different pages first, "
+                    "3) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, requires Scale plan), "
+                    "4) Some sites have very aggressive bot detection that may be unavoidable."
+                )
             response["bot_detection_warning"] = (
                 f"Page title '{title}' suggests bot detection. The site may have blocked this request. "
-                "Options: 1) Try adding delays between actions, 2) Access different pages first, "
-                "3) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, requires Scale plan), "
-                "4) Some sites have very aggressive bot detection that may be unavoidable."
+                f"{warning_options}"
             )
 
         # Include feature info on first navigation so model knows what's active
         if is_first_nav and "features" in session_info:
             features = session_info["features"]
             active_features = [k for k, v in features.items() if v]
-            if not features.get("proxies"):
+            if not features.get("proxies") and not _is_local_backend():
                 response["stealth_warning"] = (
                     "Running WITHOUT residential proxies. Bot detection may be more aggressive. "
                     "Consider upgrading Browserbase plan for proxy support."


### PR DESCRIPTION
## Summary
- suppress Browserbase proxy upsell warnings when browser_navigate is using a local backend
- keep local bot-detection guidance generic while preserving Browserbase advanced stealth guidance for cloud backends
- add navigation regression tests for local and cloud warning behavior

Fixes #54197

## Tests
- .venv/bin/python -m pytest tests/tools/test_browser_open_timeout.py -q
- .venv/bin/python -m ruff check tools/browser_tool.py tests/tools/test_browser_open_timeout.py
- .venv/bin/python -m pytest tests/tools/test_browser_open_timeout.py tests/tools/test_browser_ssrf_local.py -q
- scripts/run_tests.sh tests/tools/test_browser_open_timeout.py tests/tools/test_browser_ssrf_local.py -q