### PR TITLE
fix(dashboard): cap status gateway health probe

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1094,6 +1094,8 @@ except (ValueError, TypeError):
     )
     _GATEWAY_HEALTH_TIMEOUT = 3.0
 
+_STATUS_REMOTE_HEALTH_TIMEOUT = 1.0
+
 # DEPRECATED (scheduled for removal): GATEWAY_HEALTH_URL / GATEWAY_HEALTH_TIMEOUT.
 # Cross-container / cross-host gateway liveness detection will be folded into a
 # first-class dashboard config key so it's no longer Docker-adjacent lore buried
@@ -2170,9 +2172,18 @@ async def get_status(profile: Optional[str] = None):
 
         if not gateway_running and _GATEWAY_HEALTH_URL:
             loop = asyncio.get_running_loop()
-            alive, remote_health_body = await loop.run_in_executor(
-                None, _probe_gateway_health
-            )
+            try:
+                alive, remote_health_body = await asyncio.wait_for(
+                    loop.run_in_executor(None, _probe_gateway_health),
+                    timeout=_STATUS_REMOTE_HEALTH_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                _log.warning(
+                    "Gateway health probe timed out after %.1fs while serving /api/status",
+                    _STATUS_REMOTE_HEALTH_TIMEOUT,
+                )
+                alive = False
+                remote_health_body = None
             if alive:
                 gateway_running = True
                 # PID from the remote container (display only — not locally valid)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5,6 +5,7 @@ import os
 import json
 import shutil
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -4721,6 +4722,32 @@ class TestStatusRemoteGateway:
         data = resp.json()
         assert data["gateway_running"] is False
         assert data["gateway_health_url"] is None
+
+    def test_status_remote_probe_timeout_ignores_late_success(self, monkeypatch, caplog):
+        """A timed-out remote gateway probe must not report a stale success."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", "http://gw:8642")
+        monkeypatch.setattr(ws, "_STATUS_REMOTE_HEALTH_TIMEOUT", 0.01, raising=False)
+        monkeypatch.setattr(ws, "_probe_gateway_health", lambda: (False, None))
+        assert self.client.get("/api/status").status_code == 200
+
+        def slow_probe():
+            time.sleep(0.25)
+            return True, {"status": "ok", "pid": 999}
+
+        monkeypatch.setattr(ws, "_probe_gateway_health", slow_probe)
+
+        with caplog.at_level("WARNING", logger="hermes_cli.web_server"):
+            resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gateway_running"] is False
+        assert data["gateway_health_url"] == "http://gw:8642"
+        assert "Gateway health probe timed out" in caplog.text
 
     def test_status_remote_running_null_pid(self, monkeypatch):
         """Remote gateway running but PID not in response — pid should be None."""


### PR DESCRIPTION
Fixes #57203.

## Summary

`/api/status` now gives the remote `GATEWAY_HEALTH_URL` probe a one-second status-route budget. If the probe exceeds that budget, the endpoint logs a warning, ignores the late remote result, and continues returning the local status response instead of waiting on the full network timeout.

Successful remote probes still work normally, and the existing `GATEWAY_HEALTH_TIMEOUT` behavior inside `_probe_gateway_health()` is unchanged for the blocking probe itself.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k test_status_remote_probe_timeout_ignores_late_success -q`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'ProbeGatewayHealth or StatusRemoteGateway' -q`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q`
- `.venv/bin/python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`
