### PR TITLE
fix(xai-video): save and deliver generated videos

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -959,6 +959,7 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {
     "text_to_speech",
     "text_to_speech_tool",
     "image_generate",
+    "video_generate",
 }
 
 # ---- helpers: detect interrupted tool tails & auto-continue noise ----------
@@ -1008,11 +1009,13 @@ def _strip_auto_continue_noise(content: Any) -> Any:
     return text
 
 # Tools in this set return their deliverable artifact as a JSON payload with a
-# local-file path field rather than a literal ``MEDIA:`` tag (e.g. image_generate
-# returns ``{"success": true, "image": "/abs/path.png"}``). The auto-append path
-# extracts the path from these fields so delivery is deterministic and does not
-# depend on the model restating the path in its final reply.
-_JSON_MEDIA_TOOL_PATH_FIELDS = ("host_image", "image", "agent_visible_image")
+# local-file path field rather than a literal ``MEDIA:`` tag. The auto-append
+# path extracts the path from these fields so delivery is deterministic and does
+# not depend on the model restating the path in its final reply.
+_JSON_MEDIA_TOOL_PATH_FIELDS_BY_TOOL = {
+    "image_generate": ("host_image", "image", "agent_visible_image"),
+    "video_generate": ("video",),
+}
 
 
 # Extension-anchored MEDIA: matcher for tool results. Mirrors the dispatch-site
