### PR TITLE
fix(vision): enable native vision for kimi-coding provider and resolve provider catalog names

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -324,15 +324,11 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     Returns the context window in tokens, or None if not found.
     Handles case-insensitive matching and filters out context=0 entries.
     """
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
-    if not mdev_provider_id:
+    result = _get_provider_data(provider)
+    if result is None:
         return None
 
-    data = fetch_models_dev()
-    provider_data = data.get(mdev_provider_id)
-    if not isinstance(provider_data, dict):
-        return None
-
+    mdev_provider_id, provider_data = result
     models = provider_data.get("models", {})
     if not isinstance(models, dict):
         return None
@@ -374,6 +370,15 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
                 if ctx:
                     return ctx
 
+    # Provider-level model name that maps to a whole catalog (e.g.
+    # ``kimi-for-coding``).  Resolve to a representative model entry.
+    if mdev_provider_id and model.lower() == mdev_provider_id.lower():
+        entry = _pick_representative_model(models)
+        if entry is not None:
+            ctx = _extract_context(entry)
+            if ctx:
+                return ctx
+
     return None
 
 
@@ -410,10 +415,12 @@ class ModelCapabilities:
     model_family: str = ""
 
 
-def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
-    """Resolve a Hermes provider ID to its models dict from models.dev.
+def _get_provider_data(provider: str) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Resolve a Hermes provider ID to its models.dev entry.
 
-    Returns the models dict or None if the provider is unknown or has no data.
+    Returns a tuple of (models.dev provider ID, provider data dict) or None if
+    the provider is unknown or has no data.  Includes a case-insensitive fallback
+    for upstream registry variations.
     """
     mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
     if not mdev_provider_id:
@@ -421,9 +428,30 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
 
     data = fetch_models_dev()
     provider_data = data.get(mdev_provider_id)
+    # Case-insensitive fallback: provider catalog keys should generally be
+    # lowercase, but tolerate variations in the upstream registry.
+    if not isinstance(provider_data, dict):
+        target = mdev_provider_id.lower()
+        for pid, pdata in data.items():
+            if isinstance(pdata, dict) and pid.lower() == target:
+                provider_data = pdata
+                break
     if not isinstance(provider_data, dict):
         return None
 
+    return mdev_provider_id, provider_data
+
+
+def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
+    """Resolve a Hermes provider ID to its models dict from models.dev.
+
+    Returns the models dict or None if the provider is unknown or has no data.
+    """
+    result = _get_provider_data(provider)
+    if result is None:
+        return None
+
+    _provider_id, provider_data = result
     models = provider_data.get("models", {})
     if not isinstance(models, dict):
         return None
@@ -447,6 +475,65 @@ def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, 
     return None
 
 
+def _model_version_key(model_id: str) -> Tuple[Any, ...]:
+    """Natural-sort key for model IDs.
+
+    Splits the ID into alternating text and integer parts so that versioned
+    IDs like ``k2p5``, ``k2p9``, ``k2p10`` order numerically rather than
+    lexicographically (where ``k2p9`` > ``k2p10``).
+    """
+    parts: List[Any] = []
+    text_buf: List[str] = []
+    digit_buf: List[str] = []
+    for ch in model_id:
+        if ch.isdigit():
+            if text_buf:
+                parts.append("".join(text_buf).lower())
+                text_buf = []
+            digit_buf.append(ch)
+        else:
+            if digit_buf:
+                parts.append(int("".join(digit_buf)))
+                digit_buf = []
+            text_buf.append(ch)
+    if text_buf:
+        parts.append("".join(text_buf).lower())
+    if digit_buf:
+        parts.append(int("".join(digit_buf)))
+    return tuple(parts)
+
+
+def _pick_representative_model(models: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Pick a representative model from a provider catalog.
+
+    Prefer the latest vision-capable model so image routing reports native
+    vision when the provider supports it.  Fall back to the alphabetically
+    first model in the catalog if no vision model is found.
+    """
+    vision_entries: List[Tuple[str, Dict[str, Any]]] = []
+    valid_entries: List[Tuple[str, Dict[str, Any]]] = []
+
+    for mid, mdata in models.items():
+        if not isinstance(mdata, dict):
+            continue
+        valid_entries.append((mid, mdata))
+        mods = mdata.get("modalities")
+        if isinstance(mods, dict):
+            inputs = mods.get("input")
+            if isinstance(inputs, list) and "image" in inputs:
+                vision_entries.append((mid, mdata))
+
+    if vision_entries:
+        vision_entries.sort(key=lambda item: _model_version_key(item[0]), reverse=True)
+        return vision_entries[0][1]
+
+    if valid_entries:
+        valid_entries.sort(key=lambda item: _model_version_key(item[0]))
+        return valid_entries[0][1]
+
+    return None
+
+
 def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilities]:
     """Look up full capability metadata from models.dev cache.
 
@@ -461,11 +548,23 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
       - limit.output  (int) → max_output_tokens
       - family     (str)   → model_family
     """
