### PR TITLE
perf(agent): AIAgent hot-path salvage — prompt-cache copy, reasoning-timeout precompute, lazy compressor init

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1354,6 +1354,28 @@ class ContextCompressor(ContextEngine):
         previous = telemetry.get("aux_call_duration_ms") or 0
         telemetry["aux_call_duration_ms"] = previous + max(0, int(duration_ms))
 
+    def _emit_init_summary_once(self) -> None:
+        """Emit the informative startup line once, on first resolution.
+
+        Deferred out of ``__init__`` (#32221): the line reports resolved token
+        budgets, so emitting it there would force the synchronous
+        ``get_model_context_length()`` probe during construction. Reads via
+        the properties below are safe here because
+        ``_resolved_context_length`` is already set.
+        """
+        if not getattr(self, "_log_init_summary", False):
+            return
+        self._log_init_summary = False
+        logger.info(
+            "Context compressor initialized: model=%s context_length=%d "
+            "threshold=%d (%.0f%%) target_ratio=%.0f%% tail_budget=%d "
+            "provider=%s base_url=%s",
+            self.model, self._resolved_context_length, self.threshold_tokens,
+            self.threshold_percent * 100, self.summary_target_ratio * 100,
+            self.tail_token_budget,
+            self.provider or "none", self.base_url or "none",
+        )
+
     def _resolve_context_length(self) -> int:
         """Resolve and cache the model's context length on first access."""
         if self._resolved_context_length is None:
@@ -1374,21 +1396,7 @@ class ContextCompressor(ContextEngine):
             self.threshold_percent = self._effective_threshold_percent(
                 self._resolved_context_length, self._base_threshold_percent,
             )
-            if self._log_init_summary:
-                # Emit once, on first resolution, so the informative startup
-                # line survives without forcing a synchronous probe in
-                # __init__ (#32221). Reads via the properties below are safe
-                # here because _resolved_context_length is already set.
-                self._log_init_summary = False
-                logger.info(
-                    "Context compressor initialized: model=%s context_length=%d "
-                    "threshold=%d (%.0f%%) target_ratio=%.0f%% tail_budget=%d "
-                    "provider=%s base_url=%s",
-                    self.model, self._resolved_context_length, self.threshold_tokens,
-                    self.threshold_percent * 100, self.summary_target_ratio * 100,
-                    self.tail_token_budget,
-                    self.provider or "none", self.base_url or "none",
-                )
+            self._emit_init_summary_once()
         return self._resolved_context_length
 
     @property
@@ -1397,19 +1405,42 @@ class ContextCompressor(ContextEngine):
 
     @context_length.setter
     def context_length(self, value: int) -> None:
+        # No-op guard: repeated assignment of the SAME window (e.g. the codex
+        # app-server usage callback re-reports the window on every response)
+        # must not invalidate the derived budgets — that would wipe runtime
+        # corrections applied directly to threshold_tokens/tail_token_budget
+        # (see conversation_compression's aux-context threshold sync), which
+        # persisted on main's eager-init behavior.
+        if value == getattr(self, "_resolved_context_length", None):
+            return
         self._resolved_context_length = value
+        # Re-apply the small-context floor (raise-only) for the genuinely new
+        # window so the invalidated budgets below recompute coherently —
+        # percent and tokens must derive from the same window. Skipped on
+        # bare test instances built via object.__new__ that never ran
+        # __init__ (no _base_threshold_percent).
+        _base = getattr(self, "_base_threshold_percent", None)
+        if _base is not None:
+            self.threshold_percent = self._effective_threshold_percent(
+                value, _base,
+            )
         self._threshold_tokens = None
         self._tail_token_budget = None
         self._max_summary_tokens = None
+        self._emit_init_summary_once()
 
     @property
     def threshold_tokens(self) -> int:
         if self._threshold_tokens is None:
+            # Resolve the window FIRST (may apply the small-context floor to
+            # threshold_percent as a side effect) so the percent read below
+            # is the floored value regardless of argument evaluation order.
+            _ctx = self.context_length
             # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even
             # if the percentage would suggest a lower value (#14690 handles
             # the degenerate small-window case inside the helper).
             self._threshold_tokens = self._compute_threshold_tokens(
-                self.context_length, self.threshold_percent, self.max_tokens,
+                _ctx, self.threshold_percent, self.max_tokens,
             )
             # Apply absolute token cap (compression.threshold_tokens) —
             # takes the lower of the ratio-based threshold and the cap.
@@ -2082,9 +2113,10 @@ class ContextCompressor(ContextEngine):
         # threshold floor and the absolute threshold cap both need the
         # resolved window, so they are applied on first resolution (see
         # _resolve_context_length / the threshold_tokens property) instead
-        # of here. The pre-floor value is kept so update_model() can
-        # re-derive for a new window (switching small -> large must drop
-        # back to the configured value).
+        # of here. update_model() re-derives the floor for a new window from
+        # _config_threshold_percent (the raw config value snapshotted above),
+        # so switching small -> large correctly drops back to the configured
+        # value.
         self._config_context_length = config_context_length
         self._configured_threshold_percent = self.threshold_percent
         self._resolved_context_length: int | None = None

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1374,6 +1374,21 @@ class ContextCompressor(ContextEngine):
             self.threshold_percent = self._effective_threshold_percent(
                 self._resolved_context_length, self._base_threshold_percent,
             )
+            if self._log_init_summary:
+                # Emit once, on first resolution, so the informative startup
+                # line survives without forcing a synchronous probe in
+                # __init__ (#32221). Reads via the properties below are safe
+                # here because _resolved_context_length is already set.
+                self._log_init_summary = False
+                logger.info(
+                    "Context compressor initialized: model=%s context_length=%d "
+                    "threshold=%d (%.0f%%) target_ratio=%.0f%% tail_budget=%d "
+                    "provider=%s base_url=%s",
+                    self.model, self._resolved_context_length, self.threshold_tokens,
+                    self.threshold_percent * 100, self.summary_target_ratio * 100,
+                    self.tail_token_budget,
+                    self.provider or "none", self.base_url or "none",
+                )
         return self._resolved_context_length
 
     @property
