### PR TITLE
fix(whatsapp): lazy install aiohttp dependency

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -507,6 +507,15 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return False
 
+        try:
+            from tools.lazy_deps import ensure
+
+            ensure("platform.whatsapp", prompt=False)
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.warning("[%s] Failed to install WhatsApp Python dependencies: %s", self.name, e)
+
         logger.info("[%s] Bridge found at %s", self.name, bridge_path)
         
         # Acquire scoped lock to prevent duplicate sessions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ nemo-relay = ["nemo-relay==0.3"]
 homeassistant = ["aiohttp==3.14.1"]
 sms = ["aiohttp==3.14.1"]
 teams = ["microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"]  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525
+whatsapp = ["aiohttp==3.14.1"]
 # Computer use — macOS background desktop control via cua-driver (MCP stdio).
 # The cua-driver binary itself is installed via `hermes tools` post-setup
 # (curl install script); this extra just pins the MCP client used to talk

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -9,6 +9,7 @@ Covers:
 
 from unittest.mock import patch
 
+import pytest
 
 from gateway.config import Platform, PlatformConfig
 
@@ -103,6 +104,38 @@ class TestAdapterInit:
         config = PlatformConfig(enabled=True, extra={"reply_prefix": ""})
         adapter = WhatsAppAdapter(config)
         assert adapter._reply_prefix == ""
+
+
+@pytest.mark.asyncio
+async def test_connect_ensures_whatsapp_lazy_deps_after_pairing(tmp_path, monkeypatch):
+    from plugins.platforms.whatsapp import adapter as whatsapp_adapter
+
+    bridge_script = tmp_path / "bridge.js"
+    bridge_script.write_text("// test bridge\n")
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    (session_path / "creds.json").write_text("{}\n")
+
+    calls = []
+
+    def fake_ensure(feature: str, *, prompt: bool) -> None:
+        calls.append((feature, prompt))
+
+    monkeypatch.setattr(whatsapp_adapter, "check_whatsapp_requirements", lambda: True)
+    monkeypatch.setattr("tools.lazy_deps.ensure", fake_ensure)
+
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "bridge_script": str(bridge_script),
+            "session_path": str(session_path),
+        },
+    )
+    adapter = whatsapp_adapter.WhatsAppAdapter(config)
+    monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *args: False)
+
+    assert await adapter.connect() is False
+    assert calls == [("platform.whatsapp", False)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -135,6 +135,21 @@ def test_pyproject_aiohttp_pins_match_lazy_slack_pin():
     )
 
 
+def test_whatsapp_extra_matches_lazy_dep():
+    """WhatsApp must be explicit-installable and lazy-installable on first use."""
+    from tools.lazy_deps import LAZY_DEPS
+
+    optional_dependencies = _load_optional_dependencies()
+
+    assert "platform.whatsapp" in LAZY_DEPS
+    assert "whatsapp" in optional_dependencies
+    assert (
+        _exact_pins(optional_dependencies["whatsapp"])
+        == _exact_pins(LAZY_DEPS["platform.whatsapp"])
+        == {"aiohttp": "3.14.1"}
+    )
+
+
 def test_pyproject_pins_match_lazy_deps_pins():
     """Generalize #31817 to the whole pin surface, not just aiohttp.
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -200,6 +200,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # installed on demand like every other messaging platform; also exposed
     # as the `teams` extra in pyproject for packagers / explicit installs.
     "platform.teams": ("microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.1"),  # aiohttp 3.14.1: CVE-2026-34993(RCE)/47265 + 34513/34518/34519/34520/34525
+    "platform.whatsapp": ("aiohttp==3.14.1",),  # bridge health checks + HTTP media/send API
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),


### PR DESCRIPTION
## Summary
- add platform.whatsapp to LAZY_DEPS with the current aiohttp security pin
- expose a whatsapp optional extra for explicit installs
- ensure WhatsApp Python dependencies after pairing preflight and before bridge startup
- add metadata and adapter-entry tests for the lazy dependency path

Fixes #54217

## Tests
- .venv/bin/python -m pytest tests/test_project_metadata.py tests/gateway/test_whatsapp_reply_prefix.py -q -k "whatsapp or aiohttp"
- .venv/bin/python -m ruff check tools/lazy_deps.py plugins/platforms/whatsapp/adapter.py tests/test_project_metadata.py tests/gateway/test_whatsapp_reply_prefix.py
- .venv/bin/python -m pytest tests/test_project_metadata.py tests/gateway/test_whatsapp_reply_prefix.py -q
- scripts/run_tests.sh tests/test_project_metadata.py tests/gateway/test_whatsapp_reply_prefix.py -q