### PR TITLE
fix(tui_gateway): route setup.runtime_check + setup.status to RPC pool (supersedes #56084, #57088)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -175,6 +175,7 @@ AUTHOR_MAP = {
     "rayjun0412@gmail.com": "rayjun",  # cron model.default salvage co-author (#43952)
     "96944678+sweetcornna@users.noreply.github.com": "sweetcornna",  # cron ticker-liveness salvage co-author (#33849)
     "izumi0uu@gmail.com": "izumi0uu",  # PR #49544 salvage (native rich reply echo; #49534)
+    "zhangyingliang@outlook.com": "yingliang-zhang",  # PR #56084 (setup RPC pool routing; #57335)
     "dev@pixlmedia.no": "texhy",  # PR #27435 salvage (few-but-huge preflight compression gate; #27405)
     "qdaszx@naver.com": "qdaszx",  # PR #29190 salvage (non-blocking OSV malware preflight; #29184)
     "w31rdm4ch1n3z@protonmail.com": "w31rdm4ch1nZ",

--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -64,9 +64,11 @@ def capture(server):
 # seconds when the GIL is contended by concurrent agent turns.
 
 FRONTEND_POLLED_RPCS = [
-    "session.list",   # loads session list — SQLite query
-    "pet.info",       # petdex poll — file/network read
-    "process.list",   # background process status — process registry scan
+    "session.list",          # loads session list — SQLite query
+    "pet.info",              # petdex poll — file/network read
+    "process.list",          # background process status — process registry scan
+    "setup.runtime_check",   # runtime readiness — resolve_runtime_provider() I/O
+    "setup.status",          # provider configured check — config/credential scan
 ]
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -212,6 +212,16 @@ _LONG_HANDLERS = frozenset(
         "projects.for_cwd",
         "projects.tree",
         "projects.project_sessions",
+        # Setup readiness RPCs are polled by the Desktop frontend on connect
+        # and periodically (use-status-snapshot → evaluateRuntimeReadiness).
+        # setup.runtime_check calls resolve_runtime_provider() which reads
+        # config, checks auth state, and may probe the provider endpoint;
+        # setup.status calls _has_any_provider_configured() which scans
+        # provider config + credential files. Under GIL pressure from
+        # concurrent agent turns, either can take seconds inline, blocking
+        # the WS read loop and causing false "needs setup" (#50005 family).
+        "setup.runtime_check",
+        "setup.status",
         "session.branch",
         "session.compress",
         "session.list",


### PR DESCRIPTION
## Summary

Consolidates the two open fixes for the Desktop "Settings failed to load / needs setup" timeout into one commit, crediting both authors.

`setup.runtime_check` and `setup.status` are polled by the Desktop frontend on connect and periodically (`use-status-snapshot` → `evaluateRuntimeReadiness`), but neither was in `_LONG_HANDLERS` — so `dispatch()` ran both **inline on the WS reader thread**. Under GIL pressure from concurrent agent turns, either blocks for seconds:

- `setup.runtime_check` → `resolve_runtime_provider()` (config read, auth check, may probe the provider endpoint)
- `setup.status` → `_has_any_provider_configured()` (provider config + credential scan)

While either blocks the reader thread the WS read loop can't service later requests; the frontend RPC timeout fires, the client drops the socket, and the lost `setup.runtime_check` response reads as `ready=false` — a false "needs setup" even though the provider is configured. This is exactly the event-loop-stall + failed `setup.runtime_check` pattern in the recent support logs.

## Fix

Add **both** RPCs to `_LONG_HANDLERS` so `dispatch()` routes them to the pool and returns immediately, keeping the read loop free. Same precedent as #55545 (`session.list`/`pet.info`/`process.list`). Handlers are read-only and pool writes go through the lock-guarded `write_json`, so there's no ordering or safety concern.

## Supersedes

- **#56084** (@yingliang-zhang) — routed both `setup.runtime_check` + `setup.status`, fuller test. Carried here as the base commit (authorship preserved).
- **#57088** (@izumi0uu) — independently routed `setup.runtime_check`; credited via `Co-authored-by`. `setup.status` has the identical blocking-scan + frontend-poll shape, so routing only `runtime_check` would have left half the starvation surface inline.

Both authors diagnosed the same root cause; folded into one so it reviews and lands as a single change.

## Validation

`scripts/run_tests.sh tests/tui_gateway/test_inline_rpc_gil_starvation.py` — 8/8; the parametrized `test_frontend_polled_rpc_is_pool_routed` now covers all 5 frontend-polled RPCs. Rebased clean onto current `main`.

## Note

This removes two RPCs from the reader thread and fixes the false-"needs setup" timeout. It does **not** by itself fix a backend that genuinely stalls its event loop ~40s under GIL pressure — if that persists after this lands, the follow-up is what saturates the loop during Desktop startup, not more handler routing.

Co-authored-by: izumi0uu <izumi0uu@gmail.com>