### PR TITLE
fix(bedrock): guard client cache dicts with a threading.Lock

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 import re
+import threading
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -56,6 +57,7 @@ except Exception:
 
 _bedrock_runtime_client_cache: Dict[str, Any] = {}
 _bedrock_control_client_cache: Dict[str, Any] = {}
+_bedrock_client_cache_lock = threading.Lock()
 
 
 _MIN_BOTO3_VERSION = (1, 34, 59)
@@ -93,21 +95,23 @@ def _get_bedrock_runtime_client(region: str):
 
     Uses the default AWS credential chain (env vars → profile → instance role).
     """
-    if region not in _bedrock_runtime_client_cache:
-        boto3 = _require_boto3()
-        _bedrock_runtime_client_cache[region] = boto3.client(
-            "bedrock-runtime", region_name=region,
-        )
+    with _bedrock_client_cache_lock:
+        if region not in _bedrock_runtime_client_cache:
+            boto3 = _require_boto3()
+            _bedrock_runtime_client_cache[region] = boto3.client(
+                "bedrock-runtime", region_name=region,
+            )
     return _bedrock_runtime_client_cache[region]
 
 
 def _get_bedrock_control_client(region: str):
     """Get or create a cached ``bedrock`` control-plane client for model discovery."""
-    if region not in _bedrock_control_client_cache:
-        boto3 = _require_boto3()
-        _bedrock_control_client_cache[region] = boto3.client(
-            "bedrock", region_name=region,
-        )
+    with _bedrock_client_cache_lock:
+        if region not in _bedrock_control_client_cache:
+            boto3 = _require_boto3()
+            _bedrock_control_client_cache[region] = boto3.client(
+                "bedrock", region_name=region,
+            )
     return _bedrock_control_client_cache[region]
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition in `_get_bedrock_runtime_client()` and `_get_bedrock_control_client()` where the module-level cache dicts were read and written without a lock.

## Related Issue

No existing issue or PR found for this bug.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

Added `_bedrock_client_cache_lock = threading.Lock()` at module level and wrapped the check-and-set pattern in both functions with `with _bedrock_client_cache_lock:`.

## How to Test

Spawn multiple concurrent gateway sessions targeting the same AWS Bedrock region. Before this fix, concurrent sessions could each enter the cache-miss branch and create duplicate boto3 clients. After: only one client is created per region.

## Checklist
- [x] Single focused change
- [x] No unrelated modifications
- [x] No new dependencies