### PR TITLE
fix(agent): reset stale summary auth/network failure flags at session…

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1239,6 +1239,8 @@ class ContextCompressor(ContextEngine):
         self._summary_has_user_turn = None
         self._last_summary_error = None
         self._consecutive_timeout_failures = 0
+        self._last_summary_auth_failure = False
+        self._last_summary_network_failure = False
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
         self._last_aux_model_failure_error = None
@@ -1486,7 +1488,11 @@ class ContextCompressor(ContextEngine):
         summary generation; ``_last_compress_aborted`` can make callers think
         compression is still aborted; ``_last_aux_model_failure_*`` can surface
         stale error warnings; ``_last_summary_dropped_count`` /
-        ``_last_summary_fallback_used`` can produce misleading user warnings.
+        ``_last_summary_fallback_used`` can produce misleading user warnings;
+        ``_last_summary_auth_failure`` / ``_last_summary_network_failure`` can
+        abort compression in a later, unrelated session with a stale
+        "authentication error" message even though the new failure (if any)
+        has a different cause.
 
         ``compress()`` already guards ``_previous_summary`` leakage at the
         point of use; this is defense-in-depth that resets the full per-session
@@ -1496,6 +1502,8 @@ class ContextCompressor(ContextEngine):
         self._summary_has_user_turn = None
         self._last_summary_error = None
         self._consecutive_timeout_failures = 0
+        self._last_summary_auth_failure = False
+        self._last_summary_network_failure = False
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
         self._last_aux_model_failure_error = None
@@ -1787,6 +1795,11 @@ class ContextCompressor(ContextEngine):
         self._last_summary_error = None
         self._consecutive_timeout_failures = 0
         self._cooldown_persist_failed = False
+        # Also clear the auth/network failure flags so a manual retry has a
+        # real chance to succeed instead of aborting immediately on whatever
+        # stale reason tripped a previous, unrelated compression attempt.
+        self._last_summary_auth_failure = False
+        self._last_summary_network_failure = False
 
         session_db = getattr(self, "_session_db", None)
         session_id = getattr(self, "_session_id", "")

--- a/tests/agent/test_context_compressor_session_end_clears_state.py
+++ b/tests/agent/test_context_compressor_session_end_clears_state.py
@@ -10,6 +10,8 @@ is reused, these stale values survive:
 - _last_compress_aborted: can make callers think compression is aborted
 - _last_aux_model_failure_*: can surface stale error warnings
 - _last_summary_dropped_count / _last_summary_fallback_used: misleading warnings
+- _last_summary_auth_failure / _last_summary_network_failure: can abort
+  compression in a later, unrelated session with a stale error message
 - _context_probed / _context_probe_persistable: stale context probe state
 
 Fix: on_session_end() now clears all per-session state, matching
@@ -61,6 +63,8 @@ def _make_compressor():
     c._last_compression_savings_pct = 100.0
     c._ineffective_compression_count = 0
     c._last_summary_error = None
+    c._last_summary_auth_failure = False
+    c._last_summary_network_failure = False
     c._last_summary_dropped_count = 0
     c._last_summary_fallback_used = False
     c._last_aux_model_failure_error = None
@@ -79,6 +83,8 @@ def _simulate_cron_session_state(c):
     c._previous_summary = "Cron session summary that must not leak"
     c._summary_has_user_turn = False
     c._last_summary_error = "Cron session summary error"
+    c._last_summary_auth_failure = True
+    c._last_summary_network_failure = True
     c._last_summary_dropped_count = 5
     c._last_summary_fallback_used = True
     c._last_aux_model_failure_error = "Cron aux model error"
