### PR TITLE
fix(gateway): prefill Signal allowlist with service id

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import textwrap
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -5728,6 +5729,95 @@ def _setup_qqbot():
     print_info(f"  App ID: {credentials['app_id']}")
 
 
+def _is_signal_service_id(value: str) -> bool:
+    """Return True when *value* looks like a Signal service ID."""
+    if not value:
+        return False
+    if value.startswith("PNI:") or value.startswith("u:"):
+        return True
+    try:
+        uuid.UUID(value)
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+def _extract_signal_service_id(contact: object, phone_number: str) -> str | None:
+    """Best-effort extraction of a Signal service ID from ``listContacts``."""
+    if not isinstance(contact, dict):
+        return None
+
+    number = str(contact.get("number") or "")
+    recipient = str(contact.get("recipient") or "")
+    service_id = contact.get("uuid") or contact.get("serviceId")
+    if not service_id:
+        profile = contact.get("profile")
+        if isinstance(profile, dict):
+            service_id = profile.get("serviceId") or profile.get("uuid")
+    if not service_id:
+        return None
+    service_id = str(service_id).strip()
+    if not _is_signal_service_id(service_id):
+        return None
+    if number == phone_number or recipient == phone_number:
+        return service_id
+    return None
+
+
+def _lookup_signal_service_id(http_url: str, account: str, phone_number: str) -> str | None:
+    """Resolve ``phone_number`` to a Signal service ID via ``listContacts``."""
+    if not http_url or not account or not phone_number:
+        return None
+
+    try:
+        import httpx
+
+        resp = httpx.post(
+            f"{http_url.rstrip('/')}/api/v1/rpc",
+            json={
+                "jsonrpc": "2.0",
+                "method": "listContacts",
+                "params": {
+                    "account": account,
+                    "allRecipients": True,
+                },
+                "id": "signal_setup_listContacts",
+            },
+            timeout=10.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logger.debug(
+            "Signal setup: failed to resolve service ID for %s: %s",
+            phone_number,
+            exc,
+        )
+        return None
+
+    contacts = data.get("result") if isinstance(data, dict) else None
+    if not isinstance(contacts, list):
+        return None
+    for contact in contacts:
+        service_id = _extract_signal_service_id(contact, phone_number)
+        if service_id:
+            return service_id
+    return None
+
+
+def _join_unique_csv_values(*values: str) -> str:
+    """Join comma-separated values while preserving order and removing dupes."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        for raw in str(value or "").split(","):
+            item = raw.strip()
+            if item and item not in seen:
+                seen.add(item)
+                ordered.append(item)
+    return ",".join(ordered)
+
+
 def _setup_signal():
     """Interactive setup for Signal messenger."""
     import shutil
@@ -5813,13 +5903,26 @@ def _setup_signal():
         return
 
     save_env_value("SIGNAL_ACCOUNT", account)
+    resolved_service_id = _lookup_signal_service_id(url, account, account)
 
     # Allowed users
     print()
     print_info("  The gateway DENIES all users by default for security.")
+    print_info("  Signal may identify senders by UUID/service ID instead of phone number.")
     print_info("  Enter phone numbers or UUIDs of allowed users (comma-separated).")
     existing_allowed = get_env_value("SIGNAL_ALLOWED_USERS") or ""
-    default_allowed = existing_allowed or account
+    default_allowed = existing_allowed or _join_unique_csv_values(
+        account,
+        resolved_service_id or "",
+    )
+    if resolved_service_id and not existing_allowed:
+        print_info(
+            f"  Resolved service ID for {account}; default allowlist includes both identifiers."
+        )
+    elif not existing_allowed:
+        print_info(
+            "  If the default phone number fails, add the sender's UUID/service ID here."
+        )
     try:
         allowed = (
             input(f"  Allowed users [{default_allowed}]: ").strip() or default_allowed

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1169,3 +1169,139 @@ def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")
     assert gateway.logger.name == "hermes_cli.gateway"
+
+
+def test_lookup_signal_service_id_uses_list_contacts(monkeypatch):
+    calls = []
+    expected_uuid = "68680952-6d86-45bc-85e0-1a4d186d53ee"
+
+    class _Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "result": [
+                    {
+                        "recipient": "351935789098",
+                        "number": "+15551230000",
+                        "uuid": expected_uuid,
+                    }
+                ]
+            }
+
+    def fake_post(url, json=None, timeout=None):
+        calls.append({"url": url, "json": json, "timeout": timeout})
+        return _Response()
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    resolved = gateway._lookup_signal_service_id(
+        "http://127.0.0.1:8080",
+        "+15551230000",
+        "+15551230000",
+    )
+
+    assert resolved == expected_uuid
+    assert calls == [
+        {
+            "url": "http://127.0.0.1:8080/api/v1/rpc",
+            "json": {
+                "jsonrpc": "2.0",
+                "method": "listContacts",
+                "params": {
+                    "account": "+15551230000",
+                    "allRecipients": True,
+                },
+                "id": "signal_setup_listContacts",
+            },
+            "timeout": 10.0,
+        }
+    ]
+
+
+def test_setup_signal_defaults_allowlist_to_phone_and_resolved_uuid(monkeypatch):
+    env = {}
+    expected_uuid = "68680952-6d86-45bc-85e0-1a4d186d53ee"
+    inputs = iter(["", "+15551230000", ""])
+
+    class _GetResponse:
+        status_code = 200
+
+    class _PostResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "result": [
+                    {
+                        "number": "+15551230000",
+                        "uuid": expected_uuid,
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/signal-cli")
+    monkeypatch.setattr(
+        gateway,
+        "get_env_value",
+        lambda key: env.get(key, ""),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "save_env_value",
+        lambda key, value: env.__setitem__(key, value),
+    )
+    monkeypatch.setattr(gateway, "prompt_yes_no", lambda *args, **kwargs: False)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(inputs))
+    monkeypatch.setattr("httpx.get", lambda *args, **kwargs: _GetResponse())
+    monkeypatch.setattr("httpx.post", lambda *args, **kwargs: _PostResponse())
+
+    gateway._setup_signal()
+
+    assert env["SIGNAL_HTTP_URL"] == "http://127.0.0.1:8080"
+    assert env["SIGNAL_ACCOUNT"] == "+15551230000"
+    assert env["SIGNAL_ALLOWED_USERS"] == (
+        "+15551230000,68680952-6d86-45bc-85e0-1a4d186d53ee"
+    )
+
+
+def test_setup_signal_keeps_existing_allowlist(monkeypatch):
+    env = {
+        "SIGNAL_ALLOWED_USERS": "u:preferred-service-id",
+    }
+    inputs = iter(["", "+15551230000", ""])
+
+    class _GetResponse:
+        status_code = 200
+
+    class _PostResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "result": [
+                    {
+                        "number": "+15551230000",
+                        "uuid": "68680952-6d86-45bc-85e0-1a4d186d53ee",
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/signal-cli")
+    monkeypatch.setattr(gateway, "get_env_value", lambda key: env.get(key, ""))
+    monkeypatch.setattr(
+        gateway,
+        "save_env_value",
+        lambda key, value: env.__setitem__(key, value),
+    )
+    monkeypatch.setattr(gateway, "prompt_yes_no", lambda *args, **kwargs: False)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(inputs))
+    monkeypatch.setattr("httpx.get", lambda *args, **kwargs: _GetResponse())
+    monkeypatch.setattr("httpx.post", lambda *args, **kwargs: _PostResponse())
+
+    gateway._setup_signal()
+
+    assert env["SIGNAL_ALLOWED_USERS"] == "u:preferred-service-id"


### PR DESCRIPTION
## Summary
- resolve the configured Signal account to its service ID during `hermes gateway setup`
- prefill `SIGNAL_ALLOWED_USERS` with both the phone number and resolved service ID when available
- add setup-path tests covering UUID detection, contact lookup, and allowlist defaults

## Verification
- `uv run --frozen pytest tests/hermes_cli/test_gateway.py -k 'signal_service_id or setup_signal'`
- `uv run --frozen ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway.py`
- `git diff --check`

Fixes #52732
