### PR TITLE
test: isolate find_node_executable in test_gui_command desktop-build test

### DIFF
--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -305,7 +305,8 @@ def test_desktop_build_stamp_skips_build_when_up_to_date(tmp_path, monkeypatch):
 
     launch_ok = subprocess.CompletedProcess([], 0)
 
-    with patch("hermes_cli.main._desktop_build_needed", return_value=False), \
+    with patch("hermes_constants.find_node_executable", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=False), \
          patch("hermes_cli.main._run_npm_install_deterministic") as mock_install, \
          patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \


### PR DESCRIPTION
`test_desktop_build_stamp_skips_build_when_up_to_date` patches the build/launch pipeline but not `find_node_executable`, so the test's behavior depends on whether the host has node/npm installed and where — it fails on machines without a discoverable node even though nothing real is built or launched.

Fix: patch `hermes_constants.find_node_executable` alongside the existing patches.

`tests/hermes_cli/test_gui_command.py`: 61 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)