### PR TITLE
test: isolate Path.home in TestRefreshOauthToken — test reads the developer's real OAuth credentials

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -507,7 +507,10 @@ class TestResolveAnthropicToken:
 
 
 class TestRefreshOauthToken:
-    def test_returns_none_without_refresh_token(self):
+    def test_returns_none_without_refresh_token(self, tmp_path, monkeypatch):
+        # Isolate Path.home so the live credential file is never read (else
+        # _refresh_oauth_token adopts the real on-disk token and leaks it).
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         creds = {"accessToken": "expired", "refreshToken": "", "expiresAt": 0}
         assert _refresh_oauth_token(creds) is None
 
@@ -544,7 +547,10 @@ class TestRefreshOauthToken:
         assert written["claudeAiOauth"]["accessToken"] == "new-token-abc"
         assert written["claudeAiOauth"]["refreshToken"] == "new-refresh-456"
 
-    def test_failed_refresh_returns_none(self):
+    def test_failed_refresh_returns_none(self, tmp_path, monkeypatch):
+        # Isolate Path.home so the live credential file is never read (else
+        # _refresh_oauth_token adopts the real on-disk token and leaks it).
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         creds = {
             "accessToken": "old",
             "refreshToken": "refresh-123",


### PR DESCRIPTION
Two tests in `TestRefreshOauthToken` call `_refresh_oauth_token` without isolating `Path.home()`, so on any machine with a real `~/.claude/.credentials.json` the adapter **reads the developer's live OAuth token** during the test run. In our deployment this leaked a real `sk-ant-oat01…` token into a CI failure log (token had to be rotated).

Fix: `monkeypatch` `agent.anthropic_adapter.Path.home` to `tmp_path` in both tests, same as the neighboring tests already do.

`tests/agent/test_anthropic_adapter.py`: 173 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)