### PR TITLE
fix(journey): surface holographic memory `facts` in learning graph

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -209,6 +209,39 @@ def _memory_cards() -> list[dict[str, Any]]:
                     "body": chunk[:1200],
                 }
             )
+
+    # Holographic memory: surface rows from the `facts` table in memory_store.db
+    # so the journey graph reflects everything Hermes has learned, not just the
+    # prose files. Distinct `source: "facts"` keeps them separate from
+    # `memory:profile:N` / `memory:memory:N` IDs.
+    db_path = get_hermes_home() / "memory_store.db"
+    if db_path.exists():
+        try:
+            import sqlite3
+
+            with sqlite3.connect(str(db_path)) as db:
+                for fact_id, content, created_at, category, tags in db.execute(
+                    "SELECT fact_id, content, created_at, category, tags "
+                    "FROM facts ORDER BY created_at"
+                ):
+                    text = (content or "").strip()
+                    if not text:
+                        continue
+                    first = text.splitlines()[0].strip().lstrip("# ").strip() or "(empty)"
+                    cards.append(
+                        {
+                            "source": "facts",
+                            "timestamp": _to_int_ts(created_at),
+                            "title": f"[{category or 'general'}] {(first[:70] + '…') if len(first) > 70 else first}",
+                            "body": text[:1200],
+                            "fact_id": fact_id,
+                            "tags": tags,
+                        }
+                    )
+        except Exception:
+            # Never break /journey because the holographic store is unavailable
+            pass
+
     return cards
 
 


### PR DESCRIPTION
# PR: `/journey` should surface holographic memory `facts` rows

## Bug

`fact_store` (Holographic memory, v0.18.0) writes to the `facts` table in
`memory_store.db`. `hermes journey list` (CLI / TUI / desktop memory graph)
reads **only** from `~/.hermes/memories/MEMORY.md` and `USER.md` and
`~/.hermes/skills/*/SKILL.md`. The two data paths are **disjoint** — facts
added via `fact_store` never appear in `/journey`.

User-visible symptom: a user adds a memory via the `fact_store` API
(or any wrapper that uses it), then opens `/journey` expecting to see it on
the learning timeline. It's missing. They have no signal that the memory
saved, only a return value. Discovery-by-luck.

## Reproducer (Hermes Agent v0.18.0, fresh `~/.hermes/`)

```bash
# 1. Baseline: count journey nodes
hermes journey list | grep -c "memory:"

# Expected: N (whatever the markdown files contain)
# Actual on clean install: 10 (6 MEMORY.md chunks + 4 USER.md chunks)

# 2. Add a fact via fact_store
python3 -c "
from plugins.memory.holographic.store import FactStore
fs = FactStore()
fid = fs.add_fact(
    content='Test fact for /journey bridge',
    category='project',
    tags='test,bridge',
)
print('fact_id:', fid)
"
# Output: fact_id: 1

# 3. Verify the fact is durable
sqlite3 ~/.hermes/memory_store.db \
  "SELECT fact_id, content FROM facts WHERE fact_id=1"
# Output: 1|Test fact for /journey bridge

# 4. Open journey — fact missing
hermes journey list | grep "Test fact for /journey bridge"
# Output: (empty — fact is not there)
```

## Root cause

`/journey` is implemented as `hermes_cli/journey.py` → calls
`agent/learning_graph.build_learning_graph()` →
`_memory_cards()` in `agent/learning_graph.py` (L185–212).

`_memory_cards()` reads exactly two file sources:

```python
for fname, source in (("MEMORY.md", "memory"), ("USER.md", "profile")):
    path = base / fname
    ...
    for chunk_idx, chunk in enumerate(c.strip() for c in text.split("\\n§\\n")):
        cards.append({"source": source, "timestamp": file_ts + chunk_idx, ...})
```

`fact_store` (`plugins/memory/holographic/store.py` L146–189) writes to
`memory_store.db` table `facts` and never touches any `.md` file:

```python
cur = self._conn.execute(
    '''INSERT INTO facts (content, category, tags, trust_score)
       VALUES (?, ?, ?, ?)''',
    (content, category, tags, self.default_trust),
)
```

No other code bridges the two systems. `grep -rln "MEMORY.md" plugins/memory/`
returns 0 hits. The data flow is parallel, not merged.

## Proposed fix (Option B — modify reader, not writer)

Extend `_memory_cards()` in `agent/learning_graph.py` to also surface rows
from the `facts` table as `memory:facts:N` nodes. Distinct prefix from
`memory:profile:N` / `memory:memory:N` so existing `journey delete/edit`
references do not collide.

```python
def _memory_cards():
    base = get_hermes_home() / "memories"
    cards = []  # existing MEMORY.md / USER.md logic unchanged ...

    # NEW: surface holographic memory `facts` rows
    try:
        import sqlite3
        db_path = get_hermes_home() / "memory_store.db"
        if db_path.exists():
            db = sqlite3.connect(str(db_path))
            for row in db.execute(
                "SELECT fact_id, content, created_at, category, tags "
                "FROM facts ORDER BY created_at"
            ):
                fid, content, created_at, category, tags = row
                first_line = (content or "").splitlines()[0][:80] or "(empty)"
                cards.append({
                    "source": "facts",
                    "timestamp": _to_int_ts(created_at),
                    "title": f"[{category}] {first_line}",
                    "body": (content or "")[:1200],
                    "fact_id": fid,
                })
    except Exception:
        # Never break /journey because the holographic store is unavailable
        pass

    return cards
```

## Why Option B (not Option A — write MEMORY.md from `add_fact`)

- **No duplication.** Option A creates the invariant "every fact is also
  in MEMORY.md" that something else will eventually break (markdown writers
  in `tools/write_approval.py` use `MEMORY.md.lock`; concurrent appends
  will race).
- **No schema change.** No new tables, no migrations.
- **Aligned with intent.** `/journey` is named for the *whole* learning
  journey. The `facts` table is the durable store; `/journey` should be
  the unified view, not a partial one.
- **Reversible.** If upstream prefers a different read shape, the patch
  is one function — easy to revise or revert.

## Testing notes

Three scenarios that should be covered before merge:

1. **`facts` table empty** (fresh install or pre-0.18 user) — `/journey`
   should render normally with only the markdown cards and skills; no
   exception, no missing node IDs.
2. **Single fact added** — that fact appears in `/journey` with
   `memory:facts:1` style ID, first line of content as title, category
   shown in title prefix.
3. **Many facts (≥30)** — `/journey` renders without slowdown. The
   existing pagination / windowing for skills should apply uniformly to
   fact nodes too. If the timeline view becomes unreadable at scale,
   consider grouping by category or by week.

Also worth checking:

- `journey delete <id>` and `journey edit <id>` should refuse (or
  delegate to `fact_store`) for `memory:facts:*` IDs, since deleting from
  `/journey` alone would not actually remove the durable fact.
- `/journey --reveal 0` (replay scrubber) should still walk fact nodes
  in `created_at` order; verify the timestamp mapping.

## Out of scope (separate PRs welcome)

- Migrating the existing 10 markdown chunks into `facts` rows (would
  require a one-time seeder; deferred until a user actually asks).
- Surfacing `entities` / `fact_entities` as a separate `/journey` graph
  layer (interesting, but bigger redesign).
- Live sync from `fact_store` into the TUI/desktop memory graph
  (requires invalidation hooks, much larger change).
