### PR TITLE
fix(telegram): debug-log unmentioned group drops

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7023,6 +7023,35 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    def _log_unprocessed_group_message(
+        self,
+        msg: Message,
+        message_type: MessageType,
+        *,
+        reason: str = "unmentioned_group_message",
+    ) -> None:
+        """Debug-log a Telegram group update dropped by trigger gating.
+
+        Keep this DEBUG-only and metadata-only: operators can diagnose why a
+        group attachment/message vanished without logging user text, captions,
+        file names, media URLs, or attachment contents.
+        """
+        chat = getattr(msg, "chat", None)
+        sender = getattr(msg, "from_user", None)
+        logger.debug(
+            "[Telegram] Telegram group message dropped: reason=%s type=%s "
+            "chat_id=%s chat_type=%s chat_title=%r sender_id=%s "
+            "sender_name=%r message_id=%s",
+            reason,
+            getattr(message_type, "value", str(message_type)),
+            getattr(chat, "id", None),
+            getattr(chat, "type", None),
+            getattr(chat, "title", None) or getattr(chat, "full_name", None),
+            getattr(sender, "id", None),
+            getattr(sender, "full_name", None) or getattr(sender, "first_name", None),
+            getattr(msg, "message_id", None),
+        )
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -7047,6 +7076,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
+            else:
+                self._log_unprocessed_group_message(msg, MessageType.TEXT)
             return
         await self._ensure_forum_commands(update.message)
 
@@ -7093,6 +7124,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
+            else:
+                self._log_unprocessed_group_message(msg, MessageType.LOCATION)
             return
 
         venue = getattr(msg, "venue", None)
@@ -7294,9 +7327,9 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return
         if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
-                _observe_type = self._media_message_type(_m)
+            _m = update.message
+            _observe_type = self._media_message_type(_m)
+            if self._should_observe_unmentioned_group_message(_m):
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
                     _event.text = self._clean_bot_trigger_text(_m.caption)
@@ -7304,6 +7337,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._observe_unmentioned_group_message(
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
+            else:
+                self._log_unprocessed_group_message(_m, _observe_type)
             return
 
         msg = update.message

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -130,6 +130,28 @@ def _dm_message(text="hello", *, from_user_id=111):
     )
 
 
+def _location_group_message():
+    msg = _group_message("")
+    msg.text = None
+    msg.location = SimpleNamespace(latitude=50.9, longitude=6.2)
+    msg.venue = None
+    return msg
+
+
+def _document_group_message():
+    msg = _group_message("")
+    msg.text = None
+    msg.caption = None
+    msg.sticker = None
+    msg.photo = []
+    msg.video = None
+    msg.audio = None
+    msg.voice = None
+    msg.document = SimpleNamespace(file_name="scan.pdf", mime_type="application/pdf", file_size=1234)
+    msg.media_group_id = None
+    return msg
+
+
 def _mention_entity(text, mention="@hermes_bot"):
     offset = text.index(mention)
     return SimpleNamespace(type="mention", offset=offset, length=len(mention))
@@ -187,6 +209,110 @@ def test_unmentioned_group_messages_can_be_observed_without_dispatching():
         assert store.sources[0].chat_type == "group"
         assert store.sources[0].user_id is None
         assert store.sources[0].user_name is None
+
+    asyncio.run(_run())
+
+
+def test_unmentioned_group_text_drop_is_debug_logged(caplog):
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=False,
+        )
+        update = SimpleNamespace(
+            update_id=1002,
+            message=_group_message("side chatter"),
+            effective_message=None,
+        )
+
+        with caplog.at_level("DEBUG"):
+            await adapter._handle_text_message(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert any(
+            "Telegram group message dropped" in record.message
+            and "reason=unmentioned_group_message" in record.message
+            and "type=text" in record.message
+            for record in caplog.records
+        )
+
+    asyncio.run(_run())
+
+
+def test_unmentioned_group_location_drop_is_debug_logged(caplog):
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=False,
+        )
+        update = SimpleNamespace(
+            update_id=1004,
+            message=_location_group_message(),
+            effective_message=None,
+        )
+
+        with caplog.at_level("DEBUG"):
+            await adapter._handle_location_message(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert any(
+            "Telegram group message dropped" in record.message
+            and "reason=unmentioned_group_message" in record.message
+            and "type=location" in record.message
+            for record in caplog.records
+        )
+
+    asyncio.run(_run())
+
+
+def test_unmentioned_group_media_drop_is_debug_logged(caplog):
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=False,
+        )
+        update = SimpleNamespace(update_id=1005, message=_document_group_message())
+
+        with caplog.at_level("DEBUG"):
+            await adapter._handle_media_message(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert any(
+            "Telegram group message dropped" in record.message
+            and "reason=unmentioned_group_message" in record.message
+            and "type=document" in record.message
+            for record in caplog.records
+        )
+
+    asyncio.run(_run())
+
+
+def test_observed_unmentioned_group_message_does_not_emit_drop_log(caplog):
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        adapter._session_store = _FakeSessionStore()
+        update = SimpleNamespace(
+            update_id=1006,
+            message=_group_message("side chatter"),
+            effective_message=None,
+        )
+
+        with caplog.at_level("DEBUG"):
+            await adapter._handle_text_message(update, SimpleNamespace())
+
+        adapter._message_handler.assert_not_awaited()
+        assert not any("Telegram group message dropped" in record.message for record in caplog.records)
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- Adds DEBUG logging when Telegram group text/location/media updates are dropped by require_mention gating and observe mode is off.
- Keeps observe mode behavior unchanged.
- Logs metadata only (chat/sender/message/type/reason), not message text, captions, filenames, media URLs, or attachment contents.

Fixes #57290

## Test Plan
- [x] `scripts/run_tests.sh tests/gateway/test_telegram_group_gating.py -q` (RED before implementation: 3 new tests failed)
- [x] `scripts/run_tests.sh tests/gateway/test_telegram_group_gating.py -q`
- [x] `scripts/run_tests.sh tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_photo_interrupts.py -q`
