### PR TITLE
fix(dashboard-auth): skip auto-SSO for password-only provider (500 on login)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,12 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password providers (supports_password) have no OAuth redirect flow —
+    # their start_login() raises NotImplementedError. Auto-SSO is only for
+    # redirect-based (OAuth) providers; fall through to /login so the
+    # credential form renders instead of 500ing on start_login().
+    if getattr(provider, "supports_password", False):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -406,6 +406,29 @@ class TestAutoSsoRedirect:
         assert r.headers["location"].startswith("/login")
         assert "/auth/login" not in r.headers["location"]
 
+    def test_single_password_provider_renders_login_not_auto_sso(self, gated_app):
+        """A sole password provider (supports_password) has NO OAuth redirect
+        flow — its start_login() raises NotImplementedError. Auto-SSO must NOT
+        target it (that produced an uncaught 500 at /auth/login); we fall
+        through to the /login interstitial so the credential form renders."""
+        from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+        from hermes_cli.dashboard_auth import clear_providers, register_provider
+
+        class _PasswordStub(StubAuthProvider):
+            name = "basic"
+            display_name = "Username & Password"
+            supports_password = True
+
+            def start_login(self, *, redirect_uri: str):
+                raise NotImplementedError("password-only; no OAuth redirect")
+
+        clear_providers()
+        register_provider(_PasswordStub())
+        r = gated_app.get("/sessions", follow_redirects=False)
+        assert r.status_code == 302
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation


### PR DESCRIPTION
## Problem

With `dashboard.basic_auth` configured as the **only** auth provider and the dashboard bound to a non-loopback host (`--host 0.0.0.0`), every HTML navigation to a protected path returns `500 Internal Server Error` and the login form never renders.

Fixes #57211.

## Root cause

`_auto_sso_response` in `hermes_cli/dashboard_auth/middleware.py` fires whenever exactly one interactive provider is registered, and unconditionally 302-redirects to `/auth/login?provider=basic`. That route (`routes.py`) calls `provider.start_login()`, but `BasicAuthProvider.start_login()` (`plugins/dashboard_auth/basic/__init__.py`) raises `NotImplementedError` — it is password-only and has no OAuth redirect flow. `NotImplementedError` is not a `ProviderError`, so it escapes uncaught → 500.

Auto-SSO is documented as being for "the portal OAuth redirect", so it should never target a password provider.

## Fix

Skip auto-SSO when the sole provider is password-based (`supports_password`), so the `/login` interstitial renders its credential form instead:

```python
provider = providers[0]
if getattr(provider, "supports_password", False):
    return None
```

After this, an unauthenticated HTML load lands on `/login` (200, credential form) instead of 500ing.

## Test

Adds `test_single_password_provider_renders_login_not_auto_sso` to `TestAutoSsoRedirect`, asserting a single `supports_password` provider redirects to `/login` rather than `/auth/login`. Full file passes:

```
tests/hermes_cli/test_dashboard_auth_401_reauth.py (45 passed)
```

## Reproduction (before fix)

1. Configure `dashboard.basic_auth` (username + password_hash) as the only provider.
2. `hermes dashboard --host 0.0.0.0 --port 9119`
3. `curl -sL http://localhost:9119/` → `Internal Server Error` (500).