### PR TITLE
fix(toolsets): validate dynamic hermes-<platform> toolsets for plugin platforms

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -876,7 +876,24 @@ def validate_toolset(name: str) -> bool:
         return True
     if name in _get_plugin_toolset_names():
         return True
-    return name in _get_registry_toolset_aliases()
+    if name in _get_registry_toolset_aliases():
+        return True
+    # Plugin platforms expose a dynamic ``hermes-<platform>`` toolset that
+    # ``resolve_toolset`` generates on the fly (core tools + any tool
+    # registered under the platform's name).  Built-in platforms have static
+    # ``hermes-<platform>`` entries in ``TOOLSETS`` and validate above, but
+    # plugin platforms (e.g. teams, google_chat) do not — so without this
+    # branch ``validate_toolset`` returns False for them and callers like
+    # ``model_tools`` drop the toolset as "unknown", silently discarding the
+    # plugin's tools.  Mirror ``resolve_toolset``'s handling here.
+    if name.startswith("hermes-"):
+        try:
+            from gateway.platform_registry import platform_registry
+            if platform_registry.is_registered(name[len("hermes-"):]):
+                return True
+        except Exception:
+            pass
+    return False
 
 
 def create_custom_toolset(


### PR DESCRIPTION
`resolve_toolset` generates a dynamic `hermes-<platform>` toolset for **plugin** platforms (core tools + any tool registered under the platform's name), but `validate_toolset` has no matching branch. Built-in platforms (telegram/discord/slack) validate via their static `TOOLSETS` entries; plugin platforms (e.g. `teams`, `google_chat`) do not.

Because callers gate on `validate_toolset` **before** resolving — notably `model_tools._get_tools` (the loop mapping `enabled_toolsets` → tool schemas) — `hermes-<platform>` is treated as an unknown toolset and silently dropped. Any tool a plugin platform registers under its own toolset therefore never reaches the model. Core tools still arrive via other inferred toolsets, which masks the bug. Surfaced when a plugin platform shipped its first model tool.

**Fix:** mirror `resolve_toolset`'s dynamic handling in `validate_toolset` — accept `hermes-<platform>` when that platform is registered in `platform_registry`.

Config-only workaround for operators: `platform_toolsets.<platform>: [hermes-<platform>, <platform>]`.
