### PR TITLE
fix(kanban): unpack judge_goal's 4-tuple at the completion gate — gate silently fails open

### DIFF
--- a/.pr-scratch-test.txt
+++ b/.pr-scratch-test.txt
@@ -1,1 +1,0 @@
-pat write probe

--- a/.pr-scratch-test.txt
+++ b/.pr-scratch-test.txt
@@ -1,0 +1,1 @@
+pat write probe

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -621,7 +621,8 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
     def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
-        return "continue", "missing verification evidence", False
+        # Match the real judge_goal signature: (verdict, reason, parse_failed, wait_directive)
+        return "continue", "missing verification evidence", False, None
 
     monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
     monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -602,7 +602,10 @@ def _handle_complete(args: dict, **kw) -> str:
                 verdict = "done"
                 reason = ""
                 try:
-                    verdict, reason, _ = judge_goal(
+                    # judge_goal returns 4 values (verdict, reason, parse_failed, wait_directive)
+                    # since the upstream goals.py change; unpack all 4 or it raises ValueError and
+                    # the goal-judge acceptance gate silently fails open. (carry-fix, Bill 2026-07-01)
+                    verdict, reason, _, _ = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )


### PR DESCRIPTION
## The bug
`judge_goal` (hermes_cli/goals.py) returns a **4-tuple** — `(verdict, reason, parse_failed, wait_directive)` — but the goal-mode completion gate in `tools/kanban_tools.py` unpacks **3** values:

```python
verdict, reason, _ = judge_goal(...)
```

The resulting `ValueError` is swallowed by the defensive `except` right below it (which deliberately fails open so the judge can never wedge a worker). Net effect: **the goal-judge acceptance gate never runs** — every goal-mode `kanban_complete` is accepted as if the judge approved it, silently.

## Why CI didn't catch it
`test_complete_goal_mode_rejected_by_judge` monkeypatches `judge_goal` with a mock that returns a **3-tuple**, matching the broken call site instead of the real function's signature. Green tests, broken production.

## The fix
- Unpack all 4 values at the call site.
- Fix the test mock to return the real 4-tuple `("continue", "...", False, None)` so the test exercises the real contract (it fails on current `main` if the call site regresses).

`tests/tools/test_kanban_tools.py` + `test_kanban_redaction.py`: 105 passed.

Found in production: workers were completing goal-mode tasks without judge approval; logs showed no judge activity at completion time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)