### PR TITLE
fix: harden agent dispatch and gateway routing

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2050,6 +2050,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             pass
         return result
 
+    _generic_registry_dispatch = False
+
     if function_name == "todo":
         def _execute(next_args: dict) -> Any:
             from tools.todo_tool import todo_tool as _todo_tool
@@ -2077,6 +2079,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 ),
@@ -2137,6 +2140,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
     else:
+        _generic_registry_dispatch = True
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(
                 function_name, next_args, effective_task_id,
@@ -2151,6 +2155,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
+
+    if _generic_registry_dispatch:
+        return _execute(function_args)
 
     from hermes_cli.middleware import run_tool_execution_middleware
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1192,6 +1192,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 )

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1781,7 +1781,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, cwd: Optional[Path] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -1807,6 +1807,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        cwd: Optional subprocess working directory.  The script path is still
+            resolved and constrained to HERMES_HOME/scripts/; only the child
+            process cwd changes.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -1867,12 +1870,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         from tools.environments.local import _sanitize_subprocess_env
 
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+        run_cwd = Path(cwd).resolve() if cwd is not None else path.parent
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=str(run_cwd),
             env=_sanitize_subprocess_env(os.environ.copy()),
             **popen_kwargs,
         )
@@ -2298,7 +2302,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            ok, output = _run_job_script(script_path, cwd=Path(_job_workdir) if _job_workdir else None)
         finally:
             if _prior_cwd is not None:
                 try:
@@ -2387,7 +2391,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script(script_path)
+        _script_workdir = (job.get("workdir") or "").strip() or None
+        prerun_script = _run_job_script(
+            script_path,
+            cwd=Path(_script_workdir) if _script_workdir and Path(_script_workdir).is_dir() else None,
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2315,24 +2315,36 @@ def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
     Session keys follow the format
-    ``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
+    ``agent:{namespace}:{platform}:{chat_type}[:scope={scope_id}]:{chat_id}[:{extra}...]``.
     Returns a dict with ``platform``, ``chat_type``, ``chat_id``, and
     optionally ``thread_id`` keys, or None if the key doesn't match.
 
-    The 6th element is only returned as ``thread_id`` for chat types where
-    it is unambiguous (``dm`` and ``thread``).  For group/channel sessions
-    the suffix may be a user_id (per-user isolation) rather than a
-    thread_id, so we leave ``thread_id`` out to avoid mis-routing.
+    A scoped key has an explicit ``scope=`` segment before ``chat_id`` so it
+    can be decoded without confusing scope with chat/thread/user IDs.  The
+    first suffix after chat_id is only returned as ``thread_id`` for chat
+    types where it is unambiguous (``dm`` and ``thread``).  For group/channel
+    sessions the suffix may be a user_id (per-user isolation) rather than a
+    thread_id, so it is exposed as ``participant_id`` to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if len(parts) >= 5 and parts[0] == "agent":
+        chat_index = 4
         result = {
+            "namespace": parts[1],
             "platform": parts[2],
             "chat_type": parts[3],
-            "chat_id": parts[4],
         }
-        if len(parts) > 5 and parts[3] in {"dm", "thread"}:
-            result["thread_id"] = parts[5]
+        if parts[chat_index].startswith("scope="):
+            result["scope_id"] = parts[chat_index][len("scope="):]
+            chat_index += 1
+            if len(parts) <= chat_index:
+                return None
+        result["chat_id"] = parts[chat_index]
+        if len(parts) > chat_index + 1:
+            if parts[3] in {"dm", "thread"}:
+                result["thread_id"] = parts[chat_index + 1]
+            elif parts[3] in {"group", "channel"}:
+                result["participant_id"] = parts[chat_index + 1]
         return result
     return None
 
@@ -9524,7 +9536,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 env=sanitized_env,
                             )
                             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-                            output = (stdout or stderr).decode().strip()
