### PR TITLE
fix(gateway): request ogg for telegram auto tts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,6 +15,7 @@ import re
 import socket as _socket
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from abc import ABC, abstractmethod
@@ -5032,8 +5033,16 @@ class BasePlatformAdapter(ABC):
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
+                            audio_path = os.path.join(
+                                tempfile.gettempdir(), "hermes_voice",
+                                f"tts_reply_{uuid.uuid4().hex[:12]}.mp3",
+                            )
+                            os.makedirs(os.path.dirname(audio_path), exist_ok=True)
                             tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                                text_to_speech_tool,
+                                text=speech_text,
+                                output_path=audio_path,
+                                delivery_platform=self.platform.value,
                             )
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13383,17 +13383,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not tts_text:
                 return
 
-            # Telegram's adapter only sends native voice bubbles for OGG/Opus.
-            # Other platforms keep the existing MP3 default.
-            audio_ext = "ogg" if event.source.platform == Platform.TELEGRAM else "mp3"
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.{audio_ext}",
+                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 
             result_json = await asyncio.to_thread(
-                text_to_speech_tool, text=tts_text, output_path=audio_path
+                text_to_speech_tool,
+                text=tts_text,
+                output_path=audio_path,
+                delivery_platform=event.source.platform.value,
             )
             try:
                 result = json.loads(result_json)

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -22,9 +22,11 @@ class TestAutoVoiceReplyFormat:
         event = _make_event(Platform.TELEGRAM)
         requested_paths = []
 
-        def fake_tts(*, text, output_path):
+        def fake_tts(*, text, output_path, delivery_platform):
             requested_paths.append(output_path)
-            assert output_path.endswith(".ogg")
+            assert output_path.endswith(".mp3")
+            assert delivery_platform == "telegram"
+            output_path = str(Path(output_path).with_suffix(".ogg"))
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
             Path(output_path).write_bytes(b"fake ogg opus")
             return json.dumps({
@@ -38,7 +40,7 @@ class TestAutoVoiceReplyFormat:
             await runner._send_voice_reply(event, "hello from auto tts")
 
         assert requested_paths
-        assert requested_paths[0].endswith(".ogg")
+        assert requested_paths[0].endswith(".mp3")
         adapter.send_voice.assert_awaited_once()
         assert adapter.send_voice.await_args.kwargs["audio_path"].endswith(".ogg")
 
@@ -51,9 +53,10 @@ class TestAutoVoiceReplyFormat:
         event = _make_event(Platform.SLACK)
         requested_paths = []
 
-        def fake_tts(*, text, output_path):
+        def fake_tts(*, text, output_path, delivery_platform):
             requested_paths.append(output_path)
             assert output_path.endswith(".mp3")
+            assert delivery_platform == "slack"
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
             Path(output_path).write_bytes(b"fake mp3")
             return json.dumps({

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -296,9 +296,11 @@ class TestTelegramAutoTtsCaptionDelivery:
         with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
             "tools.tts_tool.text_to_speech_tool",
             return_value=json.dumps({"file_path": str(tts_path)}),
-        ):
+        ) as mock_tts:
             await adapter._process_message_background(event, build_session_key(event.source))
 
+        assert mock_tts.call_args.kwargs["output_path"].endswith(".mp3")
+        assert mock_tts.call_args.kwargs["delivery_platform"] == "telegram"
         adapter.play_tts.assert_awaited_once()
         assert adapter.play_tts.await_args.kwargs["caption"] == "Short reply"
         assert adapter.sent == []

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -433,7 +433,8 @@ class TestSendVoiceReply:
             await runner._send_voice_reply(event, "Hello world")
 
         mock_adapter.send_voice.assert_called_once()
-        assert mock_tts.call_args.kwargs["output_path"].endswith(".ogg")
+        assert mock_tts.call_args.kwargs["output_path"].endswith(".mp3")
+        assert mock_tts.call_args.kwargs["delivery_platform"] == "telegram"
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"
 
@@ -458,6 +459,7 @@ class TestSendVoiceReply:
 
         mock_adapter.send_voice.assert_called_once()
         assert mock_tts.call_args.kwargs["output_path"].endswith(".mp3")
+        assert mock_tts.call_args.kwargs["delivery_platform"] == "slack"
 
     @pytest.mark.asyncio
     async def test_auto_voice_reply_uses_thread_metadata_helper(self, runner):

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -68,3 +68,30 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_edge_explicit_telegram_delivery_converts_after_context_is_cleared(tmp_path, monkeypatch):
+    requested = tmp_path / "reply.ogg"
+    source = tmp_path / "reply.mp3"
+    opus = tmp_path / "reply.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(source)
+        assert source.read_bytes() == b"mp3"
+        opus.write_bytes(b"ogg opus")
+        return str(opus)
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", Mock(side_effect=fake_convert))
+
+    result = json.loads(tts_tool.text_to_speech_tool(
+        "hello",
+        output_path=str(requested),
+        delivery_platform="telegram",
+    ))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(opus)
+    assert result["voice_compatible"] is True

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2284,6 +2284,8 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 def text_to_speech_tool(
     text: str,
     output_path: Optional[str] = None,
+    *,
+    delivery_platform: Optional[str] = None,
 ) -> str:
     """
     Convert text to speech audio.
@@ -2298,6 +2300,8 @@ def text_to_speech_tool(
     Args:
         text: The text to convert to speech.
         output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
+        delivery_platform: Internal delivery target override. Gateway auto-TTS
+            uses this after the inbound session context has been cleared.
 
     Returns:
         str: JSON result with success, file_path, and optionally MEDIA tag.
@@ -2329,7 +2333,7 @@ def text_to_speech_tool(
     # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
-    platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
+    platform = (delivery_platform or get_session_env("HERMES_SESSION_PLATFORM", "")).lower()
     want_opus = (platform == "telegram")
 
     # Determine output path
@@ -2360,6 +2364,15 @@ def text_to_speech_tool(
             file_path = _configured_command_tts_output_path(
                 file_path, command_provider_config
             )
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+            # These providers can render Opus natively.  The delivery intent,
+            # not a caller-chosen suffix, controls their requested format.
+            file_path = file_path.with_suffix(".ogg")
+        elif want_opus and provider in BUILTIN_TTS_PROVIDERS and file_path.suffix == ".ogg":
+            # Conversion-backed providers (notably Edge) must first write a
+            # real source file.  Writing MP3 bytes directly to an .ogg path
+            # makes the later suffix guard incorrectly skip ffmpeg.
+            file_path = file_path.with_suffix(".mp3")
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = Path(DEFAULT_OUTPUT_DIR)


### PR DESCRIPTION
## Summary
- carry the destination platform explicitly into both gateway auto-TTS paths, including after inbound session ContextVars have been cleared
- keep conversion-backed providers on a real source path (Edge writes MP3), then return the converted OGG/Opus path for Telegram
- let native-Opus providers select `.ogg` from delivery intent rather than relying on a caller-provided suffix
- keep non-Telegram delivery on the existing MP3 behavior

## Verification
- `pytest -q tests/tools/test_tts_*.py tests/gateway/test_auto_voice_reply_format.py tests/gateway/test_base_topic_sessions.py` (262 passed)
- Ruff passes for all modified implementation and test files
