### PR TITLE
fix(gateway): honor group_allow_from for Telegram group/forum chats

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -685,10 +685,24 @@ class TelegramAdapter(BasePlatformAdapter):
         if not user_id:
             return True
 
-        # Adapter-level allow_from: when set, it is the sole authority.
+        # Adapter-level allow_from: when set, it is the sole authority — for
+        # ALL chat types (backward compat: a DM-only allow_from historically
+        # also gated groups, and several tests encode that). Group/forum
+        # chats additionally union in group_allow_from when configured, so
+        # groups can be opened up without touching the DM allowlist
+        # (mirroring gateway/authz_mixin.py's TELEGRAM_GROUP_ALLOWED_USERS ∪
+        # TELEGRAM_ALLOWED_USERS union). Previously group_allow_from was never
+        # consulted here at all, silently dropping group senders it was meant
+        # to cover.
         adapter_allow_from = self.config.extra.get("allow_from")
-        if adapter_allow_from is not None:
-            allowed = {str(u).strip() for u in adapter_allow_from if str(u).strip()}
+        adapter_group_allow_from = self.config.extra.get("group_allow_from")
+        is_group = source.chat_type in ("group", "forum")
+        if adapter_allow_from is not None or (is_group and adapter_group_allow_from is not None):
+            allowed = set()
+            if adapter_allow_from is not None:
+                allowed |= {str(u).strip() for u in adapter_allow_from if str(u).strip()}
+            if is_group and adapter_group_allow_from is not None:
+                allowed |= {str(u).strip() for u in adapter_group_allow_from if str(u).strip()}
             return user_id in allowed or "*" in allowed
 
         # Test/custom injection only. The class method named


### PR DESCRIPTION
## What
`_is_user_authorized_from_message` in `plugins/platforms/telegram/adapter.py` short-circuited on adapter-level `allow_from` for *every* chat type. `group_allow_from` was never consulted at this intake gate, even though it's a documented config key.

## Why
Practical effect discovered on a live deployment: an operator set `allow_from` (DM restricted to themselves) plus `group_allow_from: ['*']` (groups open to everyone). Real group senders were silently dropped before mention-detection ever ran — no error, no log visible to the sender, just silence. Confirmed via a two-day-old CIS Telegram group where community members got zero replies while the operator's own DM continued working normally.

The downstream `gateway/authz_mixin.py` runner-level fallback check *does* union `group_allow_from` correctly — but it's unreachable once the adapter-level gate above it returns early.

## Fix
Union `group_allow_from` into the allowed set for `group`/`forum` `chat_type` when it's configured, while preserving the existing `allow_from`-gates-everywhere behavior when `group_allow_from` is unset (this matches existing test expectations for backward compatibility — some deployments rely on a single `allow_from` restricting groups too).

## How to test
```
tests/gateway/test_telegram_auth_check.py
tests/gateway/test_telegram_bot_auth_bypass.py
tests/gateway/test_telegram_callback_auth_fail_closed.py
tests/gateway/test_telegram_group_gating.py
```
All 80 tests pass locally (fresh venv, no other changes).

## Platforms tested
Windows 10, Python 3.11, live Telegram gateway (not just unit tests) — the union behavior was verified end-to-end against a real group with a real non-operator sender getting through post-fix, and blocked pre-fix.