### PR TITLE
fix(usage): capture reasoning_tokens from completion_tokens_details on chat_completions

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -820,9 +820,22 @@ def normalize_usage(
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
     reasoning_tokens = 0
+    # Responses API shape: output_tokens_details.reasoning_tokens.
+    # Chat Completions shape (OpenAI, OpenRouter, DeepSeek, etc.):
+    # completion_tokens_details.reasoning_tokens. Reading only the former
+    # left reasoning_tokens=0 for every chat_completions reasoning model —
+    # hidden thinking was invisible in session accounting even though it
+    # dominates output spend on models like deepseek-v4-flash (measured:
+    # single calls burning 21K reasoning tokens to emit 500 visible tokens).
     output_details = getattr(response_usage, "output_tokens_details", None)
     if output_details:
         reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
+    if not reasoning_tokens:
+        completion_details = getattr(response_usage, "completion_tokens_details", None)
+        if completion_details:
+            reasoning_tokens = _to_int(
+                getattr(completion_details, "reasoning_tokens", 0)
+            )
 
     return CanonicalUsage(
         input_tokens=input_tokens,


### PR DESCRIPTION
## Summary
`reasoning_tokens` is now captured on the Chat Completions wire shape — previously it was 0 for every chat_completions reasoning model (DeepSeek, OpenAI o-series via OpenRouter, any OpenAI-compatible proxy), making hidden thinking invisible in session accounting, MoA traces, and eval token columns.

Root cause: `normalize_usage` only read `output_tokens_details.reasoning_tokens` (the Responses API shape). Chat Completions providers report it under `completion_tokens_details.reasoning_tokens` — the field was on the wire the whole time, just never read.

## Changes
- `agent/usage_pricing.py` `normalize_usage()`: after the Responses-shape read, fall back to `completion_tokens_details.reasoning_tokens`. Responses-shape behavior unchanged (fallback only fires when the primary read yields 0).

## Validation
| | Before | After |
|---|---|---|
| Chat Completions usage with `completion_tokens_details.reasoning_tokens=4500` | `reasoning_tokens=0` | `4500` |
| Codex Responses shape (`output_tokens_details`) | works | unchanged |
| usage without details objects | 0, no crash | 0, no crash |

- Live wire proof: OpenRouter + deepseek-v4-flash returns `completion_tokens_details: {reasoning_tokens: 61}` on a 74-completion-token call — confirmed via direct API probe.
- Field impact: a HermesBench MoA run (4,828 advisor calls on deepseek-v4-flash) showed `reasoning_tokens=0` on every trace record while individual calls burned up to 21.5K hidden tokens to emit ~500 visible ones — diagnosable only by inference (`output_tokens − visible_len/4`) until this fix.
- `scripts/run_tests.sh tests/agent/test_usage_pricing.py tests/run_agent/test_moa_loop_mode.py` — all pass.

## Infographic
![reasoning-tokens-fix](https://v3b.fal.media/files/b/0aa0ae17/k2hEUUDuSI85YbwNpDqv4_cZqbAR0U.png)
