### PR TITLE
fix(xai-video): preserve timeout and transport error types

### DIFF
--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -520,13 +520,21 @@ def _run_xai_video_coroutine(
     except Exception as exc:
         logger.warning("xAI video %s unexpected failure: %s", operation_label, exc, exc_info=True)
         return error_response(
-            error=f"xAI video {operation_label} failed: {exc}",
-            error_type="api_error",
+            error=f"xAI video {operation_label} failed: {type(exc).__name__}: {exc}",
+            error_type=_xai_video_wrapper_error_type(exc),
             provider="xai",
             model=model or DEFAULT_MODEL,
             prompt=prompt,
             aspect_ratio=aspect_ratio,
         )
+
+
+def _xai_video_wrapper_error_type(exc: Exception) -> str:
+    if isinstance(exc, (TimeoutError, httpx.TimeoutException)):
+        return "timeout"
+    if isinstance(exc, httpx.TransportError):
+        return "connection_error"
+    return "api_error"
 
 
 async def _generate_xai_video_async(

--- a/tests/plugins/video_gen/test_xai_plugin.py
+++ b/tests/plugins/video_gen/test_xai_plugin.py
@@ -146,6 +146,46 @@ def test_xai_no_operation_kwarg():
     assert result["error_type"] in {"auth_required", "api_error"}
 
 
+def test_xai_video_wrapper_preserves_read_timeout_error_type():
+    import httpx
+    from plugins.video_gen.xai import _run_xai_video_coroutine
+
+    async def fail_with_timeout():
+        raise httpx.ReadTimeout("")
+
+    result = _run_xai_video_coroutine(
+        fail_with_timeout(),
+        operation_label="generation",
+        model="grok-imagine-video",
+        prompt="animate the selected image",
+        aspect_ratio="16:9",
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "timeout"
+    assert "ReadTimeout" in result["error"]
+
+
+def test_xai_video_wrapper_preserves_transport_error_type():
+    import httpx
+    from plugins.video_gen.xai import _run_xai_video_coroutine
+
+    async def fail_with_transport_error():
+        raise httpx.ConnectError("network unavailable")
+
+    result = _run_xai_video_coroutine(
+        fail_with_transport_error(),
+        operation_label="generation",
+        model="grok-imagine-video",
+        prompt="animate the selected image",
+        aspect_ratio="16:9",
+    )
+
+    assert result["success"] is False
+    assert result["error_type"] == "connection_error"
+    assert "ConnectError" in result["error"]
+
+
 def test_xai_video_output_urls_prefers_stored_public_url():
     from plugins.video_gen.xai import _xai_video_output_urls
 


### PR DESCRIPTION
## Summary

- preserve timeout failures from the xAI video wrapper as `error_type="timeout"`
- preserve xAI video transport failures as `error_type="connection_error"`
- keep unrelated wrapper failures classified as `api_error`
- add focused regression coverage for `httpx.ReadTimeout` and `httpx.ConnectError`

## Problem

The synchronous xAI video wrapper catches exceptions raised while running the async generation/edit/extend coroutine. Today those wrapper-level exceptions are collapsed into `api_error`, so callers cannot distinguish a transient timeout or connection failure from a provider API response error.

That loses useful recovery signal for retry/fallback guidance and makes diagnostics less precise when the provider path fails before a structured xAI response is available.

## Fix

Add a small wrapper exception classifier:

- `TimeoutError` and `httpx.TimeoutException` map to `timeout`
- `httpx.TransportError` maps to `connection_error`
- everything else remains `api_error`

The user-facing error string now includes the exception class name, which makes empty-message timeout exceptions diagnosable without changing the response schema.

## Duplicate / Related Work Audit

I checked current `main` and GitHub issues/PRs for the same fix. I did not find an existing issue or PR that preserves xAI video wrapper timeout/transport error types.

Related but not duplicate:

- #55022 / #55021 bound xAI video response body reads.
- #57206 tracks xAI video delivery, ephemeral URLs, and a longer poll timeout.
- #52226 / #52227 cover generic agent transport recovery, not the xAI video plugin wrapper.

## Validation

- `pytest tests/plugins/video_gen` -> 46 passed
- `git diff --check`
