### PR TITLE
fix(slack): blank lines no longer break ordered list numbering

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -451,6 +451,9 @@ def render_blocks(
                         indent, ordered, txt = items[-1]
                         items[-1] = (indent, ordered, txt + " " + lines[i].strip())
                         i += 1
+                    elif not lines[i].strip():
+                        # blank line — skip without ending the list group
+                        i += 1
                     else:
                         break
                 blocks.append(_list_block(items))


### PR DESCRIPTION
Closes #57076

Blank lines between ordered list items ended the list group in render_blocks(), causing each item to be numbered '1.' independently in Slack rich_blocks. Skip blank lines without breaking the run.