### PR TITLE
fix(honcho): stop slugging configured peer display names

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -294,14 +294,16 @@ class HonchoSessionManager:
         return self._sanitize_id(f"user-{channel}-{chat_id}")
 
     def _explicit_user_peer_ids(self) -> set[str]:
-        """Return sanitized user peer IDs that came from explicit config."""
+        """Return configured peer IDs that generated runtime peers must avoid."""
         if self._config is None:
             return set()
 
         explicit_ids: set[str] = set()
         peer_name = getattr(self._config, "peer_name", None)
         if peer_name:
-            explicit_ids.add(self._sanitize_id(str(peer_name).strip()))
+            configured_peer = str(peer_name).strip()
+            explicit_ids.add(configured_peer)
+            explicit_ids.add(self._sanitize_id(configured_peer))
 
         aliases = getattr(self._config, "user_peer_aliases", {})
         if isinstance(aliases, dict):
@@ -310,6 +312,20 @@ class HonchoSessionManager:
                     explicit_ids.add(self._sanitize_id(alias.strip()))
 
         return explicit_ids
+
+    def _configured_peer_id(self, value: str | None, fallback: str) -> str:
+        """Return a configured Honcho peer display ID without lossy slugging.
+
+        Runtime/platform IDs and session IDs still need strict sanitization.
+        Explicit Honcho identity config (``peerName`` / ``aiPeer``), however,
+        is a human-readable peer display name. Slugging it turns canonical
+        peers such as ``Oleg Hermes`` and ``Prime PMAX`` into ghost peers
+        (``Oleg-Hermes`` / ``Prime-PMAX``) and fragments memory.
+        """
+
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return fallback
 
     def _generated_runtime_peer_id(self, prefix: str, runtime_id: str) -> str:
         """Return a stable peer ID for an unknown prefixed runtime user."""
@@ -336,7 +352,10 @@ class HonchoSessionManager:
             and getattr(self._config, "pin_peer_name", False) is True
         )
         if pin_peer_name:
-            return self._sanitize_id(self._config.peer_name)
+            return self._configured_peer_id(
+                getattr(self._config, "peer_name", None),
+                "hermes-user",
+            )
 
         runtime_ids = self._runtime_user_ids()
         if runtime_ids:
@@ -356,7 +375,7 @@ class HonchoSessionManager:
             return self._sanitize_id(primary_runtime_id)
 
         if self._config and self._config.peer_name:
-            return self._sanitize_id(self._config.peer_name)
+            return self._configured_peer_id(self._config.peer_name, "hermes-user")
 
         return self._session_key_fallback_peer_id(key)
 
@@ -384,8 +403,9 @@ class HonchoSessionManager:
         # ``peerName`` (see #14984).
         user_peer_id = self._resolve_user_peer_id(key)
 
-        assistant_peer_id = self._sanitize_id(
-            self._config.ai_peer if self._config else "hermes-assistant"
+        assistant_peer_id = self._configured_peer_id(
+            self._config.ai_peer if self._config else None,
+            "hermes-assistant",
         )
 
         # All expensive I/O outside the lock — Honcho's persistence is source of truth

--- a/tests/honcho_plugin/test_pin_peer_name.py
+++ b/tests/honcho_plugin/test_pin_peer_name.py
@@ -203,6 +203,7 @@ class TestPeerResolutionOrder:
         *,
         peer_name: str | None,
         pin_peer_name: bool,
+        ai_peer: str = "hermes",
         user_peer_aliases: dict[str, str] | None = None,
         runtime_peer_prefix: str = "",
         session_peer_prefix: bool = False,
@@ -212,6 +213,7 @@ class TestPeerResolutionOrder:
         return HonchoClientConfig(
             api_key="test-key",
             peer_name=peer_name,
+            ai_peer=ai_peer,
             pin_peer_name=pin_peer_name,
             user_peer_aliases=user_peer_aliases or {},
             runtime_peer_prefix=runtime_peer_prefix,
@@ -254,6 +256,38 @@ class TestPeerResolutionOrder:
 
         session = mgr.get_or_create("telegram:7654321")
         assert session.user_peer_id == "Igor"
+
+    def test_configured_assistant_peer_preserves_spaces(self):
+        """Configured AI peer names are display identities, not runtime slugs."""
+        mgr = HonchoSessionManager(
+            honcho=MagicMock(),
+            config=self._config(
+                peer_name="Arseny",
+                ai_peer="Oleg Hermes",
+                pin_peer_name=False,
+                user_peer_aliases={"7654321": "Arseny"},
+                runtime_peer_prefix="telegram_",
+            ),
+            runtime_user_peer_name="7654321",
+        )
+        _patch_manager_for_resolution_test(mgr)
+
+        session = mgr.get_or_create("telegram:7654321")
+        assert session.assistant_peer_id == "Oleg Hermes"
+
+    def test_pinned_configured_user_peer_preserves_spaces(self):
+        mgr = HonchoSessionManager(
+            honcho=MagicMock(),
+            config=self._config(
+                peer_name="Prime PMAX",
+                pin_peer_name=True,
+            ),
+            runtime_user_peer_name="7654321",
+        )
+        _patch_manager_for_resolution_test(mgr)
+
+        session = mgr.get_or_create("telegram:7654321")
+        assert session.user_peer_id == "Prime PMAX"
 
     def test_unknown_runtime_id_uses_prefix(self):
         """Unknown gateway users stay isolated but become platform-scoped."""


### PR DESCRIPTION
## Problem

Explicitly configured Honcho identities (`peerName` / `aiPeer` in `honcho.json`) are human-readable peer **display names**, but `HonchoSessionManager` runs them through `_sanitize_id()` like any runtime ID. Slugging rewrites a name like `Oleg Hermes` into `Oleg-Hermes`, which Honcho treats as a **different peer**. The result is silent "ghost peers": memory written under the configured identity and memory written under the slugged identity never see each other, fragmenting cross-agent/cross-session memory.

## Fix

- New `_configured_peer_id()` helper returns explicitly configured display names verbatim (trimmed), with a fallback when unset.
- Applied to the three places where explicit identity config is resolved:
  - pinned `peerName` (`pinPeerName: true`),
  - the `peerName` fallback path when no runtime user ID is available,
  - assistant peer resolution from `aiPeer`.
- Runtime/platform-derived IDs, session-key fallbacks, and alias values are **unchanged** and keep strict sanitization.
- `_explicit_user_peer_ids()` now reserves both the verbatim and sanitized spellings of the configured `peerName`, so generated runtime peer IDs cannot collide with either form.

## Default behavior preserved

Configured names that are already slug-safe (no spaces/special characters) resolve to exactly the same peer IDs as before, and nothing changes for users without explicit `peerName`/`aiPeer` config.

## Tests

Adds regression tests to `tests/honcho_plugin/test_pin_peer_name.py` covering space-preserving resolution for both a pinned configured user peer and a configured assistant peer. Full file passes: 45 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)