@@ -109,6 +115,14 @@ def test_on_session_end_clears_all_per_session_state():
     )
     assert c._last_summary_error is None, (
         f"_last_summary_error must be None after on_session_end, got {c._last_summary_error!r}"
+    )
+    assert c._last_summary_auth_failure is False, (
+        f"_last_summary_auth_failure must be False after on_session_end, "
+        f"got {c._last_summary_auth_failure!r}"
+    )
+    assert c._last_summary_network_failure is False, (
+        f"_last_summary_network_failure must be False after on_session_end, "
+        f"got {c._last_summary_network_failure!r}"
     )
     assert c._last_summary_dropped_count == 0, (
         f"_last_summary_dropped_count must be 0, got {c._last_summary_dropped_count}"
@@ -170,6 +184,8 @@ def test_on_session_end_matches_on_session_reset_surface():
         "_previous_summary",
         "_summary_has_user_turn",
         "_last_summary_error",
+        "_last_summary_auth_failure",
+        "_last_summary_network_failure",
         "_last_summary_dropped_count",
         "_last_summary_fallback_used",
         "_last_aux_model_failure_error",
@@ -243,3 +259,44 @@ def test_aux_model_failure_does_not_leak_across_sessions():
 
     assert c._last_aux_model_failure_error is None
     assert c._last_aux_model_failure_model is None
+
+
+def test_summary_auth_and_network_failure_do_not_leak_across_sessions():
+    """A cron/gateway session where the summarizer hit an auth or network
+    error must not abort compression in a subsequent, unrelated session
+    with a stale "authentication error" message. Regression test: these
+    two flags were the only per-session fields on_session_end() /
+    on_session_reset() forgot to clear, even though the surrounding fix
+    (#38788, #40803-style) was specifically about this exact class of
+    cross-session contamination."""
+    c = _make_compressor()
+    c._last_summary_auth_failure = True
+    c._last_summary_network_failure = True
+
+    c.on_session_end("cron-session", [])
+    assert c._last_summary_auth_failure is False
+    assert c._last_summary_network_failure is False
+
+    c2 = _make_compressor()
+    c2._last_summary_auth_failure = True
+    c2._last_summary_network_failure = True
+
+    c2.on_session_reset()
+    assert c2._last_summary_auth_failure is False
+    assert c2._last_summary_network_failure is False
+
+
+def test_compress_force_retry_clears_stale_auth_and_network_failure():
+    """Manual /compress (force=True) must give the user a working recovery
+    path: a stale auth/network failure flag from a prior attempt must not
+    make the retry abort immediately for the wrong reason.
+    _clear_compression_failure_cooldown() is the function force=True calls
+    before retrying."""
+    c = _make_compressor()
+    c._last_summary_auth_failure = True
+    c._last_summary_network_failure = True
+
+    c._clear_compression_failure_cooldown()
+
+    assert c._last_summary_auth_failure is False
+    assert c._last_summary_network_failure is False


### PR DESCRIPTION
## Summary
Fixes two summarizer-failure flags that were never cleared, causing a
one-time auth or network hiccup in the auxiliary summarizer to make a
later, unrelated compression failure report the wrong cause and abort
instead of falling back or retrying. Also fixes the same flags not
being cleared on a manual `/compress` retry, leaving no working recovery
path for the affected session.

---

## Root cause
`_last_summary_auth_failure` and `_last_summary_network_failure` in
`agent/context_compressor.py` are set to `True` when `_generate_summary()`
hits an auth or network error, and are cleared only when a summary
generation later succeeds. `on_session_end()` and `on_session_reset()`
have been extended more than once already to clear per-session
compressor state, but these two flags were left out of every prior pass
despite falling into the exact same category the docstring on
`on_session_end()` describes.

In the CLI, `/new` calls `reset_session_state()` on the live, long-running
`AIAgent` process, which calls `on_session_reset()` on the same
`ContextCompressor` instance rather than creating a fresh one. A flag set
during one CLI session therefore survives into the next session in the
same process. If a later, unrelated `compress()` call also fails to
produce a summary for any reason, the stale flag makes it report the
wrong cause and abort instead of falling back to a static summary or
retrying.

Separately, and independent of any session boundary, `_clear_compression_failure_cooldown()`
(the function called when a user runs `/compress` with `force=True`)
reset the summary error and cooldown fields but not these two flags. A
user hitting a stale flag mid-session, in either the CLI or the gateway,
had no way to recover through the one command designed for exactly that.

---

## Behavioral change
Before: an auth or network error in one summary attempt could make a
later, unrelated compression attempt abort immediately with a stale
"authentication error" message, with no way to recover other than a
lucky summary success.

After: `on_session_reset()`, `on_session_end()`, and
`_clear_compression_failure_cooldown()` all clear both flags, so a new
session (in the CLI) or a manual `/compress` retry (in either the CLI or
the gateway) starts with a clean slate and a real chance to succeed or
fall back normally.

---

## What changed
**`agent/context_compressor.py`**: added
`self._last_summary_auth_failure = False` and
`self._last_summary_network_failure = False` to `on_session_reset()`,
`on_session_end()` (also extended its docstring to document why, matching
the existing per-field rationale already there), and
`_clear_compression_failure_cooldown()`.

**`tests/agent/test_context_compressor_session_end_clears_state.py`**:
extended the existing per-session-state fixtures and the
`on_session_end` / `on_session_reset` parity test to cover the two new
fields. Added `test_summary_auth_and_network_failure_do_not_leak_across_sessions`
and `test_compress_force_retry_clears_stale_auth_and_network_failure`.

---

## What is NOT changed
- The intentional non-reset of these flags inside `compress()` itself is
  untouched: that guards against cooldown-thrashing within a single
  compression attempt, a different mechanism from the fixes here
- `bind_session_state()` is untouched: traced every call site and found
  no path where it can observe a stale value for either flag
- The 413-emergency compression retry loop in
  `agent/conversation_loop.py` is untouched: it already has its own
  independent progress check
- Gateway's `/new`, `/reset`, `/resume`, and `/branch` handlers are
  untouched: they already evict the cached agent on these paths, so a
  fresh `ContextCompressor` starts with clean flags regardless of this fix
- All existing context-compressor and compression-related tests pass