### PR TITLE
fix(tts): transcode xai ogg output paths

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -326,6 +326,40 @@ def test_generate_xai_tts_leaves_text_plain_by_default(tmp_path, monkeypatch):
     assert captured["json"]["text"] == "Bonjour Monsieur Talbot. Ceci est un test."
 
 
+def test_generate_xai_tts_transcodes_explicit_ogg_path(tmp_path, monkeypatch):
+    captured = {}
+    out = tmp_path / "out.ogg"
+    synth = tmp_path / "out.mp3"
+
+    fake_response = Mock()
+    fake_response.content = b"mp3"
+    fake_response.raise_for_status.return_value = None
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return fake_response
+
+    def fake_convert(path: str) -> str:
+        assert path == str(synth)
+        out.write_bytes(b"ogg")
+        return str(out)
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("tools.tts_tool._convert_to_opus", fake_convert)
+
+    result = _generate_xai_tts(
+        "Hello world.",
+        str(out),
+        {"xai": {"voice_id": "ara", "language": "en"}},
+    )
+
+    assert result == str(out)
+    assert synth.read_bytes() == b"mp3"
+    assert out.read_bytes() == b"ogg"
+    assert "output_format" not in captured["json"]
+
+
 def test_generate_xai_tts_omits_speed_and_latency_by_default(tmp_path, monkeypatch):
     """No speed / optimize_streaming_latency in the request body unless
     the user explicitly sets them. Keeps the existing minimal-payload

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1227,9 +1227,14 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         or DEFAULT_XAI_BASE_URL
     ).strip().rstrip("/")
 
+    wants_opus = output_path.endswith(".ogg")
+    synthesis_path = output_path
+    if wants_opus:
+        synthesis_path = output_path.rsplit(".", 1)[0] + ".mp3"
+
     # Match the documented minimal POST /v1/tts shape by default. Only send
     # output_format when Hermes actually needs a non-default format/override.
-    codec = "wav" if output_path.endswith(".wav") else "mp3"
+    codec = "wav" if synthesis_path.endswith(".wav") else "mp3"
     payload: Dict[str, Any] = {
         "text": text,
         "voice_id": voice_id,
@@ -1271,10 +1276,13 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
     )
     response.raise_for_status()
 
-    with open(output_path, "wb") as f:
+    with open(synthesis_path, "wb") as f:
         f.write(response.content)
 
-    return output_path
+    if wants_opus:
+        opus_path = _convert_to_opus(synthesis_path)
+        return opus_path or synthesis_path
+    return synthesis_path
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- synthesize xAI TTS .ogg requests to a sibling MP3 first
- transcode that MP3 with the existing Opus helper so Telegram voice targets get real OGG/Opus
- return the actual synthesized path when conversion is unavailable
- add a regression test that keeps the xAI payload on the default MP3 codec while converting the local output

Fixes #57213

## Tests
- .venv/bin/python -m pytest tests/tools/test_tts_xai_speech_tags.py -q -k "transcodes_explicit_ogg_path or omits_speed or leaves_text"
- .venv/bin/python -m ruff check tools/tts_tool.py tests/tools/test_tts_xai_speech_tags.py
- .venv/bin/python -m pytest tests/tools/test_tts_xai_speech_tags.py -q
- scripts/run_tests.sh tests/tools/test_tts_xai_speech_tags.py -q