+                            stdout_text = (stdout or b"").decode(errors="replace").strip()
+                            stderr_text = (stderr or b"").decode(errors="replace").strip()
+                            if proc.returncode:
+                                details = []
+                                if stderr_text:
+                                    details.append(stderr_text)
+                                if stdout_text:
+                                    details.append(stdout_text)
+                                output = "\n".join(details).strip()
+                                if output:
+                                    output = f"Quick command exited with code {proc.returncode}:\n{output}"
+                                else:
+                                    output = f"Quick command exited with code {proc.returncode}."
+                            else:
+                                output = stdout_text or stderr_text
                             # Redact any remaining sensitive patterns in output
                             if output:
                                 from agent.redact import redact_sensitive_text

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -853,6 +853,10 @@ def build_session_key(
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
     key_parts = [ns, platform, source.chat_type]
 
+    scope = source.scope_id or source.guild_id
+    if scope and source.platform in {Platform.DISCORD, Platform.SLACK, Platform.MATRIX}:
+        key_parts.append(f"scope={scope}")
+
     if source.chat_id:
         key_parts.append(source.chat_id)
     if source.thread_id:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -27,7 +27,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, cast
 
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -6491,7 +6491,12 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
         if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
-            return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
+            # Cache the raw merged config, not the ${ENV}-expanded value.  Env
+            # refs can rotate via /reload or process env changes without
+            # touching config.yaml, so expansion must happen on every return.
+            expanded_cached = cast(Dict[str, Any], _expand_env_vars(copy.deepcopy(cached[4])))
+            _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded_cached)
+            return copy.deepcopy(expanded_cached) if want_deepcopy else expanded_cached
 
         config = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -6512,30 +6517,29 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 _warn_config_parse_failure(config_path, e)
 
         normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
-        expanded = _expand_env_vars(normalized)
-        # Managed scope wins at the leaf. Applied AFTER user expansion so a user
-        # ${VAR} cannot shadow a managed literal: managed values are expanded only
-        # against the process environment, never against user-config-defined refs.
-        # This deliberately inverts the usual env-over-config precedence for the
-        # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
+        raw_merged: Dict[str, Any] = copy.deepcopy(normalized)
+        # Managed scope wins at the leaf. Keep the cache raw and expand after
+        # merging so env-var rotations are reflected without touching config.yaml.
+        # Managed values are expanded only against the process environment, never
+        # against user-config-defined refs. This deliberately inverts the usual
+        # env-over-config precedence for the keys the managed layer pins — see
+        # docs/design/managed-scope.md §4.1.
         managed_config = managed_scope.load_managed_config()
         if managed_config:
-            managed_expanded = _expand_env_vars(managed_config)
-            expanded = _deep_merge(expanded, managed_expanded)
+            raw_merged = _deep_merge(raw_merged, managed_config)
+        expanded = cast(Dict[str, Any], _expand_env_vars(raw_merged))
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_sig is not None:
-            # Cache stores a separate deepcopy so subsequent ``load_config()``
-            # (deepcopy=True) callers can mutate freely without affecting the
-            # cached value, and ``load_config_readonly()`` (deepcopy=False)
-            # callers all see the same stable cached object. The cached tuple is
-            # (user_mtime, user_size, managed_mtime, managed_size, value).
-            cached_copy = copy.deepcopy(expanded)
-            _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy)
-            # On the readonly path return the same cached object subsequent
-            # calls will see — keeps "two readonly calls return the same
-            # object" invariant that callers may rely on for identity checks.
+            # Cache stores the raw merged value so future reads can re-expand
+            # against the current environment while keeping config-file parsing
+            # cached. The cached tuple is
+            # (user_mtime, user_size, managed_mtime, managed_size, raw_value).
+            cached_copy = copy.deepcopy(raw_merged)
+            _LOAD_CONFIG_CACHE[path_key] = (
+                cache_sig[0], cache_sig[1], cache_sig[2], cache_sig[3], cached_copy
+            )
             if not want_deepcopy:
-                return cached_copy
+                return expanded
         else:
             _LOAD_CONFIG_CACHE.pop(path_key, None)
         # First-load result is a fresh dict (not aliased to the cache); safe

