### PR TITLE
fix(tests): stop config.set model tests writing cli-config.yaml into the repo root

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,6 +402,57 @@ def _isolate_hermes_home(_hermetic_environment):
     return None
 
 
+_REPO_ROOT_CLI_CONFIG = Path(__file__).resolve().parent.parent / "cli-config.yaml"
+
+
+@pytest.fixture(autouse=True)
+def _guard_repo_root_cli_config():
+    """Fail any test that creates or mutates ``<repo>/cli-config.yaml``.
+
+    ``cli.save_config_value()`` falls back to writing the PROJECT config —
+    ``cli-config.yaml`` next to ``cli.py``, i.e. the repo root — whenever
+    the user config (``cli._hermes_home / 'config.yaml'``) does not exist.
+    Under ``_hermetic_environment`` the per-test HERMES_HOME tempdir is
+    always empty, so any test that reaches the real ``save_config_value``
+    silently drops a ``cli-config.yaml`` into the developer's checkout.
+    The file is gitignored (invisible in ``git status``) and is then read
+    back as the project-config fallback by every later run, breaking e.g.
+    ``tests/hermes_cli/test_ignore_user_config_flags.py`` and
+    ``tests/test_hermes_state.py``.
+
+    This tripwire pins the blame on the offending test instead of letting
+    the pollution surface as unrelated failures three runs later. It also
+    restores the pre-test state so one offender can't cascade.
+    """
+    before = (
+        _REPO_ROOT_CLI_CONFIG.read_bytes()
+        if _REPO_ROOT_CLI_CONFIG.exists()
+        else None
+    )
+    yield
+    after = (
+        _REPO_ROOT_CLI_CONFIG.read_bytes()
+        if _REPO_ROOT_CLI_CONFIG.exists()
+        else None
+    )
+    if after == before:
+        return
+    # Restore first so the pollution doesn't outlive the failing test.
+    if before is None:
+        _REPO_ROOT_CLI_CONFIG.unlink()
+    else:
+        _REPO_ROOT_CLI_CONFIG.write_bytes(before)
+    pytest.fail(
+        "this test wrote to the repo-root cli-config.yaml "
+        f"({_REPO_ROOT_CLI_CONFIG}). It reached the real "
+        "cli.save_config_value() with an empty HERMES_HOME, so the write "
+        "fell through to the project-config fallback in the developer's "
+        "checkout. Point cli._hermes_home at a tmp_path containing a "
+        "config.yaml (or monkeypatch cli.save_config_value) instead. "
+        f"Written content was:\n{(after or b'').decode('utf-8', 'replace')}"
+    )
+
+
 # ── Module-level state reset — replaced by per-file process isolation ──────
 #
 # Each test FILE runs in a freshly-spawned ``python -m pytest <file>``

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3338,6 +3338,10 @@ def test_config_set_model_requires_confirmation_for_expensive_model(monkeypatch)
     )
     monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    # Plain /model persists globally by default; without this patch the real
+    # save_config_value() writes a cli-config.yaml into the repo root (the
+    # per-test HERMES_HOME is empty, so it falls through to project config).
+    monkeypatch.setattr("cli.save_config_value", lambda _key, _value: True)
 
     resp = server.handle_request(
         {
@@ -3436,6 +3440,9 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
     monkeypatch.setattr(server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1))
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "_restart_slash_worker", lambda *args, **kwargs: None)
+    # Plain /model persists globally by default; keep the real
+    # save_config_value() from writing a repo-root cli-config.yaml.
+    monkeypatch.setattr("cli.save_config_value", lambda _key, _value: True)
 
     def fake_runtime_provider(*, requested=None, target_model=None, **_kwargs):
         seen["requested"].append((requested, target_model))
@@ -3552,6 +3559,9 @@ def test_config_set_model_does_not_leak_inference_provider_env(monkeypatch):
     )
     monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    # Plain /model persists globally by default; keep the real
