### PR TITLE
fix(tts): transcode edge ogg output paths

### DIFF
--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import Mock
@@ -24,6 +25,36 @@ def _clean_session_platform(monkeypatch):
 async def _write_edge_output(_text: str, output_path: str, _tts_config: dict) -> str:
     Path(output_path).write_bytes(b"mp3")
     return output_path
+
+
+def test_generate_edge_tts_transcodes_explicit_ogg_path(tmp_path, monkeypatch):
+    out = tmp_path / "speech.ogg"
+    synth = tmp_path / "speech.mp3"
+
+    class FakeCommunicate:
+        def __init__(self, text: str, **kwargs):
+            self.text = text
+            self.kwargs = kwargs
+
+        async def save(self, output_path: str) -> None:
+            assert output_path == str(synth)
+            Path(output_path).write_bytes(b"mp3")
+
+    fake_edge = Mock()
+    fake_edge.Communicate = FakeCommunicate
+
+    def fake_convert(path: str) -> str:
+        assert path == str(synth)
+        out.write_bytes(b"ogg")
+        return str(out)
+
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: fake_edge)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", fake_convert)
+
+    result = asyncio.run(tts_tool._generate_edge_tts("hello", str(out), {}))
+
+    assert result == str(out)
+    assert out.read_bytes() == b"ogg"
 
 
 def test_edge_cli_preserves_native_mp3(tmp_path, monkeypatch):
@@ -68,3 +99,23 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_edge_explicit_ogg_is_voice_compatible(tmp_path, monkeypatch):
+    out = tmp_path / "speech.ogg"
+
+    async def fake_edge(_text: str, output_path: str, _tts_config: dict) -> str:
+        assert output_path == str(out)
+        out.write_bytes(b"ogg")
+        return str(out)
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", fake_edge)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{out}"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -953,9 +953,17 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
         pct = round((speed - 1.0) * 100)
         kwargs["rate"] = f"{pct:+d}%"
 
+    wants_opus = output_path.endswith(".ogg")
+    synthesis_path = output_path
+    if wants_opus:
+        synthesis_path = output_path.rsplit(".", 1)[0] + ".mp3"
+
     communicate = _edge_tts.Communicate(text, **kwargs)
-    await communicate.save(output_path)
-    return output_path
+    await communicate.save(synthesis_path)
+    if wants_opus:
+        opus_path = _convert_to_opus(synthesis_path)
+        return opus_path or synthesis_path
+    return synthesis_path
 
 
 # ===========================================================================
@@ -2347,11 +2355,11 @@ def text_to_speech_tool(
                 try:
                     import concurrent.futures
                     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                        pool.submit(
+                        file_str = pool.submit(
                             lambda: asyncio.run(_generate_edge_tts(text, file_str, tts_config))
                         ).result(timeout=60)
                 except RuntimeError:
-                    asyncio.run(_generate_edge_tts(text, file_str, tts_config))
+                    file_str = asyncio.run(_generate_edge_tts(text, file_str, tts_config))
             elif _check_neutts_available():
                 logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
                 provider = "neutts"
@@ -2406,6 +2414,8 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
+        elif provider == "edge" and file_str.endswith(".ogg"):
+            voice_compatible = True
         elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 


### PR DESCRIPTION
## Summary
- have Edge TTS synthesize to a sibling MP3 when the requested path ends in .ogg
- transcode that MP3 with the existing Opus conversion helper instead of leaving MP3 bytes under an .ogg name
- propagate the generated path back through text_to_speech_tool and mark converted Edge .ogg files voice-compatible

Fixes #57048

## Tests
- .venv/bin/python -m pytest tests/tools/test_tts_opus_routing.py tests/tools/test_tts_speed.py -q -k "edge or opus"
- .venv/bin/python -m ruff check tools/tts_tool.py tests/tools/test_tts_opus_routing.py
- .venv/bin/python -m pytest tests/tools/test_tts_opus_routing.py tests/tools/test_tts_speed.py -q
- scripts/run_tests.sh tests/tools/test_tts_opus_routing.py tests/tools/test_tts_speed.py -q