--- a/tests/agent/test_tool_dispatch_regressions.py
+++ b/tests/agent/test_tool_dispatch_regressions.py
@@ -1,0 +1,87 @@
+import json
+from types import SimpleNamespace
+
+from tools.registry import registry
+
+
+def test_invoke_tool_forwards_session_search_profile(monkeypatch):
+    import agent.agent_runtime_helpers as runtime_helpers
+    import hermes_cli.middleware as middleware
+    import tools.session_search_tool as session_search_tool
+
+    calls = []
+
+    def fake_session_search(**kwargs):
+        calls.append(kwargs)
+        return json.dumps({"ok": True})
+
+    monkeypatch.setattr(session_search_tool, "session_search", fake_session_search)
+    monkeypatch.setattr(
+        middleware,
+        "run_tool_execution_middleware",
+        lambda _name, args, execute, **_kw: execute(args),
+    )
+
+    agent = SimpleNamespace(
+        session_id="current-session",
+        _get_session_db_for_recall=lambda: object(),
+        _current_turn_id="turn",
+        _current_api_request_id="api",
+    )
+
+    runtime_helpers.invoke_tool(
+        agent,
+        "session_search",
+        {"query": "needle", "profile": "other-profile"},
+        "task",
+    )
+
+    assert calls[0]["profile"] == "other-profile"
+
+
+def test_generic_invoke_tool_runs_tool_execution_middleware_once(monkeypatch):
+    import agent.agent_runtime_helpers as runtime_helpers
+    import hermes_cli.middleware as middleware
+
+    tool_name = "__test_dispatch_once_tool"
+    try:
+        registry.deregister(tool_name)
+    except Exception:
+        pass
+    registry.register(
+        name=tool_name,
+        toolset="test",
+        schema={
+            "name": tool_name,
+            "description": "test tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda _args, **_kw: json.dumps({"ok": True}),
+        check_fn=lambda: True,
+    )
+
+    calls = []
+
+    def spy(name, args, execute, **_kwargs):
+        calls.append(name)
+        return execute(args)
+
+    monkeypatch.setattr(middleware, "run_tool_execution_middleware", spy)
+    agent = SimpleNamespace(
+        session_id="current-session",
+        valid_tool_names={tool_name},
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+        _current_turn_id="turn",
+        _current_api_request_id="api",
+        _memory_manager=None,
+        _context_engine_tool_names=set(),
+        context_compressor=None,
+    )
+
+    try:
+        assert runtime_helpers.invoke_tool(agent, tool_name, {}, "task") == json.dumps({"ok": True})
+    finally:
+        registry.deregister(tool_name)
+
+    assert calls == [tool_name]

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -161,6 +161,30 @@ class TestGatewayQuickCommands:
         assert result == "ok"
 
     @pytest.mark.asyncio
+    async def test_exec_command_reports_nonzero_exit_with_stderr(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {
+            "quick_commands": {
+                "boom": {
+                    "type": "exec",
+                    "command": "python -c 'import sys; print(\"OUT\"); print(\"ERR\", file=sys.stderr); sys.exit(7)'",
+                }
+            }
+        }
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("boom")
+        result = await runner._handle_message(event)
+
+        assert result is not None
+        assert "exited with code 7" in result
+        assert "ERR" in result
+        assert "OUT" in result
+
+    @pytest.mark.asyncio
     async def test_exec_command_does_not_leak_credentials(self):
         """Quick command exec must sanitize env — API keys must not appear in output."""
         from gateway.run import GatewayRunner

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -109,6 +109,18 @@ class TestRunJobScript:
         assert success is True
         assert output == "relative works"
 
+    def test_script_can_run_from_configured_workdir(self, cron_env, tmp_path):
+        from cron.scheduler import _run_job_script
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        script = cron_env / "scripts" / "cwd.py"
+        script.write_text("import os; print(os.getcwd())\n")
+
+        success, output = _run_job_script("cwd.py", cwd=workdir)
+        assert success is True
+        assert Path(output).resolve() == workdir.resolve()
+
     def test_script_not_found(self, cron_env):
         from cron.scheduler import _run_job_script
 

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -101,6 +101,25 @@ class TestSessionKeyNamespacedWhenOn:
         assert d[1] == "main" and n[1] == "coder"
         assert d[2:] == n[2:]  # everything after the namespace is identical
 
+    def test_scope_id_isolates_workspace_local_channel_ids(self):
+        a = _src(
+            platform=Platform.DISCORD,
+            chat_id="c1",
+            chat_type="channel",
+            user_id="u1",
+            scope_id="guild-a",
+        )
+        b = _src(
+            platform=Platform.DISCORD,
+            chat_id="c1",
+            chat_type="channel",
+            user_id="u1",
+            scope_id="guild-b",
+        )
+
+        assert build_session_key(a) != build_session_key(b)
+        assert build_session_key(a) == "agent:main:discord:channel:scope=guild-a:c1:u1"
+
 
 class TestMultiplexConfigFlag:
     """gateway.multiplex_profiles defaults off and round-trips."""

--- a/tests/gateway/test_session_key_parse.py
+++ b/tests/gateway/test_session_key_parse.py
@@ -1,0 +1,22 @@
+from gateway.run import _parse_session_key
+
+
+def test_parse_session_key_accepts_profile_namespace():
+    assert _parse_session_key("agent:coder:discord:group:c1:u1") == {
+        "namespace": "coder",
+        "platform": "discord",
+        "chat_type": "group",
+        "chat_id": "c1",
+        "participant_id": "u1",
+    }
+
+
+def test_parse_session_key_decodes_scope_segment():
+    assert _parse_session_key("agent:main:discord:group:scope=guild-a:c1:u1") == {
+        "namespace": "main",
+        "platform": "discord",
+        "chat_type": "group",
+        "scope_id": "guild-a",
+        "chat_id": "c1",
+        "participant_id": "u1",
+    }

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -93,6 +93,17 @@ class TestLoadConfigExpansion:
 
         assert config["model"]["api_key"] == "${NOT_SET_XYZ_123}"
 
+    def test_load_config_re_expands_env_refs_after_env_changes(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("model:\n  api_key: ${ROTATING_TEST_KEY}\n")
+
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+        monkeypatch.setenv("ROTATING_TEST_KEY", "first")
+        assert load_config()["model"]["api_key"] == "first"
+
+        monkeypatch.setenv("ROTATING_TEST_KEY", "second")
+        assert load_config()["model"]["api_key"] == "second"
+
 
 class TestLoadCliConfigExpansion:
     """Verify that load_cli_config() also expands ${VAR} references."""

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -629,7 +629,7 @@ def session_search(
     # Discovery shape
     sort: str = None,
     # Cross-profile (any shape)
-    profile: str = None,
+    profile: Optional[str] = None,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 


### PR DESCRIPTION
## Summary
- Fix scoped session keys and fallback parsing for profile/scoped gateway sessions
- Report quick-command non-zero exits with stderr/stdout instead of masking failures
- Honor cron script workdir for no-agent/pre-run scripts
- Re-expand config ${ENV} refs from the cache so rotated env values are picked up
- Forward session_search(profile=...) through inline dispatch and avoid double tool middleware execution
- Add targeted regression tests

## Verification
- scripts/run_tests.sh tests/cli/test_quick_commands.py tests/cron/test_cron_script.py tests/hermes_cli/test_config_env_expansion.py tests/gateway/test_multiplex_phase0.py tests/gateway/test_session_key_parse.py tests/agent/test_tool_dispatch_regressions.py tests/tools/test_session_search.py tests/gateway/test_slack_channel_session_scope.py tests/gateway/test_session_model_override_routing.py tests/gateway/test_session_env.py tests/cron/test_cron_workdir.py tests/cron/test_cron_no_agent.py -q
  - 220 tests passed, 0 failed
- uv run --with ruff==0.15.10 ruff check agent/agent_runtime_helpers.py agent/tool_executor.py cron/scheduler.py gateway/run.py gateway/session.py hermes_cli/config.py tools/session_search_tool.py tests/agent/test_tool_dispatch_regressions.py tests/cli/test_quick_commands.py tests/cron/test_cron_script.py tests/gateway/test_multiplex_phase0.py tests/gateway/test_session_key_parse.py tests/hermes_cli/test_config_env_expansion.py
  - All checks passed
- venv/bin/python -m compileall -q agent/agent_runtime_helpers.py agent/tool_executor.py cron/scheduler.py gateway/run.py gateway/session.py hermes_cli/config.py tools/session_search_tool.py tests/agent/test_tool_dispatch_regressions.py tests/gateway/test_session_key_parse.py
  - exit 0
