### PR TITLE
fix(windows): detect reserved paths before update autostash

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6394,16 +6394,112 @@ def _update_via_zip(args):
     _kill_stale_dashboard_processes()
 
 
+_WINDOWS_RESERVED_NAMES = {
+    "con",
+    "prn",
+    "aux",
+    "nul",
+    "com1",
+    "com2",
+    "com3",
+    "com4",
+    "com5",
+    "com6",
+    "com7",
+    "com8",
+    "com9",
+    "lpt1",
+    "lpt2",
+    "lpt3",
+    "lpt4",
+    "lpt5",
+    "lpt6",
+    "lpt7",
+    "lpt8",
+    "lpt9",
+}
+
+
+def _windows_reserved_component(path: str) -> Optional[str]:
+    normalized = path.replace("\\", "/")
+    for part in normalized.split("/"):
+        if not part or part in {".", ".."}:
+            continue
+
+        cleaned = part.rstrip(" .").lower()
+        stem = cleaned.split(".", 1)[0]
+
+        if stem in _WINDOWS_RESERVED_NAMES:
+            return part
+
+    return None
+
+
+def _iter_status_porcelain_z_paths(output: str):
+    entries = output.split("\0")
+    i = 0
+    while i < len(entries):
+        entry = entries[i]
+        i += 1
+        if not entry:
+            continue
+        if len(entry) < 4 or entry[2] != " ":
+            continue
+
+        status = entry[:2]
+        path = entry[3:]
+        if path:
+            yield path
+
+        if status[0] in {"R", "C"} or status[1] in {"R", "C"}:
+            if i < len(entries) and entries[i]:
+                yield entries[i]
+            i += 1
+
+
+def _abort_update_on_windows_reserved_status_paths(status_output: str) -> None:
+    if sys.platform != "win32":
+        return
+
+    for path in _iter_status_porcelain_z_paths(status_output):
+        reserved = _windows_reserved_component(path)
+        if reserved is None:
+            continue
+
+        print(f"ERROR: Windows reserved filename detected before update: {path}")
+        print()
+        print("Git cannot safely stash or unlink this path on Windows, which can cause")
+        print("`hermes update` to hang during the auto-stash step.")
+        print()
+        print("Workaround:")
+        print('  cd "$env:LOCALAPPDATA\\hermes\\hermes-agent"')
+        print('  Add-Content .git\\info\\exclude "`n/nul"')
+        print("  hermes update")
+        print()
+        print("Warning:")
+        print(
+            "  Avoid `git reset --hard`, `git clean -fdx`, or discarding update "
+            "stashes"
+        )
+        print(
+            "  unless you are okay losing uncommitted local changes inside this "
+            "Hermes"
+        )
+        print("  install directory.")
+        sys.exit(2)
+
+
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
     status = subprocess.run(
-        git_cmd + ["status", "--porcelain"],
+        git_cmd + ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
         cwd=cwd,
         capture_output=True,
         text=True,
         check=True,
     )
-    if not status.stdout.strip():
+    if not status.stdout:
         return None
+    _abort_update_on_windows_reserved_status_paths(status.stdout)
 
     # If the index has unmerged entries (e.g. from an interrupted merge/rebase),
     # git stash will fail with "needs merge / could not write index".  Clear the

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -39,12 +39,74 @@ def _patch_managed_uv(request):
          patch("hermes_cli.managed_uv.update_managed_uv", side_effect=_fake_update_managed_uv):
         yield
 
