### PR TITLE
feat(install): warn pip/Homebrew installs are unsupported (CLI, TUI, desktop)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-watch_file pyproject.toml uv.lock
+watch_file pyproject.toml uv.lock hermes
 watch_file package-lock.json package.json web/package.json ui-tui/package.json website/package.json apps/shared/package.json apps/desktop/package.json ui-tui/packages/hermes-ink/package.json
 watch_file flake.nix flake.lock nix/devShell.nix nix/tui.nix nix/package.nix nix/python.nix nix/hermes-agent.nix nix/desktop.nix
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -39,6 +39,7 @@ import {
 import { clearSessionSubagents, pruneDelegateFallbackSubagents, upsertSubagent } from '@/store/subagents'
 import { clearActiveSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
+import { reportInstallMethodWarning } from '@/store/updates'
 import { notifyWorkspaceChanged, toolMayMutateFiles } from '@/store/workspace-events'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -214,6 +215,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
         if (typeof payload?.credential_warning === 'string' && payload.credential_warning) {
           requestDesktopOnboarding(payload.credential_warning)
+        }
+
+        if (apply) {
+          reportInstallMethodWarning(payload?.install_warning)
         }
 
         void refreshHermesConfig()

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -19,7 +19,7 @@ import {
   setSessions,
   setYoloActive
 } from '@/store/session'
-import { reportBackendContract } from '@/store/updates'
+import { reportBackendContract, reportInstallMethodWarning } from '@/store/updates'
 import type { SessionCreateResponse, SessionInfo, SessionRuntimeInfo } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
@@ -269,6 +269,8 @@ export function applyRuntimeInfo(info: SessionRuntimeInfo | undefined): SessionR
   if (info.credential_warning) {
     requestDesktopOnboarding(info.credential_warning)
   }
+
+  reportInstallMethodWarning(info.install_warning)
 
   if (typeof info.model === 'string') {
     setCurrentModel(info.model)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -116,6 +116,7 @@ export const en: Translations = {
     backendOutOfDateTitle: 'Backend out of date',
     backendOutOfDateMessage:
       'Your Hermes backend is older than this desktop build and may not work correctly. Update to align them.',
+    installMethodUnsupportedTitle: 'Unsupported install method',
     updateHermes: 'Update Hermes',
     updateReadyTitle: 'Update ready',
     updateReadyMessage: count => `${count} new change${count === 1 ? '' : 's'} available.`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -117,6 +117,7 @@ export const ja = defineLocale({
     backendOutOfDateTitle: 'バックエンドが古いです',
     backendOutOfDateMessage:
       'Hermes バックエンドがこのデスクトップビルドより古く、正常に動作しない場合があります。更新して揃えてください。',
+    installMethodUnsupportedTitle: 'サポート対象外のインストール方法',
     updateHermes: 'Hermes を更新',
     updateReadyTitle: '更新の準備ができました',
     updateReadyMessage: count => `${count} 件の新しい変更が利用可能です。`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -158,6 +158,7 @@ export interface Translations {
     copyDetailFailed: string
     backendOutOfDateTitle: string
     backendOutOfDateMessage: string
+    installMethodUnsupportedTitle: string
     updateHermes: string
     updateReadyTitle: string
     updateReadyMessage: (count: number) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -113,6 +113,7 @@ export const zhHant = defineLocale({
     copyDetailFailed: '無法複製通知詳情',
     backendOutOfDateTitle: '後端版本過舊',
     backendOutOfDateMessage: '您的 Hermes 後端早於目前的桌面版本，可能無法正常運作。請更新以保持一致。',
+    installMethodUnsupportedTitle: '不受支援的安裝方式',
     updateHermes: '更新 Hermes',
     updateReadyTitle: '有可用更新',
     updateReadyMessage: count => `有 ${count} 項新變更可用。`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -113,6 +113,7 @@ export const zh: Translations = {
     copyDetailFailed: '无法复制通知详情',
     backendOutOfDateTitle: '后端版本过旧',
     backendOutOfDateMessage: '你的 Hermes 后端早于当前桌面构建，可能无法正常工作。请更新以保持一致。',
+    installMethodUnsupportedTitle: '不受支持的安装方式',
     updateHermes: '更新 Hermes',
     updateReadyTitle: '有可用更新',
     updateReadyMessage: count => `有 ${count} 项新更改可用。`,

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -50,6 +50,7 @@ export type GatewayEventPayload = {
   cwd?: string
   branch?: string
   credential_warning?: string
+  install_warning?: string
   personality?: string
   usage?: Partial<UsageStats>
   // agent.terminal.output — live chunk for a read-only agent terminal tab

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -111,6 +111,24 @@ function isSkewToastSnoozed(): boolean {
   return Number.isFinite(until) && Date.now() < until
 }
 
+const INSTALL_METHOD_TOAST_ID = 'install-method-not-supported'
+// Same time-based snooze pattern as the update/skew toasts: the warning is
+// re-derived from every session.info (session.create/resume/activate all
+// route through applyRuntimeInfo), so without a snooze it would re-pop on
+// every session switch even right after the user dismissed it.
+const INSTALL_METHOD_TOAST_SNOOZE_KEY = 'hermes:install-method-toast-snooze-until'
+const INSTALL_METHOD_TOAST_COOLDOWN_MS = 24 * 60 * 60 * 1000
+
+function snoozeInstallMethodToast(): void {
+  persistString(INSTALL_METHOD_TOAST_SNOOZE_KEY, String(Date.now() + INSTALL_METHOD_TOAST_COOLDOWN_MS))
+}
+
+function isInstallMethodToastSnoozed(): boolean {
+  const until = Number(storedString(INSTALL_METHOD_TOAST_SNOOZE_KEY) || 0)
+
+  return Number.isFinite(until) && Date.now() < until
+}
+
 /**
  * Guard against a desktop GUI talking to a backend that predates its contract
  * (e.g. a bb/gui-built app pointed at a `main` checkout). Rather than failing
@@ -148,6 +166,27 @@ export function reportBackendContract(contract: number | undefined): void {
     message: translateNow('notifications.backendOutOfDateMessage'),
     onDismiss: () => snoozeSkewToast(),
     title: translateNow('notifications.backendOutOfDateTitle')
+  })
+}
+
+export function reportInstallMethodWarning(message: string | undefined): void {
+  if (!message) {
+    dismissNotification(INSTALL_METHOD_TOAST_ID)
+
+    return
+  }
+
+  if (isInstallMethodToastSnoozed()) {
+    return
+  }
+
+  notify({
+    durationMs: 0,
+    id: INSTALL_METHOD_TOAST_ID,
+    kind: 'warning',
+    message,
+    onDismiss: () => snoozeInstallMethodToast(),
+    title: translateNow('notifications.installMethodUnsupportedTitle')
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -399,6 +399,7 @@ export interface SessionRuntimeInfo {
   cwd?: string
   desktop_contract?: number
   fast?: boolean
+  install_warning?: string
   model?: string
   personality?: string
   provider?: string

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -2,7 +2,6 @@
 
 Pure display functions with no HermesCLI state dependency.
 """
-
 import json
 import logging
 import os
@@ -322,7 +321,7 @@ def check_for_updates() -> Optional[int]:
     # both the Rich banner (build_welcome_banner) and the Ink badge
     # (branding.tsx, guarded on `typeof === 'number' && > 0`) show nothing.
     try:
-        from hermes_cli.config import detect_install_method
+        from hermes_cli.config import detect_install_method, get_project_root
         if detect_install_method() == "docker":
             return None
     except Exception:
@@ -873,17 +872,23 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
     except Exception:
         pass  # Never break the banner over an update check
 
-    # Pip-install warning — `pip install hermes-agent` is not the supported
-    # install path (it exists on PyPI for internal/CI reasons, not end users).
-    # Such installs miss the git checkout + installer-managed deps, so updates,
-    # self-update, and issue triage don't behave correctly. Warn, don't block.
+    # Unsupported install-method warning — pip/PyPI and Homebrew are no
+    # longer an officially supported distribution method (see
+    # website/docs/getting-started/platform-support.md). Such installs miss
+    # the git checkout + installer-managed deps, so updates, self-update, and
+    # issue triage don't behave correctly. Warn, don't block. NixOS is fully
+    # supported and never hits this.
     try:
-        from hermes_cli.config import detect_install_method
-        if detect_install_method() == "pip":
+        from hermes_cli.config import (
+            detect_install_method,
+            format_unsupported_install_warning,
+            is_unsupported_install_method,
+            get_project_root
+        )
+        _install_method = detect_install_method()
+        if is_unsupported_install_method(_install_method):
             right_lines.append(
-                "[bold yellow]⚠ pip install not officially supported[/]"
-                "[dim yellow] — exists for reasons other than user install; "
-                "expect instability and an inability to support issues[/]"
+                f"[bold yellow]⚠ {format_unsupported_install_warning(_install_method)}[/]"
             )
     except Exception:
         pass  # Never break the banner over the install-method check

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -322,7 +322,7 @@ def check_for_updates() -> Optional[int]:
     # (branding.tsx, guarded on `typeof === 'number' && > 0`) show nothing.
     try:
         from hermes_cli.config import detect_install_method, get_project_root
-        if detect_install_method() == "docker":
+        if detect_install_method(get_project_root()) == "docker":
             return None
     except Exception:
         pass
@@ -885,7 +885,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
             is_unsupported_install_method,
             get_project_root
         )
-        _install_method = detect_install_method()
+        _install_method = detect_install_method(get_project_root())
         if is_unsupported_install_method(_install_method):
             right_lines.append(
                 f"[bold yellow]⚠ {format_unsupported_install_warning(_install_method)}[/]"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -530,6 +530,50 @@ def recommended_update_command() -> str:
     return recommended_update_command_for_method(method)
 
 
+# =============================================================================
+# Unsupported install methods (pip, Homebrew) — deprecation notice
+# =============================================================================
+#
+# pip/PyPI and Homebrew are NOT an officially supported distribution method
+# (see website/docs/getting-started/platform-support.md, "Unsupported"
+# section). pip exists on PyPI for internal/CI reasons, not end-user installs;
+# Homebrew is a legacy packaging path. Unlike NixOS/Homebrew "managed mode"
+# (which hard-blocks config writes), this is a warn-don't-block deprecation
+# notice surfaced everywhere the user might see install-method state: the CLI
+# banner, the TUI/desktop session info panel, and ``hermes update``. NixOS
+# stays fully supported (Tier 2) and must never hit this path.
+
+PLATFORM_SUPPORT_DOCS_URL = "https://hermes-agent.nousresearch.com/docs/getting-started/platform-support"
+
+_UNSUPPORTED_INSTALL_METHODS = frozenset({"pip", "homebrew"})
+
+
+def is_unsupported_install_method(method: str) -> bool:
+    """Whether ``method`` (from ``detect_install_method()``) is deprecated."""
+    return method in _UNSUPPORTED_INSTALL_METHODS
+
+
+def unsupported_install_method_label(method: str) -> str:
+    """Human-readable name for an unsupported install method."""
+    return "pip" if method == "pip" else "Homebrew"
+
+
+def format_unsupported_install_warning(method: str) -> str:
+    """Plain-text (no markup) deprecation notice for pip/Homebrew installs.
+
+    Shared verbatim across the CLI banner, TUI/desktop ``session.info``, and
+    ``hermes update`` / ``hermes update --check`` so the wording — and the
+    docs link — stays consistent across every surface instead of drifting
+    into three slightly different warnings.
+    """
+    label = unsupported_install_method_label(method)
+    return (
+        f"{label} installs are no longer an officially supported platform and "
+        f"will not receive further updates. See {PLATFORM_SUPPORT_DOCS_URL} "
+        "for supported install methods."
+    )
+
+
 # Long-form text for ``hermes update`` / ``--check`` when running inside the
 # Docker image.  Surfaced by ``cmd_update`` and ``_cmd_update_check`` in
 # hermes_cli/main.py; lives here so the wording stays consistent and we

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -439,8 +439,20 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     managed = get_managed_system()
     if managed:
         return managed.lower().replace(" ", "-")
-    if (root / ".git").is_dir():
+    
+    # detect git repo installs (normal installer, development env)
+    git_path = root / ".git"
+    if git_path.is_dir():
         return "git"
+
+    # detect git repo installs from worktrees
+    if git_path.is_file():
+        try:
+            content = git_path.read_text(encoding="utf-8").strip()
+            if content.startswith("gitdir:"):
+                return "git"
+        except OSError:
+            pass
     return "pip"
 
 
@@ -526,7 +538,7 @@ def recommended_update_command() -> str:
     managed_cmd = get_managed_update_command()
     if managed_cmd:
         return managed_cmd
-    method = detect_install_method()
+    method = detect_install_method(get_project_root())
     return recommended_update_command_for_method(method)
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8375,8 +8375,14 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     on a PyPI install we surface a one-line notice instead of silently
     dropping the flag.
     """
-    from hermes_cli.config import detect_install_method
+    from hermes_cli.config import (
+        detect_install_method,
+        format_unsupported_install_warning,
+        is_unsupported_install_method,
+    )
     method = detect_install_method(PROJECT_ROOT)
+    if is_unsupported_install_method(method):
+        print(f"⚠ {format_unsupported_install_warning(method)}")
     if method == "docker":
         # Docker can't ``git fetch`` from within the container.  Surface the
         # same long-form ``docker pull`` guidance ``hermes update`` (apply
@@ -9259,9 +9265,20 @@ def cmd_update(args):
     from hermes_cli.config import (
         detect_install_method,
         format_docker_update_message,
+        format_unsupported_install_warning,
         is_managed,
+        is_unsupported_install_method,
         managed_error,
     )
+
+    # Deprecation notice for pip/Homebrew installs — printed before the
+    # managed-mode early-return below so Homebrew users (who are blocked from
+    # applying the update here) still see it. Warn, don't block: the update
+    # itself still proceeds (except Homebrew, which is managed-mode blocked
+    # for an unrelated reason — brew owns its own upgrade path).
+    _install_method_for_warning = detect_install_method(PROJECT_ROOT)
+    if is_unsupported_install_method(_install_method_for_warning):
+        print(f"⚠ {format_unsupported_install_warning(_install_method_for_warning)}")
 
     if is_managed():
         managed_error("update Hermes Agent")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -229,9 +229,9 @@ def _read_openai_version_fast() -> str | None:
 def _print_fast_version_info() -> None:
     from hermes_cli import __release_date__, __version__
 
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     print(f"Hermes Agent v{__version__} ({__release_date__})")
-    print(f"Project: {project_root}")
+    print(f"Install directory: {PROJECT_ROOT}")
+
     print(f"Python: {sys.version.split()[0]}")
 
     openai_version = _read_openai_version_fast()
@@ -4338,10 +4338,12 @@ def cmd_import(args):
 
 
 def _print_version_info(*, check_updates: bool = True) -> None:
+    from hermes_cli.config import detect_install_method
     from hermes_cli.banner import format_banner_version_label
 
     print(format_banner_version_label())
-    print(f"Project: {PROJECT_ROOT}")
+    print(f"Install directory: {PROJECT_ROOT}")
+    print(f"Install method: {detect_install_method(PROJECT_ROOT)}")
 
     # Show Python version
     print(f"Python: {sys.version.split()[0]}")

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -28,13 +28,20 @@
         packages =
           with pkgs;
           [
+            (pkgs.runCommand "hermes" { } ''
+              mkdir -p $out/bin
+              install -Dm755 ${../hermes} $out/bin/hermes
+            '')
             uv
           ]
           ++ self'.packages.default.passthru.devDeps;
         shellHook = ''
-          echo "Hermes Agent dev shell"
           ${combinedNonNpm}
           ${hermesNpmLib.mkNpmDevShellHook npmPackageJsonPaths}
+
+          # for the devshell to pick up the src
+          export HERMES_PYTHON_SRC_ROOT=$(git rev-parse --show-toplevel)
+          echo "Hermes Agent dev shell in $HERMES_PYTHON_SRC_ROOT"
           echo "Ready. Run 'hermes' to start."
         '';
       };

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -44,7 +44,7 @@ let
       dependency-groups = [ "all" ] ++ extraDependencyGroups;
     };
 
-  hermesVenv = mkHermesVenv extraDependencyGroups;
+  hermesVenv = (mkHermesVenv extraDependencyGroups).venv;
 
   hermesNpmLib = callPackage ./lib.nix {
     inherit npm-lockfile-fix nodejs;
@@ -200,32 +200,36 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru = {
-    inherit
-      hermesTui
-      hermesWeb
-      hermesNpmLib
-      hermesVenv
-      ;
+  passthru =
+    let
+      devPython = (mkHermesVenv (extraDependencyGroups ++ [ "dev" ])).editableVenv;
+    in
+    {
+      inherit
+        hermesTui
+        hermesWeb
+        hermesNpmLib
+        hermesVenv
+        ;
 
-    # `hermesDesktop` references `finalAttrs.finalPackage` (this whole
-    # derivation, after all overrides are applied) so the desktop wrapper
-    # can prepend its `/bin` to PATH.  The desktop's resolver step 4
-    # ("existing hermes on PATH") then picks up the fully wrapped
-    # `hermes` binary — venv with all deps, bundled skills/plugins,
-    # runtime PATH (ripgrep/git/ffmpeg/etc).  No re-implementation
-    # of the agent resolution in the desktop wrapper.
-    hermesDesktop = callPackage ./desktop.nix {
-      inherit hermesNpmLib electron;
-      hermesAgent = finalAttrs.finalPackage;
+      # `hermesDesktop` references `finalAttrs.finalPackage` (this whole
+      # derivation, after all overrides are applied) so the desktop wrapper
+      # can prepend its `/bin` to PATH.  The desktop's resolver step 4
+      # ("existing hermes on PATH") then picks up the fully wrapped
+      # `hermes` binary — venv with all deps, bundled skills/plugins,
+      # runtime PATH (ripgrep/git/ffmpeg/etc).  No re-implementation
+      # of the agent resolution in the desktop wrapper.
+      hermesDesktop = callPackage ./desktop.nix {
+        inherit hermesNpmLib electron;
+        hermesAgent = finalAttrs.finalPackage;
+      };
+
+      devShellHook = ''
+        export HERMES_PYTHON=${devPython}/bin/python3
+      '';
+
+      devDeps = runtimeDeps ++ [ devPython ];
     };
-
-    devShellHook = ''
-      export HERMES_PYTHON=${hermesVenv}/bin/python3
-    '';
-
-    devDeps = runtimeDeps ++ [ (mkHermesVenv (extraDependencyGroups ++ [ "dev" ])) ];
-  };
 
   meta = with lib; {
     description = "AI agent with advanced tool-calling capabilities";

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -27,7 +27,8 @@ let
     dependency-groups = { };
   };
 
-  mkPrebuiltOverride = final: from: dependencies:
+  mkPrebuiltOverride =
+    final: from: dependencies:
     hacks.nixpkgsPrebuilt {
       inherit from;
       prev = {
@@ -38,64 +39,100 @@ let
 
   # Legacy alibabacloud packages ship only sdists with setup.py/setup.cfg
   # and no pyproject.toml, so setuptools isn't declared as a build dep.
-  buildSystemOverrides = final: prev: builtins.mapAttrs
-    (name: _: prev.${name}.overrideAttrs (old: {
-      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.setuptools ];
-    }))
-    (lib.genAttrs [
-      "alibabacloud-credentials-api"
-      "alibabacloud-endpoint-util"
-      "alibabacloud-gateway-dingtalk"
-      "alibabacloud-gateway-spi"
-      "alibabacloud-tea"
-    ] (_: null));
+  buildSystemOverrides =
+    final: prev:
+    builtins.mapAttrs
+      (
+        name: _:
+        prev.${name}.overrideAttrs (old: {
+          nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.setuptools ];
+        })
+      )
+      (
+        lib.genAttrs [
+          "alibabacloud-credentials-api"
+          "alibabacloud-endpoint-util"
+          "alibabacloud-gateway-dingtalk"
+          "alibabacloud-gateway-spi"
+          "alibabacloud-tea"
+        ] (_: null)
+      );
 
-  pythonPackageOverrides = final: _prev:
-    if isAarch64Darwin then {
-      numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
+  pythonPackageOverrides =
+    final: _prev:
+    if isAarch64Darwin then
+      {
+        numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
 
-      pyarrow = mkPrebuiltOverride final python312.pkgs.pyarrow { };
+        pyarrow = mkPrebuiltOverride final python312.pkgs.pyarrow { };
 
-      av = mkPrebuiltOverride final python312.pkgs.av { };
+        av = mkPrebuiltOverride final python312.pkgs.av { };
 
-      humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
+        humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
 
-      coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
-        humanfriendly = [ ];
-      };
+        coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
+          humanfriendly = [ ];
+        };
 
-      onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
-        coloredlogs = [ ];
-        numpy = [ ];
-        packaging = [ ];
-      };
+        onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
+          coloredlogs = [ ];
+          numpy = [ ];
+          packaging = [ ];
+        };
 
-      ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
-        numpy = [ ];
-        pyyaml = [ ];
-      };
+        ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
+          numpy = [ ];
+          pyyaml = [ ];
+        };
 
-      faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
-        av = [ ];
-        ctranslate2 = [ ];
-        huggingface-hub = [ ];
-        onnxruntime = [ ];
-        tokenizers = [ ];
-        tqdm = [ ];
-      };
-    } else {};
+        faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
+          av = [ ];
+          ctranslate2 = [ ];
+          huggingface-hub = [ ];
+          onnxruntime = [ ];
+          tokenizers = [ ];
+          tqdm = [ ];
+        };
+      }
+    else
+      { };
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {
       python = python312;
     }).overrideScope
-      (lib.composeManyExtensions [
-        pyproject-build-systems.overlays.default
-        overlay
-        buildSystemOverrides
-        pythonPackageOverrides
-      ]);
+      (
+        lib.composeManyExtensions [
+          pyproject-build-systems.overlays.default
+          overlay
+          buildSystemOverrides
+          pythonPackageOverrides
+        ]
+      );
+
+  editableOverlay = workspace.mkEditablePyprojectOverlay {
+    root = "$HERMES_PYTHON_SRC_ROOT"; # resolved at shellHook time
+  };
+
+  workspaceRoot = ./..;
+  editableSet = pythonSet.overrideScope (
+    lib.composeManyExtensions [
+      editableOverlay
+      (final: prev: {
+        hermes-agent = prev.hermes-agent.overrideAttrs (old: {
+          # point straight at the real source instead of the filtered nix store copy
+          src = workspaceRoot;
+          nativeBuildInputs = old.nativeBuildInputs ++ final.resolveBuildSystem { editables = [ ]; };
+        });
+      })
+    ]
+  );
 in
-pythonSet.mkVirtualEnv "hermes-agent-env" {
-  hermes-agent = dependency-groups;
+{
+  venv = pythonSet.mkVirtualEnv "hermes-agent-env" {
+    hermes-agent = dependency-groups;
+  };
+  editableVenv = editableSet.mkVirtualEnv "hermes-agent-editable-env" {
+    hermes-agent = dependency-groups;
+  };
 }

--- a/tests/hermes_cli/test_pip_install_detection.py
+++ b/tests/hermes_cli/test_pip_install_detection.py
@@ -195,7 +195,33 @@ def test_banner_warns_on_pip_install(tmp_path):
         out = buf.getvalue()
 
     assert "officially" in out
-    assert "instability" in out
+    assert "platform-support" in out
+
+
+def test_banner_warns_on_homebrew_install(tmp_path):
+    """The welcome banner surfaces a warning when the install method is homebrew."""
+    import io
+    from rich.console import Console
+    from hermes_cli import banner
+
+    hh = tmp_path / ".hermes"
+    hh.mkdir()
+    (hh / ".install_method").write_text("homebrew\n")
+
+    with patch("hermes_cli.config.get_hermes_home", return_value=hh), \
+         patch("hermes_constants.get_hermes_home", return_value=hh):
+        buf = io.StringIO()
+        console = Console(file=buf, width=400, force_terminal=False, color_system=None)
+        banner.build_welcome_banner(
+            console, model="m", cwd="/tmp",
+            tools=[{"function": {"name": "terminal"}}],
+            enabled_toolsets=["terminal"],
+        )
+        out = buf.getvalue()
+
+    assert "officially" in out
+    assert "Homebrew" in out
+    assert "platform-support" in out
 
 
 def test_banner_no_pip_warning_on_git_install(tmp_path):

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -407,7 +407,7 @@ def test_termux_ultrafast_version_runs_before_heavy_startup(
 
     out = capsys.readouterr().out
     assert "Hermes Agent v" in out
-    assert "Project:" in out
+    assert "Install directory:" in out
     assert "Python:" in out
     assert "OpenAI SDK:" in out
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4610,6 +4610,25 @@ def test_session_info_includes_session_title(monkeypatch):
     assert info["title"] == "Dashboard title"
 
 
+def test_session_info_includes_install_warning_for_pip(monkeypatch):
+    """pip installs surface install_warning; git installs don't (issue: pip/brew deprecation)."""
+    monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda: "pip")
+
+    info = server._session_info(types.SimpleNamespace(tools=[], model="", provider=""))
+
+    assert "install_warning" in info
+    assert "pip" in info["install_warning"]
+    assert "platform-support" in info["install_warning"]
+
+
+def test_session_info_omits_install_warning_for_git(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda: "git")
+
+    info = server._session_info(types.SimpleNamespace(tools=[], model="", provider=""))
+
+    assert "install_warning" not in info
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3160,6 +3160,18 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "profile_name": _current_profile_name(),
     }
     try:
+        from hermes_cli.config import (
+            detect_install_method,
+            format_unsupported_install_warning,
+            is_unsupported_install_method,
+        )
+
+        _install_method = detect_install_method()
+        if is_unsupported_install_method(_install_method):
+            info["install_warning"] = format_unsupported_install_warning(_install_method)
+    except Exception:
+        pass
+    try:
         from hermes_cli import __version__, __release_date__
 
         info["version"] = __version__

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -412,6 +412,12 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
             </Text>
           </Text>
         )}
+
+        {info.install_warning && (
+          <Text bold color={t.color.warn} wrap="wrap">
+            ! {info.install_warning}
+          </Text>
+        )}
       </Box>
     </Box>
   )

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -150,6 +150,7 @@ export interface McpServerStatus {
 export interface SessionInfo {
   cwd?: string
   fast?: boolean
+  install_warning?: string
   lazy?: boolean
   mcp_servers?: McpServerStatus[]
   model: string


### PR DESCRIPTION
## What does this PR do?

pip and Homebrew are now [Unsupported install methods](https://hermes-agent.nousresearch.com/docs/getting-started/platform-support#unsupported).

They are legacy-only packages, and won't receive further updates.
Right now the only place that's surfaced is a pip-only line in the classic CLI banner; Homebrew users get nothing, and TUI/desktop users get nothing at all.

This PR adds a warn-don't-block deprecation notice everywhere the install method is already visible: the CLI banner, the TUI session panel, the desktop app, and `hermes update` / `hermes update --check`. It links to the platform-support docs page and states these installs will not receive further updates.

It doesn't block further updates for `pip`, in case we need to fix a security vulnerability or something.

Nix/NixOS and Termux (Tier 2, fully supported) are untouched. this only fires for `pip`/`homebrew`.

This is step 1 of 2. A follow-up stacked PR will actually remove Homebrew/PyPI publishing, after this version is published as the final release to `homebrew` & `pip`.

## Screenshots
### CLI
<img width="1429" height="945" alt="image" src="https://github.com/user-attachments/assets/62459119-11db-4d30-b377-99c3a73b9aa7" />
### TUI
<img width="1251" height="806" alt="image" src="https://github.com/user-attachments/assets/42faa52f-f311-459f-81ba-d88055660d85" />

### Desktop
<img width="1167" height="790" alt="image" src="https://github.com/user-attachments/assets/89697851-0579-4fae-bcc6-0b7fc74d9a53" />


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: new shared helpers — `PLATFORM_SUPPORT_DOCS_URL`, `is_unsupported_install_method()`, `unsupported_install_method_label()`, `format_unsupported_install_warning()` — so the wording and docs link stay consistent across every surface instead of drifting.
- `hermes_cli/banner.py`: generalized the existing pip-only banner warning to also cover Homebrew, using the shared helper.
- `hermes_cli/main.py`: `cmd_update()` (apply path) and `_cmd_update_check()` (`--check` dry-run path) both print the warning up front — the update still proceeds, this is a notice, not a block.
- `tui_gateway/server.py`: `_session_info()` gains `install_warning`, populated the same way `update_behind`/`config_warning` already are.
- `ui-tui/src/types.ts`, `ui-tui/src/components/branding.tsx`: `SessionInfo.install_warning` renders as a bold warning line in `SessionPanel`, next to the existing "N commits behind" notice — shown on every new/resume/activate session.
- `apps/desktop/src/types/hermes.ts`, `apps/desktop/src/lib/chat-messages.ts`: `SessionRuntimeInfo` / `GatewayEventPayload` gain `install_warning`.
- `apps/desktop/src/store/updates.ts`: new `reportInstallMethodWarning()`, mirroring the existing backend-contract-skew toast pattern (persistent, 24h-snoozed `notify()` warning toast).
- `apps/desktop/src/app/session/hooks/use-session-actions/utils.ts`, `.../use-message-stream/gateway-event.ts`: wire `install_warning` through `applyRuntimeInfo` (create/resume/branch) and the live `session.info` gateway event.
- `apps/desktop/src/i18n/{en,zh,zh-hant,ja}.ts`, `apps/desktop/src/i18n/types.ts`: new `notifications.installMethodUnsupportedTitle` string.
- Tests: updated the two pip-banner assertions in `tests/hermes_cli/test_pip_install_detection.py` for the new shared wording, added a Homebrew banner-warning test; added `tests/test_tui_gateway_server.py::test_session_info_includes_install_warning_for_pip` and `::test_session_info_omits_install_warning_for_git`.

## How to Test

1. Simulate a pip install: `mkdir -p /tmp/hhhh && echo pip > /tmp/hhhh/.install_method`, then run `HERMES_HOME=/tmp/hhhh hermes` — the classic CLI banner shows the yellow "pip installs are no longer an officially supported platform..." warning linking to the platform-support docs.
2. Repeat with `echo homebrew > /tmp/hhhh/.install_method` — same warning, says "Homebrew" instead of "pip".
3. Run `hermes update` or `hermes update --check` on a pip/homebrew-stamped install. the warning prints before the update proceeds (Homebrew still hits the pre-existing managed-mode block for `brew upgrade hermes-agent`; pip's update still runs).
4. In the TUI (`hermes --tui`) with a pip/homebrew-stamped install, the session intro panel shows the same warning next to the "commits behind" notice.
5. In the desktop app, the warning surfaces as a persistent, dismissible/snoozed toast on session open.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (NixOS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A, `platform-support.md` already lists pip/Homebrew as unsupported; this PR just surfaces that existing docs page from the product.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A, no new config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — the warning is install-method-gated (`detect_install_method()`), not OS-gated; behaves identically on every OS.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A, no tool schema changes.
