### PR TITLE
feat(mcp): headless client_credentials OAuth for HTTP MCP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
+
+# Local-only ops notes (infra specifics — never commit)
+ops/*.local.md

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -889,6 +889,16 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+#   # Headless machine-to-machine auth (no browser). Add via:
+#   #   hermes mcp add gateway --url https://gateway.internal/mcp --auth client_credentials
+#   gateway:
+#     url: https://gateway.internal/mcp
+#     auth: oauth
+#     oauth:
+#       grant: client_credentials
+#       client_id: my-client
+#       client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from .env — never inline
+#       scope: profile
 #
 # Sampling (server-initiated LLM requests) — enabled by default.
 # Per-server config under the 'sampling' key:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -117,9 +117,9 @@ def _remove_mcp_server(name: str) -> bool:
     return True
 
 
-def _env_key_for_server(name: str) -> str:
+def _env_key_for_server(name: str, suffix: str = "API_KEY") -> str:
     """Convert server name to an env-var key like ``MCP_MYSERVER_API_KEY``."""
-    return f"MCP_{name.upper().replace('-', '_')}_API_KEY"
+    return f"MCP_{name.upper().replace('-', '_')}_{suffix}"
 
 
 def _strip_bearer_prefix(token: str) -> str:
@@ -390,6 +390,41 @@ def cmd_mcp_add(args):
                 _info("Cancelled.")
                 return
 
+    elif url and auth_type == "client_credentials":
+        # Headless machine-to-machine: client_id + client_secret. The
+        # authorization server is discovered from the MCP server's
+        # protected-resource metadata; the secret is stored in .env and
+        # referenced via ${VAR} so it never lands in config.yaml.
+        print()
+        _info(f"Configuring client_credentials (M2M) auth for '{name}'")
+        client_id = getattr(args, "client_id", None) or _prompt("OAuth client_id")
+        if not client_id:
+            _error("client_credentials requires a client_id.")
+            return
+        secret_key = _env_key_for_server(name, "CLIENT_SECRET")
+        if get_env_value(secret_key):
+            _success(f"{secret_key}: already configured")
+        else:
+            client_secret = _prompt("OAuth client_secret", password=True)
+            if not client_secret:
+                _error("client_credentials requires a client_secret.")
+                return
+            save_env_value(secret_key, client_secret)
+            _success(f"Saved to {display_hermes_home()}/.env as {secret_key}")
+        scope = getattr(args, "scope", None)
+        if scope is None:
+            scope = _prompt("Scope (optional, space-separated)", default="")
+        oauth_cfg: Dict[str, Any] = {
+            "grant": "client_credentials",
+            "client_id": client_id,
+            "client_secret": f"${{{secret_key}}}",
+        }
+        if scope and scope.strip():
+            oauth_cfg["scope"] = scope.strip()
+        server_config["auth"] = "oauth"
+        server_config["oauth"] = oauth_cfg
+        _success("client_credentials configured (token minted on first connection)")
+
     elif url:
         # Prompt for API key / Bearer token for HTTP servers
         print()
@@ -628,7 +663,11 @@ def cmd_mcp_test(args):
     auth_type = cfg.get("auth", "")
     headers = cfg.get("headers", {})
     if auth_type == "oauth":
-        _info("Auth: OAuth 2.1 PKCE")
+        grant = str((cfg.get("oauth") or {}).get("grant", "")).strip().lower()
+        if grant == "client_credentials":
+            _info("Auth: OAuth client_credentials (headless M2M)")
+        else:
+            _info("Auth: OAuth 2.1 PKCE")
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -58,7 +58,17 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         default=[],
         help="Arguments for stdio command; must be the last option",
     )
-    mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="Auth method")
+    mcp_add_p.add_argument(
+        "--auth",
+        choices=["oauth", "header", "client_credentials"],
+        help="Auth method (oauth = browser flow; client_credentials = headless M2M)",
+    )
+    mcp_add_p.add_argument(
+        "--client-id", help="OAuth client_id (for --auth client_credentials)"
+    )
+    mcp_add_p.add_argument(
+        "--scope", help="OAuth scope (for --auth client_credentials)"
+    )
     mcp_add_p.add_argument("--preset", help="Known MCP preset name")
     mcp_add_p.add_argument(
         "--env",

--- a/ops/HANDOFF.md
+++ b/ops/HANDOFF.md
@@ -28,6 +28,7 @@ Spacebot is better-designed (Rust, co-equal multi-agent, in-box SurrealDB vector
 
 ## Dev setup (for the SurrealDB provider)
 - Hermes **forked → this fork**; cloned locally (path in `ops/INFRA.local.md`). **MemoryProvider ABC:** `agent/memory_provider.py` (+ `hermes_cli/memory_providers.py`).
+- **Spacebot work archived** — designs, deep research, plans, and the production SurrealDB impl to port — at **`ops/archive.local/`** (gitignored, local-only). See its `README.local.md` for the relevance map (`surreal_store.rs`, `design.md`, `research-llm-memory-feasibility.md`, the Rust spike). Preserved before Spacebot is deleted.
 
 ## NEXT — SurrealDB memory provider
 - **Out-of-tree plugin** — Hermes `AGENTS.md` has a "no new in-tree memory providers" policy. Ship as a standalone repo installed into `~/.hermes/plugins/` OR a pip package exposing the `hermes_agent.plugins` entry-point. **Not a fork edit.**

--- a/ops/HANDOFF.md
+++ b/ops/HANDOFF.md
@@ -1,7 +1,7 @@
 # Hermes Deployment & Migration — Handoff / Tracking
 
 > Living tracking doc for the Spacebot→Hermes migration + the deployment.
-> **No secrets, IPs, or identifiers here on purpose** — those live in `ops/INFRA.local.md` (gitignored, local-only). This file references it where specifics are needed.
+> **No secrets, IPs, or identifiers here on purpose** — those live in a **separate private ops repo** (not in this public fork).
 
 ## TL;DR
 - Spacebot's upstream maintainer is abandoning it → the prod deployment was migrated to **Hermes Agent** (NousResearch). Prod is LIVE on Hermes with Microsoft Teams working.
@@ -13,22 +13,22 @@ Spacebot is better-designed (Rust, co-equal multi-agent, in-box SurrealDB vector
 
 ## Prod deployment
 - Proxmox LXC (Debian 13), reached over a **NetBird overlay**; web admin dashboard on the overlay (basic auth). LLM = OpenRouter. Gateway = systemd **user** service `hermes-gateway`. Hermes is 0.x/fast-moving → **pin the version**.
-- Host IP / SSH / dashboard URL / credential locations → **`ops/INFRA.local.md`**.
+- Host IP / SSH / dashboard URL / credential locations → the **private ops repo**.
 
 ## Teams — LIVE on Hermes
 - New Azure bot created via the **Teams CLI** (`@microsoft/teams.cli` `teams app create`) — it uses the **Teams Developer Portal / Bot Framework registration path, with NO Azure Bot Service resource / billing / F0 tier** (that Azure resource is *optional* for a Teams bot; the mandatory parts are the Entra app + a bot registration + endpoint + Teams channel).
 - Enabling Teams required: (1) toggle the platform ON in the dashboard Messaging tab, (2) `pip install microsoft-teams-apps aiohttp` into the Hermes venv (lazy dep; the gateway logs the exact command). Webhook path `/api/messages`. Allowlist locked to the operator; allow-all off.
 - Public chain: Azure bot → public endpoint → **cloudflared** tunnel → `localhost:3978` (Hermes webhook). Verified live (real Teams message → reply).
 - Teams app: CLI-created; manifest enriched (real descriptions, accentColor) + **SHODAN-style icons** (color 192 + outline 32).
-- Bot / tenant / endpoint / allowlist identifiers → **`ops/INFRA.local.md`**.
+- Bot / tenant / endpoint / allowlist identifiers → the **private ops repo**.
 
 ## Spacebot decommission + upstream
-- `spacebot.service` stopped + disabled; data backed up on the LXC (paths in `ops/INFRA.local.md`). Binary + data dir still on disk (full `rm` pending).
+- `spacebot.service` stopped + disabled; data backed up on the LXC (paths in the private ops repo). Binary + data dir still on disk (full `rm` pending).
 - Upstream PRs (spacedriveapp/spacebot), clean/pushed: **#605** (DM `"*"` wildcard), **#607** (Teams adapter backend + `broadcast` serviceUrl routing-key fix), **#608** (Teams Channels UI + app-package generator), **#609** (`find_by_name` case-insensitive channel-id match — generic bug exposed by Teams' mixed-case ids).
 
 ## Dev setup (for the SurrealDB provider)
-- Hermes **forked → this fork**; cloned locally (path in `ops/INFRA.local.md`). **MemoryProvider ABC:** `agent/memory_provider.py` (+ `hermes_cli/memory_providers.py`).
-- **Spacebot work archived** — designs, deep research, plans, and the production SurrealDB impl to port — at **`ops/archive.local/`** (gitignored, local-only). See its `README.local.md` for the relevance map (`surreal_store.rs`, `design.md`, `research-llm-memory-feasibility.md`, the Rust spike). Preserved before Spacebot is deleted.
+- Hermes **forked → this fork**; cloned locally. **MemoryProvider ABC:** `agent/memory_provider.py` (+ `hermes_cli/memory_providers.py`).
+- **Spacebot work archived** — designs, deep research, plans, and the production SurrealDB impl to port — kept in the **separate private ops repo** (preserved before Spacebot is deleted). Its relevance map points to `surreal_store.rs`, `design.md`, `research-llm-memory-feasibility.md`, and the Rust spike.
 
 ## NEXT — SurrealDB memory provider
 - **Out-of-tree plugin** — Hermes `AGENTS.md` has a "no new in-tree memory providers" policy. Ship as a standalone repo installed into `~/.hermes/plugins/` OR a pip package exposing the `hermes_agent.plugins` entry-point. **Not a fork edit.**

--- a/ops/HANDOFF.md
+++ b/ops/HANDOFF.md
@@ -1,0 +1,42 @@
+# Hermes Deployment & Migration — Handoff / Tracking
+
+> Living tracking doc for the Spacebot→Hermes migration + the deployment.
+> **No secrets, IPs, or identifiers here on purpose** — those live in `ops/INFRA.local.md` (gitignored, local-only). This file references it where specifics are needed.
+
+## TL;DR
+- Spacebot's upstream maintainer is abandoning it → the prod deployment was migrated to **Hermes Agent** (NousResearch). Prod is LIVE on Hermes with Microsoft Teams working.
+- Spacebot decommissioned (backed up). Upstream PRs left clean.
+- **Next big work:** a **SurrealDB memory provider** for Hermes (out-of-tree plugin).
+
+## Why migrate
+Spacebot is better-designed (Rust, co-equal multi-agent, in-box SurrealDB vector memory) but **abandoned**; Hermes is future-proof — actively maintained (MIT, fast cadence), broad channels incl. Teams, pluggable everything. For a prod dependency, maintained + extensible beats elegant + abandoned. Note: Hermes's "self-improving" framing is mostly scaffolding (frozen base model + curated prompt + FTS keyword search + LLM-authored skills); **real semantic memory = the pluggable provider slot** → that is where the SurrealDB work goes.
+
+## Prod deployment
+- Proxmox LXC (Debian 13), reached over a **NetBird overlay**; web admin dashboard on the overlay (basic auth). LLM = OpenRouter. Gateway = systemd **user** service `hermes-gateway`. Hermes is 0.x/fast-moving → **pin the version**.
+- Host IP / SSH / dashboard URL / credential locations → **`ops/INFRA.local.md`**.
+
+## Teams — LIVE on Hermes
+- New Azure bot created via the **Teams CLI** (`@microsoft/teams.cli` `teams app create`) — it uses the **Teams Developer Portal / Bot Framework registration path, with NO Azure Bot Service resource / billing / F0 tier** (that Azure resource is *optional* for a Teams bot; the mandatory parts are the Entra app + a bot registration + endpoint + Teams channel).
+- Enabling Teams required: (1) toggle the platform ON in the dashboard Messaging tab, (2) `pip install microsoft-teams-apps aiohttp` into the Hermes venv (lazy dep; the gateway logs the exact command). Webhook path `/api/messages`. Allowlist locked to the operator; allow-all off.
+- Public chain: Azure bot → public endpoint → **cloudflared** tunnel → `localhost:3978` (Hermes webhook). Verified live (real Teams message → reply).
+- Teams app: CLI-created; manifest enriched (real descriptions, accentColor) + **SHODAN-style icons** (color 192 + outline 32).
+- Bot / tenant / endpoint / allowlist identifiers → **`ops/INFRA.local.md`**.
+
+## Spacebot decommission + upstream
+- `spacebot.service` stopped + disabled; data backed up on the LXC (paths in `ops/INFRA.local.md`). Binary + data dir still on disk (full `rm` pending).
+- Upstream PRs (spacedriveapp/spacebot), clean/pushed: **#605** (DM `"*"` wildcard), **#607** (Teams adapter backend + `broadcast` serviceUrl routing-key fix), **#608** (Teams Channels UI + app-package generator), **#609** (`find_by_name` case-insensitive channel-id match — generic bug exposed by Teams' mixed-case ids).
+
+## Dev setup (for the SurrealDB provider)
+- Hermes **forked → this fork**; cloned locally (path in `ops/INFRA.local.md`). **MemoryProvider ABC:** `agent/memory_provider.py` (+ `hermes_cli/memory_providers.py`).
+
+## NEXT — SurrealDB memory provider
+- **Out-of-tree plugin** — Hermes `AGENTS.md` has a "no new in-tree memory providers" policy. Ship as a standalone repo installed into `~/.hermes/plugins/` OR a pip package exposing the `hermes_agent.plugins` entry-point. **Not a fork edit.**
+- Implement the **`MemoryProvider` ABC**: required = `name`, `is_available` (NO network calls), `initialize`, `get_tool_schemas`; key hooks = **`prefetch(query)`** (recall before each turn — fast) + **`sync_turn(user, assistant)`** (persist — non-blocking, daemon thread). Optional: `system_prompt_block`, `on_memory_write`, config-schema hooks, `shutdown`, `backup_paths`.
+- **Provider owns embeddings + vector search** — Hermes hands raw text; SurrealDB native vector search (HNSW/MTREE + KNN) maps cleanly. **Reuse Spacebot's SurrealDB code** (schema, vector queries, embedding calls). Model on the **`plugins/memory/holographic`** provider (local DB + self-managed retrieval) + **`mem0`** (config/tool-schema shape). ~400–600 lines.
+- External providers **AUGMENT** the built-in SQLite/FTS5 memory (one external active via `memory.provider`).
+
+## Gotchas
+- The **dev VM also runs the operator's live `tracecat` SOAR** (Temporal) → **throttle heavy builds** (`nice -n 19 ionice -c3`, `systemd-run CPUQuota=…`) or build elsewhere; never `docker system prune`.
+- **Teams client cache:** swapping/re-uploading a Teams app → the desktop client shows the OLD app until a full client restart; admin-portal delete ≠ client uninstall; one bot App ID ↔ one Teams app.
+- **Per-user durable memory isolation** is undocumented in Hermes (sessions isolate per user; durable memory/profile is owner-centric) — validate before exposing to other end-users.
+- **An LLM does not know its own internals** — Hermes's agent confabulated its memory file paths/format/limits; verify against code/config, never the agent's self-description.

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -219,6 +219,46 @@ class TestMcpAdd:
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
+    def test_add_client_credentials(self, capsys, monkeypatch):
+        """--auth client_credentials writes the oauth block + secret to .env."""
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [("hudu_list_companies", "list companies")],
+        )
+        # client_id + scope come from flags; only the secret is prompted.
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._prompt",
+            lambda q, password=False, default="": "s3cr3t" if "secret" in q.lower() else default,
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")  # accept all tools
+
+        from hermes_cli.mcp_config import cmd_mcp_add, get_env_value
+
+        cmd_mcp_add(
+            _make_args(
+                name="gw",
+                url="https://gw/mcp",
+                auth="client_credentials",
+                client_id="mcp-gateway",
+                scope="profile",
+            )
+        )
+
+        import yaml
+
+        from hermes_cli.config import get_config_path, load_config
+
+        srv = load_config()["mcp_servers"]["gw"]
+        assert srv["auth"] == "oauth"
+        assert srv["oauth"]["grant"] == "client_credentials"
+        assert srv["oauth"]["client_id"] == "mcp-gateway"
+        assert srv["oauth"]["scope"] == "profile"
+        # The secret is stored as a ${VAR} reference in config.yaml (resolved from
+        # .env at load time) — the literal secret never lands in config.yaml.
+        raw = yaml.safe_load(get_config_path().read_text())
+        assert raw["mcp_servers"]["gw"]["oauth"]["client_secret"] == "${MCP_GW_CLIENT_SECRET}"
+        assert get_env_value("MCP_GW_CLIENT_SECRET") == "s3cr3t"
+
     def test_add_stdio_server(self, tmp_path, capsys, monkeypatch):
         """Add a stdio server."""
         fake_tools = [FakeTool("search", "Search repos")]

--- a/tests/tools/test_mcp_oauth_client_credentials.py
+++ b/tests/tools/test_mcp_oauth_client_credentials.py
@@ -1,0 +1,176 @@
+"""Tests for the headless client_credentials (M2M) MCP OAuth grant.
+
+Covers the ``oauth.grant: client_credentials`` path in ``tools/mcp_oauth.py``
+and ``tools/mcp_oauth_manager.py``: it wires the MCP SDK's headless
+``ClientCredentialsOAuthProvider`` so a daemon can authenticate to an
+OAuth-fronted MCP gateway with no browser, no callback, and no interactive
+re-auth.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+
+from tools import mcp_oauth as mo
+from tools import mcp_oauth_manager as mgr
+
+
+def _cfg(**over):
+    cfg = {
+        "grant": "client_credentials",
+        "client_id": "mcp-gateway",
+        "client_secret": "s3cr3t",
+        "scope": "profile",
+    }
+    cfg.update(over)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Grant classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsM2MGrant:
+    def test_client_credentials_selected(self):
+        assert mo.is_m2m_grant({"grant": "client_credentials"}) is True
+
+    def test_case_and_whitespace_insensitive(self):
+        assert mo.is_m2m_grant({"grant": " Client_Credentials "}) is True
+
+    def test_non_m2m_grants(self):
+        assert mo.is_m2m_grant({"grant": "authorization_code"}) is False
+        assert mo.is_m2m_grant({"grant": "private_key_jwt"}) is False  # dropped
+        assert mo.is_m2m_grant({"client_id": "x"}) is False
+        assert mo.is_m2m_grant(None) is False
+        assert mo.is_m2m_grant({}) is False
+
+
+# ---------------------------------------------------------------------------
+# Provider construction
+# ---------------------------------------------------------------------------
+
+
+class TestClientCredentials:
+    def test_builds_headless_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider("gw", "https://gw/mcp", _cfg())
+
+        assert isinstance(p, ClientCredentialsOAuthProvider)
+        assert p.context.client_metadata.grant_types == ["client_credentials"]
+        assert p.context.client_metadata.scope == "profile"
+        assert p._fixed_client_info.client_id == "mcp-gateway"
+        assert p._fixed_client_info.client_secret == "s3cr3t"
+        # Headless: base __init__ constructed with no redirect/callback handlers.
+        assert p.context.redirect_handler is None
+        assert p.context.callback_handler is None
+
+    def test_default_auth_method_is_basic(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider("gw", "https://gw/mcp", _cfg())
+        assert p.context.client_metadata.token_endpoint_auth_method == "client_secret_basic"
+
+    def test_auth_method_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider(
+            "gw", "https://gw/mcp", _cfg(token_endpoint_auth_method="client_secret_post")
+        )
+        assert p.context.client_metadata.token_endpoint_auth_method == "client_secret_post"
+
+    def test_missing_client_secret_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg()
+        del cfg["client_secret"]
+        with pytest.raises(ValueError, match="client_secret"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+    def test_missing_client_id_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg()
+        del cfg["client_id"]
+        with pytest.raises(ValueError, match="client_id"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+    def test_bad_auth_method_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with pytest.raises(ValueError, match="token_endpoint_auth_method"):
+            mo.build_client_credentials_provider(
+                "gw", "https://gw/mcp", _cfg(token_endpoint_auth_method="mtls")
+            )
+
+
+class TestDispatch:
+    def test_dispatch_client_credentials(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_m2m_provider("gw", "https://gw/mcp", _cfg())
+        assert type(p) is ClientCredentialsOAuthProvider
+
+    def test_dispatch_unknown_grant_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with pytest.raises(ValueError, match="Unknown M2M oauth grant"):
+            mo.build_m2m_provider("gw", "https://gw/mcp", {"grant": "authorization_code"})
+
+
+class TestBuildOAuthAuthHeadless:
+    def test_m2m_bypasses_non_interactive_guard(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Force a non-interactive env: the browser path would raise
+        # OAuthNonInteractiveError; the M2M path must not.
+        monkeypatch.setattr(mo, "_is_interactive", lambda: False)
+        p = mo.build_oauth_auth("gw", "https://gw/mcp", _cfg())
+        assert isinstance(p, ClientCredentialsOAuthProvider)
+
+
+# ---------------------------------------------------------------------------
+# Manager wiring
+# ---------------------------------------------------------------------------
+
+
+class TestManagerWiring:
+    def test_build_provider_uses_sdk_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mo, "_is_interactive", lambda: False)
+        entry = mgr._ProviderEntry(server_url="https://gw/mcp", oauth_config=_cfg())
+        provider = mgr.get_manager()._build_provider("gw", entry)
+        assert type(provider) is ClientCredentialsOAuthProvider
+
+    def test_is_m2m(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        mgr.reset_manager_for_tests()
+        manager = mgr.get_manager()
+        # is_m2m reads the entry's oauth_config only — no provider build needed.
+        manager._entries["gw"] = mgr._ProviderEntry(
+            server_url="https://gw/mcp", oauth_config=_cfg()
+        )
+        manager._entries["browser"] = mgr._ProviderEntry(
+            server_url="https://b/mcp", oauth_config={"client_id": "x"}
+        )
+        assert manager.is_m2m("gw") is True
+        assert manager.is_m2m("browser") is False
+        assert manager.is_m2m("never-seen") is False
+
+
+# ---------------------------------------------------------------------------
+# Auth-failure message: M2M vs interactive
+# ---------------------------------------------------------------------------
+
+
+class TestReauthMessage:
+    def test_m2m_message_does_not_prompt_login(self):
+        from tools.mcp_tool import _needs_reauth_error
+
+        payload = json.loads(_needs_reauth_error("gw", m2m=True))
+        assert payload["m2m"] is True
+        assert payload["needs_reauth"] is True
+        assert "Do NOT run" in payload["error"]
+        assert "credential/config" in payload["error"]
+
+    def test_interactive_message_prompts_login(self):
+        from tools.mcp_tool import _needs_reauth_error
+
+        payload = json.loads(_needs_reauth_error("gh", m2m=False))
+        assert "m2m" not in payload
+        assert "hermes mcp login gh" in payload["error"]

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -77,6 +77,22 @@ try:
 except ImportError:
     AnyUrl = None  # type: ignore[assignment, misc]
 
+# Machine-to-machine OAuth via the SDK's headless client_credentials extension
+# (mcp>=1.26): the client authenticates with client_id + client_secret — no
+# browser, no callback — and the SDK re-mints on expiry (no refresh_token
+# needed). Optional import so the module still loads on older SDKs.
+_M2M_AVAILABLE = False
+try:
+    from mcp.client.auth.extensions.client_credentials import (
+        ClientCredentialsOAuthProvider,
+    )
+
+    _M2M_AVAILABLE = True
+except ImportError:
+    logger.debug(
+        "MCP client_credentials extension not available -- M2M MCP auth disabled"
+    )
+
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -786,6 +802,103 @@ def _maybe_preregister_client(
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 
+# ---------------------------------------------------------------------------
+# Machine-to-machine (headless client_credentials grant)
+#
+# ``grant: client_credentials`` — client_id + client_secret, via the MCP SDK's
+# ``ClientCredentialsOAuthProvider``. Selected via ``oauth.grant``; default
+# (absent) keeps the interactive authorization_code flow below unchanged. The
+# provider mints reactively on the first 401 and re-mints on expiry inside the
+# SDK's own httpx flow (no refresh_token, no proactive path), so no Hermes
+# subclass is needed: unlike authorization_code, ``is_token_valid()`` gates
+# nothing extra for this grant.
+# ---------------------------------------------------------------------------
+
+M2M_GRANT_CLIENT_CREDENTIALS = "client_credentials"
+_M2M_GRANTS = frozenset({M2M_GRANT_CLIENT_CREDENTIALS})
+
+
+def _grant_of(oauth_config: dict | None) -> str:
+    if not oauth_config:
+        return ""
+    return str(oauth_config.get("grant", "")).strip().lower()
+
+
+def is_m2m_grant(oauth_config: dict | None) -> bool:
+    """True when the oauth block requests a headless machine-to-machine grant."""
+    return _grant_of(oauth_config) in _M2M_GRANTS
+
+
+def _require_client_id(cfg: dict, grant: str) -> str:
+    client_id = cfg.get("client_id")
+    if not client_id:
+        raise ValueError(f"MCP OAuth grant '{grant}' requires 'oauth.client_id'.")
+    return client_id
+
+
+def build_client_credentials_provider(
+    server_name: str,
+    server_url: str,
+    oauth_config: dict,
+) -> "ClientCredentialsOAuthProvider | None":
+    """Build a headless client_credentials M2M OAuth provider for an MCP server.
+
+    Shared by :func:`build_oauth_auth` and the manager's ``_build_provider`` so
+    both construction paths behave identically. The shared secret is read from
+    ``oauth.client_secret`` — resolve it from a secret via ``${VAR}``; never
+    inline a literal. Returns None if the SDK's client_credentials extension is
+    unavailable.
+    """
+    if not _M2M_AVAILABLE:
+        logger.warning(
+            "MCP OAuth grant 'client_credentials' requested for '%s' but the SDK "
+            "client_credentials extension is unavailable. Install 'mcp>=1.26.0'.",
+            server_name,
+        )
+        return None
+
+    cfg = dict(oauth_config or {})
+    client_id = _require_client_id(cfg, M2M_GRANT_CLIENT_CREDENTIALS)
+    client_secret = cfg.get("client_secret")
+    if not client_secret:
+        raise ValueError(
+            "MCP OAuth grant 'client_credentials' requires 'oauth.client_secret' "
+            "(resolve it from a secret via ${VAR}; do not inline a literal)."
+        )
+    auth_method = str(
+        cfg.get("token_endpoint_auth_method", "client_secret_basic")
+    ).strip()
+    if auth_method not in ("client_secret_basic", "client_secret_post"):
+        raise ValueError(
+            "MCP OAuth 'token_endpoint_auth_method' must be 'client_secret_basic' "
+            f"or 'client_secret_post' (got {auth_method!r})."
+        )
+    return ClientCredentialsOAuthProvider(
+        server_url=server_url,
+        storage=HermesTokenStorage(server_name),
+        client_id=client_id,
+        client_secret=client_secret,
+        token_endpoint_auth_method=auth_method,
+        scopes=cfg.get("scope"),
+    )
+
+
+def build_m2m_provider(
+    server_name: str,
+    server_url: str,
+    oauth_config: dict,
+) -> "OAuthClientProvider | None":
+    """Dispatch to the M2M provider for the configured ``oauth.grant``.
+
+    Returns None if the SDK extension is unavailable; raises ValueError for an
+    absent/unknown M2M grant (callers gate with :func:`is_m2m_grant` first).
+    """
+    grant = _grant_of(oauth_config)
+    if grant == M2M_GRANT_CLIENT_CREDENTIALS:
+        return build_client_credentials_provider(server_name, server_url, oauth_config)
+    raise ValueError(f"Unknown M2M oauth grant: {grant!r}")
+
+
 def build_oauth_auth(
     server_name: str,
     server_url: str,
@@ -815,6 +928,11 @@ def build_oauth_auth(
         return None
 
     cfg = dict(oauth_config or {})  # copy — we mutate _resolved_port
+
+    # Headless M2M grant: no browser, no callback, no interactivity gate.
+    if is_m2m_grant(cfg):
+        return build_m2m_provider(server_name, server_url, cfg)
+
     storage = HermesTokenStorage(server_name)
 
     if not _is_interactive() and not storage.has_cached_tokens():

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -526,6 +526,16 @@ class MCPOAuthManager:
             return None
 
         cfg = dict(entry.oauth_config or {})
+
+        # Headless M2M grant (client_credentials): no browser, no callback, no
+        # interactivity gate. The SDK's provider mints on the first 401 and
+        # re-mints on expiry (client_credentials — no refresh_token) inside
+        # its own httpx auth flow, so nothing extra is needed here.
+        from tools.mcp_oauth import build_m2m_provider, is_m2m_grant
+
+        if is_m2m_grant(cfg):
+            return build_m2m_provider(server_name, entry.server_url, cfg)
+
         storage = HermesTokenStorage(server_name)
 
         if not _is_interactive() and not storage.has_cached_tokens():
@@ -551,6 +561,19 @@ class MCPOAuthManager:
             callback_handler=_wait_for_callback,
             timeout=float(cfg.get("timeout", 300)),
         )
+
+    def is_m2m(self, server_name: str) -> bool:
+        """True when this server uses a headless machine-to-machine grant.
+
+        Used to tailor the auth-failure message: an M2M server has no browser
+        ``hermes mcp login`` flow, so prompting for one would be wrong.
+        """
+        entry = self._entries.get(server_name)
+        if entry is None:
+            return False
+        from tools.mcp_oauth import is_m2m_grant
+
+        return is_m2m_grant(entry.oauth_config)
 
     def remove(self, server_name: str) -> None:
         """Evict the provider from cache AND delete tokens from disk.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2679,6 +2679,42 @@ def _is_auth_error(exc: BaseException) -> bool:
     return True
 
 
+def _needs_reauth_error(server_name: str, *, m2m: bool) -> str:
+    """Build the structured auth-failure payload returned to the model.
+
+    ``m2m`` servers (client_credentials) have no interactive ``hermes mcp login``
+    flow — the SDK already re-mints on 401, so reaching this point means a
+    freshly minted token was rejected (bad client_id / signing key / scope /
+    gateway audience or group policy). Steer the model to the config, not to a
+    browser re-auth that does not exist.
+    """
+    if m2m:
+        return json.dumps({
+            "error": (
+                f"MCP server '{server_name}' rejected a freshly minted token "
+                f"(machine-to-machine auth). This is a credential/config issue, "
+                f"not a session expiry — check the OAuth client_id, signing key, "
+                f"scopes, and the gateway's audience/group policy. Do NOT run "
+                f"`hermes mcp login` (there is no interactive flow) and do NOT "
+                f"retry this tool."
+            ),
+            "needs_reauth": True,
+            "m2m": True,
+            "server": server_name,
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "error": (
+            f"MCP server '{server_name}' requires re-authentication. "
+            f"Run `hermes mcp login {server_name}` (or delete the tokens "
+            f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
+            f"this tool — ask the user to re-authenticate."
+        ),
+        "needs_reauth": True,
+        "server": server_name,
+    }, ensure_ascii=False)
+
+
 def _handle_auth_error_and_retry(
     server_name: str,
     exc: BaseException,
@@ -2790,16 +2826,7 @@ def _handle_auth_error_and_retry(
     # needs_reauth error. Bumps the circuit breaker so the model stops
     # retrying the tool.
     _bump_server_error(server_name)
-    return json.dumps({
-        "error": (
-            f"MCP server '{server_name}' requires re-authentication. "
-            f"Run `hermes mcp login {server_name}` (or delete the tokens "
-            f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
-            f"this tool — ask the user to re-authenticate."
-        ),
-        "needs_reauth": True,
-        "server": server_name,
-    }, ensure_ascii=False)
+    return _needs_reauth_error(server_name, m2m=manager.is_m2m(server_name))
 
 
 # Substrings (lower-cased match) that indicate the MCP server rejected

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -289,3 +289,39 @@ Behavior:
 - Tokens are persisted to `~/.hermes/mcp-tokens/<server>.json` and reused across sessions
 - Token refresh is automatic; re-authorization only happens when refresh fails
 - Only applies to HTTP/StreamableHTTP transport (`url`-based servers)
+
+### Machine-to-machine (`client_credentials`)
+
+The interactive flow above needs a human at first connect. For a **headless**
+deployment (a daemon/gateway with no browser), set `oauth.grant:
+client_credentials` to use the SDK's client-credentials extension: the client
+authenticates with a client ID + shared secret — no browser, no callback. Keep
+the secret in a secret store and reference it via `${VAR}`; never inline it.
+
+You can also add this server with the CLI wizard:
+`hermes mcp add gateway --url https://gateway.internal/mcp --auth client_credentials`
+(it prompts for the client ID, secret, and scope).
+
+```yaml
+mcp_servers:
+  gateway:
+    url: "https://gateway.internal/mcp"
+    auth: oauth
+    oauth:
+      grant: client_credentials
+      client_id: "my-client"
+      client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from ~/.hermes/.env — never inline
+      scope: "profile"
+      # token_endpoint_auth_method: client_secret_basic   # or client_secret_post (default: basic)
+```
+
+Behavior:
+- Fully headless: no browser, no local callback server, no interactivity gate
+- The token is a client-credentials access token, **re-minted automatically on
+  expiry** — the SDK re-runs the exchange on a 401 (no `refresh_token` required)
+- The authorization server is discovered from the MCP server's protected-resource
+  metadata (RFC 9728) — no token endpoint to configure by hand
+- Requires `mcp>=1.26`; otherwise the server fails to connect with a clear error
+- The secret is referenced (env var), never stored in config
+- If a *freshly minted* token is rejected, the error points at the client
+  credentials / scopes / gateway policy — there is no interactive re-auth


### PR DESCRIPTION
## What does this PR do?

Adds non-interactive OAuth 2.0 **`client_credentials`** auth for HTTP MCP servers, so a **headless** Hermes deployment (a gateway/daemon with no browser) can authenticate to an OAuth-fronted MCP server without the interactive PKCE browser flow.

Today `auth: oauth` only supports the interactive `authorization_code` + PKCE flow, which needs a human at first connect (`hermes mcp login`). Machine-to-machine servers behind an OAuth gateway (e.g. an internal MCP gateway fronted by an identity provider) can't use that. This wires the MCP SDK's own `ClientCredentialsOAuthProvider` (shipped in `mcp>=1.26`) behind a new `oauth.grant: client_credentials`.

This has been running in a production deployment (an internal MCP gateway fronted by Authentik, `client_credentials` + a service account): token minted at runtime, group-scoped RBAC enforced by the gateway, tools served.

## Related Issue / prior art

No open issue. Prior `client_credentials` proposals exist but are stalled/partial — #30613 (draft since May), #46488 (labeled `duplicate`). This one differs by wiring the **SDK's own extension provider** (small surface, `mcp>=1.26` is already pinned) rather than a hand-rolled token minter, and by integrating with the `hermes mcp add` wizard + `hermes mcp test` display.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/mcp_oauth.py` — `build_client_credentials_provider` / `build_m2m_provider` + `is_m2m_grant`, wiring the SDK's `ClientCredentialsOAuthProvider`; the M2M grant is routed in `build_oauth_auth` before the interactivity gate.
- `tools/mcp_oauth_manager.py` — M2M branch in `_build_provider` (headless, no interactivity gate) + `is_m2m` accessor.
- `tools/mcp_tool.py` — grant-aware auth-failure message: M2M servers have no `hermes mcp login`, so a rejected *freshly minted* token points at credentials/scopes/gateway policy instead of prompting for re-auth.
- `hermes_cli/subcommands/mcp.py`, `hermes_cli/mcp_config.py` — `hermes mcp add --auth client_credentials` wizard (`--client-id` / `--scope` flags; prompts for the secret and stores it in `.env`, referenced via `${VAR}`); `hermes mcp test` shows the M2M auth mode.
- `website/docs/reference/mcp-config-reference.md`, `cli-config.yaml.example` — docs + example.
- Tests: `tests/tools/test_mcp_oauth_client_credentials.py` (provider construction, dispatch, headless bypass, manager wiring, message branches — against the real SDK) + a `hermes mcp add --auth client_credentials` wizard test in `tests/hermes_cli/test_mcp_config.py`.

Behavior: fully headless (no browser/callback); the authorization server is discovered from the MCP server's protected-resource metadata (RFC 9728); tokens are re-minted on expiry (no `refresh_token`); the secret is referenced via `${VAR}`, never stored in config. Default (grant absent) keeps the interactive flow unchanged.

## How to Test

Config-only:

```yaml
mcp_servers:
  gateway:
    url: https://your-gateway/mcp
    auth: oauth
    oauth:
      grant: client_credentials
      client_id: my-client
      client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from .env
      scope: profile
```

…or the wizard: `hermes mcp add gateway --url https://your-gateway/mcp --auth client_credentials`

Automated:

```
pytest tests/tools/test_mcp_oauth_client_credentials.py tests/hermes_cli/test_mcp_config.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(mcp):`)
- [x] I searched for existing PRs (referenced #30613 / #46488 above)
- [x] My PR contains **only** changes related to this feature
- [x] I've run the tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`mcp-config-reference.md`, docstrings)
- [x] I've updated `cli-config.yaml.example` (new `oauth.grant` config keys)
- [x] N/A — no CONTRIBUTING/AGENTS architecture change
- [x] Cross-platform: pure-Python, no OS-specific calls
- [x] N/A — no tool schema changes
