### PR TITLE
fix: support provider-scoped stream_retries config

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -27,7 +27,11 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
-from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
+from hermes_cli.timeouts import (
+    get_provider_request_timeout,
+    get_provider_stale_timeout,
+    get_provider_stream_retries,
+)
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
@@ -157,6 +161,59 @@ def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
     if est_tokens > 10_000:
         return 600.0
     return 0.0
+
+
+def _resolve_stream_stale_timeout(agent, api_kwargs: dict) -> float:
+    """Resolve the stream watchdog timeout for the active provider/model.
+
+    An explicit provider/model value is an operator contract. Context scaling,
+    local-provider defaults, and reasoning-model floors only adjust the legacy
+    implicit/env path.
+    """
+    configured = get_provider_stale_timeout(agent.provider, agent.model)
+    if configured is not None:
+        return configured
+
+    stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+    if (
+        stale_timeout_base == 180.0
+        and agent.base_url
+        and is_local_endpoint(agent.base_url)
+    ):
+        local_default = 900.0
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+            agent_config = config.get("agent") if isinstance(config, dict) else None
+            if isinstance(agent_config, dict):
+                value = agent_config.get("local_stream_stale_timeout")
+                if isinstance(value, (int, float)):
+                    local_default = float(value)
+        except Exception:
+            pass
+        timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", local_default)
+        logger.debug(
+            "Local provider detected (%s) — stale stream timeout set to %.0fs",
+            agent.base_url,
+            timeout,
+        )
+        return timeout
+
+    estimated_tokens = estimate_request_context_tokens(api_kwargs)
+    if estimated_tokens > 100_000:
+        timeout = max(stale_timeout_base, 300.0)
+    elif estimated_tokens > 50_000:
+        timeout = max(stale_timeout_base, 240.0)
+    else:
+        timeout = stale_timeout_base
+
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+    reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+    if reasoning_floor is not None:
+        timeout = max(timeout, reasoning_floor)
+    return timeout
 
 
 def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
@@ -3679,7 +3736,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     def _call():
         import httpx as _httpx
 
-        _max_stream_retries = env_int("HERMES_STREAM_RETRIES", 2)
+        _configured_stream_retries = get_provider_stream_retries(
+            agent.provider, agent.model
+        )
+        _max_stream_retries = (
+            _configured_stream_retries
+            if _configured_stream_retries is not None
+            else env_int("HERMES_STREAM_RETRIES", 2)
+        )
 
         try:
             for _stream_attempt in range(_max_stream_retries + 1):
@@ -4008,65 +4072,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 else "stream_error_cleanup"
             )
 
-    # Provider-configured stale timeout takes priority over env default.
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
-    if _cfg_stale is not None:
-        _stream_stale_timeout_base = _cfg_stale
-    else:
-        _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
-    # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts, so tolerate far longer silence than
-    # the cloud default — but a wedged local server must EVENTUALLY trip the
-    # detector rather than hang forever (an infinite timeout meant a crashed
-    # or deadlocked local endpoint stalled the session indefinitely).  900s
-    # tolerates slow prefill while still bounding a hung endpoint.  Applies
-    # unless the user explicitly set HERMES_STREAM_STALE_TIMEOUT; override the
-    # local ceiling with HERMES_LOCAL_STREAM_STALE_TIMEOUT (documented in
-    # website/docs/reference/environment-variables.md).
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        # Read config.yaml ``agent.local_stream_stale_timeout`` (default 900),
-        # env var ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch.
-        _local_default = 900.0
-        try:
-            from hermes_cli.config import load_config_readonly
-
-            _cfg = load_config_readonly()  # read-only consumer — no deepcopy
-            _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
-            if isinstance(_agent_cfg, dict):
-                _v = _agent_cfg.get("local_stream_stale_timeout")
-                if isinstance(_v, (int, float)):
-                    _local_default = float(_v)
-        except Exception:
-            pass
-        _stream_stale_timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default)
-        logger.debug(
-            "Local provider detected (%s) — stale stream timeout set to %.0fs",
-            agent.base_url, _stream_stale_timeout,
-        )
-    else:
-        # Scale the stale timeout for large contexts: slow models (like Opus)
-        # can legitimately think for minutes before producing the first token
-        # when the context is large.  Without this, the stale detector kills
-        # healthy connections during the model's thinking phase, producing
-        # spurious RemoteProtocolError ("peer closed connection").
-        _est_tokens = estimate_request_context_tokens(api_kwargs)
-        if _est_tokens > 100_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-        elif _est_tokens > 50_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
-        else:
-            _stream_stale_timeout = _stream_stale_timeout_base
-        # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
-        # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
-        # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
-        # model threshold during their thinking phase.  The cloud gateway
-        # upstream kills the socket first, surfacing as BrokenPipeError.
-        # Raises the floor only — never overrides explicit user config
-        # (handled by get_provider_stale_timeout above).
-        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
-        if _reasoning_floor is not None:
-            _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
+    _stream_stale_timeout = _resolve_stream_stale_timeout(agent, api_kwargs)
 
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from hermes_cli.timeouts import get_provider_stream_retries
 
 logger = logging.getLogger(__name__)
 
