### PR TITLE
[codex] Fix Windows update output decoding

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4461,7 +4461,7 @@ _UPDATE_CRITICAL_FILES = (
 def _capture_head_sha(git_cmd, cwd) -> str | None:
     """Return the current HEAD SHA, or None if it can't be resolved."""
     try:
-        result = subprocess.run(
+        result = _run_update_subprocess(
             git_cmd + ["rev-parse", "HEAD"],
             cwd=cwd,
             capture_output=True,
@@ -6394,8 +6394,16 @@ def _update_via_zip(args):
     _kill_stale_dashboard_processes()
 
 
+def _run_update_subprocess(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Run update subprocesses with safe text decoding on non-UTF-8 Windows."""
+    if kwargs.get("text") is True or kwargs.get("universal_newlines") is True:
+        kwargs.setdefault("encoding", "utf-8")
+        kwargs.setdefault("errors", "replace")
+    return subprocess.run(cmd, **kwargs)
+
+
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
-    status = subprocess.run(
+    status = _run_update_subprocess(
         git_cmd + ["status", "--porcelain"],
         cwd=cwd,
         capture_output=True,
@@ -6409,7 +6417,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
     # git stash will fail with "needs merge / could not write index".  Clear the
     # conflict state with `git reset` so the stash can proceed.  Working-tree
     # changes are preserved; only the index conflict markers are dropped.
-    unmerged = subprocess.run(
+    unmerged = _run_update_subprocess(
         git_cmd + ["ls-files", "--unmerged"],
         cwd=cwd,
         capture_output=True,
@@ -6417,7 +6425,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
     )
     if unmerged.stdout.strip():
         print("→ Clearing unmerged index entries from a previous conflict...")
-        subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True)
+        _run_update_subprocess(git_cmd + ["reset"], cwd=cwd, capture_output=True)
 
     from datetime import datetime, timezone
 
@@ -6425,12 +6433,12 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         "hermes-update-autostash-%Y%m%d-%H%M%S"
     )
     print("→ Local changes detected — stashing before update...")
-    subprocess.run(
+    _run_update_subprocess(
         git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
         cwd=cwd,
         check=True,
     )
-    stash_ref = subprocess.run(
+    stash_ref = _run_update_subprocess(
         git_cmd + ["rev-parse", "--verify", "refs/stash"],
         cwd=cwd,
         capture_output=True,
@@ -6443,7 +6451,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
 def _resolve_stash_selector(
     git_cmd: list[str], cwd: Path, stash_ref: str
 ) -> Optional[str]:
-    stash_list = subprocess.run(
+    stash_list = _run_update_subprocess(
         git_cmd + ["stash", "list", "--format=%gd %H"],
         cwd=cwd,
         capture_output=True,
@@ -6498,7 +6506,7 @@ def _restore_stashed_changes(
             return False
 
     print("→ Restoring local changes...")
-    restore = subprocess.run(
+    restore = _run_update_subprocess(
         git_cmd + ["stash", "apply", stash_ref],
         cwd=cwd,
         capture_output=True,
@@ -6506,7 +6514,7 @@ def _restore_stashed_changes(
     )
 
     # Check for unmerged (conflicted) files — can happen even when returncode is 0
-    unmerged = subprocess.run(
+    unmerged = _run_update_subprocess(
         git_cmd + ["diff", "--name-only", "--diff-filter=U"],
         cwd=cwd,
         capture_output=True,
@@ -6534,7 +6542,7 @@ def _restore_stashed_changes(
         # Always reset to clean state — leaving conflict markers in source
         # files makes hermes completely unrunnable (SyntaxError on import).
         # The user's changes are safe in the stash for manual recovery.
-        subprocess.run(
+        _run_update_subprocess(
             git_cmd + ["reset", "--hard", "HEAD"],
             cwd=cwd,
             capture_output=True,
@@ -6556,7 +6564,7 @@ def _restore_stashed_changes(
         )
         _print_stash_cleanup_guidance(stash_ref)
     else:
-        drop = subprocess.run(
+        drop = _run_update_subprocess(
             git_cmd + ["stash", "drop", stash_selector],
             cwd=cwd,
             capture_output=True,
@@ -6608,7 +6616,7 @@ def _discard_stashed_changes(
         _print_stash_cleanup_guidance(stash_ref)
         return False
 
-    drop = subprocess.run(
+    drop = _run_update_subprocess(
         git_cmd + ["stash", "drop", stash_selector],
         cwd=cwd,
         capture_output=True,
@@ -6645,7 +6653,7 @@ SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"
 def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
     """Get the URL of the origin remote, or None if not set."""
     try:
-        result = subprocess.run(
+        result = _run_update_subprocess(
             git_cmd + ["remote", "get-url", "origin"],
             cwd=cwd,
             capture_output=True,
@@ -6678,7 +6686,7 @@ def _is_fork(origin_url: Optional[str]) -> bool:
 def _has_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
     """Check if an 'upstream' remote already exists."""
     try:
-        result = subprocess.run(
+        result = _run_update_subprocess(
             git_cmd + ["remote", "get-url", "upstream"],
             cwd=cwd,
             capture_output=True,
@@ -6692,7 +6700,7 @@ def _has_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
 def _add_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
     """Add the official repo as the 'upstream' remote. Returns True on success."""
     try:
-        result = subprocess.run(
+        result = _run_update_subprocess(
             git_cmd + ["remote", "add", "upstream", OFFICIAL_REPO_URL],
             cwd=cwd,
             capture_output=True,
@@ -6706,7 +6714,7 @@ def _add_upstream_remote(git_cmd: list[str], cwd: Path) -> bool:
 def _count_commits_between(git_cmd: list[str], cwd: Path, base: str, head: str) -> int:
     """Count commits on `head` that are not on `base`. Returns -1 on error."""
     try:
-        result = subprocess.run(
+        result = _run_update_subprocess(
             git_cmd + ["rev-list", "--count", f"{base}..{head}"],
             cwd=cwd,
             capture_output=True,
@@ -6742,7 +6750,7 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
     Returns True if push succeeded, False otherwise.
     """
     try:
-        result = subprocess.run(
+        result = _run_update_subprocess(
             git_cmd + ["push", "origin", "main", "--force-with-lease"],
             cwd=cwd,
             capture_output=True,
@@ -7874,7 +7882,7 @@ def _verify_core_dependencies_installed(
             "print('\\n'.join(missing))\n"
         )
         try:
-            result = subprocess.run(
+            result = _run_update_subprocess(
                 [str(venv_python), "-c", check_script, *applicable],
                 capture_output=True,
                 text=True,
@@ -8421,7 +8429,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     # would then report a huge bogus "behind" number. Detect shallow up front:
     # fetch with --depth 1 to preserve the boundary and report presence-only.
     is_shallow = (
-        subprocess.run(
+        _run_update_subprocess(
             git_cmd + ["rev-parse", "--is-shallow-repository"],
             cwd=PROJECT_ROOT,
             capture_output=True,
@@ -8433,7 +8441,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
 
     if branch == "main":
         print("→ Fetching from upstream...")
-        fetch_result = subprocess.run(
+        fetch_result = _run_update_subprocess(
             git_cmd + ["fetch"] + depth_args + ["upstream", branch],
             cwd=PROJECT_ROOT,
             capture_output=True,
@@ -8442,7 +8450,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         if fetch_result.returncode != 0:
             # Fallback to origin if upstream doesn't exist
             print("→ Fetching from origin...")
-            fetch_result = subprocess.run(
+            fetch_result = _run_update_subprocess(
                 git_cmd + ["fetch"] + depth_args + ["origin", branch],
                 cwd=PROJECT_ROOT,
                 capture_output=True,
@@ -8456,7 +8464,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     else:
         # Non-default branch: compare against origin/<branch> directly.
         print("→ Fetching from origin...")
-        fetch_result = subprocess.run(
+        fetch_result = _run_update_subprocess(
             git_cmd + ["fetch"] + depth_args + ["origin", branch],
             cwd=PROJECT_ROOT,
             capture_output=True,
@@ -8481,7 +8489,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     # Without this, `git rev-list HEAD..origin/<bogus> --count` exits 128 and
     # (with check=True) raises CalledProcessError, surfacing a Python
     # traceback. Friendlier to detect-and-report.
-    verify_result = subprocess.run(
+    verify_result = _run_update_subprocess(
         git_cmd + ["rev-parse", "--verify", "--quiet", compare_branch],
         cwd=PROJECT_ROOT,
         capture_output=True,
@@ -8494,11 +8502,11 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     if is_shallow:
         # No history to count across the shallow boundary. Compare tip SHAs and
         # report presence-only (mirrors the banner's _check_via_local_git).
-        head_sha = subprocess.run(
+        head_sha = _run_update_subprocess(
             git_cmd + ["rev-parse", "HEAD"],
             cwd=PROJECT_ROOT, capture_output=True, text=True,
         ).stdout.strip()
-        target_sha = subprocess.run(
+        target_sha = _run_update_subprocess(
             git_cmd + ["rev-parse", compare_branch],
             cwd=PROJECT_ROOT, capture_output=True, text=True,
         ).stdout.strip()
@@ -8511,7 +8519,7 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
             print(f"  Run '{recommended_update_command()}' to install.")
         return
 
-    rev_result = subprocess.run(
+    rev_result = _run_update_subprocess(
         git_cmd + ["rev-list", f"HEAD..{compare_branch}", "--count"],
         cwd=PROJECT_ROOT,
         capture_output=True,
@@ -8564,7 +8572,7 @@ def _ensure_fhs_path_guard() -> None:
     # which is the exact scenario where RHEL root loses /usr/local/bin.
     home = os.environ.get("HOME") or "/root"
     try:
-        probe = subprocess.run(
+        probe = _run_update_subprocess(
             [
                 "env",
                 "-i",
@@ -9027,7 +9035,7 @@ def _discard_lockfile_churn(git_cmd, repo_root):
     Best-effort; only ever touches files named ``package-lock.json``.
     """
     try:
-        diff = subprocess.run(
+        diff = _run_update_subprocess(
             git_cmd + ["diff", "--name-only"],
             cwd=repo_root,
             capture_output=True,
@@ -9048,7 +9056,7 @@ def _discard_lockfile_churn(git_cmd, repo_root):
         ]
         if not dirty:
             return
-        subprocess.run(
+        _run_update_subprocess(
             git_cmd + ["checkout", "--", *dirty],
             cwd=repo_root,
             capture_output=True,
@@ -9314,7 +9322,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         branch = _resolve_update_branch(args)
 
         print("→ Fetching updates...")
-        fetch_result = subprocess.run(
+        fetch_result = _run_update_subprocess(
             git_cmd + ["fetch", "origin", branch],
             cwd=PROJECT_ROOT,
             capture_output=True,
@@ -9338,7 +9346,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             sys.exit(1)
 
         # Get current branch (returns literal "HEAD" when detached)
-        result = subprocess.run(
+        result = _run_update_subprocess(
             git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
             cwd=PROJECT_ROOT,
             capture_output=True,
@@ -9361,7 +9369,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(f"  ⚠ Currently on {label} — switching to {branch} for update...")
             # Stash before checkout so uncommitted work isn't lost
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
-            checkout_result = subprocess.run(
+            checkout_result = _run_update_subprocess(
                 git_cmd + ["checkout", branch],
                 cwd=PROJECT_ROOT,
                 capture_output=True,
@@ -9372,7 +9380,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # it up as a tracking branch of origin/<branch>. This is
                 # the common case when the requested branch exists upstream
                 # but was never checked out locally.
-                track_result = subprocess.run(
+                track_result = _run_update_subprocess(
                     git_cmd + ["checkout", "-B", branch, f"origin/{branch}"],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
@@ -9403,7 +9411,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
 
         # Check if there are updates
-        result = subprocess.run(
+        result = _run_update_subprocess(
             git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
             cwd=PROJECT_ROOT,
             capture_output=True,
@@ -9429,7 +9437,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     input_fn=gw_input_fn,
                 )
             if current_branch not in {branch, "HEAD"}:
-                subprocess.run(
+                _run_update_subprocess(
                     git_cmd + ["checkout", current_branch],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
@@ -9468,7 +9476,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # the bad commit and the fix landing).
         pre_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
         try:
-            pull_result = subprocess.run(
+            pull_result = _run_update_subprocess(
                 git_cmd + ["pull", "--ff-only", "origin", branch],
                 cwd=PROJECT_ROOT,
                 capture_output=True,
@@ -9481,7 +9489,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print(
                     "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
                 )
-                reset_result = subprocess.run(
+                reset_result = _run_update_subprocess(
                     git_cmd + ["reset", "--hard", f"origin/{branch}"],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
@@ -9517,7 +9525,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 if pre_pull_sha:
                     print()
                     print(f"→ Rolling back to {pre_pull_sha[:10]}...")
-                    rollback_result = subprocess.run(
+                    rollback_result = _run_update_subprocess(
                         git_cmd + ["reset", "--hard", pre_pull_sha],
                         cwd=PROJECT_ROOT,
                         capture_output=True,
@@ -10052,7 +10060,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 deadline = _time.monotonic() + max(timeout, 0.5)
                 while True:
                     try:
-                        _verify = subprocess.run(
+                        _verify = _run_update_subprocess(
                             scope_cmd_ + ["is-active", svc_name_],
                             capture_output=True,
                             text=True,
@@ -10080,7 +10088,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 conclude the unit didn't relaunch.
                 """
                 try:
-                    _show = subprocess.run(
+                    _show = _run_update_subprocess(
                         scope_cmd_
                         + [
                             "show",
@@ -10226,7 +10234,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     ("system", ["systemctl"]),
                 ]:
                     try:
-                        result = subprocess.run(
+                        result = _run_update_subprocess(
                             scope_cmd
                             + [
                                 "list-units",
@@ -10250,7 +10258,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 continue
                             svc_name = unit.removesuffix(".service")
                             # Check if active
-                            check = subprocess.run(
+                            check = _run_update_subprocess(
                                 scope_cmd + ["is-active", svc_name],
                                 capture_output=True,
                                 text=True,
@@ -10277,7 +10285,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             # exit; systemd's Restart=always respawns the unit.
                             _main_pid = 0
                             try:
-                                _show = subprocess.run(
+                                _show = _run_update_subprocess(
                                     scope_cmd
                                     + [
                                         "show",
@@ -10336,13 +10344,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 # auto-restart still relaunches the unit after
                                 # RestartSec, no privileges required.
                                 if _manage_cmd is not None:
-                                    subprocess.run(
+                                    _run_update_subprocess(
                                         _manage_cmd + ["reset-failed", svc_name],
                                         capture_output=True,
                                         text=True,
                                         timeout=10,
                                     )
-                                    subprocess.run(
+                                    _run_update_subprocess(
                                         _manage_cmd + ["start", svc_name],
                                         capture_output=True,
                                         text=True,
@@ -10425,13 +10433,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             # the restart idempotent.  Mirrors the recovery
                             # path in `hermes gateway restart`
                             # (`systemd_restart()`) as of PR #20949.
-                            subprocess.run(
+                            _run_update_subprocess(
                                 _manage_cmd + ["reset-failed", svc_name],
                                 capture_output=True,
                                 text=True,
                                 timeout=10,
                             )
-                            restart = subprocess.run(
+                            restart = _run_update_subprocess(
                                 _manage_cmd + ["restart", svc_name],
                                 capture_output=True,
                                 text=True,
@@ -10457,13 +10465,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                     print(
                                         f"  ⚠ {svc_name} died after restart, retrying..."
                                     )
-                                    subprocess.run(
+                                    _run_update_subprocess(
                                         _manage_cmd + ["reset-failed", svc_name],
                                         capture_output=True,
                                         text=True,
                                         timeout=10,
                                     )
-                                    subprocess.run(
+                                    _run_update_subprocess(
                                         _manage_cmd + ["restart", svc_name],
                                         capture_output=True,
                                         text=True,
@@ -10513,7 +10521,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
                     plist_path = get_launchd_plist_path()
                     if plist_path.exists():
-                        check = subprocess.run(
+                        check = _run_update_subprocess(
                             ["launchctl", "list", get_launchd_label()],
                             capture_output=True,
                             text=True,

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -23,6 +23,16 @@ from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
+
+def _run_captured_text(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Capture subprocess text without relying on the Windows locale codec."""
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    kwargs.setdefault("encoding", "utf-8")
+    kwargs.setdefault("errors", "replace")
+    return subprocess.run(cmd, **kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Public helpers
 # ---------------------------------------------------------------------------
@@ -112,10 +122,8 @@ def _ensure_uv_path() -> Optional[str]:
     # Verify
     result = resolve_uv()
     if result:
-        version = subprocess.run(
+        version = _run_captured_text(
             [result, "--version"],
-            capture_output=True,
-            text=True,
             check=False,
         ).stdout.strip()
         print(f"  ✓ Managed uv installed ({version})")
@@ -167,17 +175,13 @@ def update_managed_uv() -> Optional[str]:
         # Not installed yet — ensure_uv() will handle that elsewhere.
         return None
 
-    result = subprocess.run(
+    result = _run_captured_text(
         [existing, "self", "update"],
-        capture_output=True,
-        text=True,
         check=False,
     )
     if result.returncode == 0:
-        version = subprocess.run(
+        version = _run_captured_text(
             [existing, "--version"],
-            capture_output=True,
-            text=True,
             check=False,
         ).stdout.strip()
         print(f"  ✓ Managed uv updated ({version})")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -77,6 +77,16 @@ _CLONE_ALL_STRIP: list[str] = [
     "processes.json",
 ]
 
+
+def _run_captured_text(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Capture subprocess text without relying on the Windows locale codec."""
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    kwargs.setdefault("encoding", "utf-8")
+    kwargs.setdefault("errors", "replace")
+    return subprocess.run(cmd, **kwargs)
+
+
 # Infrastructure artifacts excluded from --clone-all when the source is the
 # default profile (``~/.hermes``).  Named profiles never contain these
 # directories at root, so the exclusion is gated to avoid silently dropping
@@ -1180,13 +1190,13 @@ def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict
         }
     project_root = Path(__file__).parent.parent.resolve()
     try:
-        result = subprocess.run(
+        result = _run_captured_text(
             [sys.executable, "-c",
              "import json; from tools.skills_sync import sync_skills; "
              "r = sync_skills(quiet=True); print(json.dumps(r))"],
             env={**os.environ, "HERMES_HOME": str(profile_dir)},
             cwd=str(project_root),
-            capture_output=True, text=True, timeout=60,
+            timeout=60,
         )
         if result.returncode == 0 and result.stdout.strip():
             return json.loads(result.stdout.strip())

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -209,6 +209,7 @@ class TestUpdateManagedUv:
     def test_self_update_success(self, tmp_path):
         _make_executable(tmp_path / "bin" / "uv")
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.platform.system", return_value="Linux"), \
              patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
             # uv self update succeeds
             mock_run.return_value = MagicMock(returncode=0, stdout="uv 0.2.0")
@@ -218,10 +219,15 @@ class TestUpdateManagedUv:
             # First call is self update, second is --version
             assert mock_run.call_count == 2
             assert mock_run.call_args_list[0][0][0] == [str(tmp_path / "bin" / "uv"), "self", "update"]
+            assert mock_run.call_args_list[0].kwargs["encoding"] == "utf-8"
+            assert mock_run.call_args_list[0].kwargs["errors"] == "replace"
+            assert mock_run.call_args_list[1].kwargs["encoding"] == "utf-8"
+            assert mock_run.call_args_list[1].kwargs["errors"] == "replace"
 
     def test_self_update_failure_non_fatal(self, tmp_path):
         _make_executable(tmp_path / "bin" / "uv")
         with patch("hermes_cli.managed_uv.get_hermes_home", return_value=tmp_path), \
+             patch("hermes_cli.managed_uv.platform.system", return_value="Linux"), \
              patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stderr="nope")
             from hermes_cli.managed_uv import update_managed_uv

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -203,9 +203,15 @@ def test_restore_stashed_changes_keeps_going_when_stash_entry_cannot_be_resolved
     restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=False)
 
     assert restored is True
-    assert calls[0] == (["git", "stash", "apply", "abc123"], {"cwd": tmp_path, "capture_output": True, "text": True})
-    assert calls[1] == (["git", "diff", "--name-only", "--diff-filter=U"], {"cwd": tmp_path, "capture_output": True, "text": True})
-    assert calls[2] == (["git", "stash", "list", "--format=%gd %H"], {"cwd": tmp_path, "capture_output": True, "text": True, "check": True})
+    assert calls[0][0] == ["git", "stash", "apply", "abc123"]
+    assert calls[1][0] == ["git", "diff", "--name-only", "--diff-filter=U"]
+    assert calls[2][0] == ["git", "stash", "list", "--format=%gd %H"]
+    assert calls[0][1]["cwd"] == tmp_path
+    assert calls[0][1]["capture_output"] is True
+    assert calls[0][1]["text"] is True
+    assert calls[0][1]["encoding"] == "utf-8"
+    assert calls[0][1]["errors"] == "replace"
+    assert calls[2][1]["check"] is True
     out = capsys.readouterr().out
     assert "couldn't find the stash entry to drop" in out
     assert "stash was left in place" in out
@@ -901,3 +907,26 @@ def test_bootstrap_marker_not_autostashed_by_update(tmp_path):
         ["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True
     ).stdout
     assert ".hermes-bootstrap-complete" not in status
+
+
+def test_cmd_update_text_subprocesses_use_utf8_replace(monkeypatch, tmp_path):
+    """Captured update subprocess output must not decode with the Windows locale."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect()
+    text_calls = []
+
+    def fake_run(cmd, **kwargs):
+        if kwargs.get("text") is True:
+            text_calls.append((cmd, kwargs))
+        return side_effect(cmd, **kwargs)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert recorded
+    assert text_calls
+    assert all(kwargs.get("encoding") == "utf-8" for _, kwargs in text_calls)
+    assert all(kwargs.get("errors") in {"replace", "ignore"} for _, kwargs in text_calls)

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -13,6 +13,8 @@ call is mocked — we never actually shell out during unit tests.
 from __future__ import annotations
 
 
+from types import SimpleNamespace
+
 import pytest
 
 import tools.lazy_deps as ld
@@ -404,3 +406,26 @@ class TestRefreshActiveFeatures:
         result = ld.refresh_active_features()
         assert result["a.ok"] == "current"
         assert result["b.fail"].startswith("failed:")
+
+
+class TestLazyInstallSubprocessEncoding:
+    def test_venv_pip_install_captures_text_with_utf8_replace(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "uv" if name == "uv" else None)
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        result = ld._venv_pip_install(("zzzfake==1.0",), timeout=5)
+
+        assert result.success is True
+        assert calls
+        _, kwargs = calls[0]
+        assert kwargs["text"] is True
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -281,6 +281,15 @@ class _InstallResult:
     stderr: str
 
 
+def _run_captured_text(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Capture subprocess text without relying on the Windows locale codec."""
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    kwargs.setdefault("encoding", "utf-8")
+    kwargs.setdefault("errors", "replace")
+    return subprocess.run(cmd, **kwargs)
+
+
 # =============================================================================
 # Internals
 # =============================================================================
@@ -646,9 +655,9 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         uv_bin = shutil.which("uv")
         if uv_bin:
             try:
-                r = subprocess.run(
+                r = _run_captured_text(
                     [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
-                    capture_output=True, text=True, timeout=timeout, env=uv_env,
+                    timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                 )
                 if r.returncode == 0:
@@ -662,18 +671,18 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         # Tier 2: python -m pip (with ensurepip bootstrap if needed)
         pip_cmd = [sys.executable, "-m", "pip"]
         try:
-            probe = subprocess.run(
+            probe = _run_captured_text(
                 pip_cmd + ["--version"],
-                capture_output=True, text=True, timeout=15,
+                timeout=15,
                 stdin=subprocess.DEVNULL,
             )
             if probe.returncode != 0:
                 raise FileNotFoundError("pip not in venv")
         except (subprocess.TimeoutExpired, FileNotFoundError):
             try:
-                subprocess.run(
+                _run_captured_text(
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                    capture_output=True, text=True, timeout=120, check=True,
+                    timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
@@ -681,9 +690,9 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                                       f"pip not available and ensurepip failed: {e}")
 
         try:
-            r = subprocess.run(
+            r = _run_captured_text(
                 pip_cmd + ["install", *target_args, *constraint_args, *specs],
-                capture_output=True, text=True, timeout=timeout,
+                timeout=timeout,
                 stdin=subprocess.DEVNULL,
             )
             if r.returncode == 0 and target is not None:


### PR DESCRIPTION
﻿## What does this PR do?

- Adds UTF-8 + replacement decoding for captured text subprocesses used by `hermes update` and related update-time helpers.
- Covers the update git path, managed `uv self update` / `uv --version`, profile skill seeding during update, and lazy dependency installer subprocess output.
- Adds focused tests that assert these captured text calls no longer fall back to the Windows locale codec.

## Why?

On Chinese Windows locales, Python's default text-mode subprocess decoding can use GBK. When a child process emits bytes that are not valid GBK, the reader thread raises `UnicodeDecodeError` before Hermes can handle the command result. This can crash `hermes update` or update-triggered dependency/skill refresh paths.

Related: #53428

## Proof

Passed:

```powershell
uv run --with pytest python -m pytest --basetemp work\pytest-tmp -p no:cacheprovider tests\tools\test_lazy_deps.py::TestLazyInstallSubprocessEncoding::test_venv_pip_install_captures_text_with_utf8_replace tests\hermes_cli\test_update_autostash.py::test_cmd_update_text_subprocesses_use_utf8_replace tests\hermes_cli\test_managed_uv.py::TestUpdateManagedUv::test_self_update_success -q
# 3 passed
```

```powershell
uv run python -m py_compile hermes_cli\main.py hermes_cli\managed_uv.py hermes_cli\profiles.py tools\lazy_deps.py tests\hermes_cli\test_update_autostash.py tests\hermes_cli\test_managed_uv.py tests\tools\test_lazy_deps.py
```

```powershell
$env:PYTHONUTF8='1'; $env:PYTHONIOENCODING='utf-8'; python C:\Users\Administrator\.codex\skills\autoreview\scripts\autoreview --mode local --parallel-tests "New-Item -ItemType Directory -Force work | Out-Null; uv run --with pytest python -m pytest --basetemp work\pytest-review-tmp -p no:cacheprovider tests\tools\test_lazy_deps.py::TestLazyInstallSubprocessEncoding::test_venv_pip_install_captures_text_with_utf8_replace tests\hermes_cli\test_update_autostash.py::test_cmd_update_text_subprocesses_use_utf8_replace tests\hermes_cli\test_managed_uv.py::TestUpdateManagedUv::test_self_update_success -q" --parallel-tests-shell powershell
# autoreview clean; tests exit 0
```

Note: I also tried the broader `tests\tools\test_lazy_deps.py tests\hermes_cli\test_update_autostash.py` file run on native Windows. It reached 89 passed / 7 failed; the failures are existing Windows test-environment assumptions such as hard-coded non-Windows git argv expectations and locale-sensitive `.gitignore` reading, not this patch's focused assertions.
