### PR TITLE
fix(vision): pass auxiliary.vision provider/model/base_url/api_key to async_call_llm

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1089,6 +1089,15 @@ async def vision_analyze_tool(
         # Local vision models (llama.cpp, ollama) can take well over 30s.
         vision_timeout = 120.0
         vision_temperature = 0.1
+        # Read full auxiliary.vision config so the call respects provider,
+        # model, base_url, and api_key. async_call_llm(task="vision") does
+        # internal fallback to the wrong model when these are missing, which
+        # makes user-configured vision providers silently fail with
+        # "unknown model '<chat default>'" from the vision backend.
+        vision_provider = None
+        vision_model_cfg = None
+        vision_base_url = None
+        vision_api_key = None
         try:
             from hermes_cli.config import cfg_get, load_config
             _cfg = load_config()
@@ -1099,6 +1108,12 @@ async def vision_analyze_tool(
             _vtemp = _vision_cfg.get("temperature")
             if _vtemp is not None:
                 vision_temperature = float(_vtemp)
+            vision_provider = (_vision_cfg.get("provider") or "").strip() or None
+            vision_model_cfg = (_vision_cfg.get("model") or "").strip() or None
+            vision_base_url = (_vision_cfg.get("base_url") or "").strip() or None
+            _ak = _vision_cfg.get("api_key")
+            if isinstance(_ak, str) and _ak.strip():
+                vision_api_key = _ak.strip()
         except Exception:
             pass
         call_kwargs = {
@@ -1110,6 +1125,14 @@ async def vision_analyze_tool(
         }
         if model:
             call_kwargs["model"] = model
+        elif vision_model_cfg:
+            call_kwargs["model"] = vision_model_cfg
+        if vision_provider:
+            call_kwargs["provider"] = vision_provider
+        if vision_base_url:
+            call_kwargs["base_url"] = vision_base_url
+        if vision_api_key:
+            call_kwargs["api_key"] = vision_api_key
         # Try full-size image first; on size-related rejection, downscale and retry.
         try:
             response = await async_call_llm(**call_kwargs)


### PR DESCRIPTION
## Summary

`vision_analyze` silently ignores the user's `auxiliary.vision` provider/model/base_url/api_key configuration and falls back to the chat default model — so vision breaks for any user with a non-default vision backend (e.g. a domestic Chinese provider, a dedicated vision endpoint, or any model the chat default backend doesn't recognize).

The visible symptom is a 400 error from the vision backend like:
```
"invalid params, unknown model 'deepseek-v4-flash' (2013)"
```
…even though `auxiliary.vision.model` is set to something else in `config.yaml`.

## Root cause

In `tools/vision_tools.py`, the `call_kwargs` dict passed to `async_call_llm(task="vision", ...)` only sets `model` when an explicit `model` parameter is supplied by the caller. It never reads `provider`, `base_url`, or `api_key` from `auxiliary.vision` config at all. So `async_call_llm` falls through to its internal default resolution, which uses the main chat model on the main chat endpoint, instead of the user's configured vision backend.

## Fix

Read the full `auxiliary.vision` config block and pass `provider`, `model`, `base_url`, and `api_key` into `call_kwargs` explicitly. The explicit `model` parameter (when called programmatically) still wins, matching existing behavior.

## Reproduction

```yaml
# ~/.hermes/config.yaml
auxiliary:
  vision:
    provider: minimax-m3
    model: MiniMax-M3
    base_url: https://api.minimax.chat/v1
    api_key: ${MINIMAX_API_KEY}
```

Then call `vision_analyze` with any image. Before the fix: `400 unknown model 'deepseek-v4-flash'` (the chat default). After the fix: correct vision result.

## Test plan

- [ ] Configure `auxiliary.vision` to a non-chat provider
- [ ] Call `vision_analyze` with a public image
- [ ] Confirm `success: true` and accurate description
- [ ] Confirm the explicit `model` arg to `_run_vision` (when called programmatically) still overrides config

## Notes

- Only the **image** path is patched. The `video_url` path (line 1614 in v0.18.0's installed copy) has the same shape but a different fallback chain — I left it alone to keep this PR minimal. Happy to extend if the maintainers want symmetry.
- Backward-compatible: if `auxiliary.vision` is unset, behavior is unchanged.
