### PR TITLE
fix(runtime): close opencode-go/zen model-switch 404 on both resolver paths (#57259)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -38,10 +38,17 @@ class CLIAgentSetupMixin:
         _primary_exc = None
         runtime = None
         try:
+            # Pass the active model so the resolver can derive the correct
+            # api_mode / base_url for it (e.g. opencode-go needs to pick
+            # ``chat_completions`` for non-MiniMax models even when the config
+            # default is a MiniMax model that would imply ``anthropic_messages``
+            # and strip ``/v1`` from the endpoint).
+            _target_model = getattr(self, "model", None) or None
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=_target_model,
             )
         except Exception as exc:
             _primary_exc = exc

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -478,7 +478,26 @@ def _resolve_runtime_from_pool_entry(
         if configured_provider == provider and pool_url_is_default:
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
             if cfg_base_url:
-                base_url = cfg_base_url
+                # For opencode-zen/opencode-go: the gateway /model handler
+                # persists ``model.base_url`` on every switch.  When switching
+                # TO an ``anthropic_messages`` model (e.g. minimax-m3) the
+                # URL is stored WITHOUT ``/v1`` (correct for that mode — the
+                # Anthropic SDK appends ``/v1/messages``).  When the user
+                # then switches to a ``chat_completions`` model (e.g. glm-5.2)
+                # that stale URL would win the config override here and the
+                # OpenAI SDK would hit ``…/chat/completions`` without ``/v1``
+                # → HTTP 404.  Guard by requiring the config URL to still
+                # match the provider's current ``inference_base_url``; if it
+                # does not, silently keep the pool default (which has ``/v1``).
+                # Other providers are unaffected — their config overrides are
+                # legitimate user customizations (proxy URLs, etc.) and pass
+                # through unchanged.
+                if provider in {"opencode-zen", "opencode-go"}:
+                    if cfg_base_url == pconfig.inference_base_url.rstrip("/"):
+                        base_url = cfg_base_url
+                    # Else: keep pool default (with /v1).
+                else:
+                    base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
         if provider in {"opencode-zen", "opencode-go"}:
             # Re-derive api_mode from the effective model rather than the

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2011,6 +2011,24 @@ def resolve_runtime_provider(
         cfg_base_url = ""
         if cfg_provider == provider:
             cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+            # For opencode-zen/opencode-go: a switch TO an anthropic_messages
+            # model (e.g. minimax-m3) persists model.base_url WITHOUT /v1 (the
+            # Anthropic SDK appends /v1/messages itself).  When resolving a
+            # chat_completions model (e.g. deepseek-v4-flash, glm-5.2) that
+            # stale URL would win the override here and the OpenAI SDK would hit
+            # …/chat/completions without /v1 → HTTP 404.  Only honour the config
+            # override when it still matches the provider's inference_base_url;
+            # otherwise drop it and fall back to the default (which carries
+            # /v1).  Mirrors the pool-entry guard in
+            # _resolve_runtime_from_pool_entry — this is the sibling code path
+            # for opencode keys resolved via env/config (no pool entry).
+            # Refs #57259, #56158.
+            if (
+                provider in {"opencode-zen", "opencode-go"}
+                and cfg_base_url
+                and cfg_base_url != pconfig.inference_base_url.rstrip("/")
+            ):
+                cfg_base_url = ""
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -124,6 +124,7 @@ AUTHOR_MAP = {
     "carlosmcejas@gmail.com": "cmcejas",  # PR #41188 salvage (early Telegram auth gate before event build/observe; #40863)
     "ha-agent@homelab.4410.us": "oreoluwa",  # PR #49845 salvage (skip preflight content-type probe for OAuth MCP servers so OAuth discovery runs; Akiflow/Hospitable)
     "prathamesh290504@gmail.com": "PRATHAMESH75",  # PR #37550 salvage (ExecStopPost cgroup-orphan reaper to unblock systemd restart; #37454)
+    "josema.vizcainourban@gmail.com": "joviur",  # PR #56157 (opencode-go/zen stale base_url pool-entry guard + target_model propagation; folded into #57281)
     "der@konsi.org": "konsisumer",  # PR #19608 salvage (read-modify-write merge in write_credential_pool to preserve concurrently-added credentials; #19566)
     "linyubin@users.noreply.github.com": "linyubin",  # PR #50228 salvage (eager fallback on persistent transport timeout/overloaded; #22277)
     "bradhallett@users.noreply.github.com": "bradhallett",  # PR #46948 salvage (force app exit after update/uninstall handoff on macOS; #46948)

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -882,3 +882,57 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
     entries = saved.get("custom_providers", [])
     assert len(entries) == 1
     assert entries[0]["name"] == "Ollama"
+
+
+def test_ensure_runtime_credentials_passes_target_model_to_resolver(monkeypatch):
+    """Regression: ``_ensure_runtime_credentials`` must pass the active
+    ``self.model`` as ``target_model`` to ``resolve_runtime_provider`` so
+    the api_mode / base_url are derived for the model actually being used,
+    not the config default.
+
+    Before the fix, the resolver used ``model_cfg.default`` (e.g.
+    ``minimax-m3`` → ``anthropic_messages``) and so the resulting
+    ``self.api_mode`` was wrong for any chat invoked with ``-m <other>``.
+    """
+    cli = _import_cli()
+    captured_kwargs = {}
+
+    def _runtime_resolve(**kwargs):
+        captured_kwargs.update(kwargs)
+        return {
+            "provider": "opencode-go",
+            "api_mode": "chat_completions",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "api_key": "test-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
+
+    # User runs: hermes chat -m qwen3.7-plus
+    shell = cli.HermesCLI(
+        model="qwen3.7-plus", provider="opencode-go", compact=True, max_turns=1
+    )
+
+    assert shell.model == "qwen3.7-plus"
+    assert shell.requested_provider == "opencode-go"
+
+    assert shell._ensure_runtime_credentials() is True
+
+    # The fix: resolver must receive the active model so it can pick the
+    # right api_mode (chat_completions for qwen3.7-plus, not
+    # anthropic_messages that the minimax-m3 default would imply).
+    assert captured_kwargs.get("target_model") == "qwen3.7-plus", (
+        f"_ensure_runtime_credentials must pass self.model as target_model; "
+        f"got kwargs={captured_kwargs!r}"
+    )
+    # And the resulting CLI state should reflect the chat_completions
+    # resolution, not whatever the config default would have implied.
+    assert shell.api_mode == "chat_completions"
+    assert shell.base_url == "https://opencode.ai/zen/go/v1"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3360,3 +3360,79 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+
+
+def _patch_opencode_go_apikey(monkeypatch, *, config_default, stale_base_url):
+    """Force the api_key-credential resolver path (no pool entry) for
+    opencode-go with a stale persisted ``model.base_url``.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "base_url": stale_base_url,
+            "default": config_default,
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": "opencode-go",
+            "api_key": "oc-key",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "source": "OPENCODE_GO_API_KEY",
+        },
+    )
+
+
+def test_resolve_runtime_provider_opencode_go_apikey_ignores_stale_base_url(monkeypatch):
+    """Regression for #57259: on the api_key-credential path (no pool entry),
+    a ``model.base_url`` persisted WITHOUT ``/v1`` by a previous switch to a
+    MiniMax (anthropic_messages) model must not win the config override when
+    resolving a chat_completions model — otherwise the OpenAI SDK hits
+    ``…/zen/go/chat/completions`` (no ``/v1``) and returns HTTP 404.
+    """
+    _patch_opencode_go_apikey(
+        monkeypatch,
+        config_default="deepseek-v4-flash",
+        stale_base_url="https://opencode.ai/zen/go",  # stale, /v1 stripped
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="opencode-go", target_model="deepseek-v4-flash"
+    )
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "chat_completions"
+    # The stale (no-/v1) URL is dropped; the /v1 default is restored so the
+    # OpenAI SDK builds ``…/zen/go/v1/chat/completions``.
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
+def test_resolve_runtime_provider_opencode_go_apikey_minimax_round_trips(monkeypatch):
+    """The guard must not break the MiniMax (anthropic_messages) direction:
+    the /v1 default is restored, then stripped for the Anthropic SDK, yielding
+    ``…/zen/go`` — so switching back and forth between MiniMax and
+    chat_completions models keeps working.
+    """
+    _patch_opencode_go_apikey(
+        monkeypatch,
+        config_default="minimax-m3",
+        stale_base_url="https://opencode.ai/zen/go",
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="opencode-go", target_model="minimax-m3"
+    )
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1683,6 +1683,46 @@ def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch
     assert resolved["api_mode"] == "anthropic_messages"
 
 
+def test_opencode_go_stale_config_base_url_ignored_for_chat_completions(monkeypatch):
+    """When the gateway persists a ``model.base_url`` from a previous
+    /model switch (e.g. to MiniMax, which stores the URL without ``/v1``
+    because ``anthropic_messages`` mode strips it), that stale URL must
+    NOT override the provider's ``inference_base_url`` for a subsequent
+    ``chat_completions`` model.  Otherwise the OpenAI SDK constructs
+    ``…/chat/completions`` without ``/v1`` and every non-MiniMax model
+    404s on opencode-go.
+
+    The fix in ``_resolve_runtime_from_pool_entry`` only honours the
+    config ``base_url`` when it still matches the provider's current
+    ``inference_base_url``.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "default": "minimax-m3",
+            # Stale URL persisted by a previous /model minimax-m3 switch —
+            # the /v1 was stripped because anthropic_messages mode did it.
+            "base_url": "https://opencode.ai/zen/go",
+        },
+    )
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    # Resolve for a chat_completions model (GLM) with the stale config.
+    resolved = rp.resolve_runtime_provider(
+        requested="opencode-go", target_model="glm-5.2"
+    )
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "chat_completions"
+    # The stale config URL (without /v1) must NOT win — the pool default
+    # (with /v1) should be used instead.
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")


### PR DESCRIPTION
## What does this PR do?

Fully closes the **opencode-go / opencode-zen** model-switch `HTTP 404` by fixing **both** resolver code paths that honour a stale `model.base_url`. Concretely: pick **MiniMax M3** (works), then switch to **Deepseek V4 / GLM** → previously 404, now works.

Root cause: switching **to** a MiniMax model (which routes via `anthropic_messages`) persists `model.base_url` **without** `/v1` — correct for that mode, since the Anthropic SDK appends `/v1/messages` itself. When you then switch to a `chat_completions` model, that stale URL wins the config override and the OpenAI SDK hits `https://opencode.ai/zen/go/chat/completions` (no `/v1`) → OpenCode's HTML 404 page.

`resolve_runtime_provider` honours `model.base_url` in **two** places, and the 404 reproduces through either one:

1. **Pool-entry resolver** (`_resolve_runtime_from_pool_entry`) — used when the OpenCode key comes from an OAuth/credential **pool**.
2. **Api-key–credential resolver** (the `pconfig.auth_type == "api_key"` branch) — used when the key is supplied via **env/config with no pool entry** (the "integrated an API key" setup in #57259).

Both now apply the same guard: for `opencode-zen`/`opencode-go`, only honour `model.base_url` when it still matches the provider's `inference_base_url`; otherwise drop it and fall back to the default (which carries `/v1`). Other providers are unaffected — their overrides are legitimate custom endpoints and pass through unchanged. The api-key path also gets the `target_model` plumbing so api_mode/base_url are derived for the model actually in use.

This PR **folds together** two sibling fixes that a triage comment recommended landing as one:
- **@joviur's [#56157](https://github.com/NousResearch/hermes-agent/pull/56157)** — guards the *pool-entry* resolver (+ `target_model` propagation in `_ensure_runtime_credentials`). Included here as their original commits, authorship preserved.
- This change — guards the *api-key–credential* resolver, the path #56157 does not cover.

## Related Issue

Fixes #57259

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — guard the `model.base_url` override for `opencode-zen`/`opencode-go` in **both** the pool-entry resolver (@joviur) and the api-key–credential resolver (this change): keep it only when it equals `pconfig.inference_base_url`, else fall back to the provider default (with `/v1`).
- `hermes_cli/cli_agent_setup_mixin.py` — pass the active `self.model` as `target_model` to `resolve_runtime_provider` (@joviur), so api_mode/base_url derive for the model being used.
- `tests/hermes_cli/test_runtime_provider_resolution.py` — regression tests for the pool-entry path (@joviur) and two for the api-key path (this change): a stale `/v1`-stripped `base_url` is ignored for a `chat_completions` model, and the MiniMax (`anthropic_messages`) direction still round-trips.
- `tests/cli/test_cli_provider_resolution.py` — regression for `target_model` propagation (@joviur).

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py tests/cli/test_cli_provider_resolution.py
```

Result: **174 passed, 0 failed**. `test_resolve_runtime_provider_opencode_go_apikey_ignores_stale_base_url` fails without the api-key-path guard (`assert 'https://opencode.ai/zen/go' == 'https://opencode.ai/zen/go/v1'`) and passes with it; @joviur's `test_opencode_go_stale_config_base_url_ignored_for_chat_completions` covers the pool-entry path.

Manual repro (matches #57259): with an OpenCode Go API key configured, `/model minimax-m3` then `/model deepseek-v4-flash` → previously 404; now routes to `.../zen/go/v1/chat/completions`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Credits

Incorporates **@joviur's [#56157](https://github.com/NousResearch/hermes-agent/pull/56157)** in full — their three commits are included with original authorship preserved (`git cherry-pick`), covering the pool-entry resolver and `target_model` propagation. This PR adds the sibling api-key–credential-path guard on top. Folded per @alt-glitch's triage suggestion to land both together. If maintainers prefer, #56157 can be closed in favour of this combined PR — or this can be trimmed back to just the api-key-path delta on top of #56157.
