### PR TITLE
feat(mcp): add xmemory to optional-mcps

### DIFF
--- a/optional-mcps/xmemory-admin/manifest.yaml
+++ b/optional-mcps/xmemory-admin/manifest.yaml
@@ -1,0 +1,22 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+# OPTIONAL admin (control-plane) connection — destructive ops. Drop this entry
+# if a memory-only listing is preferred.
+manifest_version: 1
+
+name: xmemory-admin
+description: Manage xmemory instances — create, list, and delete instances and their schemas (control plane).
+source: https://xmemory.ai
+
+transport:
+  type: http
+  url: https://mcp.xmemory.ai/admin
+
+auth:
+  type: oauth
+  # Native MCP OAuth. Browser flow on first connect.
+
+post_install: |
+  Admin (control-plane) connection. On first connection, Hermes opens a browser
+  to authenticate with xmemory. This surface includes destructive operations
+  such as deleting an instance — use with care.

--- a/optional-mcps/xmemory-admin/manifest.yaml
+++ b/optional-mcps/xmemory-admin/manifest.yaml
@@ -16,7 +16,27 @@ auth:
   type: oauth
   # Native MCP OAuth. Browser flow on first connect.
 
+# Tool selection at install time:
+# xmemory-admin exposes the full control plane. Mutating ops (create / delete /
+# update / patch instances and their schemas) are pruned from the default so a
+# casual install gets a read-only observability surface. Users see the full list
+# in the install-time checklist and opt into the destructive tools per their
+# threat model via `hermes mcp configure xmemory-admin`.
+tools:
+  default_enabled:
+    - admin_list_clusters
+    - admin_get_cluster
+    - admin_list_instances
+    - admin_list_own_instances
+    - admin_get_instance
+    - admin_get_instance_by_id
+    - admin_get_instance_schema_by_id
+
 post_install: |
   Admin (control-plane) connection. On first connection, Hermes opens a browser
   to authenticate with xmemory. This surface includes destructive operations
   such as deleting an instance — use with care.
+
+  Only read-only tools (list / get instances, clusters, and schemas) are enabled
+  by default. To opt into instance create/delete or schema updates, run
+  `hermes mcp configure xmemory-admin`.

--- a/optional-mcps/xmemory/manifest.yaml
+++ b/optional-mcps/xmemory/manifest.yaml
@@ -1,0 +1,24 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: xmemory
+description: Persistent structured memory — save, recall, and update facts, decisions, people, and projects across sessions.
+source: https://xmemory.ai
+
+# xmemory ships a remote MCP server over Streamable HTTP at the bare host root,
+# with native MCP OAuth 2.1 (discovery + dynamic client registration + PKCE).
+# Hermes's MCP client + mcp_oauth_manager handle the browser flow and refresh on
+# first connect — nothing to install locally.
+transport:
+  type: http
+  url: https://mcp.xmemory.ai
+
+auth:
+  type: oauth
+  # No `provider:` — native MCP OAuth (case 1). Browser flow on first connect.
+
+post_install: |
+  On first connection, Hermes opens a browser to authenticate with xmemory and
+  lets you choose the memory instance to use. After auth, restart your Hermes
+  session so the memory tools (read / write / write_async) are loaded.


### PR DESCRIPTION
## What does this PR do?

Adds **xmemory** (https://xmemory.ai) to the MCP catalog — persistent, schema-structured memory for agents: write and read in natural language, stored as typed, schema-validated data in xmemory's backend. Two entries:

- `optional-mcps/xmemory` — memory / data plane at `https://mcp.xmemory.ai` (native MCP OAuth; the user picks the instance to bind during sign-in)
- `optional-mcps/xmemory-admin` — optional instance-management / control plane at `https://mcp.xmemory.ai/admin`; kept as a separate, deliberate entry because it includes destructive operations (e.g. deleting an instance)

## Related Issue

N/A — self-contained catalog addition.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/xmemory/manifest.yaml`
- `optional-mcps/xmemory-admin/manifest.yaml`

## How to Test

1. `pytest tests/hermes_cli/test_mcp_catalog.py -q` — **35 passed** with these manifests included
2. Install the `xmemory` entry; on first connect the OAuth flow (discovery + dynamic client registration + PKCE) completes against `https://mcp.xmemory.ai` and the instance picker appears
3. Ask Hermes to remember something, then recall it (`write_async` / `read` tools)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the catalog contract test (`pytest tests/hermes_cli/test_mcp_catalog.py -q`) — all pass; change is data-only manifests
- [ ] I've added tests for my changes — N/A (covered by the existing catalog contract test)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] Relevant documentation — N/A (catalog manifests carry their own metadata)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact — N/A (data-only)
- [x] Tool descriptions/schemas — N/A (tools are advertised by the remote MCP server)

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_mcp_catalog.py -q
...................................                                      [100%]
35 passed in 0.88s
```
