### PR TITLE
fix(feishu): wildcard FEISHU_ALLOWED_USERS for DM admission

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4209,6 +4209,9 @@ class FeishuAdapter(BasePlatformAdapter):
             # Gateway auth fail-closes agent access until approval.
             if not self._allowed_group_users:
                 return None
+            # Wildcard "*" means allow all users.
+            if "*" in self._allowed_group_users:
+                return None
             if not (sender_ids and (sender_ids & self._allowed_group_users)):
                 return "dm_policy_rejected"
             return None

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -419,6 +419,17 @@ def test_dm_allowlist_admits_configured_sender(monkeypatch):
     assert adapter._admit(sender, message) is None
 
 
+def test_dm_wildcard_admits_any_sender(monkeypatch):
+    """FEISHU_ALLOWED_USERS=* must allow all DM senders."""
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = make_adapter_skeleton()
+    adapter._allowed_group_users = frozenset({"*"})
+    sender = make_sender(open_id="ou_random_user")
+    message = make_message(chat_type="p2p")
+    assert adapter._admit(sender, message) is None
+
+
 def test_admit_skips_mention_check_under_all_mode():
     # Tripwire: under allow_bots=all the mention path must not be probed.
     adapter = make_adapter_skeleton(bot_open_id="ou_self", allow_bots="all")


### PR DESCRIPTION
## What does this PR do?

Fixes the `FEISHU_ALLOWED_USERS=*` wildcard for DM messages. When the env var is set to `*` (meaning "allow all users"), the `_admit()` method was doing a literal set intersection (`sender_ids & {"*"}`) which always fails because `*` is not a valid Feishu open_id. DM messages were silently rejected with `dm_policy_rejected`.

The fix adds a wildcard check after the empty-set guard: if `"*"` is in `_allowed_group_users`, return `None` (admit).

## Related Issue

Fixes #57202

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/feishu/adapter.py`: Added `if "*" in self._allowed_group_users: return None` in `_admit()` DM path (3 lines including comment)
- `tests/gateway/test_feishu_bot_admission.py`: Added `test_dm_wildcard_admits_any_sender` regression test (11 lines)

## How to Test

1. Set `FEISHU_ALLOWED_USERS=*` in `.env`
2. Restart gateway with feishu-platform plugin
3. Send a DM to the bot on Feishu
4. Message should be delivered to gateway (not silently dropped)
5. Run `pytest tests/gateway/test_feishu_bot_admission.py::test_dm_wildcard_admits_any_sender -q` — should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A

