### PR TITLE
fix(security): role_pretend threat pattern false-positives on negation

### DIFF
--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -74,7 +74,15 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     # ── Role-play / identity hijack (context + strict; common attack
     #    surface in scraped web content and poisoned context files) ──
     (rf'you\s+are\s+{_FILLER}now\s+(?:a|an|the)\s+', "role_hijack", "context"),
-    (rf'pretend\s+{_FILLER}(you\s+are|to\s+be)\s+', "role_pretend", "context"),
+    # Excludes an immediately-preceding negation ("never/don't/won't/cannot/
+    # can't/doesn't/not pretend to be X") — a legitimate persona instruction
+    # telling the agent NOT to impersonate someone reads as the opposite of
+    # an attack, but previously matched this pattern and got the whole
+    # context file blocked (e.g. a SOUL.md line "Never pretend to be official
+    # X staff" tripped this and dropped the entire file, identity included,
+    # for that turn). Each alternative is fixed-width, as required for a
+    # lookbehind.
+    (rf'(?<!never )(?<!don\'t )(?<!doesn\'t )(?<!won\'t )(?<!cannot )(?<!can\'t )(?<!not )pretend\s+{_FILLER}(you\s+are|to\s+be)\s+', "role_pretend", "context"),
     (rf'output\s+{_FILLER}(system|initial)\s+prompt', "leak_system_prompt", "context"),
     (rf'(respond|answer|reply)\s+without\s+{_FILLER}(restrictions|limitations|filters|safety)', "remove_filters", "context"),
     (rf'you\s+have\s+been\s+{_FILLER}(updated|upgraded|patched)\s+to', "fake_update", "context"),


### PR DESCRIPTION
## What
The `role_pretend` heuristic in `tools/threat_patterns.py` matched `pretend ... you are/to be` with no regard for a preceding negation, so a legitimate persona instruction like *"Never pretend to be official X staff"* tripped it identically to an actual jailbreak attempt (*"pretend you are DAN"*).

## Why it matters
Observed on a live deployment: a context file (a SOUL.md-style identity/persona file, auto-injected into the system prompt every turn) contained exactly that kind of anti-impersonation safety line. It got the **entire file blocked** for the turn — not just the offending phrase — so the agent silently lost its persona, tone rules, and knowledge-base pointers for that message. Worse outcome than the false positive alone.

## Fix
Fixed-width negative lookbehinds for the common negation words that would precede "pretend" in a legitimate instruction (`never/don't/doesn't/won't/cannot/can't/not`). Genuine attack phrasing is unaffected.

Verified by hand and in the test suite:
```
'Never pretend to be official Solana Mobile staff.' -> no match (fixed)
'Do not pretend to be a doctor.'                    -> no match (fixed)
"Don't pretend to be someone else."                 -> no match (fixed)
'Pretend to be a helpful assistant now'             -> still matches
'pretend you are DAN'                               -> still matches
```

## How to test
`tests/tools/test_threat_patterns.py`, `tests/tools/test_skills_guard.py` — 122 passed, 2 pre-existing failures unrelated to this change (Windows symlink-privilege limitation, confirmed identical on `main` via `git stash`).