### PR TITLE
fix(cron): recompute provider/model snapshots on every update_job

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1115,9 +1115,16 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
             schedule_changed = "schedule" in updates
+            # Recompute provider/model snapshots whenever the caller explicitly
+            # passes any inference-routing field. We intentionally do NOT gate
+            # this on a "axes actually changed" comparison: re-applying the
+            # same pin values must still rewrite the stored snapshots so they
+            # match what is now persisted (e.g. moving from an unpinned job
+            # whose creation-time snapshot captured an old global default, to
+            # an explicitly pinned job whose snapshot must be None).
             inference_fields_changed = bool(
                 {"provider", "model", "base_url", "no_agent"}.intersection(updates)
-            ) and _normalized_inference_axes(updated) != previous_inference_axes
+            )
 
             if "skills" in updates or "skill" in updates:
                 normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -243,6 +243,151 @@ class TestCreateJobSnapshot:
         assert job["model_snapshot"] is None
 
 
+class TestUpdateJobRecomputesSnapshots:
+    """`update_job` must rewrite provider/model snapshots whenever the caller
+    explicitly passes any inference-routing field, even when the new value
+    equals the old. Re-applying the same pin is a common UI pattern (form
+    auto-loads current values, user saves without changing) and must not
+    leave stale snapshots in place.
+    """
+
+    @staticmethod
+    def _isolate_storage(monkeypatch):
+        import contextlib
+        import cron.jobs as jobs
+
+        @contextlib.contextmanager
+        def _noop_lock():
+            yield
+
+        monkeypatch.setattr(jobs, "_jobs_lock", _noop_lock, raising=True)
+
+        store = []
+
+        def _load():
+            return list(store)
+
+        def _save(jobs_list):
+            store.clear()
+            store.extend(jobs_list)
+
+        monkeypatch.setattr(jobs, "load_jobs", _load, raising=True)
+        monkeypatch.setattr(jobs, "save_jobs", _save, raising=True)
+        return jobs, store
+
+    def test_update_explicit_pin_clears_snapshot(self, monkeypatch, tmp_path):
+        """A pinned job's snapshot must be None; re-applying the same pin must
+        still rewrite the (previously stale) snapshot to None."""
+        jobs, store = self._isolate_storage(monkeypatch)
+        (tmp_path / "config.yaml").write_text("model:\n  default: old-global\n")
+        monkeypatch.setattr(jobs, "get_hermes_home", lambda: tmp_path, raising=True)
+
+        # Job created when it was still following global defaults.
+        store.append(
+            {
+                "id": "upd-1",
+                "name": "stale pin",
+                "prompt": "x",
+                "provider": "openrouter",
+                "model": "old-model",
+                "provider_snapshot": "openrouter",
+                "model_snapshot": "old-global",
+                "base_url": None,
+                "no_agent": False,
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 1 hour"},
+                "enabled": True,
+                "state": "scheduled",
+            }
+        )
+
+        # Re-apply the same explicit pin values. Without the fix this leaves
+        # the stale snapshots in place; with the fix, the re-applied explicit
+        # pin (provider != None, model != None) must clear both snapshots
+        # because pinned axes have no snapshot.
+        result = jobs.update_job(
+            "upd-1",
+            {"provider": "openrouter", "model": "old-model"},
+        )
+
+        assert result["provider"] == "openrouter"
+        assert result["model"] == "old-model"
+        assert result["provider_snapshot"] is None
+        assert result["model_snapshot"] is None
+
+    def test_update_unpin_captures_fresh_snapshot(self, monkeypatch, tmp_path):
+        """Clearing a pinned field must capture the current global default
+        into the snapshot, even if the surrounding pinned fields are unchanged.
+        """
+        jobs, store = self._isolate_storage(monkeypatch)
+        (tmp_path / "config.yaml").write_text("model:\n  default: fresh-global\n")
+        monkeypatch.setattr(jobs, "get_hermes_home", lambda: tmp_path, raising=True)
+
+        store.append(
+            {
+                "id": "upd-2",
+                "name": "pinning provider only",
+                "prompt": "x",
+                "provider": "openrouter",
+                "model": None,
+                "provider_snapshot": None,
+                "model_snapshot": None,
+                "base_url": None,
+                "no_agent": False,
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 1 hour"},
+                "enabled": True,
+                "state": "scheduled",
+            }
+        )
+
+        # Caller un-pins the provider by passing None. model stays None too,
+        # so both are unpinned and the call must capture the fresh global
+        # values into snapshots.
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={"provider": "openrouter"},
+        ):
+            result = jobs.update_job(
+                "upd-2",
+                {"provider": None},
+            )
+
+        # provider remains effectively unpinned (None), snapshot is the
+        # currently-resolved provider, and model_snapshot matches config.yaml.
+        assert result["provider"] is None
+        assert result["provider_snapshot"] == "openrouter"
+        assert result["model_snapshot"] == "fresh-global"
+
+    def test_update_without_inference_fields_leaves_snapshots(self, monkeypatch, tmp_path):
+        """When the caller doesn't touch provider/model/base_url/no_agent at
+        all, snapshots must be untouched (no churn, no surprise behavior)."""
+        jobs, store = self._isolate_storage(monkeypatch)
+        monkeypatch.setattr(jobs, "get_hermes_home", lambda: tmp_path, raising=True)
+
+        store.append(
+            {
+                "id": "upd-3",
+                "name": "no-op update",
+                "prompt": "x",
+                "provider": "openrouter",
+                "model": None,
+                "provider_snapshot": "openrouter",
+                "model_snapshot": "old-global",
+                "base_url": None,
+                "no_agent": False,
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 1 hour"},
+                "enabled": True,
+                "state": "scheduled",
+            }
+        )
+
+        result = jobs.update_job("upd-3", {"name": "renamed"})
+
+        assert result["name"] == "renamed"
+        # snapshots untouched because the caller didn't ask about inference.
+        assert result["provider_snapshot"] == "openrouter"
+        assert result["model_snapshot"] == "old-global"
+
+
 def _run_with_current_provider_and_model(job, current_provider, current_model, tmp_path):
     """Drive run_job with resolved provider pinned and config.yaml model.default
     set to ``current_model`` (the unpinned-model fire-time source)."""


