### PR TITLE
fix(gateway): scope session-reset and busy-ack notices to DM only

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5272,6 +5272,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("Busy ack suppressed for session %s", session_key)
             return True  # input still processed, just no ack sent
 
+        # Busy-ack wording surfaces Hermes CLI internals (interrupt/queue/steer
+        # modes, /busy commands) that mean nothing to a public group/forum
+        # audience and read as raw internal-mechanics leakage there. The
+        # interrupt/queue/steer routing above still runs normally; only this
+        # user-facing text is skipped for groups. DMs (single operator who
+        # understands the jargon) are unaffected. Observed on a live
+        # deployment: a random group member saw "⚡ Interrupting current
+        # task... Send /busy queue to queue follow-ups..." with no context
+        # for what any of it meant.
+        if getattr(event.source, "chat_type", "dm") in ("group", "forum"):
+            logger.debug("Busy ack suppressed for group/forum session %s", session_key)
+            return True
+
         # Debounce: only send an acknowledgment once every 30 seconds per session
         # to avoid spamming the user when they send multiple messages quickly
         _BUSY_ACK_COOLDOWN = 30
@@ -10462,12 +10475,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 platform_name = source.platform.value if source.platform else ""
                 had_activity = getattr(session_entry, 'reset_had_activity', False)
+                # Session-reset notices (including model/provider/context info
+                # via _format_session_info) are operational detail meant for
+                # the operator, not group/forum members — restrict delivery
+                # to DMs regardless of reset reason. Observed on a live
+                # deployment: this notice fired in whichever chat happened to
+                # get the first post-reset message, including a public group
+                # of 400+ people, exposing the active model/provider/context
+                # size to every member.
+                is_dm = getattr(source, 'chat_type', 'dm') == 'dm'
                 # Suspended sessions always notify (they were explicitly stopped
                 # or crashed mid-operation) — skip the policy check.
-                should_notify = reset_reason == "suspended" or (
-                    policy.notify
-                    and had_activity
-                    and platform_name not in policy.notify_exclude_platforms
+                should_notify = is_dm and (
+                    reset_reason == "suspended" or (
+                        policy.notify
+                        and had_activity
+                        and platform_name not in policy.notify_exclude_platforms
+                    )
                 )
                 if should_notify:
                     adapter = self.adapters.get(source.platform)


### PR DESCRIPTION
## What
Two internal operational notices were being delivered to whatever chat happened to receive the triggering message, including public group/forum chats:

1. The **session-reset notice** (fires after a daily/idle auto-reset) includes model/provider/context-size info via `_format_session_info()` — operator-facing detail, not something a random group member should see.
2. The **busy-ack notice** (`"⚡ Interrupting current task... Send /busy queue to..."`) surfaces Hermes CLI-specific jargon (interrupt/queue/steer modes, `/busy` commands) that means nothing outside a 1:1 operator conversation.

## Fix
Both are now gated to `chat_type == 'dm'`. The underlying mechanics (interrupt/queue/steer routing, session reset itself) are untouched — only the user-facing notice *text* is suppressed for groups/forums.

## Real-world impact
Observed on a live deployment: a random group member (not the operator) saw the full busy-ack text including the `/busy` command hints, and separately a public CIS Telegram group got a session-reset notice announcing the active model and provider to 400+ people.

## Note for maintainers
This changes default behavior for every deployment that uses group/forum chats — these notices previously appeared there too. Happy to make it a config flag instead of an unconditional change if that's preferred; I opted for unconditional here since I couldn't think of a case where CLI jargon or model/provider info is *wanted* in front of a chat's general membership, but you'd know better than I would — genuinely open to feedback on this one.

## How to test
`tests/gateway/test_fresh_reset_skill_injection.py`, `tests/gateway/test_busy_session_ack.py`, `tests/gateway/test_busy_session_auth_bypass.py`, `tests/gateway/test_internal_event_never_interrupts_busy_session.py`, `tests/cli/test_busy_input_mode_command.py`, `tests/cli/test_cli_steer_busy_path.py` — 53 passed.