### PR TITLE
fix(tools): wrap web_extract provider calls with 120s timeout

### DIFF
--- a/tests/tools/test_web_extract_robustness.py
+++ b/tests/tools/test_web_extract_robustness.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
 import tools.web_tools as wt
 
 
@@ -52,3 +54,54 @@ def test_small_page_not_truncated_no_footer(tmp_path, monkeypatch):
     assert not truncated
     assert model_text == content
     assert "[TRUNCATED]" not in model_text
+
+
+@pytest.mark.asyncio
+async def test_extract_timeout_returns_error_results(monkeypatch, tmp_path):
+    """When a provider hangs past _DEFAULT_EXTRACT_TIMEOUT_S, the wrapper
+    should cancel the coroutine and return per-URL error results instead of
+    blocking the event loop indefinitely (#57155)."""
+    import asyncio
+    import json
+    import sys
+    import types
+
+    import tools.web_tools as wt
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    async def _slow_extract(self, urls, **_kw):
+        """Simulates a provider that hangs forever."""
+        await asyncio.sleep(9999)
+        return [{"url": u, "content": "never"} for u in urls]
+
+    # Patch the timeout to 0.3s so the test is fast.
+    monkeypatch.setattr(wt, "_DEFAULT_EXTRACT_TIMEOUT_S", 0.3)
+
+    # Patch the SSRF check and backend resolution so only the dispatch runs.
+    async def _safe(url):
+        return True
+    monkeypatch.setattr(wt, "async_is_safe_url", _safe)
+
+    class _FakeProvider:
+        name = "fake"
+        def supports_extract(self):
+            return True
+        extract = _slow_extract  # async
+
+    monkeypatch.setattr(wt, "_get_extract_backend", lambda: "fake")
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+
+    # The import-mock for the registry inside web_extract_tool
+    fake_registry = types.ModuleType("agent.web_search_registry")
+    fake_registry.get_active_extract_provider = lambda: _FakeProvider()
+    fake_registry.get_provider = lambda _: _FakeProvider()
+    monkeypatch.setitem(sys.modules, "agent.web_search_registry", fake_registry)
+
+    result_json = await wt.web_extract_tool(["https://example.com/slow"])
+    result = json.loads(result_json)
+    assert "results" in result
+    assert len(result["results"]) == 1
+    entry = result["results"][0]
+    assert "timed out" in entry.get("error", "").lower()
+    assert entry["url"] == "https://example.com/slow"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -102,6 +102,13 @@ import sys
 
 logger = logging.getLogger(__name__)
 
+# Maximum seconds to wait for a single web_extract provider call.  When a
+# provider (parallel, exa, tavily) hangs on a slow page, the event loop is
+# blocked — preventing WebSocket heartbeats and crashing the desktop GUI.
+# Firecrawl already applies its own 60 s per-URL timeout; this wraps the
+# other providers so *every* backend has an upper bound.
+_DEFAULT_EXTRACT_TIMEOUT_S = 120.0
+
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
@@ -763,14 +770,38 @@ async def web_extract_tool(
             # Async-or-sync dispatch: parallel + firecrawl have async
             # extract(); exa + tavily are sync.
             import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
-            else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+            extract_timeout = _DEFAULT_EXTRACT_TIMEOUT_S
+            try:
+                if inspect.iscoroutinefunction(provider.extract):
+                    results = await asyncio.wait_for(
+                        provider.extract(safe_urls, format=format),
+                        timeout=extract_timeout,
+                    )
+                else:
+                    # Run sync extract() in a thread so we don't block the
+                    # event loop on network I/O.
+                    results = await asyncio.wait_for(
+                        asyncio.to_thread(
+                            provider.extract, safe_urls, format=format
+                        ),
+                        timeout=extract_timeout,
+                    )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Web extract timed out after %.0fs for %s via %s",
+                    extract_timeout,
+                    safe_urls,
+                    provider.name,
                 )
+                results = [
+                    {
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "error": f"Extract timed out after {extract_timeout:.0f}s",
+                    }
+                    for url in safe_urls
+                ]
 
         # Merge any SSRF-blocked results back in
         if ssrf_blocked:


### PR DESCRIPTION
## What does this PR do?

Wraps `web_extract` provider calls with `asyncio.wait_for()` so that a hanging backend (Parallel, Exa, Tavily) cannot block the event loop indefinitely. When a provider exceeds the 120-second timeout, the tool returns per-URL error results instead of stalling the event loop and killing WebSocket heartbeats.

## Related Issue

Fixes #57155

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/web_tools.py`: Added `_DEFAULT_EXTRACT_TIMEOUT_S = 120.0` constant and wrapped both the async (`await provider.extract(...)`) and sync (`await asyncio.to_thread(provider.extract, ...)`) dispatch paths with `asyncio.wait_for(..., timeout=extract_timeout)`. On `TimeoutError`, returns per-URL error entries with a descriptive message.
- `tests/tools/test_web_extract_robustness.py`: Added `test_extract_timeout_returns_error_results` — verifies that a hanging async provider is cancelled within the timeout and that the tool returns structured error results instead of blocking.

## How to Test

1. Run `python -m pytest tests/tools/test_web_extract_robustness.py tests/tools/test_web_tools*.py tests/tools/test_website_policy.py -q` — all 100 tests should pass.
2. The new test `test_extract_timeout_returns_error_results` patches `_DEFAULT_EXTRACT_TIMEOUT_S` to 0.3s, injects a provider that sleeps 9999s, and asserts the tool returns `"timed out"` errors within ~1 second.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
