### PR TITLE
fix(desktop): parse multiline slash commands so long-context skill/goal payloads stop vanishing (fixes #41323, supersedes #55541)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { textPart } from '@/lib/chat-messages'
-import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
+import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $busy, $connection, $messages, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -271,6 +271,70 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
 
     expect(renderedText).toContain('⊙ Goal set. Starting now.')
     expect(renderedText).not.toContain('/goal: no output')
+  })
+
+  it('dispatches a slash command with a multiline arg instead of "empty slash command" (#41323, #55510)', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const states: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'slash.exec') {
+        return { type: 'send', message: 'Write a Python script\nthat prints Hello World' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => states.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/goal Write a Python script\nthat prints Hello World')
+
+    // The newline lives in the arg — the command still reaches the gateway
+    // whole, exactly as the CLI and Telegram handle it.
+    expect(calls.map(c => c.method)).toEqual(['slash.exec', 'prompt.submit'])
+    expect(calls[0]?.params).toEqual({
+      command: 'goal Write a Python script\nthat prints Hello World',
+      session_id: RUNTIME_SESSION_ID
+    })
+
+    const renderedText = states
+      .flatMap(state => {
+        const messages = Array.isArray(state.messages)
+          ? (state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+          : []
+
+        return messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      })
+      .join('\n')
+
+    expect(renderedText).not.toContain('empty slash command')
+  })
+
+  it('restores a degenerate slash payload to the composer instead of losing it', async () => {
+    setComposerDraft('')
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    // `/ text` parses to an empty command name on every surface (CLI parity).
+    // The composer draft was already cleared on submit and slash input never
+    // enters the Up-arrow history ring, so the payload must be handed back.
+    await handle!.submitText('/ pasted context that must not vanish')
+
+    expect($composerDraft.get()).toBe('/ pasted context that must not vanish')
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -561,6 +561,14 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         const { name, arg } = parseSlashCommand(command)
 
         if (!name) {
+          // The composer draft was already cleared on submit, and slash input
+          // never lands in the Up-arrow history ring (it derives from sent user
+          // messages) — so without this restore, any payload after a degenerate
+          // slash (`/ text`, `/` + newline) is lost forever. Hand it back.
+          if (command.replace(/^\/+/, '').trim()) {
+            setComposerDraft(command)
+          }
+
           const sessionId = await ensureSessionId(sessionHint)
 
           if (sessionId) {

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -6,7 +6,8 @@ import {
   attachmentDisplayText,
   coerceThinkingText,
   optimisticAttachmentRef,
-  parseCommandDispatch
+  parseCommandDispatch,
+  parseSlashCommand
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
@@ -109,5 +110,43 @@ describe('parseCommandDispatch', () => {
 
   it('rejects a prefill directive missing its message', () => {
     expect(parseCommandDispatch({ type: 'prefill', notice: 'x' })).toBeNull()
+  })
+})
+
+describe('parseSlashCommand', () => {
+  it('parses a single-line command', () => {
+    expect(parseSlashCommand('/some-skill do something')).toEqual({
+      arg: 'do something',
+      name: 'some-skill'
+    })
+  })
+
+  it('keeps a multiline arg intact instead of failing the whole parse (#41323)', () => {
+    expect(parseSlashCommand('/goal Write a Python script\nthat prints Hello World')).toEqual({
+      arg: 'Write a Python script\nthat prints Hello World',
+      name: 'goal'
+    })
+  })
+
+  it('parses a skill command with a long pasted multi-paragraph context (#55510)', () => {
+    const context = 'summarize this:\n\nparagraph one\nparagraph two\n\nparagraph three'
+
+    expect(parseSlashCommand(`/some-skill ${context}`)).toEqual({
+      arg: context,
+      name: 'some-skill'
+    })
+  })
+
+  it('takes the name across a newline boundary like the CLI and gateway (split on any whitespace)', () => {
+    expect(parseSlashCommand('/goal\npasted block')).toEqual({ arg: 'pasted block', name: 'goal' })
+  })
+
+  it('keeps truly empty slash input empty', () => {
+    expect(parseSlashCommand('/')).toEqual({ arg: '', name: '' })
+    expect(parseSlashCommand('/   ')).toEqual({ arg: '', name: '' })
+  })
+
+  it('does not treat text after horizontal whitespace as a command name (CLI parity)', () => {
+    expect(parseSlashCommand('/ some words')).toEqual({ arg: '', name: '' })
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -223,7 +223,12 @@ export function normalizePersonalityValue(value: string): string {
 }
 
 export function parseSlashCommand(command: string) {
-  const match = command.replace(/^\/+/, '').match(/^(\S+)\s*(.*)$/)
+  // `[\s\S]*` (not `.*`): the arg may span newlines — `/goal <multi-line text>`
+  // or a skill command with a long pasted context. The old `.*$` regex failed
+  // the whole match on any newline, so every multiline slash command parsed as
+  // an empty name and got swallowed (#41323, #55510). The backend and CLI both
+  // split on any whitespace (`split(maxsplit=1)`), so this is the parity fix.
+  const match = command.replace(/^\/+/, '').match(/^(\S+)([\s\S]*)$/)
 
   return match ? { name: match[1], arg: match[2].trim() } : { name: '', arg: '' }
 }


### PR DESCRIPTION
## Summary

A user report pinned the real reproduction for the `empty slash command` family: **any slash command whose argument contains a newline** — `/goal` with a multi-line description, or a skill command with a long pasted context — was rejected with `empty slash command`, and the payload was **lost forever**: the composer draft is cleared on submit, and slash input never enters the Up-arrow history ring (it derives from sent user messages only).

Root cause is one regex in `parseSlashCommand` (`apps/desktop/src/lib/chat-runtime.ts`):

```ts
command.replace(/^\/+/, '').match(/^(\S+)\s*(.*)$/)
```

`.` can't cross a newline and `$` anchors end-of-string, so `skill arg\nmore` fails the **whole** match — not just the tail — and returns `{ name: '', arg: '' }`. The dispatcher's `!name` branch then renders the `empty slash command` system line and drops the text.

## Changes

- **`parseSlashCommand` splits the name on any whitespace and keeps a multiline arg intact** (`/^(\S+)([\s\S]*)$/`). This is the parity fix: the CLI (`cmd_lower.split()[0]`) and the gateway's `slash.exec` (`split(maxsplit=1)`) both already handle multiline commands — Desktop was the only surface that couldn't.
- **The residual empty-name branch hands the payload back.** Genuinely degenerate input (bare `/`, `/ text`) still shows the `empty slash command` line, but the submitted text is restored to the composer draft instead of being eaten. Nothing the user typed can vanish anymore.

`/ text` (horizontal whitespace after the slash) intentionally still parses as empty — same as the CLI, and the composer deliberately lets Space after a bare `/` type literal text (`acceptOnSpace` gate).

## Why this supersedes #55541

#55541 chased the same symptom via a chip-degradation theory (recovering a slash chip whose payload collapsed to `/`), but that state has no producer — every chip is created with label ≡ `data-ref-text`, so the recovery branch could never fire, and its parser change explicitly *preserved* the multiline failure. The user report ("skill with `/` + long context → empty slash command, prompt unrecoverable") is reproduced exactly by the newline path fixed here.

## Validation

| Check | Result |
|---|---|
| `vitest` `chat-runtime.test.ts` + `use-prompt-actions/index.test.tsx` (jsdom) | 56/56 passing (8 new) |
| `tsc -p . --noEmit` (apps/desktop) | clean |
| `eslint` (changed files) | clean |
| wider `src/app/chat/composer` + `src/app/session` + `desktop-slash-commands` suites | 168 passing; the 2 failures (`attachments.test.tsx`, `use-preview-routing.test.tsx`) reproduce on clean `origin/main` — pre-existing, unrelated |

New regression tests: multiline `/goal` arg preserved; skill command with multi-paragraph pasted context; name split across a newline (CLI/gateway parity); bare `/` and `/ text` stay empty; end-to-end dispatch of a multiline command through `slash.exec` without the `empty slash command` line; degenerate payload restored to the composer draft.

Fixes #41323. Fixes #55510. Supersedes #55541.