### PR TITLE
fix(tts): transcode openai voice output to opus

### DIFF
--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -68,3 +68,53 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_openai_compatible_telegram_transcodes_mp3_for_opus_voice(
+    tmp_path, monkeypatch
+):
+    out = tmp_path / "speech.ogg"
+    synth = tmp_path / "speech.mp3"
+    create = MagicMock()
+
+    def fake_stream(path: str) -> None:
+        Path(path).write_bytes(b"mp3")
+
+    response = MagicMock()
+    response.stream_to_file.side_effect = fake_stream
+    create.return_value = response
+
+    mock_client = MagicMock()
+    mock_client.audio.speech.create = create
+    mock_client_cls = MagicMock(return_value=mock_client)
+
+    def fake_convert(path: str) -> str:
+        assert path == str(synth)
+        out.write_bytes(b"ogg")
+        return str(out)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(
+        tts_tool,
+        "_load_tts_config",
+        lambda: {
+            "provider": "openai",
+            "openai": {"base_url": "https://compatible.example/v1"},
+        },
+    )
+    monkeypatch.setattr(
+        tts_tool,
+        "_resolve_openai_audio_client_config",
+        lambda: ("key", None, False),
+    )
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: mock_client_cls)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", fake_convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{out}"
+    assert create.call_args.kwargs["response_format"] == "mp3"
+    response.stream_to_file.assert_called_once_with(str(synth))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1047,9 +1047,22 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         )
         model = DEFAULT_OPENAI_MODEL
 
-    # Determine response format from extension
-    if output_path.endswith(".ogg"):
+    wants_opus = output_path.endswith(".ogg")
+    base_url_text = str(base_url or DEFAULT_OPENAI_BASE_URL).rstrip("/")
+    official_base_url = DEFAULT_OPENAI_BASE_URL.rstrip("/")
+    can_request_native_opus = (
+        wants_opus
+        and not is_managed
+        and not custom_base_url
+        and base_url_text == official_base_url
+    )
+
+    synthesis_path = output_path
+    if can_request_native_opus:
         response_format = "opus"
+    elif wants_opus:
+        response_format = "mp3"
+        synthesis_path = output_path.rsplit(".", 1)[0] + ".mp3"
     else:
         response_format = "mp3"
 
@@ -1067,8 +1080,11 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         response = client.audio.speech.create(**create_kwargs)
 
-        response.stream_to_file(output_path)
-        return output_path
+        response.stream_to_file(synthesis_path)
+        if wants_opus:
+            opus_path = _convert_to_opus(synthesis_path)
+            return opus_path or synthesis_path
+        return synthesis_path
     finally:
         close = getattr(client, "close", None)
         if callable(close):
@@ -2292,7 +2308,7 @@ def text_to_speech_tool(
                     "error": "OpenAI provider selected but 'openai' package not installed."
                 }, ensure_ascii=False)
             logger.info("Generating speech with OpenAI TTS...")
-            _generate_openai_tts(text, file_str, tts_config)
+            file_str = _generate_openai_tts(text, file_str, tts_config)
 
         elif provider == "minimax":
             logger.info("Generating speech with MiniMax TTS...")


### PR DESCRIPTION
## Summary
- request MP3 from OpenAI-compatible TTS backends for .ogg voice targets
- transcode the synthesized MP3 to OGG/Opus with the existing ffmpeg helper
- propagate the generated path back through text_to_speech_tool so voice media tags point at the converted file

Fixes #54589

## Tests
- .venv/bin/python -m pytest tests/tools/test_tts_opus_routing.py tests/tools/test_tts_speed.py -q -k "openai or opus"
- .venv/bin/python -m ruff check tools/tts_tool.py tests/tools/test_tts_opus_routing.py
- .venv/bin/python -m pytest tests/tools/test_tts_opus_routing.py tests/tools/test_tts_speed.py -q
- scripts/run_tests.sh tests/tools/test_tts_opus_routing.py tests/tools/test_tts_speed.py -q