### PR TITLE
fix(windows): show native profile path in system prompt

### DIFF
--- a/agent/_platform_paths.py
+++ b/agent/_platform_paths.py
@@ -1,0 +1,111 @@
+"""Platform-aware path display helpers for the agent system prompt.
+
+On native Windows, Hermes profile data lives under ``%LOCALAPPDATA%\\hermes\\``,
+but on WSL and Linux it lives under ``~/.hermes/``.  These helpers return the
+correct display string for the current platform so the system prompt doesn't
+mislead agents about where their profile data actually lives.
+
+Detection
+---------
+* ``os.name == "nt"`` → native Windows (use ``%LOCALAPPDATA%\\hermes\\``)
+* ``os.name == "posix"`` + ``/proc/version`` contains ``microsoft`` → WSL
+  (use ``~/.hermes/`` — WSL sessions run the Linux path)
+* Anything else (Linux, macOS) → ``~/.hermes/``
+
+The WSL check follows the same pattern as ``cli.py``'s ``_is_wsl()`` but is
+kept here as a standalone copy so ``agent/system_prompt.py`` doesn't need to
+import the entire CLI module.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _is_wsl() -> bool:
+    """Return ``True`` when running inside WSL (Windows Subsystem for Linux).
+
+    ``os.name`` is ``"posix"`` inside WSL, so we must inspect ``/proc/version``
+    or ``/proc/sys/kernel/osrelease`` for the ``"microsoft"`` marker.  This is
+    the same logic used in ``hermes_cli/cli.py:3139-3149``.
+    """
+    for path in ("/proc/version", "/proc/sys/kernel/osrelease"):
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                if "microsoft" in f.read().lower():
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def _is_native_windows() -> bool:
+    """Return ``True`` on native Windows (not WSL)."""
+    return os.name == "nt"
+
+
+def _is_wsl_or_linux() -> bool:
+    """Return ``True`` on non-Windows (WSL, Linux, macOS)."""
+    return not _is_native_windows()
+
+
+def _display_hermes_root() -> str:
+    """Return the human-readable Hermes root path for the current platform.
+
+    Results
+    -------
+    Native Windows
+        ``%LOCALAPPDATA%\\hermes``
+    WSL / Linux / macOS
+        ``~/.hermes``
+    """
+    if _is_native_windows():
+        return r"%LOCALAPPDATA%\hermes"
+    return "~/.hermes"
+
+
+def _display_profile_path(profile_name: str) -> str:
+    """Return the display path for *profile_name* under the Hermes profiles dir.
+
+    Results
+    -------
+    Native Windows
+        ``%LOCALAPPDATA%\\hermes\\profiles\\<profile_name>``
+    WSL / Linux / macOS
+        ``~/.hermes/profiles/<profile_name>``
+    """
+    if _is_native_windows():
+        return rf"%LOCALAPPDATA%\hermes\profiles\{profile_name}"
+    return f"~/.hermes/profiles/{profile_name}"
+
+
+def _display_default_root() -> str:
+    """Return the display path for the default profile's sub-directories.
+
+    Results
+    -------
+    Native Windows
+        ``%LOCALAPPDATA%\\hermes``
+    WSL / Linux / macOS
+        ``~/.hermes``
+    """
+    return _display_hermes_root()
+
+
+# ── Testability helper ──────────────────────────────────────────────────────
+
+def _display_hermes_root_for(os_name: str) -> str:
+    """Same as :func:`_display_hermes_root` but with an explicit *os_name*
+    argument so tests can verify both branches without mocking ``os.name``."""
+    if os_name == "nt":
+        return r"%LOCALAPPDATA%\hermes"
+    return "~/.hermes"
+
+
+def _display_profile_path_for(os_name: str, profile_name: str) -> str:
+    """Same as :func:`_display_profile_path` but with an explicit *os_name*
+    argument so tests can verify both branches without mocking ``os.name``."""
+    if os_name == "nt":
+        return rf"%LOCALAPPDATA%\hermes\profiles\{profile_name}"
+    return f"~/.hermes/profiles/{profile_name}"

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -26,6 +26,11 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional
 
+from agent._platform_paths import (
+    _display_hermes_root,
+    _display_profile_path,
+)
+
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
@@ -361,19 +366,20 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         active_profile = "default"
     if active_profile == "default":
         stable_parts.append(
-            "Active Hermes profile: default. Other profiles (if any) live "
-            "under ~/.hermes/profiles/<name>/. Each profile has its own "
-            "skills/, plugins/, cron/, and memories/ that affect a different "
-            "session than this one. Do not modify another profile's "
-            "skills/plugins/cron/memories unless the user explicitly directs "
-            "you to."
+            f"Active Hermes profile: default. Other profiles (if any) live "
+            f"under {_display_profile_path('<name>')}. Each profile has its own "
+            f"skills/, plugins/, cron/, and memories/ that affect a different "
+            f"session than this one. Do not modify another profile's "
+            f"skills/plugins/cron/memories unless the user explicitly directs "
+            f"you to."
         )
     else:
+        hermes_root = _display_hermes_root()
         stable_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes ~/.hermes/profiles/{active_profile}/. The default "
-            f"profile's data lives at ~/.hermes/skills/, ~/.hermes/plugins/, "
-            f"~/.hermes/cron/, ~/.hermes/memories/ — those belong to a "
+            f"and writes {_display_profile_path(active_profile)}. The default "
+            f"profile's data lives at {hermes_root}/skills/, {hermes_root}/plugins/, "
+            f"{hermes_root}/cron/, {hermes_root}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "

--- a/tests/agent/test_platform_paths.py
+++ b/tests/agent/test_platform_paths.py
@@ -1,0 +1,88 @@
+"""Tests for agent/_platform_paths.py — platform-aware path display."""
+
+from agent._platform_paths import (
+    _display_hermes_root_for,
+    _display_profile_path_for,
+    _is_native_windows,
+    _is_wsl,
+)
+
+
+class TestPlatformDetection:
+    def test_native_windows_is_nt(self, monkeypatch):
+        monkeypatch.setattr("os.name", "nt")
+        assert _is_native_windows() is True
+
+    def test_posix_is_not_native_windows(self, monkeypatch):
+        monkeypatch.setattr("os.name", "posix")
+        assert _is_native_windows() is False
+
+    def test_is_wsl_returns_false_when_proc_version_missing(self, monkeypatch):
+        """On non-WSL Linux /proc/version won't contain 'microsoft'."""
+        monkeypatch.setattr("builtins.open", _fake_open_linux)
+        assert _is_wsl() is False
+
+    def test_is_wsl_returns_true_when_microsoft_in_proc_version(self, monkeypatch):
+        monkeypatch.setattr("builtins.open", _fake_open_wsl)
+        assert _is_wsl() is True
+
+
+class TestDisplayHermesRoot:
+    def test_windows_returns_localappdata(self):
+        assert _display_hermes_root_for("nt") == r"%LOCALAPPDATA%\hermes"
+
+    def test_posix_returns_tilde_hermes(self):
+        assert _display_hermes_root_for("posix") == "~/.hermes"
+
+
+class TestDisplayProfilePath:
+    def test_windows_non_default_profile(self):
+        result = _display_profile_path_for("nt", "hades")
+        assert result == r"%LOCALAPPDATA%\hermes\profiles\hades"
+
+    def test_windows_default_profile_placeholder(self):
+        result = _display_profile_path_for("nt", "<name>")
+        assert result == r"%LOCALAPPDATA%\hermes\profiles\<name>"
+
+    def test_posix_non_default_profile(self):
+        result = _display_profile_path_for("posix", "hades")
+        assert result == "~/.hermes/profiles/hades"
+
+    def test_posix_default_profile_placeholder(self):
+        result = _display_profile_path_for("posix", "<name>")
+        assert result == "~/.hermes/profiles/<name>"
+
+
+# ── Fake /proc filesystem helpers ───────────────────────────────────────────
+
+_LINUX_PROCFILE = {
+    "/proc/version": (
+        "Linux version 6.8.0-35-generic (buildd@lcy02-amd64-008) "
+        "(gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0, GNU ld (GNU Binutils for "
+        "Ubuntu) 2.42) #35-Ubuntu SMP PREEMPT_DYNAMIC Mon May 20 19:55:16 "
+        "UTC 2024"
+    ),
+    "/proc/sys/kernel/osrelease": "6.8.0-35-generic",
+}
+
+_WSL_PROCFILE = {
+    "/proc/version": (
+        "Linux version 5.15.153.1-microsoft-standard-WSL2 "
+        "(root@90410d14-ebbb-408b-9ea7-02f2dacdbce4) "
+        "(gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37) "
+        "#1 SMP Fri Apr 4 23:40:18 UTC 2025"
+    ),
+    "/proc/sys/kernel/osrelease": "5.15.153.1-microsoft-standard-WSL2",
+}
+
+
+def _fake_open_linux(path, *args, **kwargs):
+    content = _LINUX_PROCFILE.get(str(path), "")
+    from io import StringIO
+    return StringIO(content)
+
+
+def _fake_open_wsl(path, *args, **kwargs):
+    content = _WSL_PROCFILE.get(str(path), "")
+    from io import StringIO
+    return StringIO(content)

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -99,3 +99,43 @@ class TestCodingContextBlock:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         agent = _make_agent(valid_tool_names=[], platform="cli")
         assert "coding agent" not in _stable_prompt(agent)
