### PR TITLE
fix(cli): preserve custom_providers in dashboard model switcher

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -995,6 +995,20 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     model_in = (model or "").strip()
     canonical = normalize_provider(prov_in)
 
+    # Custom providers defined in config.yaml are valid targets — skip the
+    # vendor-prefix fallback so the dashboard doesn't rewrite them to
+    # openrouter (#57143).
+    try:
+        _custom_names = {
+            cp.get("name", "").strip().lower()
+            for cp in (load_config().get("custom_providers") or [])
+            if isinstance(cp, dict) and cp.get("name")
+        }
+        if canonical in _custom_names or prov_in.lower() in _custom_names:
+            return prov_in, model_in
+    except Exception:
+        pass
+
     if canonical not in _KNOWN_PROVIDER_NAMES and "/" in model_in:
         # Vendor prefix posing as a provider (analytics fallback). Resolve
         # against the user's current provider when it's an aggregator that

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -6520,3 +6520,36 @@ class TestDesktopCronTicker:
 
         with self._client():
             assert not called.wait(0.5), "ticker must not run outside the desktop app"
+
+    def test_normalize_main_model_assignment_preserves_custom_provider(self):
+        """_normalize_main_model_assignment must not rewrite custom providers
+        from config.yaml to openrouter (#57143)."""
+        from hermes_cli.web_server import _normalize_main_model_assignment
+
+        # Patch load_config to return a custom provider.
+        from unittest.mock import patch as _patch
+
+        fake_cfg = {
+            "custom_providers": [
+                {
+                    "name": "siliconflow",
+                    "base_url": "https://api.siliconflow.cn/v1",
+                    "api_key": "sk-xxx",
+                    "api_mode": "chat_completions",
+                }
+            ]
+        }
+        with _patch("hermes_cli.web_server.load_config", return_value=fake_cfg):
+            prov, model = _normalize_main_model_assignment(
+                "siliconflow", "deepseek-ai/DeepSeek-V4-Flash"
+            )
+        # Must keep the custom provider verbatim, not rewrite to openrouter.
+        assert prov == "siliconflow"
+        assert model == "deepseek-ai/DeepSeek-V4-Flash"
+
+        # Non-custom unknown provider with vendor-prefixed model → openrouter.
+        with _patch("hermes_cli.web_server.load_config", return_value=fake_cfg):
+            prov, model = _normalize_main_model_assignment(
+                "someunknown", "anthropic/claude-opus-4.8"
+            )
+        assert prov == "openrouter"


### PR DESCRIPTION
## What does this PR do?

When the Dashboard model switcher sends a custom provider name (e.g. `siliconflow`), `_normalize_main_model_assignment` didn't recognize it because it only checked `_KNOWN_PROVIDER_NAMES` (built-in providers). The function fell through to the openrouter default, silently overwriting the user's custom provider selection. This fix checks `custom_providers` from config.yaml before the fallback.

## Related Issue

Fixes #57143

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: In `_normalize_main_model_assignment`, added an early check against `custom_providers` from config. If the provider name matches a custom provider, return immediately without entering the vendor-prefix fallback.
- `tests/hermes_cli/test_web_server.py`: Added `test_normalize_main_model_assignment_preserves_custom_provider` — verifies custom providers are preserved and non-custom unknowns still fall back to openrouter.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_web_server.py -k "test_normalize_main_model_assignment_preserves_custom_provider" -q` — should pass.
2. Run `python -m pytest tests/hermes_cli/test_web_server.py -q` — all 339 tests should pass.
3. The test patches `load_config` to return a `custom_providers` entry with name `siliconflow`, then asserts `_normalize_main_model_assignment("siliconflow", "deepseek-ai/DeepSeek-V4-Flash")` returns `("siliconflow", "deepseek-ai/DeepSeek-V4-Flash")` instead of `("openrouter", ...)`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