@@ -2078,16 +2093,12 @@ class ContextCompressor(ContextEngine):
         self._max_summary_tokens: int | None = None
         self.compression_count = 0
 
-        if not quiet_mode:
-            logger.info(
-                "Context compressor initialized: model=%s context_length=%d "
-                "threshold=%d (%.0f%%) target_ratio=%.0f%% tail_budget=%d "
-                "provider=%s base_url=%s",
-                model, self.context_length, self.threshold_tokens,
-                threshold_percent * 100, self.summary_target_ratio * 100,
-                self.tail_token_budget,
-                provider or "none", base_url or "none",
-            )
+        # The "initialized" log reports resolved token budgets, which would
+        # force the deferred get_model_context_length() probe to run inside
+        # __init__ and re-introduce the exact synchronous blocking this change
+        # removes (#32221). Emit it on first context-length resolution instead
+        # so construction stays non-blocking on every path (not just quiet).
+        self._log_init_summary = not quiet_mode
         self._context_probed = False  # True after a step-down from context error
 
         self.last_prompt_tokens = 0

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1354,6 +1354,79 @@ class ContextCompressor(ContextEngine):
         previous = telemetry.get("aux_call_duration_ms") or 0
         telemetry["aux_call_duration_ms"] = previous + max(0, int(duration_ms))
 
+    def _resolve_context_length(self) -> int:
+        """Resolve and cache the model's context length on first access."""
+        if self._resolved_context_length is None:
+            self._resolved_context_length = get_model_context_length(
+                self.model,
+                base_url=self.base_url,
+                api_key=self.api_key,
+                config_context_length=self._config_context_length,
+                provider=self.provider,
+            )
+            # Small-context threshold floor: models under 512K trigger at
+            # >=75% so compaction doesn't fire with half the window still
+            # free. Raise-only; must run AFTER context_length is resolved
+            # and BEFORE threshold_tokens is derived (deferred here from
+            # __init__ along with the resolution itself, #32221).
+            # _base_threshold_percent already has the per-model override
+            # applied, so the floor stacks on top of it.
+            self.threshold_percent = self._effective_threshold_percent(
+                self._resolved_context_length, self._base_threshold_percent,
+            )
+        return self._resolved_context_length
+
+    @property
+    def context_length(self) -> int:
+        return self._resolve_context_length()
+
+    @context_length.setter
+    def context_length(self, value: int) -> None:
+        self._resolved_context_length = value
+        self._threshold_tokens = None
+        self._tail_token_budget = None
+        self._max_summary_tokens = None
+
+    @property
+    def threshold_tokens(self) -> int:
+        if self._threshold_tokens is None:
+            # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even
+            # if the percentage would suggest a lower value (#14690 handles
+            # the degenerate small-window case inside the helper).
+            self._threshold_tokens = self._compute_threshold_tokens(
+                self.context_length, self.threshold_percent, self.max_tokens,
+            )
+            # Apply absolute token cap (compression.threshold_tokens) —
+            # takes the lower of the ratio-based threshold and the cap.
+            self._apply_threshold_tokens_cap()
+        return self._threshold_tokens
+
+    @threshold_tokens.setter
+    def threshold_tokens(self, value: int) -> None:
+        self._threshold_tokens = value
+
+    @property
+    def tail_token_budget(self) -> int:
+        if self._tail_token_budget is None:
+            self._tail_token_budget = int(self.threshold_tokens * self.summary_target_ratio)
+        return self._tail_token_budget
+
+    @tail_token_budget.setter
+    def tail_token_budget(self, value: int) -> None:
+        self._tail_token_budget = value
+
+    @property
+    def max_summary_tokens(self) -> int:
+        if self._max_summary_tokens is None:
+            self._max_summary_tokens = min(
+                int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+            )
+        return self._max_summary_tokens
+
+    @max_summary_tokens.setter
+    def max_summary_tokens(self, value: int) -> None:
+        self._max_summary_tokens = value
+
     def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Clear all per-session compaction state at a real session boundary.
 
@@ -1988,45 +2061,22 @@ class ContextCompressor(ContextEngine):
         # deterministic "summary unavailable" handoff and drop the middle window.
         self.abort_on_summary_failure = abort_on_summary_failure
 
-        self.context_length = get_model_context_length(
-            model, base_url=base_url, api_key=api_key,
-            config_context_length=config_context_length,
-            provider=provider,
-        )
-        # Small-context threshold floor: models under 512K trigger at >=75%
-        # so compaction doesn't fire with half the window still free (the
-        # incompressible floor makes 50%-triggered compaction thrash on
-        # 128K-262K models). Raise-only; must run AFTER context_length is
-        # resolved and BEFORE threshold_tokens is derived. The pre-floor
-        # value is kept so update_model() can re-derive for a new window
-        # (switching small -> large must drop back to the configured value).
-        # Note: _base_threshold_percent already has the per-model override
-        # applied, so the floor stacks on top of any model-specific threshold.
+        # Defer context-length resolution to first access (#32221):
+        # get_model_context_length() can issue a synchronous /models HTTP
+        # probe, which must not block AIAgent construction. The small-context
+        # threshold floor and the absolute threshold cap both need the
+        # resolved window, so they are applied on first resolution (see
+        # _resolve_context_length / the threshold_tokens property) instead
+        # of here. The pre-floor value is kept so update_model() can
+        # re-derive for a new window (switching small -> large must drop
+        # back to the configured value).
+        self._config_context_length = config_context_length
         self._configured_threshold_percent = self.threshold_percent
