### PR TITLE
fix(state,cli,tui-gateway): keep reasoning fields intact across forks and branches

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1259,6 +1259,9 @@ class CLICommandsMixin:
                         "tool_calls": msg.get("tool_calls"),
                         "tool_call_id": msg.get("tool_call_id"),
                         "reasoning": msg.get("reasoning"),
+                        "reasoning_details": msg.get("reasoning_details"),
+                        "codex_reasoning_items": msg.get("codex_reasoning_items"),
+                        "codex_message_items": msg.get("codex_message_items"),
                         # Keep the api_content sidecar so the branch's first turn
                         # replays the parent's exact wire bytes (warm provider
                         # prompt cache) instead of a full cold prefill.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6302,6 +6302,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         return meta
 
+    @staticmethod
+    def _reasoning_json_text(value: Any) -> Optional[str]:
+        """Serialize a structured reasoning field for its TEXT column.
+
+        ``reasoning_details`` / ``codex_reasoning_items`` / ``codex_message_items``
+        arrive as list/dict structures from the live runtime, but callers that
+        round-trip stored rows — ``get_messages`` straight into
+        ``replace_messages``, e.g. the POST /api/sessions/{id}/fork handler —
+        hand back the raw TEXT these columns already hold, because
+        ``get_messages`` only deserializes ``content`` and ``tool_calls``.
+        Re-dumping that TEXT double-encodes it, and the forked session's next
+        ``get_messages_as_conversation`` json.loads then yields the inner
+        string instead of the original list, so every reasoning-replay consumer
+        (all of which check ``isinstance(..., list)``) silently drops it.
+        Strings are therefore stored as-is; structures are dumped.
+        """
+        if not value:
+            return None
+        if isinstance(value, str):
+            return value
+        return json.dumps(value)
+
     def append_message(
         self,
         session_id: str,
@@ -6350,18 +6372,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # context role/content replayed to providers.
         display_metadata_json = self._encode_display_metadata(display_metadata)
         # Serialize structured fields to JSON before entering the write txn
-        reasoning_details_json = (
-            json.dumps(reasoning_details)
-            if reasoning_details else None
-        )
-        codex_items_json = (
-            json.dumps(codex_reasoning_items)
-            if codex_reasoning_items else None
-        )
-        codex_message_items_json = (
-            json.dumps(codex_message_items)
-            if codex_message_items else None
-        )
+        reasoning_details_json = self._reasoning_json_text(reasoning_details)
+        codex_items_json = self._reasoning_json_text(codex_reasoning_items)
+        codex_message_items_json = self._reasoning_json_text(codex_message_items)
         # tool_calls may arrive as a Python list (from the live agent) or
         # as a JSON string (from import/export). Parse first to avoid
         # double-encoding.
@@ -6796,15 +6809,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             codex_message_items = (
                 msg.get("codex_message_items") if role == "assistant" else None
             )
-            reasoning_details_json = (
-                json.dumps(reasoning_details) if reasoning_details else None
-            )
-            codex_items_json = (
-                json.dumps(codex_reasoning_items) if codex_reasoning_items else None
-            )
-            codex_message_items_json = (
-                json.dumps(codex_message_items) if codex_message_items else None
-            )
+            reasoning_details_json = self._reasoning_json_text(reasoning_details)
+            codex_items_json = self._reasoning_json_text(codex_reasoning_items)
+            codex_message_items_json = self._reasoning_json_text(codex_message_items)
             # tool_calls may arrive as a Python list (from the live agent)
             # or as a JSON string (from import_sessions / export_session,
             # which store it as TEXT). json.dumps on an already-serialized

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -6,6 +6,7 @@ Verifies that:
 - Auto-generated titles use lineage numbering
 - Custom branch names are used when provided
 - parent_session_id links are set correctly
+- Structured reasoning fields survive the copy
 - Edge cases: empty conversation, missing session DB
 """
 
@@ -181,3 +182,53 @@ class TestBranchFlushesBeforeEndSession:
             cli_instance.conversation_history,
             conversation_history=cli_instance.conversation_history,
         )
+
+
+REASONING_DETAILS = [
+    {"type": "reasoning.text", "text": "sort in place instead", "format": "unknown"}
+]
+CODEX_REASONING_ITEMS = [
+    {"id": "rs_1", "type": "reasoning", "encrypted_content": "opaque-blob"}
+]
+CODEX_MESSAGE_ITEMS = [
+    {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "done"}],
+    }
+]
+
+
+class TestBranchPreservesReasoningFields:
+    """The copy loop must carry the structured reasoning columns across.
+
+    Only ``reasoning`` was forwarded to append_message, so a branch dropped
+    the preserved Anthropic thinking blocks and the Codex
+    encrypted-reasoning/message-item continuation state that the parent had
+    accumulated — the branch then replayed without them, because every
+    consumer gates on isinstance(..., list) and a missing field reads as None.
+    """
+
+    def test_reasoning_fields_survive_branch(self, cli_instance, session_db):
+        from cli import HermesCLI
+
+        cli_instance.conversation_history = [
+            {"role": "user", "content": "Sort this list."},
+            {
+                "role": "assistant",
+                "content": "def sort_list(lst): return sorted(lst)",
+                "reasoning": "picked sorted()",
+                "reasoning_details": REASONING_DETAILS,
+                "codex_reasoning_items": CODEX_REASONING_ITEMS,
+                "codex_message_items": CODEX_MESSAGE_ITEMS,
+            },
+        ]
+
+        HermesCLI._handle_branch_command(cli_instance, "/branch")
+
+        messages = session_db.get_messages_as_conversation(cli_instance.session_id)
+        assistant = next(m for m in messages if m["role"] == "assistant")
+        assert assistant["reasoning_details"] == REASONING_DETAILS
+        assert assistant["codex_reasoning_items"] == CODEX_REASONING_ITEMS
+        assert assistant["codex_message_items"] == CODEX_MESSAGE_ITEMS

--- a/tests/hermes_state/test_reasoning_roundtrip.py
+++ b/tests/hermes_state/test_reasoning_roundtrip.py
@@ -1,0 +1,118 @@
+"""Round-trip tests for the structured reasoning columns.
+
+get_messages() returns reasoning_details / codex_reasoning_items /
+codex_message_items as the raw TEXT stored in their columns (it only
+hydrates content and tool_calls). Callers that feed those rows straight
+back into a write — the POST /api/sessions/{id}/fork handler pipes
+get_messages() into replace_messages() — must not re-encode that TEXT,
+or the forked session replays with reasoning fields decoding to strings
+and every isinstance(..., list) consumer silently drops them.
+"""
+import pytest
+
+from hermes_state import SessionDB
+
+
+REASONING_DETAILS = [
+    {"type": "reasoning.text", "text": "compare both branches first", "format": "unknown"}
+]
+CODEX_REASONING_ITEMS = [
+    {"id": "rs_1", "type": "reasoning", "encrypted_content": "opaque-blob"}
+]
+CODEX_MESSAGE_ITEMS = [
+    {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "done"}],
+    }
+]
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _seed(db, sid="src"):
+    """Session with one assistant message carrying all three reasoning fields."""
+    db.create_session(sid, source="cli")
+    db.append_message(sid, role="user", content="hi")
+    db.append_message(
+        sid,
+        role="assistant",
+        content="done",
+        reasoning_details=REASONING_DETAILS,
+        codex_reasoning_items=CODEX_REASONING_ITEMS,
+        codex_message_items=CODEX_MESSAGE_ITEMS,
+    )
+
+
+def _fork(db, src, dst):
+    """The fork handler's copy step: raw get_messages rows into replace_messages."""
+    db.create_session(dst, source="cli")
+    db.replace_messages(dst, db.get_messages(src))
+
+
+def _assistant(conversation):
+    return next(m for m in conversation if m["role"] == "assistant")
+
+
+class TestDirectWrite:
+    """Live-runtime path: structured values in, structured values back."""
+
+    def test_reasoning_fields_hydrate_as_structures(self, db):
+        _seed(db)
+        msg = _assistant(db.get_messages_as_conversation("src"))
+        assert msg["reasoning_details"] == REASONING_DETAILS
+        assert msg["codex_reasoning_items"] == CODEX_REASONING_ITEMS
+        assert msg["codex_message_items"] == CODEX_MESSAGE_ITEMS
+
+
+class TestForkRoundTrip:
+    """get_messages -> replace_messages must keep the stored TEXT intact."""
+
+    def test_reasoning_details_survive_fork(self, db):
+        _seed(db)
+        _fork(db, "src", "fork")
+        msg = _assistant(db.get_messages_as_conversation("fork"))
+        assert msg["reasoning_details"] == REASONING_DETAILS
+
+    def test_codex_reasoning_items_survive_fork(self, db):
+        _seed(db)
+        _fork(db, "src", "fork")
+        msg = _assistant(db.get_messages_as_conversation("fork"))
+        assert msg["codex_reasoning_items"] == CODEX_REASONING_ITEMS
+
+    def test_codex_message_items_survive_fork(self, db):
+        _seed(db)
+        _fork(db, "src", "fork")
+        msg = _assistant(db.get_messages_as_conversation("fork"))
+        assert msg["codex_message_items"] == CODEX_MESSAGE_ITEMS
+
+    def test_fork_of_fork_stays_stable(self, db):
+        # Each extra round-trip used to add another encoding layer.
+        _seed(db)
+        _fork(db, "src", "fork1")
+        _fork(db, "fork1", "fork2")
+        msg = _assistant(db.get_messages_as_conversation("fork2"))
+        assert msg["reasoning_details"] == REASONING_DETAILS
+        assert msg["codex_reasoning_items"] == CODEX_REASONING_ITEMS
+        assert msg["codex_message_items"] == CODEX_MESSAGE_ITEMS
+
+
+class TestAppendMessageRoundTrip:
+    """append_message accepts a stored row's already-serialized TEXT too."""
+
+    def test_string_value_not_double_encoded(self, db):
+        _seed(db)
+        row = next(m for m in db.get_messages("src") if m["role"] == "assistant")
+        db.create_session("copy", source="cli")
+        db.append_message(
+            "copy",
+            role="assistant",
+            content="done",
+            reasoning_details=row["reasoning_details"],
+        )
+        msg = _assistant(db.get_messages_as_conversation("copy"))
+        assert msg["reasoning_details"] == REASONING_DETAILS

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16191,3 +16191,119 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         assert cleanup_order == ["trim", "reset_home"]
     finally:
         server._sessions.pop("sid_trim", None)
+
+
+BRANCH_REASONING = "the parent's chain of thought"
+BRANCH_REASONING_CONTENT = "the parent's reasoning content"
+BRANCH_REASONING_DETAILS = [
+    {"type": "reasoning.text", "text": "keep the parent's plan", "format": "unknown"}
+]
+BRANCH_CODEX_REASONING_ITEMS = [
+    {"id": "rs_1", "type": "reasoning", "encrypted_content": "opaque-blob"}
+]
+BRANCH_CODEX_MESSAGE_ITEMS = [
+    {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "done"}],
+    }
+]
+
+
+def _branch_history():
+    return [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": "done",
+            "reasoning": BRANCH_REASONING,
+            "reasoning_content": BRANCH_REASONING_CONTENT,
+            "reasoning_details": BRANCH_REASONING_DETAILS,
+            "codex_reasoning_items": BRANCH_CODEX_REASONING_ITEMS,
+            "codex_message_items": BRANCH_CODEX_MESSAGE_ITEMS,
+        },
+    ]
+
+
+def _branched_assistant(db, session_key):
+    return next(
+        m
+        for m in db.get_messages_as_conversation(session_key)
+        if m["role"] == "assistant"
+    )
+
+
+def test_persist_branch_seed_keeps_reasoning_fields(monkeypatch, tmp_path):
+    """The seed write must carry the parent's reasoning fields.
+
+    A branch is a draft until its first submit, so this is the only write that
+    ever persists the copied transcript. Persisting role/content alone left the
+    branch resuming without the parent's reasoning, preserved thinking blocks or
+    Codex encrypted-reasoning/message-item continuation state.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session = _session(
+        session_key="branch-key",
+        parent_session_id="parent-key",
+        history=_branch_history(),
+    )
+    try:
+        db.create_session("branch-key", source="tui")
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+
+        server._persist_branch_seed(session)
+
+        assistant = _branched_assistant(db, "branch-key")
+        assert assistant["reasoning"] == BRANCH_REASONING
+        assert assistant["reasoning_content"] == BRANCH_REASONING_CONTENT
+        assert assistant["reasoning_details"] == BRANCH_REASONING_DETAILS
+        assert assistant["codex_reasoning_items"] == BRANCH_CODEX_REASONING_ITEMS
+        assert assistant["codex_message_items"] == BRANCH_CODEX_MESSAGE_ITEMS
+        assert session["_branch_seed_persisted"] is True
+    finally:
+        db.close()
+
+
+def test_session_branch_keeps_reasoning_fields(monkeypatch, tmp_path):
+    """session.branch copies the live transcript with its reasoning fields.
+
+    Same drop as the seed path: the copy loop wrote only role/content, so the
+    new session row replayed without the reasoning context the parent had.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    server._sessions["sid"] = _session(history=_branch_history())
+    try:
+        db.create_session("session-key", source="tui")
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(server, "_new_session_key", lambda: "branch-key")
+        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+        monkeypatch.setattr(server, "_wait_agent", lambda session, rid: None)
+        monkeypatch.setattr(
+            server, "_claim_active_session_slot", lambda *args, **kwargs: (None, None)
+        )
+        monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+        monkeypatch.setattr(server, "_session_cwd", lambda session: str(tmp_path))
+        monkeypatch.setattr(
+            server, "_make_agent", lambda *args, **kwargs: types.SimpleNamespace()
+        )
+        monkeypatch.setattr(server, "_init_session", lambda *args, **kwargs: None)
+
+        resp = server.handle_request(
+            {"id": "1", "method": "session.branch", "params": {"session_id": "sid"}}
+        )
+
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+        assistant = _branched_assistant(db, "branch-key")
+        assert assistant["reasoning"] == BRANCH_REASONING
+        assert assistant["reasoning_content"] == BRANCH_REASONING_CONTENT
+        assert assistant["reasoning_details"] == BRANCH_REASONING_DETAILS
+        assert assistant["codex_reasoning_items"] == BRANCH_CODEX_REASONING_ITEMS
+        assert assistant["codex_message_items"] == BRANCH_CODEX_MESSAGE_ITEMS
+    finally:
+        server._sessions.pop("sid", None)
+        db.close()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2732,6 +2732,11 @@ def _(rid, params: dict) -> dict:
                     {
                         "role": msg.get("role", "user"),
                         "content": msg.get("content"),
+                        "reasoning": msg.get("reasoning"),
+                        "reasoning_content": msg.get("reasoning_content"),
+                        "reasoning_details": msg.get("reasoning_details"),
+                        "codex_reasoning_items": msg.get("codex_reasoning_items"),
+                        "codex_message_items": msg.get("codex_message_items"),
                         # Preserve the parent's original message timestamps —
                         # branch copies are history, not new activity (9d73006ad).
                         "timestamp": msg.get("timestamp"),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2763,6 +2763,11 @@ def _persist_branch_seed(session: dict) -> None:
                     {
                         "role": msg.get("role", "user"),
                         "content": msg.get("content"),
+                        "reasoning": msg.get("reasoning"),
+                        "reasoning_content": msg.get("reasoning_content"),
+                        "reasoning_details": msg.get("reasoning_details"),
+                        "codex_reasoning_items": msg.get("codex_reasoning_items"),
+                        "codex_message_items": msg.get("codex_message_items"),
                         # Preserve the parent's original message timestamps —
                         # append_message would otherwise stamp time.time() and the
                         # branch's copied history would all appear authored "now".


### PR DESCRIPTION
## What does this PR do?

Keeps a session's reasoning fields intact when the session is copied. Both
copy paths lost them, two different ways.

**Fork, double-encoding.** `get_messages()` returns `reasoning_details` /
`codex_reasoning_items` / `codex_message_items` as the raw TEXT stored in
those columns (only `content` and `tool_calls` are hydrated), and both
writers re-ran an unguarded `json.dumps()` on whatever they received. The
fork endpoint pipes `get_messages()` straight into `replace_messages()`
(`_handle_fork_session` in `gateway/platforms/api_server.py`, lines
3498-3499), so every forked session stored its reasoning fields wrapped in
one extra JSON-string layer. On resume,
`get_messages_as_conversation()` decoded the column back to the inner
string, and every consumer's `isinstance(..., list)` gate silently dropped
it: preserved Anthropic thinking blocks, Codex encrypted-reasoning and
message-item replay, and OpenRouter multi-turn reasoning context were all
lost after a fork. One more encoding layer accumulates per fork, and the
double-encoded string still went out to providers in a shape none of them
ever produced.

**Branch, dropped columns.** The branch writers never agreed on what to
copy. `gateway/slash_commands.py` forwarded the full field set, but the
`hermes_cli` `/branch` loop forwarded `reasoning` and none of the structured
columns, and both TUI branch writers persisted role/content/timestamp alone,
so the same `/branch`, typed in three places, produced three different rows.
A TUI branch is a draft until its first submit, so the seed write is the only
write that ever persists the copied transcript: whatever it drops is gone.
Same end state as the fork bug, reached by omission instead of encoding.

The `hermes_state.py` writers now route the three structured fields through
a shared guard that keeps already-serialized TEXT as-is and dumps live
structures exactly as before. The CLI and TUI branch writers now forward the
reasoning fields the gateway path already forwarded. The read path is
untouched, so `get_messages`, the GET messages endpoint, session export and
session search all keep their current shapes.

## Related Issue

Fixes #57240

**Related PRs, not duplicates.** Three open PRs overlap this area. #57454
("preserve reasoning fields when forking sessions", 2026-07-03) is an
independent fix for the same issue, scoped to the fork path; if it lands
first, only the branch half of this PR is still needed. #24769 ("preserve
tool and reasoning metadata during branch", 2026-05-13) and #42273 ("persist
full message history when branching", 2026-06-08) both predate this PR, sit
on older bases, and address the branch half alone. This PR is the only one
that covers the fork and branch paths together, at the writer level.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`
  - new `SessionDB._reasoning_json_text()` helper: falsy → `NULL`, `str`
    (the column's own TEXT coming back through `get_messages`) → stored
    as-is, anything else → `json.dumps` as before
  - `append_message` and `_insert_message_rows` use it at all six dumps
    sites (3 fields × 2 writers)
- `hermes_cli/cli_commands_mixin.py`
  - the `/branch` copy loop forwards `reasoning_details`,
    `codex_reasoning_items` and `codex_message_items` next to the
    `reasoning` it already carried
- `tui_gateway/server.py`, `tui_gateway/methods_session.py`
  - `_persist_branch_seed()` and the `session.branch` RPC forward the
    reasoning fields instead of role/content/timestamp alone
- `tests/hermes_state/test_reasoning_roundtrip.py` (new)
  - fork round-trip per field (`get_messages` → `replace_messages`, the
    fork handler's exact copy step), fork-of-fork stability, an
    `append_message` round-trip with a stored row's TEXT, and a
    direct-write control pinning that live-runtime serialization is
    unchanged
- `tests/cli/test_branch_command.py`, `tests/test_tui_gateway_server.py`
  - one branch regression per writer: branch a session whose assistant
    turn carries every reasoning field, reload the branched session, and
    assert each field came back

The branch writers and their regressions were added in response to
review on this PR; the round-trip guard alone left the branch
paths dropping the same fields before they ever reached it.

## How to Test

1. Cherry-picked onto current `main`, the three suites this PR touches:
   `python -m pytest tests/cli/test_branch_command.py tests/hermes_state/test_reasoning_roundtrip.py tests/test_tui_gateway_server.py -q`
   gives 535 passed.
2. The same command on `main`, with the new tests in place and the
   production changes reverted: 8 failed, 527 passed. The 8 are exactly the
   8 new tests (the 5 round-trip variants, the CLI branch regression, and
   the two TUI branch regressions). The 6th test in the new file,
   `TestDirectWrite::test_reasoning_fields_hydrate_as_structures`, passes in
   both runs, pinning that live writes behave identically before and after.
3. Reverting only the branch-writer forwarding leaves the three branch
   regressions failing on the reloaded row with a `KeyError` on the first
   dropped field (`'reasoning_details'` in the CLI test, whose writer
   already carried `reasoning`; `'reasoning'` in both TUI tests), so they
   cannot pass against the unfixed writers.
4. Quick manual check (the repro from #57240):

```python
import tempfile
from pathlib import Path

from hermes_state import SessionDB

db = SessionDB(Path(tempfile.mkdtemp()) / "state.db")
db.create_session("src", source="cli")
db.append_message(
    "src", role="assistant", content="done",
    reasoning_details=[{"type": "reasoning.text", "text": "step one"}],
)
db.create_session("fork", source="cli")
db.replace_messages("fork", db.get_messages("src"))
print(type(db.get_messages_as_conversation("fork")[0]["reasoning_details"]))
```

Before: `<class 'str'>`. After: `<class 'list'>`.

Verified on Windows 11, Python 3.13.

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31055688426

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. The three neighbours are disclosed above.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits). One commit, one defect: reasoning fields lost when a session is copied; the branch writers were added at the reviewer's request
- [x] I've run the suites this PR touches (`tests/cli/test_branch_command.py`, `tests/hermes_state/test_reasoning_roundtrip.py`, `tests/test_tui_gateway_server.py`): 535 passed. Full `pytest tests/ -q` in my environment has pre-existing collection errors from optional deps that aren't installed, unrelated to this change; the full matrix is covered by the ubuntu run linked above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): the helper's docstring documents the round-trip contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): stdlib-only, tests use `tmp_path`
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A, no tool change

## Screenshots / Logs

```
$ python -m pytest tests/cli/test_branch_command.py tests/hermes_state/test_reasoning_roundtrip.py tests/test_tui_gateway_server.py -q   # with this PR
535 passed in 56.49s
```

On `main`, with the new tests in place and the production changes reverted:

```
$ python -m pytest tests/cli/test_branch_command.py tests/hermes_state/test_reasoning_roundtrip.py tests/test_tui_gateway_server.py -q
FAILED tests/cli/test_branch_command.py::TestBranchPreservesReasoningFields::test_reasoning_fields_survive_branch
FAILED tests/hermes_state/test_reasoning_roundtrip.py::TestAppendMessageRoundTrip::test_string_value_not_double_encoded
FAILED tests/hermes_state/test_reasoning_roundtrip.py::TestForkRoundTrip::test_codex_message_items_survive_fork
FAILED tests/hermes_state/test_reasoning_roundtrip.py::TestForkRoundTrip::test_codex_reasoning_items_survive_fork
FAILED tests/hermes_state/test_reasoning_roundtrip.py::TestForkRoundTrip::test_fork_of_fork_stays_stable
FAILED tests/hermes_state/test_reasoning_roundtrip.py::TestForkRoundTrip::test_reasoning_details_survive_fork
FAILED tests/test_tui_gateway_server.py::test_persist_branch_seed_keeps_reasoning_fields
FAILED tests/test_tui_gateway_server.py::test_session_branch_keeps_reasoning_fields
8 failed, 527 passed in 70.47s
```

With the branch-writer forwarding reverted, the new branch regressions:

```
E       KeyError: 'reasoning_details'
FAILED tests/cli/test_branch_command.py::TestBranchPreservesReasoningFields::test_reasoning_fields_survive_branch
E           KeyError: 'reasoning'
FAILED tests/test_tui_gateway_server.py::test_persist_branch_seed_keeps_reasoning_fields
FAILED tests/test_tui_gateway_server.py::test_session_branch_keeps_reasoning_fields
3 failed
```