+
+@pytest.mark.parametrize(
+    ("path", "component"),
+    [
+        ("nul", "nul"),
+        ("NUL", "NUL"),
+        ("nul.txt", "nul.txt"),
+        ("dir/nul", "nul"),
+        (r"dir\nul", "nul"),
+        ("con", "con"),
+        ("aux.log", "aux.log"),
+        ("COM1", "COM1"),
+        ("LPT9.txt", "LPT9.txt"),
+        ("dir/nul. ", "nul. "),
+    ],
+)
+def test_windows_reserved_component_detects_device_names(path, component):
+    assert hermes_main._windows_reserved_component(path) == component
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "normal.txt",
+        "annul",
+        "console",
+        "company1",
+        "lpt10",
+        "com10",
+    ],
+)
+def test_windows_reserved_component_ignores_normal_paths(path):
+    assert hermes_main._windows_reserved_component(path) is None
+
+
+def test_stash_local_changes_if_needed_aborts_before_stash_for_windows_reserved_path(
+    monkeypatch, tmp_path, capsys
+):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[-4:] == ["status", "--porcelain=v1", "-z", "--untracked-files=all"]:
+            return SimpleNamespace(stdout="?? nul\0", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr(hermes_main.sys, "platform", "win32")
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
+
+    assert exc_info.value.code == 2
+    assert not any(
+        cmd[1:4] == ["stash", "push", "--include-untracked"]
+        for cmd, _ in calls
+    )
+    out = capsys.readouterr().out
+    assert "Windows reserved filename detected before update: nul" in out
+    assert "git reset --hard" in out
+
+
 def test_stash_local_changes_if_needed_returns_none_when_tree_clean(monkeypatch, tmp_path):
     calls = []
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
-        if cmd[-2:] == ["status", "--porcelain"]:
+        if cmd[-4:] == ["status", "--porcelain=v1", "-z", "--untracked-files=all"]:
             return SimpleNamespace(stdout="", returncode=0)
         raise AssertionError(f"unexpected command: {cmd}")
 
@@ -53,7 +115,9 @@ def test_stash_local_changes_if_needed_returns_none_when_tree_clean(monkeypatch,
     stash_ref = hermes_main._stash_local_changes_if_needed(["git"], tmp_path)
 
     assert stash_ref is None
-    assert [cmd[-2:] for cmd, _ in calls] == [["status", "--porcelain"]]
+    assert [cmd[-4:] for cmd, _ in calls] == [
+        ["status", "--porcelain=v1", "-z", "--untracked-files=all"]
+    ]
 
 
 def test_stash_local_changes_if_needed_returns_specific_stash_commit(monkeypatch, tmp_path):
@@ -61,8 +125,8 @@ def test_stash_local_changes_if_needed_returns_specific_stash_commit(monkeypatch
 
     def fake_run(cmd, **kwargs):
         calls.append((cmd, kwargs))
-        if cmd[-2:] == ["status", "--porcelain"]:
-            return SimpleNamespace(stdout=" M hermes_cli/main.py\n?? notes.txt\n", returncode=0)
+        if cmd[-4:] == ["status", "--porcelain=v1", "-z", "--untracked-files=all"]:
+            return SimpleNamespace(stdout=" M hermes_cli/main.py\0?? notes.txt\0", returncode=0)
         if cmd[-2:] == ["ls-files", "--unmerged"]:
             return SimpleNamespace(stdout="", returncode=0)
         if cmd[1:4] == ["stash", "push", "--include-untracked"]:
@@ -306,8 +370,8 @@ def test_restore_stashed_changes_auto_resets_non_interactive(monkeypatch, tmp_pa
 
 def test_stash_local_changes_if_needed_raises_when_stash_ref_missing(monkeypatch, tmp_path):
     def fake_run(cmd, **kwargs):
-        if cmd[-2:] == ["status", "--porcelain"]:
-            return SimpleNamespace(stdout=" M hermes_cli/main.py\n", returncode=0)
+        if cmd[-4:] == ["status", "--porcelain=v1", "-z", "--untracked-files=all"]:
+            return SimpleNamespace(stdout=" M hermes_cli/main.py\0", returncode=0)
         if cmd[-2:] == ["ls-files", "--unmerged"]:
             return SimpleNamespace(stdout="", returncode=0)
         if cmd[1:4] == ["stash", "push", "--include-untracked"]:


### PR DESCRIPTION
﻿Fixes #57081.

## Summary

Adds a Windows preflight check before the update auto-stash step to detect reserved device-name paths such as `nul`.

On Windows, Git can hang or prompt interactively during `git stash` when an untracked reserved path exists in the working tree:

```text
Ignoring path nul
Unlink of file 'nul' failed. Should I try again? (y/n)
```

This caused `hermes update` to appear stuck at:

```text
-> Local changes detected - stashing before update...
```

## Behavior after this change

Instead of invoking `git stash` and potentially hanging, Hermes fails fast with a clear Windows-specific message and a safe local workaround.

The fix does not automatically delete files, modify `.git/info/exclude`, reset the repo, clean the repo, or restore stashes.

## Safety note

Manual recovery commands such as `git reset --hard`, `git clean -fdx`, clearing stashes, or declining stash restore can discard uncommitted local changes inside the Hermes install repo. This PR intentionally avoids those destructive actions and only detects/reports the unsafe path before autostash.

## Follow-up idea

A future PR could add a self-updating manifest/update-state file for Hermes updates. That manifest could track installed SHA, target SHA, Python version, dependency-install status, pre-update snapshot, backup path, autostash state, process-lock detection, and recovery status.

That would make updates more resumable/idempotent and could support a future `hermes update doctor` or `hermes repair` command for partial updates, locked executables, failed dependency installs, and stale update stashes.

## Testing

* `python -m py_compile hermes_cli\\main.py tests\\hermes_cli\\test_update_autostash.py`
* `python -m ruff check hermes_cli\\main.py tests\\hermes_cli\\test_update_autostash.py`
* `python -m pytest tests\\hermes_cli\\test_update_autostash.py -k "windows_reserved_component or aborts_before_stash or stash_local_changes_if_needed"`
* Attempted full `python -m pytest tests\\hermes_cli\\test_update_autostash.py`; 46 passed and 4 failed on existing Windows test assumptions around `git -c windows.appendAtomically=false` command shape, outside this change.