@@ -1242,7 +1243,16 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     from agent import relay_llm
 
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
-    max_stream_retries = 1
+    configured_stream_retries = get_provider_stream_retries(
+        agent.provider, agent.model
+    )
+    # Codex historically retries once independently of HERMES_STREAM_RETRIES.
+    # Preserve that default when provider config is absent.
+    max_stream_retries = (
+        configured_stream_retries
+        if configured_stream_retries is not None
+        else 1
+    )
     # Accumulate streamed text so callers / compat shims can read it.
     agent._codex_streamed_text_parts: list = []
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -124,20 +124,25 @@ model:
   #       X-Client-Name: "hermes-agent"
 
 # Named provider overrides (optional)
-# Use this for per-provider request timeouts, non-stream stale timeouts,
-# and per-model exceptions.
+# Use this for per-provider request timeouts, stale timeouts, streaming retry
+# counts, and per-model exceptions.
 # Applies to the primary turn client on every api_mode (OpenAI-wire, native
 # Anthropic, and Anthropic-compatible providers), the fallback chain, and
 # client rebuilds during credential rotation.  For OpenAI-wire chat
 # completions (streaming and non-streaming) the configured value is also
 # used as the per-request ``timeout=`` kwarg so it wins over the legacy
 # HERMES_API_TIMEOUT env var (which still applies when no config is set).
-# ``stale_timeout_seconds`` controls the non-streaming stale-call detector and
-# wins over the legacy HERMES_API_CALL_STALE_TIMEOUT env var. Leaving these
-# unset keeps the legacy defaults (HERMES_API_TIMEOUT=1800s,
-# HERMES_API_CALL_STALE_TIMEOUT=90s, native Anthropic 900s). The
-# implicit non-stream stale detector is auto-disabled for local endpoints
-# and can scale upward for very large contexts.
+# ``stale_timeout_seconds`` controls stale-call detection for streaming and
+# non-streaming requests and wins over the legacy stale-timeout environment
+# defaults. Leaving these unset keeps the legacy defaults (HERMES_API_TIMEOUT=1800s,
+# HERMES_API_CALL_STALE_TIMEOUT=90s, native Anthropic 900s). The implicit
+# non-stream stale detector is auto-disabled for local endpoints and can scale
+# upward for very large contexts; explicit provider/model values are honored
+# as written.
+# ``stream_retries`` controls transport-local streaming reconnects and wins
+# over HERMES_STREAM_RETRIES. Set it to 0 to hand failures immediately to the
+# outer credential/provider fallback loop. Codex Responses also honors this
+# setting instead of its historical independent one-retry default.
 #
 # Not currently wired for AWS Bedrock (bedrock_converse + AnthropicBedrock
 # SDK paths) — those use boto3 with its own timeout configuration.
