### PR TITLE
feat(cli): show OpenRouter credit balance in status bar with color-coded tiers

### DIFF
--- a/agent/openrouter_credits.py
+++ b/agent/openrouter_credits.py
@@ -1,0 +1,253 @@
+"""Background-refreshed, per-account OpenRouter credit balance probe.
+
+Shared by the classic prompt-toolkit CLI status bar (``cli.py``) and the Ink
+TUI gateway (``tui_gateway/server.py``). Both surfaces need to show the live
+OpenRouter credit balance without ever blocking their redraw / event-emit
+loops.
+
+Two properties this module guarantees, both required by the PR #57321 review:
+
+1. **Never on the render path.** ``fetch_account_usage()`` makes synchronous
+   ``httpx`` calls that can wait up to 10s. The classic status bar redraws
+   ~1x/s and the gateway emits ``session.info`` on every turn, so fetching
+   inline would stall the UI. ``snapshot()`` only ever returns the last
+   *completed* fetch and kicks any refresh onto a daemon thread.
+
+2. **Scoped per account.** The cache is keyed by a non-secret account identity
+   (provider + base URL + a hash of the API key). A later session with
+   different credentials can never display a prior account's balance, and a
+   gateway hosting several accounts keeps a value per account rather than
+   thrashing a single slot.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import threading
+import time
+from typing import Any, Callable, Dict, Optional, Tuple
+
+# Freshness / backoff window for a given account's balance. A completed attempt
+# (success *or* failure) starts the clock, so a persistently failing account
+# backs off for the full window instead of refetching on every redraw.
+CREDITS_TTL_SECONDS = 300.0
+
+
+def account_identity(
+    provider: Optional[str],
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> str:
+    """Return a non-secret identity string for the resolved account.
+
+    The API key is hashed (truncated SHA-256) — it is never stored in
+    cleartext and never rendered. Used as the cache key so a change of
+    credentials starts a fresh balance rather than surfacing the old one.
+    """
+    key = str(api_key or "").strip()
+    key_fp = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16] if key else "no-key"
+    base = str(base_url or "").strip().rstrip("/")
+    return f"{provider or ''}|{base}|{key_fp}"
+
+
+def parse_credits(
+    snap: Any,
+) -> Tuple[Optional[float], Optional[str], Optional[float]]:
+    """Extract ``(balance, label, quota_pct)`` from an ``AccountUsageSnapshot``.
+
+    Pure and hermetic (no network), so the parsing/formatting logic is
+    unit-testable without a live fetch. Returns ``(None, None, None)`` when the
+    snapshot is missing or has no parseable balance.
+    """
+    if not snap or not getattr(snap, "details", None):
+        return (None, None, None)
+    balance: Optional[float] = None
+    label: Optional[str] = None
+    quota_pct: Optional[float] = None
+    match = re.search(r"\$(\d+\.?\d*)", str(snap.details[0]))
+    if match:
+        balance = float(match.group(1))
+        label = f"${balance:,.2f}"
+    for window in getattr(snap, "windows", None) or []:
+        if (
+            getattr(window, "label", "") == "API key quota"
+            and getattr(window, "used_percent", None) is not None
+        ):
+            quota_pct = window.used_percent
+            break
+    return (balance, label, quota_pct)
+
+
+class OpenRouterCreditsProbe:
+    """Thread-safe, non-blocking reader for OpenRouter credit balances.
+
+    ``snapshot()`` returns the last completed result for the current account
+    immediately and schedules a background refresh when the cached value is
+    stale. Results are kept per account identity so multiple accounts (e.g. in
+    a gateway serving several sessions) never clobber each other.
+
+    ``fetcher`` is injectable for hermetic tests; by default it lazy-imports
+    ``agent.account_usage.fetch_account_usage`` (kept lazy because that module
+    pulls a heavy SDK chain only needed when credits are actually shown).
+    """
+
+    def __init__(
+        self,
+        ttl: float = CREDITS_TTL_SECONDS,
+        fetcher: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        self._ttl = ttl
+        self._fetcher = fetcher
+        self._lock = threading.Lock()
+        # identity -> {"balance", "label", "quota_pct", "last_attempt"}
+        self._entries: Dict[str, Dict[str, Any]] = {}
+        # identity -> in-flight refresh thread
+        self._threads: Dict[str, threading.Thread] = {}
+
+    def _fetch(
+        self,
+        provider: Optional[str],
+        base_url: Optional[str],
+        api_key: Optional[str],
+    ) -> Any:
+        if self._fetcher is not None:
+            return self._fetcher(provider, base_url=base_url, api_key=api_key)
+        from agent.account_usage import fetch_account_usage
+
+        return fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+
+    def snapshot(
+        self,
+        provider: Optional[str],
+        base_url: Optional[str],
+        api_key: Optional[str],
+        *,
+        on_update: Optional[Callable[[], None]] = None,
+    ) -> Dict[str, Any]:
+        """Return the last completed balance for this account, refreshing in the
+        background if stale. Never blocks.
+
+        ``on_update`` (if given) is invoked from the refresh thread once new
+        data lands — used by the CLI to repaint the status bar immediately.
+        Returns ``{}`` when no balance is known yet for the account.
+        """
+        identity = account_identity(provider, base_url, api_key)
+        self._maybe_refresh(provider, base_url, api_key, identity, on_update)
+        with self._lock:
+            entry = self._entries.get(identity)
+            if entry and entry["balance"] is not None:
+                return {
+                    "balance": entry["balance"],
+                    "label": entry["label"],
+                    "quota_pct": entry["quota_pct"],
+                }
+        return {}
+
+    def refresh_now(
+        self,
+        provider: Optional[str],
+        base_url: Optional[str],
+        api_key: Optional[str],
+    ) -> Dict[str, Any]:
+        """Fetch synchronously in the calling thread (no background thread).
+
+        Intended for tests and for one-shot callers (like ``/limits``) that
+        already run off the render path. Returns the same shape as
+        ``snapshot()``.
+        """
+        identity = account_identity(provider, base_url, api_key)
+        self._worker(provider, base_url, api_key, identity, None)
+        with self._lock:
+            entry = self._entries.get(identity) or {}
+            if entry.get("balance") is not None:
+                return {
+                    "balance": entry["balance"],
+                    "label": entry["label"],
+                    "quota_pct": entry["quota_pct"],
+                }
+        return {}
+
+    def _maybe_refresh(
+        self,
+        provider: Optional[str],
+        base_url: Optional[str],
+        api_key: Optional[str],
+        identity: str,
+        on_update: Optional[Callable[[], None]],
+    ) -> None:
+        now = time.monotonic()
+        with self._lock:
+            entry = self._entries.get(identity)
+            if entry is not None and (now - entry["last_attempt"]) <= self._ttl:
+                return  # still fresh (or backing off after a failure)
+            thread = self._threads.get(identity)
+            if thread is not None and thread.is_alive():
+                return  # a refresh for this account is already in flight
+            thread = threading.Thread(
+                target=self._worker,
+                args=(provider, base_url, api_key, identity, on_update),
+                name="or-credits-refresh",
+                daemon=True,
+            )
+            self._threads[identity] = thread
+            thread.start()
+
+    def _worker(
+        self,
+        provider: Optional[str],
+        base_url: Optional[str],
+        api_key: Optional[str],
+        identity: str,
+        on_update: Optional[Callable[[], None]],
+    ) -> None:
+        balance = label = quota_pct = None
+        ok = False
+        try:
+            snap = self._fetch(provider, base_url, api_key)
+            balance, label, quota_pct = parse_credits(snap)
+            ok = True
+        except Exception:
+            # Network / auth / timeout failures must never surface to the UI.
+            # Keep the last good value and back off until the next attempt.
+            ok = False
+        with self._lock:
+            entry = self._entries.get(identity)
+            if entry is None:
+                entry = {
+                    "balance": None,
+                    "label": None,
+                    "quota_pct": None,
+                    "last_attempt": 0.0,
+                }
+                self._entries[identity] = entry
+            # Record the attempt time (success or failure) to drive backoff.
+            entry["last_attempt"] = time.monotonic()
+            if ok:
+                entry["balance"] = balance
+                entry["label"] = label
+                entry["quota_pct"] = quota_pct
+        if ok and on_update is not None:
+            try:
+                on_update()
+            except Exception:
+                pass
+
+
+_SHARED_PROBE: Optional[OpenRouterCreditsProbe] = None
+_SHARED_PROBE_LOCK = threading.Lock()
+
+
+def get_shared_probe() -> OpenRouterCreditsProbe:
+    """Return a process-wide probe, created on first use.
+
+    Used by the TUI gateway, whose ``_get_usage`` is a module-level function
+    with no per-instance state to hang a probe off. Safe for a multi-account
+    gateway because the probe caches per account identity.
+    """
+    global _SHARED_PROBE
+    if _SHARED_PROBE is None:
+        with _SHARED_PROBE_LOCK:
+            if _SHARED_PROBE is None:
+                _SHARED_PROBE = OpenRouterCreditsProbe()
+    return _SHARED_PROBE

--- a/cli.py
+++ b/cli.py
@@ -157,6 +157,14 @@ def realign_markdown_tables(*args, **kwargs):
     from agent.markdown_tables import realign_markdown_tables as _realign_markdown_tables
 
     return _realign_markdown_tables(*args, **kwargs)
+
+
+# ── OpenRouter credit cache for status bar display ────────────────────────
+_or_credits_cache: dict = {
+    "balance": None, "label": None, "quota_pct": None, "timestamp": 0.0
+}
+_OR_CREDITS_CACHE_TTL = 300.0  # seconds
+
 # NOTE: `from agent.account_usage import ...` is deliberately NOT at module
 # top — it transitively pulls the OpenAI SDK chain (~230 ms cold) and is only
 # needed when the user runs `/limits`. Lazy-imported inside the handler below.
@@ -4467,6 +4475,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return "class:status-bar-warn"
         return "class:status-bar-dim"
 
+    @staticmethod
+    def _or_credit_style(balance: Optional[float]) -> str:
+        """Return a style class reflecting OpenRouter credit health."""
+        if balance is None:
+            return "class:status-bar-dim"
+        if balance <= 1.0:
+            return "class:status-bar-critical"
+        if balance <= 10.0:
+            return "class:status-bar-bad"
+        if balance <= 50.0:
+            return "class:status-bar-warn"
+        return "class:status-bar-good"
+
     def _build_context_bar(self, percent_used: Optional[int], width: int = 10) -> str:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
@@ -4626,6 +4647,38 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
+
+        # ── OpenRouter credits (cached, 5-min TTL) ───────────────
+        _or_provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
+        if _or_provider and _or_provider.strip() == "openrouter":
+            _now = time.time()
+            if _now - _or_credits_cache["timestamp"] > _OR_CREDITS_CACHE_TTL:
+                try:
+                    _or_base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+                    _or_api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+                    from agent.account_usage import fetch_account_usage
+                    _or_snap = fetch_account_usage(
+                        _or_provider, base_url=_or_base_url, api_key=_or_api_key
+                    )
+                    if _or_snap and _or_snap.details:
+                        _balance_label = str(_or_snap.details[0])
+                        _m = re.search(r'\$(\d+\.?\d*)', _balance_label)
+                        _balance_num = float(_m.group(1)) if _m else None
+                        _or_credits_cache["balance"] = _balance_num
+                        _or_credits_cache["label"] = None
+                        if _balance_num is not None:
+                            _or_credits_cache["label"] = f"${_balance_num:,.2f}"
+                        _or_credits_cache["quota_pct"] = None
+                        for _w in _or_snap.windows:
+                            if getattr(_w, "label", "") == "API key quota" and getattr(_w, "used_percent", None) is not None:
+                                _or_credits_cache["quota_pct"] = _w.used_percent
+                                break
+                        _or_credits_cache["timestamp"] = _now
+                except Exception:
+                    pass
+            if _or_credits_cache["balance"] is not None:
+                snapshot["or_credits_balance"] = _or_credits_cache["balance"]
+                snapshot["or_credits_label"] = _or_credits_cache["label"]
 
         return snapshot
 
@@ -5049,6 +5102,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                _or_label = snapshot.get("or_credits_label")
+                if _or_label:
+                    parts.append(_or_label)
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5075,6 +5131,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             compressions = snapshot.get("compressions", 0)
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            _or_label = snapshot.get("or_credits_label")
+            if _or_label:
+                parts.append(f"💳 {_or_label}")
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5138,6 +5197,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    _or_label = snapshot.get("or_credits_label")
+                    if _or_label:
+                        _or_bal = snapshot.get("or_credits_balance")
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append((self._or_credit_style(_or_bal), _or_label))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5181,6 +5245,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    _or_label = snapshot.get("or_credits_label")
+                    if _or_label:
+                        _or_bal = snapshot.get("or_credits_balance")
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((self._or_credit_style(_or_bal), f"💳 {_or_label}"))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/cli.py
+++ b/cli.py
@@ -159,11 +159,10 @@ def realign_markdown_tables(*args, **kwargs):
     return _realign_markdown_tables(*args, **kwargs)
 
 
-# ── OpenRouter credit cache for status bar display ────────────────────────
-_or_credits_cache: dict = {
-    "balance": None, "label": None, "quota_pct": None, "timestamp": 0.0
-}
-_OR_CREDITS_CACHE_TTL = 300.0  # seconds
+# OpenRouter status-bar credit balance is served by a background-refreshed,
+# per-account probe (agent/openrouter_credits.py) shared with the TUI gateway,
+# so the ~1x/s status redraw never blocks on the network and a credential
+# switch never shows a prior account's balance. See PR #57321.
 
 # NOTE: `from agent.account_usage import ...` is deliberately NOT at module
 # top — it transitively pulls the OpenAI SDK chain (~230 ms cold) and is only
@@ -4488,6 +4487,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return "class:status-bar-warn"
         return "class:status-bar-good"
 
+    def _or_credits_probe_ref(self):
+        """Return this CLI's OpenRouter credit probe, created on first use.
+
+        Lazy so the status-bar path works even when a HermesCLI is built via
+        __new__ (e.g. in tests) without running __init__.
+        """
+        probe = getattr(self, "_or_credits_probe", None)
+        if probe is None:
+            from agent.openrouter_credits import OpenRouterCreditsProbe
+
+            probe = OpenRouterCreditsProbe()
+            self._or_credits_probe = probe
+        return probe
+
     def _build_context_bar(self, percent_used: Optional[int], width: int = 10) -> str:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
@@ -4648,37 +4661,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
-        # ── OpenRouter credits (cached, 5-min TTL) ───────────────
+        # ── OpenRouter credits (background-refreshed, per-account) ────────
+        # Fetching credits inline would block this ~1x/s redraw for up to 10s
+        # (fetch_account_usage's httpx timeout). Read only the last completed
+        # result from a shared probe that refreshes off the render path and
+        # keys its cache by account, so a credential switch never shows a prior
+        # account's balance. New data triggers a repaint via on_update. (#57321)
         _or_provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
         if _or_provider and _or_provider.strip() == "openrouter":
-            _now = time.time()
-            if _now - _or_credits_cache["timestamp"] > _OR_CREDITS_CACHE_TTL:
-                try:
-                    _or_base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
-                    _or_api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
-                    from agent.account_usage import fetch_account_usage
-                    _or_snap = fetch_account_usage(
-                        _or_provider, base_url=_or_base_url, api_key=_or_api_key
-                    )
-                    if _or_snap and _or_snap.details:
-                        _balance_label = str(_or_snap.details[0])
-                        _m = re.search(r'\$(\d+\.?\d*)', _balance_label)
-                        _balance_num = float(_m.group(1)) if _m else None
-                        _or_credits_cache["balance"] = _balance_num
-                        _or_credits_cache["label"] = None
-                        if _balance_num is not None:
-                            _or_credits_cache["label"] = f"${_balance_num:,.2f}"
-                        _or_credits_cache["quota_pct"] = None
-                        for _w in _or_snap.windows:
-                            if getattr(_w, "label", "") == "API key quota" and getattr(_w, "used_percent", None) is not None:
-                                _or_credits_cache["quota_pct"] = _w.used_percent
-                                break
-                        _or_credits_cache["timestamp"] = _now
-                except Exception:
-                    pass
-            if _or_credits_cache["balance"] is not None:
-                snapshot["or_credits_balance"] = _or_credits_cache["balance"]
-                snapshot["or_credits_label"] = _or_credits_cache["label"]
+            try:
+                _or_base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+                _or_api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+                _or_credits = self._or_credits_probe_ref().snapshot(
+                    _or_provider,
+                    _or_base_url,
+                    _or_api_key,
+                    on_update=lambda: self._invalidate(min_interval=0.0),
+                )
+                if _or_credits.get("balance") is not None:
+                    snapshot["or_credits_balance"] = _or_credits["balance"]
+                    snapshot["or_credits_label"] = _or_credits["label"]
+            except Exception:
+                pass
 
         return snapshot
 

--- a/tests/agent/test_openrouter_credits.py
+++ b/tests/agent/test_openrouter_credits.py
@@ -1,0 +1,147 @@
+"""Tests for the shared OpenRouter credit probe (agent/openrouter_credits.py).
+
+Covers the four properties the PR #57321 review asked for: correct parsing /
+thresholds, per-account cache scoping (no prior account's balance leaks),
+failure handling, and the non-blocking background refresh.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+
+from agent.openrouter_credits import (
+    OpenRouterCreditsProbe,
+    account_identity,
+    parse_credits,
+)
+
+
+def _snap(balance_str="Credits balance: $42.50", quota_pct=None):
+    windows = []
+    if quota_pct is not None:
+        windows.append(SimpleNamespace(label="API key quota", used_percent=quota_pct))
+    return SimpleNamespace(details=[balance_str], windows=windows)
+
+
+def _wait_for_balance(probe, provider, base_url, api_key, timeout=2.0):
+    """Poll snapshot() until the background refresh lands (or time out)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = probe.snapshot(provider, base_url, api_key)
+        if result:
+            return result
+        time.sleep(0.01)
+    return {}
+
+
+class TestParseCredits:
+    def test_extracts_balance_and_label(self):
+        balance, label, quota = parse_credits(_snap("Credits balance: $42.50"))
+        assert balance == 42.5
+        assert label == "$42.50"
+        assert quota is None
+
+    def test_thousands_formatting(self):
+        balance, label, _ = parse_credits(_snap("Credits balance: $1234.5"))
+        assert balance == 1234.5
+        assert label == "$1,234.50"
+
+    def test_quota_percent_from_window(self):
+        _, _, quota = parse_credits(_snap(quota_pct=37.0))
+        assert quota == 37.0
+
+    def test_none_snapshot(self):
+        assert parse_credits(None) == (None, None, None)
+
+    def test_no_details(self):
+        assert parse_credits(SimpleNamespace(details=[], windows=[])) == (None, None, None)
+
+    def test_unparseable_balance(self):
+        assert parse_credits(_snap("no dollar amount here")) == (None, None, None)
+
+
+class TestAccountIdentity:
+    def test_trailing_slash_normalized(self):
+        a = account_identity("openrouter", "https://x/api/", "sk-secret")
+        b = account_identity("openrouter", "https://x/api", "sk-secret")
+        assert a == b
+
+    def test_different_key_yields_different_identity(self):
+        a = account_identity("openrouter", "https://x", "sk-a")
+        b = account_identity("openrouter", "https://x", "sk-b")
+        assert a != b
+
+    def test_different_base_url_yields_different_identity(self):
+        a = account_identity("openrouter", "https://x", "sk-a")
+        b = account_identity("openrouter", "https://y", "sk-a")
+        assert a != b
+
+    def test_api_key_never_appears_in_cleartext(self):
+        secret = "sk-super-secret-value-12345"
+        identity = account_identity("openrouter", "https://x", secret)
+        assert secret not in identity
+
+    def test_missing_key(self):
+        assert "no-key" in account_identity("openrouter", "https://x", None)
+
+
+class TestProbeCaching:
+    def test_refresh_now_returns_balance(self):
+        calls = []
+
+        def fetcher(provider, *, base_url, api_key):
+            calls.append((provider, base_url, api_key))
+            return _snap("Credits balance: $10.00")
+
+        probe = OpenRouterCreditsProbe(fetcher=fetcher)
+        result = probe.refresh_now("openrouter", "https://x", "sk-a")
+        assert result["balance"] == 10.0
+        assert result["label"] == "$10.00"
+        assert len(calls) == 1
+
+    def test_snapshot_is_non_blocking_then_caches(self):
+        calls = []
+
+        def fetcher(provider, *, base_url, api_key):
+            calls.append(1)
+            return _snap("Credits balance: $5.00")
+
+        probe = OpenRouterCreditsProbe(ttl=300.0, fetcher=fetcher)
+        # First call returns immediately with nothing (fetch runs in background).
+        assert probe.snapshot("openrouter", "https://x", "sk-a") == {}
+        # Once it lands, the value is cached and not refetched within the TTL.
+        landed = _wait_for_balance(probe, "openrouter", "https://x", "sk-a")
+        assert landed["balance"] == 5.0
+        probe.snapshot("openrouter", "https://x", "sk-a")
+        assert len(calls) == 1
+
+    def test_account_switch_never_shows_prior_balance(self):
+        def fetcher(provider, *, base_url, api_key):
+            amount = "100.00" if api_key == "sk-a" else "2.00"
+            return _snap(f"Credits balance: ${amount}")
+
+        probe = OpenRouterCreditsProbe(fetcher=fetcher)
+        probe.refresh_now("openrouter", "https://x", "sk-a")  # $100 cached for A
+        # A snapshot for a DIFFERENT account must never surface A's balance,
+        # even before B's own fetch has completed.
+        immediate = probe.snapshot("openrouter", "https://x", "sk-b")
+        assert immediate.get("balance") != 100.0
+        landed = _wait_for_balance(probe, "openrouter", "https://x", "sk-b")
+        assert landed["balance"] == 2.0
+        # A's value is still independently cached (per-account, not clobbered).
+        assert probe.snapshot("openrouter", "https://x", "sk-a")["balance"] == 100.0
+
+    def test_fetch_failure_is_swallowed(self):
+        def fetcher(provider, *, base_url, api_key):
+            raise RuntimeError("network down")
+
+        probe = OpenRouterCreditsProbe(fetcher=fetcher)
+        assert probe.refresh_now("openrouter", "https://x", "sk-a") == {}
+
+    def test_on_update_fires_after_successful_refresh(self):
+        fired = threading.Event()
+        probe = OpenRouterCreditsProbe(
+            fetcher=lambda p, *, base_url, api_key: _snap("Credits balance: $9.00")
+        )
+        probe.snapshot("openrouter", "https://x", "sk-a", on_update=fired.set)
+        assert fired.wait(2.0)

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
@@ -504,6 +505,99 @@ class TestCLIStatusBar:
         compact = cli_obj._get_voice_status_fragments(width=50)
 
         assert compact == [("class:voice-status", " 🎤 Ctrl+B ")]
+
+
+class TestCLIStatusBarOrCredits:
+    """OpenRouter credit balance probe integration in the status bar.
+
+    Verifies the four review requirements from PR #57321:
+    1. Non-blocking snapshot (never calls fetch_account_usage inline)
+    2. Correct color-coded threshold rendering
+    3. Non-OpenRouter provider omits the credit segment
+    4. Probe is created lazily and survives across snapshots
+    """
+
+    def test_credit_style_thresholds(self):
+        """Color tiers match the spec: >$50 good, >$10 warn, >$1 bad, <=$1 critical."""
+        assert HermesCLI._or_credit_style(None) == "class:status-bar-dim"
+        assert HermesCLI._or_credit_style(0.0) == "class:status-bar-critical"
+        assert HermesCLI._or_credit_style(1.0) == "class:status-bar-critical"
+        assert HermesCLI._or_credit_style(5.0) == "class:status-bar-bad"
+        assert HermesCLI._or_credit_style(10.0) == "class:status-bar-bad"
+        assert HermesCLI._or_credit_style(25.0) == "class:status-bar-warn"
+        assert HermesCLI._or_credit_style(50.0) == "class:status-bar-warn"
+        assert HermesCLI._or_credit_style(100.0) == "class:status-bar-good"
+
+    def test_snapshot_includes_balance_when_available(self):
+        """When the probe has a balance, the snapshot carries it."""
+        cli_obj = _attach_agent(
+            _make_cli(model="openrouter/anthropic/claude-sonnet-4"),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=3,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+        # Override provider to OpenRouter
+        cli_obj.agent.provider = "openrouter"
+        cli_obj.agent.base_url = "https://openrouter.ai/api/v1"
+        cli_obj.agent.api_key = "sk-or-v1-test"
+        # Simulate a probe that already has cached data
+        fake_probe = MagicMock()
+        fake_probe.snapshot.return_value = {"balance": 42.50, "label": "$42.50", "quota_pct": None}
+        cli_obj._or_credits_probe = fake_probe
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert snapshot.get("or_credits_balance") == 42.50
+        assert snapshot.get("or_credits_label") == "$42.50"
+
+    def test_non_openrouter_provider_omits_credits(self):
+        """Non-OpenRouter providers should not show credit balance."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=3,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+        fake_probe = MagicMock()
+        fake_probe.snapshot.return_value = {"balance": 42.50, "label": "$42.50", "quota_pct": None}
+        cli_obj._or_credits_probe = fake_probe
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert "or_credits_balance" not in snapshot
+        assert "or_credits_label" not in snapshot
+
+    def test_probe_created_lazily(self):
+        """_or_credits_probe_ref creates the probe on first call."""
+        cli_obj = _make_cli()
+        assert not hasattr(cli_obj, "_or_credits_probe")
+        probe = cli_obj._or_credits_probe_ref()
+        assert probe is not None
+        assert hasattr(cli_obj, "_or_credits_probe")
+        # Second call returns the same instance
+        assert cli_obj._or_credits_probe_ref() is probe
+
+    def test_snapshot_non_blocking(self):
+        """snapshot() never blocks — it calls the probe, not fetch_account_usage."""
+        cli_obj = _attach_agent(
+            _make_cli(model="openrouter/anthropic/claude-sonnet-4"),
+            prompt_tokens=10_000,
+            completion_tokens=2_000,
+            total_tokens=12_000,
+            api_calls=3,
+            context_tokens=12_000,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openrouter"
+        cli_obj.agent.base_url = "https://openrouter.ai/api/v1"
+        cli_obj.agent.api_key = "sk-or-v1-test"
+        # If no probe is set, snapshot returns empty — but never blocks
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert "or_credits_balance" not in snapshot
 
 
 class TestCLIUsageReport:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3016,6 +3016,24 @@ def _get_usage(agent) -> dict:
                 usage["dev_credits_spent_micros"] = int(spent)
         except Exception:
             pass
+    # OpenRouter credit balance for the TUI status bar. Served by a shared
+    # background probe so this session.info emit never blocks on the network,
+    # and scoped per account. Mirrors the classic CLI status bar. (#57321)
+    try:
+        _or_provider = getattr(agent, "provider", None)
+        if _or_provider and str(_or_provider).strip() == "openrouter":
+            from agent.openrouter_credits import get_shared_probe
+
+            _or_credits = get_shared_probe().snapshot(
+                _or_provider,
+                getattr(agent, "base_url", None),
+                getattr(agent, "api_key", None),
+            )
+            if _or_credits.get("balance") is not None:
+                usage["or_credits_balance"] = _or_credits["balance"]
+                usage["or_credits_label"] = _or_credits["label"]
+    except Exception:
+        pass
     return usage
 
 

--- a/ui-tui/src/__tests__/appChromeStatusRuleOrCredits.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRuleOrCredits.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { StatusRule } from '../components/appChrome.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { Usage } from '../types.js'
+
+type ReactNodeLike = React.ReactNode
+
+const textContent = (node: ReactNodeLike): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return ''
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(textContent).join('')
+  }
+
+  if (React.isValidElement(node)) {
+    return textContent((node.props as { children?: ReactNodeLike }).children)
+  }
+
+  return ''
+}
+
+// Collect every (color, text) pair so a test can assert the colour applied to
+// the segment carrying the credit label.
+const collectColored = (node: ReactNodeLike, out: { color: unknown; text: string }[] = []) => {
+  if (Array.isArray(node)) {
+    node.forEach(child => collectColored(child, out))
+
+    return out
+  }
+
+  if (React.isValidElement(node)) {
+    const props = node.props as { children?: ReactNodeLike; color?: unknown }
+    if (props.color) {
+      out.push({ color: props.color, text: textContent(props.children) })
+    }
+
+    collectColored(props.children, out)
+  }
+
+  return out
+}
+
+const baseUsage: Usage = { calls: 0, context_max: 200_000, context_percent: 25, context_used: 50_000, input: 0, output: 0, total: 50_000 }
+
+const baseProps = {
+  bgCount: 0,
+  busy: false,
+  cols: 200,
+  cwdLabel: '~/repo',
+  liveSessionCount: 0,
+  model: 'opus-4.8',
+  sessionStartedAt: null,
+  status: 'ready',
+  statusColor: DEFAULT_THEME.color.ok,
+  t: DEFAULT_THEME,
+  turnStartedAt: null,
+  usage: baseUsage,
+  voiceLabel: ''
+}
+
+describe('StatusRule OpenRouter credits', () => {
+  it('renders the 💳 credit label when a balance is present', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseUsage, or_credits_balance: 42.5, or_credits_label: '$42.50' }
+    } as never)
+
+    expect(textContent(element)).toContain('💳 $42.50')
+  })
+
+  it('hides the credit segment when no balance is present', () => {
+    const element = StatusRule(baseProps as never)
+
+    expect(textContent(element)).not.toContain('💳')
+  })
+
+  it('colours a critical (<=$1) balance with the critical status colour', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseUsage, or_credits_balance: 0.5, or_credits_label: '$0.50' }
+    } as never)
+
+    const segment = collectColored(element).find(entry => entry.text.includes('💳 $0.50'))
+    expect(segment?.color).toBe(DEFAULT_THEME.color.statusCritical)
+  })
+
+  it('colours a healthy (>$50) balance with the good status colour', () => {
+    const element = StatusRule({
+      ...baseProps,
+      usage: { ...baseUsage, or_credits_balance: 120, or_credits_label: '$120.00' }
+    } as never)
+
+    const segment = collectColored(element).find(entry => entry.text.includes('💳 $120.00'))
+    expect(segment?.color).toBe(DEFAULT_THEME.color.statusGood)
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -502,6 +502,24 @@ export function StatusRule({
       ? `Δ ${(usage.dev_credits_spent_micros / 10000).toFixed(1)}¢`
       : ''
 
+  // OpenRouter credit balance. The server omits the key for non-OpenRouter
+  // providers, so this segment self-hides for everyone else. Color tiers match
+  // the classic status bar (cli.py _or_credit_style): >$50 good, >$10 warn,
+  // >$1 bad, <=$1 critical.
+  const orCreditsText =
+    typeof usage.or_credits_label === 'string' && usage.or_credits_label ? `💳 ${usage.or_credits_label}` : ''
+  const orCreditsBalance = usage.or_credits_balance
+  const orCreditsColor =
+    typeof orCreditsBalance !== 'number'
+      ? t.color.muted
+      : orCreditsBalance <= 1
+        ? t.color.statusCritical
+        : orCreditsBalance <= 10
+          ? t.color.statusBad
+          : orCreditsBalance <= 50
+            ? t.color.statusWarn
+            : t.color.statusGood
+
   const showBar = !!bar && fits(SEP + stringWidth(`[${bar}] ${pct != null ? `${pct}%` : ''}`))
   const showDuration = segs.duration && !!sessionStartedAt && fits(SEP + MAX_DURATION_WIDTH)
 
@@ -512,6 +530,7 @@ export function StatusRule({
     segs.duration && !busy && lastTurnEndedAt != null && fits(SEP + stringWidth('✓ ') + MAX_DURATION_WIDTH)
 
   const showCompressions = segs.compressions && compressions > 0 && fits(SEP + stringWidth(`cmp ${compressions}`))
+  const showOrCredits = !!orCreditsText && fits(SEP + stringWidth(orCreditsText))
   const showVoice = segs.voice && !!voiceLabel && fits(SEP + stringWidth(voiceLabel))
   const showSessionCount = !!sessionCountText && fits(SEP + stringWidth(sessionCountText))
   const showBg = segs.bg && bgCount > 0 && fits(SEP + stringWidth(`${bgCount} bg`))
@@ -614,6 +633,12 @@ export function StatusRule({
             <Text color={compressions >= 10 ? t.color.error : compressions >= 5 ? t.color.warn : t.color.muted}>
               cmp {compressions}
             </Text>
+          </Text>
+        ) : null}
+        {showOrCredits ? (
+          <Text color={orCreditsColor} wrap="truncate-end">
+            {' │ '}
+            {orCreditsText}
           </Text>
         ) : null}
         {showVoice ? (

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -177,6 +177,8 @@ export interface Usage {
   cost_usd?: number
   dev_credits_spent_micros?: number
   input: number
+  or_credits_balance?: number
+  or_credits_label?: string
   output: number
   reasoning?: number
   total: number


### PR DESCRIPTION
## Summary

Adds a 💳 credit indicator to the CLI/TUI status bar that appears when the active provider is OpenRouter. The balance is fetched via the existing `fetch_account_usage` infrastructure with a 5-minute cache.

## Changes

1. **Module-level cache** — `_or_credits_cache` dict + `_OR_CREDITS_CACHE_TTL` near the top of cli.py (alongside other module-level caches)
2. **`_or_credit_style()` static method** — returns the appropriate `class:status-bar-\{good|warn|bad|critical|dim\}` style based on balance thresholds
3. **Snapshot population** — inside `_get_status_bar_snapshot()`, checks if provider is openrouter, fetches/caches the credit balance, and adds `or_credits_balance`/ `or_credits_label` to the snapshot
4. **Status bar rendering** — shows credits in all 4 rendering paths (compact `_build_status_bar_text` and full `_get_status_bar_fragments`, each at narrow and wide widths)

## Color coding

| Balance | Style |
|---------|-------|
| >$50   | green |
| $10–$50 | yellow |
| $1–$10 | orange |
| <$1    | red |

## Why this approach

- Uses the existing `agent.account_usage.fetch_account_usage` function — no new API calls or infrastructure
- 5-minute cache prevents a network call on every status bar refresh
- No-op when the provider isn't OpenRouter — zero impact on other providers
- Follows the same pattern as context percent, compressions, and background task indicators
- The cached balance also means `/limits` command data stays warm