### PR TITLE
fix(agent): route MoA streaming through virtual client

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2016,12 +2016,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # 'stream_options'`), so omit it only for that endpoint.
         if not is_native_gemini_base_url(agent.base_url):
             stream_kwargs["stream_options"] = {"include_usage": True}
-        request_client = _set_request_client(
-            agent._create_request_openai_client(
-                reason="chat_completion_stream_request",
-                api_kwargs=stream_kwargs,
+        if agent.provider == "moa":
+            request_client = None
+            create = agent.client.chat.completions.create
+        else:
+            request_client = _set_request_client(
+                agent._create_request_openai_client(
+                    reason="chat_completion_stream_request",
+                    api_kwargs=stream_kwargs,
+                )
             )
-        )
+            create = request_client.chat.completions.create
         # Reset stale-stream timer so the detector measures from this
         # attempt's start, not a previous attempt's last chunk.
         last_chunk_time["t"] = time.time()
@@ -2031,7 +2036,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # ``request_client_holder["diag"]`` for closure access.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
-        stream = request_client.chat.completions.create(**stream_kwargs)
+        stream = create(**stream_kwargs)
 
         # Some OpenAI-compatible adapters (for example copilot-acp, and the MoA
         # openai-codex aggregator) accept stream=True but still return a

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -694,7 +694,9 @@ class TestStreamingFallback:
 
         mock_client = MagicMock()
         mock_client.chat.completions.create.return_value = final_response
-        mock_create.return_value = mock_client
+        mock_create.side_effect = AssertionError(
+            "MoA streaming must use the in-process MoA client, not a request OpenAI client"
+        )
 
         agent = AIAgent(
             model="default",
@@ -707,6 +709,7 @@ class TestStreamingFallback:
         )
         agent.api_mode = "chat_completions"
         agent._interrupt_requested = False
+        agent.client = mock_client
 
         deltas = []
         agent._stream_callback = lambda text: deltas.append(text)
@@ -717,6 +720,52 @@ class TestStreamingFallback:
         assert response is final_response
         assert agent._disable_streaming is True
         assert deltas == []
+        mock_create.assert_not_called()
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_moa_streaming_uses_virtual_client_facade(self, mock_close, mock_create):
+        """MoA is a virtual provider; streaming must not target moa://local with OpenAI."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(content="MoA", model="moa-test"),
+            _make_stream_chunk(content=" streamed", finish_reason="stop", model="moa-test"),
+            _make_empty_chunk(usage=SimpleNamespace(prompt_tokens=4, completion_tokens=2)),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.side_effect = AssertionError(
+            "MoA streaming must use the in-process MoA client, not a request OpenAI client"
+        )
+
+        agent = AIAgent(
+            model="default",
+            provider="moa",
+            api_key="test-key",
+            base_url="moa://local",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent.client = mock_client
+
+        deltas = []
+        agent._stream_callback = lambda text: deltas.append(text)
+
+        response = agent._interruptible_streaming_api_call({"model": "default", "messages": []})
+
+        assert response.choices[0].message.content == "MoA streamed"
+        assert response.choices[0].finish_reason == "stop"
+        assert response.usage.prompt_tokens == 4
+        assert deltas == ["MoA", " streamed"]
+        mock_create.assert_not_called()
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["stream"] is True
+        assert call_kwargs["stream_options"] == {"include_usage": True}
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")


### PR DESCRIPTION
## What does this PR do?

Routes MoA streaming requests through the existing in-process MoA client facade instead of constructing a request-local OpenAI client for the virtual `moa://local` endpoint.

Root cause: `interruptible_streaming_api_call()` always used `_create_request_openai_client()` for chat-completions streaming. That is correct for real OpenAI-compatible endpoints, but MoA is a virtual provider backed by `agent.client.chat.completions.create(...)`. Gateway platforms using streaming therefore tried to connect to `moa://local` and failed with `APIConnectionError`.

## Related Issue

Fixes #57251

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/chat_completion_helpers.py`: use `agent.client.chat.completions.create` for `provider == "moa"` in the streaming path while preserving existing streaming assembly, timeout, diagnostics, and fallback behavior.
- `tests/run_agent/test_streaming.py`: add regression coverage proving MoA streaming does not create a request OpenAI client and still forwards `stream=True` / `stream_options` to the MoA facade.

## How to Test

1. `python -m pytest tests/run_agent/test_streaming.py -q`
2. `python -m pytest tests/run_agent/test_moa_streaming.py tests/agent/test_moa_trace_streamed_capture.py -q`
3. `python scripts/run_tests_parallel.py tests/run_agent/test_streaming.py tests/run_agent/test_moa_streaming.py tests/agent/test_moa_trace_streamed_capture.py -q`
4. `python -m ruff check agent/chat_completion_helpers.py tests/run_agent/test_streaming.py`

Local result:

- `tests/run_agent/test_streaming.py`: 43 passed, 2 skipped
- `tests/run_agent/test_moa_streaming.py` + `tests/agent/test_moa_trace_streamed_capture.py`: 12 passed
- `scripts/run_tests_parallel.py ...`: 55 passed, 0 failed
- `ruff check ...`: all checks passed

## Checklist

### Code

- [x] I read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I added tests for my changes
- [x] I tested on my platform: Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: change is provider dispatch only, no OS-specific behavior
- [x] Tool descriptions/schemas update N/A
