### PR TITLE
fix(auth): unify provider alias normalization between auth commands and model selection

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1578,30 +1578,15 @@ def _get_config_hint_for_unknown_provider(provider_name: str) -> str:
         return ""
 
 
-def resolve_provider(
-    requested: Optional[str] = None,
-    *,
-    explicit_api_key: Optional[str] = None,
-    explicit_base_url: Optional[str] = None,
-) -> str:
-    """
-    Determine which inference provider to use.
+def build_provider_alias_map() -> dict[str, str]:
+    """Build the canonical provider alias map.
 
-    Priority (when requested="auto" or None) — explicit user intent wins over a
-    stale logged-in OAuth provider (#29285):
-    1. Explicit CLI api_key/base_url -> "openrouter"
-    2. config.yaml `model.provider`
-    3. OPENAI_API_KEY / OPENROUTER_API_KEY env vars -> "openrouter"
-    4. OpenRouter credential pool
-    5. Provider-specific API keys (GLM, Kimi, MiniMax, ...) -> that provider
-    6. auth.json `active_provider` (logged-in OAuth) — last-resort fallback
-    7. AWS Bedrock credential chain
-    8. Error (no provider configured)
+    Shared between ``resolve_provider()`` and ``auth_commands._normalize_provider()``
+    so that CLI sub-commands accept the same aliases as model/provider selection.
+    Plugin providers extend the map via their existing ``aliases`` field.
     """
-    normalized = (requested or "auto").strip().lower()
-
-    # Normalize provider aliases
-    _PROVIDER_ALIASES = {
+    aliases: dict[str, str] = {
+        "or": "openrouter", "open-router": "openrouter",
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
         "x-ai": "xai", "x.ai": "xai", "grok": "xai",
@@ -1621,7 +1606,7 @@ def resolve_provider(
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
         "opencode": "opencode-zen", "zen": "opencode-zen",
-        "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
+        "qwen": "qwen-oauth", "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
         "tencent": "tencent-tokenhub", "tokenhub": "tencent-tokenhub",
@@ -1642,11 +1627,44 @@ def resolve_provider(
         from providers import list_providers as _lp
         for _pp in _lp():
             for _alias in _pp.aliases:
-                if _alias not in _PROVIDER_ALIASES:
-                    _PROVIDER_ALIASES[_alias] = _pp.name
+                if _alias not in aliases:
+                    aliases[_alias] = _pp.name
     except Exception:
         pass
-    normalized = _PROVIDER_ALIASES.get(normalized, normalized)
+    return aliases
+
+
+def normalize_provider_alias(name: str) -> str:
+    """Resolve a provider alias to its canonical provider name.
+
+    Returns the canonical name if the alias is recognized, otherwise returns
+    *name* unchanged.  This is the single source of truth shared between
+    ``resolve_provider()`` and ``auth_commands._normalize_provider()``.
+    """
+    return build_provider_alias_map().get(name.strip().lower(), name.strip().lower())
+
+
+def resolve_provider(
+    requested: Optional[str] = None,
+    *,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+) -> str:
+    """
+    Determine which inference provider to use.
+
+    Priority (when requested="auto" or None) — explicit user intent wins over a
+    stale logged-in OAuth provider (#29285):
+    1. Explicit CLI api_key/base_url -> "openrouter"
+    2. config.yaml `model.provider`
+    3. OPENAI_API_KEY / OPENROUTER_API_KEY env vars -> "openrouter"
+    4. OpenRouter credential pool
+    5. Provider-specific API keys (GLM, Kimi, MiniMax, ...) -> that provider
+    6. auth.json `active_provider` (logged-in OAuth) — last-resort fallback
+    7. AWS Bedrock credential chain
+    8. Error (no provider configured)
+    """
+    normalized = normalize_provider_alias(requested or "auto")
 
     if normalized == "openrouter":
         return "openrouter"

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -28,7 +28,7 @@ from agent.credential_pool import (
     load_pool,
 )
 import hermes_cli.auth as auth_mod
-from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.auth import PROVIDER_REGISTRY, normalize_provider_alias
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -76,10 +76,9 @@ def _resolve_custom_provider_input(raw: str) -> str | None:
 
 def _normalize_provider(provider: str) -> str:
     normalized = (provider or "").strip().lower()
-    if normalized in {"or", "open-router"}:
-        return "openrouter"
-    if normalized in {"grok-oauth", "xai-oauth", "x-ai-oauth", "xai-grok-oauth"}:
-        return "xai-oauth"
+    # Use the canonical alias map from auth.py so that CLI sub-commands
+    # accept the same aliases as model/provider selection (#57309).
+    normalized = normalize_provider_alias(normalized)
     # Check if it matches a custom provider name
     custom_key = _resolve_custom_provider_input(normalized)
     if custom_key:


### PR DESCRIPTION
## What does this PR do?

`hermes auth add` uses a separate, smaller alias map (`_normalize_provider()` in `auth_commands.py`) that only handles 6 aliases, while `hermes model` uses a comprehensive ~35-entry alias map in `auth.py`'s `resolve_provider()`. This means `hermes auth add qwen` fails with "Unknown provider" even though `hermes model --provider qwen` works correctly.

This PR extracts the alias map into a shared `build_provider_alias_map()` function and a `normalize_provider_alias()` helper in `auth.py`, then reuses it in `auth_commands._normalize_provider()`. Both codepaths now share the same canonical source of truth.

Also adds two missing aliases: `"qwen"` → `"qwen-oauth"` and `"or"` / `"open-router"` → `"openrouter"`.

## Related Issue

Fixes #57309

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py`: Extracted `_PROVIDER_ALIASES` dict from `resolve_provider()` into `build_provider_alias_map()` and `normalize_provider_alias()`. Added `"qwen"` → `"qwen-oauth"` and `"or"` / `"open-router"` → `"openrouter"` aliases. Updated `resolve_provider()` to use the shared function.
- `hermes_cli/auth_commands.py`: Replaced hardcoded 6-alias normalization in `_normalize_provider()` with a call to `normalize_provider_alias()` from `auth.py`.
- `tests/hermes_cli/test_auth_commands.py`: Added regression test `test_normalize_provider_uses_shared_alias_map()` per mudrii's suggestion in #57327.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_auth_commands.py -q` — should pass all tests
2. Run `python -c 'from hermes_cli.auth import normalize_provider_alias; assert normalize_provider_alias("qwen") == "qwen-oauth"; assert normalize_provider_alias("glm") == "zai"; assert normalize_provider_alias("or") == "openrouter"'` — should succeed silently
3. Verify `hermes auth add qwen` no longer shows "Unknown provider: qwen" (it will proceed to the credential flow or show a credential-specific error instead)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.3

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->