### PR TITLE
fix(debug): avoid logger writes during debug share

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -743,11 +743,6 @@ def build_debug_share(
     # applied inside collect_share_bundle.
     bundle = collect_share_bundle(log_lines=log_lines, redact=redact)
 
-    if redact:
-        logger.info(
-            "hermes debug share: applied force-mode redaction to log snapshots before upload"
-        )
-
     report = bundle["report"]
 
     urls: dict[str, str] = {}
@@ -916,10 +911,6 @@ def _run_debug_share_nous(args, *, log_lines: int, redact: bool) -> None:
     _best_effort_sweep_expired_pastes()
 
     bundle = collect_share_bundle(log_lines=log_lines, redact=redact)
-    if redact:
-        logger.info(
-            "hermes debug share --nous: applied force-mode redaction before upload"
-        )
     blob = build_nous_bundle(bundle, redact=redact)
 
     print("Uploading to Nous diagnostics storage...")

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -817,6 +817,34 @@ class TestRunDebugShareRedaction:
                 "redaction banner missing from upload-bound content"
             )
 
+    def test_default_share_skips_nonessential_logger_write(
+        self, hermes_home_with_secret, capsys
+    ):
+        """Debug share should not depend on a writable log file to upload."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.nous = False
+        args.no_redact = False
+
+        captured: list[str] = []
+
+        def fake_upload(content, expiry_days=7):
+            captured.append(content)
+            return f"https://paste.rs/{len(captured)}"
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)), \
+             patch("hermes_cli.debug.upload_to_pastebin", side_effect=fake_upload), \
+             patch("hermes_cli.debug.logger.info", side_effect=AssertionError("logger.info should not be called")):
+            run_debug_share(args)
+
+        assert len(captured) >= 1
+        assert "redacted at upload time" in captured[0]
+
     def test_no_redact_flag_disables_redaction_and_banner(
         self, hermes_home_with_secret, capsys
     ):
@@ -1762,4 +1790,3 @@ class TestShareConsentGate:
 
         mock_upload.assert_not_called()
         assert "Aborted" not in capsys.readouterr().out
-


### PR DESCRIPTION
## What does this PR do?

Avoids a nonessential logger write during `hermes debug share`, so the command can still upload the report cleanly when the local log file cannot be flushed because the disk is full.

## Related Issue

Fixes #57209

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Removed the force-redaction `logger.info(...)` writes from the paste-share and `--nous` debug-share upload paths in `hermes_cli/debug.py`.
- Added a regression test in `tests/hermes_cli/test_debug.py` that asserts the default share path does not depend on `logger.info()` being writable.

## How to Test

1. Run `uv run --frozen pytest tests/hermes_cli/test_debug.py -k 'default_share or share_'`.
2. Run `uv run --frozen ruff check hermes_cli/debug.py tests/hermes_cli/test_debug.py`.
3. Verify `git diff --check` is clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted proof only:
- `uv run --frozen pytest tests/hermes_cli/test_debug.py -k 'default_share or share_'` -> `14 passed, 85 deselected`
- `uv run --frozen ruff check hermes_cli/debug.py tests/hermes_cli/test_debug.py` -> `All checks passed!`
- `git diff --check` -> clean
