### PR TITLE
fix(guardrails): soft-block exact repeated tool-call failures by default

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -4,6 +4,19 @@ The controller in this module is intentionally side-effect free: it tracks
 per-turn tool-call observations and returns decisions. Runtime code owns whether
 those decisions become warning guidance, synthetic tool results, or controlled
 turn halts.
+
+Escalation tiers:
+
+1. **Warnings** (default on) — guidance appended to failing tool results.
+2. **Soft blocks** (default on) — after ``exact_failure_block_after`` identical
+   failed calls, the exact same call is no longer executed; a synthetic error
+   result is returned instead and the turn continues. Soft-block messages are
+   deliberately *varied* between attempts: smaller models loop precisely
+   because the context fills with byte-identical call/error rounds, and
+   uniform guidance gets absorbed into the repeated pattern instead of
+   breaking it.
+3. **Hard stops** (explicit opt-in via ``hard_stop_enabled``) — blocks also
+   end the turn with a controlled halt response.
 """
 
 from __future__ import annotations
@@ -64,12 +77,17 @@ MUTATING_TOOL_NAMES = frozenset(
 class ToolCallGuardrailConfig:
     """Thresholds for per-turn tool-call loop detection.
 
-    Warnings are enabled by default and never prevent tool execution. Hard stops
-    are explicit opt-in so interactive CLI/TUI sessions get a gentle nudge unless
-    the user enables circuit-breaker behavior in config.yaml.
+    Warnings are enabled by default and never prevent tool execution. Soft
+    blocks (``block_enabled``) are also on by default: once the exact same
+    call has failed ``exact_failure_block_after`` times, the guardrail stops
+    executing it and returns a synthetic error result instead — the turn
+    continues, so the model can recover. Hard stops (ending the turn) remain
+    explicit opt-in so interactive CLI/TUI sessions keep control unless the
+    user enables circuit-breaker behavior in config.yaml.
     """
 
     warnings_enabled: bool = True
+    block_enabled: bool = True
     hard_stop_enabled: bool = False
     exact_failure_warn_after: int = 2
     exact_failure_block_after: int = 5
@@ -96,6 +114,7 @@ class ToolCallGuardrailConfig:
         defaults = cls()
         return cls(
             warnings_enabled=_as_bool(data.get("warnings_enabled"), defaults.warnings_enabled),
+            block_enabled=_as_bool(data.get("block_enabled"), defaults.block_enabled),
             hard_stop_enabled=_as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled),
             exact_failure_warn_after=_positive_int(
                 warn_after.get("exact_failure", data.get("exact_failure_warn_after")),
@@ -151,6 +170,9 @@ class ToolGuardrailDecision:
     tool_name: str = ""
     count: int = 0
     signature: ToolCallSignature | None = None
+    # Soft decisions skip execution but never end the turn: the runtime
+    # synthesizes a tool result and the model continues with fresh context.
+    soft: bool = False
 
     @property
     def allows_execution(self) -> bool:
@@ -158,7 +180,7 @@ class ToolGuardrailDecision:
 
     @property
     def should_halt(self) -> bool:
-        return self.action in {"block", "halt"}
+        return self.action in {"block", "halt"} and not self.soft
 
     def to_metadata(self) -> dict[str, Any]:
         data: dict[str, Any] = {
@@ -168,6 +190,8 @@ class ToolGuardrailDecision:
             "tool_name": self.tool_name,
             "count": self.count,
         }
+        if self.soft:
+            data["soft"] = True
         if self.signature is not None:
             data["signature"] = self.signature.to_metadata()
         return data
@@ -240,45 +264,81 @@ class ToolCallGuardrailController:
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
-        if not self.config.hard_stop_enabled:
+        if not (self.config.hard_stop_enabled or self.config.block_enabled):
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
         exact_count = self._exact_failure_counts.get(signature, 0)
         if exact_count >= self.config.exact_failure_block_after:
-            decision = ToolGuardrailDecision(
+            if self.config.hard_stop_enabled:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="repeated_exact_failure_block",
+                    message=(
+                        f"Blocked {tool_name}: the same tool call failed {exact_count} "
+                        "times with identical arguments. Stop retrying it unchanged; "
+                        "change strategy or explain the blocker."
+                    ),
+                    tool_name=tool_name,
+                    count=exact_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+
+            # Soft block: skip execution but keep the turn alive. Blocked
+            # attempts never reach after_call, so record the attempt here —
+            # consecutive blocks must keep escalating, and the streak must
+            # stay accurate for the message rotation below.
+            blocked_count = exact_count + 1
+            self._exact_failure_counts[signature] = blocked_count
+            self._same_tool_failure_counts[tool_name] = (
+                self._same_tool_failure_counts.get(tool_name, 0) + 1
+            )
+            attempt = blocked_count - self.config.exact_failure_block_after
+            return ToolGuardrailDecision(
                 action="block",
                 code="repeated_exact_failure_block",
-                message=(
-                    f"Blocked {tool_name}: the same tool call failed {exact_count} "
-                    "times with identical arguments. Stop retrying it unchanged; "
-                    "change strategy or explain the blocker."
-                ),
+                message=_soft_block_message(tool_name, blocked_count, attempt),
                 tool_name=tool_name,
-                count=exact_count,
+                count=blocked_count,
                 signature=signature,
+                soft=True,
             )
-            self._halt_decision = decision
-            return decision
 
         if self._is_idempotent(tool_name):
             record = self._no_progress.get(signature)
             if record is not None:
-                _result_hash, repeat_count = record
+                result_hash, repeat_count = record
                 if repeat_count >= self.config.no_progress_block_after:
-                    decision = ToolGuardrailDecision(
+                    if self.config.hard_stop_enabled:
+                        decision = ToolGuardrailDecision(
+                            action="block",
+                            code="idempotent_no_progress_block",
+                            message=(
+                                f"Blocked {tool_name}: this read-only call returned the same "
+                                f"result {repeat_count} times. Stop repeating it unchanged; "
+                                "use the result already provided or try a different query."
+                            ),
+                            tool_name=tool_name,
+                            count=repeat_count,
+                            signature=signature,
+                        )
+                        self._halt_decision = decision
+                        return decision
+
+                    # Soft block, same bookkeeping rationale as above.
+                    blocked_count = repeat_count + 1
+                    self._no_progress[signature] = (result_hash, blocked_count)
+                    attempt = blocked_count - self.config.no_progress_block_after
+                    return ToolGuardrailDecision(
                         action="block",
                         code="idempotent_no_progress_block",
-                        message=(
-                            f"Blocked {tool_name}: this read-only call returned the same "
-                            f"result {repeat_count} times. Stop repeating it unchanged; "
-                            "use the result already provided or try a different query."
-                        ),
+                        message=_soft_no_progress_message(tool_name, blocked_count, attempt),
                         tool_name=tool_name,
-                        count=repeat_count,
+                        count=blocked_count,
                         signature=signature,
+                        soft=True,
                     )
-                    self._halt_decision = decision
-                    return decision
 
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -401,6 +461,50 @@ def append_toolguard_guidance(result: str, decision: ToolGuardrailDecision) -> s
         f"{decision.code}; count={decision.count}; {decision.message}]"
     )
     return (result or "") + suffix
+
+
+# Rotated between consecutive soft blocks on purpose: a context full of
+# byte-identical call/error rounds is what sustains a tool-call loop, and
+# guidance repeated verbatim gets absorbed into that pattern. Distinct
+# wording per attempt is a load-bearing part of breaking the loop.
+_SOFT_BLOCK_MESSAGES = (
+    "Not executed: this exact {tool} call already failed {count} times with "
+    "identical arguments, so re-sending it unchanged cannot succeed. Re-read "
+    "the error in the earlier tool results and change the argument(s) it "
+    "points at, or take a different approach.",
+    "Still not executing this ({count} identical failures so far). The call "
+    "is byte-identical to the ones that already failed — nothing has changed, "
+    "so nothing different can happen. Change at least one argument of the "
+    "{tool} call, switch to a different tool, or report the blocker.",
+    "STOP: identical {tool} call, attempt #{count}. Compare your call against "
+    "the earlier error message field by field — at least one argument must "
+    "change before this can be executed again. If you cannot determine what "
+    "to change, stop calling tools and explain the blocker in plain text.",
+)
+
+
+def _soft_block_message(tool_name: str, count: int, attempt: int) -> str:
+    template = _SOFT_BLOCK_MESSAGES[(max(attempt, 1) - 1) % len(_SOFT_BLOCK_MESSAGES)]
+    return template.format(tool=tool_name, count=count)
+
+
+_SOFT_NO_PROGRESS_MESSAGES = (
+    "Not executed: this exact {tool} call already ran {count} times and "
+    "returned the same result every time. The answer is already in the "
+    "earlier tool results — use it, or change the query/path if it wasn't "
+    "what you needed.",
+    "Skipped (attempt #{count}, identical result each time). Running the same "
+    "{tool} call again cannot produce new information. Work with the result "
+    "you already have, broaden or narrow the query, or try a different tool.",
+    "STOP repeating this {tool} call — {count} identical runs, identical "
+    "output. If the earlier result didn't answer your question, the fix is a "
+    "DIFFERENT call (other arguments or another tool), not the same one again.",
+)
+
+
+def _soft_no_progress_message(tool_name: str, count: int, attempt: int) -> str:
+    template = _SOFT_NO_PROGRESS_MESSAGES[(max(attempt, 1) - 1) % len(_SOFT_NO_PROGRESS_MESSAGES)]
+    return template.format(tool=tool_name, count=count)
 
 
 def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -370,11 +370,18 @@ browser:
 # Tool Loop Guardrails
 # =============================================================================
 # Soft warnings are enabled by default. They append guidance to repeated failed
-# or non-progressing tool results but still let the tool execute. Hard stops are
-# opt-in circuit breakers for autonomous/cron sessions where stopping a loop is
-# preferable to spending the full iteration budget.
+# or non-progressing tool results but still let the tool execute. Soft blocks
+# (block_enabled) are also on by default: once the exact same call has failed
+# hard_stop_after.exact_failure times with identical arguments (or a read-only
+# call has returned an identical result hard_stop_after.idempotent_no_progress
+# times), it is no longer executed — the model gets a synthetic error result
+# (with wording that varies between attempts) and the turn continues. Hard
+# stops are opt-in circuit
+# breakers for autonomous/cron sessions where stopping a loop is preferable to
+# spending the full iteration budget.
 tool_loop_guardrails:
   warnings_enabled: true
+  block_enabled: true
   hard_stop_enabled: false
   warn_after:
     exact_failure: 2

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1400,9 +1400,15 @@ DEFAULT_CONFIG = {
 
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
-    # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
+    # block_enabled additionally refuses to re-execute a call that already
+    # failed hard_stop_after.exact_failure times with identical arguments,
+    # or a read-only call that returned an identical result
+    # hard_stop_after.idempotent_no_progress times (the turn continues with
+    # a synthetic error result). Hard stops are opt-in so interactive
+    # CLI/TUI sessions keep flowing.
     "tool_loop_guardrails": {
         "warnings_enabled": True,
+        "block_enabled": True,
         "hard_stop_enabled": False,
         "warn_after": {
             "exact_failure": 2,

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -37,6 +37,7 @@ def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
     cfg = ToolCallGuardrailConfig()
 
     assert cfg.warnings_enabled is True
+    assert cfg.block_enabled is True
     assert cfg.hard_stop_enabled is False
     assert cfg.exact_failure_warn_after == 2
     assert cfg.same_tool_failure_warn_after == 3
@@ -74,7 +75,7 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
     assert cfg.no_progress_block_after == 8
 
 
-def test_default_repeated_identical_failed_call_warns_without_blocking():
+def test_default_repeated_identical_failed_call_warns_then_soft_blocks():
     controller = ToolCallGuardrailController()
     args = {"query": "same"}
 
@@ -88,8 +89,91 @@ def test_default_repeated_identical_failed_call_warns_without_blocking():
     assert decisions[0].action == "allow"
     assert [d.action for d in decisions[1:]] == ["warn", "warn", "warn", "warn"]
     assert {d.code for d in decisions[1:]} == {"repeated_exact_failure_warning"}
+
+    # 6th identical attempt: soft-blocked without executing, turn keeps going.
+    blocked = controller.before_call("web_search", args)
+    assert blocked.action == "block"
+    assert blocked.code == "repeated_exact_failure_block"
+    assert blocked.soft is True
+    assert blocked.allows_execution is False
+    assert blocked.should_halt is False
+    assert controller.halt_decision is None
+
+
+def test_warn_only_legacy_behavior_when_block_disabled():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(block_enabled=False)
+    )
+    args = {"query": "same"}
+
+    for _ in range(8):
+        assert controller.before_call("web_search", args).action == "allow"
+        controller.after_call("web_search", args, '{"error":"boom"}', failed=True)
+
     assert controller.before_call("web_search", args).action == "allow"
     assert controller.halt_decision is None
+
+
+def test_consecutive_soft_blocks_escalate_count_and_vary_message():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(exact_failure_block_after=2)
+    )
+    args = {"command": "npm run dev"}
+
+    controller.after_call("terminal", args, '{"exit_code":-1,"error":"boom"}', failed=True)
+    controller.after_call("terminal", args, '{"exit_code":-1,"error":"boom"}', failed=True)
+
+    first = controller.before_call("terminal", args)
+    second = controller.before_call("terminal", args)
+    third = controller.before_call("terminal", args)
+
+    assert [d.action for d in (first, second, third)] == ["block", "block", "block"]
+    assert [d.soft for d in (first, second, third)] == [True, True, True]
+    # Blocked attempts count as failed attempts so the streak keeps escalating.
+    assert [d.count for d in (first, second, third)] == [3, 4, 5]
+    # Wording must differ between consecutive blocks — uniform guidance gets
+    # absorbed into the loop pattern instead of breaking it.
+    assert len({first.message, second.message, third.message}) == 3
+    assert controller.halt_decision is None
+
+
+def test_soft_block_success_after_changed_args_resets_streak():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(exact_failure_block_after=2)
+    )
+    bad = {"command": "npm run dev"}
+    fixed = {"command": "npm run dev", "background": True}
+
+    controller.after_call("terminal", bad, '{"exit_code":-1,"error":"boom"}', failed=True)
+    controller.after_call("terminal", bad, '{"exit_code":-1,"error":"boom"}', failed=True)
+    assert controller.before_call("terminal", bad).action == "block"
+
+    # A different call is never blocked.
+    assert controller.before_call("terminal", fixed).action == "allow"
+    controller.after_call("terminal", fixed, '{"exit_code":0}', failed=False)
+
+    # The old signature stays blocked until its streak is cleared by a success.
+    assert controller.before_call("terminal", bad).action == "block"
+    controller.after_call("terminal", bad, '{"exit_code":0}', failed=False)
+    assert controller.before_call("terminal", bad).action == "allow"
+
+
+def test_soft_block_metadata_marks_decision_as_soft():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(exact_failure_block_after=1)
+    )
+    controller.after_call("web_search", {"q": "x"}, '{"error":"boom"}', failed=True)
+    blocked = controller.before_call("web_search", {"q": "x"})
+
+    metadata = blocked.to_metadata()
+    assert metadata["soft"] is True
+    assert metadata["action"] == "block"
+
+
+def test_config_parses_block_enabled_flag():
+    cfg = ToolCallGuardrailConfig.from_mapping({"block_enabled": False})
+    assert cfg.block_enabled is False
+    assert ToolCallGuardrailConfig.from_mapping({}).block_enabled is True
 
 
 def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution():
@@ -188,19 +272,44 @@ def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
     assert third.count == 3
 
 
-def test_idempotent_no_progress_repeated_result_warns_without_blocking_by_default():
+def test_idempotent_no_progress_repeated_result_warns_then_soft_blocks_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
     )
     args = {"path": "/tmp/same.txt"}
     result = "same file contents"
 
-    for _ in range(4):
-        assert controller.before_call("read_file", args).action == "allow"
-        decision = controller.after_call("read_file", args, result, failed=False)
+    assert controller.before_call("read_file", args).action == "allow"
+    assert controller.after_call("read_file", args, result, failed=False).action == "allow"
+    assert controller.before_call("read_file", args).action == "allow"
+    warn = controller.after_call("read_file", args, result, failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "idempotent_no_progress_warning"
 
-    assert decision.action == "warn"
-    assert decision.code == "idempotent_no_progress_warning"
+    # Threshold reached: identical read is soft-blocked, turn keeps going.
+    first = controller.before_call("read_file", args)
+    second = controller.before_call("read_file", args)
+    assert [d.action for d in (first, second)] == ["block", "block"]
+    assert [d.soft for d in (first, second)] == [True, True]
+    assert first.code == "idempotent_no_progress_block"
+    assert first.message != second.message
+    assert controller.halt_decision is None
+
+    # A changed result clears the streak.
+    controller.after_call("read_file", args, "new contents", failed=False)
+    assert controller.before_call("read_file", args).action == "allow"
+
+
+def test_no_progress_soft_block_disabled_with_block_enabled_false():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(block_enabled=False, no_progress_warn_after=2, no_progress_block_after=2)
+    )
+    args = {"path": "/tmp/same.txt"}
+
+    for _ in range(5):
+        assert controller.before_call("read_file", args).action == "allow"
+        controller.after_call("read_file", args, "same file contents", failed=False)
+
     assert controller.before_call("read_file", args).action == "allow"
     assert controller.halt_decision is None
 

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -287,6 +287,36 @@ def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_
     assert completed_events[0][1] == "web_search"
 
 
+def test_default_concurrent_path_soft_blocks_without_halting_and_preserves_result_order():
+    agent = _make_agent("web_search")
+    blocked_args = {"query": "blocked"}
+    allowed_args = {"query": "allowed"}
+    _seed_exact_failures(agent, "web_search", blocked_args, count=5)
+    starts = []
+    agent.tool_start_callback = lambda tool_call_id, name, args: starts.append((tool_call_id, name, args))
+    calls = [
+        _mock_tool_call("web_search", json.dumps(blocked_args), "c-softblock"),
+        _mock_tool_call("web_search", json.dumps(allowed_args), "c-allow"),
+    ]
+    msg = SimpleNamespace(content="", tool_calls=calls)
+    messages = []
+    executed = []
+
+    def fake_handle(name, args, task_id, **kwargs):
+        executed.append((name, args, kwargs["tool_call_id"]))
+        return json.dumps({"ok": args["query"]})
+
+    with patch("run_agent.handle_function_call", side_effect=fake_handle):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    assert executed == [("web_search", allowed_args, "c-allow")]
+    assert starts == [("c-allow", "web_search", allowed_args)]
+    assert [m["tool_call_id"] for m in messages] == ["c-softblock", "c-allow"]
+    assert "repeated_exact_failure_block" in messages[0]["content"]
+    assert json.loads(messages[1]["content"]) == {"ok": "allowed"}
+    assert agent._tool_guardrail_halt_decision is None
+
+
 def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     agent = _make_agent("web_search")
     args = {"query": "same"}

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -153,6 +153,73 @@ def test_sequential_after_call_appends_guidance_to_tool_result_without_extra_mes
     assert "repeated_exact_failure_warning" in messages[0]["content"]
 
 
+def test_default_sequential_path_soft_blocks_after_exact_failure_threshold_without_halting():
+    agent = _make_agent("web_search")
+    args = {"query": "same"}
+    _seed_exact_failures(agent, "web_search", args, count=5)
+    starts = []
+    agent.tool_start_callback = lambda *a, **k: starts.append((a, k))
+    tc = _mock_tool_call("web_search", json.dumps(args), "c-softblock")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-1")
+
+    mock_hfc.assert_not_called()
+    assert starts == []
+    assert len(messages) == 1
+    assert messages[0]["role"] == "tool"
+    assert messages[0]["tool_call_id"] == "c-softblock"
+    assert "repeated_exact_failure_block" in messages[0]["content"]
+    # Soft block must not end the turn.
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_default_run_conversation_soft_blocks_identical_failures_and_recovers_without_halt():
+    agent = _make_agent("web_search", max_iterations=12)
+    same_args = {"query": "same"}
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps(same_args), f"c{i}")],
+        )
+        for i in range(1, 8)
+    ]
+    responses.append(_mock_response(content="done", finish_reason="stop", tool_calls=None))
+    agent.client.chat.completions.create.side_effect = responses
+
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"error": "boom"})) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search repeatedly")
+
+    # Attempts 1-5 execute and fail; attempts 6-7 are soft-blocked without
+    # executing; the model then answers and the turn ends normally.
+    assert mock_hfc.call_count == 5
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert "guardrail" not in result
+    assert result["final_response"] == "done"
+
+    tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
+    blocked = [c for c in tool_contents if "repeated_exact_failure_block" in c]
+    assert len(blocked) == 2
+    # Consecutive soft blocks must not read identically — varied wording is
+    # what breaks the self-conditioning loop.
+    assert blocked[0] != blocked[1]
+
+    # Every assistant tool_call still has a matching tool result.
+    for m in result["messages"]:
+        if m.get("role") == "assistant" and m.get("tool_calls"):
+            call_ids = [tc["id"] for tc in m["tool_calls"]]
+            results = [t for t in result["messages"] if t.get("role") == "tool" and t.get("tool_call_id") in call_ids]
+            assert len(results) == len(call_ids)
+
+
 def test_same_tool_failure_warning_tells_model_to_recover_with_tools():
     agent = _make_agent("terminal")
     guardrails = getattr(agent, "_tool_guardrails")

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1389,14 +1389,15 @@ agent:
 
 ## Tool-Loop Guardrails
 
-Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent call returning the same result with no progress. By default it injects a **warning** into the tool result so the model self-corrects; it does not hard-stop, since a person watching the CLI/TUI can intervene.
+Hermes detects when the agent is stuck in an unproductive tool-calling loop — the same tool call failing repeatedly, the same tool failing over and over, or an idempotent call returning the same result with no progress. By default it first injects a **warning**, then **soft-blocks** an exact repeated failure or idempotent no-progress call at the configured threshold. A soft block skips that call, returns recovery guidance to the model, and lets the turn continue. It does not end the turn.
 
 For unattended gateway / server deployments, enable hard stops so a stuck agent is circuit-broken instead of burning the iteration budget:
 
 ```yaml
 tool_loop_guardrails:
   warnings_enabled: true       # inject warnings into tool results (default: true)
-  hard_stop_enabled: false     # also BLOCK the call past the hard-stop threshold (default: false)
+  block_enabled: true          # soft-block exact/no-progress loops (default: true)
+  hard_stop_enabled: false     # end the turn at a hard-stop threshold (default: false)
   warn_after:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
@@ -1407,7 +1408,7 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 ```
 
-`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
+Set `block_enabled: false` to restore warning-only behavior. `hard_stop_enabled` is a separate, stronger circuit breaker: it defaults to `false` because interactive sessions have a human in the loop, but unattended deployments (gateway, cron, kanban workers) can set it to `true` to end a stuck turn at the hard-stop threshold. See also [Docker / unattended deployments](docker.md).
 
 ## TTS Configuration
 

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -70,8 +70,10 @@ This behavior applies to the s6-based image only. Earlier (tini-based) images st
 See the [Where the logs go](#where-the-logs-go) section below for the full routing map (per-profile gateways, dashboard, boot reconciler, container-wide `docker logs`).
 :::
 
-:::note Tool-loop hard stops for unattended gateways
-The `tool_loop_guardrails.hard_stop_enabled` setting defaults to `false`, which is reasonable for interactive CLI and TUI sessions where a person can see repeated tool-call warnings. In unattended gateway or server deployments, warnings alone may not stop an agent that gets stuck in a repeated tool-call loop. Operators who want circuit-breaker behavior should explicitly enable hard stops in the profile's `config.yaml`:
+:::note Tool-loop guardrails for unattended gateways
+By default, repeated exact failures and idempotent no-progress calls are soft-blocked: Hermes skips the repeated call, gives the model recovery guidance, and continues the turn. Set `tool_loop_guardrails.block_enabled: false` only when warning-only behavior is desired.
+
+`hard_stop_enabled` is a stronger circuit breaker that ends the turn, and it defaults to `false`. Operators of unattended gateway or server deployments can explicitly enable it in the profile's `config.yaml`:
 
 ```yaml
 tool_loop_guardrails:


### PR DESCRIPTION
## What does this PR do?

Makes the tool-loop guardrail's block tier actually fire in default configuration — as a **soft block** that skips execution but keeps the turn alive — instead of being dead code unless `hard_stop_enabled` is set.

Today, with default config, a model that repeats a byte-identical failing tool call gets a `repeated_exact_failure_warning` appended to every failure… and nothing else, forever. In a production session on a local model (qwen3.6-27b), the same rejected `terminal` call was re-sent 20+ consecutive times; the stored transcript shows the guardrail warning firing at `count=11, 13, 15, 17` with zero effect, burning the iteration budget (default 300) on a call that failed deterministically in ~3ms. Context compaction did not break the loop — the compaction summary described the loop and the model resumed it as its first post-compaction action.

This PR adds a middle tier between "warn" and "halt the turn":

- After `hard_stop_after.exact_failure` (default 5) identical failed calls, the exact call is no longer executed. The model receives a synthetic error result and the turn continues, so it can recover on its own.
- Same treatment for the idempotent no-progress axis (`hard_stop_after.idempotent_no_progress` identical results from a read-only call) — this is the exact scenario in #41490.
- **Soft-block wording rotates between attempts.** This is load-bearing, not cosmetic: replaying a real stuck context against the same model showed the loop is self-conditioning — with 3 identical failed rounds in context the model fixed the call 6/6 samples, at 8 rounds it started repeating (2/6), and a prefix containing one fresh interleaved user message sampled 0/6 repeats. Identical guidance gets absorbed into the repeated pattern; varied guidance breaks it. (Anti-repetition samplers were also tested and made things *worse* — `dry_multiplier 0.8` / `repeat_penalty 1.1` penalize re-sending the command string, so the model mangles the command instead of changing the failing argument.)
- Hard stops (`hard_stop_enabled: true`) are completely unchanged: blocks still end the turn with the controlled halt response, thresholds and messages identical.
- Opt-out via `tool_loop_guardrails.block_enabled: false` restores today's warn-only behavior.

Blocked attempts are recorded inside `before_call` (blocked calls never reach `after_call`), so consecutive blocks keep escalating the count and, when hard stops are enabled, streaks stay accurate.

Known limitation (shared with the existing opt-in hard block): a soft-blocked read-only signature stays blocked for the rest of the turn even if a later mutation would have changed its result; the model can always issue a modified call.

Relationship to nearby work: #37490 adds turn-continuation redirect guidance at the conversation-loop layer for tool-*reported* loop blocks; #54340 addresses the same-tool (varying-args) failure axis; #49189 flips hard stops on for non-interactive platforms. This PR is orthogonal to all three — it makes the *exact-identical* block tiers exist at all in default mode — and implements the failure/no-progress subset of RFC #35573 within the existing guardrail framework.

## Related Issue

Fixes #41490

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_guardrails.py`: `block_enabled` config flag (default true); `soft` field on `ToolGuardrailDecision` (`should_halt` excludes soft decisions, `to_metadata()` reports it); `before_call` returns soft blocks for exact-failure and idempotent-no-progress streaks when hard stops are off; rotating message templates for both axes.
- `hermes_cli/config.py`: `block_enabled: True` in `DEFAULT_CONFIG["tool_loop_guardrails"]` + comment.
- `cli-config.yaml.example`: document the new tier and flag.
- `tests/agent/test_tool_guardrails.py`: soft-block coverage (escalation, message variation, reset-on-success, metadata, opt-out, config parsing); updated the two default-behavior tests that pinned warn-only forever.
- `tests/run_agent/test_tool_call_guardrail_runtime.py`: sequential-path soft block (no execution, no halt) and a full `run_conversation` recovery test (5 executed failures → 2 soft blocks with distinct wording → model answers, turn ends normally, every tool_call keeps a paired tool result).

## How to Test

1. `python -m pytest tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py -q` → 35 passed.
2. `python -m pytest tests/agent tests/run_agent -q` → passes (see PR checks).
3. Manual repro: with default config, force any tool to fail 6+ times with identical arguments; observe the 6th attempt returns `repeated_exact_failure_block` guardrail JSON without executing, wording varies on subsequent attempts, and the turn continues (no `guardrail_halt`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (native, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module + config docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python controller change, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Production transcript excerpt (message ids from the local session DB) showing warn-only failing at scale:

```
terminal {"command":"cd ~/hermes-forge && npm run dev 2>&1","timeout":600}
→ {"exit_code": -1, "error": "This foreground command appears to start a long-lived server/watch process. Run it with background=true, ..."}
   [Tool loop warning: repeated_exact_failure_warning; count=11; ...]
(identical call re-sent)
   [Tool loop warning: ... count=13 ...]
(identical call re-sent)
   [Tool loop warning: ... count=15 ...]
(identical call re-sent)
   [Tool loop warning: ... count=17 ...]
... model never once changed the arguments; its own reasoning text correctly
identified the fix ("I need to set background=true") every single turn.
```
