### PR TITLE
fix(terminal): block raw-PID kills of the gateway's own process

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -73,6 +73,43 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(text))
 
 
+# A kill/pkill invocation inside a shell command line. Anchored on a shell
+# position where a command can start (line start, separator, substitution,
+# or a common wrapper like sudo/exec) so quoted prose such as
+# ``grep 'kill' notes.md`` cannot fire. The argument capture stops at the
+# next separator or newline so a PID appearing in a *later* command on the
+# same line is not attributed to the kill.
+_KILL_INVOCATION = re.compile(
+    r"(?i)"
+    r"(?:^|[;&|`(\n]|\$\(|\b(?:sudo|exec|env|command|nohup|setsid)\s+)\s*"
+    r"(?:[\w./-]+/)?p?kill\b([^;&|`)\n]*)"
+)
+
+
+def command_kills_pid(text: str, pid: int) -> bool:
+    """Return True if *text* contains a kill/pkill invocation whose argument
+    list includes *pid* as a literal token.
+
+    The word-based ``_GATEWAY_LIFECYCLE_PATTERN`` cannot catch
+    ``kill -TERM <pid>`` with a raw numeric PID — no ``hermes``/``gateway``
+    token appears (real incident: an in-gateway agent, blocked four times by
+    the pattern guard, killed the gateway by literal PID). At terminal
+    execution time the gateway knows its own PID, so a literal-token match
+    is exact: it cannot false-positive on prose or on kills of unrelated
+    processes.
+
+    Dynamic forms (``kill $PID``, ``... | xargs kill``) are out of scope —
+    this is a foot-gun guard, not a security boundary.
+    """
+    if not text or pid <= 1:
+        return False
+    pid_token = re.compile(r"(?<![\w.-])" + str(pid) + r"(?![\w.-])")
+    for match in _KILL_INVOCATION.finditer(text):
+        if pid_token.search(match.group(1)):
+            return True
+    return False
+
+
 def _resolve_script_path(script_path: str) -> Path:
     """Resolve a cron ``script`` value the same way the scheduler does.
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -531,3 +531,120 @@ class TestRestartLoopGuard:
         rlg.check_and_record(3, 60, now=1001.0)
         rlg.clear()
         assert rlg.check_and_record(3, 60, now=1002.0) is False
+
+
+# ---------------------------------------------------------------------------
+# Defense 3b: terminal_tool blocks raw-PID kills of the gateway's own process
+# ---------------------------------------------------------------------------
+
+class TestCommandKillsPid:
+    """cron.lifecycle_guard.command_kills_pid — literal-PID kill detection.
+
+    Real incident (2026-06-30): an in-gateway agent, blocked four times by the
+    word-based lifecycle pattern, ran `kill -TERM <gateway-pid>` with the raw
+    numeric PID. No 'hermes'/'gateway' token appears, so Branch D never fires.
+    At terminal-execution time the gateway knows its own PID, so a literal
+    match is exact and cannot false-positive on prose.
+    """
+
+    def test_matches_kill_variants(self):
+        from cron.lifecycle_guard import command_kills_pid
+        for cmd in [
+            "kill -TERM 12345",
+            "kill -9 12345",
+            "kill 12345",
+            "sudo kill -TERM 12345",
+            "/bin/kill 12345",
+            "kill -TERM 12345 || true",
+            "kill -TERM 12345 67890",       # multi-pid, gateway included
+            "kill -TERM 67890 12345",
+            "echo hi; kill -KILL 12345",    # compound command
+            "kill -s TERM 12345",
+            "kill -TERM 12345\nsleep 5",   # multi-line command (as observed)
+        ]:
+            assert command_kills_pid(cmd, 12345), f"Should match: {cmd!r}"
+
+    def test_ignores_other_pids_and_prose(self):
+        from cron.lifecycle_guard import command_kills_pid
+        for cmd in [
+            "kill -TERM 99999",              # different pid
+            "kill -TERM 123456",             # gateway pid as substring only
+            "kill -TERM 2345",               # suffix substring
+            "echo 12345",                    # no kill at all
+            "pkill -f myapp",                # no literal pid
+            "kill $GATEWAY_PID",             # dynamic — out of scope
+            "ls file-12345.txt && kill -0 67890",  # pid appears outside kill args
+            "grep 'kill' notes-12345.md",    # kill as prose/word, pid in filename
+            "kill -TERM 999\necho 12345",   # pid on a later line, not a kill arg
+        ]:
+            assert not command_kills_pid(cmd, 12345), f"Should NOT match: {cmd!r}"
+
+    def test_edge_inputs(self):
+        from cron.lifecycle_guard import command_kills_pid
+        assert not command_kills_pid("", 12345)
+        assert not command_kills_pid("kill -TERM 0", 0)
+        assert not command_kills_pid("kill -TERM 1", 1)  # refuse pid <= 1
+
+
+class TestTerminalToolRawPidKillGuard:
+    """terminal_tool must refuse kill commands that target the gateway's own
+    PID when running inside the gateway (_HERMES_GATEWAY=1)."""
+
+    def _make_fake_env(self, calls=None):
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):
+                if calls is None:  # pragma: no cover
+                    raise AssertionError("execute must not be reached")
+                calls.append(command)
+                return {"output": "", "returncode": 0}
+        return _FakeEnv()
+
+    def _minimal_config(self):
+        return {"env_type": "local", "cwd": "/tmp", "timeout": 60, "lifetime_seconds": 3600}
+
+    def _patch_env(self, monkeypatch, fake_env, *, inside_gateway: bool):
+        import tools.terminal_tool as tt
+        eid = "default"
+        monkeypatch.setattr(tt, "_active_environments", {eid: fake_env})
+        monkeypatch.setattr(tt, "_last_activity", {eid: 0.0})
+        monkeypatch.setattr(tt, "_task_env_overrides", {})
+        monkeypatch.setattr(tt, "_get_env_config", self._minimal_config)
+        if inside_gateway:
+            monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        else:
+            monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+
+    def test_blocks_kill_of_own_pid_inside_gateway(self, monkeypatch):
+        import os
+        import tools.terminal_tool as tt
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command=f"kill -TERM {os.getpid()}"))
+
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
+    def test_kill_of_unrelated_pid_passes_through(self, monkeypatch):
+        import tools.terminal_tool as tt
+        calls = []
+        self._patch_env(monkeypatch, self._make_fake_env(calls), inside_gateway=True)
+        monkeypatch.setattr(tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True})
+
+        result = json.loads(tt.terminal_tool(command="kill -TERM 99999999"))
+
+        assert result["exit_code"] == 0
+        assert calls == ["kill -TERM 99999999"]
+
+    def test_kill_of_own_pid_allowed_outside_gateway(self, monkeypatch):
+        import os
+        import tools.terminal_tool as tt
+        calls = []
+        self._patch_env(monkeypatch, self._make_fake_env(calls), inside_gateway=False)
+        monkeypatch.setattr(tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True})
+
+        cmd = f"kill -0 {os.getpid()}"
+        result = json.loads(tt.terminal_tool(command=cmd))
+
+        assert result["exit_code"] == 0
+        assert calls == [cmd]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2228,14 +2228,32 @@ def terminal_tool(
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
         # Hard-block: gateway lifecycle commands (systemctl/launchctl/hermes
-        # restart|stop targeting hermes-gateway) must never run inside the
-        # gateway process itself. The restart would SIGTERM the gateway, which
-        # kills this very subprocess before it can complete — the service may
-        # never restart. This mirrors the `hermes gateway restart` guard in
+        # restart|stop targeting hermes-gateway, or a raw `kill` of the
+        # gateway's own PID) must never run inside the gateway process
+        # itself. The restart would SIGTERM the gateway, which kills this
+        # very subprocess before it can complete — the service may never
+        # restart. This mirrors the `hermes gateway restart` guard in
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
-        # but applies unconditionally (force=True cannot help here).
+        # but applies unconditionally (force=True cannot help here). The
+        # PID check runs first: it is exact (literal current PID), while the
+        # word-pattern check is heuristic.
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from hermes_cli.cron import _contains_gateway_lifecycle_command
+            from cron.lifecycle_guard import command_kills_pid
+            if command_kills_pid(command, os.getpid()):
+                return json.dumps({
+                    "output": "",
+                    "exit_code": 1,
+                    "error": (
+                        "Blocked: this command signals the gateway's own process "
+                        f"(PID {os.getpid()}) from inside the gateway. The kill "
+                        "would terminate this command mid-flight and register as "
+                        "an unplanned failure with the service supervisor. Run "
+                        "`hermes gateway restart` from a separate shell outside "
+                        "the running gateway."
+                    ),
+                    "status": "error",
+                }, ensure_ascii=False)
             if _contains_gateway_lifecycle_command(command):
                 return json.dumps({
                     "output": "",


### PR DESCRIPTION
## Problem

The in-gateway terminal guard (`_HERMES_GATEWAY=1`) blocks gateway lifecycle commands by word pattern — `systemctl restart hermes-gateway`, `hermes gateway restart`, `pkill ... hermes ... gateway`. It does not catch `kill -TERM <pid>` with a raw numeric PID, because no `hermes`/`gateway` token appears in the command.

This is not hypothetical. Observed in production (2026-06-30): an agent doing maintenance inside the gateway was blocked four times by the pattern guard (including a `systemd-run --on-active=3s` delayed variant), then listed processes, found the gateway's PID, and ran `kill -TERM <pid>` — which sailed through. The gateway received an unplanned SIGTERM outside any supervisor stop transaction, exited nonzero, was marked `Failed` by systemd, and only came back via `Restart=on-failure`. The same session had already killed four sibling services by raw PID.

## Fix

`cron/lifecycle_guard.py` gains `command_kills_pid(text, pid)`: returns True when a kill/pkill invocation's argument list contains *pid* as a literal token. The terminal guard calls it with `os.getpid()` before the existing word-pattern check.

Because the check requires the literal current PID, it is exact where the word pattern is heuristic:
- no false positives on prose (`grep 'kill' notes.md`), unrelated kills (`kill -TERM 99999`), or the PID embedded in longer numbers/filenames;
- catches the observed shapes: multi-PID kills, `sudo`/path-prefixed kill, compound and multi-line commands.

Dynamic forms (`kill $PID`, `xargs kill`) are documented as out of scope — this is a foot-gun guard, not a security boundary, consistent with the module's existing design notes.

## Tests

6 new tests (detector unit tests + terminal-tool integration: blocks own-PID kill inside gateway, passes unrelated kills through, inactive outside gateway). Full `tests/tools/test_terminal_tool.py`, `tests/cron/`, and `tests/hermes_cli/test_gateway_restart_loop.py`: 708 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)