### PR TITLE
fix(gateway): close webhook sessions on delivery completion so prune can reap them

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -708,8 +708,19 @@ class WebhookAdapter(BasePlatformAdapter):
             delivery_id,
         )
 
-        # Non-blocking — return 202 Accepted immediately
-        task = asyncio.create_task(self.handle_message(event))
+        # Non-blocking — return 202 Accepted immediately.  Wrap the agent run
+        # so that the per-delivery webhook session is marked ended in state.db
+        # once the run finishes.  A webhook delivery uses a unique one-shot
+        # session (delivery_id is baked into the session key above), so it
+        # will never receive another turn — it must be closed on completion,
+        # exactly like a cron run closes its session with "cron_complete"
+        # (cron/scheduler.py).  Without this, webhook sessions keep
+        # ``ended_at`` NULL forever; ``SessionDB.prune_sessions`` only reaps
+        # rows with ``ended_at`` set, so unclosed webhook sessions accumulate
+        # unbounded and drive state.db bloat (the ghost-session leak).
+        task = asyncio.create_task(
+            self._run_delivery_and_close(event, session_chat_id)
+        )
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
@@ -722,6 +733,81 @@ class WebhookAdapter(BasePlatformAdapter):
             },
             status=202,
         )
+
+    async def _run_delivery_and_close(
+        self, event: "MessageEvent", session_chat_id: str
+    ) -> None:
+        """Run the agent for one webhook delivery, then close its session.
+
+        A webhook delivery is one-shot: the ``delivery_id`` is baked into the
+        session key so the session will never receive a second turn.  Mirror
+        the cron completion path (``cron/scheduler.py`` →
+        ``end_session(..., "cron_complete")``) by marking the session ended
+        once the run finishes.  ``end_session()`` is first-reason-wins and
+        no-ops on an already-ended row, so this is safe even when a terminal
+        path (compression split, ``/new``, ``agent_close``) already closed it.
+        The close runs in ``finally`` so an agent error still reaps the row —
+        otherwise the ghost-session leak persists on the failure path too.
+        """
+        try:
+            await self.handle_message(event)
+        finally:
+            await self._end_webhook_session(event, session_chat_id)
+
+    async def _end_webhook_session(
+        self, event: "MessageEvent", session_chat_id: str
+    ) -> None:
+        """Mark the per-delivery webhook session ended in state.db.
+
+        Resolves the persisted ``session_id`` from the gateway session store
+        using the SAME source the run was keyed on (so profile multiplexing
+        and key construction match exactly), then closes it via the existing
+        ``SessionDB.end_session`` API — never a hand-written UPDATE.
+        """
+        runner = self.gateway_runner
+        if runner is None:
+            return
+        session_db = getattr(runner, "_session_db", None)
+        store = getattr(runner, "session_store", None)
+        if session_db is None or store is None:
+            return
+        try:
+            key_fn = getattr(runner, "_session_key_for_source", None)
+            if key_fn is None:
+                return
+            session_key = key_fn(event.source)
+            if hasattr(store, "_ensure_loaded"):
+                try:
+                    store._ensure_loaded()
+                except Exception:
+                    pass
+            entries = getattr(store, "_entries", {}) or {}
+            entry = entries.get(session_key)
+            session_id = getattr(entry, "session_id", None) if entry else None
+            if not session_id:
+                logger.debug(
+                    "[webhook] No session_id to close for %s (key=%s)",
+                    session_chat_id,
+                    session_key,
+                )
+                return
+            # AsyncSessionDB forwards end_session via asyncio.to_thread; a
+            # plain SessionDB exposes it synchronously.  Handle both.
+            _end = session_db.end_session
+            result = _end(session_id, "webhook_complete")
+            if asyncio.iscoroutine(result):
+                await result
+            logger.debug(
+                "[webhook] Closed session %s for delivery %s",
+                session_id,
+                session_chat_id,
+            )
+        except Exception as e:
+            logger.debug(
+                "[webhook] Failed to close session for %s: %s",
+                session_chat_id,
+                e,
+            )
 
     # ------------------------------------------------------------------
     # Signature validation

