### PR TITLE
feat(dashboard): auto-refresh CronPage every 30s

### DIFF
--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -607,6 +607,21 @@ export default function CronPage() {
     loadJobs();
   }, [loadJobs]);
 
+  // Cron state changes outside this tab — the scheduler recording a run
+  // result, CLI/other-process edits — and there is no push channel (the same
+  // gap SessionsPage polls around), so refresh silently every 30s. Errors
+  // are swallowed: a failed background tick must not toast; the next user
+  // action surfaces problems through loadJobs' own handler.
+  useEffect(() => {
+    const id = setInterval(() => {
+      api
+        .getCronJobs(selectedProfile)
+        .then(setJobs)
+        .catch(() => {});
+    }, 30_000);
+    return () => clearInterval(id);
+  }, [selectedProfile]);
+
   // Load resources from the profile the create/edit form actually targets.
   // Pass "default" explicitly so the global dashboard profile switch cannot
   // redirect a default-profile cron form to some other profile.


### PR DESCRIPTION
Split out of #57265 (closed as duplicate of #54887 on the auth side) per triage.

CronPage renders once and never refreshes — job state (last run, next run, enabled, last_status) goes stale until a manual reload, unlike SessionsPage which already background-refreshes. This applies the same silent 30s background-refresh pattern SessionsPage uses (~15 lines, no visual flicker: refresh skips the loading state when data is already present).

Verified with `npx tsc --noEmit` and live on a private deployment (job state updates land within 30s of a cron fire, no observed re-render flicker).

Related: #55130 discusses the underlying polling-vs-push question for the dashboard broadly; this is the minimal parity fix for CronPage in the meantime.