### PR TITLE
feat(mcp): add Comfy Cloud to the MCP catalog (remote HTTP + native OAuth 2.1)

### DIFF
--- a/optional-mcps/comfy-cloud/manifest.yaml
+++ b/optional-mcps/comfy-cloud/manifest.yaml
@@ -1,0 +1,42 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: comfy-cloud
+description: Generate images, video, audio, and 3D on Comfy Cloud — ComfyUI workflows, templates, and partner models (Flux, Kling, Veo, ...).
+source: https://docs.comfy.org/agent-tools/cloud
+
+# Comfy Cloud ships a hosted remote MCP server (Streamable HTTP) with native
+# MCP OAuth 2.1 + Dynamic Client Registration — same shape as the linear
+# entry. Hermes's MCP client + mcp_oauth_manager handle discovery, PKCE,
+# token exchange, and refresh — nothing to install locally.
+transport:
+  type: http
+  url: https://cloud.comfy.org/mcp
+
+auth:
+  type: oauth
+  # No `provider:` — native MCP OAuth (case 1), not a third-party provider
+  # like Google. The MCP client triggers the browser flow on the first
+  # probe / first connect.
+
+# Tool selection at install time:
+# The server exposes ~30 tools across generation (partner_generate,
+# submit_workflow, run_template), job lifecycle (get_job_status, wait_for_job,
+# get_output), asset handling (upload_file, use_previous_output), and
+# discovery (search_templates / search_models / search_nodes). We leave
+# `default_enabled` unset so the install-time checklist starts with
+# everything pre-checked — users prune what they don't want.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with your
+  Comfy account. After auth, restart your Hermes session so the Comfy Cloud
+  tools are loaded.
+
+  Discovery tools (search_templates / search_models / search_nodes) work with
+  any Comfy account. Generation tools run on Comfy Cloud and consume credits,
+  so they need a subscription or credit balance — see
+  https://www.comfy.org/cloud for plans.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure comfy-cloud

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,6 +332,7 @@ locales = ["locales/*.yaml"]
 # catalog iterates over (a shared `optional-mcps/*/*` glob would collapse all
 # manifests into one colliding optional-mcps/manifest.yaml). One target per
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
+"optional-mcps/comfy-cloud" = ["optional-mcps/comfy-cloud/manifest.yaml"]
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 


### PR DESCRIPTION
## What

Adds **Comfy Cloud** to the Nous-approved MCP catalog (`optional-mcps/comfy-cloud/manifest.yaml`), so users can:

```
hermes mcp install comfy-cloud
```

Comfy Cloud ships a first-party hosted remote MCP server at `https://cloud.comfy.org/mcp` — Streamable HTTP with **native MCP OAuth 2.1** (Dynamic Client Registration + PKCE + refresh), i.e. the exact same shape as the existing `linear` catalog entry. Nothing to install locally; Hermes's MCP client handles discovery and the browser flow on first connect.

The server exposes ~30 tools for AI generation on Comfy Cloud:

- **Generation** — `partner_generate` (Flux, Kling, Veo, Ideogram, ElevenLabs, …), `submit_workflow` (arbitrary ComfyUI graphs: OSS models, LoRA, ControlNet, multi-step pipelines), `run_template` (curated comfy.org templates)
- **Job lifecycle** — `get_job_status`, `wait_for_job`, `get_output`, `get_queue`, `cancel_job`
- **Assets** — `upload_file`, `use_previous_output`
- **Discovery** — `search_templates`, `search_models`, `search_nodes`

`tools.default_enabled` is left unset (all pre-checked at install, users prune), mirroring the `linear` entry's reasoning.

Also adds the per-entry `data-files` target in `pyproject.toml`, per the one-target-per-entry pattern documented there.

## Why

This is the clean replacement for the local ComfyUI REST-wrapper approaches previously discussed in #11143 (closed) and #13271 — a first-party hosted MCP server maintained by Comfy ([Comfy-Org/comfy-cloud-mcp-server](https://github.com/Comfy-Org/comfy-cloud-mcp-server)), instead of a skill teaching the agent to script a local ComfyUI instance. We (Comfy) have been coordinating with the Nous team on this integration.

## How to test

```
hermes mcp install comfy-cloud
# browser opens → sign in with a Comfy account (OAuth 2.1)
# restart the Hermes session, then ask it to generate an image
```

Notes for testers: discovery tools (`search_*`) work with any Comfy account; generation tools consume Comfy Cloud credits (subscription — https://www.comfy.org/cloud). The `post_install` text says the same to users.

Server-side OAuth discovery is live and verifiable without an account:

```
curl https://cloud.comfy.org/mcp/health                          # 200
curl https://cloud.comfy.org/.well-known/oauth-protected-resource # RFC 9728 metadata
```

## Validation

- Manifest parses through `hermes_cli.mcp_catalog._parse_manifest` (name/transport/auth/tools all validated)
- `tests/hermes_cli/test_mcp_catalog.py` — 35 passed
- `tests/test_packaging_metadata.py` — 11 passed
- Tested on macOS

## Scope

Manifest + one `pyproject.toml` line only — zero core code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)