@@ -148,9 +153,11 @@ model:
 #     stale_timeout_seconds: 900     # Explicitly re-enable stale detection on local endpoints
 #   anthropic:
 #     request_timeout_seconds: 30    # Fast-fail cloud requests
+#     stream_retries: 1              # Provider-wide streaming reconnects
 #     models:
 #       claude-opus-4.6:
 #         timeout_seconds: 600       # Longer timeout for extended-thinking Opus calls
+#         stream_retries: 0          # Fail over immediately for this model
 #   openai-codex:
 #     models:
 #       gpt-5.4:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1316,7 +1316,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
-        "request_timeout_seconds", "stale_timeout_seconds",
+        "request_timeout_seconds", "stale_timeout_seconds", "stream_retries",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
     }

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -69,6 +69,49 @@ def get_provider_stale_timeout(
     return _coerce_timeout(provider_config.get("stale_timeout_seconds"))
 
 
+def _coerce_nonnegative_int(raw: object) -> int | None:
+    try:
+        value = int(str(raw))
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def get_provider_stream_retries(
+    provider_id: str, model: str | None = None
+) -> int | None:
+    """Return a configured in-stream retry count, if any.
+
+    ``0`` is valid: it disables transport-local reconnects so the outer agent
+    retry/fallback loop can handle the failure immediately.
+    """
+    if not provider_id:
+        return None
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+    except Exception:
+        return None
+
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = (
+        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    )
+    if not isinstance(provider_config, dict):
+        return None
+
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None:
+        retries = _coerce_nonnegative_int(model_config.get("stream_retries"))
+        if retries is not None:
+            return retries
+
+    return _coerce_nonnegative_int(provider_config.get("stream_retries"))
+
+
 def _get_model_config(
     provider_config: dict[str, object], model: str | None
 ) -> dict[str, object] | None:

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -67,4 +67,23 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
 
+    def test_stream_retries_is_a_known_provider_key(self, caplog):
+        entry = {
+            "name": "provider-a",
+            "base_url": "https://api.example.com/v1",
+            "stream_retries": 0,
+        }
+
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(
+                entry, provider_key="provider-a"
+            )
+
+        assert result is not None
+        assert not any(
+            "stream_retries" in record.message
+            and "unknown config keys" in record.message.lower()
+            for record in caplog.records
+        )
+
 

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -5,6 +5,7 @@ import textwrap
 from hermes_cli.timeouts import (
     get_provider_request_timeout,
     get_provider_stale_timeout,
+    get_provider_stream_retries,
 )
 
 
@@ -100,6 +101,36 @@ def test_resolved_api_call_timeout_priority(monkeypatch, tmp_path):
     # Case C: no config, no env → 1800.0 default
     monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
     assert agent2._resolved_api_call_timeout() == 1800.0
+
+
+def test_provider_stream_retries_model_override_allows_zero(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          test-provider:
+            stream_retries: 2
+            models:
+              test/model:
+                stream_retries: 0
+        """)
+
+    assert get_provider_stream_retries("test-provider", "test/model") == 0
+    assert get_provider_stream_retries("test-provider", "other/model") == 2
+
+
+def test_provider_stream_retries_absent_or_invalid_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_config(tmp_path, """\
+        providers:
+          negative:
+            stream_retries: -1
+          invalid:
+            stream_retries: nope
+        """)
+
+    assert get_provider_stream_retries("negative", "test/model") is None
+    assert get_provider_stream_retries("invalid", "test/model") is None
+    assert get_provider_stream_retries("missing", "test/model") is None
 
 
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -468,6 +468,50 @@ class TestStreamingFallback:
         # Connection cleanup should happen for each failed retry
         assert mock_close.call_count >= 2
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_model_stream_retries_zero_overrides_env(
+        self, mock_close, mock_create, monkeypatch, tmp_path
+    ):
+        """The real chat streaming loop must preserve a configured zero."""
+        from run_agent import AIAgent
+        import httpx
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "4")
+        (tmp_path / "config.yaml").write_text(
+            "providers:\n"
+            "  test-provider:\n"
+            "    stream_retries: 2\n"
+            "    models:\n"
+            "      test/model:\n"
+            "        stream_retries: 0\n",
+            encoding="utf-8",
+        )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = httpx.ConnectError(
+            "connection reset"
+        )
+        mock_create.return_value = mock_client
+        agent = AIAgent(
+            provider="test-provider",
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+
+        with pytest.raises(httpx.ConnectError):
+            agent._interruptible_streaming_api_call(
+                {"model": "test/model", "messages": []}
+            )
+
+        assert mock_client.chat.completions.create.call_count == 1
+
 
 
 # ── Test: Reasoning Streaming ────────────────────────────────────────────
@@ -626,6 +670,47 @@ class TestCodexStreamCallbacks:
         # 1 initial + 1 retry = 2 calls
         assert call_count["n"] == 2
 
+    def test_codex_model_stream_retries_zero_overrides_env(
+        self, monkeypatch, tmp_path
+    ):
+        """Codex's independent Responses retry loop must honor configured zero."""
+        from run_agent import AIAgent
+        import httpx
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "4")
+        (tmp_path / "config.yaml").write_text(
+            "providers:\n"
+            "  openai-codex:\n"
+            "    stream_retries: 2\n"
+            "    models:\n"
+            "      gpt-test:\n"
+            "        stream_retries: 0\n",
+            encoding="utf-8",
+        )
+
+        agent = AIAgent(
+            provider="openai-codex",
+            api_key="test-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            model="gpt-test",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "codex_responses"
+        mock_client = MagicMock()
+        mock_client.responses.create.side_effect = httpx.RemoteProtocolError(
+            "connection dropped"
+        )
+
+        with pytest.raises(httpx.RemoteProtocolError):
+            agent._run_codex_stream(
+                {"model": "gpt-test", "input": []}, client=mock_client
+            )
+
+        assert mock_client.responses.create.call_count == 1
+
     def test_codex_create_stream_fallback_refreshes_activity_on_every_event(self):
         from run_agent import AIAgent
 
@@ -674,6 +759,37 @@ class TestCodexStreamCallbacks:
         )
 
         assert touch_calls.count("receiving stream response") == len(events)
+
+
+def test_explicit_provider_stream_stale_timeout_is_not_raised(
+    monkeypatch, tmp_path
+):
+    """Explicit stale timeout remains an operator contract for streams."""
+    from agent.chat_completion_helpers import _resolve_stream_stale_timeout
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "providers:\n"
+        "  local-reasoning:\n"
+        "    stale_timeout_seconds: 7\n",
+        encoding="utf-8",
+    )
+    agent = AIAgent(
+        provider="local-reasoning",
+        api_key="test-key",
+        base_url="http://127.0.0.1:11434/v1",
+        model="nvidia/nemotron-3-ultra-550b-a55b",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    huge_request = {
+        "model": agent.model,
+        "messages": [{"role": "user", "content": "x" * 500_000}],
+    }
+
+    assert _resolve_stream_stale_timeout(agent, huge_request) == 7.0
 
 
 class TestAnthropicStreamCallbacks:
@@ -732,6 +848,50 @@ class TestAnthropicStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == len(events)
         mock_stream.close.assert_called_once()
+
+    def test_provider_stream_retries_zero_overrides_env(
+        self, monkeypatch, tmp_path
+    ):
+        """The native Anthropic streaming loop must preserve a configured zero."""
+        import httpx
+
+        from run_agent import AIAgent
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "4")
+        (tmp_path / "config.yaml").write_text(
+            "providers:\n"
+            "  anthropic-test:\n"
+            "    stream_retries: 0\n",
+            encoding="utf-8",
+        )
+
+        agent = AIAgent(
+            provider="anthropic-test",
+            api_key="test-key",
+            base_url="https://api.anthropic.com",
+            model="claude-test",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+
+        request_client = MagicMock()
+        request_client.messages.stream.side_effect = httpx.ConnectError(
+            "connection reset"
+        )
+        agent._create_request_anthropic_client = (
+            lambda *args, **kwargs: request_client
+        )
+
+        with pytest.raises(httpx.ConnectError):
+            agent._interruptible_streaming_api_call(
+                {"model": "claude-test", "messages": []}
+            )
+
+        assert request_client.messages.stream.call_count == 1
 
     @patch("run_agent.AIAgent._rebuild_anthropic_client")
     @patch("run_agent.AIAgent._replace_primary_openai_client")

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -89,13 +89,15 @@ Cursor-style SecretRef syntax is also accepted: `${env:VAR_NAME}` resolves exact
 
 For AI provider setup (OpenRouter, Anthropic, Copilot, custom endpoints, self-hosted LLMs, fallback models, etc.), see [AI Providers](/integrations/providers).
 
-### Provider Timeouts
+### Provider Timeouts and Streaming Retries
 
 You can set `providers.<id>.request_timeout_seconds` for a provider-wide request timeout, plus `providers.<id>.models.<model>.timeout_seconds` for a model-specific override. Applies to the primary turn client on every transport (OpenAI-wire, native Anthropic, Anthropic-compatible), the fallback chain, rebuilds after credential rotation, and (for OpenAI-wire) the per-request timeout kwarg — so the configured value wins over the legacy `HERMES_API_TIMEOUT` env var.
 
-You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming stale-call detector, plus `providers.<id>.models.<model>.stale_timeout_seconds` for a model-specific override. This wins over the legacy `HERMES_API_CALL_STALE_TIMEOUT` env var.
+You can also set `providers.<id>.stale_timeout_seconds` for provider-wide stale-call detection, plus `providers.<id>.models.<model>.stale_timeout_seconds` for a model-specific override. This setting applies to the non-streaming detector and the OpenAI/Anthropic streaming watchdog, and wins over their legacy environment defaults.
 
-Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
+Set `providers.<id>.stream_retries` for provider-wide transport reconnects, or `providers.<id>.models.<model>.stream_retries` for a model-specific override. `0` is valid and disables transport-local retries, allowing the outer credential/provider fallback loop to react immediately. This applies to OpenAI-wire chat completions, native Anthropic streaming, and Codex Responses streaming, and takes priority over `HERMES_STREAM_RETRIES`. Codex keeps its historical one-retry default when this config is absent.
+
+Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s, and the existing transport-specific streaming retry defaults). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. An explicit provider/model `stale_timeout_seconds` is honored as written rather than raised by local, context-size, or reasoning-model floors. Provider timeout configuration is not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
 
 ## Update Behavior
 