@@ -1080,16 +1083,16 @@ def _collect_auto_append_media_tags(
             continue
         content = str(msg.get("content") or "")
         tool_name = tool_name_by_call_id.get(call_id)
-        # JSON-payload tools (image_generate) return a local-file path in a
-        # known field rather than a MEDIA: tag. Extract it so delivery is
-        # deterministic even when the model omits the path from its reply.
-        if tool_name == "image_generate" and "MEDIA:" not in content:
+        # JSON-payload media tools return a local-file path in a known field
+        # rather than a MEDIA: tag.
+        fields = _JSON_MEDIA_TOOL_PATH_FIELDS_BY_TOOL.get(tool_name)
+        if fields and "MEDIA:" not in content:
             try:
                 payload = json.loads(content)
             except Exception:
                 payload = None
             if isinstance(payload, dict) and payload.get("success"):
-                for field in _JSON_MEDIA_TOOL_PATH_FIELDS:
+                for field in fields:
                     path = payload.get(field)
                     if (isinstance(path, str)
                             and _TOOL_MEDIA_RE.fullmatch(f"MEDIA:{path}")
@@ -1115,8 +1118,8 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
     Used to dedup auto-appended MEDIA tags so the same file is not re-sent on
     later turns. Must cover BOTH delivery shapes:
       * ``MEDIA:<path>`` text tags in tool results, and
-      * ``image_generate`` JSON-payload paths (``host_image`` / ``image`` /
-        ``agent_visible_image``), which carry no MEDIA: tag.
+      * JSON-payload media paths (``image_generate`` / ``video_generate``),
+        which carry no MEDIA: tag.
 
     Missing the JSON-payload shape caused #46627: after a compression
     boundary the auto-append fallback rescans full history, re-discovers an
@@ -1144,13 +1147,14 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
                     paths.add(p)
             continue
         cid = str(msg.get("tool_call_id") or msg.get("call_id") or "")
-        if tool_name_by_call_id.get(cid) == "image_generate":
+        fields = _JSON_MEDIA_TOOL_PATH_FIELDS_BY_TOOL.get(tool_name_by_call_id.get(cid, ""))
+        if fields:
             try:
                 payload = json.loads(content)
             except Exception:
                 payload = None
             if isinstance(payload, dict) and payload.get("success"):
-                for field in _JSON_MEDIA_TOOL_PATH_FIELDS:
+                for field in fields:
                     jp = payload.get(field)
                     if isinstance(jp, str) and jp:
                         paths.add(jp)

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -11,9 +11,9 @@ Authentication: xAI Grok OAuth tokens (preferred — billed against the
 user's SuperGrok or X Premium+ subscription) or ``XAI_API_KEY``. Both routes are
 resolved through ``tools.xai_http.resolve_xai_http_credentials`` so a
 single login covers chat + TTS + image gen + video gen + transcription.
-When xAI storage is enabled, the primary ``video`` / ``public_url`` fields are the
-stored files-cdn HTTPS link. Pass that public MP4 URL as ``video_url`` for
-edit/extend; it is sent to xAI as ``video.url``.
+Completed generation outputs are downloaded to the local Hermes video cache
+for the primary ``video`` field, while ``public_url`` keeps the public MP4 URL
+for edit/extend chaining.
 """
 
 from __future__ import annotations
@@ -32,6 +32,7 @@ import httpx
 from agent.video_gen_provider import (
     VideoGenProvider,
     error_response,
+    save_bytes_video,
     success_response,
 )
 
@@ -49,7 +50,7 @@ DEFAULT_MODEL = DEFAULT_TEXT_TO_VIDEO_MODEL
 DEFAULT_DURATION = 8
 DEFAULT_ASPECT_RATIO = "16:9"
 DEFAULT_RESOLUTION = "720p"
-DEFAULT_TIMEOUT_SECONDS = 240
+DEFAULT_TIMEOUT_SECONDS = 600
 DEFAULT_POLL_INTERVAL_SECONDS = 5
 DEFAULT_EXTEND_DURATION = 6
 
@@ -818,59 +819,77 @@ async def _submit_xai_video_payload(
             poll_interval=DEFAULT_POLL_INTERVAL_SECONDS,
         )
 
-    status = poll_result["status"]
-    body = poll_result["body"]
+        status = poll_result["status"]
+        body = poll_result["body"]
 
-    if status == "done":
-        video = body.get("video") or {}
-        if not isinstance(video, dict):
-            video = {}
-        file_output = video.get("file_output") if isinstance(video.get("file_output"), dict) else {}
-        file_output = file_output or {}
-        public_video_url, temporary_url, stored_public_url = _xai_video_output_urls(video)
-        if not public_video_url:
-            return error_response(
-                error="xAI video request completed without a video URL",
-                error_type="empty_response",
-                provider="xai",
+        if status == "done":
+            video = body.get("video") or {}
+            if not isinstance(video, dict):
+                video = {}
+            file_output = video.get("file_output") if isinstance(video.get("file_output"), dict) else {}
+            file_output = file_output or {}
+            public_video_url, temporary_url, _stored_public_url = _xai_video_output_urls(video)
+            if not public_video_url:
+                return error_response(
+                    error="xAI video request completed without a video URL",
+                    error_type="empty_response",
+                    provider="xai",
+                    model=body.get("model") or resolved_model,
+                    prompt=prompt,
+                )
+            extra: Dict[str, Any] = {
+                "request_id": request_id,
+                "operation": operation,
+                "storage_enabled": bool(storage_cfg.get("enabled")),
+                "public_url": public_video_url,
+            }
+            if resolution:
+                extra["resolution"] = resolution
+            if storage_notice:
+                extra["storage_notice"] = storage_notice
+            if temporary_url:
+                extra["temporary_url"] = temporary_url
+            if file_output:
+                for key in (
+                    "filename",
+                    "expires_at",
+                    "public_url_expires_at",
+                    "public_url_error",
+                    "storage_error",
+                ):
+                    if key in file_output:
+                        extra[key] = file_output[key]
+            if body.get("usage"):
+                extra["usage"] = body["usage"]
+
+            video_output = public_video_url
+            try:
+                download_response = await client.get(public_video_url, timeout=120)
+                download_response.raise_for_status()
+                video_output = str(
+                    save_bytes_video(
+                        download_response.content,
+                        prefix="xai_video",
+                        extension="mp4",
+                    )
+                )
+            except Exception as exc:
+                logger.warning("Failed to cache xAI video output locally: %s", exc)
+                extra["download_error"] = str(exc)
+
+            return success_response(
+                video=video_output,
                 model=body.get("model") or resolved_model,
                 prompt=prompt,
+                modality=modality,
+                aspect_ratio=aspect_ratio,
+                duration=video.get("duration") or duration,
+                provider="xai",
+                extra=extra,
             )
-        extra: Dict[str, Any] = {
-            "request_id": request_id,
-            "operation": operation,
-            "storage_enabled": bool(storage_cfg.get("enabled")),
-        }
-        if resolution:
-            extra["resolution"] = resolution
-        if storage_notice:
-            extra["storage_notice"] = storage_notice
-        if stored_public_url:
-            extra["public_url"] = stored_public_url
-        if temporary_url:
-            extra["temporary_url"] = temporary_url
-        if file_output:
-            for key in (
-                "filename",
-                "expires_at",
-                "public_url_expires_at",
-                "public_url_error",
-                "storage_error",
-            ):
-                if key in file_output:
-                    extra[key] = file_output[key]
-        if body.get("usage"):
-            extra["usage"] = body["usage"]
-        return success_response(
-            video=public_video_url,
-            model=body.get("model") or resolved_model,
-            prompt=prompt,
-            modality=modality,
-            aspect_ratio=aspect_ratio,
-            duration=video.get("duration") or duration,
-            provider="xai",
-            extra=extra,
-        )
+
+    status = poll_result["status"]
+    body = poll_result["body"]
 
     if status == "timeout":
         return error_response(

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -236,6 +236,57 @@ caption
         )
         assert tags == []
 
+    def test_gateway_auto_append_video_generate_json_path(self):
+        """video_generate returns a local path in JSON and should deliver it."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {"role": "user", "content": "Make me a short video"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_video", "function": {"name": "video_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_video",
+                "content": '{"success": true, "video": "/tmp/gen/waves.mp4", "public_url": "https://vidgen.x.ai/waves.mp4"}',
+            },
+            {"role": "assistant", "content": "Here's your video."},
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == ["MEDIA:/tmp/gen/waves.mp4"]
+        assert voice is False
+
+    def test_gateway_auto_append_video_generate_failure_and_url_ignored(self):
+        """Failed video generations and remote URLs are not auto-delivered."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        def _video_msgs(content):
+            return [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "c", "function": {"name": "video_generate"}}
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "c", "content": content},
+            ]
+
+        tags, _ = _collect_auto_append_media_tags(
+            _video_msgs('{"success": false, "video": null, "error": "boom"}'),
+            history_offset=0,
+        )
+        assert tags == []
+
+        tags, _ = _collect_auto_append_media_tags(
+            _video_msgs('{"success": true, "video": "https://vidgen.x.ai/out.mp4"}'),
+            history_offset=0,
+        )
+        assert tags == []
+
     def test_gateway_auto_append_image_generate_dedupes_history(self):
         """A generated image path already in history is not re-sent."""
         from gateway.run import _collect_auto_append_media_tags
@@ -289,6 +340,25 @@ caption
         paths = _collect_history_media_paths(history)
         assert "/tmp/gen/cat.png" in paths  # JSON-payload path (the bug)
         assert "/tmp/voice/note.ogg" in paths  # MEDIA: text path (already worked)
+
+    def test_collect_history_media_paths_includes_video_generate_json(self):
+        """Generated video paths in tool JSON should not be re-sent later."""
+        from gateway.run import _collect_history_media_paths
+
+        history = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "c", "function": {"name": "video_generate"}}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c",
+                "content": '{"success": true, "video": "/tmp/gen/waves.mp4"}',
+            },
+        ]
+
+        paths = _collect_history_media_paths(history)
+        assert "/tmp/gen/waves.mp4" in paths
 
     def test_image_generate_not_reemitted_after_compression(self):
         """End-to-end of the #46627 fix: collect history paths, then the

--- a/tests/plugins/video_gen/test_xai_plugin_integration.py
+++ b/tests/plugins/video_gen/test_xai_plugin_integration.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pytest
@@ -24,10 +25,16 @@ def _reset_registry():
 
 
 class _FakeResponse:
-    def __init__(self, status: int = 200, payload: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        status: int = 200,
+        payload: Optional[Dict[str, Any]] = None,
+        content: bytes = b"",
+    ):
         self.status_code = status
         self._payload = payload or {}
         self.text = json.dumps(self._payload)
+        self.content = content
 
     def raise_for_status(self):
         if self.status_code >= 400:
@@ -41,6 +48,7 @@ class _FakeResponse:
 class _FakeAsyncClient:
     def __init__(self):
         self.posts: List[Dict[str, Any]] = []
+        self.gets: List[str] = []
 
     async def __aenter__(self):
         return self
@@ -53,6 +61,9 @@ class _FakeAsyncClient:
         return _FakeResponse(200, {"request_id": "req-123"})
 
     async def get(self, url, headers=None, timeout=None):
+        self.gets.append(url)
+        if url == "https://xai-cdn/out.mp4":
+            return _FakeResponse(200, content=b"fake-mp4-bytes")
         return _FakeResponse(200, {
             "status": "done",
             "video": {"url": "https://xai-cdn/out.mp4", "duration": 8},
@@ -61,8 +72,9 @@ class _FakeAsyncClient:
 
 
 @pytest.fixture
-def xai_provider(monkeypatch):
+def xai_provider(monkeypatch, tmp_path):
     monkeypatch.setenv("XAI_API_KEY", "test-key")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
 
     import plugins.video_gen.xai as xai_plugin
 
@@ -96,6 +108,17 @@ class TestXAIEndpoint:
         assert result["success"] is True
         assert _last_post(captured)["url"].endswith("/videos/generations")
         assert result["modality"] == "text"
+
+    def test_completed_generation_downloads_video_to_local_cache(self, xai_provider):
+        provider, _ = xai_provider
+        result = provider.generate("a dog on a skateboard")
+
+        assert result["success"] is True
+        assert result["public_url"] == "https://xai-cdn/out.mp4"
+        video_path = Path(result["video"])
+        assert video_path.suffix == ".mp4"
+        assert video_path.is_file()
+        assert video_path.read_bytes() == b"fake-mp4-bytes"
 
     def test_image_to_video_hits_generations(self, xai_provider):
         provider, captured = xai_provider
@@ -194,6 +217,11 @@ class TestXAIValidation:
 
 
 class TestXAIClamping:
+    def test_default_timeout_allows_slow_xai_renders(self):
+        import plugins.video_gen.xai as xai_plugin
+
+        assert xai_plugin.DEFAULT_TIMEOUT_SECONDS == 600
+
     def test_duration_clamped_to_15(self, xai_provider):
         provider, captured = xai_provider
         provider.generate("x", duration=30)


### PR DESCRIPTION
## Summary

- Download completed xAI video outputs into the Hermes video cache and return the local `.mp4` path in `video`.
- Preserve the remote xAI MP4 URL in `public_url` for edit/extend chaining and diagnostics.
- Add `video_generate` to gateway auto-append so local video paths in tool JSON become `MEDIA:` attachments, with remote URLs and failed generations ignored.
- Raise the xAI video poll timeout from 240s to 600s for slower renders that still complete successfully.

## Root cause

`plugins/video_gen/xai` returned only the short-lived `vidgen.x.ai` URL from a completed job, so no durable local file existed for gateway delivery. The gateway auto-append path also only understood TTS and `image_generate`, so even a local `video` field from `video_generate` would not be attached unless the model restated it.

Related: #43065 covers the gateway auto-append bridge for already-local video outputs. This PR includes that minimal bridge because #57206 also needs xAI to materialize the video file and keep the longer provider poll window.

Fixes #57206.

## Validation

- `scripts/run_tests.sh tests/plugins/video_gen/test_xai_plugin_integration.py -q` -> 15 passed
- `scripts/run_tests.sh tests/gateway/test_media_extraction.py -q` -> 18 passed
- `scripts/run_tests.sh tests/plugins/video_gen/test_xai_plugin_integration.py tests/gateway/test_media_extraction.py -q` -> 33 passed
- `.venv/bin/python -m py_compile plugins/video_gen/xai/__init__.py gateway/run.py tests/plugins/video_gen/test_xai_plugin_integration.py tests/gateway/test_media_extraction.py`
- `.venv/bin/ruff check plugins/video_gen/xai/__init__.py gateway/run.py tests/plugins/video_gen/test_xai_plugin_integration.py tests/gateway/test_media_extraction.py` -> all checks passed
- `git diff --check`

Broader note: `scripts/run_tests.sh tests/plugins/video_gen tests/gateway/test_media_extraction.py -q` still fails in untouched `tests/plugins/video_gen/test_fal_plugin.py` because the FAL fixture path returns `missing_dependency`; the touched xAI and gateway files pass.
