### PR TITLE
fix(logging): suppress disk-full log tracebacks

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -29,6 +29,7 @@ Session context:
 
 import atexit
 import copy
+import errno
 import io
 import logging
 import os
@@ -137,6 +138,10 @@ def _is_windows_concurrent_log_lock_timeout(exc: BaseException | None) -> bool:
         and isinstance(exc, RuntimeError)
         and _CONCURRENT_LOG_LOCK_TIMEOUT in str(exc)
     )
+
+
+def _is_no_space_left(exc: BaseException | None) -> bool:
+    return isinstance(exc, OSError) and getattr(exc, "errno", None) == errno.ENOSPC
 
 
 # Third-party loggers that are noisy at DEBUG/INFO level.
@@ -530,7 +535,7 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         the stdlib handler prints it to stderr (which, under the Desktop
         slash-worker, is captured and surfaced into chat output)."""
         exc = sys.exc_info()[1]
-        if _is_windows_concurrent_log_lock_timeout(exc):
+        if _is_windows_concurrent_log_lock_timeout(exc) or _is_no_space_left(exc):
             return
         super().handleError(record)
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1,4 +1,5 @@
 """Tests for hermes_logging — centralized logging setup."""
+import errno
 import io
 import logging
 import os
@@ -858,6 +859,38 @@ class TestWindowsConcurrentLogLockTimeout:
         finally:
             logger.removeHandler(handler)
             handler.close()
+
+    def test_enospc_through_queued_handler_is_suppressed(self, tmp_path, capsys):
+        """Disk-full failures stay silent through the production queue path."""
+        hermes_logging.setup_logging(hermes_home=tmp_path)
+        handler = next(
+            item
+            for item in hermes_logging.rotating_file_handlers()
+            if Path(item.baseFilename).name == "agent.log"
+        )
+        original_stream = handler.stream
+
+        class FullDiskStream:
+            def write(self, _message):
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            def flush(self):
+                pass
+
+            def close(self):
+                pass
+
+        try:
+            handler.stream = FullDiskStream()
+            with patch.object(handler, "shouldRollover", return_value=False):
+                logging.getLogger("debug.share").info("debug share upload")
+                hermes_logging.flush_log_queue()
+
+            captured = capsys.readouterr()
+            assert "No space left on device" not in captured.err
+            assert "--- Logging error ---" not in captured.err
+        finally:
+            handler.stream = original_stream
 
     def test_other_errors_routed_to_handle_error_still_print(self, tmp_path, capsys):
         """An unrelated failure routed through ``handleError`` must still emit the


### PR DESCRIPTION
## Summary
- detect ENOSPC in Hermes' managed rotating log handler error path
- suppress disk-full logging tracebacks so support commands like hermes debug share can still print their useful upload result
- keep unrelated logging failures visible through the normal logging error path

Fixes #57209

## Tests
- .venv/bin/python -m pytest tests/test_hermes_logging.py -q -k "handle_error or enospc or concurrent_lock"
- .venv/bin/python -m ruff check hermes_logging.py tests/test_hermes_logging.py
- .venv/bin/python -m pytest tests/test_hermes_logging.py -q
- scripts/run_tests.sh tests/test_hermes_logging.py -q