### PR TITLE
fix(setup): exclude posture toolsets from blank-slate disabled_toolsets

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3053,6 +3053,12 @@ def _blank_slate_minimal_toolsets(config: dict):
                 continue  # platform composites — not user-facing toolsets
             if isinstance(tdef, dict) and tdef.get("includes"):
                 continue  # composite groupings, not leaf toolsets
+            if isinstance(tdef, dict) and tdef.get("posture"):
+                continue  # posture toolsets (e.g. coding) are session-level
+                # selections made by agent/coding_context.py — not permanent
+                # user-facing disables. Adding them here causes model_tools
+                # to subtract their tools (terminal, read_file, …) from the
+                # minimal Blank Slate surface (#57315).
             all_keys.add(k)
 
         disabled = sorted(all_keys - keep)

--- a/tests/hermes_cli/test_setup_blank_slate.py
+++ b/tests/hermes_cli/test_setup_blank_slate.py
@@ -34,6 +34,17 @@ class TestBlankSlateMinimalToolsets:
         # The recovered non-configurable toolset that used to leak is suppressed.
         assert "kanban" in disabled
 
+    def test_disabled_toolsets_excludes_posture_toolsets(self):
+        """Posture toolsets (e.g. coding) are session-level selections made by
+        agent/coding_context.py — not permanent user-facing disables.  Including
+        them in disabled_toolsets causes model_tools to subtract their tools
+        (terminal, read_file, …) from the minimal Blank Slate surface (#57315).
+        """
+        cfg = {}
+        _blank_slate_minimal_toolsets(cfg)
+        disabled = set(cfg["agent"]["disabled_toolsets"])
+        assert "coding" not in disabled
+
     def test_resolver_yields_exactly_file_and_terminal(self):
         from hermes_cli.tools_config import _get_platform_tools
         cfg = {}
@@ -52,6 +63,30 @@ class TestBlankSlateMinimalToolsets:
         enabled = sorted(_get_platform_tools(cfg, "cli"))
         defs = model_tools.get_tool_definitions(
             enabled_toolsets=enabled, disabled_toolsets=None, quiet_mode=True
+        )
+        names = sorted(
+            {(d.get("function") or {}).get("name") or d.get("name") for d in defs}
+        )
+        assert names == ["patch", "process", "read_file", "search_files",
+                         "terminal", "write_file"]
+
+    def test_tool_schema_survives_disabled_toolsets_from_config(self):
+        """Regression: disabled_toolsets must not erase the minimal Blank Slate
+        surface when passed to model_tools.  Before the fix, posture toolsets
+        like ``coding`` in disabled_toolsets caused model_tools to subtract
+        terminal, read_file, write_file, etc. (#57315).
+        """
+        import model_tools
+        from hermes_cli.tools_config import _get_platform_tools
+        cfg = {}
+        _blank_slate_minimal_toolsets(cfg)
+        _blank_slate_minimize_config(cfg)
+        enabled = sorted(_get_platform_tools(cfg, "cli"))
+        disabled = cfg.get("agent", {}).get("disabled_toolsets") or []
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=enabled,
+            disabled_toolsets=disabled,
+            quiet_mode=True,
         )
         names = sorted(
             {(d.get("function") or {}).get("name") or d.get("name") for d in defs}


### PR DESCRIPTION
## What does this PR do?

Fixes Blank Slate installations losing all tools except `cronjob` after setup.

`_blank_slate_minimal_toolsets()` iterates every `TOOLSETS` entry to build `agent.disabled_toolsets`. It skips `hermes-*` composites and `includes`-only groups, but does not skip **posture** toolsets. The `coding` posture toolset (selected per-session by `agent/coding_context.py`) is a superset of `file` + `terminal` — it contains `terminal`, `read_file`, `write_file`, `patch`, `search_files`, and `process`.

At runtime, `model_tools.get_tool_definitions()` resolves every entry in `disabled_toolsets` and subtracts its tools. With `coding` in the disabled list, the entire Blank Slate minimal surface is erased. The agent ends up with only `cronjob`.

## Related Issue

Fixes #57315

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎎 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py`: Skip posture toolsets (`posture: True`) when computing the Blank Slate `disabled_toolsets` list. Posture toolsets are session-level selections, not permanent user-facing disables.
- `tests/hermes_cli/test_setup_blank_slate.py`: Added `test_disabled_toolsets_excludes_posture_toolsets` (unit) and `test_tool_schema_survives_disabled_toolsets_from_config` (end-to-end with actual `disabled_toolsets` passed to `model_tools`).

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_setup_blank_slate.py -v`
2. All 10 tests should pass, including the two new ones
3. Verify `coding` is NOT in the disabled list: `python -c "from hermes_cli.setup import _blank_slate_minimal_toolsets; c = {}; _blank_slate_minimal_toolsets(c); print('coding' in c['agent']['disabled_toolsets'])"` should print `False`
4. End-to-end: for a Blank Slate config, `model_tools.get_tool_definitions()` with the actual `disabled_toolsets` should yield 6 tools: `patch`, `process`, `read_file`, `search_files`, `terminal`, `write_file`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_setup_blank_slate.py tests/test_model_tools.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before fix** — `coding` in `disabled_toolsets`:
```
agent.disabled_toolsets:
  - browser
  - coding          ← posture toolset, overlaps file+terminal tools
  - code_execution
  - cronjob
  - ...
```
`model_tools.get_tool_definitions(disabled_toolsets=["coding", ...])` → 0 tools (all subtracted).

**After fix** — `coding` excluded:
```
agent.disabled_toolsets:
  - browser
  - code_execution
  - cronjob
  - ...              ← no "coding"
```
`model_tools.get_tool_definitions(disabled_toolsets=[...])` → 6 tools: `patch`, `process`, `read_file`, `search_files`, `terminal`, `write_file`.