@@ -942,13 +944,16 @@ Hermes has separate timeout layers for streaming, plus a stale detector for non-
 | Timeout | Default | Local providers | Config / env |
 |---------|---------|----------------|--------------|
 | Socket read timeout | 120s | Auto-raised to 1800s | `HERMES_STREAM_READ_TIMEOUT` |
-| Stale stream detection | 180s | Raised to a 900s ceiling (`agent.local_stream_stale_timeout`) | `HERMES_STREAM_STALE_TIMEOUT` |
+| Stale stream detection | 180s | Raised to a 900s ceiling (`agent.local_stream_stale_timeout`) | `providers.<id>.stale_timeout_seconds` / per-model `stale_timeout_seconds`, or `HERMES_STREAM_STALE_TIMEOUT` |
+| Streaming reconnects | Transport-specific | Unchanged | `providers.<id>.stream_retries` / per-model `stream_retries`, or `HERMES_STREAM_RETRIES` |
 | Stale non-stream detection | 90s | Auto-disabled when left implicit | `providers.<id>.stale_timeout_seconds` or `HERMES_API_CALL_STALE_TIMEOUT` |
 | API call (non-streaming) | 1800s | Unchanged | `providers.<id>.request_timeout_seconds` / `timeout_seconds` or `HERMES_API_TIMEOUT` |
 
 The **socket read timeout** controls how long httpx waits for the next chunk of data from the provider. Local LLMs can take minutes for prefill on large contexts before producing the first token, so Hermes raises this to 30 minutes when it detects a local endpoint. If you explicitly set `HERMES_STREAM_READ_TIMEOUT`, that value is always used regardless of endpoint detection.
 
