### PR TITLE
fix(agent): compact stale prompt payloads

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1436,6 +1436,13 @@ def init_agent(
     except Exception:
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
+    try:
+        from agent.context_assembly import context_assembly_config_from_mapping
+        agent._context_assembly_config = context_assembly_config_from_mapping(
+            _compression_cfg
+        )
+    except Exception:
+        agent._context_assembly_config = {}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # protect_first_n is the number of non-system messages to protect at

--- a/agent/context_assembly.py
+++ b/agent/context_assembly.py
@@ -1,0 +1,267 @@
+"""Non-destructive prompt-view compaction for stale heavy payloads."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set
+
+from agent.model_metadata import estimate_messages_tokens_rough
+
+
+DEFAULT_PROTECT_LAST_N = 20
+DEFAULT_MIN_CHARS = 12_000
+DEFAULT_PREVIEW_CHARS = 600
+
+
+@dataclass
+class ContextAssemblyStats:
+    """Stats for payloads compacted out of an API-only prompt view."""
+
+    messages_compacted: int = 0
+    tool_results_compacted: int = 0
+    tool_call_args_compacted: int = 0
+    media_parts_compacted: int = 0
+    estimated_tokens_before: int = 0
+    estimated_tokens_after: int = 0
+
+    @property
+    def estimated_tokens_evicted(self) -> int:
+        return max(0, self.estimated_tokens_before - self.estimated_tokens_after)
+
+
+def compact_stale_payloads_for_prompt(
+    messages: List[Dict[str, Any]],
+    *,
+    enabled: bool = True,
+    protect_last_n: int = DEFAULT_PROTECT_LAST_N,
+    min_chars: int = DEFAULT_MIN_CHARS,
+    preview_chars: int = DEFAULT_PREVIEW_CHARS,
+    preserve_tools: Optional[Iterable[str]] = None,
+) -> tuple[List[Dict[str, Any]], ContextAssemblyStats]:
+    """Return an API-only message view with old heavy payloads replaced.
+
+    The returned list is detached from ``messages`` only when a payload is
+    compacted.  Callers may therefore pass canonical conversation history; this
+    helper never mutates it.
+    """
+
+    stats = ContextAssemblyStats()
+    if not enabled or not messages:
+        return messages, stats
+
+    protect_last_n = max(0, int(protect_last_n))
+    min_chars = max(0, int(min_chars))
+    preview_chars = max(0, int(preview_chars))
+    protected = _protected_message_indexes(messages, protect_last_n)
+    preserve_tool_names = {str(t) for t in (preserve_tools or []) if str(t)}
+
+    compacted: Optional[List[Dict[str, Any]]] = None
+    changed_indexes: Set[int] = set()
+
+    def editable(index: int) -> Dict[str, Any]:
+        nonlocal compacted
+        if compacted is None:
+            compacted = [copy.deepcopy(m) for m in messages]
+        changed_indexes.add(index)
+        return compacted[index]
+
+    for idx, msg in enumerate(messages):
+        if idx in protected or not isinstance(msg, dict):
+            continue
+
+        role = msg.get("role")
+        tool_name = str(msg.get("tool_name") or "")
+        if role == "tool" and tool_name not in preserve_tool_names:
+            content = msg.get("content")
+            if _payload_chars(content) >= min_chars:
+                new_msg = editable(idx)
+                new_msg["content"] = _tool_result_placeholder(
+                    tool_name=tool_name or "unknown",
+                    tool_call_id=str(msg.get("tool_call_id") or ""),
+                    content=content,
+                    preview_chars=preview_chars,
+                )
+                stats.tool_results_compacted += 1
+
+        tool_calls = msg.get("tool_calls")
+        if isinstance(tool_calls, list):
+            new_calls = None
+            compacted_args = 0
+            for call_idx, tool_call in enumerate(tool_calls):
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function")
+                if not isinstance(function, dict):
+                    continue
+                name = str(function.get("name") or "unknown")
+                if name in preserve_tool_names:
+                    continue
+                arguments = function.get("arguments")
+                if not isinstance(arguments, str) or len(arguments) < min_chars:
+                    continue
+                if new_calls is None:
+                    new_calls = copy.deepcopy(tool_calls)
+                new_calls[call_idx]["function"]["arguments"] = _compact_arguments_json(
+                    arguments,
+                    tool_name=name,
+                    preview_chars=preview_chars,
+                )
+                compacted_args += 1
+            if compacted_args:
+                editable(idx)["tool_calls"] = new_calls
+                stats.tool_call_args_compacted += compacted_args
+
+        content = msg.get("content")
+        replaced = _compact_media_content(content)
+        if replaced is not content:
+            editable(idx)["content"] = replaced
+            stats.media_parts_compacted += 1
+
+    if compacted is None:
+        return messages, stats
+
+    stats.messages_compacted = len(changed_indexes)
+    stats.estimated_tokens_before = estimate_messages_tokens_rough(messages)
+    stats.estimated_tokens_after = estimate_messages_tokens_rough(compacted)
+    return compacted, stats
+
+
+def context_assembly_config_from_mapping(
+    compression_config: Mapping[str, Any] | None,
+) -> Dict[str, Any]:
+    """Normalize ``compression.context_assembly`` settings."""
+
+    raw = {}
+    if isinstance(compression_config, Mapping):
+        value = compression_config.get("context_assembly", {})
+        if isinstance(value, Mapping):
+            raw = dict(value)
+
+    return {
+        "enabled": _as_bool(raw.get("enabled", True), default=True),
+        "protect_last_n": _as_int(
+            raw.get("protect_last_n", DEFAULT_PROTECT_LAST_N),
+            default=DEFAULT_PROTECT_LAST_N,
+            minimum=0,
+        ),
+        "min_chars": _as_int(
+            raw.get("min_chars", DEFAULT_MIN_CHARS),
+            default=DEFAULT_MIN_CHARS,
+            minimum=1,
+        ),
+        "preview_chars": _as_int(
+            raw.get("preview_chars", DEFAULT_PREVIEW_CHARS),
+            default=DEFAULT_PREVIEW_CHARS,
+            minimum=0,
+        ),
+        "preserve_tools": _as_str_list(raw.get("preserve_tools", [])),
+    }
+
+
+def _protected_message_indexes(messages: List[Dict[str, Any]], protect_last_n: int) -> Set[int]:
+    if protect_last_n <= 0:
+        return set()
+    non_system = [
+        idx for idx, msg in enumerate(messages)
+        if isinstance(msg, dict) and msg.get("role") != "system"
+    ]
+    return set(non_system[-protect_last_n:])
+
+
+def _payload_chars(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        return len(value)
+    return len(str(value))
+
+
+def _preview(value: Any, limit: int) -> str:
+    text = value if isinstance(value, str) else str(value)
+    text = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    head = max(0, limit // 2)
+    tail = max(0, limit - head)
+    return f"{text[:head]}\n...\n{text[-tail:]}"
+
+
+def _tool_result_placeholder(
+    *,
+    tool_name: str,
+    tool_call_id: str,
+    content: Any,
+    preview_chars: int,
+) -> str:
+    size = _payload_chars(content)
+    preview = _preview(content, preview_chars)
+    lines = [
+        "[stale tool result compacted before model call]",
+        f"tool: {tool_name}",
+        f"tool_call_id: {tool_call_id or 'unknown'}",
+        f"original_chars: {size}",
+    ]
+    if preview:
+        lines.extend(["preview:", preview])
+    return "\n".join(lines)
+
+
+def _compact_arguments_json(arguments: str, *, tool_name: str, preview_chars: int) -> str:
+    preview = _preview(arguments, preview_chars)
+    placeholder = {
+        "_hermes_compacted_stale_tool_arguments": True,
+        "tool": tool_name,
+        "original_chars": len(arguments),
+        "preview": preview,
+    }
+    return json.dumps(placeholder, separators=(",", ":"), sort_keys=True)
+
+
+def _compact_media_content(content: Any) -> Any:
+    if not isinstance(content, list):
+        return content
+
+    changed = False
+    compacted = []
+    for part in content:
+        if not isinstance(part, dict):
+            compacted.append(part)
+            continue
+        ptype = part.get("type")
+        if ptype in {"image", "image_url", "input_image"}:
+            changed = True
+            compacted.append({
+                "type": "text",
+                "text": "[stale media payload compacted before model call]",
+            })
+        else:
+            compacted.append(part)
+    return compacted if changed else content
+
+
+def _as_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _as_int(value: Any, *, default: int, minimum: int) -> int:
+    try:
+        if isinstance(value, bool):
+            raise ValueError
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, parsed)
+
+
+def _as_str_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import conversation_history_after_compression
+from agent.context_assembly import compact_stale_payloads_for_prompt
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
@@ -945,6 +946,28 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        _assembly_cfg = getattr(agent, "_context_assembly_config", None) or {}
+        api_messages, _assembly_stats = compact_stale_payloads_for_prompt(
+            api_messages,
+            enabled=bool(_assembly_cfg.get("enabled", True)),
+            protect_last_n=int(_assembly_cfg.get("protect_last_n", 20)),
+            min_chars=int(_assembly_cfg.get("min_chars", 12_000)),
+            preview_chars=int(_assembly_cfg.get("preview_chars", 600)),
+            preserve_tools=_assembly_cfg.get("preserve_tools", []),
+        )
+        if _assembly_stats.messages_compacted:
+            logger.info(
+                "Context assembly compacted stale payloads before request: "
+                "messages=%s tool_results=%s tool_call_args=%s media=%s "
+                "estimated_tokens_evicted=%s session=%s",
+                _assembly_stats.messages_compacted,
+                _assembly_stats.tool_results_compacted,
+                _assembly_stats.tool_call_args_compacted,
+                _assembly_stats.media_parts_compacted,
+                _assembly_stats.estimated_tokens_evicted,
+                agent.session_id or "-",
+            )
 
         # Calculate approximate request size for logging
         total_chars = sum(len(str(msg)) for msg in api_messages)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -437,6 +437,16 @@ compression:
   # To pin a specific model/provider for compression summaries, use the
   # auxiliary section below (auxiliary.compression.provider / model).
 
+  # Non-destructive prompt-view cleanup that runs before each model call.
+  # This does NOT rewrite the saved transcript; it only replaces stale heavy
+  # payloads in the active API request after preserving the recent tail.
+  context_assembly:
+    enabled: true
+    protect_last_n: 20
+    min_chars: 12000
+    preview_chars: 600
+    preserve_tools: []
+
 # =============================================================================
 # Anthropic prompt caching TTL
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1337,6 +1337,20 @@ DEFAULT_CONFIG = {
                                       # 0 for long-running rolling-compaction sessions
                                       # where you want nothing pinned except the
                                       # system prompt + rolling summary + recent tail.
+        "context_assembly": {
+            "enabled": True,          # non-destructively compact stale heavy
+                                      # payloads in the API prompt view before
+                                      # each model call; canonical history stays
+                                      # intact in SQLite/transcripts.
+            "protect_last_n": 20,     # most-recent non-system messages preserved
+                                      # exactly before stale-payload compaction.
+            "min_chars": 12_000,      # old tool results / tool-call arguments
+                                      # at or above this size are replaced with
+                                      # compact placeholders in the prompt view.
+            "preview_chars": 600,     # total head/tail preview kept in each
+                                      # placeholder.
+            "preserve_tools": [],     # tool names to never compact.
+        },
         "abort_on_summary_failure": False,  # When True, auto-compression that fails
                                       # to generate a summary (aux LLM errored / returned
                                       # non-JSON / timed out) aborts entirely instead of

--- a/tests/agent/test_context_assembly.py
+++ b/tests/agent/test_context_assembly.py
@@ -1,0 +1,163 @@
+import json
+
+from agent.context_assembly import (
+    compact_stale_payloads_for_prompt,
+    context_assembly_config_from_mapping,
+)
+
+
+def test_compacts_stale_tool_result_without_mutating_history():
+    old_payload = "build log line\n" * 200
+    recent_payload = "recent error\n" * 200
+    messages = [
+        {"role": "system", "content": "SYSTEM"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-old",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-old",
+            "tool_name": "terminal",
+            "content": old_payload,
+        },
+        {"role": "user", "content": "what failed?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-new",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-new",
+            "tool_name": "terminal",
+            "content": recent_payload,
+        },
+    ]
+
+    prompt_view, stats = compact_stale_payloads_for_prompt(
+        messages,
+        protect_last_n=3,
+        min_chars=100,
+        preview_chars=80,
+    )
+
+    assert prompt_view is not messages
+    assert messages[2]["content"] == old_payload
+    assert prompt_view[2]["content"].startswith(
+        "[stale tool result compacted before model call]"
+    )
+    assert "tool: terminal" in prompt_view[2]["content"]
+    assert "original_chars:" in prompt_view[2]["content"]
+    assert prompt_view[5]["content"] == recent_payload
+    assert stats.tool_results_compacted == 1
+    assert stats.messages_compacted == 1
+    assert stats.estimated_tokens_evicted > 0
+
+
+def test_compacts_old_tool_call_arguments_as_valid_json():
+    large_args = json.dumps({"path": "/tmp/out.txt", "content": "x" * 500})
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": large_args},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "ok"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    prompt_view, stats = compact_stale_payloads_for_prompt(
+        messages,
+        protect_last_n=1,
+        min_chars=100,
+        preview_chars=40,
+    )
+
+    compacted_args = prompt_view[0]["tool_calls"][0]["function"]["arguments"]
+    parsed = json.loads(compacted_args)
+    assert parsed["_hermes_compacted_stale_tool_arguments"] is True
+    assert parsed["tool"] == "write_file"
+    assert parsed["original_chars"] == len(large_args)
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == large_args
+    assert stats.tool_call_args_compacted == 1
+
+
+def test_preserves_configured_tool_and_recent_media():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "old screenshot"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,old"}},
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_name": "debug_dump",
+            "content": "x" * 200,
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "see screenshot"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        },
+    ]
+
+    prompt_view, stats = compact_stale_payloads_for_prompt(
+        messages,
+        protect_last_n=1,
+        min_chars=100,
+        preserve_tools=["debug_dump"],
+    )
+
+    assert prompt_view is not messages
+    assert prompt_view[0]["content"][1] == {
+        "type": "text",
+        "text": "[stale media payload compacted before model call]",
+    }
+    assert prompt_view[1]["content"] == "x" * 200
+    assert prompt_view[2]["content"][1]["type"] == "image_url"
+    assert stats.messages_compacted == 1
+    assert stats.media_parts_compacted == 1
+
+
+def test_context_assembly_config_normalizes_values():
+    cfg = context_assembly_config_from_mapping({
+        "context_assembly": {
+            "enabled": "false",
+            "protect_last_n": "-2",
+            "min_chars": "bad",
+            "preview_chars": 0,
+            "preserve_tools": ["terminal", 123],
+        }
+    })
+
+    assert cfg == {
+        "enabled": False,
+        "protect_last_n": 0,
+        "min_chars": 12_000,
+        "preview_chars": 0,
+        "preserve_tools": ["terminal", "123"],
+    }


### PR DESCRIPTION
## What does this PR do?

Adds a non-destructive context-assembly pass that compacts stale heavy payloads in the outgoing API prompt view before each model call, while leaving the saved transcript and SQLite session history unchanged.

## Related Issue

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Shared root cause

- Long-running sessions only had coarse threshold compression, so already-persisted heavy payloads such as old tool results, bulky tool-call arguments, and stale media blocks stayed in every active prompt view until full compression happened.
- The new `agent.context_assembly` layer runs during API message assembly, after provider-shape sanitization and before request-size accounting, preserving the recent tail exactly and compacting only older oversized payloads in the API copy.

## How this fixes each issue

- #35466: older heavy payload blocks are replaced with compact placeholders containing source metadata, original size, and a bounded preview before the model call; canonical history is not destructively mutated.
- #35577: long sessions now get a lightweight always-on per-call reduction layer ahead of the coarse compressor, reducing prompt bloat from stale heavy payloads without adding a summarization round trip.

## Changes Made

- Added `agent/context_assembly.py` for deterministic prompt-view compaction and normalized `compression.context_assembly` config.
- Wired the compactor into `agent/conversation_loop.py` before request-size accounting and provider calls.
- Added defaults in `hermes_cli/config.py` and documented the settings in `cli-config.yaml.example`.
- Added unit tests covering stale tool-result compaction, valid JSON replacement for old tool-call arguments, media compaction, recent-tail preservation, configured tool preservation, and config normalization.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`
2. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/agent/test_context_assembly.py tests/agent/test_turn_context.py -q --timeout=60'`
3. `BASE=$(git merge-base origin/main HEAD); { git diff --name-only --diff-filter=d "$BASE"; git ls-files --others --exclude-standard; } | grep -E '\.pyi?$' | sort -u | xargs ruff check`
4. `/opt/homebrew/bin/timeout -k 30 480 python scripts/check-windows-footguns.py agent/context_assembly.py agent/conversation_loop.py agent/agent_init.py hermes_cli/config.py tests/agent/test_context_assembly.py`

Full-suite note: the broad pytest command aborted during collection in this local Python 3.14 environment because `fastapi`/`uvicorn` are missing and lazy dependency installation is blocked by PEP 668. The covering subset above passed.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #35466
Refs #35577

<!-- autocontrib:worker-id=pr-spanning-333304f5 kind=pr-open -->