### PR TITLE
feat(agent): add native_first image input routing mode

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -1,6 +1,6 @@
 """Routing helpers for inbound user-attached images.
 
-Two modes:
+Modes:
 
   native  — attach images as OpenAI-style ``image_url`` content parts on the
             user turn. Provider adapters (Anthropic, Gemini, Bedrock, Codex,
@@ -12,9 +12,15 @@ Two modes:
             it only sees a lossy text summary. This is the pre-existing
             behaviour and still the right choice for non-vision models.
 
+  native_first — attach natively when the active model reports vision support;
+            otherwise use the text pipeline. Unlike ``auto``, an explicit
+            auxiliary vision backend is treated as a fallback rather than an
+            override.
+
 The decision is made once per message turn by :func:`decide_image_input_mode`.
 It reads ``agent.image_input_mode`` from config.yaml (``auto`` | ``native``
-| ``text``, default ``auto``) and the active model's capability metadata.
+| ``native_first`` | ``text``, default ``auto``) and the active model's
+capability metadata.
 
 In ``auto`` mode:
   - If the user has explicitly configured ``auxiliary.vision.provider``
@@ -45,7 +51,7 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
-_VALID_MODES = frozenset({"auto", "native", "text"})
+_VALID_MODES = frozenset({"auto", "native", "native_first", "text"})
 
 
 # Image extensions used by extract_image_refs(). Kept tight on purpose — we
@@ -424,6 +430,11 @@ def decide_image_input_mode(
     if mode_cfg == "native":
         return "native"
     if mode_cfg == "text":
+        return "text"
+    if mode_cfg == "native_first":
+        supports = _lookup_supports_vision(provider, model, cfg)
+        if supports is True:
+            return "native"
         return "text"
 
     # auto

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1070,6 +1070,9 @@ DEFAULT_CONFIG = {
         #   "native" — always attach natively; non-vision models will either
         #              error at the provider or get a last-chance text fallback
         #              (see run_agent._prepare_messages_for_api).
+        #   "native_first" — attach natively when the active model reports
+        #              supports_vision=True, even when auxiliary.vision is
+        #              configured; otherwise fall back to text.
         #   "text"   — always pre-analyze with vision_analyze and prepend the
         #              description as text; the main model never sees pixels.
         # Affects gateway platforms, the TUI, and CLI /attach.  vision_analyze

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -103,6 +103,24 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "text"
 
+    def test_native_first_uses_native_even_with_aux_vision_override(self):
+        cfg = {
+            "agent": {"image_input_mode": "native_first"},
+            "auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}},
+        }
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "native"
+
+    def test_native_first_uses_text_for_non_vision_model(self):
+        cfg = {"agent": {"image_input_mode": "native_first"}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=False):
+            assert decide_image_input_mode("openrouter", "qwen/qwen3-235b", cfg) == "text"
+
+    def test_native_first_uses_text_for_unknown_model(self):
+        cfg = {"agent": {"image_input_mode": "native_first"}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert decide_image_input_mode("openrouter", "brand-new-slug", cfg) == "text"
+
     def test_none_config_is_auto(self):
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", None) == "native"


### PR DESCRIPTION
## Summary
- Add `native_first` as a fourth `agent.image_input_mode` option.
- Keep the existing `auto`, `native`, and `text` behavior unchanged.
- Document the new mode and add regression coverage for auxiliary-vision fallback semantics.

## Why
`auto` currently treats an explicit `auxiliary.vision` backend as an override, so user-attached images are pre-analyzed into text even when the active main model supports native vision. `native_first` fills the gap between `auto` and forced `native`: use native vision when the main model reports `supports_vision=True`, otherwise fall back to the existing text / `vision_analyze` pipeline.

This lets users keep a dedicated auxiliary vision backend configured as a fallback without bypassing native vision-capable main models.

## Testing
- `uv run --extra dev python -m pytest tests/agent/test_image_routing.py -q` — 92 passed
- `python -m py_compile agent/image_routing.py hermes_cli/config.py`