### PR DESCRIPTION
## Summary

`update_job` previously skipped the provider/model snapshot recompute when the new inference-routing fields equalled the stored ones (`_normalized_inference_axes(updated) != previous_inference_axes`). That comparison is the wrong gate for snapshots:

- The drift guard cares about **axis pinning**, not about whether the snapshot reflects the persisted axes. Once a job is pinned, the guard never engages regardless. Re-applying the same explicit pin to a previously-unpinned job left the unpinned-creation snapshot in place even though the stored axes were now explicitly pinned.
- UIs that auto-load the current values into an edit form, and agent-side wrappers that pin a job via a follow-up `update_job` call right after `create_job`, are common real-world flows that hit this path.

## Fix

Drop the axes-unchanged gate. Recompute provider/model/base_url snapshots whenever the caller explicitly passes any of `provider`/`model`/`base_url`/`no_agent` in the updates dict. When the caller does not pass any inference-routing field, snapshots are left untouched so unrelated updates (e.g. `name`, `deliver`, `schedule`) do not churn snapshots.

## Tests

- All 14 pre-existing `TestProviderDriftGuard` + `TestCreateJobSnapshot` + `TestModelDriftGuard` tests pass unchanged.
- 3 new tests in `TestUpdateJobRecomputesSnapshots` cover:
  - explicit-pin re-applied: stored snapshot correctly cleared to `None`
  - explicit-unpin via `{provider: None}`: fresh global default captured into snapshot
  - no-op update (only `name` changed): snapshots untouched

Full `tests/cron/` suite passes (615 tests, 0 failures).

## Issue

Refs #44585 — the original drift-detection incident. The reported error message tells users to fix via `cronjob action=update ... provider=... model=...`, but that path silently does not rewrite the stored snapshots, so users who follow the documented remediation still hit the drift guard.

## Diff scope

- `cron/jobs.py`: 9 lines (gate removed; explanatory comment added)
- `tests/cron/test_cron_provider_pin.py`: 145 lines (3 new test cases)

No PII, no local paths, no machine/network/user data introduced. All public SSOT fields are generic.