### PR TITLE
fix(desktop): resolve desktop toolsets through cli defaults

### DIFF
--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -20,6 +20,7 @@ class PlatformInfo(NamedTuple):
 # Ordered so that TUI menus are deterministic.
 PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("cli",            PlatformInfo(label="🖥️  CLI",            default_toolset="hermes-cli")),
+    ("desktop",        PlatformInfo(label="🖥️  Desktop",        default_toolset="hermes-cli")),
     ("telegram",       PlatformInfo(label="📱 Telegram",        default_toolset="hermes-telegram")),
     ("discord",        PlatformInfo(label="💬 Discord",         default_toolset="hermes-discord")),
     ("slack",          PlatformInfo(label="💼 Slack",           default_toolset="hermes-slack")),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1420,6 +1420,19 @@ def _get_platform_tools(
     from toolsets import resolve_toolset, TOOLSETS
 
     platform_toolsets = config.get("platform_toolsets") or {}
+
+    # Desktop/TUI settings are intentionally stored in the CLI toolset lane
+    # today (see the Desktop /api/tools endpoints). If a runtime caller starts
+    # passing the Desktop session source key, keep that existing configuration
+    # contract instead of falling through to a non-existent hermes-desktop
+    # composite. A user-provided platform_toolsets.desktop entry still wins.
+    if platform == "desktop" and "desktop" not in platform_toolsets:
+        return _get_platform_tools(
+            config,
+            "cli",
+            include_default_mcp_servers=include_default_mcp_servers,
+        )
+
     toolset_names = platform_toolsets.get(platform)
 
     if toolset_names is None or not isinstance(toolset_names, list):

--- a/tests/hermes_cli/test_desktop_toolset_platform.py
+++ b/tests/hermes_cli/test_desktop_toolset_platform.py
@@ -1,0 +1,35 @@
+from hermes_cli.platforms import PLATFORMS
+from hermes_cli.tools_config import _get_platform_tools
+
+
+def test_desktop_platform_uses_cli_default_toolset():
+    assert PLATFORMS["desktop"].default_toolset == "hermes-cli"
+
+    enabled = _get_platform_tools({}, "desktop", include_default_mcp_servers=False)
+
+    assert "web" in enabled
+    assert "terminal" in enabled
+    assert "file" in enabled
+    assert "hermes-desktop" not in enabled
+
+
+def test_desktop_platform_inherits_saved_cli_toolsets():
+    enabled = _get_platform_tools(
+        {"platform_toolsets": {"cli": ["web"]}},
+        "desktop",
+        include_default_mcp_servers=False,
+    )
+
+    assert "web" in enabled
+    assert "terminal" not in enabled
+
+
+def test_desktop_platform_override_wins_when_present():
+    enabled = _get_platform_tools(
+        {"platform_toolsets": {"cli": ["terminal"], "desktop": ["web"]}},
+        "desktop",
+        include_default_mcp_servers=False,
+    )
+
+    assert "web" in enabled
+    assert "terminal" not in enabled

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -960,7 +960,7 @@ class TestPlatformToolsetConsistency:
 
         gateway_includes = set(TOOLSETS["hermes-gateway"]["includes"])
         # Exclude non-messaging platforms from the check
-        non_messaging = {"cli", "api_server", "cron"}
+        non_messaging = {"cli", "desktop", "api_server", "cron"}
         for platform, meta in PLATFORMS.items():
             if platform in non_messaging:
                 continue


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop toolset resolution when a caller uses the `desktop` platform/source key.

Before this change, `desktop` was not registered in the shared platform registry, so `_get_platform_tools(config, "desktop")` could fall through to the derived `hermes-desktop` composite. That composite does not provide the normal CLI/Desktop tool universe, so future Desktop paths that pass `desktop` can miss expected toolsets.

This PR registers `desktop` as a platform using the `hermes-cli` default toolset and keeps Desktop compatible with the existing Desktop/TUI settings contract: unless `platform_toolsets.desktop` is explicitly configured, Desktop resolves through the saved `platform_toolsets.cli` lane that the current Desktop settings UI already reads and writes.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1522322669947715826

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/platforms.py`: registers `desktop` with the `hermes-cli` default toolset.
- `hermes_cli/tools_config.py`: makes `desktop` inherit the existing `platform_toolsets.cli` configuration unless an explicit `platform_toolsets.desktop` override exists.
- `tests/hermes_cli/test_desktop_toolset_platform.py`: adds regression coverage for the default Desktop toolset, CLI-lane inheritance, and explicit Desktop override behavior.

## How to Test

1. Confirm `_get_platform_tools({}, "desktop")` includes normal CLI toolsets like `web`, `terminal`, and `file`, not `hermes-desktop`.
2. Confirm `platform_toolsets.cli` entries are honored for `desktop` when no explicit Desktop override exists.
3. Confirm `platform_toolsets.desktop` still wins when present.

Validated with:

- `scripts/run_tests.sh -j 4 tests/hermes_cli/test_desktop_toolset_platform.py tests/test_toolsets.py -q`
- `scripts/run_tests.sh -j 4 tests/hermes_cli/test_toolset_validation.py tests/hermes_cli/test_web_server_session_search.py tests/test_tui_gateway_server.py -q`
- `venv/bin/ruff check hermes_cli/platforms.py hermes_cli/tools_config.py tests/hermes_cli/test_desktop_toolset_platform.py`
- `python3 -m py_compile hermes_cli/platforms.py hermes_cli/tools_config.py tests/hermes_cli/test_desktop_toolset_platform.py`
- `git diff --check -- hermes_cli/platforms.py hermes_cli/tools_config.py tests/hermes_cli/test_desktop_toolset_platform.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL checkout, focused Python tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; resolver/test-only fix.
