### PR TITLE
fix(feishu): honor DM allowlist wildcard

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4209,6 +4209,8 @@ class FeishuAdapter(BasePlatformAdapter):
             # Gateway auth fail-closes agent access until approval.
             if not self._allowed_group_users:
                 return None
+            if "*" in self._allowed_group_users:
+                return None
             if not (sender_ids and (sender_ids & self._allowed_group_users)):
                 return "dm_policy_rejected"
             return None

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -419,6 +419,16 @@ def test_dm_allowlist_admits_configured_sender(monkeypatch):
     assert adapter._admit(sender, message) is None
 
 
+def test_dm_allowlist_wildcard_admits_any_sender(monkeypatch):
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = make_adapter_skeleton()
+    adapter._allowed_group_users = frozenset({"*"})
+    sender = make_sender(open_id="ou_unknown")
+    message = make_message(chat_type="p2p")
+    assert adapter._admit(sender, message) is None
+
+
 def test_admit_skips_mention_check_under_all_mode():
     # Tripwire: under allow_bots=all the mention path must not be probed.
     adapter = make_adapter_skeleton(bot_open_id="ou_self", allow_bots="all")

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -374,7 +374,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `FEISHU_CONNECTION_MODE` | `websocket` (recommended) or `webhook`. Default: `websocket` |
 | `FEISHU_ENCRYPT_KEY` | Optional encryption key for webhook mode |
 | `FEISHU_VERIFICATION_TOKEN` | Optional verification token for webhook mode |
-| `FEISHU_ALLOWED_USERS` | Comma-separated Feishu user IDs allowed to message the bot |
+| `FEISHU_ALLOWED_USERS` | Comma-separated Feishu user IDs allowed to message the bot. For direct messages, set `*` to allow every sender. |
 | `FEISHU_ALLOW_BOTS` | `none` (default) / `mentions` / `all` — accept inbound messages from other bots. See [bot-to-bot messaging](../user-guide/messaging/feishu.md#bot-to-bot-messaging) |
 | `FEISHU_REQUIRE_MENTION` | `true` (default) / `false` — whether group messages must @mention the bot. Override per-chat via `group_rules.<chat_id>.require_mention`. |
 | `FEISHU_HOME_CHANNEL` | Feishu chat ID for cron delivery and notifications |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -544,7 +544,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `FEISHU_APP_SECRET` | ✅ | — | Feishu/Lark App Secret |
 | `FEISHU_DOMAIN` | — | `feishu` | `feishu` (China) or `lark` (international) |
 | `FEISHU_CONNECTION_MODE` | — | `websocket` | `websocket` or `webhook` |
-| `FEISHU_ALLOWED_USERS` | — | _(empty)_ | Comma-separated open_id list for user allowlist |
+| `FEISHU_ALLOWED_USERS` | — | _(empty)_ | Comma-separated open_id list for the user allowlist. For direct messages, set `*` to allow every sender. |
 | `FEISHU_ALLOW_BOTS` | — | `none` | Accept messages from other bots: `none`, `mentions`, or `all` |
 | `FEISHU_REQUIRE_MENTION` | — | `true` | Whether group messages must @mention the bot |
 | `FEISHU_HOME_CHANNEL` | — | — | Chat ID for cron/notification output |


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu DM admission when `FEISHU_ALLOWED_USERS=*` is configured.

The DM allowlist path already allowed an empty allowlist for pairing mode, and it allowed explicitly listed user IDs. It did not treat `*` as allow all, so a DM sender could be rejected with `dm_policy_rejected` even though the env var was meant to allow everyone.

## Related Issue

Fixes #57202

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Treat `*` in `FEISHU_ALLOWED_USERS` as allow-all for Feishu DM admission.
- Add a focused regression test for the DM wildcard path.

## How to Test

1. Set `FEISHU_ALLOWED_USERS=*`.
2. Send a Feishu DM from any user.
3. The adapter should admit the message instead of returning `dm_policy_rejected`.

Verification run locally:

```bash
/Users/blackishgreen03/workspace/hermes-agent/venv/bin/python -m pytest tests/gateway/test_feishu_bot_admission.py -q
```

Result: `64 passed`.

Also ran:

```bash
git diff --check
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, focused pytest

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, adapter admission logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
