### PR TITLE
fix: transform_llm_output appended content silently dropped in CLI streaming mode

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -335,6 +335,7 @@ def finalize_turn(
             logger.debug("turn-completion explainer failed: %s", _exp_err)
 
     _response_transformed = False
+    _pre_transform_response = None
 
     # Plugin hook: transform_llm_output
     # Fired once per turn after the tool-calling loop completes.
@@ -352,6 +353,7 @@ def finalize_turn(
             )
             for _hook_result in _transform_results:
                 if isinstance(_hook_result, str) and _hook_result:
+                    _pre_transform_response = final_response
                     final_response = _hook_result
                     _response_transformed = True
                     break  # First non-empty string wins
@@ -408,6 +410,7 @@ def finalize_turn(
         "partial": False,  # True only when stopped due to invalid tool calls
         "interrupted": interrupted,
         "response_transformed": _response_transformed,
+        "pre_transform_response": _pre_transform_response,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
         "model": agent.model,
         "provider": agent.provider,

--- a/cli.py
+++ b/cli.py
@@ -2412,6 +2412,25 @@ def _render_final_assistant_content(text: str, mode: str = "render"):
     return Markdown(plain)
 
 
+def _post_stream_transform_output(response: str, result: dict | None) -> str:
+    """Return text that still needs display after a streamed response transform.
+
+    A transform hook is allowed to replace the final response, not merely append
+    to it. When the transformed text retains the streamed response as a prefix,
+    printing only its suffix avoids duplicating the already-rendered body. A
+    replacement has no safe suffix, so deliberately print the complete final
+    response rather than silently dropping it.
+    """
+    if not result or not result.get("response_transformed"):
+        return ""
+
+    original = result.get("pre_transform_response") or ""
+    if original and response.startswith(original):
+        return response[len(original):]
+
+    return f"\n[Response transformed after streaming]\n{response}"
+
+
 _OUTPUT_HISTORY_ENABLED = True
 _OUTPUT_HISTORY_REPLAYING = False
 _OUTPUT_HISTORY_SUPPRESSED = False
@@ -12398,13 +12417,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 elif already_streamed:
                     # Response was already streamed token-by-token with box framing;
                     # _flush_stream() already closed the box. Skip Rich Panel.
-                    # If a plugin appended content (shout, trace) after streaming,
-                    # print only the appended portion now.
-                    if result and result.get("response_transformed"):
-                        _pre = result.get("pre_transform_response") or ""
-                        _appended = response[len(_pre):]
-                        if _appended.strip():
-                            _cprint(_appended)
+                    # A transform hook runs after streaming. Show a suffix for
+                    # append-only changes, or the complete replacement otherwise.
+                    _post_stream_text = _post_stream_transform_output(response, result)
+                    if _post_stream_text.strip():
+                        _cprint(_post_stream_text)
                 else:
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(

--- a/cli.py
+++ b/cli.py
@@ -12398,7 +12398,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 elif already_streamed:
                     # Response was already streamed token-by-token with box framing;
                     # _flush_stream() already closed the box. Skip Rich Panel.
-                    pass
+                    # If a plugin appended content (shout, trace) after streaming,
+                    # print only the appended portion now.
+                    if result and result.get("response_transformed"):
+                        _pre = result.get("pre_transform_response") or ""
+                        _appended = response[len(_pre):]
+                        if _appended.strip():
+                            _cprint(_appended)
                 else:
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -30,6 +30,8 @@ Context dict passed to ``agent:start`` / ``agent:end`` handlers:
 
 ``agent:end`` adds:
   response     -- agent response text (truncated to 500 chars)
+  model        -- model name that handled the turn
+  provider     -- provider that handled the turn
 
 Handlers posting a follow-up into the same Telegram forum-topic should
 include ``message_thread_id=int(thread_id)`` when ``chat_type == "forum"``

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11086,6 +11086,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 **hook_ctx,
                 "response": (response or "")[:500],
                 "model": agent_result.get("model", "") if agent_result else "",
+                "provider": agent_result.get("provider", "") if agent_result else "",
             })
             
             # Check for pending process watchers (check_interval on background processes)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11085,6 +11085,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
                 "response": (response or "")[:500],
+                "model": agent_result.get("model", "") if agent_result else "",
             })
             
             # Check for pending process watchers (check_interval on background processes)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -385,6 +385,7 @@ AUTHOR_MAP = {
     "frowte3k@gmail.com": "Frowtek",
     "211828103+julio-cloudvisor@users.noreply.github.com": "julio-cloudvisor",
     "17778+kweiner@users.noreply.github.com": "kweiner",
