### PR TITLE
fix(dashboard-auth): skip auto-SSO redirect for password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -182,9 +182,16 @@ def _auto_sso_response(request: Request) -> Response | None:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None
 
-    from hermes_cli.dashboard_auth.prefix import prefix_from_request
-
     provider = providers[0]
+    # A password-only provider (e.g. basic auth) cannot participate in the
+    # OAuth redirect flow — ``start_login`` raises NotImplementedError.
+    # Skip the auto-redirect so the /login page renders the password form
+    # (which POSTs to /auth/password-login) instead of bouncing the user
+    # to a 500.
+    if provider.supports_password:
+        return None
+
+    from hermes_cli.dashboard_auth.prefix import prefix_from_request
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -406,6 +406,26 @@ class TestAutoSsoRedirect:
         assert r.headers["location"].startswith("/login")
         assert "/auth/login" not in r.headers["location"]
 
+    def test_password_provider_skips_auto_sso(self, gated_app):
+        """A password-only provider must NOT be auto-redirected to the OAuth
+        initiation route (/auth/login) — basic auth cannot participate in the
+        OAuth redirect flow and ``start_login`` raises NotImplementedError.
+        Instead, the middleware should fall through to the /login interstitial
+        which renders the password form (POSTing to /auth/password-login)."""
+        from hermes_cli.dashboard_auth import clear_providers, register_provider
+
+        class _PasswordStub(StubAuthProvider):
+            name = "password-stub"
+            display_name = "Password Stub"
+            supports_password = True
+
+        clear_providers()
+        register_provider(_PasswordStub())
+        r = gated_app.get("/sessions", follow_redirects=False)
+        # Must NOT redirect to /auth/login (the OAuth route) — that would 500.
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation


### PR DESCRIPTION
## What does this PR do?

Fix an Internal Server Error (500) when accessing an auth-gated dashboard that uses `basic_auth` as its sole authentication provider.

The auto-SSO middleware redirects unauthenticated HTML loads to `/auth/login?provider=basic` — the OAuth initiation route. But basic auth doesn't support OAuth; `start_login()` raises `NotImplementedError`. The fix skips the auto-redirect for password-only providers so the `/login` page renders the password form (POST to `/auth/password-login`) instead.

## Related Issue

Fixes a crash when `dashboard.basic_auth.password` is configured and the dashboard is bound to a non-loopback host (e.g. `--host 0.0.0.0`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/dashboard_auth/middleware.py` — skip auto-SSO redirect when the sole provider has `supports_password = True`
- `tests/hermes_cli/test_dashboard_auth_401_reauth.py` — add `test_password_provider_skips_auto_sso`

## How to Test

1. Configure `dashboard.basic_auth.password` in `config.yaml`
2. Start dashboard with `hermes dashboard --host 0.0.0.0 --port 9119`
3. Access `http://<host>:9119` without session cookie
4. **Before fix**: 500 Internal Server Error
5. **After fix**: `/login` page renders with username/password form

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (LTS) + macOS 15.x

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) — N/A, auth middleware is platform-agnostic