### PR TITLE
fix(cli): keep current provider visible in model pickers

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -293,14 +293,53 @@ def _apply_capabilities(rows: list[dict]) -> None:
 
 
 def _append_unconfigured_rows(rows: list[dict], ctx: ConfigContext) -> list[dict]:
-    """Build skeleton rows for canonical providers missing from ``rows``."""
+    """Build fallback rows for canonical providers missing from ``rows``.
+
+    Most missing canonical providers become empty setup skeletons. The one
+    exception is the *current* configured provider: if config.yaml still points
+    at it but credentials are presently unavailable, keep a visible row carrying
+    the saved model so GUI pickers don't silently snap to some other provider.
+    """
+    from hermes_cli.auth import PROVIDER_REGISTRY
     from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_LABELS
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
+    cur_model = str(ctx.current_model or "").strip()
     extras: list[dict] = []
     for entry in CANONICAL_PROVIDERS:
         if entry.slug.lower() in seen:
+            continue
+        if entry.slug.lower() == cur:
+            cfg = PROVIDER_REGISTRY.get(entry.slug)
+            auth_type = cfg.auth_type if cfg else "api_key"
+            key_env = (
+                cfg.api_key_env_vars[0]
+                if (cfg and cfg.api_key_env_vars)
+                else ""
+            )
+            warning = (
+                f"Configured provider missing usable credentials; paste {key_env} to reactivate. "
+                "Showing the saved model only."
+                if auth_type == "api_key" and key_env
+                else "Configured provider is not authenticated; run `hermes model` to reactivate. "
+                "Showing the saved model only."
+            )
+            extras.append(
+                {
+                    "slug": entry.slug,
+                    "name": _PROVIDER_LABELS.get(entry.slug, entry.label),
+                    "is_current": True,
+                    "is_user_defined": False,
+                    "models": [cur_model] if cur_model else [],
+                    "total_models": 1 if cur_model else 0,
+                    "source": "configured-current",
+                    "authenticated": False,
+                    "auth_type": auth_type,
+                    "key_env": key_env,
+                    "warning": warning,
+                }
+            )
             continue
         extras.append(
             {

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -415,7 +415,25 @@ def test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_
         "gemini",
         "custom:lab",
     ]
+def test_include_unconfigured_keeps_current_provider_visible_without_credentials():
+    """If the saved provider is currently unauthenticated, keep a visible row
+    with the saved model so GUI pickers don't silently jump to another
+    authenticated provider."""
+    ctx = _empty_ctx(provider="deepseek", model="deepseek-v4-pro")
+    with _list_auth_returning([]):
+        payload = build_models_payload(
+            ctx, include_unconfigured=True, picker_hints=True,
+        )
 
+    deepseek = next(r for r in payload["providers"] if r["slug"] == "deepseek")
+    assert deepseek["source"] == "configured-current"
+    assert deepseek["is_current"] is True
+    assert deepseek["authenticated"] is False
+    assert deepseek["models"] == ["deepseek-v4-pro"]
+    assert deepseek["total_models"] == 1
+    assert deepseek["auth_type"] == "api_key"
+    assert "DEEPSEEK_API_KEY" in deepseek["warning"]
+    assert "saved model only" in deepseek["warning"]
 
 def test_explicit_only_keeps_moa_when_raw_config_has_enabled_preset():
     rows = [
@@ -452,8 +470,6 @@ def test_explicit_only_keeps_moa_when_raw_config_has_enabled_preset():
 
     assert [row["slug"] for row in payload["providers"]] == ["moa"]
     assert payload["providers"][0]["models"] == ["review"]
-
-
 # ─── picker_hints ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Keeps the saved current provider visible in GUI/TUI model pickers when that provider is configured in `config.yaml` but no longer has usable credentials. Instead of dropping the row and letting another authenticated provider appear to be the active one, Hermes now preserves a visible fallback row with the saved model and an explicit re-auth warning.

## Related Issue

Fixes #57065

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/inventory.py`: preserve a `configured-current` fallback row for the current canonical provider when it is missing from the authenticated provider list, carrying the saved model plus a reactivation warning instead of disappearing from picker payloads.
- `tests/hermes_cli/test_inventory.py`: add a regression test covering a configured `deepseek` provider with a saved `deepseek-v4-pro` model and missing credentials.

## How to Test

1. Configure `model.provider: deepseek` and `model.default: deepseek-v4-pro`, then remove `DEEPSEEK_API_KEY` while leaving another provider authenticated.
2. Open a model picker backed by `/api/model/options` or `model.options`; verify the `deepseek` row remains visible, marked current, shows `deepseek-v4-pro`, and includes a missing-credentials warning instead of disappearing.
3. Run `pytest tests/hermes_cli/test_inventory.py tests/hermes_cli/test_inventory_pricing.py -q`.
4. Run `ruff check hermes_cli/inventory.py tests/hermes_cli/test_inventory.py`.
5. Note: the repo-wide local command `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` aborts during collection in this environment on `tests/hermes_cli/test_cron_fire_dashboard.py` because `fastapi`/`uvicorn` are not installed in the managed Python.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## What platforms tested on

- macOS on darwin-arm64 (local)

## Screenshots / Logs

- `pytest tests/hermes_cli/test_inventory.py tests/hermes_cli/test_inventory_pricing.py -q` → `40 passed in 3.77s`
- `ruff check hermes_cli/inventory.py tests/hermes_cli/test_inventory.py` → `All checks passed!`

<!-- autocontrib:worker-id=issue-new-f42c5050 kind=pr-open -->