-    models = _get_provider_models(provider)
-    if models is None:
+    result = _get_provider_data(provider)
+    if result is None:
         return None
 
+    mdev_provider_id, provider_data = result
+    models = provider_data.get("models", {})
+    if not isinstance(models, dict):
+        return None
+
+    # Some provider APIs accept a provider-level model name (e.g.
+    # ``kimi-for-coding``) that maps to a whole model catalog in models.dev.
+    # When the model string matches the provider catalog ID, resolve to a
+    # representative model from that catalog for capability detection. The
+    # actual API endpoint still decides which model runs.
     entry = _find_model_entry(models, model)
+    if entry is None and mdev_provider_id and model.lower() == mdev_provider_id.lower():
+        entry = _pick_representative_model(models)
     if entry is None:
         return None
 
@@ -698,16 +797,16 @@ def get_model_info(
     """Get full model metadata from models.dev.
 
     Accepts Hermes or models.dev provider ID.  Tries exact match then
-    case-insensitive fallback.  Returns None if not found.
+    case-insensitive fallback.  If ``model_id`` matches the provider catalog
+    ID, resolves to a representative model from that catalog.  Returns None
+    if not found.
     """
-    mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
-
-    data = fetch_models_dev()
-    pdata = data.get(mdev_id)
-    if not isinstance(pdata, dict):
+    result = _get_provider_data(provider_id)
+    if result is None:
         return None
 
-    models = pdata.get("models", {})
+    mdev_id, provider_data = result
+    models = provider_data.get("models", {})
     if not isinstance(models, dict):
         return None
 
@@ -721,5 +820,12 @@ def get_model_info(
     for mid, mdata in models.items():
         if mid.lower() == model_lower and isinstance(mdata, dict):
             return _parse_model_info(mid, mdata, mdev_id)
+
+    # Provider-level model name that maps to a whole catalog (e.g.
+    # ``kimi-for-coding``).  Resolve to a representative model entry.
+    if model_id.lower() == mdev_id.lower():
+        entry = _pick_representative_model(models)
+        if entry is not None:
+            return _parse_model_info(model_id, entry, mdev_id)
 
     return None

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -63,6 +63,7 @@ kimi = KimiProfile(
     default_max_tokens=32000,
     default_headers={"User-Agent": "hermes-agent/1.0"},
     default_aux_model="kimi-k2-turbo-preview",
+    supports_vision=True,
 )
 
 kimi_cn = KimiProfile(
@@ -74,6 +75,7 @@ kimi_cn = KimiProfile(
     default_max_tokens=32000,
     default_headers={"User-Agent": "hermes-agent/1.0"},
     default_aux_model="kimi-k2-turbo-preview",
+    supports_vision=True,
 )
 
 register_provider(kimi)

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -4,8 +4,11 @@ from unittest.mock import patch, MagicMock
 from agent.models_dev import (
     PROVIDER_TO_MODELS_DEV,
     _extract_context,
+    _model_version_key,
+    _pick_representative_model,
     fetch_models_dev,
     get_model_capabilities,
+    get_model_info,
     lookup_models_dev_context,
 )
 
@@ -401,3 +404,162 @@ class TestGetModelCapabilities:
         with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
             caps = get_model_capabilities("anthropic", "nonexistent-model")
         assert caps is None
+
+    def test_provider_catalog_name_resolves_to_latest_vision_model(self):
+        """Config model 'kimi-for-coding' matches provider catalog and picks latest vision model."""
+        registry = {
+            "kimi-for-coding": {
+                "id": "kimi-for-coding",
+                "name": "Kimi For Coding",
+                "models": {
+                    "k2p5": {
+                        "id": "k2p5",
+                        "name": "Kimi K2.5",
+                        "tool_call": True,
+                        "modalities": {"input": ["text", "image", "video"]},
+                        "limit": {"context": 262144, "output": 32768},
+                    },
+                    "k2p6": {
+                        "id": "k2p6",
+                        "name": "Kimi K2.6",
+                        "tool_call": True,
+                        "modalities": {"input": ["text", "image", "video"]},
+                        "limit": {"context": 262144, "output": 32768},
+                    },
+                    "k2p7": {
+                        "id": "k2p7",
+                        "name": "Kimi K2.7 Code",
+                        "tool_call": True,
+                        "modalities": {"input": ["text", "image", "video"]},
+                        "limit": {"context": 262144, "output": 32768},
+                    },
+                    "k2p10": {
+                        "id": "k2p10",
+                        "name": "Kimi K2.10 Code",
+                        "tool_call": True,
+                        "modalities": {"input": ["text", "image", "video"]},
+                        "limit": {"context": 524288, "output": 32768},
+                    },
+                    "kimi-k2-thinking": {
+                        "id": "kimi-k2-thinking",
+                        "name": "Kimi K2 Thinking",
+                        "tool_call": True,
+                        "modalities": {"input": ["text"]},
+                        "limit": {"context": 262144, "output": 32768},
+                    },
+                },
+            },
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("kimi-coding", "kimi-for-coding")
+            info = get_model_info("kimi-coding", "kimi-for-coding")
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.supports_tools is True
+        # k2p10 is the latest vision model (natural sort, not lexicographic).
+        assert caps.context_window == 524288
+        assert info is not None
+        assert info.id == "kimi-for-coding"
+        assert info.name == "Kimi K2.10 Code"
+
+    def test_provider_catalog_case_insensitive(self):
+        """Provider catalog matching is case-insensitive for both key and model name."""
+        registry = {
+            "Kimi-For-Coding": {
+                "id": "Kimi-For-Coding",
+                "models": {
+                    "k2p7": {
+                        "id": "k2p7",
+                        "tool_call": True,
+                        "modalities": {"input": ["text", "image"]},
+                        "limit": {"context": 262144, "output": 32768},
+                    },
+                },
+            },
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("kimi-coding", "kimi-for-coding")
+            ctx = lookup_models_dev_context("kimi-coding", "kimi-for-coding")
+            info = get_model_info("kimi-coding", "kimi-for-coding")
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert ctx == 262144
+        assert info is not None
+        assert info.context_window == 262144
+
+    def test_provider_catalog_literal_model_takes_precedence(self):
+        """If the catalog contains a model literally named like the catalog ID, use it."""
+        registry = {
+            "kimi-for-coding": {
+                "id": "kimi-for-coding",
+                "models": {
+                    "kimi-for-coding": {
+                        "id": "kimi-for-coding",
+                        "name": "Kimi For Coding (specific)",
+                        "tool_call": True,
+                        "modalities": {"input": ["text"]},
+                        "limit": {"context": 131072, "output": 16384},
+                    },
+                    "k2p7": {
+                        "id": "k2p7",
+                        "name": "Kimi K2.7 Code",
+                        "tool_call": True,
+                        "modalities": {"input": ["text", "image"]},
+                        "limit": {"context": 262144, "output": 32768},
+                    },
+                },
+            },
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("kimi-coding", "kimi-for-coding")
+            info = get_model_info("kimi-coding", "kimi-for-coding")
+        assert caps is not None
+        # Literal model entry is text-only, so capabilities reflect that.
+        assert caps.supports_vision is False
+        assert caps.context_window == 131072
+        assert info is not None
+        assert info.name == "Kimi For Coding (specific)"
+
+    def test_provider_catalog_no_vision_falls_back_to_first_model(self):
+        """A catalog with no vision models falls back to a deterministic text model."""
+        registry = {
+            "kimi-for-coding": {
+                "id": "kimi-for-coding",
+                "models": {
+                    "zzz-thinking": {
+                        "id": "zzz-thinking",
+                        "tool_call": True,
+                        "modalities": {"input": ["text"]},
+                        "limit": {"context": 131072, "output": 16384},
+                    },
+                    "aaa-text": {
+                        "id": "aaa-text",
+                        "tool_call": True,
+                        "modalities": {"input": ["text"]},
+                        "limit": {"context": 65536, "output": 8192},
+                    },
+                },
+            },
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            caps = get_model_capabilities("kimi-coding", "kimi-for-coding")
+        assert caps is not None
+        assert caps.supports_vision is False
+        # Alphabetical first valid model is chosen.
+        assert caps.context_window == 65536
+
+    def test_pick_representative_model_natural_sort(self):
+        """Model IDs sort numerically, not lexicographically."""
+        models = {
+            "k2p5": {"modalities": {"input": ["text", "image"]}},
+            "k2p9": {"modalities": {"input": ["text", "image"]}},
+            "k2p10": {"modalities": {"input": ["text", "image"]}},
+        }
+        entry = _pick_representative_model(models)
+        assert entry is models["k2p10"]
+
+    def test_model_version_key(self):
+        """Natural version key separates text and numeric parts."""
+        assert _model_version_key("k2p10") > _model_version_key("k2p9")
+        assert _model_version_key("k2p10") > _model_version_key("k2p2")
+        assert _model_version_key("v1.10") > _model_version_key("v1.2")

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -56,6 +56,15 @@ class TestSupportsMediaInToolResults:
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False
 
+    def test_kimi_coding_yes(self):
+        assert _supports_media_in_tool_results("kimi-coding", "kimi-for-coding") is True
+
+    def test_kimi_coding_cn_yes(self):
+        assert _supports_media_in_tool_results("kimi-coding-cn", "kimi-k2.5") is True
+
+    def test_moonshot_yes(self):
+        assert _supports_media_in_tool_results("moonshot", "kimi-k2.5") is True
+
     def test_empty_provider_no(self):
         assert _supports_media_in_tool_results("", "anything") is False
         assert _supports_media_in_tool_results(None, "anything") is False  # type: ignore[arg-type]

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -687,6 +687,10 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in {"openai", "openai-chat", "openai-codex", "azure-openai"}:
         return True
 
+    # Kimi / Moonshot — K2.5+ and K2.6 support multimodal tool results
+    if p in {"kimi-coding", "kimi-coding-cn", "kimi", "moonshot"}:
+        return True
+
     # Gemini — gate on model name; older Gemini variants did not support
     # multimodal functionResponse. Gemini 3.x does.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:


### PR DESCRIPTION
## What does this PR do?

Fixes native vision routing for the `kimi-coding` provider when the configured model is `kimi-for-coding`.

Hermes was falling back to the auxiliary-LLM vision path even though the Kimi API routes `kimi-for-coding` to a vision-capable model (K2.5, K2.6, K2.7, etc.) based on the subscription. This PR makes Hermes recognize that setup and send images directly.

Three things were wrong:

1. `tools/vision_tools.py` did not include `kimi-coding`, `kimi-coding-cn`, `kimi`, or `moonshot` in the allowlist for media inside tool results.
2. `agent/models_dev.py` failed to resolve `kimi-for-coding` because it is a provider catalog ID in `models.dev`, not a specific model ID. Hermes looked for a model literally named `kimi-for-coding`, found nothing, and assumed no vision.
3. The `kimi-coding` provider profile did not set `supports_vision=True`.

The fix is intentionally narrow. PR #24682 proposes a similar fix using a hardcoded alias map from `kimi-for-coding` to `k2p6`; this PR takes a more general approach by resolving the provider catalog dynamically, so it stays correct as the upstream catalog changes.

## Related Issue

Relates to / alternative to #24682. Re-creates #56368 after a repository reorganization.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py`: include `kimi-coding`, `kimi-coding-cn`, `kimi`, and `moonshot` in `_supports_media_in_tool_results`.
- `agent/models_dev.py`: add `_get_provider_data` helper with case-insensitive catalog key fallback; add `_model_version_key` and `_pick_representative_model`; use them in `lookup_models_dev_context`, `get_model_capabilities`, and `get_model_info` when the model name is the provider catalog ID.
- `plugins/model-providers/kimi-coding/__init__.py`: set `supports_vision=True` on `kimi` and `kimi_cn` profiles.
- `tests/tools/test_vision_native_fast_path.py`: new tests for Kimi/Moonshot providers.
- `tests/agent/test_models_dev.py`: new tests for `kimi-for-coding` provider-catalog resolution, case-insensitive matching, literal-model precedence, no-vision fallback, and natural sort.

## How to Test

1. Configure `provider: kimi-coding` and `model: kimi-for-coding`.
2. Send an image to a tool that returns one back, or run:
   ```bash
   pytest tests/agent/test_models_dev.py tests/tools/test_vision_native_fast_path.py -q
   ```
3. End-to-end with a live Kimi key:
   ```bash
   hermes chat -q "What color is this square? Reply with one word." \
     --image /tmp/red_square.png --provider kimi-coding -m kimi-for-coding -Q
   ```
   Result: `Red` (native vision fast path used).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests (`tests/agent/test_models_dev.py`, `tests/tools/test_vision_native_fast_path.py`) and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (unit tests + manual `hermes` run with live `kimi-coding` / `kimi-for-coding`)

### Documentation & Housekeeping

- [x] N/A — no documentation updates needed (README, `docs/`, docstrings unchanged)
- [x] N/A — no config keys added/changed (`cli-config.yaml.example` unchanged)
- [x] N/A — no architecture or workflow changes (`CONTRIBUTING.md` / `AGENTS.md` unchanged)
- [x] Cross-platform impact considered — pure Python logic, no file I/O or process management
- [x] N/A — no tool descriptions/schemas changed

## For New Skills

N/A

## Screenshots / Logs

N/A
