### PR TITLE
fix: keep goal loops open for phase closures

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -137,7 +137,10 @@ JUDGE_SYSTEM_PROMPT = (
     "busy-work because the agent can't progress until the async thing "
     "finishes.\n\n"
     "CONTINUE — not done, and there is a concrete next step the agent can "
-    "take right now. This is the default when in doubt.\n\n"
+    "take right now. This is the default when in doubt. Also choose CONTINUE "
+    "when a structured closure report says a bounded phase is complete but "
+    "the standing goal state remains_open; phase closure is not goal "
+    "completion.\n\n"
     "Reply ONLY with a single JSON object on one line. Shapes:\n"
     '{"verdict": "done", "reason": "<one sentence>"}\n'
     '{"verdict": "continue", "reason": "<one sentence>"}\n'
@@ -833,6 +836,37 @@ def _render_background_block(background_processes: Optional[List[Dict[str, Any]]
     return JUDGE_BACKGROUND_BLOCK_TEMPLATE.format(background_lines="\n".join(lines))
 
 
+
+def _long_horizon_remains_open_override(last_response: str) -> Optional[str]:
+    """Return a continue reason for structured long-horizon phase reports.
+
+    Some durable project loops report bounded phase closure separately from the
+    standing goal state, e.g. ``phase_closure: complete`` together with
+    ``standing_goal_state: remains_open``. The generic judge rubric treats
+    completion/block/no-next-step language as DONE, which incorrectly clears
+    these long-horizon goals. When the agent explicitly labels the standing
+    goal as remaining open in that structured report, keep the loop active
+    instead of asking the generic judge to reinterpret that state.
+    """
+    if not last_response:
+        return None
+    has_phase_closure = re.search(
+        r"^\s*phase_closure\s*[:=]\s*\S.*$",
+        last_response,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+    has_remaining_standing_goal = re.search(
+        r"^\s*standing_goal_state\s*[:=]\s*remains_open\s*$",
+        last_response,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+    if has_phase_closure and has_remaining_standing_goal:
+        return (
+            "structured closure report says "
+            "standing_goal_state=remains_open; bounded phase closure is not goal completion"
+        )
+    return None
+
 def judge_goal(
     goal: str,
     last_response: str,
@@ -876,6 +910,11 @@ def judge_goal(
     if not last_response.strip():
         # No substantive reply this turn — almost certainly not done yet.
         return "continue", "empty response (nothing to evaluate)", False, None
+
+    long_horizon_reason = _long_horizon_remains_open_override(last_response)
+    if long_horizon_reason:
+        logger.info("goal judge: forced continue for long-horizon phase closure")
+        return "continue", long_horizon_reason, False, None
 
     try:
         from agent.auxiliary_client import get_auxiliary_extra_body, get_text_auxiliary_client

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -531,6 +531,9 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
     Accepts the legacy ``spawn_failure_threshold`` config key for
     back-compat.
     """
+    if _task_field(task, "status") == "done":
+        return []
+
     threshold = _positive_int(cfg.get(
         "failure_threshold",
         cfg.get("spawn_failure_threshold", 3),
@@ -649,7 +652,15 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
     total failures) so the operator gets a crash-specific heads-up
     before the unified rule kicks in. Suppresses itself when the
     unified rule is also about to fire, to avoid double-flagging.
+
+    A task-level manual completion resolves the operator-visible crash-loop
+    even if no successful ``task_runs`` row was written. Without this guard,
+    historical crashed runs keep completed tasks in the dashboard's
+    "tasks need attention" strip forever.
     """
+    if _task_field(task, "status") == "done":
+        return []
+
     failure_threshold = int(cfg.get(
         "failure_threshold",
         cfg.get("spawn_failure_threshold", 3),
@@ -722,7 +733,6 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
         count=consecutive,
         data={"consecutive_crashes": consecutive, "last_error": last_err},
     )]
-
 
 def _rule_stuck_in_blocked(task, events, runs, now, cfg) -> list[Diagnostic]:
     """Task has been in ``blocked`` status for too long without a comment.

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -225,6 +225,79 @@ class TestJudgeGoal:
         assert reason == "not yet"
 
 
+    def test_long_horizon_remains_open_phase_closure_forces_continue(self, monkeypatch):
+        """Project/goal-loop closure reports can legitimately say a bounded
+        phase is complete while the standing goal remains open. That explicit
+        structured state must not be delegated to the generic judge, whose
+        completion rubric treats blocked/no-next-step language as DONE.
+        """
+        import sys
+        import types
+        import agent
+        from hermes_cli import goals
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content='{"verdict": "done", "reason": "phase closed"}')
+                )
+            ]
+        )
+        response = """
+        phase_closure: complete
+        standing_goal_state: remains_open
+        current_runtime_state: no_live_kanban_work
+        next_task_materialization: no_safe_candidate
+        """
+        fake_aux = types.SimpleNamespace(
+            get_text_auxiliary_client=lambda task: (fake_client, "judge-model"),
+            get_auxiliary_extra_body=lambda: None,
+        )
+        monkeypatch.setitem(sys.modules, "agent.auxiliary_client", fake_aux)
+        monkeypatch.setattr(agent, "auxiliary_client", fake_aux, raising=False)
+        verdict, reason, parse_failed, wait = goals.judge_goal(
+            "Maintain the long-horizon Kanban-driven project loop",
+            response,
+        )
+        assert verdict == "continue"
+        assert parse_failed is False
+        assert wait is None
+        assert "standing_goal_state=remains_open" in reason
+        fake_client.chat.completions.create.assert_not_called()
+
+    def test_long_horizon_override_ignores_unstructured_quoted_marker(self, monkeypatch):
+        """Quoting the marker in ordinary prose is not enough to bypass the
+        judge; the override requires a line-structured phase closure report.
+        """
+        import sys
+        import types
+        import agent
+        from hermes_cli import goals
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content='{"verdict": "done", "reason": "ordinary done"}')
+                )
+            ]
+        )
+        response = "The document mentions `standing_goal_state: remains_open`, but the task is done."
+        fake_aux = types.SimpleNamespace(
+            get_text_auxiliary_client=lambda task: (fake_client, "judge-model"),
+            get_auxiliary_extra_body=lambda: None,
+        )
+        monkeypatch.setitem(sys.modules, "agent.auxiliary_client", fake_aux)
+        monkeypatch.setattr(agent, "auxiliary_client", fake_aux, raising=False)
+        verdict, reason, parse_failed, wait = goals.judge_goal("goal", response)
+        assert verdict == "done"
+        assert reason == "ordinary done"
+        assert parse_failed is False
+        assert wait is None
+        fake_client.chat.completions.create.assert_called_once()
+
+
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager lifecycle + persistence
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -181,6 +181,23 @@ def test_repeated_failures_below_threshold_silent():
     assert kd.compute_task_diagnostics(task, [], []) == []
 
 
+def test_repeated_failures_clears_when_task_completed_with_failure_counter():
+    """A completed task is not operator-actionable even if its persisted
+    unified failure counter was not reset by the completion path.
+    """
+    task = _task(
+        status="done",
+        consecutive_failures=4,
+        last_failure_error="pid 222 not alive",
+    )
+    runs = [
+        _run(outcome="crashed", run_id=1, error="pid 111 not alive"),
+        _run(outcome="crashed", run_id=2, error="pid 222 not alive"),
+    ]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    assert [d for d in diags if d.kind == "repeated_failures"] == []
+
+
 def test_repeated_failures_default_matches_dispatcher_failure_limit():
     """Default dispatcher auto-blocks at 2 failures, so diagnostics must
     also surface at 2 instead of waiting for the stale threshold of 3.
@@ -263,6 +280,27 @@ def test_repeated_crashes_breaks_on_recent_success():
         _run(outcome="completed", run_id=3),
     ]
     assert kd.compute_task_diagnostics(task, [], runs) == []
+
+
+def test_repeated_crashes_clears_when_task_completed_after_crashed_runs():
+    """Manual task completion after dispatcher crash attempts resolves the
+    operator-visible crash-loop. A done task must not stay in the dashboard's
+    "tasks need attention" strip just because its historical task_runs still
+    end in crashed.
+    """
+    task = _task(status="done", assignee="default")
+    events = [
+        _event("crashed", ts=100),
+        _event("gave_up", ts=101),
+        _event("unblocked", ts=200),
+        _event("completed", ts=201),
+    ]
+    runs = [
+        _run(outcome="crashed", run_id=1, error="pid 111 not alive"),
+        _run(outcome="crashed", run_id=2, error="pid 222 not alive"),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, runs, now=300)
+    assert [d for d in diags if d.kind == "repeated_crashes"] == []
 
 
 def test_repeated_crashes_escalates_on_many_crashes():
@@ -369,7 +407,7 @@ def test_repeated_crashes_truncates_huge_tracebacks():
 def test_diagnostics_sorted_critical_first():
     """A task with both a critical (many spawn failures) and a warning
     (prose phantoms) diagnostic should list the critical one first."""
-    task = _task(status="done", consecutive_failures=10,
+    task = _task(status="ready", consecutive_failures=10,
                  last_failure_error="nope")
     events = [
         _event("completed", ts=100, summary="referenced t_missing"),


### PR DESCRIPTION
## Summary
- Prevent completed Kanban tasks from retaining active failure diagnostics (`repeated_crashes` and `repeated_failures`) based only on historical crashed runs or persisted failure counters.
- Force `/goal` to continue only when a line-structured long-horizon closure report includes both `phase_closure` and `standing_goal_state: remains_open`, avoiding accidental matches from quoted prose.
- Add regression tests for completed crash-loop diagnostics, completed unified-failure diagnostics, long-horizon phase-closure judge behavior, and the unstructured quoted-marker non-bypass case.

## Test plan
- `python -m py_compile hermes_cli/kanban_diagnostics.py hermes_cli/goals.py`
- `PYTHONPATH=$(pwd) python -m pytest -o 'addopts=' tests/hermes_cli/test_kanban_diagnostics.py::test_repeated_failures_clears_when_task_completed_with_failure_counter tests/hermes_cli/test_kanban_diagnostics.py::test_repeated_crashes_clears_when_task_completed_after_crashed_runs tests/hermes_cli/test_goals.py::TestJudgeGoal::test_long_horizon_remains_open_phase_closure_forces_continue tests/hermes_cli/test_goals.py::TestJudgeGoal::test_long_horizon_override_ignores_unstructured_quoted_marker -q --tb=short`
- `PYTHONPATH=$(pwd) python -m pytest -o 'addopts=' tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_goals.py -q --tb=short`

## Verification results
- Focused review-suggestion regressions: `4 passed`
- Broader targeted files: `151 passed`
- `git diff --check`: clean
- Added-line static/security scan: no findings

## Operational evidence
- Live `hermes kanban diagnostics` reported no active diagnostics after applying the fix locally.
- `t_f5a587f3` and `t_61462924` each reported `0 active diagnostic(s)`.

## Notes
- This PR intentionally does not include the local `package-lock.json` line-ending drift observed in the installed working tree.
- Independent review passed with no security concerns or blocking logic errors; its two non-blocking suggestions were incorporated in the amended commit.