### PR TITLE
fix(tui): honor checkpoints.enabled from config.yaml

### DIFF
--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -237,6 +237,157 @@ def test_make_agent_honors_tui_launch_env_flags():
         assert kwargs["skip_memory"] is True
 
 
+def test_make_agent_honors_checkpoints_enabled_in_config():
+    """``checkpoints.enabled: true`` in config.yaml must enable checkpoints
+    in the TUI even when the ``HERMES_TUI_CHECKPOINTS`` env var is unset.
+
+    Regression: the TUI previously only read the env var, so the config
+    setting was silently ignored and /rollback reported "checkpoints are
+    not enabled".  The classic CLI (cli.py) already honored config.
+    """
+
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "agent": {"system_prompt": ""},
+        "model": {"default": "glm-5"},
+        "checkpoints": {"enabled": True, "max_snapshots": 50},
+    }
+
+    # Ensure the env var is NOT set so we test the config path.
+    clean_env = {k: v for k, v in os.environ.items()
+                 if k != "HERMES_TUI_CHECKPOINTS"}
+    with (
+        patch.dict(os.environ, clean_env, clear=True),
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-cp-cfg", "key-cp-cfg")
+
+        assert mock_agent.call_args.kwargs["checkpoints_enabled"] is True
+
+
+def test_make_agent_checkpoints_disabled_by_default():
+    """No ``checkpoints`` config and no env var → checkpoints off."""
+
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {"agent": {"system_prompt": ""}, "model": {"default": "glm-5"}}
+
+    clean_env = {k: v for k, v in os.environ.items()
+                 if k != "HERMES_TUI_CHECKPOINTS"}
+    with (
+        patch.dict(os.environ, clean_env, clear=True),
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-cp-off", "key-cp-off")
+
+        assert mock_agent.call_args.kwargs["checkpoints_enabled"] is False
+
+
+def test_make_agent_checkpoints_env_var_overrides_config_false():
+    """``HERMES_TUI_CHECKPOINTS=1`` (from ``--checkpoints`` flag) must
+    enable checkpoints even when config says ``enabled: false``.
+    Mirrors CLI precedence: CLI flag > config."""
+
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "agent": {"system_prompt": ""},
+        "model": {"default": "glm-5"},
+        "checkpoints": {"enabled": False},
+    }
+
+    with (
+        patch.dict(os.environ, {"HERMES_TUI_CHECKPOINTS": "1"}),
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-cp-env", "key-cp-env")
+
+        assert mock_agent.call_args.kwargs["checkpoints_enabled"] is True
+
+
+def test_make_agent_checkpoints_bool_config_shorthand():
+    """A bare ``checkpoints: true`` (bool instead of dict) must also work."""
+
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "agent": {"system_prompt": ""},
+        "model": {"default": "glm-5"},
+        "checkpoints": True,
+    }
+
+    clean_env = {k: v for k, v in os.environ.items()
+                 if k != "HERMES_TUI_CHECKPOINTS"}
+    with (
+        patch.dict(os.environ, clean_env, clear=True),
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-cp-bool", "key-cp-bool")
+
+        assert mock_agent.call_args.kwargs["checkpoints_enabled"] is True
+
+
 def test_probe_config_health_flags_null_sections():
     """Bare YAML keys (`agent:` with no value) parse as None and silently
     drop nested settings; probe must surface them so users can fix."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4340,6 +4340,18 @@ def _make_agent(
             "target_model": model or None,
         })
     _pr = _load_provider_routing()
+    # Checkpoints: env var override wins (CLI parity: --checkpoints > config),
+    # then fall back to config.yaml ``checkpoints.enabled``.  The TUI previously
+    # only read the env var, so users who set ``checkpoints.enabled: true`` in
+    # config saw "checkpoints are not enabled" in the TUI while the classic CLI
+    # honoured the same config.  Mirrors cli.py's merge logic.
+    _cp_cfg = cfg.get("checkpoints", {})
+    if isinstance(_cp_cfg, bool):
+        _cp_cfg = {"enabled": _cp_cfg}
+    _cp_enabled = (
+        is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS"))
+        or _cp_cfg.get("enabled", False)
+    )
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 90),
@@ -4380,7 +4392,7 @@ def _make_agent(
         session_id=session_id or key,
         session_db=session_db if session_db is not None else _get_db(),
         ephemeral_system_prompt=system_prompt or None,
-        checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
+        checkpoints_enabled=_cp_enabled,
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),


### PR DESCRIPTION
## Problem

The TUI gateway (`_make_agent` in `tui_gateway/server.py`) only read the `HERMES_TUI_CHECKPOINTS` env var to decide whether filesystem checkpoints were enabled, ignoring the `checkpoints.enabled` config.yaml setting entirely.

This meant users who set `checkpoints.enabled: true` in config saw `/rollback` report **"checkpoints are not enabled"** in the TUI, while the classic CLI (`cli.py`) honored the same config correctly.

## Root cause

The env var is set by the `--checkpoints` CLI flag when launching the TUI subprocess (`hermes_cli/main.py:2071-2072`), so the flag worked — but config-driven checkpoints (the documented, persistent way to enable them) were broken on the TUI/desktop surface.

| Surface | Reads config? | Result |
|---------|:---:|--------|
| `hermes chat` (classic CLI) | ✅ `cli.py:3873` | Works |
| `hermes chat --checkpoints` | ✅ flag override | Works |
| `hermes` TUI with `--checkpoints` flag | ✅ env var bridge | Works |
| **`hermes` TUI with `checkpoints.enabled: true` in config** | ❌ only read env var | **Broken** |

## Fix

Merge config + env var in `_make_agent`, mirroring `cli.py`'s logic. Env var still wins (CLI parity: `--checkpoints > config`), then fall back to config, then `False`. Handles both dict and bool config shapes.

```python
_cp_cfg = cfg.get("checkpoints", {})
if isinstance(_cp_cfg, bool):
    _cp_cfg = {"enabled": _cp_cfg}
_cp_enabled = (
    is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS"))
    or _cp_cfg.get("enabled", False)
)
```

## Tests

4 new cases in `tests/tui_gateway/test_make_agent_provider.py`:

- `test_make_agent_honors_checkpoints_enabled_in_config` — config `enabled: True` → checkpoints on (the bug)
- `test_make_agent_checkpoints_disabled_by_default` — no config, no env → off
- `test_make_agent_checkpoints_env_var_overrides_config_false` — env var overrides config `enabled: False` (precedence)
- `test_make_agent_checkpoints_bool_config_shorthand` — bare `checkpoints: true` bool shorthand

All 15 tests in the file pass.

## Test plan

- [x] `pytest tests/tui_gateway/test_make_agent_provider.py -v` — 15 passed
- [ ] Set `checkpoints.enabled: true` in config, launch TUI without `--checkpoints` flag, verify `/rollback` lists checkpoints instead of reporting "not enabled"