### PR TITLE
fix(desktop): read attachment previews local-first in remote mode (follow-up to #56572)

### DIFF
--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { type DroppedFile, extractDroppedFiles, HERMES_PATHS_MIME, partitionDroppedFiles } from './use-composer-actions'
+import { $connection } from '@/store/session'
+
+import {
+  attachmentPreviewDataUrl,
+  type DroppedFile,
+  extractDroppedFiles,
+  HERMES_PATHS_MIME,
+  partitionDroppedFiles
+} from './use-composer-actions'
 
 // A Finder/Explorer drop carries a native File handle; an in-app drag (project
 // tree, gutter line ref) is path-only. The split decides whether a drop becomes
@@ -176,5 +184,63 @@ describe('extractDroppedFiles', () => {
 
     expect(result).toHaveLength(1)
     expect(result[0]?.isDirectory).toBe(true)
+  })
+})
+
+describe('attachmentPreviewDataUrl', () => {
+  const LOCAL_PREVIEW = 'data:image/png;base64,bG9jYWw='
+  const REMOTE_PREVIEW = 'data:image/png;base64,cmVtb3Rl'
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    $connection.set(null)
+  })
+
+  it('reads a local path via the local bridge even in remote mode (paperclip/paste/OS drop)', async () => {
+    const readFileDataUrl = vi.fn(async () => LOCAL_PREVIEW)
+    const api = vi.fn()
+
+    vi.stubGlobal('window', { hermesDesktop: { api, readFileDataUrl } })
+    $connection.set({ mode: 'remote' } as never)
+
+    await expect(attachmentPreviewDataUrl('/Users/me/Pictures/pic.png')).resolves.toBe(LOCAL_PREVIEW)
+
+    expect(readFileDataUrl).toHaveBeenCalledWith('/Users/me/Pictures/pic.png')
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the remote fs bridge when the path is not on this machine (project-tree drag)', async () => {
+    const readFileDataUrl = vi.fn(async () => {
+      throw new Error('ENOENT')
+    })
+
+    const api = vi.fn(async ({ path }: { path: string }) => {
+      if (path.startsWith('/api/fs/read-data-url?')) {
+        return { dataUrl: REMOTE_PREVIEW }
+      }
+
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    vi.stubGlobal('window', { hermesDesktop: { api, readFileDataUrl } })
+    $connection.set({ mode: 'remote' } as never)
+
+    await expect(attachmentPreviewDataUrl('/home/gateway/shot.png')).resolves.toBe(REMOTE_PREVIEW)
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/fs/read-data-url?path=%2Fhome%2Fgateway%2Fshot.png'
+    })
+  })
+
+  it('falls back when the local bridge returns an empty read', async () => {
+    const readFileDataUrl = vi.fn(async () => '')
+
+    const api = vi.fn(async () => ({ dataUrl: REMOTE_PREVIEW }))
+
+    vi.stubGlobal('window', { hermesDesktop: { api, readFileDataUrl } })
+    $connection.set({ mode: 'remote' } as never)
+
+    await expect(attachmentPreviewDataUrl('/home/gateway/shot.png')).resolves.toBe(REMOTE_PREVIEW)
   })
 })

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -39,6 +39,29 @@ export function isImagePath(filePath: string): boolean {
   return IMAGE_EXTENSION_PATTERN.test(filePath)
 }
 
+/**
+ * Read an attachment's thumbnail preview, local disk first. Paperclip picks,
+ * clipboard saves, and OS drops always hand us paths on THIS machine — the
+ * remote-routed fs facade would 404 them against the gateway and toast a bogus
+ * "preview failed" even though the attach itself works (upload reads local
+ * bytes too). In-app drags from the remote project tree are the opposite case:
+ * the local read fails there, so fall back to the facade (remote fs bridge).
+ * In local mode the facade IS the local bridge, so this stays a single read.
+ */
+export async function attachmentPreviewDataUrl(filePath: string): Promise<string> {
+  try {
+    const local = await window.hermesDesktop?.readFileDataUrl?.(filePath)
+
+    if (local) {
+      return local
+    }
+  } catch {
+    // Not on this machine (or unreadable locally) — try the gateway.
+  }
+
+  return readDesktopFileDataUrl(filePath)
+}
+
 export interface DroppedFile {
   /** Browser-native File handle. Absent for in-app drags (e.g. project tree). */
   file?: File
@@ -367,7 +390,7 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
       attachToMain(baseAttachment)
 
       try {
-        const previewUrl = await readDesktopFileDataUrl(filePath)
+        const previewUrl = await attachmentPreviewDataUrl(filePath)
 
         if (previewUrl) {
           addComposerAttachment({ ...baseAttachment, previewUrl })


### PR DESCRIPTION
## Summary

Follow-up to #56572 (restored remote paperclip picking). The attach itself works in remote mode because the upload path reads bytes through the local Electron bridge — but the thumbnail preview in `attachImagePath` reads through `readDesktopFileDataUrl`, which remote-routes every read to the gateway fs bridge. For paperclip picks, clipboard pastes, and OS drops the path is on the **local** machine, so the gateway read 404s: the user gets an "image preview failed" toast and no thumbnail on every remote-mode image attach, even though the attachment uploads fine.

New `attachmentPreviewDataUrl` helper: try the local bridge first, fall back to the remote facade. The fallback still serves the one caller that legitimately passes gateway paths — image drags from the remote project tree (`attachDroppedItems` path-only entries). Local mode is unchanged: the facade already reads the local disk there, so the local-first read just short-circuits it.

## Validation

- `use-composer-actions` suite: 13/13 (3 new — local-first in remote mode, remote fallback for project-tree paths, empty-read fallback)
- `tsc --noEmit` clean, eslint clean

## Test plan

- [x] Remote mode: paperclip-pick a local image → thumbnail renders, no error toast
- [x] Remote mode: drag an image from the remote project tree → thumbnail served by the gateway fs bridge
- [x] Local mode unchanged