### PR TITLE
fix(agent): wait for MCP discovery before init_agent tool snapshot (#57170)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1057,6 +1057,17 @@ def init_agent(
     # Get available tools with filtering. Capture the registry generation this
     # snapshot is derived from FIRST, so a later concurrent refresh can tell
     # whether it holds a newer or staler view (see refresh_agent_mcp_tools).
+    #
+    # Wait for in-flight MCP discovery on every init path (CLI, TUI, gateway
+    # sub-agents, API server children). Some callers already wait before
+    # AIAgent(), but others don't; without this, slow HTTP MCP servers that
+    # connect after the bounded wait miss the one-time snapshot (#57170).
+    try:
+        from hermes_cli.mcp_startup import wait_for_mcp_discovery
+
+        wait_for_mcp_discovery()
+    except Exception:
+        logger.debug("MCP discovery wait before tool snapshot failed", exc_info=True)
     try:
         from tools.registry import registry as _snapshot_registry
         agent._tool_snapshot_generation = _snapshot_registry._generation

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1280,12 +1280,14 @@ DEFAULT_CONFIG = {
     # case) or fast servers pay ~0s regardless of this value — the bound is
     # only reached when a server is genuinely still connecting.  The old 0.75s
     # default was a touch short for HTTP/OAuth servers on a cold connect; a
-    # modest bump lets more of them land in the FIRST turn's snapshot.  This is
+    # modest bump lets more of them land in the FIRST turn's snapshot.  The
+    # previous 1.5s default still missed some HTTP cold connects (#57170); 2.0s
+    # is a modest further bump.  This is
     # only a turn-1 latency/UX knob: a server that misses this window is still
     # picked up automatically on the next turn by the between-turns refresh
     # (see agent/turn_context.py), so correctness never depends on it.  Keep it
     # small so a slow/dead server adds little to first-response latency.
-    "mcp_discovery_timeout": 1.5,
+    "mcp_discovery_timeout": 2.0,
 
     # Tool-output truncation thresholds. When terminal output or a
     # single read_file page exceeds these limits, Hermes truncates the

--- a/tests/agent/test_init_agent_mcp_wait.py
+++ b/tests/agent/test_init_agent_mcp_wait.py
@@ -1,0 +1,99 @@
+"""Regression tests for MCP discovery wait before init_agent tool snapshot (#57170)."""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import time
+import types
+
+from agent import agent_init
+from run_agent import AIAgent
+
+
+def test_init_agent_waits_for_mcp_discovery_before_tool_snapshot():
+    """init_agent must wait for MCP discovery before snapshotting tools."""
+    src = inspect.getsource(agent_init.init_agent)
+    wait_idx = src.index("wait_for_mcp_discovery")
+    snap_idx = src.index("agent.tools = _ra().get_tool_definitions")
+    assert wait_idx < snap_idx
+
+
+def test_init_agent_calls_wait_for_mcp_discovery(monkeypatch):
+    """Behavioral check: init_agent invokes wait_for_mcp_discovery()."""
+    order: list[str] = []
+
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.wait_for_mcp_discovery",
+        lambda timeout=None: order.append("wait"),
+    )
+
+    def _get_tools(**_kwargs):
+        order.append("snapshot")
+        return []
+
+    import run_agent
+
+    monkeypatch.setattr(run_agent, "get_tool_definitions", _get_tools)
+    monkeypatch.setattr(
+        run_agent,
+        "OpenAI",
+        lambda **_kwargs: types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=lambda **_k: None))
+        ),
+    )
+
+    agent = object.__new__(AIAgent)
+    agent_init.init_agent(
+        agent,
+        base_url="http://test/v1",
+        api_key="k",
+        provider="openai",
+        model="test-model",
+        quiet_mode=True,
+    )
+
+    assert order[:2] == ["wait", "snapshot"]
+
+
+def test_slow_mcp_thread_lands_before_snapshot_when_init_agent_waits(monkeypatch):
+    """Slow background MCP discovery should complete before tool snapshot."""
+    import run_agent
+
+    registered = threading.Event()
+
+    def _slow_discover():
+        time.sleep(0.08)
+        registered.set()
+
+    thread = threading.Thread(target=_slow_discover, daemon=True)
+    thread.start()
+
+    import hermes_cli.mcp_startup as mcp_startup
+
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", thread)
+
+    def _get_tools(**_kwargs):
+        assert registered.is_set(), "tool snapshot ran before MCP discovery finished"
+        return []
+
+    monkeypatch.setattr(run_agent, "get_tool_definitions", _get_tools)
+    monkeypatch.setattr(
+        run_agent,
+        "OpenAI",
+        lambda **_kwargs: types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=lambda **_k: None))
+        ),
+    )
+
+    agent = object.__new__(AIAgent)
+    agent_init.init_agent(
+        agent,
+        base_url="http://test/v1",
+        api_key="k",
+        provider="openai",
+        model="test-model",
+        quiet_mode=True,
+    )
+
+    assert not thread.is_alive()


### PR DESCRIPTION
## Summary

- Slow HTTP MCP servers can register tools after the agent one-time tool snapshot, leaving them invisible for the whole session (#57170).
- Call wait_for_mcp_discovery() inside init_agent() before get_tool_definitions() so every entry path (CLI, TUI, gateway sub-agents, API children) waits consistently.
- Bump default mcp_discovery_timeout from 1.5s to 2.0s for cold HTTP connects.

## Test plan

- [x] 	ests/agent/test_init_agent_mcp_wait.py - structural + behavioral wait-before-snapshot tests
- [x] Slow discovery thread completes before snapshot when init_agent waits
- [ ] CI green

Fixes #57170
