### PR TITLE
fix(scripts): isolate parallel-runner pytest children from console Ctrl+C on Windows

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -251,7 +251,36 @@ def _run_one_file(
     bound a pathologically slow or hung file as a whole.
     """
     cmd = [sys.executable, "-m", "pytest", str(file), *pytest_args]
-    
+
+    # Isolate each pytest child from the runner's console / process group.
+    #
+    # POSIX: start_new_session=True → os.setsid() in the child, placing it
+    # at the head of its own process group so _kill_tree can SIGKILL the
+    # group atomically.
+    #
+    # Windows: start_new_session only maps to CREATE_NEW_PROCESS_GROUP in
+    # CPython 3.12+ — on 3.11 it is silently ignored, so every child
+    # shared the runner's console process group. One os.kill(pid, 0)
+    # liveness probe anywhere in the run — which on Windows routes through
+    # GenerateConsoleCtrlEvent (bpo-14484) — then broadcast
+    # KeyboardInterrupt to every concurrent child AND the runner itself.
+    # Pass the creationflags explicitly, on every Python version:
+    #   CREATE_NEW_PROCESS_GROUP — child is its own ctrl-event group root,
+    #     so console ctrl events can't fan out across children;
+    #   CREATE_NO_WINDOW — child gets its own invisible console, fully
+    #     insulating it from ctrl-event broadcasts on the runner's console
+    #     (and suppressing per-child conhost window flashes).
+    # _kill_tree handles the Windows kill path via taskkill /F /T.
+    if sys.platform == "win32":
+        isolation_kwargs: Dict[str, object] = {
+            "creationflags": (
+                subprocess.CREATE_NEW_PROCESS_GROUP
+                | subprocess.CREATE_NO_WINDOW
+            ),
+        }
+    else:
+        isolation_kwargs = {"start_new_session": True}
+
     subproc_start = time.monotonic()
     # launch the pytest process
     proc = subprocess.Popen(
@@ -262,11 +291,7 @@ def _run_one_file(
         text=True,
         # skipping writing bytecode because we're running a bunch of parallel python processes on the same code
         env={**os.environ, 'PYTHONDONTWRITEBYTECODE': '1'},
-        # POSIX: place the child at the head of its own process group so
-        # _kill_tree can SIGKILL the group atomically.
-        # Windows: this maps to CREATE_NEW_PROCESS_GROUP in CPython 3.12+;
-        # _kill_tree handles the Windows path via taskkill /F /T.
-        start_new_session=True,
+        **isolation_kwargs,
     )
 
     # Capture the pgid NOW, before the leader can exit and be reaped. Once

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -91,6 +91,35 @@ _DEFAULT_FILE_TIMEOUT_SECONDS = 300.0
 _DURATIONS_FILE = "test_durations.json"
 
 
+# These Win32 values are exposed by ``subprocess`` only on Windows. Keep
+# local fallbacks so the pure kwargs contract can be tested on Linux too; the
+# values are passed to Popen only when the running host is Windows.
+_CREATE_NEW_PROCESS_GROUP = 0x00000200
+_CREATE_NO_WINDOW = 0x08000000
+
+
+def _child_process_isolation_kwargs(*, is_windows: bool | None = None) -> Dict[str, int | bool]:
+    """Return Popen kwargs that isolate one pytest child from the runner.
+
+    POSIX needs a new session because :func:`_kill_tree` later kills the
+    captured process group with ``killpg``. Windows needs explicit creation
+    flags: ``start_new_session`` is the POSIX session mechanism, not a
+    Windows process-group boundary. In particular, don't treat
+    ``os.kill(pid, 0)`` as a harmless Windows liveness probe: zero aliases a
+    console-control-event value there, unlike POSIX signal zero.
+
+    ``is_windows`` makes the platform-specific result a pure, Linux-testable
+    contract; production leaves it as the host platform.
+    """
+    if is_windows is None:
+        is_windows = sys.platform == "win32"
+    if is_windows:
+        return {
+            "creationflags": _CREATE_NEW_PROCESS_GROUP | _CREATE_NO_WINDOW,
+        }
+    return {"start_new_session": True}
+
+
 def _approximately_count_tests(
     files: List[Path], repo_root: Path
 ) -> dict[Path, int]:
@@ -252,34 +281,7 @@ def _run_one_file(
     """
     cmd = [sys.executable, "-m", "pytest", str(file), *pytest_args]
 
-    # Isolate each pytest child from the runner's console / process group.
-    #
-    # POSIX: start_new_session=True → os.setsid() in the child, placing it
-    # at the head of its own process group so _kill_tree can SIGKILL the
-    # group atomically.
-    #
-    # Windows: start_new_session only maps to CREATE_NEW_PROCESS_GROUP in
-    # CPython 3.12+ — on 3.11 it is silently ignored, so every child
-    # shared the runner's console process group. One os.kill(pid, 0)
-    # liveness probe anywhere in the run — which on Windows routes through
-    # GenerateConsoleCtrlEvent (bpo-14484) — then broadcast
-    # KeyboardInterrupt to every concurrent child AND the runner itself.
-    # Pass the creationflags explicitly, on every Python version:
-    #   CREATE_NEW_PROCESS_GROUP — child is its own ctrl-event group root,
-    #     so console ctrl events can't fan out across children;
-    #   CREATE_NO_WINDOW — child gets its own invisible console, fully
-    #     insulating it from ctrl-event broadcasts on the runner's console
-    #     (and suppressing per-child conhost window flashes).
-    # _kill_tree handles the Windows kill path via taskkill /F /T.
-    if sys.platform == "win32":
-        isolation_kwargs: Dict[str, object] = {
-            "creationflags": (
-                subprocess.CREATE_NEW_PROCESS_GROUP
-                | subprocess.CREATE_NO_WINDOW
-            ),
-        }
-    else:
-        isolation_kwargs = {"start_new_session": True}
+    isolation_kwargs = _child_process_isolation_kwargs()
 
     subproc_start = time.monotonic()
     # launch the pytest process

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -277,3 +277,66 @@ def test_positional_path_not_treated_as_flag(tmp_path: Path) -> None:
     # Discovery found the probe file (2 tests), proving the positional path
     # was consumed as a root, not forwarded to pytest as a bad flag.
     assert "test_flagprobe.py" in proc.stdout, proc.stdout
+
+
+def _load_runner_module():
+    """Import scripts/run_tests_parallel.py as a module (it's not a package)."""
+    import importlib.util
+
+    runner = Path(__file__).resolve().parent.parent / "scripts" / "run_tests_parallel.py"
+    spec = importlib.util.spec_from_file_location("_run_tests_parallel_under_test", runner)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_children_spawn_in_their_own_process_group(monkeypatch, tmp_path: Path) -> None:
+    """Every pytest child must be isolated from the runner's process group.
+
+    POSIX: ``start_new_session=True`` (os.setsid) so ``_kill_tree`` can
+    SIGKILL the group atomically.
+
+    Windows: ``start_new_session`` is silently IGNORED before CPython 3.12,
+    so the runner must pass ``CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW``
+    creationflags explicitly. Without them every child shares the runner's
+    console process group, and a single ``os.kill(pid, 0)`` liveness probe
+    anywhere in the run — which on Windows routes through
+    GenerateConsoleCtrlEvent (bpo-14484) — broadcasts KeyboardInterrupt to
+    every concurrent child AND the runner itself (observed: the runner died
+    at 100% completion with ~200 collateral KeyboardInterrupt failures).
+    """
+    mod = _load_runner_module()
+    captured: dict = {}
+
+    class _FakeProc:
+        pid = 99999
+        returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("1 passed", None)
+
+        def poll(self):
+            return 0
+
+        def kill(self):
+            pass
+
+    def fake_popen(cmd, **kwargs):
+        captured.update(kwargs)
+        return _FakeProc()
+
+    monkeypatch.setattr(mod.subprocess, "Popen", fake_popen)
+    # _kill_tree shells out to taskkill on Windows — neuter it so the fake
+    # pid can't hit a real process.
+    monkeypatch.setattr(mod, "_kill_tree", lambda proc, pgid=None: None)
+
+    probe = tmp_path / "test_probe.py"
+    probe.write_text("def test_ok():\n    assert True\n")
+    mod._run_one_file(probe, [], tmp_path, 30.0)
+
+    if sys.platform == "win32":
+        flags = captured.get("creationflags", 0)
+        assert flags & subprocess.CREATE_NEW_PROCESS_GROUP, captured
+        assert flags & subprocess.CREATE_NO_WINDOW, captured
+    else:
+        assert captured.get("start_new_session") is True, captured

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -24,43 +24,25 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import textwrap
 import time
 from pathlib import Path
 
+import psutil
 import pytest
 
 
-# Both tests share the same handoff file: the leaker writes here, the
-# verifier reads here. We park it in $TMPDIR with a unique-per-run name
-# so concurrent invocations of the suite don't clobber each other.
-_HANDOFF_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-isolation-probe"
-_HANDOFF_DIR.mkdir(exist_ok=True)
-
-
 def _handoff_path_for(nonce: str) -> Path:
-    return _HANDOFF_DIR / f"grandchild-{nonce}.json"
+    """Return a cross-platform handoff path without writing at import time."""
+    handoff_dir = Path(tempfile.gettempdir()) / "hermes-isolation-probe"
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    return handoff_dir / f"grandchild-{nonce}.json"
 
 
 def _pid_alive(pid: int) -> bool:
-    """POSIX: send signal 0 to probe whether ``pid`` is still alive.
-
-    ``os.kill(pid, 0)`` raises ``ProcessLookupError`` if the process is
-    gone, ``PermissionError`` if it exists but we can't signal it
-    (someone else's pid). We treat PermissionError as "alive" because
-    the process exists and that's all we need to know.
-    """
-    if sys.platform == "win32":  # pragma: no cover — POSIX-only test
-        # On Windows we'd use OpenProcess + GetExitCodeProcess; this
-        # test is skipped on Windows so the path is unreachable.
-        raise RuntimeError("_pid_alive POSIX-only")
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    return True
+    """Return whether a process exists without relying on signal-zero semantics."""
+    return psutil.pid_exists(pid)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only probe")
@@ -290,23 +272,28 @@ def _load_runner_module():
     return mod
 
 
-def test_children_spawn_in_their_own_process_group(monkeypatch, tmp_path: Path) -> None:
-    """Every pytest child must be isolated from the runner's process group.
+def test_child_process_isolation_kwargs_are_portable() -> None:
+    """Both OS contracts remain testable without pretending to run Windows."""
+    mod = _load_runner_module()
 
-    POSIX: ``start_new_session=True`` (os.setsid) so ``_kill_tree`` can
-    SIGKILL the group atomically.
+    assert mod._child_process_isolation_kwargs(is_windows=False) == {
+        "start_new_session": True,
+    }
+    assert mod._child_process_isolation_kwargs(is_windows=True) == {
+        "creationflags": (
+            mod._CREATE_NEW_PROCESS_GROUP | mod._CREATE_NO_WINDOW
+        ),
+    }
 
-    Windows: ``start_new_session`` is silently IGNORED before CPython 3.12,
-    so the runner must pass ``CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW``
-    creationflags explicitly. Without them every child shares the runner's
-    console process group, and a single ``os.kill(pid, 0)`` liveness probe
-    anywhere in the run — which on Windows routes through
-    GenerateConsoleCtrlEvent (bpo-14484) — broadcasts KeyboardInterrupt to
-    every concurrent child AND the runner itself (observed: the runner died
-    at 100% completion with ~200 collateral KeyboardInterrupt failures).
-    """
+
+@pytest.mark.parametrize("is_windows", [False, True])
+def test_runner_passes_child_isolation_kwargs_to_popen(
+    monkeypatch, tmp_path: Path, is_windows: bool,
+) -> None:
+    """Both platform kwargs flow through the Popen launch on every host."""
     mod = _load_runner_module()
     captured: dict = {}
+    isolation_kwargs = mod._child_process_isolation_kwargs
 
     class _FakeProc:
         pid = 99999
@@ -329,14 +316,15 @@ def test_children_spawn_in_their_own_process_group(monkeypatch, tmp_path: Path) 
     # _kill_tree shells out to taskkill on Windows — neuter it so the fake
     # pid can't hit a real process.
     monkeypatch.setattr(mod, "_kill_tree", lambda proc, pgid=None: None)
+    monkeypatch.setattr(
+        mod,
+        "_child_process_isolation_kwargs",
+        lambda: isolation_kwargs(is_windows=is_windows),
+    )
 
     probe = tmp_path / "test_probe.py"
-    probe.write_text("def test_ok():\n    assert True\n")
+    probe.write_text("def test_ok():\n    assert True\n", encoding="utf-8")
     mod._run_one_file(probe, [], tmp_path, 30.0)
 
-    if sys.platform == "win32":
-        flags = captured.get("creationflags", 0)
-        assert flags & subprocess.CREATE_NEW_PROCESS_GROUP, captured
-        assert flags & subprocess.CREATE_NO_WINDOW, captured
-    else:
-        assert captured.get("start_new_session") is True, captured
+    expected = isolation_kwargs(is_windows=is_windows)
+    assert {key: captured[key] for key in expected} == expected

--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -5,12 +5,11 @@ Reproduction for issue #7131: zombie process accumulation on long-running
 gateway deployments.
 """
 
-import os
-import signal
 import subprocess
 import sys
 import threading
 
+import psutil
 
 
 def _spawn_sleep(seconds: float = 60) -> subprocess.Popen:
@@ -21,12 +20,15 @@ def _spawn_sleep(seconds: float = 60) -> subprocess.Popen:
 
 
 def _pid_alive(pid: int) -> bool:
-    """Return True if a process with the given PID is still running."""
-    try:
-        os.kill(pid, 0)
-        return True
-    except (ProcessLookupError, PermissionError):
-        return False
+    """Return True if a process with the given PID is still running.
+
+    Never probe with ``os.kill(pid, 0)`` here: on Windows that is NOT a
+    no-op — it routes through GenerateConsoleCtrlEvent (bpo-14484) and
+    broadcasts Ctrl+C across the shared console, killing every concurrent
+    pytest child AND the parallel-runner process. psutil probes via
+    OpenProcess/GetExitCodeProcess on Windows (no signals involved).
+    """
+    return psutil.pid_exists(pid)
 
 
 class TestZombieReproduction:
@@ -36,13 +38,14 @@ class TestZombieReproduction:
         """REPRODUCTION: processes spawned directly survive if no one kills
         them — this models the gap that causes zombie accumulation when
         the gateway drops agent references without calling close()."""
-        pids = []
+        procs = []
 
         try:
             for _ in range(3):
                 proc = _spawn_sleep(60)
-                pids.append(proc.pid)
+                procs.append(proc)
 
+            pids = [p.pid for p in procs]
             for pid in pids:
                 assert _pid_alive(pid), f"PID {pid} should be alive after spawn"
 
@@ -56,10 +59,14 @@ class TestZombieReproduction:
                     f"expected it to survive (demonstrating the bug)"
                 )
         finally:
-            for pid in pids:
+            # Popen.kill() (TerminateProcess on Windows, SIGKILL on POSIX)
+            # instead of os.kill(pid, signal.SIGKILL): signal.SIGKILL does
+            # not exist on Windows, so the old cleanup raised AttributeError.
+            for p in procs:
                 try:
-                    os.kill(pid, signal.SIGKILL)
-                except (ProcessLookupError, PermissionError):
+                    p.kill()
+                    p.wait(timeout=5)
+                except Exception:
                     pass
 
     def test_explicit_terminate_reaps_processes(self):


### PR DESCRIPTION
## What does this PR do?

Makes full-suite runs of `scripts/run_tests_parallel.py` survivable on native Windows with the project's Python 3.11 venv.

The runner relied on `start_new_session=True` to isolate its per-file pytest children — but on Windows that flag only maps to `CREATE_NEW_PROCESS_GROUP` starting with CPython **3.12** (the comment at the Popen call already admitted this). On 3.11 it is silently ignored, so every child shared the runner's console process group. Combined with `os.kill(pid, 0)` being a `GenerateConsoleCtrlEvent` broadcast on Windows (bpo-14484) rather than a liveness probe, a single probe anywhere in the run sprayed `KeyboardInterrupt` into every concurrent child **and the runner itself** — observed as the runner dying at 100% completion with ~200 collateral `KeyboardInterrupt` failures per full-suite run.

The fix passes explicit `creationflags=CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW` on win32 (each child becomes its own ctrl-event group root on its own invisible console — ctrl-event broadcasts can no longer fan out across children, and per-child conhost flashes disappear as a bonus), keeping `start_new_session=True` on POSIX where `_kill_tree`'s `killpg` cleanup needs it.

It also fixes the one unguarded broadcaster the audit found: `tests/tools/test_zombie_process_cleanup.py` probed its three spawned `sleep(60)` children with bare `os.kill(pid, 0)` on all platforms (now `psutil.pid_exists()`, per the CONTRIBUTING rule), and its cleanup used `os.kill(pid, signal.SIGKILL)` — `signal.SIGKILL` doesn't exist on Windows (now portable `Popen.kill()`). The other `os.kill(pid, 0)` call sites in tests are already win32-skipped; production call sites were migrated previously.

## Related Issue

Fixes #57145

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/run_tests_parallel.py` — platform-split isolation kwargs for the per-file pytest Popen: explicit `CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW` creationflags on win32, `start_new_session=True` on POSIX.
- `tests/tools/test_zombie_process_cleanup.py` — probe via `psutil.pid_exists()` instead of `os.kill(pid, 0)`; clean up via `Popen.kill()` instead of the Windows-nonexistent `signal.SIGKILL`.
- `tests/test_run_tests_parallel.py` — new regression test `test_children_spawn_in_their_own_process_group` asserting the per-platform Popen isolation kwargs.

## How to Test

1. On native Windows with a Python 3.11 venv, run `python scripts/run_tests_parallel.py -q` — before this change the runner intermittently died near completion with mass collateral `KeyboardInterrupt` failures whenever a test performed an `os.kill(pid, 0)` probe; with it, the run completes.
2. `python -m pytest tests/test_run_tests_parallel.py tests/tools/test_zombie_process_cleanup.py -q` on both Windows and POSIX.
3. `python scripts/check-windows-footguns.py --all` stays green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite via `scripts/run_tests_parallel.py` on native Windows now **completes end-to-end** (before this fix the runner itself died near 100% with ~200 collateral KeyboardInterrupt failures). The remaining failures are pre-existing native-Windows failures unrelated to this change: spot-checked files (e.g. `tests/tools/test_file_tools.py`, `tests/tools/test_local_background_child_hang.py`) reproduce identical failure counts under **plain `python -m pytest`** with no runner involved. Targeted suites for the touched files are green: `tests/test_run_tests_parallel.py` (all but one pre-existing Windows failure tracked in #57149), `tests/tools/test_zombie_process_cleanup.py` (13/13).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro (native, no WSL), CPython 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the Popen comment block documents the trap in place
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — POSIX behavior is byte-identical (`start_new_session=True` as before)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