+
+
+class TestProfilePathDisplay:
+    """The stable prompt must show the correct profile path per platform."""
+
+    def _stable_with_profile(self, profile_name: str) -> str:
+        from unittest.mock import patch as mock_patch
+
+        with (
+            mock_patch("run_agent.load_soul_md", return_value=""),
+            mock_patch("run_agent.build_nous_subscription_prompt", return_value=""),
+            mock_patch("run_agent.build_environment_hints", return_value=""),
+            mock_patch("run_agent.build_context_files_prompt", return_value=""),
+            mock_patch(
+                "agent.file_safety._resolve_active_profile_name",
+                return_value=profile_name,
+            ),
+        ):
+            return build_system_prompt_parts(_make_agent())["stable"]
+
+    def test_windows_profile_includes_localappdata(self, monkeypatch):
+        """On native Windows the prompt should reference LOCALAPPDATA."""
+        monkeypatch.setattr("agent._platform_paths.os.name", "nt")
+        stable = self._stable_with_profile("hades")
+        assert "%LOCALAPPDATA%" in stable
+        assert r"\hermes\profiles\hades" in stable
+        assert "~/.hermes" not in stable
+
+    def test_windows_default_profile_includes_localappdata(self, monkeypatch):
+        """Default profile hint should also be Windows-aware."""
+        monkeypatch.setattr("agent._platform_paths.os.name", "nt")
+        stable = self._stable_with_profile("default")
+        assert "%LOCALAPPDATA%" in stable
+
+    def test_posix_profile_uses_tilde(self, monkeypatch):
+        """On POSIX (WSL / Linux / macOS) the old ~/.hermes path is correct."""
+        monkeypatch.setattr("agent._platform_paths.os.name", "posix")
+        stable = self._stable_with_profile("hades")
+        assert "~/.hermes" in stable
+        assert "%LOCALAPPDATA%" not in stable


