### PR TITLE
feat(cron): honor a per-job max_turns cap in the scheduler

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -744,6 +744,24 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
+def _normalize_job_max_turns(value: Any) -> Optional[int]:
+    """Normalize a per-job ``max_turns`` (agent tool-iteration ceiling).
+
+    A positive integer caps how many tool-use iterations THIS scheduled job may
+    run before the agent stops — bounding a runaway job's cost independently of
+    the global ``agent.max_turns`` default. Anything else (None, absent,
+    non-integer, zero, or negative) normalizes to ``None`` = "unset", so the
+    scheduler falls back to the config-level cap or the built-in default.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    return n if n > 0 else None
+
+
 def _resolve_default_model_snapshot() -> Optional[str]:
     """Resolve the global default model the same way the cron ticker does.
 
@@ -865,6 +883,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    max_turns: Optional[int] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -909,6 +928,10 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        max_turns: Optional per-job ceiling on agent tool-use iterations for THIS
+                job. A positive integer; the job stops after that many iterations
+                instead of the global ``agent.max_turns`` default (90), bounding a
+                runaway job's cost. Omit (None) to inherit the config/global cap.
 
     Returns:
         The created job dict
@@ -941,6 +964,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_max_turns = _normalize_job_max_turns(max_turns)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1022,6 +1046,10 @@ def create_job(
     # global cron.mirror_delivery config, default off).
     if normalized_attach is not None:
         job["attach_to_session"] = normalized_attach
+    # Same byte-identical rule for max_turns: only stamp the key when a positive
+    # cap was given (absent key => the scheduler uses the config/global default).
+    if normalized_max_turns is not None:
+        job["max_turns"] = normalized_max_turns
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -1111,6 +1139,12 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            # Normalize a max_turns update: a positive int caps this job; 0 /
+            # negative / junk / None clears it (stored as None → the scheduler
+            # falls back to the config/global cap), same shape as workdir clears.
+            if "max_turns" in updates:
+                updates["max_turns"] = _normalize_job_max_turns(updates["max_turns"])
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2250,6 +2250,29 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
+def _resolve_max_iterations(job: dict, cfg: dict) -> int:
+    """Resolve the agent tool-iteration ceiling for one cron job run.
+
+    Precedence:
+      1. A positive per-job ``max_turns`` on the job dict (declared by the job —
+         e.g. a Talent's cron cost policy). This lets a cheap scheduled job run
+         under a tight cap so a runaway loop stops early, WITHOUT lowering the
+         ceiling for the tenant's interactive turns.
+      2. The config-level ``agent.max_turns`` (or legacy top-level ``max_turns``).
+      3. The built-in default, 90.
+
+    A non-positive, boolean, or non-integer per-job value (e.g. from a
+    hand-edited jobs.json) is ignored so it can never silently disable the cap.
+    """
+    job_cap = job.get("max_turns") if isinstance(job, dict) else None
+    if not (isinstance(job_cap, int) and not isinstance(job_cap, bool) and job_cap > 0):
+        job_cap = None
+    agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(agent_cfg, dict):
+        agent_cfg = {}
+    return job_cap or agent_cfg.get("max_turns") or cfg.get("max_turns") or 90
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -2649,8 +2672,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
                     prefill_messages = None
 
-        # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        # Max iterations: a per-job ``max_turns`` cap wins (declared by the job
+        # itself — e.g. a Talent's cron cost policy), else the config-level
+        # ``agent.max_turns``, else the built-in default. See
+        # _resolve_max_iterations for the precedence and the rationale.
+        max_iterations = _resolve_max_iterations(job, _cfg)
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -310,6 +310,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        max_turns=getattr(args, "max_turns", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -326,6 +327,8 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if job_data.get("max_turns"):
+        print(f"  Max turns: {job_data['max_turns']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -373,6 +376,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        max_turns=getattr(args, "max_turns", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -70,6 +70,12 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
+    cron_create.add_argument(
+        "--max-turns",
+        dest="max_turns",
+        type=int,
+        help="Per-job ceiling on agent tool-use iterations (steps). The job stops after this many steps instead of the global default (90), bounding a runaway job's cost. Omit to inherit the config/global cap.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -133,6 +139,12 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument(
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--max-turns",
+        dest="max_turns",
+        type=int,
+        help="Per-job ceiling on agent tool-use iterations (steps). Pass 0 to clear it back to the config/global default (90).",
     )
 
     # lifecycle actions

--- a/tests/cron/test_cron_max_turns.py
+++ b/tests/cron/test_cron_max_turns.py
@@ -1,0 +1,235 @@
+"""Tests for per-job ``max_turns`` support in cron jobs.
+
+A per-job ``max_turns`` caps how many agent tool-use iterations a single
+scheduled job may run, independently of the global ``agent.max_turns`` default
+(90). This bounds a runaway job's cost — a one-shot reminder that starts looping
+stops early — without lowering the ceiling for the tenant's interactive turns.
+
+Covers:
+  - jobs._normalize_job_max_turns: positive int / string / zero / negative /
+    junk / bool / None
+  - jobs.create_job: param plumbing, byte-identical when unset
+  - jobs.update_job: set, clear (0), re-normalize
+  - tools.cronjob_tools.cronjob: create + update JSON round-trip, schema
+    advertises max_turns, _format_job exposes it only when set
+  - scheduler._resolve_max_iterations: per-job cap wins, config + default
+    fallback, junk ignored
+  - tools.blueprints: max_turns parses, validates, and reaches the job spec
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Isolate cron job storage into a temp dir so tests don't stomp on real jobs."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# jobs._normalize_job_max_turns
+# ---------------------------------------------------------------------------
+
+class TestNormalizeJobMaxTurns:
+    def test_none_returns_none(self):
+        from cron.jobs import _normalize_job_max_turns
+        assert _normalize_job_max_turns(None) is None
+
+    def test_positive_int_passthrough(self):
+        from cron.jobs import _normalize_job_max_turns
+        assert _normalize_job_max_turns(3) == 3
+        assert _normalize_job_max_turns(90) == 90
+
+    def test_numeric_string_coerced(self):
+        from cron.jobs import _normalize_job_max_turns
+        assert _normalize_job_max_turns("15") == 15
+
+    def test_zero_returns_none(self):
+        from cron.jobs import _normalize_job_max_turns
+        assert _normalize_job_max_turns(0) is None
+
+    def test_negative_returns_none(self):
+        from cron.jobs import _normalize_job_max_turns
+        assert _normalize_job_max_turns(-5) is None
+
+    def test_junk_returns_none(self):
+        from cron.jobs import _normalize_job_max_turns
+        assert _normalize_job_max_turns("nope") is None
+        assert _normalize_job_max_turns([3]) is None
+
+    def test_bool_returns_none(self):
+        # A YAML ``max_turns: true`` must NOT become a cap of 1.
+        from cron.jobs import _normalize_job_max_turns
+        assert _normalize_job_max_turns(True) is None
+        assert _normalize_job_max_turns(False) is None
+
+
+# ---------------------------------------------------------------------------
+# jobs.create_job and update_job
+# ---------------------------------------------------------------------------
+
+class TestCreateJobMaxTurns:
+    def test_max_turns_stored_when_set(self, tmp_cron_dir):
+        from cron.jobs import create_job, get_job
+        job = create_job(prompt="hello", schedule="every 1h", max_turns=3)
+        assert get_job(job["id"])["max_turns"] == 3
+
+    def test_unset_stays_byte_identical(self, tmp_cron_dir):
+        # Like attach_to_session, an unset max_turns leaves NO key on the stored
+        # job so existing jobs / the common case stay byte-identical.
+        from cron.jobs import create_job, get_job
+        job = create_job(prompt="hello", schedule="every 1h")
+        assert "max_turns" not in get_job(job["id"])
+
+    def test_nonpositive_not_stored(self, tmp_cron_dir):
+        from cron.jobs import create_job, get_job
+        job = create_job(prompt="hello", schedule="every 1h", max_turns=0)
+        assert "max_turns" not in get_job(job["id"])
+
+    def test_numeric_string_coerced_on_create(self, tmp_cron_dir):
+        from cron.jobs import create_job, get_job
+        job = create_job(prompt="hello", schedule="every 1h", max_turns="7")
+        assert get_job(job["id"])["max_turns"] == 7
+
+
+class TestUpdateJobMaxTurns:
+    def test_set_via_update(self, tmp_cron_dir):
+        from cron.jobs import create_job, get_job, update_job
+        job = create_job(prompt="x", schedule="every 1h")
+        update_job(job["id"], {"max_turns": 12})
+        assert get_job(job["id"])["max_turns"] == 12
+
+    def test_clear_with_zero(self, tmp_cron_dir):
+        from cron.jobs import create_job, get_job, update_job
+        job = create_job(prompt="x", schedule="every 1h", max_turns=5)
+        update_job(job["id"], {"max_turns": 0})
+        # Cleared back to None → scheduler falls back to the config/global cap.
+        assert get_job(job["id"]).get("max_turns") is None
+
+    def test_junk_update_clears(self, tmp_cron_dir):
+        from cron.jobs import create_job, get_job, update_job
+        job = create_job(prompt="x", schedule="every 1h", max_turns=5)
+        update_job(job["id"], {"max_turns": "bogus"})
+        assert get_job(job["id"]).get("max_turns") is None
+
+
+# ---------------------------------------------------------------------------
+# tools.cronjob_tools: end-to-end JSON round-trip
+# ---------------------------------------------------------------------------
+
+class TestCronjobToolMaxTurns:
+    def test_create_with_max_turns_json_roundtrip(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+        result = json.loads(
+            cronjob(action="create", prompt="hi", schedule="every 1h", max_turns=3)
+        )
+        assert result["success"] is True
+        assert result["job"]["max_turns"] == 3
+
+    def test_create_without_max_turns_hides_field(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+        result = json.loads(
+            cronjob(action="create", prompt="hi", schedule="every 1h")
+        )
+        assert result["success"] is True
+        assert "max_turns" not in result["job"]
+
+    def test_update_sets_and_clears_max_turns(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+        created = json.loads(
+            cronjob(action="create", prompt="hi", schedule="every 1h")
+        )
+        job_id = created["job_id"]
+
+        updated = json.loads(cronjob(action="update", job_id=job_id, max_turns=8))
+        assert updated["success"] is True
+        assert updated["job"]["max_turns"] == 8
+
+        cleared = json.loads(cronjob(action="update", job_id=job_id, max_turns=0))
+        assert cleared["success"] is True
+        assert "max_turns" not in cleared["job"]
+
+    def test_schema_advertises_max_turns(self):
+        from tools.cronjob_tools import CRONJOB_SCHEMA
+        props = CRONJOB_SCHEMA["parameters"]["properties"]
+        assert "max_turns" in props
+        assert props["max_turns"]["type"] == "integer"
+
+
+# ---------------------------------------------------------------------------
+# scheduler._resolve_max_iterations: precedence
+# ---------------------------------------------------------------------------
+
+class TestResolveMaxIterations:
+    def test_per_job_cap_wins(self):
+        from cron.scheduler import _resolve_max_iterations
+        assert _resolve_max_iterations({"max_turns": 3}, {"agent": {"max_turns": 50}}) == 3
+
+    def test_config_agent_cap_used_when_no_job_cap(self):
+        from cron.scheduler import _resolve_max_iterations
+        assert _resolve_max_iterations({}, {"agent": {"max_turns": 25}}) == 25
+
+    def test_legacy_top_level_max_turns(self):
+        from cron.scheduler import _resolve_max_iterations
+        assert _resolve_max_iterations({}, {"max_turns": 40}) == 40
+
+    def test_default_90(self):
+        from cron.scheduler import _resolve_max_iterations
+        assert _resolve_max_iterations({}, {}) == 90
+
+    def test_junk_job_cap_ignored_falls_back(self):
+        # A hand-edited jobs.json with a non-positive / bool value must never
+        # silently disable the cap — fall back to config, then the default.
+        from cron.scheduler import _resolve_max_iterations
+        assert _resolve_max_iterations({"max_turns": 0}, {"agent": {"max_turns": 30}}) == 30
+        assert _resolve_max_iterations({"max_turns": -1}, {}) == 90
+        assert _resolve_max_iterations({"max_turns": True}, {}) == 90
+
+    def test_job_cap_can_exceed_config(self):
+        # A per-job cap is authoritative in BOTH directions — a long weekly job
+        # may legitimately declare more headroom than the tenant default.
+        from cron.scheduler import _resolve_max_iterations
+        assert _resolve_max_iterations({"max_turns": 120}, {"agent": {"max_turns": 30}}) == 120
+
+
+# ---------------------------------------------------------------------------
+# tools.blueprints: max_turns round-trip
+# ---------------------------------------------------------------------------
+
+class TestBlueprintMaxTurns:
+    _SKILL_MD = (
+        "---\n"
+        "name: demo-skill\n"
+        "metadata:\n"
+        "  hermes:\n"
+        "    blueprint:\n"
+        "      schedule: '0 9 * * *'\n"
+        "      prompt: do the thing\n"
+        "      max_turns: 5\n"
+        "---\n"
+        "# Demo\n"
+    )
+
+    def test_parse_reads_max_turns(self):
+        from tools.blueprints import parse_blueprint
+        spec = parse_blueprint(self._SKILL_MD)
+        assert spec is not None
+        assert spec.max_turns == 5
+
+    def test_job_spec_carries_max_turns(self):
+        from tools.blueprints import parse_blueprint, blueprint_to_job_spec
+        spec = parse_blueprint(self._SKILL_MD)
+        assert blueprint_to_job_spec(spec)["max_turns"] == 5
+
+    def test_invalid_max_turns_rejected(self):
+        from tools.blueprints import parse_blueprint, BlueprintError
+        bad = self._SKILL_MD.replace("max_turns: 5", "max_turns: -3")
+        with pytest.raises(BlueprintError, match="max_turns"):
+            parse_blueprint(bad)

--- a/tools/blueprints.py
+++ b/tools/blueprints.py
@@ -66,6 +66,7 @@ class BlueprintSpec:
     model: Optional[str] = None
     provider: Optional[str] = None
     enabled_toolsets: Optional[List[str]] = None
+    max_turns: Optional[int] = None
     raw: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -128,6 +129,12 @@ def parse_blueprint(skill_md_text: str) -> Optional[BlueprintSpec]:
     if toolsets is not None and not isinstance(toolsets, list):
         raise BlueprintError("blueprint.enabled_toolsets must be a list when present")
 
+    max_turns = blueprint.get("max_turns")
+    if max_turns is not None and (
+        not isinstance(max_turns, int) or isinstance(max_turns, bool) or max_turns <= 0
+    ):
+        raise BlueprintError("blueprint.max_turns must be a positive integer when present")
+
     return BlueprintSpec(
         skill_name=name,
         schedule=schedule,
@@ -137,6 +144,7 @@ def parse_blueprint(skill_md_text: str) -> Optional[BlueprintSpec]:
         model=str(model).strip() if model else None,
         provider=str(provider).strip() if provider else None,
         enabled_toolsets=[str(t) for t in toolsets] if toolsets else None,
+        max_turns=max_turns,
         raw=blueprint,
     )
 
@@ -191,6 +199,7 @@ def blueprint_to_job_spec(
         "provider": spec.provider,
         "enabled_toolsets": spec.enabled_toolsets,
         "no_agent": spec.no_agent,
+        "max_turns": spec.max_turns,
     }
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -598,6 +598,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("max_turns"):
+        result["max_turns"] = job["max_turns"]
     return result
 
 
@@ -667,6 +669,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    max_turns: Optional[int] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -740,6 +743,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                max_turns=max_turns,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -913,6 +917,10 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if max_turns is not None:
+                # Pass through raw; update_job() normalizes (a positive int caps
+                # the job, 0 / negative clears it back to the config/global cap).
+                updates["max_turns"] = max_turns
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1075,6 +1083,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "max_turns": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional per-job ceiling on agent tool-use iterations (steps) for THIS scheduled job. The job stops after this many iterations instead of the global agent.max_turns default (90), which bounds a runaway job's cost without lowering the ceiling for interactive turns. Size it from the job's expected healthy step count plus margin — a single-message reminder needs only a few, a script-and-report job more. Omit to inherit the config/global cap. On update, pass 0 to clear it back to the default."
+            },
         },
         "required": ["action"]
     }
@@ -1130,6 +1143,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        max_turns=args.get("max_turns"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## What

Add an optional **per-job `max_turns`** — a ceiling on how many agent tool-use
iterations a single cron job may run — and honor it in the scheduler over the
global `agent.max_turns` default (90).

## Why

Today the only iteration ceiling is `agent.max_turns` in `config.yaml`. It is
**global**: it caps a scheduled job and the user's interactive turns with the
same number. So there is no way to say "this daily reminder should never take
more than a few steps" without also throttling real interactive work down to
that same low ceiling.

The failure mode this closes: a cheap scheduled job (a one-shot reminder, a
data-collection ping) that starts **looping** — re-calling tools well past what
the task needs — runs all the way to the global default of 90 iterations before
the max-iteration guard stops it, and every one of those iterations is a paid
model call. We saw exactly this in production: a handful of runaway cron fires
were a meaningful fraction of one account's spend. A per-job cap lets the job's
author bound that blast radius (`max_turns: 3` on a single-message reminder)
while interactive turns keep the full ceiling.

There is no per-job cap at any released version, which is why this goes upstream
rather than staying a downstream config tweak.

## What changed

The field travels the exact path `enabled_toolsets` / `workdir` already do:

- **`cron/scheduler.py`** — new `_resolve_max_iterations(job, cfg)`: precedence
  is per-job `max_turns` → config `agent.max_turns` (or legacy top-level
  `max_turns`) → default 90. A junk / boolean / non-positive per-job value
  (e.g. a hand-edited `jobs.json`) is ignored, so it can never silently disable
  the cap. `run_job` now calls it in place of the inline expression.
- **`cron/jobs.py`** — `create_job` / `update_job` accept, normalize
  (`_normalize_job_max_turns`: positive int or `None`), and persist `max_turns`.
  Storage stays **byte-identical when unset** (the key is only written when a
  positive cap is given, like `attach_to_session`); on update, `0` clears it
  back to the default.
- **`tools/cronjob_tools.py`** — `max_turns` parameter on the `cronjob` tool,
  a JSON-schema entry (`integer`, `minimum: 1`), `_format_job` output, and the
  registry wiring so an agent can set it.
- **`hermes cron create` / `edit`** — a `--max-turns` flag (pass `0` on edit to
  clear).
- **`tools/blueprints.py`** — a blueprint may declare `max_turns`; it is parsed,
  validated (positive int), and carried into the job spec.

## Backward compatibility

No behavior change for any existing job or config: with `max_turns` unset the
scheduler resolves exactly as before (`agent.max_turns` → 90), and stored jobs
are byte-for-byte unchanged.

## Tests

`tests/cron/test_cron_max_turns.py` — 27 cases: the normalizer, create/update
(set, clear, byte-identical-when-unset), the `cronjob` tool JSON round-trip +
schema, `_resolve_max_iterations` precedence (per-job wins in both directions,
config/default fallback, junk ignored), and blueprint parse/validate/round-trip.
All green.

---

### Separately noticed: `install.sh` update path can't `git checkout <tag>`

While pinning a fleet to a released tag we hit a bug in `scripts/install.sh`
(happy to split this into its own issue/PR): the **update** path (existing
checkout) runs roughly

```
git remote set-branches origin "$BRANCH"
git fetch origin "$BRANCH"
git checkout "$BRANCH"
```

which treats `--branch <tag>` as a branch. The tag lands in `FETCH_HEAD` but
never becomes a local ref, so `git checkout v2026.7.1` fails with
`pathspec … did not match` on any **already-provisioned** host. The fresh-clone
path works (a clone fetches all tags), which hides it until the first in-place
update. A fetch of the tag ref (`git fetch origin "refs/tags/$TAG:refs/tags/$TAG"`
when the arg is a tag), or documenting `--commit <sha>` as the pin-to-tag path,
would fix it. We currently work around it by resolving tag → sha with
`git ls-remote` and passing `--commit`.
