### PR TITLE
fix(desktop): converge profile deletion — stop respawn + refresh rail (supersedes #52301, #49335)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5419,19 +5419,24 @@ function profileNameFromDeleteRequest(request) {
   return name.toLowerCase()
 }
 
+// Returns the profile name whose backend was torn down, or null when the
+// request is not a profile-delete.  The caller uses this to skip ensureBackend
+// for the just-torn-down profile — otherwise ensureBackend respawns a pool
+// backend whose ensure_hermes_home() recreates the deleted profile directory.
 async function prepareProfileDeleteRequest(request) {
   const profile = profileNameFromDeleteRequest(request)
   if (!profile || profile === 'default' || !PROFILE_NAME_RE.test(profile)) {
-    return
+    return null
   }
 
   if (profile === primaryProfileKey()) {
     writeActiveDesktopProfile('default')
     await teardownPrimaryBackendAndWait()
-    return
+    return profile
   }
 
   await teardownPoolBackendAndWait(profile)
+  return profile
 }
 
 async function startHermes() {
@@ -6465,10 +6470,15 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     return rerouted
   }
 
-  await prepareProfileDeleteRequest(request)
+  const tornDownProfile = await prepareProfileDeleteRequest(request)
 
   const profile = request?.profile
-  const connection = await ensureBackend(profile)
+  // After tearing down a backend for profile deletion, route to the primary
+  // backend instead of spawning a fresh pool backend.  A freshly spawned
+  // backend calls ensure_hermes_home() which recreates the profile directory,
+  // defeating the deletion and leaving a zombie process.
+  const routeProfile = tornDownProfile ? null : profile
+  const connection = await ensureBackend(routeProfile)
   const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
   const requestPath = pathWithGlobalRemoteProfile(request.path, profile, {
     globalRemote: globalRemoteActive(),

--- a/apps/desktop/electron/profile-delete-respawn.test.cjs
+++ b/apps/desktop/electron/profile-delete-respawn.test.cjs
@@ -1,0 +1,66 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ELECTRON_DIR = __dirname
+
+function readElectronFile(name) {
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
+}
+
+// ---------------------------------------------------------------------------
+// prepareProfileDeleteRequest must return the torn-down profile name so the
+// caller can skip ensureBackend for that profile (issue #52279).
+// ---------------------------------------------------------------------------
+
+test('prepareProfileDeleteRequest returns the torn-down profile name', () => {
+  const source = readElectronFile('main.cjs')
+
+  // Locate the function definition and its closing brace.
+  const fnStart = source.indexOf('async function prepareProfileDeleteRequest(')
+  assert.notEqual(fnStart, -1, 'prepareProfileDeleteRequest function not found')
+
+  // The function must contain "return profile" (pool and primary paths).
+  const fnBody = source.slice(fnStart, fnStart + 800)
+  const returnProfileCount = (fnBody.match(/return profile/g) || []).length
+  assert.ok(
+    returnProfileCount >= 2,
+    `expected at least 2 "return profile" statements (primary + pool paths), found ${returnProfileCount}`
+  )
+
+  // The early-exit guard must return null (not void/undefined).
+  assert.match(
+    fnBody,
+    /return null/,
+    'early-exit guard should return null, not undefined'
+  )
+})
+
+test('hermes:api handler routes profile-delete requests to the primary backend', () => {
+  const source = readElectronFile('main.cjs')
+
+  // The handler must capture prepareProfileDeleteRequest's return value.
+  assert.match(
+    source,
+    /const tornDownProfile = await prepareProfileDeleteRequest\(request\)/,
+    'handler should capture the return value of prepareProfileDeleteRequest'
+  )
+
+  // The handler must use the return value to skip ensureBackend for the
+  // torn-down profile, routing to the primary (null) instead.
+  assert.match(
+    source,
+    /const routeProfile = tornDownProfile \? null : profile/,
+    'handler should route to primary backend when a profile was just torn down'
+  )
+
+  // ensureBackend must be called with the conditional route profile.
+  assert.match(
+    source,
+    /const connection = await ensureBackend\(routeProfile\)/,
+    'handler should pass routeProfile (not raw profile) to ensureBackend'
+  )
+})

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -19,7 +19,6 @@ import { Textarea } from '@/components/ui/textarea'
 import {
   createProfile,
   deleteProfile,
-  getProfiles,
   getProfileSoul,
   type ProfileInfo,
   renameProfile,
@@ -31,7 +30,7 @@ import { profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
 import { slug } from '@/lib/sanitize'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileColors } from '@/store/profile'
+import { $profileColors, refreshProfiles } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import {
@@ -72,7 +71,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
 
   const refresh = useCallback(async () => {
     try {
-      const { profiles: list } = await getProfiles()
+      const list = await refreshProfiles()
       setProfiles(list)
       setSelectedName(current => {
         if (current && list.some(p => p.name === current)) {

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesConnection } from '@/global'
+import type { ProfileInfo } from '@/types/hermes'
 
 // Keep profile.ts's side-effecting imports inert: the gateway socket layer and
 // the REST query client must not run for real in a unit test.
@@ -17,9 +18,20 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ queryClient: { invalidateQueries: vi.fn() } }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, ensureGatewayProfile } = await import('./profile')
+const { $activeGatewayProfile, $profiles, ensureGatewayProfile, refreshProfiles } = await import('./profile')
 const { $connection } = await import('./session')
 const { queryClient } = await import('@/lib/query-client')
+const { getProfiles } = await import('@/hermes')
+
+const profile = (name: string, isDefault = false): ProfileInfo => ({
+  has_env: false,
+  is_default: isDefault,
+  model: null,
+  name,
+  path: `/tmp/hermes/${name}`,
+  provider: null,
+  skill_count: 0
+})
 
 const remoteConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
   ({ baseUrl: 'https://hermes-roy.tail.ts.net', mode: 'remote', profile: 'vps-remote', ...over }) as HermesConnection
@@ -35,6 +47,7 @@ beforeEach(() => {
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
+  $profiles.set([])
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
   vi.mocked(queryClient.invalidateQueries).mockClear()
   resetStarmapGraph.mockClear()
@@ -99,5 +112,25 @@ describe('profile-scoped cache invalidation', () => {
 
     expect(queryClient.invalidateQueries).toHaveBeenCalled()
     expect(resetStarmapGraph).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('refreshProfiles shared rail list (#49289)', () => {
+  it('removes a deleted profile from the shared $profiles cache after Manage Profiles refreshes', async () => {
+    $profiles.set([profile('default', true), profile('test1')])
+    vi.mocked(getProfiles).mockResolvedValueOnce({ profiles: [profile('default', true)] })
+
+    await refreshProfiles()
+
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default'])
+  })
+
+  it('leaves the shared $profiles cache intact when the refresh fails', async () => {
+    $profiles.set([profile('default', true), profile('test1')])
+    vi.mocked(getProfiles).mockRejectedValueOnce(new Error('backend unavailable'))
+
+    await expect(refreshProfiles()).rejects.toThrow('backend unavailable')
+
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'test1'])
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -38,6 +38,13 @@ export function setActiveProfile(name: string): void {
   $activeProfile.set(name || 'default')
 }
 
+export async function refreshProfiles(): Promise<ProfileInfo[]> {
+  const { profiles } = await getProfiles()
+  $profiles.set(profiles)
+
+  return profiles
+}
+
 // ── Rail order ─────────────────────────────────────────────────────────────
 // User-defined order for the named (non-default) profile squares in the rail.
 // Names absent from the list fall back to alphabetical, appended at the tail —
@@ -111,8 +118,7 @@ export async function refreshActiveProfile(): Promise<void> {
   }
 
   try {
-    const { profiles } = await getProfiles()
-    $profiles.set(profiles)
+    await refreshProfiles()
   } catch {
     // Leave the cached list in place.
   }


### PR DESCRIPTION
## Summary

Consolidates the two Desktop-side halves of the profile-deletion bug (#47368) into one review unit, since they compose into a single behavior — "when a profile is deleted, it actually goes away and stays gone in the UI":

- **Stop the respawn (from #52301, @liuhao1024).** `prepareProfileDeleteRequest` now returns the torn-down profile name, and the `hermes:api` handler routes that request to the **primary** backend instead of spawning a fresh pool backend. A freshly spawned pool backend calls `ensure_hermes_home()`, which would recreate the just-deleted profile directory and leave a zombie process. This is the Desktop-side complement to the CLI recreation guard in #49435.
- **Refresh the rail (from #49335, @Tranquil-Flow).** Adds a shared `refreshProfiles()` helper on `$profiles` and points the Manage-Profiles view's `refresh()` at it, so a deletion updates the shared rail cache instead of only the local list. Preserves the existing list on a failed refresh.

Both commits are cherry-picked with original authorship intact.

## Why one PR

These are the same language (desktop TS/Electron), the same CI lane, and the same user-visible outcome; they don't overlap in code but they finish each other's job. The CLI root-cause fix (#49435, recreation guard) lands separately — with it, a backend spawned into a deleted profile now exits on `FileNotFoundError` instead of resurrecting the tree, and these two changes make the Desktop stop spawning it and reflect the deletion immediately.

## Supersedes

- #52301 — respawn skip (@liuhao1024) → `Closes #52279`
- #49335 — rail refresh (@Tranquil-Flow) → `Closes #49289`

Part of #47368.

## Validation

| Check | Result |
|---|---|
| `tsc -p . --noEmit` (apps/desktop) | clean |
| `node --test electron/profile-delete-respawn.test.cjs` | 2/2 |
| `vitest run src/store/profile.test.ts` | 7/7 |
| `eslint` (all touched files) | clean |

#49335 was stale against `main` (import drift around `$profileColors` / `getProfileSetupCommand` and the starmap-cache test block); reconciled during the cherry-pick.

Co-authored-by: liuhao1024 <sunsky.lau@gmail.com>
Co-authored-by: Tranquil-Flow <66773372+Tranquil-Flow@users.noreply.github.com>