--- a/tests/gateway/test_webhook_session_close.py
+++ b/tests/gateway/test_webhook_session_close.py
@@ -1,0 +1,178 @@
+"""Invariant test: a completed webhook delivery closes its session.
+
+Regression guard for the ghost-session leak.  Webhook deliveries create a
+unique one-shot session (``delivery_id`` baked into the session key), but the
+adapter historically fired ``handle_message`` without ever ending the session.
+``SessionDB.prune_sessions`` only reaps rows where ``ended_at IS NOT NULL``, so
+every webhook session stayed unprunable and state.db grew without bound (this
+was the primary driver of the SQLite lock-contention gateway outage).
+
+The invariant asserted here is a *behavior contract*, not a snapshot: once a
+webhook delivery's agent run completes, the session row for that delivery must
+have ``ended_at`` set — mirroring how a cron run closes its session with
+``end_session(..., "cron_complete")``.  We exercise the REAL close path
+(``WebhookAdapter._run_delivery_and_close`` → ``_end_webhook_session`` →
+``SessionDB.end_session``) against a REAL ``SessionStore`` + ``SessionDB`` on a
+temp HERMES_HOME, so an integration regression can't hide behind a mock.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+from gateway.session import SessionSource, SessionStore
+from hermes_state import SessionDB
+
+
+def _make_adapter(routes, **extra_kw) -> WebhookAdapter:
+    extra = {"host": "127.0.0.1", "port": 0, "routes": routes}
+    extra.update(extra_kw)
+    config = PlatformConfig(enabled=True, extra=extra)
+    return WebhookAdapter(config)
+
+
+class _FakeRunner:
+    """Minimal gateway runner surface the webhook close path depends on.
+
+    Wires a real ``SessionStore`` (which owns a real ``SessionDB``) and reuses
+    that same ``SessionDB`` as ``_session_db`` so the row created at routing
+    time is the row the close path ends — exactly the wiring the live gateway
+    has (``self.session_store`` + ``self._session_db``).
+    """
+
+    def __init__(self, store: SessionStore):
+        self.session_store = store
+        self._session_db = store._db
+
+    def _session_key_for_source(self, source: SessionSource) -> str:
+        return self.session_store._generate_session_key(source)
+
+
+@pytest.mark.asyncio
+async def test_completed_webhook_delivery_closes_its_session(tmp_path):
+    """After a webhook run finishes, its session row has ended_at set."""
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    config = GatewayConfig(
+        platforms={Platform.WEBHOOK: PlatformConfig(enabled=True)}
+    )
+    store = SessionStore(sessions_dir=sessions_dir, config=config)
+    assert store._db is not None, "test requires a real SessionDB"
+    runner = _FakeRunner(store)
+
+    adapter = _make_adapter(
+        {
+            "alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Alert: {message}",
+                "deliver": "log",
+            }
+        }
+    )
+    adapter.gateway_runner = runner
+
+    # The gateway creates the session row when it routes the inbound event to
+    # the agent.  Simulate that inside handle_message so the close path has a
+    # real row to reap, and capture the session_id for the assertion.
+    created = {}
+
+    async def _fake_handle_message(event: MessageEvent) -> None:
+        entry = store.get_or_create_session(event.source)
+        created["session_id"] = entry.session_id
+
+    adapter.handle_message = _fake_handle_message
+
+    delivery_id = "alert-close-001"
+    session_chat_id = f"webhook:alerts:{delivery_id}"
+    source = adapter.build_source(
+        chat_id=session_chat_id,
+        chat_name="webhook/alerts",
+        chat_type="webhook",
+        user_id="webhook:alerts",
+        user_name="alerts",
+    )
+    event = MessageEvent(
+        text="Alert: server on fire",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message={"message": "server on fire"},
+        message_id=delivery_id,
+    )
+
+    # Run the exact wrapper the adapter now schedules on delivery.
+    await adapter._run_delivery_and_close(event, session_chat_id)
+
+    session_id = created["session_id"]
+    row = store._db.get_session(session_id)
+    assert row is not None
+
+    # INVARIANT: a completed webhook session must be closed so prune can reap it.
+    assert row["ended_at"] is not None, (
+        "webhook session was never closed — ended_at is NULL, so "
+        "prune_sessions can never reap it (the ghost-session leak)"
+    )
+    assert row["end_reason"] == "webhook_complete"
+
+    # And the closed row is actually prunable, unlike the pre-fix leak.
+    pruned = store._db.prune_sessions(older_than_days=0, source="webhook")
+    assert pruned >= 1
+    store._db.close()
+
+
+@pytest.mark.asyncio
+async def test_webhook_session_closed_even_when_agent_run_raises(tmp_path):
+    """A failing agent run still closes the session (finally-path)."""
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    config = GatewayConfig(
+        platforms={Platform.WEBHOOK: PlatformConfig(enabled=True)}
+    )
+    store = SessionStore(sessions_dir=sessions_dir, config=config)
+    runner = _FakeRunner(store)
+
+    adapter = _make_adapter(
+        {"alerts": {"secret": _INSECURE_NO_AUTH, "prompt": "x", "deliver": "log"}}
+    )
+    adapter.gateway_runner = runner
+
+    created = {}
+
+    async def _boom(event: MessageEvent) -> None:
+        # Row exists (routing happened) before the run blows up mid-turn.
+        entry = store.get_or_create_session(event.source)
+        created["session_id"] = entry.session_id
+        raise RuntimeError("agent exploded mid-run")
+
+    adapter.handle_message = _boom
+
+    delivery_id = "alert-fail-001"
+    session_chat_id = f"webhook:alerts:{delivery_id}"
+    source = adapter.build_source(
+        chat_id=session_chat_id,
+        chat_name="webhook/alerts",
+        chat_type="webhook",
+        user_id="webhook:alerts",
+        user_name="alerts",
+    )
+    event = MessageEvent(
+        text="x",
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message={},
+        message_id=delivery_id,
+    )
+
+    with pytest.raises(RuntimeError):
+        await adapter._run_delivery_and_close(event, session_chat_id)
+
+    row = store._db.get_session(created["session_id"])
+    assert row is not None
+    assert row["ended_at"] is not None, (
+        "session left open after a failed webhook run — the leak persists "
+        "on the error path"
+    )
+    assert row["end_reason"] == "webhook_complete"
+    store._db.close()


### PR DESCRIPTION
## Problem
Webhook deliveries create a unique one-shot session (delivery_id is baked into the session key at `gateway/platforms/webhook.py`) but fire `handle_message` via `asyncio.create_task` **without ever ending the session**. Nothing else closes it — the gateway caches/expires the agent per session_key but never calls `end_session` for the webhook path, and the `_end_session_on_close` teardown doesn't run for these fire-and-forget tasks.

`SessionDB.prune_sessions` (hermes_state.py) only deletes rows `WHERE ended_at IS NOT NULL`. So every webhook session stayed with `ended_at` NULL → **unprunable → unbounded state.db growth**. On a production install this grew state.db to ~32 GB and caused a SQLite lock-contention gateway outage (webhook was the single largest source at 13k+ sessions, none reapable at any retention).

## Fix
Wrap the delivery in `_run_delivery_and_close`, which awaits `handle_message` then (in `finally`, so failures still reap) calls `_end_webhook_session` → `SessionDB.end_session(session_id, 'webhook_complete')`. This mirrors how cron closes its session with `cron_complete` (`cron/scheduler.py`). `end_session` is first-reason-wins and no-ops on an already-ended row, so it never clobbers a compression/`agent_close` reason.

## Test
Adds `tests/gateway/test_webhook_session_close.py` asserting the invariant (a completed webhook session has `ended_at` set + is prunable), including the error-path case, against a real SessionStore + SessionDB.

Verified locally: `305 passed` across the new webhook test + full SessionDB lifecycle/prune suite. Also validated on the affected production install — webhook sessions created after the fix now close (ended_at set), confirmed via live DB inspection.