### PR TITLE
fix(feishu): honor wildcard allowed users

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -449,6 +449,10 @@ def _sender_identity(sender: Any) -> frozenset:
     )
 
 
+def _allowlist_admits(sender_ids: frozenset, allowlist: set[str] | frozenset[str]) -> bool:
+    return "*" in allowlist or bool(sender_ids and (sender_ids & allowlist))
+
+
 # ---------------------------------------------------------------------------
 # Markdown rendering helpers
 # ---------------------------------------------------------------------------
@@ -4209,7 +4213,7 @@ class FeishuAdapter(BasePlatformAdapter):
             # Gateway auth fail-closes agent access until approval.
             if not self._allowed_group_users:
                 return None
-            if not (sender_ids and (sender_ids & self._allowed_group_users)):
+            if not _allowlist_admits(sender_ids, self._allowed_group_users):
                 return "dm_policy_rejected"
             return None
 
@@ -4266,11 +4270,11 @@ class FeishuAdapter(BasePlatformAdapter):
             return True
 
         if policy == "allowlist":
-            return bool(sender_ids and (sender_ids & allowlist))
+            return _allowlist_admits(sender_ids, allowlist)
         if policy == "blacklist":
             return bool(sender_ids and not (sender_ids & blacklist))
 
-        return bool(sender_ids and (sender_ids & self._allowed_group_users))
+        return _allowlist_admits(sender_ids, self._allowed_group_users)
 
     # --- Mention detection ----------------------------------------------------
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -419,6 +419,25 @@ def test_dm_allowlist_admits_configured_sender(monkeypatch):
     assert adapter._admit(sender, message) is None
 
 
+def test_dm_allowlist_wildcard_admits_any_sender(monkeypatch):
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    adapter = make_adapter_skeleton()
+    adapter._allowed_group_users = frozenset({"*"})
+    sender = make_sender(open_id="ou_unknown")
+    message = make_message(chat_type="p2p")
+    assert adapter._admit(sender, message) is None
+
+
+def test_group_allowlist_wildcard_admits_any_mentioned_sender():
+    adapter = make_adapter_skeleton(group_policy="allowlist")
+    adapter._allowed_group_users = frozenset({"*"})
+    stub_mention(adapter, True)
+    sender = make_sender(open_id="ou_unknown")
+    message = make_message(chat_type="group")
+    assert adapter._admit(sender, message) is None
+
+
 def test_admit_skips_mention_check_under_all_mode():
     # Tripwire: under allow_bots=all the mention path must not be probed.
     adapter = make_adapter_skeleton(bot_open_id="ou_self", allow_bots="all")


### PR DESCRIPTION
## Summary
- treat FEISHU_ALLOWED_USERS=* as allow-all during inbound admission
- reuse the wildcard-aware allowlist check for DM and group allowlist paths
- add regression coverage for wildcard DMs and mentioned group messages

Fixes #57202

## Tests
- .venv/bin/python -m pytest tests/gateway/test_feishu_bot_admission.py -q -k "wildcard or dm_allowlist"
- .venv/bin/python -m ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu_bot_admission.py
- .venv/bin/python -m pytest tests/gateway/test_feishu_bot_admission.py -q
- scripts/run_tests.sh tests/gateway/test_feishu_bot_admission.py -q