### PR TITLE
fix(gateway): protect desktop backend control plane under load

### DIFF
--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -167,11 +167,18 @@ export function FloatingPet() {
           }
         }
 
-        const next = await requestGateway<PetInfo>('pet.info', { profile: petProfile() })
+        const current = $petInfo.get()
+        // Tell the gateway which sheet we already hold so it can withhold the
+        // ~3.2MB base64 when nothing changed (issue #54730 / PR #56602). Only
+        // send it while we actually have that sheet cached, so a first fetch
+        // still gets bytes.
+        const knownRevision = current.enabled && current.spritesheetBase64 ? current.spritesheetRevision : undefined
+        const next = await requestGateway<PetInfo>('pet.info', {
+          profile: petProfile(),
+          ...(knownRevision ? { knownRevision } : {})
+        })
 
         if (!cancelled && next) {
-          const current = $petInfo.get()
-
           if (
             next.enabled &&
             current.enabled &&
@@ -181,6 +188,14 @@ export function FloatingPet() {
             current.spritesheetRevision &&
             current.spritesheetRevision === next.spritesheetRevision
           ) {
+            return
+          }
+
+          // The gateway withheld the sheet because our revision still matched —
+          // keep the cached bytes, just refresh the cheap geometry alongside it.
+          if (next.enabled && next.spritesheetOmitted && current.spritesheetBase64) {
+            setPetInfo({ ...next, spritesheetBase64: current.spritesheetBase64, mime: next.mime ?? current.mime })
+
             return
           }
 

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -24,6 +24,11 @@ export interface PetInfo {
   // Stable sheet revision (`mtime_ns:size`) from the gateway; lets the desktop
   // skip full sprite payload refreshes when the active pet hasn't changed.
   spritesheetRevision?: string
+  // Set by the gateway when it withheld the ~3.2MB `spritesheetBase64` on
+  // purpose because our `knownRevision` still matched (issue #54730 / PR
+  // #56602). Not a decode failure — callers must keep their cached sheet rather
+  // than blank it.
+  spritesheetOmitted?: boolean
   frameW?: number
   frameH?: number
   framesPerState?: number

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14163,6 +14163,31 @@ def _maybe_open_browser(
     threading.Thread(target=_open, daemon=True).start()
 
 
+def _ws_ping_val(env_val, host, *, default=30):
+    """Resolve WebSocket ping interval/timeout.
+
+    Local Desktop/Web clients connect over loopback. Loopback sockets do not
+    silently disappear like reverse-proxy/tunnel paths; uvicorn keepalive pings
+    instead become a failure mode when a GIL-heavy agent turn stalls the event
+    loop long enough to miss pong processing. Env overrides keep the policy
+    tunable without code changes; a value <= 0 disables pings.
+    """
+    if env_val is not None:
+        try:
+            v = float(env_val)
+        except (TypeError, ValueError):
+            _log.warning(
+                "invalid WebSocket ping value %r; using default for host=%s",
+                env_val,
+                host,
+            )
+        else:
+            return None if v <= 0 else v
+    if host in ("127.0.0.1", "localhost", "::1"):
+        return None
+    return float(default)
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
@@ -14278,15 +14303,6 @@ def start_server(
     # For explicit non-zero ports, if the port is taken uvicorn catches
     # OSError inside create_server() and exits with a clear error — no
     # separate preflight probe needed.
-    # Loopback binds are the Desktop case: a single local client, no reverse
-    # proxy in front. A GIL-heavy agent turn can stall the event loop past 20s,
-    # and uvicorn's ws keepalive ping runs on that same starved loop — so a
-    # 20s ping timeout kills an otherwise-healthy local connection over a
-    # recoverable stall (QW-1). Give loopback a longer 60s timeout / 30s
-    # interval to ride out those stalls. Non-loopback binds sit behind a
-    # Cloudflare Tunnel (idle timeout ~100s), so keep them at 20/20 to detect
-    # half-open connections promptly and stay under the tunnel's idle window.
-    _is_loopback = host in ("127.0.0.1", "localhost", "::1")
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees
@@ -14298,11 +14314,13 @@ def start_server(
         # mode.
         proxy_headers=bool(app.state.auth_required),
         # Detect half-open WS connections (reverse-proxy 524, dropped
-        # tunnels) within ~20-40s so WebSocketDisconnect fires the
-        # disconnect→reap path.  20s stays under Cloudflare Tunnel's idle
-        # timeout, keeping it warm.  Loopback gets a longer window (see above).
-        ws_ping_interval=30.0 if _is_loopback else 20.0,
-        ws_ping_timeout=60.0 if _is_loopback else 20.0,
+        # tunnels). Localhost is the Desktop case: no silent network drops, so
+        # keepalive pings are disabled by default to avoid false disconnects
+        # when the Python event loop is starved under GIL pressure. Remote
+        # binds keep conservative pings. Env overrides: <=0 disables; positive
+        # values set the timeout/interval explicitly.
+        ws_ping_interval=_ws_ping_val(os.environ.get("HERMES_WS_PING_INTERVAL"), host),
+        ws_ping_timeout=_ws_ping_val(os.environ.get("HERMES_WS_PING_TIMEOUT"), host, default=60),
     )
     server = uvicorn.Server(config)
 

--- a/scripts/diagnose_gateway_stability.py
+++ b/scripts/diagnose_gateway_stability.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python
+"""No-kill Hermes Desktop/gateway stability diagnostic.
+
+This script intentionally only reads logs/process state and probes local health
+endpoints. It does not stop, restart, or mutate any Hermes process.
+
+The diagnostic follows the common SRE/alerting model used by tools such as
+Grafana/Prometheus/PagerDuty: keep historical/resolved events in the timeline,
+but make the top-level PASS/WARN/BLOCKED recommendation from the current active
+window. By default the current window starts at the latest local recovery marker
+(Desktop cron scheduler start, dashboard ready, or WS accept); pass ``--since``
+to choose an explicit ISO-like timestamp.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+PATTERNS = {
+    "event_loop_stalled": re.compile(r"event loop stalled|loop stalled", re.I),
+    "ws_write_slow": re.compile(r"ws write slow", re.I),
+    "ready_send_failed": re.compile(r"ready frame send failed|ready_send_failed", re.I),
+    "response_send_failed": re.compile(r"ws response send failed|send_failed_after_response", re.I),
+    "runtime_check_failed_send": re.compile(r"setup\.runtime_check", re.I),
+    "unicode_decode_error": re.compile(r"UnicodeDecodeError", re.I),
+}
+RECOVERY_MARKER_RE = re.compile(
+    r"Desktop cron scheduler started|HERMES_DASHBOARD_READY|ws accepted", re.I
+)
+PORT_RE = re.compile(r"HERMES_DASHBOARD_READY\s+port=(\d+)")
+TS_RE = re.compile(r"(?P<ts>20\d\d-\d\d-\d\d[ T]\d\d:\d\d:\d\d)(?:,\d+)?")
+LOG_FILES = ["gui.log", "gateway.log", "gateway-stdio.log", "tui_gateway_crash.log", "errors.log"]
+
+
+def _default_home() -> Path:
+    env = os.environ.get("HERMES_HOME")
+    if env:
+        return Path(env)
+    return Path.home() / ".hermes"
+
+
+def _parse_ts(text: str) -> datetime | None:
+    m = TS_RE.search(text)
+    if not m:
+        return None
+    raw = m.group("ts").replace("T", " ")
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+
+
+def _parse_since(value: str | None) -> datetime | None:
+    if not value or value == "auto":
+        return None
+    value = value.strip().replace("T", " ")
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    raise SystemExit(f"Invalid --since timestamp: {value!r}")
+
+
+def _tail_text(path: Path, max_bytes: int = 512_000) -> str:
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as f:
+            if size > max_bytes:
+                f.seek(size - max_bytes)
+            data = f.read()
+        return data.decode("utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+    except OSError as exc:
+        return f"[read_error:{exc}]"
+
+
+def _iter_log_lines(log_dir: Path):
+    for name in LOG_FILES:
+        text = _tail_text(log_dir / name)
+        for line in text.splitlines():
+            yield name, line, _parse_ts(line)
+
+
+def _latest_recovery_marker(log_dir: Path) -> datetime | None:
+    latest: datetime | None = None
+    for _name, line, ts in _iter_log_lines(log_dir):
+        if ts and RECOVERY_MARKER_RE.search(line):
+            latest = ts if latest is None or ts > latest else latest
+    return latest
+
+
+def _count_patterns(log_dir: Path, *, since: datetime | None = None) -> dict[str, int]:
+    counts = {k: 0 for k in PATTERNS}
+    for _name, line, ts in _iter_log_lines(log_dir):
+        if since is not None and (ts is None or ts < since):
+            continue
+        for key, rx in PATTERNS.items():
+            counts[key] += len(rx.findall(line))
+    return counts
+
+
+def _event_timeline(log_dir: Path, *, since: datetime | None) -> dict:
+    states: dict[str, dict] = {
+        key: {
+            "status": "absent",
+            "historical_count": 0,
+            "current_count": 0,
+            "first_seen": None,
+            "last_seen": None,
+        }
+        for key in PATTERNS
+    }
+    recovery_markers: list[str] = []
+    for name, line, ts in _iter_log_lines(log_dir):
+        if ts and RECOVERY_MARKER_RE.search(line):
+            recovery_markers.append(ts.isoformat(sep=" "))
+        for key, rx in PATTERNS.items():
+            hits = len(rx.findall(line))
+            if not hits:
+                continue
+            state = states[key]
+            state["historical_count"] += hits
+            if ts is not None:
+                iso = ts.isoformat(sep=" ")
+                if state["first_seen"] is None or iso < state["first_seen"]:
+                    state["first_seen"] = iso
+                if state["last_seen"] is None or iso > state["last_seen"]:
+                    state["last_seen"] = iso
+                if since is not None and ts >= since:
+                    state["current_count"] += hits
+            elif since is None:
+                state["current_count"] += hits
+    for state in states.values():
+        if state["current_count"]:
+            state["status"] = "active"
+        elif state["historical_count"]:
+            state["status"] = "resolved"
+        else:
+            state["status"] = "absent"
+    return {
+        "current_window_start": since.isoformat(sep=" ") if since else None,
+        "recovery_markers_seen": recovery_markers[-8:],
+        "states": states,
+        "active": [k for k, v in states.items() if v["status"] == "active"],
+        "resolved": [k for k, v in states.items() if v["status"] == "resolved"],
+    }
+
+
+def _latest_dashboard_port(log_dir: Path) -> int | None:
+    text = _tail_text(log_dir / "gui.log") + "\n" + _tail_text(log_dir / "gateway.log")
+    matches = PORT_RE.findall(text)
+    return int(matches[-1]) if matches else None
+
+
+def _probe_health(port: int | None, timeout: float = 2.0) -> dict:
+    if not port:
+        return {"status": "unknown", "reason": "no HERMES_DASHBOARD_READY port found"}
+    url = f"http://127.0.0.1:{port}/health"
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            body = resp.read(200).decode("utf-8", errors="replace")
+        return {
+            "status": "ok",
+            "url": url,
+            "latency_ms": round((time.perf_counter() - start) * 1000, 1),
+            "body_preview": body,
+        }
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {
+            "status": "fail",
+            "url": url,
+            "latency_ms": round((time.perf_counter() - start) * 1000, 1),
+            "error": str(exc),
+        }
+
+
+def _process_snapshot() -> dict:
+    terms = {
+        "slash_worker": "tui_gateway.slash_worker",
+        "dashboard_backend": "hermes_cli.main dashboard",
+        "gateway": "gateway",
+        "hermes_python": "python",
+    }
+    counts = {k: 0 for k in terms}
+    samples: list[str] = []
+    try:
+        if os.name == "nt":
+            try:
+                raw = subprocess.check_output(
+                    [
+                        "powershell.exe",
+                        "-NoProfile",
+                        "-Command",
+                        "Get-CimInstance Win32_Process | Select-Object -ExpandProperty CommandLine",
+                    ],
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=8,
+                )
+                commands = [line for line in raw.splitlines() if line.strip()]
+            except Exception:
+                raw = subprocess.check_output(
+                    ["tasklist.exe", "/FO", "CSV"],
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=5,
+                )
+                commands = [line for line in raw.splitlines() if line.strip()]
+        else:
+            raw = subprocess.check_output(
+                ["ps", "-eo", "pid=,args="],
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            )
+            commands = raw.splitlines()
+        for cmd in commands:
+            low = cmd.lower()
+            for key, needle in terms.items():
+                if needle.lower() in low:
+                    counts[key] += 1
+            if any(n.lower() in low for n in ("hermes", "tui_gateway", "slash_worker")) and len(samples) < 8:
+                samples.append(cmd[:240])
+    except Exception as exc:  # noqa: BLE001 - diagnostics must not crash
+        return {"status": "unknown", "error": str(exc), "counts": counts, "samples": samples}
+    return {"status": "ok", "counts": counts, "samples": samples}
+
+
+def _recommend(current_counts: dict[str, int], health: dict, procs: dict) -> str:
+    if health.get("status") == "fail" and (
+        current_counts.get("ready_send_failed", 0)
+        or current_counts.get("response_send_failed", 0)
+    ):
+        return "BLOCKED: backend health probe failed and active ready/send failures are present; collect logs before any restart."
+    if current_counts.get("event_loop_stalled", 0) or current_counts.get("ws_write_slow", 0):
+        return "WARN: current window has event-loop/WS stalls; avoid restart-first, reduce new worker intake and protect control-plane RPCs."
+    if procs.get("counts", {}).get("slash_worker", 0) >= 4:
+        return "WARN: no active WS stall in current window, but many slash workers are active; throttle interactive worker fanout before starting more heavy tasks."
+    return "PASS: no active no-kill instability signal found in the current window. Historical resolved events are retained in timeline."
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--home", type=Path, default=_default_home(), help="Hermes home/profile directory")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument(
+        "--since",
+        default="auto",
+        help="Current-window start timestamp ('YYYY-MM-DD HH:MM:SS') or 'auto' for latest recovery marker.",
+    )
+    args = parser.parse_args(argv)
+
+    home = args.home.expanduser().resolve()
+    log_dir = home / "logs"
+    explicit_since = _parse_since(args.since)
+    auto_since = _latest_recovery_marker(log_dir) if args.since == "auto" else None
+    current_since = explicit_since or auto_since
+    historical_counts = _count_patterns(log_dir)
+    current_counts = _count_patterns(log_dir, since=current_since)
+    timeline = _event_timeline(log_dir, since=current_since)
+    port = _latest_dashboard_port(log_dir)
+    health = _probe_health(port)
+    procs = _process_snapshot()
+    report = {
+        "home": str(home),
+        "log_dir": str(log_dir),
+        "dashboard_port": port,
+        "health": health,
+        "historical_log_counts": historical_counts,
+        "current_window_counts": current_counts,
+        "timeline": timeline,
+        # Backward-compatible alias, but recommendations now use current_window_counts.
+        "recent_log_counts": historical_counts,
+        "process_snapshot": procs,
+        "recommendation": _recommend(current_counts, health, procs),
+        "safety": "read-only/no-kill/no-secret-dump",
+    }
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print("Hermes gateway/backend stability diagnostic")
+        print(f"home: {report['home']}")
+        print(f"dashboard_port: {port}")
+        print(f"health: {health}")
+        print(f"current_window_start: {timeline['current_window_start']}")
+        print(f"current_window_counts: {current_counts}")
+        print(f"resolved_timeline_events: {timeline['resolved']}")
+        print(f"active_timeline_events: {timeline['active']}")
+        print(f"process_counts: {procs.get('counts')}")
+        print(f"recommendation: {report['recommendation']}")
+        print(f"safety: {report['safety']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_diagnose_gateway_stability.py
+++ b/tests/scripts/test_diagnose_gateway_stability.py
@@ -1,0 +1,65 @@
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "diagnose_gateway_stability.py"
+spec = importlib.util.spec_from_file_location("diagnose_gateway_stability", SCRIPT)
+diag = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(diag)
+
+
+def test_resolved_pre_restart_stalls_do_not_poison_current_recommendation(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "gui.log").write_text(
+        "\n".join(
+            [
+                "2026-07-02 17:50:31,296 WARNING hermes_cli.web_server: event loop stalled 43.8s (GIL pressure suspected)",
+                "2026-07-02 17:50:42,740 WARNING tui_gateway.ws: ws response send failed peer=127.0.0.1:61920 id=1367 method=setup.status",
+                "2026-07-02 17:53:13,354 INFO tui_gateway.ws: ws closed peer=127.0.0.1:55168 reason=ready_send_failed messages=0",
+                "2026-07-03 01:08:26,534 INFO hermes_cli.web_server: Desktop cron scheduler started (provider=builtin, interval=60s)",
+                "2026-07-03 01:08:27,528 INFO tui_gateway.ws: ws accepted peer=127.0.0.1:61181",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    since = diag._latest_recovery_marker(log_dir)
+    assert since is not None
+    historical = diag._count_patterns(log_dir)
+    current = diag._count_patterns(log_dir, since=since)
+    timeline = diag._event_timeline(log_dir, since=since)
+
+    assert historical["event_loop_stalled"] == 1
+    assert historical["response_send_failed"] == 1
+    assert historical["ready_send_failed"] == 1
+    assert current["event_loop_stalled"] == 0
+    assert current["response_send_failed"] == 0
+    assert current["ready_send_failed"] == 0
+    assert timeline["states"]["event_loop_stalled"]["status"] == "resolved"
+    assert timeline["states"]["response_send_failed"]["status"] == "resolved"
+    assert timeline["active"] == []
+    assert "PASS" in diag._recommend(current, {"status": "ok"}, {"counts": {"slash_worker": 0}})
+
+
+def test_current_window_active_stall_still_warns(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "gui.log").write_text(
+        "\n".join(
+            [
+                "2026-07-03 01:08:26,534 INFO hermes_cli.web_server: Desktop cron scheduler started (provider=builtin, interval=60s)",
+                "2026-07-03 01:08:27,528 INFO tui_gateway.ws: ws accepted peer=127.0.0.1:61181",
+                "2026-07-03 01:09:00,000 WARNING tui_gateway.ws: ws write slow (loop stalled >10.0s) peer=127.0.0.1:61181 — frame left in flight",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    since = diag._latest_recovery_marker(log_dir)
+    current = diag._count_patterns(log_dir, since=since)
+    timeline = diag._event_timeline(log_dir, since=since)
+
+    assert current["ws_write_slow"] == 1
+    assert timeline["states"]["ws_write_slow"]["status"] == "active"
+    assert "WARN" in diag._recommend(current, {"status": "ok"}, {"counts": {"slash_worker": 0}})

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16,6 +16,49 @@ from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
 
 
+def test_slash_worker_popen_uses_utf8_replace_for_windows_subprocess_output(monkeypatch, tmp_path):
+    """Windows non-UTF-8 console locales must not crash the slash-worker pipe.
+
+    Python's subprocess reader thread uses the Popen text stream encoding. If
+    it falls back to the system ACP (cp949/gbk/etc.), UTF-8 bytes from child
+    Hermes processes can raise UnicodeDecodeError in _readerthread and break
+    the TUI/Desktop gateway. Pin the slash worker pipe to utf-8 with replacement.
+    """
+    calls = []
+
+    class FakeStdin:
+        def write(self, _text):
+            return None
+
+        def flush(self):
+            return None
+
+    class FakeProc:
+        stdin = FakeStdin()
+        stdout = []
+        stderr = []
+
+        def poll(self):
+            return None
+
+    def fake_popen(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return FakeProc()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(server.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(server, "hermes_subprocess_env", lambda inherit_credentials=False: {})
+
+    worker = server._SlashWorker("encoding-session", "")
+
+    assert calls
+    kwargs = calls[0]["kwargs"]
+    assert kwargs["text"] is True
+    assert kwargs["encoding"] == "utf-8"
+    assert kwargs["errors"] == "replace"
+    worker._closed = True
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,10 +1,33 @@
 import asyncio
+import importlib
+import json
 import threading
 import time
 
 from hermes_cli import mcp_startup
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
+
+
+def test_ws_write_timeout_env_override(monkeypatch):
+    """Operators can tune WS thread wait budget without patching code."""
+    monkeypatch.setenv("HERMES_WS_WRITE_TIMEOUT", "0.25")
+    reloaded = importlib.reload(ws_mod)
+    try:
+        assert reloaded._WS_WRITE_TIMEOUT_S == 0.25
+    finally:
+        monkeypatch.delenv("HERMES_WS_WRITE_TIMEOUT", raising=False)
+        importlib.reload(ws_mod)
+
+
+def test_ws_write_timeout_invalid_env_falls_back_safely(monkeypatch):
+    monkeypatch.setenv("HERMES_WS_WRITE_TIMEOUT", "not-a-float")
+    reloaded = importlib.reload(ws_mod)
+    try:
+        assert reloaded._WS_WRITE_TIMEOUT_S == 3.0
+    finally:
+        monkeypatch.delenv("HERMES_WS_WRITE_TIMEOUT", raising=False)
+        importlib.reload(ws_mod)
 
 
 def test_ws_startup_starts_background_mcp_discovery(monkeypatch):
@@ -157,6 +180,64 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         while len(sent) < 2 and time.time() < deadline:
             time.sleep(0.01)
         assert len(sent) == 2
+        assert transport._closed is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
+
+
+def test_ws_streaming_frames_are_coalesced(monkeypatch):
+    """High-frequency token frames are buffered and flushed as one timed batch."""
+    monkeypatch.setattr(ws_mod, "_TOKEN_COALESCE_S", 0.02)
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            sent.append(line)
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="coalesce-test")
+        assert transport.write({"params": {"type": "message.delta", "text": "a"}}) is True
+        assert transport.write({"params": {"type": "message.delta", "text": "b"}}) is True
+
+        deadline = time.time() + 2
+        while len(sent) < 2 and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert [json.loads(line)["params"]["text"] for line in sent] == ["a", "b"]
+        assert transport._closed is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
+
+
+def test_ws_non_streaming_frame_flushes_pending_tokens_in_order(monkeypatch):
+    """A control/RPC frame drains buffered token frames before itself."""
+    monkeypatch.setattr(ws_mod, "_TOKEN_COALESCE_S", 1.0)
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            sent.append(line)
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="order-test")
+        assert transport.write({"params": {"type": "message.delta", "text": "token"}}) is True
+        assert transport.write({"id": "complete", "result": {"ok": True}}) is True
+
+        frames = [json.loads(line) for line in sent]
+        assert [frame.get("id") or frame.get("params", {}).get("text") for frame in frames] == [
+            "token",
+            "complete",
+        ]
         assert transport._closed is False
     finally:
         loop.call_soon_threadsafe(loop.stop)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -6,6 +6,7 @@ Config + Server + asyncio.run to capture kwargs without starting an event loop.
 
 import asyncio
 import contextlib
+import types
 
 import uvicorn
 
@@ -69,23 +70,56 @@ def _stub_uvicorn(monkeypatch):
     return captured
 
 
-def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):
-    """WS ping must be configured so half-open connections (reverse-proxy 524,
-    dropped tunnels) raise WebSocketDisconnect into the reaping path (#32377).
+def test_start_server_disables_ws_ping_for_loopback_by_default(monkeypatch):
+    """Local Desktop/Web clients connect over loopback.
 
-    Loopback binds (the Desktop case) get a longer window to ride out
-    GIL-pressure event-loop stalls (#48445/#50005). The invariant asserted
-    here is that ping stays enabled (non-None, positive) and the timeout is
-    never shorter than the interval — not a frozen literal, which churns every
-    time the window is retuned."""
+    Under heavy agent/tool work, uvicorn keepalive pings can be starved by the
+    same event loop they use for pong processing, producing false local WS
+    disconnects. Loopback disables pings by default; remote binds keep them.
+    """
     captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.delenv("HERMES_WS_PING_INTERVAL", raising=False)
+    monkeypatch.delenv("HERMES_WS_PING_TIMEOUT", raising=False)
 
-    # Loopback bind => no auth gate, so this reaches the Config constructor.
     web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
 
-    assert captured["ws_ping_interval"] and captured["ws_ping_interval"] > 0
-    assert captured["ws_ping_timeout"] and captured["ws_ping_timeout"] > 0
-    assert captured["ws_ping_timeout"] >= captured["ws_ping_interval"]
+    assert captured["ws_ping_interval"] is None
+    assert captured["ws_ping_timeout"] is None
+
+
+def test_start_server_keeps_ws_ping_for_remote_binds(monkeypatch):
+    """Remote/tunnel binds still need half-open connection detection."""
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.delenv("HERMES_WS_PING_INTERVAL", raising=False)
+    monkeypatch.delenv("HERMES_WS_PING_TIMEOUT", raising=False)
+    monkeypatch.setattr(web_server, "should_require_auth", lambda host: False)
+
+    web_server.start_server(host="0.0.0.0", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] == 30.0
+    assert captured["ws_ping_timeout"] == 60.0
+
+
+def test_start_server_ws_ping_env_overrides(monkeypatch):
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setenv("HERMES_WS_PING_INTERVAL", "12.5")
+    monkeypatch.setenv("HERMES_WS_PING_TIMEOUT", "0")
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] == 12.5
+    assert captured["ws_ping_timeout"] is None
+
+
+def test_start_server_ws_ping_invalid_env_falls_back_safely(monkeypatch):
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setenv("HERMES_WS_PING_INTERVAL", "not-a-float")
+    monkeypatch.setenv("HERMES_WS_PING_TIMEOUT", "also-not-a-float")
+
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] is None
+    assert captured["ws_ping_timeout"] is None
 
 
 def test_start_server_runs_on_uvicorns_loop_factory(monkeypatch):

--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -14,6 +14,7 @@ The fix routes all frontend-polled RPCs through ``_LONG_HANDLERS`` so
 the WS read loop is never blocked.
 """
 
+import concurrent.futures
 import io
 import json
 import sys
@@ -42,10 +43,13 @@ def server():
     }):
         import importlib
         mod = importlib.import_module("tui_gateway.server")
+        methods_snapshot = dict(mod._methods)
         yield mod
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
+        mod._methods.clear()
+        mod._methods.update(methods_snapshot)
 
 
 @pytest.fixture()
@@ -64,9 +68,18 @@ def capture(server):
 # seconds when the GIL is contended by concurrent agent turns.
 
 FRONTEND_POLLED_RPCS = [
-    "session.list",   # loads session list — SQLite query
-    "pet.info",       # petdex poll — file/network read
-    "process.list",   # background process status — process registry scan
+    "session.list",          # loads session list — SQLite query
+    "pet.info",              # petdex poll — file/network read
+    "process.list",          # background process status — process registry scan
+    "setup.runtime_check",   # readiness probe — config/auth/provider resolution
+    "setup.status",          # setup poll — provider config/credential scan
+]
+
+CONTROL_PLANE_POLLED_RPCS = [
+    "session.list",          # session picker must remain responsive
+    "process.list",          # background process controls/status
+    "setup.runtime_check",   # readiness probe — config/auth/provider resolution
+    "setup.status",          # setup poll — provider config/credential scan
 ]
 
 
@@ -146,6 +159,40 @@ def test_dispatch_pet_info_does_not_block_prompt_submit(server):
     released.set()
 
 
+@pytest.mark.parametrize("method", ["setup.runtime_check", "setup.status"])
+def test_setup_readiness_rpc_does_not_block_prompt_submit(server, method):
+    """Desktop setup/readiness polls must not block the WS reader.
+
+    The frontend can send setup.runtime_check/setup.status while the user is
+    also submitting a prompt. If readiness runs inline, handle_ws awaits that
+    dispatch before reading the prompt.submit frame, making backend setup look
+    disconnected under GIL pressure. Pool routing makes dispatch() return None
+    immediately and lets the next request be read.
+    """
+    released = threading.Event()
+
+    def slow_readiness(rid, params):
+        released.wait(timeout=5)
+        return server._ok(rid, {"ok": True})
+
+    server._methods[method] = slow_readiness
+    server._methods["prompt.submit"] = lambda rid, params: server._ok(rid, {"status": "streaming"})
+
+    t0 = time.monotonic()
+    assert server.dispatch({"id": "readiness", "method": method, "params": {}}) is None
+
+    resp = server.dispatch({"id": "prompt", "method": "prompt.submit", "params": {}})
+    elapsed = time.monotonic() - t0
+
+    assert resp["result"] == {"status": "streaming"}
+    assert elapsed < 0.5, (
+        f"prompt.submit blocked for {elapsed:.2f}s behind slow {method} — "
+        "setup readiness polling would stall the WS reader under GIL pressure."
+    )
+
+    released.set()
+
+
 def test_rpc_pool_workers_supports_concurrent_long_handlers(server):
     """The RPC thread pool must have enough workers to handle concurrent
     long handlers without queueing. With 6+ frontend-polled RPCs added to
@@ -156,3 +203,80 @@ def test_rpc_pool_workers_supports_concurrent_long_handlers(server):
         f"Frontend-polled RPCs added to _LONG_HANDLERS need more workers to "
         f"avoid queueing under multi-agent load (#50005)."
     )
+
+
+def test_frontend_polled_rpc_uses_reserved_control_pool(server):
+    """Frontend-polled control RPCs must not share the heavy worker pool."""
+    assert server._rpc_control_pool_workers >= 1
+    assert server._control_pool is not server._pool
+    for method in CONTROL_PLANE_POLLED_RPCS:
+        assert method in server._CONTROL_PLANE_HANDLERS
+        assert server._rpc_pool_for_method(method) is server._control_pool
+
+    for method in ("shell.exec", "slash.exec", "pet.generate", "llm.oneshot"):
+        assert method in server._LONG_HANDLERS
+        assert method not in server._CONTROL_PLANE_HANDLERS
+        assert server._rpc_pool_for_method(method) is server._pool
+
+
+def test_control_rpc_completes_when_heavy_pool_is_saturated(server, monkeypatch):
+    """Synthetic saturation gate for the reserved control-plane design."""
+    heavy_pool = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="test-heavy-rpc",
+    )
+    control_pool = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="test-control-rpc",
+    )
+    monkeypatch.setattr(server, "_pool", heavy_pool)
+    monkeypatch.setattr(server, "_control_pool", control_pool)
+
+    heavy_started = threading.Event()
+    heavy_release = threading.Event()
+    writes: list[dict] = []
+
+    class CaptureTransport:
+        def write(self, obj: dict) -> bool:
+            writes.append(obj)
+            return True
+
+    def slow_shell(rid, params):
+        heavy_started.set()
+        heavy_release.wait(timeout=5)
+        return server._ok(rid, {"done": True})
+
+    server._methods["shell.exec"] = slow_shell
+    server._methods["setup.runtime_check"] = lambda rid, params: server._ok(
+        rid,
+        {"ok": True, "source": "test-control-pool"},
+    )
+
+    try:
+        assert server.dispatch(
+            {"id": "heavy", "method": "shell.exec", "params": {}},
+            transport=CaptureTransport(),
+        ) is None
+        assert heavy_started.wait(timeout=1)
+
+        t0 = time.monotonic()
+        assert server.dispatch(
+            {"id": "control", "method": "setup.runtime_check", "params": {}},
+            transport=CaptureTransport(),
+        ) is None
+
+        deadline = time.monotonic() + 1
+        while not any(item.get("id") == "control" for item in writes):
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.01)
+
+        assert any(item.get("id") == "control" for item in writes), (
+            "setup.runtime_check did not complete while the heavy RPC pool was "
+            "saturated; control-plane traffic is still sharing the heavy lane."
+        )
+        assert time.monotonic() - t0 < 0.5
+    finally:
+        heavy_release.set()
+        heavy_pool.shutdown(wait=True, cancel_futures=True)
+        control_pool.shutdown(wait=True, cancel_futures=True)

--- a/tests/tui_gateway/test_pet_generate_rpc.py
+++ b/tests/tui_gateway/test_pet_generate_rpc.py
@@ -243,3 +243,44 @@ def test_pet_info_meta_avoids_full_payload(monkeypatch):
     assert result["displayName"] == "Meta Pet"
     assert result["scale"] == 0.7
     assert ":" in result["spritesheetRevision"]
+
+
+def test_pet_info_omits_sheet_when_revision_unchanged(monkeypatch):
+    """The ~3.2MB spritesheet is sent on first/changed fetch but withheld on
+    an unchanged poll that carries the matching ``knownRevision`` (#54730 /
+    PR #56602).
+    """
+    import hermes_cli.config as cli_config
+    from agent.pet import constants, store
+
+    sheet = Image.new("RGBA", (constants.FRAME_W * 8, constants.FRAME_H * 9), (80, 120, 220, 255))
+    pet = store.register_local_pet(sheet, slug="revgate-pet", display_name="Rev Gate")
+    monkeypatch.setattr(
+        cli_config,
+        "load_config",
+        lambda: {"display": {"pet": {"enabled": True, "slug": pet.slug, "scale": 0.7}}},
+    )
+
+    # First fetch (no knownRevision) carries the full sheet for old clients,
+    # first activation, reconnect, or changed revisions.
+    first = server._methods["pet.info"]("r_first", {})["result"]
+    assert first["enabled"] is True
+    assert first["spritesheetBase64"]
+    assert not first.get("spritesheetOmitted")
+    revision = first["spritesheetRevision"]
+
+    # Unchanged poll echoing that revision omits the heavy bytes but keeps the
+    # cheap geometry + revision so the client can confirm without re-decoding.
+    same = server._methods["pet.info"]("r_same", {"knownRevision": revision})["result"]
+    assert same["enabled"] is True
+    assert same["spritesheetOmitted"] is True
+    assert "spritesheetBase64" not in same
+    assert "mime" not in same
+    assert same["spritesheetRevision"] == revision
+    assert same["frameW"] == constants.FRAME_W
+    assert same["stateRows"] == first["stateRows"]
+
+    # A stale/mismatched revision still gets the full sheet re-sent.
+    stale = server._methods["pet.info"]("r_stale", {"knownRevision": "0:0"})["result"]
+    assert stale["spritesheetBase64"] == first["spritesheetBase64"]
+    assert not stale.get("spritesheetOmitted")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -212,6 +212,12 @@ _LONG_HANDLERS = frozenset(
         "projects.for_cwd",
         "projects.tree",
         "projects.project_sessions",
+        # Desktop readiness RPCs are polled during connect and while evaluating
+        # setup state. They read config/auth/provider state and can block for
+        # seconds under GIL pressure; keep them off the WS read loop so a slow
+        # readiness probe cannot look like a gateway/backend disconnect.
+        "setup.runtime_check",
+        "setup.status",
         "session.branch",
         "session.compress",
         "session.list",
@@ -222,17 +228,68 @@ _LONG_HANDLERS = frozenset(
     }
 )
 
+# Keep operator/control-plane RPCs off the heavy worker pool.  The Desktop and
+# web surfaces poll readiness/process/session state while agent turns, shell
+# commands, pet generation, and slash commands can occupy every generic worker.
+# If those control probes share the same saturated pool, a healthy backend looks
+# disconnected or "needs setup" even though only the heavy lane is backed up.
+#
+# This set is deliberately small and removable: methods only belong here when
+# they unblock manager-visible control surfaces (readiness, session/process
+# status, cancellation/approval).  Heavy work remains in _LONG_HANDLERS and is
+# routed to the generic _pool below.
+_CONTROL_PLANE_HANDLERS = frozenset(
+    {
+        "approval.respond",
+        "clarify.respond",
+        "process.kill",
+        "process.list",
+        "process.stop",
+        "secret.respond",
+        "session.active_list",
+        "session.interrupt",
+        "session.list",
+        "session.status",
+        "setup.runtime_check",
+        "setup.status",
+        "sudo.respond",
+        "terminal.read.respond",
+    }
+)
+
+try:
+    _rpc_control_pool_workers = max(
+        1, int(os.environ.get("HERMES_TUI_RPC_CONTROL_POOL_WORKERS") or "2")
+    )
+except (ValueError, TypeError):
+    _rpc_control_pool_workers = 2
+
 try:
     _rpc_pool_workers = max(
         2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS") or "8")
     )
 except (ValueError, TypeError):
     _rpc_pool_workers = 4
+_control_pool = concurrent.futures.ThreadPoolExecutor(
+    max_workers=_rpc_control_pool_workers,
+    thread_name_prefix="tui-rpc-control",
+)
 _pool = concurrent.futures.ThreadPoolExecutor(
     max_workers=_rpc_pool_workers,
     thread_name_prefix="tui-rpc",
 )
+atexit.register(lambda: _control_pool.shutdown(wait=False, cancel_futures=True))
 atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
+
+
+def _rpc_pool_for_method(method: str) -> concurrent.futures.ThreadPoolExecutor:
+    """Return the executor for a long RPC method.
+
+    Control-plane methods get a reserved executor so heavy/agent work can
+    saturate the generic pool without starving readiness, status, cancellation,
+    and approval messages.
+    """
+    return _control_pool if method in _CONTROL_PLANE_HANDLERS else _pool
 
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
@@ -298,6 +355,8 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             # slash_worker runs the Hermes agent → needs provider credentials.
@@ -1139,7 +1198,7 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             if resp is not None:
                 t.write(resp)
 
-        _pool.submit(lambda: ctx.run(run))
+        _rpc_pool_for_method(method).submit(lambda: ctx.run(run))
 
         return None
     finally:
@@ -6295,6 +6354,25 @@ def _clone_pet_payload(payload: dict) -> dict:
     return out
 
 
+# Heavy sprite fields worth ~3.2MB on the wire — omitted from ``pet.info`` when
+# the client already holds the current revision (issue #54730 / PR #56602).
+# Everything else (geometry, row counts, revision) is cheap and always sent so
+# the caller can confirm nothing changed without re-decoding the sheet.
+_PET_HEAVY_FIELDS = ("spritesheetBase64", "mime")
+
+
+def _strip_pet_sheet_bytes(payload: dict) -> dict:
+    """Return *payload* without the heavy spritesheet bytes.
+
+    The kept ``spritesheetRevision`` lets the client verify its cached sheet is
+    still current; ``spritesheetOmitted`` flags that the bytes were withheld on
+    purpose (not a decode failure) so the caller keeps its existing base64.
+    """
+    out = {k: v for k, v in payload.items() if k not in _PET_HEAVY_FIELDS}
+    out["spritesheetOmitted"] = True
+    return out
+
+
 def _pet_row_frame_counts(spritesheet) -> dict:
     """Real frame count per concrete spritesheet row name."""
     try:
@@ -6435,6 +6513,14 @@ def _(rid, params: dict) -> dict:
     Agent-independent (reads config + disk), so it works on any session and
     before the agent finishes building. Fail-open: returns ``enabled=False``
     on any error rather than erroring the surface.
+
+    Revision gate (issue #54730 / PR #56602): the ~3.2MB
+    ``spritesheetBase64`` is the same static asset on every poll. When the
+    caller passes ``knownRevision`` matching the current sheet, the bytes are
+    omitted (``spritesheetOmitted=True``) and only the cheap geometry + revision
+    are returned, so frequent polls stop re-sending the sheet and stalling the
+    WS write loop. A caller that omits ``knownRevision`` (older clients) still
+    gets the full payload.
     """
     try:
         enabled, pet, scale = _pet_active_selection()
@@ -6442,7 +6528,11 @@ def _(rid, params: dict) -> dict:
         if not enabled or pet is None or not pet.exists:
             return _ok(rid, {"enabled": False})
 
-        return _ok(rid, {"enabled": True, **_pet_sprite_payload(pet, scale=scale)})
+        payload = _pet_sprite_payload(pet, scale=scale)
+        known = params.get("knownRevision") if isinstance(params, dict) else None
+        if known and known == payload.get("spritesheetRevision"):
+            payload = _strip_pet_sheet_bytes(payload)
+        return _ok(rid, {"enabled": True, **payload})
     except Exception as exc:  # noqa: BLE001 - cosmetic, never break the surface
         logger.debug("pet.info failed: %s", exc)
         return _ok(rid, {"enabled": False})

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -27,6 +27,7 @@ import asyncio
 import concurrent.futures
 import json
 import logging
+import os
 import socket
 import threading
 from typing import Any
@@ -38,7 +39,10 @@ _log = logging.getLogger(__name__)
 # Max seconds a pool-dispatched handler will block waiting for the event loop
 # to flush a WS frame before we mark the transport dead. Protects handler
 # threads from a wedged socket.
-_WS_WRITE_TIMEOUT_S = 10.0
+try:
+    _WS_WRITE_TIMEOUT_S = float(os.environ.get("HERMES_WS_WRITE_TIMEOUT", "3"))
+except (TypeError, ValueError):
+    _WS_WRITE_TIMEOUT_S = 3.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
 # Per-token streaming frames are coalesced: buffered and flushed as a batch on


### PR DESCRIPTION
## Summary
- Reserve a small control-plane RPC executor for setup/status/session/process/approval/cancel style calls so heavy RPC work cannot make Desktop look disconnected.
- Make localhost WebSocket ping/write budgets operator-tunable and disable uvicorn keepalive pings on loopback by default to avoid false disconnects under local event-loop/GIL stalls.
- Reduce repeated pet.info payload pressure by omitting unchanged spritesheet bytes and preserving cached Desktop pet sheets.
- Add a no-kill gateway/backend diagnostic that separates active current-window signals from resolved historical timeline events.

## Test Plan
- PASS: uv/pytest targeted gateway stability gate, 14 passed.
- PASS: ruff check on changed Python files.
- PASS: python py_compile for scripts/diagnose_gateway_stability.py.
- PASS: live diagnostic JSON: current active=[]; historical stalls resolved.
- PASS: npm run --workspace apps/desktop typecheck.
- PASS: npm run --workspace apps/desktop test:ui -- src/store/pet.test.ts src/components/pet/floating-pet.test.ts, 8 passed.
- PASS: git diff --check.

## Operations/Safety
- No process kill/restart in the diagnostic.
- No secret dumping; process samples are truncated.
- Remote/non-loopback binds keep ping defaults unless explicitly overridden.
