### PR TITLE
feat(model-picker): per-model descriptions in Telegram and desktop pickers

### DIFF
--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -205,6 +205,7 @@ function ModelResults({
               const isCurrent = model === currentModel && provider.slug === currentProvider
               const price = provider.pricing?.[model]
               const locked = unavailable.has(model)
+              const description = provider.descriptions?.[model]
 
               return (
                 <CommandItem
@@ -223,7 +224,19 @@ function ModelResults({
                   }}
                   value={`${provider.slug}:${model}`}
                 >
-                  <span className="min-w-0 flex-1 truncate">{model}</span>
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate">{model}</span>
+                    {description && (
+                      <span
+                        className={cn(
+                          'block truncate font-sans text-[0.68rem] leading-tight',
+                          isCurrent ? 'opacity-80' : 'text-muted-foreground'
+                        )}
+                      >
+                        {description}
+                      </span>
+                    )}
+                  </div>
                   {locked && (
                     <span className="shrink-0 text-[0.62rem] uppercase tracking-wide opacity-80">{copy.pro}</span>
                   )}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -273,6 +273,9 @@ export interface ModelOptionProvider {
   /** Per-model option support, keyed by model id (present when the picker
    *  requested capabilities). Lets the UI gate fast/reasoning controls. */
   capabilities?: Record<string, ModelCapabilities>
+  /** Per-model description/tagline keyed by model id (sourced from
+   *  `models.<id>.description` in config). Rendered under the model name. */
+  descriptions?: Record<string, string>
 }
 
 export interface ModelCapabilities {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1974,6 +1974,15 @@ def list_authenticated_providers(
                     if m and m not in models_list:
                         models_list.append(m)
 
+            # Optional per-model ``description`` annotations from
+            # ``providers.<slug>.models.<id>.description`` — surfaced in the
+            # picker so users can label what each configured model is best for.
+            model_descriptions: dict = {}
+            if isinstance(cfg_models, dict):
+                for _mid, _mv in cfg_models.items():
+                    if isinstance(_mv, dict) and _mv.get("description"):
+                        model_descriptions[_mid] = str(_mv["description"])
+
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.
             if not models_list:
@@ -2025,6 +2034,7 @@ def list_authenticated_providers(
                 "total_models": len(models_list) if models_list else 0,
                 "source": "user-config",
                 "api_url": api_url,
+                "descriptions": model_descriptions,
             })
             seen_slugs.add(ep_name.lower())
             seen_slugs.add(custom_provider_slug(display_name).lower())
@@ -2187,6 +2197,15 @@ def list_authenticated_providers(
                     if m and m not in groups[group_key]["models"]:
                         groups[group_key]["models"].append(m)
 
+            # Accumulate optional per-model ``description`` annotations
+            # (custom_providers[].models.<id>.description) across entries in
+            # this grouped row, surfaced in the picker.
+            if isinstance(cfg_models, dict):
+                _grp_desc = groups[group_key].setdefault("descriptions", {})
+                for _mid, _mv in cfg_models.items():
+                    if isinstance(_mv, dict) and _mv.get("description") and _mid not in _grp_desc:
+                        _grp_desc[_mid] = str(_mv["description"])
+
         _section4_emitted_slugs: set = set()
         _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
         _current_base_url_group_count = sum(
@@ -2294,6 +2313,7 @@ def list_authenticated_providers(
                 "total_models": len(grp["models"]),
                 "source": "user-config",
                 "api_url": grp["api_url"],
+                "descriptions": grp.get("descriptions", {}),
             })
             seen_slugs.add(slug.lower())
             _section4_emitted_slugs.add(slug.lower())

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4807,6 +4807,28 @@ class TelegramAdapter(BasePlatformAdapter):
         page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
         return InlineKeyboardMarkup(rows), page_info
 
+    def _build_model_legend(self, provider: dict, models: list) -> str:
+        """Return a MarkdownV2-ready legend of per-model descriptions.
+
+        Uses the ``descriptions`` map on the picker payload row (sourced from
+        ``models.<id>.description`` in config). Empty string when there are
+        none, so providers without descriptions are unaffected. Best-effort:
+        any error yields no legend rather than breaking the picker.
+        """
+        try:
+            desc_map = provider.get("descriptions") if isinstance(provider, dict) else None
+            if not isinstance(desc_map, dict) or not desc_map:
+                return ""
+            lines: list = []
+            for mid in models:
+                desc = desc_map.get(mid)
+                if desc:
+                    short = mid.split("/")[-1] if "/" in mid else mid
+                    lines.append(f"`{short}` — {desc}")
+            return ("\n\n" + "\n".join(lines)) if lines else ""
+        except Exception:
+            return ""
+
     async def _handle_model_picker_callback(
         self, query, data: str, chat_id: str
     ) -> None:
@@ -4845,13 +4867,14 @@ class TelegramAdapter(BasePlatformAdapter):
             total = provider.get("total_models", len(models))
             shown = len(models)
             extra = f"\n_{total - shown} more available — type `/model <name>` directly_" if total > shown else ""
+            legend = self._build_model_legend(provider, models)
 
             await query.edit_message_text(
                 text=self.format_message(
                     (
                         f"⚙ *Model Configuration*\n\n"
                         f"Provider: *{pname}*{page_info}\n"
-                        f"Select a model:{extra}"
+                        f"Select a model:{extra}{legend}"
                     )
                 ),
                 parse_mode=ParseMode.MARKDOWN_V2,
@@ -4881,13 +4904,14 @@ class TelegramAdapter(BasePlatformAdapter):
             total = provider.get("total_models", len(models)) if provider else len(models)
             shown = len(models)
             extra = f"\n_{total - shown} more available — type `/model <name>` directly_" if total > shown else ""
+            legend = self._build_model_legend(provider or {}, models)
 
             await query.edit_message_text(
                 text=self.format_message(
                     (
                         f"⚙ *Model Configuration*\n\n"
                         f"Provider: *{pname}*{page_info}\n"
-                        f"Select a model:{extra}"
+                        f"Select a model:{extra}{legend}"
                     )
                 ),
                 parse_mode=ParseMode.MARKDOWN_V2,

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -69,6 +69,53 @@ def test_list_authenticated_providers_can_skip_custom_provider_live_probe(monkey
     assert row["total_models"] == 1
 
 
+def test_custom_provider_model_descriptions_surface(monkeypatch):
+    """``models.<id>.description`` flows into the picker row's ``descriptions``.
+
+    Covers both the user ``providers:`` dict path and the ``custom_providers:``
+    list path. Models without a description are simply omitted from the map.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    # providers: dict path — discovery off keeps the explicit model subset.
+    via_providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={
+            "custom:mynim": {
+                "base_url": "https://example.com/v1",
+                "discover_models": False,
+                "models": {
+                    "vendor/alpha": {"description": "great for code"},
+                    "vendor/beta": {},
+                },
+            }
+        },
+        custom_providers=[],
+        max_models=50,
+    )
+    row = next(p for p in via_providers if p["slug"] == "custom:mynim")
+    assert row["descriptions"] == {"vendor/alpha": "great for code"}
+    assert set(row["models"]) == {"vendor/alpha", "vendor/beta"}
+
+    # custom_providers: list path.
+    via_custom = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "mynim2",
+                "base_url": "https://example2.com/v1",
+                "discover_models": False,
+                "models": {"vendor/gamma": {"description": "fast"}},
+            }
+        ],
+        max_models=50,
+    )
+    row2 = next(p for p in via_custom if p["slug"] == "custom:mynim2")
+    assert row2["descriptions"] == {"vendor/gamma": "fast"}
+
+
 def test_resolve_provider_full_finds_named_custom_provider():
     """Explicit /model --provider should resolve saved custom_providers entries."""
     resolved = resolve_provider_full(


### PR DESCRIPTION
# feat(model-picker): per-model descriptions in Telegram and desktop pickers

## What
Let users annotate their configured models with a short description that
shows up in the model picker, so a `/model` menu reads:

```
kimi-k2.6 — great for code + reasoning
deepseek-v4-flash — fast, cheap coding
nemotron-3-ultra-550b — strong reasoning, very fast
```

Descriptions come from the existing per-model config block:
```yaml
providers:
  custom:nvidia-nim:
    models:
      moonshotai/kimi-k2.6: { description: "great for code + reasoning" }
      deepseek-ai/deepseek-v4-flash: { description: "fast, cheap coding" }
```
(the `custom_providers:` list form is supported too).

## How
- **`hermes_cli/model_switch.py`** — `list_authenticated_providers` collects
  `models.<id>.description` into a `descriptions` `{model_id: text}` map and
  attaches it to user-defined provider rows. Both `list_picker_providers`
  (Telegram/CLI) and `build_models_payload` (desktop) already pass row fields
  through, so both surfaces get it from one place.
- **Telegram** (`plugins/platforms/telegram/adapter.py`) — `/model` renders
  the descriptions as a legend above the model buttons (code-span model name +
  text, escaped by the existing MarkdownV2 formatter; buttons stay short).
- **Desktop** (`apps/desktop/src/…`) — `ModelOptionProvider` gains an optional
  `descriptions?: Record<string, string>`; the picker renders each description
  as a muted line under the model name (mirrors the existing pricing/capability
  affordances).

## Safety / scope
- Purely additive and opt-in: providers without descriptions get an empty map,
  so no legend (Telegram) and no extra line (desktop) render — zero change for
  existing setups.
- No change to model resolution or selection; `descriptions` is display-only.

## Testing
- New test `test_custom_provider_model_descriptions_surface` asserts
  descriptions surface via both the `providers:` dict and `custom_providers:`
  list paths (models without a description are omitted from the map).
- Verified end-to-end on a live Telegram gateway: `/model` shows the legend
  for a custom provider's configured models.

## Note
The desktop TS/React change follows the existing picker patterns
(`pricing` / `capabilities`), but was not exercised through a full Electron
renderer build in this branch — worth a quick visual check when building the
desktop app.
