### PR TITLE
fix(install): quote AGENT_BROWSER_EXECUTABLE_PATH for spaced paths

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -357,12 +357,12 @@ function Write-BrowserEnv {
     }
     $envFile = Join-Path $HermesHome ".env"
     if (-not (Test-Path $envFile)) {
-        Set-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=$BrowserPath" -Encoding UTF8
+        Set-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=`"$BrowserPath`"" -Encoding UTF8
         return
     }
     $content = Get-Content $envFile -Raw -ErrorAction SilentlyContinue
     if ($content -and $content -match "AGENT_BROWSER_EXECUTABLE_PATH=") { return }
-    Add-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=$BrowserPath" -Encoding UTF8
+    Add-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=`"$BrowserPath`"" -Encoding UTF8
 }
 
 function Install-AgentBrowser {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -350,19 +350,26 @@ function Find-SystemBrowser {
     return $null
 }
 
+function ConvertTo-DotEnvDoubleQuoted {
+    param([string]$Value)
+    $escaped = $Value.Replace('\', '\\').Replace('"', '\"')
+    return '"' + $escaped + '"'
+}
+
 function Write-BrowserEnv {
     param([string]$BrowserPath)
     if (-not (Test-Path $HermesHome)) {
         New-Item -ItemType Directory -Force -Path $HermesHome | Out-Null
     }
     $envFile = Join-Path $HermesHome ".env"
+    $quotedBrowserPath = ConvertTo-DotEnvDoubleQuoted $BrowserPath
     if (-not (Test-Path $envFile)) {
-        Set-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=`"$BrowserPath`"" -Encoding UTF8
+        Set-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=$quotedBrowserPath" -Encoding UTF8
         return
     }
     $content = Get-Content $envFile -Raw -ErrorAction SilentlyContinue
     if ($content -and $content -match "AGENT_BROWSER_EXECUTABLE_PATH=") { return }
-    Add-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=`"$BrowserPath`"" -Encoding UTF8
+    Add-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=$quotedBrowserPath" -Encoding UTF8
 }
 
 function Install-AgentBrowser {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2036,11 +2036,11 @@ strip_snap_browser_override() {
     local env_file="$HERMES_HOME/.env"
 
     [ -f "$env_file" ] || return 0
-    grep -Eq '^AGENT_BROWSER_EXECUTABLE_PATH=/snap/' "$env_file" 2>/dev/null || return 0
+    grep -Eq '^AGENT_BROWSER_EXECUTABLE_PATH="?/snap/' "$env_file" 2>/dev/null || return 0
 
     local tmp
     tmp="$(mktemp)" || return 0
-    if grep -Ev '^AGENT_BROWSER_EXECUTABLE_PATH=/snap/|^# Hermes Agent browser tools' "$env_file" > "$tmp"; then
+    if grep -Ev '^AGENT_BROWSER_EXECUTABLE_PATH="?/snap/|^# Hermes Agent browser tools' "$env_file" > "$tmp"; then
         mv "$tmp" "$env_file"
         log_warn "Removed stale Snap browser override (AGENT_BROWSER_EXECUTABLE_PATH=/snap/...) from $env_file"
         log_info "Hermes will use the bundled Chromium instead."
@@ -2265,7 +2265,7 @@ configure_browser_env_from_system_browser() {
     {
         echo ""
         echo "# Hermes Agent browser tools — explicit browser override."
-        echo "AGENT_BROWSER_EXECUTABLE_PATH=$browser_path"
+        echo "AGENT_BROWSER_EXECUTABLE_PATH=\"$browser_path\""
     } >> "$env_file"
     log_success "Configured browser tools to use $browser_path"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -243,6 +243,14 @@ json_escape() {
         -e 's/"/\\"/g'
 }
 
+dotenv_double_quote() {
+    printf '"'
+    printf '%s' "$1" | sed \
+        -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g'
+    printf '"'
+}
+
 # npm rewrites tracked package-lock.json files non-deterministically during
 # `npm install` / `npm run pack`. On a managed install those diffs are never
 # intentional, but they leave the checkout dirty — which forces `hermes update`
@@ -2036,11 +2044,11 @@ strip_snap_browser_override() {
     local env_file="$HERMES_HOME/.env"
 
     [ -f "$env_file" ] || return 0
-    grep -Eq '^AGENT_BROWSER_EXECUTABLE_PATH="?/snap/' "$env_file" 2>/dev/null || return 0
+    grep -Eq "^AGENT_BROWSER_EXECUTABLE_PATH=['\"]?/snap/" "$env_file" 2>/dev/null || return 0
 
     local tmp
     tmp="$(mktemp)" || return 0
-    if grep -Ev '^AGENT_BROWSER_EXECUTABLE_PATH="?/snap/|^# Hermes Agent browser tools' "$env_file" > "$tmp"; then
+    if grep -Ev "^AGENT_BROWSER_EXECUTABLE_PATH=['\"]?/snap/|^# Hermes Agent browser tools" "$env_file" > "$tmp"; then
         mv "$tmp" "$env_file"
         log_warn "Removed stale Snap browser override (AGENT_BROWSER_EXECUTABLE_PATH=/snap/...) from $env_file"
         log_info "Hermes will use the bundled Chromium instead."
@@ -2263,9 +2271,11 @@ configure_browser_env_from_system_browser() {
     fi
 
     {
-        echo ""
-        echo "# Hermes Agent browser tools — explicit browser override."
-        echo "AGENT_BROWSER_EXECUTABLE_PATH=\"$browser_path\""
+        printf '\n'
+        printf '%s\n' "# Hermes Agent browser tools — explicit browser override."
+        printf 'AGENT_BROWSER_EXECUTABLE_PATH='
+        dotenv_double_quote "$browser_path"
+        printf '\n'
     } >> "$env_file"
     log_success "Configured browser tools to use $browser_path"
 }

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -3,15 +3,40 @@
 Browser automation is optional. The installer should not leave Hermes
 half-installed just because Playwright's managed Chromium download hangs on an
 unsupported distribution.
+
+Also covers quoted AGENT_BROWSER_EXECUTABLE_PATH writes: spaced paths, escape
+round-trips through python-dotenv and POSIX sh, and Snap override cleanup.
 """
 
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
 from pathlib import Path
+
+import pytest
+from dotenv import dotenv_values
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+BROWSER_ENV_KEY = "AGENT_BROWSER_EXECUTABLE_PATH"
 
+ROUND_TRIP_PATHS = [
+    pytest.param("browser executable with spaces", id="spaces"),
+    pytest.param(r"C:\Users\p\scoop\apps\chrome.exe", id="windows-chrome"),
+    pytest.param(r"D:\bin\firefox.exe", id="windows-firefox"),
+    pytest.param(r"E:\tools\tbrowser.exe", id="literal-backslash-t"),
+    pytest.param("browser's executable", id="apostrophe"),
+    pytest.param('browser "beta" executable', id="double-quote"),
+]
 
+SHELL_EXPANSION_PATHS = [
+    pytest.param("browser-$HOME", id="dollar"),
+    pytest.param("browser-`printf shell`", id="backtick"),
+]
 
 
 def test_install_script_honors_explicit_browser_override_only() -> None:
@@ -21,24 +46,6 @@ def test_install_script_honors_explicit_browser_override_only() -> None:
     assert 'override="${AGENT_BROWSER_EXECUTABLE_PATH:-}"' in text
     # An explicit override still skips the bundled download (override, not fallback).
     assert "Skipping bundled Chromium download" in text
-
-
-def test_install_script_strips_stale_snap_browser_override() -> None:
-    """Already-affected installs must auto-recover.
-
-    A pre-existing AGENT_BROWSER_EXECUTABLE_PATH pointing at a Snap Chromium is
-    the exact value that hangs the browser tool, and the runtime reads it from
-    .env — so the installer strips it (and a Snap override is rejected even when
-    set explicitly) so the bundled Chromium download runs on update.
-    """
-    text = INSTALL_SH.read_text()
-
-    assert "strip_snap_browser_override()" in text
-    assert '^AGENT_BROWSER_EXECUTABLE_PATH="?/snap/' in text
-    # Both install paths invoke the migration before resolving a browser.
-    assert text.count("strip_snap_browser_override") >= 3
-    # A snap path is rejected by find_system_browser itself.
-    assert "/snap/*) return 1 ;;" in text
 
 
 def test_playwright_installs_are_timeout_guarded() -> None:
@@ -60,7 +67,6 @@ def test_playwright_installs_are_timeout_guarded() -> None:
     assert 'run_browser_install_with_timeout "$timeout_seconds" "$@"' in text
 
 
-
 def test_install_script_supports_skip_browser_flag() -> None:
     """--skip-browser (and --no-playwright alias) skips the Playwright install."""
     text = INSTALL_SH.read_text()
@@ -69,10 +75,6 @@ def test_install_script_supports_skip_browser_flag() -> None:
     assert "SKIP_BROWSER=true" in text
     assert 'if [ "$SKIP_BROWSER" = true ]; then' in text
     assert "--skip-browser Skip Playwright/Chromium install" in text
-
-
-
-
 
 
 def test_browser_install_timeout_stays_interruptible() -> None:
@@ -100,8 +102,6 @@ def test_browser_install_timeout_stays_interruptible() -> None:
 # host Playwright already supports.
 # ---------------------------------------------------------------------------
 
-import subprocess
-
 
 def _run_install_fn(distro: str, version: str, *, native_fails: bool,
                     arch: str = "x86_64", operator_override: str = "") -> dict:
@@ -122,7 +122,6 @@ def _run_install_fn(distro: str, version: str, *, native_fails: bool,
         "run_playwright_install",
     ]
     src = INSTALL_SH.read_text()
-    import re
 
     extracted = []
     for name in fn_names:
@@ -167,7 +166,6 @@ npx() {{
 run_playwright_install 600 npx playwright install --with-deps chromium
 echo "FINAL_RC=$?"
 """
-    import tempfile, os
     with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as lf:
         runlog = lf.name
     try:
@@ -193,10 +191,6 @@ def test_override_retry_fires_on_ubuntu_26() -> None:
     assert r["final_rc"] == 0
 
 
-
-
-
-
 def test_override_retry_fires_on_debian_14() -> None:
     """Debian 14 (> 13) is the too-new apt case → retry with override."""
     r = _run_install_fn("debian", "14", native_fails=True)
@@ -213,76 +207,222 @@ def test_no_retry_when_native_succeeds_on_ubuntu_26() -> None:
     assert r["final_rc"] == 0
 
 
-
-
-
-
 # ---------------------------------------------------------------------------
-# §4.6 — quoted env write: a browser path containing spaces must round-trip
-# through .env intact. The override is written double-quoted
-# (AGENT_BROWSER_EXECUTABLE_PATH="<path>") so `set -a; . .env` sources the
-# full path as one word under both bash and POSIX sh, instead of splitting on
-# the space and leaving the tail as a bare assignment/parse error.
+# Quoted AGENT_BROWSER_EXECUTABLE_PATH writes (PR #57249 suite): drive the
+# supported installer stages and assert dotenv + POSIX sh round-trips.
 # ---------------------------------------------------------------------------
 
-def _run_configure_and_source(shell: str, browser_path: str) -> dict:
-    """Run configure_browser_env_from_system_browser against a temp HERMES_HOME
-    with a pre-seeded DETECTED_BROWSER_EXECUTABLE, then re-source the resulting
-    .env under the requested shell and return AGENT_BROWSER_EXECUTABLE_PATH."""
-    import tempfile, os
-    src = INSTALL_SH.read_text()
-    import re
-    m = re.search(r"^configure_browser_env_from_system_browser\(\) \{.*?^\}",
-                  src, re.MULTILINE | re.DOTALL)
-    assert m, "could not extract configure_browser_env_from_system_browser()"
-    body = m.group(0)
 
-    with tempfile.TemporaryDirectory() as tmp:
-        harness = f"""
-set -u
-HERMES_HOME={tmp!r}
-DETECTED_BROWSER_EXECUTABLE={browser_path!r}
-log_info() {{ :; }}
-log_success() {{ :; }}
-log_warn() {{ :; }}
-find_system_browser() {{ printf '%s' {browser_path!r}; }}
-{body}
-configure_browser_env_from_system_browser
-"""
-        # First run configure_*() under bash (the installer's own shell).
-        proc = subprocess.run(["bash", "-c", harness], capture_output=True,
-                              text=True)
-        assert proc.returncode == 0, proc.stderr
-        env_file = Path(tmp) / ".env"
-        assert env_file.exists(), ".env was not created"
-        raw = env_file.read_text()
-        # Re-source the written .env under the requested shell and read back
-        # the value of AGENT_BROWSER_EXECUTABLE_PATH, simulating the runtime
-        # loader. `set -a` exports every assignment so it survives the subshell.
-        env_path = str(env_file)
-        source_cmd = f"set -a; . '{env_path}' >/dev/null 2>&1; printf '%s' \"${{AGENT_BROWSER_EXECUTABLE_PATH:-<unset>}}\""
-        proc2 = subprocess.run([shell, "-c", source_cmd],
-                               capture_output=True, text=True)
-        return {"raw_env": raw, "sourced": proc2.stdout, "rc": proc2.returncode,
-                "stderr": proc2.stderr}
+def _make_executable(
+    path: Path,
+    body: str = "#!/bin/sh\nexit 0\n",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    path.chmod(0o755)
 
 
-def test_quoted_spaced_browser_path_round_trips_under_bash() -> None:
-    """A browser path with a space survives the write+source round-trip (bash)."""
-    spaced = "/opt/My Browser/chrome"
-    r = _run_configure_and_source("bash", spaced)
-    assert r["sourced"] == spaced, (r["raw_env"], r["sourced"], r["stderr"])
+def _run_config_stage(
+    tmp_path: Path,
+    browser_path: str | None,
+    *,
+    path_prefix: Path | None = None,
+) -> Path:
+    """Run the supported config stage against isolated install and data dirs."""
+    install_dir = tmp_path / "install"
+    hermes_home = tmp_path / "home"
+    install_dir.mkdir()
+
+    if browser_path is not None:
+        _make_executable(install_dir / browser_path)
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["HERMES_INSTALL_DIR"] = str(install_dir)
+    env.pop(BROWSER_ENV_KEY, None)
+    if browser_path is not None:
+        env[BROWSER_ENV_KEY] = browser_path
+    if path_prefix is not None:
+        env["PATH"] = f"{path_prefix}{os.pathsep}{env['PATH']}"
+
+    installer = subprocess.run(
+        ["bash", str(INSTALL_SH), "--stage", "config", "--no-skills"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert installer.returncode == 0, (installer.stdout, installer.stderr)
+    assert installer.stderr == "", (installer.stdout, installer.stderr)
+
+    env_file = hermes_home / ".env"
+    assert env_file.is_file()
+    return env_file
 
 
-def test_quoted_spaced_browser_path_round_trips_under_sh() -> None:
-    """A browser path with a space survives the write+source round-trip (POSIX sh)."""
-    spaced = "/opt/My Browser/chrome"
-    r = _run_configure_and_source("sh", spaced)
-    assert r["sourced"] == spaced, (r["raw_env"], r["sourced"], r["stderr"])
+def _run_node_deps_snap_cleanup(tmp_path: Path, quote: str) -> Path:
+    """Run snap cleanup through node-deps with all Node commands stubbed."""
+    install_dir = tmp_path / "install"
+    hermes_home = tmp_path / "home"
+    fake_bin = tmp_path / "fake-bin"
+    install_dir.mkdir()
+    hermes_home.mkdir()
+    (install_dir / "package.json").write_text("{}\n")
+
+    _make_executable(
+        fake_bin / "node",
+        "#!/bin/sh\nprintf 'v22.12.0\\n'\n",
+    )
+    _make_executable(fake_bin / "npm")
+    _make_executable(fake_bin / "npx")
+    _make_executable(
+        fake_bin / "timeout",
+        """#!/bin/sh
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --foreground) shift ;;
+        -k) shift 2 ;;
+        [0-9]*) shift; break ;;
+        *) break ;;
+    esac
+done
+exec "$@"
+""",
+    )
+
+    env_file = hermes_home / ".env"
+    env_file.write_text(
+        "# Hermes Agent browser tools — explicit browser override.\n"
+        f"{BROWSER_ENV_KEY}={quote}/snap/bin/chromium{quote}\n"
+        "KEEP_ME=1\n"
+    )
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["HERMES_INSTALL_DIR"] = str(install_dir)
+    env[BROWSER_ENV_KEY] = "/snap/bin/chromium"
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+    installer = subprocess.run(
+        ["bash", str(INSTALL_SH), "--stage", "node-deps"],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert installer.returncode == 0, (installer.stdout, installer.stderr)
+    assert installer.stderr == "", (installer.stdout, installer.stderr)
+    return env_file
 
 
-def test_quoted_browser_env_write_is_double_quoted() -> None:
-    """The .env line is written double-quoted so the loader keeps it whole."""
-    r = _run_configure_and_source("bash", "/usr/bin/chromium")
-    assert 'AGENT_BROWSER_EXECUTABLE_PATH="/usr/bin/chromium"' in r["raw_env"]
+def _expected_serialized_line(browser_path: str) -> str:
+    escaped = browser_path.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{BROWSER_ENV_KEY}="{escaped}"'
 
+
+def _serialized_browser_line(env_file: Path) -> str:
+    return next(
+        line
+        for line in env_file.read_text().splitlines()
+        if line.startswith(f"{BROWSER_ENV_KEY}=")
+    )
+
+
+def _source_with_posix_sh(env_file: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "sh",
+            "-c",
+            '. "$1"\nprintf \'%s\' "$AGENT_BROWSER_EXECUTABLE_PATH"\n',
+            "sh",
+            str(env_file),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("browser_path", ROUND_TRIP_PATHS)
+def test_config_stage_browser_path_round_trips_through_dotenv_and_sh(
+    tmp_path: Path,
+    browser_path: str,
+) -> None:
+    env_file = _run_config_stage(tmp_path, browser_path)
+
+    assert _serialized_browser_line(env_file) == _expected_serialized_line(browser_path)
+    assert dotenv_values(env_file)[BROWSER_ENV_KEY] == browser_path
+
+    sourced = _source_with_posix_sh(env_file)
+    assert sourced.returncode == 0, (sourced.stdout, sourced.stderr)
+    assert sourced.stderr == "", (sourced.stdout, sourced.stderr)
+    assert sourced.stdout == browser_path
+
+
+@pytest.mark.parametrize("browser_path", SHELL_EXPANSION_PATHS)
+def test_dotenv_preserves_literal_shell_expansion_paths(
+    tmp_path: Path,
+    browser_path: str,
+) -> None:
+    """The canonical dotenv reader must preserve literal dollar/backtick paths."""
+    env_file = _run_config_stage(tmp_path, browser_path)
+
+    assert _serialized_browser_line(env_file) == _expected_serialized_line(browser_path)
+    assert dotenv_values(env_file)[BROWSER_ENV_KEY] == browser_path
+
+
+@pytest.mark.parametrize("browser_path", SHELL_EXPANSION_PATHS)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "The canonical dotenv double-quoted form does not escape POSIX-shell "
+        "$ or backtick expansion, so sourcing cannot preserve these filenames."
+    ),
+)
+def test_posix_sh_does_not_round_trip_shell_expansion_paths(
+    tmp_path: Path,
+    browser_path: str,
+) -> None:
+    """Document the known shell incompatibility without weakening dotenv coverage."""
+    env_file = _run_config_stage(tmp_path, browser_path)
+
+    assert _serialized_browser_line(env_file) == _expected_serialized_line(browser_path)
+    assert dotenv_values(env_file)[BROWSER_ENV_KEY] == browser_path
+
+    sourced = _source_with_posix_sh(env_file)
+    assert sourced.returncode == 0, (sourced.stdout, sourced.stderr)
+    assert sourced.stderr == "", (sourced.stdout, sourced.stderr)
+    assert sourced.stdout == browser_path
+
+
+@pytest.mark.parametrize(
+    "quote",
+    ["", "'", '"'],
+    ids=["unquoted", "single-quoted", "double-quoted"],
+)
+def test_node_deps_stage_strips_quoted_snap_override(
+    tmp_path: Path,
+    quote: str,
+) -> None:
+    env_file = _run_node_deps_snap_cleanup(tmp_path, quote)
+    raw_env = env_file.read_text()
+
+    assert BROWSER_ENV_KEY not in dotenv_values(env_file)
+    assert "Hermes Agent browser tools" not in raw_env
+    assert "KEEP_ME=1" in raw_env
+
+
+def test_config_stage_does_not_autodetect_browser_from_path(tmp_path: Path) -> None:
+    """A PATH browser is ignored unless the operator sets an explicit override."""
+    fake_bin = tmp_path / "fake-bin"
+    _make_executable(fake_bin / "chromium")
+
+    env_file = _run_config_stage(tmp_path, None, path_prefix=fake_bin)
+
+    assert BROWSER_ENV_KEY not in dotenv_values(env_file)
+    assert not any(
+        line.startswith(f"{BROWSER_ENV_KEY}=")
+        for line in env_file.read_text().splitlines()
+    )

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -23,6 +23,22 @@ def test_install_script_honors_explicit_browser_override_only() -> None:
     assert "Skipping bundled Chromium download" in text
 
 
+def test_install_script_strips_stale_snap_browser_override() -> None:
+    """Already-affected installs must auto-recover.
+
+    A pre-existing AGENT_BROWSER_EXECUTABLE_PATH pointing at a Snap Chromium is
+    the exact value that hangs the browser tool, and the runtime reads it from
+    .env — so the installer strips it (and a Snap override is rejected even when
+    set explicitly) so the bundled Chromium download runs on update.
+    """
+    text = INSTALL_SH.read_text()
+
+    assert "strip_snap_browser_override()" in text
+    assert '^AGENT_BROWSER_EXECUTABLE_PATH="?/snap/' in text
+    # Both install paths invoke the migration before resolving a browser.
+    assert text.count("strip_snap_browser_override") >= 3
+    # A snap path is rejected by find_system_browser itself.
+    assert "/snap/*) return 1 ;;" in text
 
 
 def test_playwright_installs_are_timeout_guarded() -> None:
@@ -199,4 +215,74 @@ def test_no_retry_when_native_succeeds_on_ubuntu_26() -> None:
 
 
 
+
+
+# ---------------------------------------------------------------------------
+# §4.6 — quoted env write: a browser path containing spaces must round-trip
+# through .env intact. The override is written double-quoted
+# (AGENT_BROWSER_EXECUTABLE_PATH="<path>") so `set -a; . .env` sources the
+# full path as one word under both bash and POSIX sh, instead of splitting on
+# the space and leaving the tail as a bare assignment/parse error.
+# ---------------------------------------------------------------------------
+
+def _run_configure_and_source(shell: str, browser_path: str) -> dict:
+    """Run configure_browser_env_from_system_browser against a temp HERMES_HOME
+    with a pre-seeded DETECTED_BROWSER_EXECUTABLE, then re-source the resulting
+    .env under the requested shell and return AGENT_BROWSER_EXECUTABLE_PATH."""
+    import tempfile, os
+    src = INSTALL_SH.read_text()
+    import re
+    m = re.search(r"^configure_browser_env_from_system_browser\(\) \{.*?^\}",
+                  src, re.MULTILINE | re.DOTALL)
+    assert m, "could not extract configure_browser_env_from_system_browser()"
+    body = m.group(0)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        harness = f"""
+set -u
+HERMES_HOME={tmp!r}
+DETECTED_BROWSER_EXECUTABLE={browser_path!r}
+log_info() {{ :; }}
+log_success() {{ :; }}
+log_warn() {{ :; }}
+find_system_browser() {{ printf '%s' {browser_path!r}; }}
+{body}
+configure_browser_env_from_system_browser
+"""
+        # First run configure_*() under bash (the installer's own shell).
+        proc = subprocess.run(["bash", "-c", harness], capture_output=True,
+                              text=True)
+        assert proc.returncode == 0, proc.stderr
+        env_file = Path(tmp) / ".env"
+        assert env_file.exists(), ".env was not created"
+        raw = env_file.read_text()
+        # Re-source the written .env under the requested shell and read back
+        # the value of AGENT_BROWSER_EXECUTABLE_PATH, simulating the runtime
+        # loader. `set -a` exports every assignment so it survives the subshell.
+        env_path = str(env_file)
+        source_cmd = f"set -a; . '{env_path}' >/dev/null 2>&1; printf '%s' \"${{AGENT_BROWSER_EXECUTABLE_PATH:-<unset>}}\""
+        proc2 = subprocess.run([shell, "-c", source_cmd],
+                               capture_output=True, text=True)
+        return {"raw_env": raw, "sourced": proc2.stdout, "rc": proc2.returncode,
+                "stderr": proc2.stderr}
+
+
+def test_quoted_spaced_browser_path_round_trips_under_bash() -> None:
+    """A browser path with a space survives the write+source round-trip (bash)."""
+    spaced = "/opt/My Browser/chrome"
+    r = _run_configure_and_source("bash", spaced)
+    assert r["sourced"] == spaced, (r["raw_env"], r["sourced"], r["stderr"])
+
+
+def test_quoted_spaced_browser_path_round_trips_under_sh() -> None:
+    """A browser path with a space survives the write+source round-trip (POSIX sh)."""
+    spaced = "/opt/My Browser/chrome"
+    r = _run_configure_and_source("sh", spaced)
+    assert r["sourced"] == spaced, (r["raw_env"], r["sourced"], r["stderr"])
+
+
+def test_quoted_browser_env_write_is_double_quoted() -> None:
+    """The .env line is written double-quoted so the loader keeps it whole."""
+    r = _run_configure_and_source("bash", "/usr/bin/chromium")
+    assert 'AGENT_BROWSER_EXECUTABLE_PATH="/usr/bin/chromium"' in r["raw_env"]
 


### PR DESCRIPTION
Fixes #57247

## Problem

See #57247. The installer persists the user's explicit browser override into `~/.hermes/.env` unquoted. Spaced paths (macOS app bundles, Windows Program Files) produce a line that fails POSIX shell `source`, leaving the var empty with a stderr error.

Opt-in only: post-#50852 the installer no longer auto-detects a browser. Default installs are unaffected.

## Why naive quoting is wrong

Quoting the value is exactly what makes `python-dotenv` escape-decode it, so the value **must** be escaped. Naive double-quoting corrupts real Windows paths under python-dotenv 1.2.2:

| Path written as `"..."` (no escapes) | After `dotenv_values` |
|---|---|
| `C:\Users\p\scoop\apps\chrome.exe` | `C:\Users\p\scoop` + BEL + `pps\chrome.exe` (`\a` → BEL) |
| `D:\bin\firefox.exe` | `D:` + BS + `in` + FF + `irefox.exe` (`\b`/`\f` control chars) |
| `E:\tools\tbrowser.exe` | `E:` + TAB + `ools` + TAB + `browser.exe` (`\t` → tab) |

## Core constraint

`python-dotenv` escape-decodes double-quoted values while `sh` expands `$`/backtick, and dotenv leaves `\$` literal, so **no double-quoted form is safe for both readers**.

Escaped double quotes are correct for Hermes because:

1. `python-dotenv` is the reader Hermes actually uses (`hermes_cli/env_loader.py`)
2. It is the dialect `_quote_env_value` already writes (`hermes_cli/config.py`)

Single quotes are shell-perfect but silently drop apostrophe paths under `python-dotenv`.

## Changes

- `scripts/install.sh:244` - `dotenv_double_quote` helper next to `json_escape` (backslash + `"` escape, then wrap in `"`)
- `scripts/install.sh:2118` - writer uses the helper instead of raw `echo`
- `scripts/install.sh:1888,1892` - snap strip regex generalized to `['\"]?/snap/` (tolerates `'`, `"`, or unquoted)
- `scripts/install.sh:1861` - `find_system_browser` already rejects `/snap/*`, so quoted-snap stripping is defensive migration only
- `scripts/install.ps1:340` - `ConvertTo-DotEnvDoubleQuoted` using ordinal `.Replace` (not `-replace`; regex would mangle backslashes)
- `scripts/install.ps1:354,359` - both `Write-BrowserEnv` writer sites use the helper
- `tests/test_install_sh_browser_install.py` - behavioral coverage via supported `--stage config` / `--stage node-deps` boundaries (no source reading; per AGENTS.md)

## Testing

Boundary-driven tests (no installer source extraction):

```bash
scripts/run_tests.sh tests/test_install_sh_browser_install.py -q
```

On this head (`ee3b81c4a`): **14 collected** - **12 passed**, **2 xfailed (strict)** documenting the `$`/backtick shell limitation.

Coverage:

- 6 dotenv + POSIX `sh` round-trips (spaces, Windows backslash paths, apostrophe, embedded `"`)
- 2 dotenv-only cases for literal `$` / backtick paths
- 2 strict `xfail`s: POSIX `sh` cannot round-trip `$` / backtick under any dotenv-compatible double-quoted form
- 3 snap-cleanup cases (unquoted / single / double) via `--stage node-deps`
- 1 PATH autodetection negative via `--stage config`
- stderr preserved; `rc == 0` and empty stderr asserted on installer and `sh` source

Also verified:

- PowerShell helper executed under **pwsh 7.4.6** with python-dotenv round-trip (Gate A: 7/7)
- GitHub CI on `ee3b81c4a`: **23 SUCCESS / 7 SKIPPED / 1 NEUTRAL**

## Limitation

`$` / backtick paths remain shell-source hostile in any dotenv-compatible double-quoted form. Documented by strict `xfail` tests; dotenv still preserves the literal path.

## Platforms tested

- **macOS**: real installer stages + full test module
- **pwsh 7.4.6**: `ConvertTo-DotEnvDoubleQuoted` executed with dotenv round-trip
- **Windows PowerShell 5.1**: **not** run on Windows

---
Update (2026-08-04): rebased onto upstream/main
(36cb5ae55) following the triage disposition
on #57247 recommending this PR as the fix. Installer
fix content is unchanged (per-file patch-id verified
on scripts/install.sh and scripts/install.ps1). The
test file was merged with the current upstream suite:
all upstream tests retained, this PR's round-trip
suite added, and 4 earlier interim tests dropped
as superseded (mapping in the table below). All
checks green at 697baf10b. Ready for review.

| Dropped interim test | Covering successor | Behavior covered |
| --- | --- | --- |
| `test_quoted_spaced_browser_path_round_trips_under_bash` | `test_config_stage_browser_path_round_trips_through_dotenv_and_sh` | Spaced browser path survives write + shell source (bash) |
| `test_quoted_spaced_browser_path_round_trips_under_sh` | `test_config_stage_browser_path_round_trips_through_dotenv_and_sh` | Spaced browser path survives write + shell source (POSIX sh) |
| `test_quoted_browser_env_write_is_double_quoted` | `test_config_stage_browser_path_round_trips_through_dotenv_and_sh` (via `_expected_serialized_line`) | .env line is double-quoted with backslash and quote escapes |
| `test_install_script_strips_stale_snap_browser_override` | `test_node_deps_stage_strips_quoted_snap_override` | Stale Snap override stripped for unquoted/single/double forms |
| `_run_configure_and_source` (helper) | `_run_config_stage` + `_source_with_posix_sh` | Source-extract harness replaced by supported stage boundary |
