### PR TITLE
feat(desktop): auto-detect system locale for initial UI language

### DIFF
--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -24,10 +24,82 @@ function LanguageProbe({ target = 'zh' }: { target?: Locale }) {
   )
 }
 
+// Override `navigator.languages` for a test via an own property; `cleanup()`
+// below removes it so jsdom's default (`['en-US']`) applies again.
+function stubSystemLocales(languages: readonly string[]) {
+  Object.defineProperty(window.navigator, 'languages', {
+    configurable: true,
+    get: () => languages
+  })
+}
+
 describe('I18nProvider', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    Reflect.deleteProperty(window.navigator, 'languages')
+  })
+
+  it('detects the system locale on first launch when no language is configured', async () => {
+    stubSystemLocales(['ja-JP', 'en-US'])
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({}),
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+
+    expect(screen.getByTestId('locale').textContent).toBe('ja')
+    expect(screen.getByTestId('save').textContent).toBe('保存')
+    // Detection must not persist anything — the user hasn't chosen a language.
+    expect(configClient.saveConfig).not.toHaveBeenCalled()
+  })
+
+  it('lets an explicit configured language win over the system locale', async () => {
+    stubSystemLocales(['ja-JP'])
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({ display: { language: 'zh-Hans' } }),
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+
+    expect(screen.getByTestId('locale').textContent).toBe('zh')
+    expect(configClient.saveConfig).not.toHaveBeenCalled()
+  })
+
+  it('falls back to English when the system locale is unsupported and none is configured', async () => {
+    stubSystemLocales(['de-DE', 'fr-FR'])
+
+    const configClient: I18nConfigClient = {
+      getConfig: vi.fn().mockResolvedValue({}),
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+
+    expect(screen.getByTestId('locale').textContent).toBe('en')
+    expect(configClient.saveConfig).not.toHaveBeenCalled()
   })
 
   it('defaults to English without a config client', () => {

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -3,7 +3,7 @@ import { createContext, type ReactNode, useCallback, useContext, useEffect, useM
 import { getHermesConfigRecord, type HermesConfigRecord, saveHermesConfig } from '@/hermes'
 
 import { TRANSLATIONS } from './catalog'
-import { DEFAULT_LOCALE, localeConfigValue, normalizeLocale } from './languages'
+import { DEFAULT_LOCALE, localeConfigValue, resolveInitialLocale } from './languages'
 import { setRuntimeI18nLocale } from './runtime'
 import type { Locale, Translations } from './types'
 
@@ -33,6 +33,24 @@ const defaultConfigClient: I18nConfigClient = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// The operating-system UI languages in priority order. In the Electron renderer
+// `navigator.languages` follows Chromium's locale, which is seeded from
+// `app.getLocale()` (the same OS locale the main process uses for the
+// spellchecker). Reading it here keeps the detection in the renderer with no
+// extra IPC plumbing. Guarded so non-browser environments (SSR/tests without a
+// navigator) fall back to an empty list.
+function getSystemPreferredLocales(): readonly string[] {
+  if (typeof navigator === 'undefined') {
+    return []
+  }
+
+  if (Array.isArray(navigator.languages) && navigator.languages.length > 0) {
+    return navigator.languages
+  }
+
+  return typeof navigator.language === 'string' && navigator.language ? [navigator.language] : []
 }
 
 export function getConfigDisplayLanguage(config: HermesConfigRecord): unknown {
@@ -82,7 +100,9 @@ export interface I18nProviderProps {
 }
 
 export function I18nProvider({ children, configClient = defaultConfigClient, initialLocale }: I18nProviderProps) {
-  const [locale, setLocaleState] = useState<Locale>(() => normalizeLocale(initialLocale))
+  const [locale, setLocaleState] = useState<Locale>(() =>
+    resolveInitialLocale(initialLocale, getSystemPreferredLocales())
+  )
   const [isLoadingConfig, setIsLoadingConfig] = useState(false)
   const [isSavingLocale, setIsSavingLocale] = useState(false)
   const [configLoadError, setConfigLoadError] = useState<Error | null>(null)
@@ -108,7 +128,7 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
       .getConfig()
       .then(config => {
         if (!cancelled) {
-          setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
+          setLocaleState(resolveInitialLocale(getConfigDisplayLanguage(config), getSystemPreferredLocales()))
         }
       })
       .catch(error => {

--- a/apps/desktop/src/i18n/languages.test.ts
+++ b/apps/desktop/src/i18n/languages.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { DEFAULT_LOCALE, isLocale, isSupportedLocaleValue, localeConfigValue, normalizeLocale } from './languages'
+import {
+  DEFAULT_LOCALE,
+  isLocale,
+  isSupportedLocaleValue,
+  localeConfigValue,
+  matchPreferredLocale,
+  normalizeLocale,
+  resolveInitialLocale
+} from './languages'
 
 describe('desktop i18n languages', () => {
   it('normalizes supported locale aliases', () => {
@@ -39,5 +47,37 @@ describe('desktop i18n languages', () => {
     expect(localeConfigValue('zh')).toBe('zh')
     expect(localeConfigValue('zh-hant')).toBe('zh-hant')
     expect(localeConfigValue('ja')).toBe('ja')
+  })
+
+  it('matches the first supported locale from the platform preference list', () => {
+    expect(matchPreferredLocale(['ja-JP', 'en-US'])).toBe('ja')
+    expect(matchPreferredLocale(['zh-TW', 'zh-CN'])).toBe('zh-hant')
+    // Unsupported entries are skipped in favor of the first supported one.
+    expect(matchPreferredLocale(['de-DE', 'fr-FR', 'zh-Hans'])).toBe('zh')
+  })
+
+  it('returns null when no preferred locale is supported', () => {
+    expect(matchPreferredLocale(['de-DE', 'fr-FR'])).toBeNull()
+    expect(matchPreferredLocale([])).toBeNull()
+    expect(matchPreferredLocale(null)).toBeNull()
+    expect(matchPreferredLocale(undefined)).toBeNull()
+  })
+
+  it('prefers an explicit configured language over the system locale', () => {
+    expect(resolveInitialLocale('ja-JP', ['zh-CN'])).toBe('ja')
+    // An unsupported but explicit configured value still wins and falls back to
+    // English, so a manual selection is never overridden by the system locale.
+    expect(resolveInitialLocale('de', ['zh-CN'])).toBe(DEFAULT_LOCALE)
+  })
+
+  it('falls back to the system locale only when no language is configured', () => {
+    expect(resolveInitialLocale(undefined, ['zh-CN', 'en-US'])).toBe('zh')
+    expect(resolveInitialLocale('', ['ja-JP'])).toBe('ja')
+    expect(resolveInitialLocale('   ', ['zh-TW'])).toBe('zh-hant')
+  })
+
+  it('falls back to English when neither config nor system locale is supported', () => {
+    expect(resolveInitialLocale(undefined, ['de-DE'])).toBe(DEFAULT_LOCALE)
+    expect(resolveInitialLocale(null, [])).toBe(DEFAULT_LOCALE)
   })
 })

--- a/apps/desktop/src/i18n/languages.ts
+++ b/apps/desktop/src/i18n/languages.ts
@@ -84,3 +84,39 @@ export function isSupportedLocaleValue(value: unknown): boolean {
 export function localeConfigValue(locale: Locale): string {
   return LOCALE_OPTIONS.find(item => item.id === locale)?.configValue ?? DEFAULT_LOCALE
 }
+
+// Given the platform's preferred locales in priority order (most-preferred
+// first, e.g. `navigator.languages`), return the first one that maps to a
+// supported UI locale, or null when none do. Used to seed the initial UI
+// language from the operating-system locale on first launch, before the user
+// has explicitly picked one.
+export function matchPreferredLocale(preferred: readonly string[] | null | undefined): Locale | null {
+  if (!preferred) {
+    return null
+  }
+
+  for (const value of preferred) {
+    if (isSupportedLocaleValue(value)) {
+      return normalizeLocale(value)
+    }
+  }
+
+  return null
+}
+
+// Resolve the UI locale to show before the user has made an explicit choice.
+// An explicit, non-empty `display.language` config value always wins — mirroring
+// the previous `normalizeLocale` behavior, including falling back to English for
+// an unsupported configured value so a manual selection is never silently
+// overridden. Only when no language is configured do we consult the system
+// locale, and finally fall back to English.
+export function resolveInitialLocale(
+  configuredLanguage: unknown,
+  systemPreferred: readonly string[] | null | undefined
+): Locale {
+  if (typeof configuredLanguage === 'string' && configuredLanguage.trim() !== '') {
+    return normalizeLocale(configuredLanguage)
+  }
+
+  return matchPreferredLocale(systemPreferred) ?? DEFAULT_LOCALE
+}


### PR DESCRIPTION
## What

On first launch with no `display.language` configured, Hermes Desktop always showed its UI in **English**, regardless of the OS locale. This seeds the initial UI locale from the **system locale** so a user on a `zh` / `ja` / etc. system sees their language without opening Settings.

Closes #57217.

## Why

The app already reads the OS locale for the spellchecker (`app.getLocale()` in `main.cjs`) but the UI display language never consulted it — `context.tsx` fell straight through to `DEFAULT_LOCALE = 'en'` whenever `display.language` was empty.

## How

Reuses the existing `normalizeLocale()` / `LOCALE_ALIASES` machinery — no new locale-mapping logic:

- **`i18n/languages.ts`** — two pure, exported helpers:
  - `matchPreferredLocale(preferred)` — first supported locale from a preference list (e.g. `navigator.languages`), else `null`.
  - `resolveInitialLocale(configuredLanguage, systemPreferred)` — explicit config wins → else system locale → else English.
- **`i18n/context.tsx`** — `getSystemPreferredLocales()` reads `navigator.languages`, which in the Electron renderer follows `app.getLocale()`, so **no preload/IPC plumbing is needed**. Wired into both the initial `useState` seed and the config-load effect.

## Behavior

- Manual selection in Settings → Appearance → Language still wins and persists (unchanged).
- An explicit but unsupported configured value still falls back to English — a manual choice is never silently overridden by the system locale.
- Unsupported system locales fall back to English (unchanged default).

## Design note

I used `navigator.languages` (renderer-side, zero IPC) rather than plumbing `app.getLocale()` through preload as the issue's prose suggests — same OS locale, much smaller and more testable diff. Happy to switch to explicit IPC if preferred.

## Tests

- 6 pure-function cases in `languages.test.ts` + 3 provider integration tests in `context.test.tsx` (system-locale detection, explicit-config-wins, unsupported→English fallback).
- `npx vitest run --environment jsdom src/i18n/languages.test.ts src/i18n/context.test.tsx` → **22/22 pass**.
- Full desktop UI suite is identical on this branch vs `main` (same pre-existing/environmental failures), with **+8 new passing tests and 0 new failures**.