### PR TITLE
fix(gateway): use getattr for __cause__ in _is_transient_network_error

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -267,7 +267,7 @@ def _is_transient_network_error(exc: BaseException) -> bool:
         name = type(cur).__name__
         if name in transient_class_names:
             return True
-        cur = cur.__cause__ or cur.__context__
+        cur = getattr(cur, "__cause__", None) or getattr(cur, "__context__", None)
     return False
 
 

--- a/tests/gateway/test_loop_exception_handler.py
+++ b/tests/gateway/test_loop_exception_handler.py
@@ -113,6 +113,22 @@ def test_transient_classifier_does_not_infinite_loop_on_cyclic_cause():
     assert _is_transient_network_error(exc) is False
 
 
+def test_transient_classifier_tolerates_missing_chain_attributes():
+    """Regression for #57298: objects without __cause__/__context__ don't crash.
+
+    A ``traceback.TracebackException`` (or any duck-typed exception-like
+    object) may lack ``__cause__`` and ``__context__`` as instance
+    attributes.  The classifier must return ``False`` instead of raising
+    ``AttributeError``.
+    """
+
+    class TracebackLike:
+        """Mimics an object that has no exception-chain attributes."""
+        pass
+
+    assert _is_transient_network_error(TracebackLike()) is False
+
+
 # ---------------------------------------------------------------------
 # Loop handler
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #57298.

## Changes
- `gateway/run.py`: Replace direct `cur.__cause__` access with `getattr(cur, "__cause__", None)` in `_is_transient_network_error()`

## Behavior
| Scenario | Before | After |
|---|---|---|
| Exception chain contains `TracebackException` | `AttributeError` crash, reconnect fails silently | Chain walked safely, transient error detected |
| Normal exception chain | Works | Works (no change) |

## Testing
- Verified `getattr` returns correct values for both live exceptions and `TracebackException` objects
- Pattern matches existing safe access at `plugins/platforms/telegram/adapter.py:878,913`
- 1-line change, zero new surface area