### PR TITLE
fix(memory): forward reranker config and rerank param in OSSBackend

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -123,6 +123,8 @@ class OSSBackend(Mem0Backend):
             "embedder": oss_config["embedder"],
             "version": "v1.1",
         }
+        if "reranker" in oss_config:
+            config["reranker"] = oss_config["reranker"]
         self._memory = Memory.from_config(config)
 
     @staticmethod
@@ -190,7 +192,7 @@ class OSSBackend(Mem0Backend):
                 pass
 
     def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = True) -> list[dict]:
-        response = self._memory.search(query, filters=filters, top_k=top_k)
+        response = self._memory.search(query, filters=filters, top_k=top_k, rerank=rerank)
         return _unwrap_results(response)
 
     def get_all(self, *, filters: dict, page: int = 1, page_size: int = 100) -> dict:

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -157,11 +157,69 @@ class TestOSSBackend:
         assert memory.calls[0][2]["filters"] == {"user_id": "u1"}
         assert memory.calls[0][2]["top_k"] == 3
 
-    def test_search_ignores_rerank(self):
-        """OSS backend accepts rerank param but does not forward it to Memory."""
+    def test_search_forwards_rerank(self):
+        """OSS backend forwards rerank param to Memory.search()."""
         backend, memory = self._make()
         backend.search("q", filters={}, rerank=True)
-        assert "rerank" not in memory.calls[0][2]
+        assert memory.calls[0][2]["rerank"] is True
+
+    def test_search_forwards_rerank_false(self):
+        backend, memory = self._make()
+        backend.search("q", filters={}, rerank=False)
+        assert memory.calls[0][2]["rerank"] is False
+
+    def test_init_forwards_reranker_config(self):
+        """OSSBackend.__init__ forwards reranker config to Memory.from_config()."""
+        import sys
+        import unittest.mock as mock
+
+        captured_configs = []
+
+        def fake_from_config(config):
+            captured_configs.append(config)
+            return FakeOSSMemory()
+
+        mock_mem0 = mock.MagicMock()
+        mock_mem0.Memory.from_config = fake_from_config
+
+        oss_config = {
+            "vector_store": {"provider": "qdrant", "config": {"path": "/tmp/test"}},
+            "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+            "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small", "embedding_dims": 1536}},
+            "reranker": {"provider": "cohere", "config": {"model": "rerank-v3.5"}},
+        }
+
+        with mock.patch.dict(sys.modules, {"mem0": mock_mem0}):
+            backend = OSSBackend(oss_config)
+
+        assert len(captured_configs) == 1
+        assert "reranker" in captured_configs[0]
+        assert captured_configs[0]["reranker"] == {"provider": "cohere", "config": {"model": "rerank-v3.5"}}
+
+    def test_init_omits_reranker_when_absent(self):
+        """OSSBackend.__init__ omits reranker key when not in config."""
+        import sys
+        import unittest.mock as mock
+
+        captured_configs = []
+
+        def fake_from_config(config):
+            captured_configs.append(config)
+            return FakeOSSMemory()
+
+        mock_mem0 = mock.MagicMock()
+        mock_mem0.Memory.from_config = fake_from_config
+
+        oss_config = {
+            "vector_store": {"provider": "qdrant", "config": {"path": "/tmp/test"}},
+            "llm": {"provider": "openai", "config": {"model": "gpt-4o-mini"}},
+            "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small", "embedding_dims": 1536}},
+        }
+
+        with mock.patch.dict(sys.modules, {"mem0": mock_mem0}):
+            backend = OSSBackend(oss_config)
+
+        assert "reranker" not in captured_configs[0]
 
     def test_get_all_ignores_pagination(self):
         """OSSBackend accepts page/page_size but does NOT forward to Memory.get_all()."""


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `OSSBackend` that cause the configured reranker to be silently ignored when using mem0 in self-hosted (OSS) mode. All searches fall back to vector-only similarity even with a correctly configured reranker.

## Related Issue

Fixes #57263

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/_backend.py`: Forward `reranker` config from `oss_config` to `Memory.from_config()` in `OSSBackend.__init__()` (Bug 1)
- `plugins/memory/mem0/_backend.py`: Pass `rerank` parameter through to `self._memory.search()` in `OSSBackend.search()` (Bug 2)
- `tests/plugins/memory/test_mem0_backend.py`: Replace `test_search_ignores_rerank` with `test_search_forwards_rerank` and `test_search_forwards_rerank_false` to verify correct forwarding
- `tests/plugins/memory/test_mem0_backend.py`: Add `test_init_forwards_reranker_config` and `test_init_omits_reranker_when_absent` to verify `__init__` config forwarding

## How to Test

1. Run `pytest tests/plugins/memory/test_mem0_backend.py -q` — all 23 tests should pass
2. With a mem0 OSS config that includes a `reranker` section, searches should now use the configured reranker instead of falling back to vector-only similarity
3. The `rerank` parameter on `search()` should now be respected (previously silently dropped)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/plugins/memory/test_mem0_backend.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