+    # save_config_value() from writing a repo-root cli-config.yaml.
+    monkeypatch.setattr("cli.save_config_value", lambda _key, _value: True)
 
     try:
         server.handle_request(
@@ -3613,6 +3623,9 @@ def test_config_set_model_records_per_session_override_not_env(monkeypatch):
     )
     monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    # Plain /model persists globally by default; keep the real
+    # save_config_value() from writing a repo-root cli-config.yaml.
+    monkeypatch.setattr("cli.save_config_value", lambda _key, _value: True)
 
     try:
         server.handle_request(
@@ -3695,6 +3708,9 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
     monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
     monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    # Plain /model persists globally by default; keep the real
+    # save_config_value() from writing a repo-root cli-config.yaml.
+    monkeypatch.setattr("cli.save_config_value", lambda _key, _value: True)
 
     def fake_switch_model(**kwargs):
         return types.SimpleNamespace(


### PR DESCRIPTION
## What does this PR do?

Stops the test suite from silently writing a `cli-config.yaml` into the repo root of the developer's checkout, and adds a tripwire so any future offender fails loudly by name.

`cli.save_config_value()` writes the user config at `cli._hermes_home / 'config.yaml'` **only if it already exists**, otherwise it falls back to the project config — `cli-config.yaml` next to `cli.py`, i.e. the repo root. The suite's hermetic fixture points HERMES_HOME at a fresh *empty* per-test tempdir, so during tests the user config never exists and any real `save_config_value()` call lands in the repo root. The file is gitignored (invisible in `git status`) and is read back as the project-config fallback by every later run, silently breaking `tests/hermes_cli/test_ignore_user_config_flags.py` and `tests/test_hermes_state.py`.

Five tests in `tests/test_tui_gateway_server.py` hit this: they drive a real `/model` switch through `server.handle_request` without patching `cli.save_config_value` — and a plain `/model` (no flag) persists globally by default (`resolve_persist_behavior` → `model.persist_switch_by_default` defaults `True`), so `_persist_model_switch` ran the real save with `model.default: anthropic/claude-sonnet-4.6`, `provider: anthropic`, `base_url: https://api.anthropic.com`.

## Related Issue

Fixes #57147

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/test_tui_gateway_server.py` — patch `cli.save_config_value` in the five offending tests (`test_config_set_model_requires_confirmation_for_expensive_model`, `test_config_set_model_explicit_provider_skips_broken_default_init`, `test_config_set_model_does_not_leak_inference_provider_env`, `test_config_set_model_records_per_session_override_not_env`, `test_config_set_model_switches_agent_without_touching_env`), matching the existing pattern in `test_config_set_model_global_persists`.
- `tests/conftest.py` — new autouse `_guard_repo_root_cli_config` fixture: fails any test that creates or mutates the repo-root `cli-config.yaml`, and restores the pre-test state so one offender can't cascade into unrelated failures. (This tripwire is how the five tests above were identified.)

## How to Test

1. On a clean checkout **without** this PR: `python -m pytest tests/test_tui_gateway_server.py -q` → an untracked `cli-config.yaml` appears at the repo root afterwards (it's gitignored — check with `ls`, not `git status`).
2. With this PR: same command → 303 passed, no `cli-config.yaml`.
3. Revert one of the five test patches while keeping the conftest guard → the guard fails that exact test with a message naming the file and the written content.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — `tests/test_tui_gateway_server.py` is fully green with this change (303 passed, 0 errors, repo root clean afterwards), and a full-suite run via `scripts/run_tests_parallel.py` on native Windows (together with the #57145 fix) ends with **no repo-root `cli-config.yaml`**. Remaining full-suite failures are pre-existing native-Windows failures that reproduce under plain `python -m pytest` on unmodified `main` — none involve the new guard.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — the conftest tripwire is the regression guard
- [x] I've tested on my platform: Windows 11 Pro (native, no WSL), CPython 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the fixture docstring documents the fallback trap
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-pathlib guard, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
