### PR TITLE
fix(desktop): preserve streamed text on empty completion

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -28,7 +28,12 @@ import { setSessionTodos } from '@/store/todos'
 import type { ClientSessionState } from '../../../types'
 
 import { useGatewayEventHandler } from './gateway-event'
-import { completionErrorText, delegateTaskPayloads, STREAM_DELTA_FLUSH_MS } from './utils'
+import {
+  completionErrorText,
+  delegateTaskPayloads,
+  shouldPreserveStreamedTextOnEmptyComplete,
+  STREAM_DELTA_FLUSH_MS
+} from './utils'
 
 interface MessageStreamOptions {
   activeSessionIdRef: MutableRefObject<string | null>
@@ -385,6 +390,11 @@ export function useMessageStream({
                 parts: message.parts.filter(part => part.type !== 'text'),
                 pending: false
               }
+            : shouldPreserveStreamedTextOnEmptyComplete(finalText, chatMessageText(message))
+              ? {
+                  ...message,
+                  pending: false
+                }
             : {
                 ...message,
                 parts: replaceTextPart(message.parts),

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.test.ts
@@ -7,6 +7,7 @@ import {
   delegateTaskPayloads,
   hasSessionInfoStatePatch,
   sessionInfoStatePatch,
+  shouldPreserveStreamedTextOnEmptyComplete,
   toTodoPayload
 } from './utils'
 
@@ -19,6 +20,18 @@ describe('completionErrorText', () => {
     expect(completionErrorText('Gateway error: nope')).toMatch(/^Gateway error/)
     expect(completionErrorText('here is your answer')).toBeNull()
     expect(completionErrorText('   ')).toBeNull()
+  })
+})
+
+describe('shouldPreserveStreamedTextOnEmptyComplete', () => {
+  it('keeps streamed text when a completion frame has no final text', () => {
+    expect(shouldPreserveStreamedTextOnEmptyComplete('', 'already streamed answer')).toBe(true)
+    expect(shouldPreserveStreamedTextOnEmptyComplete('   ', 'already streamed answer')).toBe(true)
+  })
+
+  it('allows explicit completion text to replace the streamed text', () => {
+    expect(shouldPreserveStreamedTextOnEmptyComplete('final answer', 'already streamed answer')).toBe(false)
+    expect(shouldPreserveStreamedTextOnEmptyComplete('', '')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -81,6 +81,10 @@ export function completionErrorText(finalText: string): string | null {
   return text && COMPLETION_ERROR_PATTERNS.some(re => re.test(text)) ? text : null
 }
 
+export function shouldPreserveStreamedTextOnEmptyComplete(finalText: string, existingText: string): boolean {
+  return !finalText.trim() && Boolean(existingText.trim())
+}
+
 export const SUBAGENT_EVENT_TYPES = new Set([
   'subagent.spawn_requested',
   'subagent.start',


### PR DESCRIPTION
## Summary
- Preserve already streamed assistant text when a completion frame arrives with empty/whitespace final text.
- Explicit final text still replaces streamed text, and empty existing text remains empty.

## Test Plan
- PASS: npm run --workspace apps/desktop typecheck.
- PASS: npm run --workspace apps/desktop test:ui -- src/app/session/hooks/use-message-stream/utils.test.ts, 8 passed.
- PASS: git diff --check.

## User Impact
- Reduces answer disappearance after a stream completed without a final text payload, so non-developer users do not need to rerun or inspect logs.
