### PR TITLE
fix(install): pass --python to uv pip install in lazy_deps

### DIFF
--- a/tests/tools/test_lazy_deps_durable_target.py
+++ b/tests/tools/test_lazy_deps_durable_target.py
@@ -233,6 +233,26 @@ class TestInstallArgConstruction:
         assert "--target" not in captured["cmd"]
         assert "--constraint" not in captured["cmd"]
 
+    def test_uv_pip_install_passes_python_flag(self, monkeypatch):
+        """uv pip install must include --python sys.executable so uv targets
+        the active venv instead of falling back to its managed Python."""
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        # Make uv discoverable.
+        monkeypatch.setattr(ld.shutil, "which", lambda name: "/fake/uv" if name == "uv" else None)
+        captured = {}
+
+        def fake_run(cmd, *a, **k):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        result = ld._venv_pip_install(("somepkg==1.0",))
+        assert result.success
+        cmd = captured["cmd"]
+        assert "--python" in cmd, f"--python flag missing from uv command: {cmd}"
+        python_idx = cmd.index("--python")
+        assert cmd[python_idx + 1] == sys.executable
+
 
 @pytest.mark.skipif(
     os.environ.get("HERMES_RUN_NETWORK_TESTS") != "1",

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -643,11 +643,16 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         uv_env["VIRTUAL_ENV"] = str(venv_root)
 
         # Tier 1: uv (preferred — fast, doesn't need pip in the venv)
+        # --python is required: without it, uv may fall back to its own
+        # managed Python instead of the active venv on Windows, causing
+        # packages to install to the wrong location.  sys.executable is
+        # always the running interpreter, so it points at the correct venv
+        # regardless of PATH, VIRTUAL_ENV, or overlay mounts.
         uv_bin = shutil.which("uv")
         if uv_bin:
             try:
                 r = subprocess.run(
-                    [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
+                    [uv_bin, "pip", "install", *target_args, *constraint_args, "--python", sys.executable, *specs],
                     capture_output=True, text=True, timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                 )


### PR DESCRIPTION
## What & why

`_venv_pip_install()` in `tools/lazy_deps.py` invokes `uv pip install` without an explicit `--python` flag.  uv discovers the target Python through a search chain (`VIRTUAL_ENV` → managed installs → PATH), and when any step in that chain is wrong or missing, packages install to the wrong location.

**On Windows**, uv may resolve to its own managed Python (`AppData/Roaming/uv/python/...`) instead of the active Hermes venv, causing lazy dependency installs (TTS, STT, etc.) to land outside the venv.  Packages appear missing on the next trigger and the install ladder re-fires.

**On Docker/NixOS**, `Path(sys.executable).parent.parent` can resolve through overlay layers to the wrong root (see #24735).  `sys.executable` itself is always correct — it's the running interpreter — so passing it via `--python` sidesteps both issues.

## Fix

Add `"--python", sys.executable` to the uv pip install command:

```python
# Before
[uv_bin, "pip", "install", *target_args, *constraint_args, *specs]

# After
[uv_bin, "pip", "install", *target_args, *constraint_args, "--python", sys.executable, *specs]
```

This is a no-op on environments where uv already resolves correctly (venv Python on PATH), but makes the intent unambiguous and removes the dependency on discovery heuristics that change across uv versions.

## Verification

Tested on Windows with uv 0.8.14:

| Scenario | Before (no --python) | After (--python) |
|---|---|---|
| Venv Python on PATH | ✅ Correct (by accident) | ✅ Correct (by contract) |
| VIRTUAL_ENV set, no PATH | ✅ uv honors VIRTUAL_ENV | ✅ Correct |
| Neither on PATH nor VIRTUAL_ENV | ❌ Fails / wrong target | ✅ Correct |
| uv targeting own managed Python | Installs to `AppData/Roaming/uv/` | N/A — flag prevents this |

The fix doesn't change behavior on working setups.  It prevents breakage when PATH or VIRTUAL_ENV discovery changes in future uv releases.

## Context

Supersedes #44036 (stale, merge conflicts with current main after `target_args`/`constraint_args` refactor).

Also related: #24735 (Docker overlay `sys.executable.parent.parent` issue, closed without merge) and #50524 (status poll triggering installs on every request).