-        self.threshold_percent = self._effective_threshold_percent(
-            self.context_length, self._base_threshold_percent,
-        )
-        threshold_percent = self.threshold_percent
-        # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
-        # the percentage would suggest a lower value.  This prevents premature
-        # compression on large-context models at 50% while keeping the % sane
-        # for models right at the minimum. _compute_threshold_tokens also
-        # guards the degenerate case where the floor would equal/exceed the
-        # window (small models), so auto-compression can still fire (#14690).
-        self.threshold_tokens = self._compute_threshold_tokens(
-            self.context_length, threshold_percent, self.max_tokens,
-        )
-        # Apply absolute token cap (compression.threshold_tokens) — takes
-        # the lower of the ratio-based threshold and the cap.
-        self._apply_threshold_tokens_cap()
+        self._resolved_context_length: int | None = None
+        self._threshold_tokens: int | None = None
+        self._tail_token_budget: int | None = None
+        self._max_summary_tokens: int | None = None
         self.compression_count = 0
-
-        # Derive token budgets: ratio is relative to the threshold, not total context
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
-        self.max_summary_tokens = min(
-            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
-        )
 
         if not quiet_mode:
             logger.info(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2721,16 +2721,28 @@ def try_shrink_image_parts_in_messages(
             media_type = "image/jpeg"
         return f"data:{media_type};base64,{data}"
 
-    def _write_data_url_to_source(source: dict, data_url: str) -> None:
+    def _write_data_url_to_source(source: dict, data_url: str) -> dict:
+        """Return a NEW source dict carrying the re-encoded payload.
+
+        Copy-on-write: content parts on the per-call ``api_messages`` list may
+        be shared references into the persistent conversation history (the
+        per-message copy is shallow, and cache decoration only deep-copies the
+        marked messages). Mutating the existing dict would rewrite the stored
+        transcript with the degraded image — so the caller replaces the part,
+        never edits it in place.
+        """
         header, _, data = data_url.partition(",")
         media_type = "image/jpeg"
         if header.startswith("data:"):
             candidate = header[len("data:"):].split(";", 1)[0].strip()
             if candidate.startswith("image/"):
                 media_type = candidate
-        source["type"] = "base64"
-        source["media_type"] = media_type
-        source["data"] = data
+        return {
+            **source,
+            "type": "base64",
+            "media_type": media_type,
+            "data": data,
+        }
 
     for msg in api_messages:
         if not isinstance(msg, dict):
@@ -2738,7 +2750,13 @@ def try_shrink_image_parts_in_messages(
         content = msg.get("content")
         if not isinstance(content, list):
             continue
-        for part in content:
+        # Copy-on-write per message: never mutate part/source dicts in place —
+        # they can alias the stored conversation history (see
+        # _write_data_url_to_source). Build a replacement content list on the
+        # first shrunken part and reassign msg["content"] (a top-level write on
+        # the per-call message copy, which never reaches history).
+        new_content: list | None = None
+        for part_idx, part in enumerate(content):
             if not isinstance(part, dict):
                 continue
             ptype = part.get("type")
@@ -2747,7 +2765,12 @@ def try_shrink_image_parts_in_messages(
                 url = _source_to_data_url(source)
                 resized, unshrinkable = _shrink_data_url(url or "")
                 if resized and isinstance(source, dict):
-                    _write_data_url_to_source(source, resized)
+                    if new_content is None:
+                        new_content = list(content)
+                    new_content[part_idx] = {
+                        **part,
+                        "source": _write_data_url_to_source(source, resized),
+                    }
                     changed_count += 1
                 elif unshrinkable:
                     unshrinkable_oversized += 1
@@ -2761,17 +2784,26 @@ def try_shrink_image_parts_in_messages(
                 url = image_value.get("url", "")
                 resized, unshrinkable = _shrink_data_url(url)
                 if resized:
-                    image_value["url"] = resized
+                    if new_content is None:
+                        new_content = list(content)
+                    new_content[part_idx] = {
+                        **part,
+                        "image_url": {**image_value, "url": resized},
+                    }
                     changed_count += 1
                 elif unshrinkable:
                     unshrinkable_oversized += 1
             elif isinstance(image_value, str):
                 resized, unshrinkable = _shrink_data_url(image_value)
                 if resized:
-                    part["image_url"] = resized
+                    if new_content is None:
+                        new_content = list(content)
+                    new_content[part_idx] = {**part, "image_url": resized}
                     changed_count += 1
                 elif unshrinkable:
                     unshrinkable_oversized += 1
+        if new_content is not None:
+            msg["content"] = new_content
 
     if changed_count:
         logger.info(

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -187,17 +187,18 @@ def apply_anthropic_cache_control(
     is retained.
 
     Returns:
-        Deep copy of messages with cache_control breakpoints injected.
+        Shallow copy of message list with selective deep copies of modified messages.
     """
-    messages = copy.deepcopy(api_messages)
-    if not messages:
-        return messages
+    if not api_messages:
+        return api_messages
 
+    messages = list(api_messages)
     marker = _build_marker(cache_ttl)
 
     breakpoints_used = 0
 
     if messages[0].get("role") == "system":
+        messages[0] = copy.deepcopy(messages[0])
         breakpoints_used = _apply_system_cache_markers(
             messages[0],
             marker,
@@ -213,6 +214,7 @@ def apply_anthropic_cache_control(
         and _can_carry_marker(messages[i], native_anthropic=native_anthropic)
     ]
     for idx in non_sys[-remaining:]:
+        messages[idx] = copy.deepcopy(messages[idx])
         _apply_cache_marker(messages[idx], marker, native_anthropic=native_anthropic)
 
     return messages

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -148,8 +148,10 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
 # gateway timing is the same).
 # Pre-compile all patterns at module load time to avoid per-call regex
 # compilation and thread-safety issues with the mutable _PATTERN_CACHE.
-# Tuples are immutable after creation, so this is safe for free-threaded
-# Python 3.13+ without any locking.
+# The list is built once at import and never mutated afterwards, so it is
+# safe for free-threaded Python 3.13+ without any locking. The slug is kept
+# in each entry for debuggability (log/inspection), even though _match_any
+# only consumes floor + pattern.
 _SORTED_REASONING_FLOORS: list[tuple[str, float, re.Pattern[str]]] = [
     (slug, floor, re.compile(r"^" + re.escape(slug) + r"(?:$|[\-._])"))
     for slug, floor in sorted(

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -146,19 +146,16 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
 # so we accept that community forks inheriting the same prefix are
 # treated as reasoning models (a reasonable default — the upstream
 # gateway timing is the same).
-_PATTERN_CACHE: dict[str, re.Pattern[str]] = {}
-
-
-def _get_pattern(slug: str) -> re.Pattern[str]:
-    compiled = _PATTERN_CACHE.get(slug)
-    if compiled is None:
-        compiled = re.compile(
-            r"^"
-            + re.escape(slug)
-            + r"(?:$|[\-._])"
-        )
-        _PATTERN_CACHE[slug] = compiled
-    return compiled
+# Pre-compile all patterns at module load time to avoid per-call regex
+# compilation and thread-safety issues with the mutable _PATTERN_CACHE.
+# Tuples are immutable after creation, so this is safe for free-threaded
+# Python 3.13+ without any locking.
+_SORTED_REASONING_FLOORS: list[tuple[str, float, re.Pattern[str]]] = [
+    (slug, floor, re.compile(r"^" + re.escape(slug) + r"(?:$|[\-._])"))
+    for slug, floor in sorted(
+        _REASONING_STALE_TIMEOUT_FLOORS, key=lambda kv: -len(kv[0])
+    )
+]
 
 
 def _match_any(model_lower: str) -> Optional[float]:
@@ -169,13 +166,8 @@ def _match_any(model_lower: str) -> Optional[float]:
     order is irrelevant: longest slug wins (so ``o3-mini`` beats
     ``o3`` on a model like ``openai/o3-mini``).
     """
-    # Sort by slug length descending so longer / more-specific slugs
-    # win on shared prefixes (o3-mini beats o3).
-    sorted_floors = sorted(
-        _REASONING_STALE_TIMEOUT_FLOORS, key=lambda kv: -len(kv[0])
-    )
-    for slug, floor in sorted_floors:
-        if _get_pattern(slug).search(model_lower):
+    for _slug, floor, pattern in _SORTED_REASONING_FLOORS:
+        if pattern.search(model_lower):
             return float(floor)
     return None
 

--- a/contributors/emails/tutors1997@outlook.com
+++ b/contributors/emails/tutors1997@outlook.com
@@ -1,0 +1,2 @@
+Stoltemberg
+# PR #56081 salvage (pre-compute sorted reasoning timeout floors)

--- a/tests/agent/test_cjk_token_estimation.py
+++ b/tests/agent/test_cjk_token_estimation.py
@@ -35,6 +35,8 @@ def test_cjk_tail_does_not_expand_to_english_char_budget():
             summary_target_ratio=0.2,
             quiet_mode=True,
         )
+        # Resolve while the mock is active (lazy init, #32221).
+        _ = compressor.context_length
 
     messages = [
         {"role": "user", "content": "head 1"},

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -18,6 +18,7 @@ def _make_compressor():
     compressor.context_length = 200000
     compressor.threshold_percent = 0.80
     compressor.threshold_tokens = 160000
+    compressor.summary_target_ratio = 0.20
     compressor.max_summary_tokens = 10000
     compressor.quiet_mode = True
     compressor.compression_count = 0

--- a/tests/agent/test_compression_small_ctx_threshold_floor.py
+++ b/tests/agent/test_compression_small_ctx_threshold_floor.py
@@ -20,9 +20,13 @@ from agent.context_compressor import ContextCompressor
 
 def _make(ctx: int, pct: float = 0.50) -> ContextCompressor:
     with patch.object(cc, "get_model_context_length", return_value=ctx):
-        return ContextCompressor(
+        comp = ContextCompressor(
             model="test/model", threshold_percent=pct, quiet_mode=True,
         )
+        # Resolve while the mock is active — lazy init (#32221) defers the
+        # window probe (and the floor application) past __init__.
+        _ = comp.context_length
+        return comp
 
 
 class TestSmallContextThresholdFloor:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -4627,3 +4627,45 @@ class TestMinTailUserMessages:
         exactly the pre-feature single-anchor behavior."""
         from hermes_cli.config import DEFAULT_CONFIG
         assert DEFAULT_CONFIG["compression"]["min_tail_user_messages"] == 1
+
+
+class TestContextLengthSetterCoherence:
+    """The context_length setter must (a) not wipe runtime corrections on
+    no-op re-assignment of the same window (codex app-server usage callback
+    re-reports it every response), and (b) re-apply the small-context
+    threshold floor for a genuinely new window so percent and tokens derive
+    from the same window."""
+
+    def test_same_value_reassignment_preserves_threshold_override(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+            _ = c.context_length
+        # Runtime correction (aux-context threshold sync pattern).
+        c.threshold_tokens = 42_000
+        c.tail_token_budget = 8_400
+        # Codex usage callback re-reports the same window every response.
+        c.context_length = 200_000
+        assert c.threshold_tokens == 42_000
+        assert c.tail_token_budget == 8_400
+
+    def test_new_value_assignment_refloors_and_invalidates(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+            _ = c.context_length
+        assert c.threshold_percent == 0.50  # 1M >= 512K: configured value
+        # Switch to a small window via direct assignment (codex path).
+        c.context_length = 200_000
+        # Floor re-applied for the new window...
+        assert c.threshold_percent == 0.75
+        # ...and budgets recompute from the same window+percent.
+        assert c.threshold_tokens == 150_000
+
+    def test_new_value_assignment_drops_floor_when_growing(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+            _ = c.context_length
+        assert c.threshold_percent == 0.75  # floored
+        c.context_length = 1_000_000
+        # Raise-only floor no longer applies: back to configured value.
+        assert c.threshold_percent == 0.50
+        assert c.threshold_tokens == 500_000

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3527,6 +3527,49 @@ class TestLazyContextResolution:
             _ = c.context_length
             mock_get.assert_called_once()
 
+    def test_init_does_not_probe_when_not_quiet(self, caplog):
+        """quiet_mode=False must ALSO stay non-blocking in __init__.
+
+        Regression for the lazy-init defect: the "Context compressor
+        initialized" log reads context_length/threshold_tokens/tail_token_budget,
+        so emitting it in __init__ forced the deferred get_model_context_length()
+        probe to run during construction whenever quiet_mode was False (the
+        interactive CLI path) — silently re-introducing the #32221 blocking that
+        the original PR set out to remove. The informative line must instead be
+        emitted once, on first context-length resolution.
+        """
+        import logging
+
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ) as mock_get:
+            c = ContextCompressor(model="test/model", quiet_mode=False)
+            # No probe, and no init log, at construction time.
+            mock_get.assert_not_called()
+
+            with caplog.at_level(logging.INFO, logger="agent.context_compressor"):
+                _ = c.context_length
+            mock_get.assert_called_once()
+            init_lines = [
+                r for r in caplog.records
+                if "Context compressor initialized" in r.getMessage()
+            ]
+            assert len(init_lines) == 1, (
+                f"expected exactly one init log on first access, got {len(init_lines)}"
+            )
+
+            # Subsequent access must not re-probe or re-log.
+            with caplog.at_level(logging.INFO, logger="agent.context_compressor"):
+                _ = c.context_length
+                _ = c.threshold_tokens
+            mock_get.assert_called_once()
+            again = [
+                r for r in caplog.records
+                if "Context compressor initialized" in r.getMessage()
+            ]
+            assert len(again) == 1, "init log fired more than once"
+
     def test_context_length_setter_bypasses_resolution(self):
         """Assigning to .context_length directly must skip the network probe
         entirely and return the assigned value."""

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -34,6 +34,9 @@ def compressor():
             protect_last_n=2,
             quiet_mode=True,
         )
+        # Resolve context_length while the mock is still active so the
+        # fixture returns a fully-initialized compressor.
+        _ = c.context_length
         return c
 
 
@@ -2584,11 +2587,14 @@ class TestSummaryTargetRatio:
         """Tail token budget should be threshold_tokens * summary_target_ratio."""
         with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
             c = ContextCompressor(model="test", quiet_mode=True, summary_target_ratio=0.40)
+            # Resolve while mock is active (lazy init defers this past __init__).
+            _ = c.context_length
         # 200K < 512K → threshold floored at 75%: 150K * 0.40 ratio = 60K
         assert c.tail_token_budget == 60_000
 
         with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
             c = ContextCompressor(model="test", quiet_mode=True, summary_target_ratio=0.40)
+            _ = c.context_length
         # 1M * 0.50 threshold * 0.40 ratio = 200K
         assert c.tail_token_budget == 200_000
 
@@ -2596,10 +2602,12 @@ class TestSummaryTargetRatio:
         """Max summary tokens should be 5% of context, capped at 10K."""
         with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
             c = ContextCompressor(model="test", quiet_mode=True)
+            _ = c.context_length
         assert c.max_summary_tokens == 10_000  # 200K * 0.05
 
         with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
             c = ContextCompressor(model="test", quiet_mode=True)
+            _ = c.context_length
         assert c.max_summary_tokens == 10_000  # capped at 10K ceiling
 
     def test_ratio_clamped(self):
@@ -2616,6 +2624,7 @@ class TestSummaryTargetRatio:
         """Sub-512K models get the 75% small-context threshold floor."""
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
             c = ContextCompressor(model="test", quiet_mode=True)
+            _ = c.context_length
         assert c.threshold_percent == 0.75
         # 75% of 100K = 75K, above the 64K minimum floor
         assert c.threshold_tokens == 75_000
@@ -2624,6 +2633,7 @@ class TestSummaryTargetRatio:
         """At 512K+ the configured (default 50%) percentage is used directly."""
         with patch("agent.context_compressor.get_model_context_length", return_value=512_000):
             c = ContextCompressor(model="test", quiet_mode=True)
+            _ = c.context_length
         assert c.threshold_percent == 0.50
         assert c.threshold_tokens == 256_000
 
@@ -3490,6 +3500,61 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+
+class TestLazyContextResolution:
+    """Verify that ContextCompressor defers get_model_context_length until
+    context_length is first accessed, so construction never blocks on network
+    I/O or blocks startup when the model metadata service is slow."""
+
+    def test_init_does_not_call_get_model_context_length(self):
+        """get_model_context_length must NOT be called during __init__; it
+        should only be called on first access of .context_length."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+        ) as mock_get:
+            c = ContextCompressor(
+                model="test/model",
+                threshold_percent=0.85,
+                protect_first_n=2,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+            mock_get.assert_not_called()
+
+            # First access triggers resolution
+            _ = c.context_length
+            mock_get.assert_called_once()
+
+    def test_context_length_setter_bypasses_resolution(self):
+        """Assigning to .context_length directly must skip the network probe
+        entirely and return the assigned value."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+        ) as mock_get:
+            c = ContextCompressor(
+                model="test/model",
+                quiet_mode=True,
+            )
+            c.context_length = 100_000
+            result = c.context_length
+            mock_get.assert_not_called()
+            assert result == 100_000
+
+    def test_config_context_length_skips_network_probe(self):
+        """When config_context_length is provided, the resolver must use it
+        as the cached value and not make a network call."""
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            side_effect=lambda model, **kwargs: kwargs.get("config_context_length"),
+        ) as mock_get:
+            c = ContextCompressor(
+                model="test/model",
+                quiet_mode=True,
+                config_context_length=200_000,
+            )
+            result = c.context_length
+            assert result == 200_000
 
 
 class TestPreflightSentinelGuard:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1788,8 +1788,7 @@ class TestSummaryFailureTrackingForGatewayWarning:
         fallback = next(m["content"] for m in result if "Summary generation was unavailable" in m.get("content", ""))
         assert len(fallback) <= 8300
         assert "deterministic fallback" in fallback
-        assert "1 compacted message(s)" in fallback
-        assert "ASSISTANT: head assistant" in fallback
+        assert "important detail" in fallback
 
     def test_compress_clears_fallback_flag_on_subsequent_success(self):
         mock_response = MagicMock()
@@ -3203,6 +3202,8 @@ class TestThresholdTokensCap:
                 "model-a", threshold_percent=0.50, quiet_mode=True,
                 threshold_tokens_cap=2_000_000,
             )
+            # Resolve while mock is active (lazy init defers this past __init__).
+            _ = comp.context_length
         # Ratio-based: 1000000 * 0.50 = 500000. Cap: 2000000, clamped to 1000000.
         # Effective: min(500000, 1000000) = 500000.
         assert comp.threshold_tokens == 500_000
@@ -3213,6 +3214,7 @@ class TestThresholdTokensCap:
             comp = ContextCompressor(
                 "model-a", threshold_percent=0.50, quiet_mode=True,
             )
+            _ = comp.context_length
         assert comp.threshold_tokens == 500_000
         assert comp.threshold_tokens_cap is None
 
@@ -3259,6 +3261,7 @@ class TestThresholdTokensCap:
                 "model-a", threshold_percent=0.50, quiet_mode=True,
                 threshold_tokens_cap=500_000,
             )
+            _ = comp.context_length
         # 64000 * 0.50 = 32000, floored to 64000 (MINIMUM_CONTEXT_LENGTH),
         # degenerate: floored >= window → 85% of 64000 = 54400.
         # Cap 500000 clamped to 64000. min(54400, 64000) = 54400.
@@ -3368,6 +3371,7 @@ class TestThresholdTokensCap:
                 "model-a", threshold_percent=0.50, quiet_mode=True,
                 threshold_tokens_cap=100_000,
             )
+            _ = comp.context_length
         # Floor raised pct to 0.75 (200K < 512K) regardless of the cap.
         assert comp.threshold_percent == 0.75
         # Cap clamps the token trigger below the floored pct value (150K).
@@ -3513,6 +3517,7 @@ class TestLazyContextResolution:
         should only be called on first access of .context_length."""
         with patch(
             "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
         ) as mock_get:
             c = ContextCompressor(
                 model="test/model",

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1788,7 +1788,8 @@ class TestSummaryFailureTrackingForGatewayWarning:
         fallback = next(m["content"] for m in result if "Summary generation was unavailable" in m.get("content", ""))
         assert len(fallback) <= 8300
         assert "deterministic fallback" in fallback
-        assert "important detail" in fallback
+        assert "1 compacted message(s)" in fallback
+        assert "ASSISTANT: head assistant" in fallback
 
     def test_compress_clears_fallback_flag_on_subsequent_success(self):
         mock_response = MagicMock()

--- a/tests/agent/test_pre_compress_memory_context.py
+++ b/tests/agent/test_pre_compress_memory_context.py
@@ -13,10 +13,14 @@ def _make_compressor():
     compressor = ContextCompressor.__new__(ContextCompressor)
     compressor.protect_first_n = 2
     compressor.protect_last_n = 5
-    compressor.tail_token_budget = 20_000
+    # Set context_length BEFORE the derived budgets: its setter resets the
+    # lazily-cached threshold/tail/summary budgets (#32221 lazy init), so
+    # assigning it later would clear the explicit values below.
     compressor.context_length = 200_000
     compressor.threshold_percent = 0.80
     compressor.threshold_tokens = 160_000
+    compressor.summary_target_ratio = 0.20
+    compressor.tail_token_budget = 20_000
     compressor.max_summary_tokens = 10_000
     compressor.quiet_mode = True
     compressor.compression_count = 0

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -3,6 +3,7 @@
 
 from agent.prompt_caching import (
     _apply_cache_marker,
+    _build_marker,
     _can_carry_marker,
     apply_anthropic_cache_control,
     strip_anthropic_cache_control,
@@ -131,6 +132,90 @@ class TestApplyAnthropicCacheControl:
         assert result[0] is not msgs[0]
         # Original should be unmodified
         assert "cache_control" not in msgs[0].get("content", "")
+
+    def test_caller_list_not_mutated_and_unmarked_msgs_shared(self):
+        """Guard the shallow-copy change (was full deepcopy).
+
+        The optimization returns ``list(api_messages)`` and deep-copies ONLY
+        the <=4 messages that receive a cache_control marker. This test pins
+        two invariants that a "deep-copies too little / too much" regression
+        would break (prompt caching is sacred — the caller's history must
+        never be mutated):
+
+        1. The caller's original list and every message dict in it is left
+           byte-identical after the call (no in-place marker leaks upstream).
+        2. Un-marked messages in the middle are returned as the SAME object
+           (shared reference) — proving we did not needlessly deep-copy the
+           whole history — while marked messages are fresh copies.
+        """
+        import copy
+
+        msgs = [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "middle-unmarked-1"},
+            {"role": "assistant", "content": "middle-unmarked-2"},
+            {"role": "user", "content": "m3"},
+            {"role": "assistant", "content": "m4"},
+            {"role": "user", "content": "m5"},
+        ]
+        before = copy.deepcopy(msgs)
+        result = apply_anthropic_cache_control(msgs, cache_ttl="5m")
+
+        # (1) caller list + every element unchanged after the call.
+        assert msgs == before, "apply_anthropic_cache_control mutated the caller's list"
+
+        # System (0) + last 3 non-system (3,4,5) get markers => index 1 and 2
+        # are un-marked and must be the SAME objects (shallow, not deep-copied).
+        assert result[1] is msgs[1]
+        assert result[2] is msgs[2]
+        # Marked messages must be fresh copies (never the caller's objects).
+        assert result[0] is not msgs[0]
+        assert result[-1] is not msgs[-1]
+
+        # Mutating a returned marked message must not bleed into the caller.
+        result[0]["content"] = "TAMPERED"
+        assert msgs[0]["content"] == "System"
+
+    def test_output_equivalent_to_full_deepcopy_impl(self):
+        """Byte-equivalence: shallow-copy output structurally matches what a
+        naive full-deepcopy implementation would produce (same breakpoints,
+        same TTL, same positions) for both native_anthropic modes."""
+        import copy
+
+        def _reference_full_deepcopy(api_messages, cache_ttl, native_anthropic):
+            # Mirror of the pre-optimization implementation: deepcopy the whole
+            # list, then apply markers to system + last (4 - used) non-system.
+            messages = copy.deepcopy(api_messages)
+            if not messages:
+                return messages
+            marker = _build_marker(cache_ttl)
+            used = 0
+            if messages[0].get("role") == "system":
+                _apply_cache_marker(messages[0], marker, native_anthropic=native_anthropic)
+                used += 1
+            remaining = 4 - used
+            non_sys = [i for i in range(len(messages)) if messages[i].get("role") != "system"]
+            for idx in non_sys[-remaining:]:
+                _apply_cache_marker(messages[idx], marker, native_anthropic=native_anthropic)
+            return messages
+
+        base = [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+            {"role": "user", "content": "u3"},
+        ]
+        for native in (True, False):
+            for ttl in ("5m", "1h"):
+                got = apply_anthropic_cache_control(
+                    copy.deepcopy(base), cache_ttl=ttl, native_anthropic=native
+                )
+                want = _reference_full_deepcopy(
+                    copy.deepcopy(base), cache_ttl=ttl, native_anthropic=native
+                )
+                assert got == want, f"structural mismatch native={native} ttl={ttl}"
 
     def test_system_message_gets_marker(self):
         msgs = [

--- a/tests/agent/test_turn_context_overflow_warning.py
+++ b/tests/agent/test_turn_context_overflow_warning.py
@@ -34,7 +34,10 @@ def _make_compressor(**kwargs) -> ContextCompressor:
     # 96K context -> small-context floor raises threshold_percent to 0.75,
     # so threshold_tokens = 72_000. 73_000 is "over threshold".
     with patch("agent.context_compressor.get_model_context_length", return_value=96000):
-        return ContextCompressor(**defaults)
+        comp = ContextCompressor(**defaults)
+        # Resolve while the mock is active (lazy init, #32221).
+        _ = comp.context_length
+        return comp
 
 
 class TestShouldCompressInfo:

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -661,3 +661,62 @@ class TestShrinkImagePartsHelper:
         # Default cap (8000) — no explicit max_dimension passed.
         assert agent._try_shrink_image_parts_in_messages(msgs) is True
         assert msgs[0]["content"][0]["image_url"]["url"] == shrunk
+
+
+class TestShrinkCopyOnWriteHistoryIsolation:
+    """The shrink recovery must never rewrite the stored conversation history.
+
+    With selective prompt-cache copying (#57046 salvage), un-marked messages
+    on the decorated per-call list share their nested content parts with
+    ``agent.messages``. The shrink helper therefore replaces parts
+    copy-on-write and reassigns ``msg["content"]`` instead of mutating the
+    aliased part/source dicts in place.
+    """
+
+    def test_shrink_does_not_mutate_aliased_history_parts(self, monkeypatch):
+        agent = _make_agent()
+        oversized_url = _big_png_data_url(5000)
+        shrunk = "data:image/jpeg;base64," + "C" * 1000
+
+        monkeypatch.setattr(
+            "tools.vision_tools._resize_image_for_vision",
+            lambda *a, **kw: shrunk,
+            raising=False,
+        )
+
+        # Simulate the persistent history and the per-call api_messages list:
+        # top-level dicts are shallow copies, nested content parts are ALIASED
+        # (exactly what conversation_loop's msg.copy() + selective cache
+        # decoration produce for un-marked messages).
+        history_part = {"type": "image_url", "image_url": {"url": oversized_url}}
+        history_msg = {"role": "user", "content": [history_part]}
+        api_msg = history_msg.copy()  # shares the content list + part dicts
+
+        assert agent._try_shrink_image_parts_in_messages([api_msg]) is True
+        # The outgoing copy carries the shrunken image...
+        assert api_msg["content"][0]["image_url"]["url"] == shrunk
+        # ...but the stored history still has the original bytes.
+        assert history_msg["content"][0] is history_part
+        assert history_part["image_url"]["url"] == oversized_url
+
+    def test_shrink_anthropic_source_does_not_mutate_history(self, monkeypatch):
+        agent = _make_agent()
+        raw_b64 = _big_png_data_url(5000).split(",", 1)[1]
+        shrunk = "data:image/jpeg;base64," + "D" * 1000
+
+        monkeypatch.setattr(
+            "tools.vision_tools._resize_image_for_vision",
+            lambda *a, **kw: shrunk,
+            raising=False,
+        )
+
+        source = {"type": "base64", "media_type": "image/png", "data": raw_b64}
+        history_part = {"type": "image", "source": source}
+        history_msg = {"role": "user", "content": [history_part]}
+        api_msg = history_msg.copy()
+
+        assert agent._try_shrink_image_parts_in_messages([api_msg]) is True
+        assert api_msg["content"][0]["source"]["data"] == "D" * 1000
+        # Aliased history source untouched.
+        assert history_part["source"] is source
+        assert source["data"] == raw_b64

--- a/tests/run_agent/test_per_model_compression_threshold.py
+++ b/tests/run_agent/test_per_model_compression_threshold.py
@@ -89,6 +89,8 @@ class TestContextCompressorModelThresholds:
             model_thresholds={"glm-5.2": 0.40},
             quiet_mode=True,
         )
+        # Resolve while mock is active (lazy init defers floor past __init__).
+        _ = cc.context_length
         # 256K < 512K → floor at 0.75; override 0.40 < 0.75, so floor wins
         assert cc.threshold_percent == 0.75
         assert cc.threshold_tokens == int(256_000 * 0.75)
@@ -113,6 +115,8 @@ class TestContextCompressorModelThresholds:
             threshold_percent=0.50,
             quiet_mode=True,
         )
+        # Resolve while mock is active (lazy init defers floor past __init__).
+        _ = cc.context_length
         # 256K < 512K → floored at 0.75
         assert cc.threshold_percent == 0.75
         assert cc.model_thresholds == {}


### PR DESCRIPTION
## Summary

Combined salvage of three verified, non-conflicting AIAgent hot-path
performance fixes, rebased onto current `main` with original authorship
preserved.

**Supersedes #57046, #56081, #38991** — these can be closed in favor of this PR.

## What's included

### perf(caching): selective copy instead of deepcopy entire history — @kohoj (#57046)
`apply_anthropic_cache_control` deep-copied the **entire** message history on
every Anthropic-wire API call (`agent/prompt_caching.py`), from the
`run_conversation` hot path. It now shallow-copies the list and deep-copies
only the ≤4 messages that receive a `cache_control` marker. Merged with main's
newer `static_system_prefix` two-marker system split (the system message is
deep-copied before `_apply_system_cache_markers`).
- Verified: output byte-identical to a reference full-deepcopy implementation
  across native_anthropic × TTL × static-prefix combos; input list never mutated.
- Original benchmark (401-message / ~3 MB history): **0.78 ms → 0.02 ms/call (~39×)**,
  paid every turn.

### perf: pre-compute sorted reasoning timeout floors — @Stoltemberg (#56081)
`_match_any()` re-sorted the floors table and lazily compiled regexes into a
mutable dict on every call (`agent/reasoning_timeouts.py`). Sorted, pre-compiled
`(slug, floor, pattern)` tuples are now built once at import — faster and
thread-safe. Verified: 162 probe model names resolve identically to `main`.

### perf(agent): defer synchronous httpx probe out of AIAgent.__init__ — @rodboev (#38991, closes #32221)
`ContextCompressor.__init__` resolved the model context length eagerly via
`get_model_context_length()`, which can issue a **synchronous** `/models` HTTP
probe — blocking agent construction. Resolution is deferred to first access via
lazy properties (with setters for direct assignment). Main's newer
small-context threshold floor (75% under 512K) and absolute `threshold_tokens`
cap are applied at first resolution / first threshold derivation, so behavior
after resolution is identical to eager init.

### fix(compression): keep ContextCompressor init non-blocking when quiet_mode=False — @kshitijk4poor
The "Context compressor initialized" log line (quiet_mode=False, interactive
CLI) reads `context_length`/`threshold_tokens`/`tail_token_budget` — property
reads that resolve the deferred value, so #38991's deferral silently didn't
fire on the non-quiet path (its tests only exercised quiet_mode=True). The line
is now emitted once, on first resolution. Regression test asserts no probe in
`__init__` for both quiet modes and exactly one init log on first access.

### fix(compression): copy-on-write in image-shrink recovery — @kshitijk4poor
Found by the Hermes-specific review pass of the selective-copy change:
un-marked messages on the decorated per-call list share nested content parts
with the persistent conversation history. `try_shrink_image_parts_in_messages`
wrote re-encoded images INTO those aliased part/source dicts, so an
image-too-large retry on an Anthropic route would replace the original image
bytes in `agent.messages` and persist the degraded copy. Now rebuilds the
content list copy-on-write and reassigns `msg["content"]` (top-level write on
the per-call copy). Two regression tests simulate the aliasing; both fail
against the in-place implementation (mutation-verified).

## Test plan

- Targeted suites: `tests/agent/test_context_compressor.py`,
  `test_compress_focus.py`, `test_prompt_caching.py`,
  `test_reasoning_stale_timeout_floor.py` — **320 passed**
- Image-shrink + routing + caching suites — **182 passed**
- Broad baseline diff (tests/agent/ + 9 run_agent compression files +
  context_switch_guard, ~7,200 tests) run on this branch AND clean
  `upstream/main`: identical failure sets (182 pre-existing environmental
  failures on both) — **zero PR-caused regressions**
- E2E with real imports, temp HERMES_HOME:
  prompt_caching byte-identical vs reference deepcopy impl, input never
  mutated (8 combos); 162 reasoning-timeout probes identical to old impl;
  no probe in `__init__` (both quiet modes), floor applied on first
  resolution, single probe
- ruff clean on all touched files

## Attribution

`contributors/emails/tutors1997@outlook.com` → Stoltemberg added (kohoj and
rodboev already mapped). Commit authorship preserved in git history;
contributor_audit --strict passes.
