### PR TITLE
feat(credential-pool): opt-in preemptive key rotation + footer credential field

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2927,4 +2927,51 @@ __all__ = [
     "apply_pending_steer_to_tool_results",
     "_iter_pool_sockets",
     "force_close_tcp_sockets",
+    "preemptive_rotate_credential",
 ]
+
+
+def preemptive_rotate_credential(agent) -> None:
+    """Advance the round_robin/least_used credential cursor once per API call.
+
+    Hermes' credential pool is reactive by default: it only rotates to the
+    next key inside the 429/401 error-recovery path, so a single long-running
+    session keeps hitting one key until it is rate-limited. When
+    ``HERMES_PREEMPTIVE_KEY_ROTATION`` is truthy, this helper is invoked at the
+    top of every conversation-loop iteration to select the next pool entry
+    *before* the request is sent, spreading load across all keys.
+
+    Opt-in and inert by default. Only fires for API-key pools using the
+    ``round_robin`` or ``least_used`` strategies with at least one available
+    entry; OAuth / single-key / ``fill_first`` providers are never touched.
+    Every error is swallowed so a rotation hiccup can never break the turn.
+    """
+    if not env_var_enabled("HERMES_PREEMPTIVE_KEY_ROTATION"):
+        return
+    try:
+        from agent.credential_pool import (
+            STRATEGY_ROUND_ROBIN,
+            STRATEGY_LEAST_USED,
+        )
+
+        pool = getattr(agent, "_credential_pool", None)
+        if pool is None or not pool.has_available():
+            return
+        if getattr(pool, "_strategy", None) not in (
+            STRATEGY_ROUND_ROBIN,
+            STRATEGY_LEAST_USED,
+        ):
+            return
+        entry = pool.select()
+        if entry is None:
+            return
+        if getattr(entry, "runtime_api_key", None) or getattr(
+            entry, "access_token", ""
+        ):
+            agent._swap_credential(entry)
+            logger.debug(
+                "credential pool: preemptive rotation -> %s",
+                entry.label or entry.id[:8],
+            )
+    except Exception as exc:  # never let rotation break the turn
+        logger.debug("preemptive credential rotation skipped: %s", exc)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -626,6 +626,13 @@ def run_conversation(
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
 
+        # Preemptive per-turn credential rotation (opt-in via env
+        # HERMES_PREEMPTIVE_KEY_ROTATION). No-op unless enabled; spreads load
+        # across pool keys before a request is sent instead of only rotating
+        # reactively on a 429. See agent_runtime_helpers.preemptive_rotate_credential.
+        from agent.agent_runtime_helpers import preemptive_rotate_credential as _preempt_rotate
+        _preempt_rotate(agent)
+
         # Grace call: the budget is exhausted but we gave the model one
         # more chance.  Consume the grace flag so the loop exits after
         # this iteration regardless of outcome.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10605,6 +10605,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
+                _cred_label = ""
+                try:
+                    _fa = self._running_agents.get(session_key)
+                    if _fa is None or _fa is _AGENT_PENDING_SENTINEL:
+                        _fc = self._agent_cache.get(session_key)
+                        _fa = _fc[0] if isinstance(_fc, tuple) else _fc
+                    _fp = getattr(_fa, "_credential_pool", None) if _fa else None
+                    _fcur = _fp.current() if _fp is not None else None
+                    if _fcur is not None:
+                        _cred_label = _fcur.label or _fcur.id[:8]
+                except Exception:
+                    _cred_label = ""
                 from gateway.runtime_footer import build_footer_line as _bfl
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
@@ -10613,6 +10625,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    credential=_cred_label,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -94,6 +94,7 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    credential: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -115,6 +116,9 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "credential":
+            if credential:
+                parts.append(f"🔑 {credential}")
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -130,6 +134,7 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    credential: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -145,5 +150,6 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        credential=credential,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )


### PR DESCRIPTION
# feat(credential-pool): opt-in preemptive key rotation + footer credential field

## Problem
The credential pool rotates **reactively only** — `pool.select()` is consulted
inside the 429/401 error-recovery path (`recover_with_credential_pool`) and on
session restore, never per-request in the mainline loop. With `round_robin` /
`least_used` configured, a single long-running session keeps sending every
request on the same key until it is rate-limited, then rotates. Operators with
a pool of N keys expect the load to spread across all N proactively.

Long-standing, still-open request: #22212, #22407, #22916.

## Changes

**1. Preemptive rotation** (`HERMES_PREEMPTIVE_KEY_ROTATION`, default off)
`run_conversation` calls a new helper at the top of every loop iteration:
`agent_runtime_helpers.preemptive_rotate_credential(agent)` advances the pool
cursor via the existing `pool.select()` and swaps the credential in with the
existing `agent._swap_credential(entry)` — the same primitives the restore path
already uses. No new rotation logic.

**2. Footer credential field**
`gateway/runtime_footer.py` gains an optional `credential` field; `gateway/run.py`
resolves the active pooled credential label (from the cached/running agent's
pool) and passes it in. Lets operators see which pooled key served each turn:
```yaml
display:
  runtime_footer:
    fields: [model, credential, context_pct, cwd]
```

## Safety / scope
- **Inert by default.** Flag unset → helper returns immediately; footer field
  only renders when added to `fields`. Zero behavior change for existing setups.
- **Narrow trigger.** Rotation only fires for `round_robin` / `least_used`
  api-key pools with an available entry. OAuth, single-key, and `fill_first`
  providers are never touched.
- **Never breaks a turn.** Both the rotation helper and the footer lookup are
  fully wrapped; any exception is swallowed (debug-logged).
- Reuses `pool.select()` + `agent._swap_credential()` — no changes to
  `credential_pool.py` semantics.

## Testing
- `round_robin` `pool.select()` returns a distinct entry per call across a
  20-key pool (20/20 distinct over one cycle, then wraps).
- Verified end-to-end on a live Telegram gateway: consecutive turns rotated
  across distinct keys, surfaced in the footer (`🔑 api-key-9` → `api-key-17`
  → `NIM Key 3`).
- Gateway and headless backend (`hermes serve`) boot cleanly with the flag on;
  flag off is a verified no-op.
- `py_compile` clean on all four touched files.

## Notes
Env-flag chosen over a config key to keep the surface minimal and the default
untouched; happy to move rotation behind `credential_pool_strategies` / a config
option if maintainers prefer that shape.