+    "ken@kenweiner.com": "kweiner",
     "223516181+faisfamilytravel@users.noreply.github.com": "faisfamilytravel",
     "45189813+baofuen@users.noreply.github.com": "baofuen",
     "interstellar.consulting@gmail.com": "Interstellar-code",

--- a/tests/cli/test_transformed_stream_output.py
+++ b/tests/cli/test_transformed_stream_output.py
@@ -1,0 +1,31 @@
+"""Regression coverage for CLI delivery after transform_llm_output streaming."""
+
+from cli import _post_stream_transform_output
+
+
+def test_streamed_transform_prints_only_appended_suffix():
+    output = _post_stream_transform_output(
+        "original answer\n\n[plugin appended this]",
+        {
+            "response_transformed": True,
+            "pre_transform_response": "original answer",
+        },
+    )
+
+    assert output == "\n\n[plugin appended this]"
+
+
+def test_streamed_transform_prints_full_replacement_instead_of_dropping_it():
+    output = _post_stream_transform_output(
+        "XYZ",
+        {
+            "response_transformed": True,
+            "pre_transform_response": "abc",
+        },
+    )
+
+    assert output == "\n[Response transformed after streaming]\nXYZ"
+
+
+def test_untransformed_stream_has_no_post_stream_output():
+    assert _post_stream_transform_output("original answer", {}) == ""

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -163,3 +163,35 @@ async def test_prose_mentioning_silence_token_is_delivered(monkeypatch, tmp_path
     )
 
     assert response == text
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_includes_model_and_provider(monkeypatch, tmp_path):
+    """Gateway hooks receive the actual model/provider for post-turn routing."""
+    runner = _runner(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(return_value={
+        "final_response": "done",
+        "messages": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": False,
+        "model": "gpt-5.6-terra",
+        "provider": "openai-codex",
+    })
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    end_context = next(
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    )
+    assert end_context["model"] == "gpt-5.6-terra"
+    assert end_context["provider"] == "openai-codex"

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1264,6 +1264,11 @@ def my_callback(
 
 **Use cases:** Apply a personality/vocabulary transform (pirate-speak, Spongebob), redact user-specific identifiers from the final text, append a project-specific signature footer, enforce a house style guide without burning tokens on SOUL instructions.
 
+When CLI streaming is enabled, an append-only transform is printed after the
+streamed body. A transform that replaces the response is printed in full after
+the streamed body, labeled as a post-stream transformation, so replacement
+content is never silently lost.
+
 ```python
 import os, re
 


### PR DESCRIPTION
## What does this PR do?

Fixes two related gaps in the plugin hook system:

1. **`transform_llm_output` output is dropped in CLI streaming mode.** When the CLI streams a response token-by-token, it marks the response as already displayed. `transform_llm_output` fires after streaming completes, but any content the plugin appended is never shown to the user — the `already_streamed` branch just executes `pass`. The fix tracks the pre-transform response in `finalize_turn()` and uses it in the CLI to print only the appended suffix after streaming, without re-printing the streamed body.

2. **`model` and `provider` are missing from the `agent:end` hook payload.** Gateway hook plugins have no way to know which LLM model or provider handled the turn. `finalize_turn()` already returns these in the result dict, but they weren't forwarded to the `agent:end` emit. Two-line fix.

## Related Issue

Fixes #57269

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_finalizer.py` — initialize `_pre_transform_response = None`; set it to the current response value immediately before applying a plugin transform; include it in the result dict alongside the existing `response_transformed` flag.
- `cli.py` — in the `already_streamed` branch, check `result.get("response_transformed")`; if true, compute the appended suffix (`response[len(pre):]`) and print it with `_cprint`.
- `gateway/run.py` — add `"model"` and `"provider"` from `agent_result` to the `agent:end` hook payload.

All three changes are backwards-compatible. When no plugin transforms the response, `pre_transform_response` is `None` and the `already_streamed` branch behaves exactly as before.

## How to Test

**Streaming fix:**
1. Create a minimal plugin that implements `transform_llm_output` and appends a fixed string (e.g. `"\n\n[appended by plugin]"`) to the response.
2. Install and enable the plugin: `hermes plugins install file:///path/to/plugin --enable`
3. Run `hermes` in interactive CLI mode and send any message.
4. Confirm the appended string appears in the terminal after the streamed response.
5. Confirm the streamed body is not duplicated.

**agent:end payload fix:**
1. Create a minimal gateway hook that logs `context.get("model")` and `context.get("provider")` inside the `agent:end` handler.
2. Send a message through the gateway.
3. Confirm both fields are populated in the hook context.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact — changes are pure Python with no platform-specific behavior