### PR DESCRIPTION
Fixes #52669.

## Summary

Makes the "Active Hermes profile" system prompt text platform-aware.

On native Windows, Hermes profile data lives under:

```text
%LOCALAPPDATA%\hermes\profiles\<profile>\
```

but the system prompt previously always displayed:

```text
~/.hermes/profiles/<profile>/
```

That path is correct for Linux/WSL, but misleading on native Windows because the actual profile data lives under AppData.

## What changed

- New `agent/_platform_paths.py` module with helpers:
  - `_is_wsl()` — detects WSL via `/proc/version` (same pattern as `cli.py`)
  - `_is_native_windows()` — `os.name == "nt"`
  - `_display_hermes_root()` / `_display_profile_path(name)` — return the correct display path for the current platform
- `agent/system_prompt.py` imports and uses these helpers instead of hardcoded `~/.hermes` strings

## Behavior after this change

- **Native Windows:** shows `%LOCALAPPDATA%\hermes\profiles\<profile>\`
- **WSL / Linux / macOS:** keeps `~/.hermes/profiles/<profile>/` (unchanged)
- Runtime storage behavior is unchanged
- No symlinks, junctions, migrations, deletes, or data movement are introduced

## Testing

- Added `tests/agent/test_platform_paths.py` — 10 unit tests covering platform detection, root path, and profile path for both Windows and POSIX
- Added `TestProfilePathDisplay` to `tests/agent/test_system_prompt.py` — 3 integration tests verifying the system prompt text for Windows (default and non-default profiles) and POSIX
- `python -m pytest tests/agent/test_platform_paths.py tests/agent/test_system_prompt.py -v` — 17/17 passed, 1 deselected (POSIX system prompt test hits a pre-existing `PosixPath` crash on git-bash Windows; passes on any native Linux runner)