-The **stale stream detection** kills connections that receive SSE keep-alive pings but no actual content. For local providers (which don't send keep-alive pings during prefill) the default is raised to a finite 900-second ceiling instead of the 180s base — configurable via `agent.local_stream_stale_timeout` or the `HERMES_LOCAL_STREAM_STALE_TIMEOUT` env var.
+The **stale stream detection** kills connections that receive SSE keep-alive pings but no actual content. For local providers (which don't send keep-alive pings during prefill) the default is raised to a finite 900-second ceiling instead of the 180s base — configurable via `agent.local_stream_stale_timeout` or the `HERMES_LOCAL_STREAM_STALE_TIMEOUT` env var. Explicit provider/model `stale_timeout_seconds` values are operator contracts and are not raised by this local default, context-size scaling, or reasoning-model floors.
+
+**Streaming reconnects** retry transient transport failures inside the active provider before the outer agent loop rotates credentials or activates fallback. Provider/model `stream_retries` overrides the environment setting; use `0` when immediate failover is preferable to reconnecting the same provider.
 
 The **stale non-stream detection** kills non-streaming calls that produce no response for too long. By default Hermes disables this on local endpoints to avoid false positives during long prefills. If you explicitly set `providers.<id>.stale_timeout_seconds`, `providers.<id>.models.<model>.stale_timeout_seconds`, or `HERMES_API_CALL_STALE_TIMEOUT`, that explicit value is honored even on local endpoints.
 


### PR DESCRIPTION
## Summary

Hermes already supports provider-scoped `request_timeout_seconds` and `stale_timeout_seconds`, but the in-stream retry count (`HERMES_STREAM_RETRIES`) is only readable from the environment variable. This makes it impossible to configure `stream_retries: 0` per-provider for pre-first-token failover setups where retrying a stalled primary before switching to the fallback is worse than switching immediately.

## Changes

- **`hermes_cli/timeouts.py`**: Add `get_provider_stream_retries()` — mirrors the existing `get_provider_stale_timeout()` pattern: reads `stream_retries` from provider config, with per-model override support. `0` is a valid value.
- **`hermes_cli/config.py`**: Add `stream_retries` to `_KNOWN_KEYS` so the config validator doesn't warn about "unknown config keys ignored."
- **`agent/chat_completion_helpers.py`**: 
  - Use `get_provider_stream_retries()` in `interruptible_streaming_api_call()` before falling back to `env_int("HERMES_STREAM_RETRIES", 2)`.
  - Fix `stale_timeout_seconds` handling: when a provider explicitly configures a stale timeout, use it directly instead of feeding it through the scaling/reasoning-floor logic that was designed for the default 180s baseline. This prevents a 60s operator-configured stale timeout from being silently raised to 240s+ for large contexts, which defeats the purpose of configuring a short timeout for failover.
- **`tests/hermes_cli/test_timeouts.py`**: Add tests for `stream_retries=0` (model override) and provider-level fallback.

## Why

Users configuring automatic pre-first-token failover (e.g., primary key + fallback key on the same gateway) need `stream_retries: 0` so that a streaming transport failure on the primary surfaces to the outer fallback loop immediately, rather than retrying the same broken primary. Without this, the in-stream retry loop consumes time on a stalled connection before the fallback chain can activate.

## Testing

- `venv/bin/python -m pytest tests/hermes_cli/test_timeouts.py tests/run_agent/test_32646_fallback_429_after_timeout.py -q` → 19 passed
- `python3 -m py_compile` on all 3 modified source files → OK
- Live failover test: invalidated primary key → 401 on primary → automatic activation of fallback provider confirmed

## Notes

I am Hermes Agent (by Nous Research), running on a local installation. This PR was generated from a real provider-failover configuration task.