### PR TITLE
fix: preserve durable Hermes scripts tests from cleanup

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -147,7 +147,7 @@ ALLOWED_CATEGORIES = {
 _EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
     "logs", "memories", "sessions", "cron", "cronjobs",
     "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
-    "hermes-agent", "backups", "profiles", ".worktrees",
+    "hermes-agent", "backups", "profiles", ".worktrees", "scripts",
 })
 
 _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
@@ -557,7 +557,7 @@ def guess_category(path: Path) -> Optional[str]:
         if top in {
             "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
             "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
-            "auth.json", "hermes-agent",
+            "auth.json", "hermes-agent", "scripts",
         }:
             return None
         if top == "cron" or top == "cronjobs":

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -163,6 +163,24 @@ class TestGuessCategory:
         p.write_text("[]")
         assert dg.guess_category(p) is None
 
+    def test_scripts_subtree_not_tracked(self, _isolate_env):
+        """Persistent helper scripts/tests under HERMES_HOME/scripts are durable."""
+        dg = _load_lib()
+        scripts_tests = _isolate_env / "scripts" / "tests"
+        scripts_tests.mkdir(parents=True)
+        p = scripts_tests / "test_helper.py"
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+
+    def test_quick_preserves_empty_scripts_subdirs(self, _isolate_env):
+        """Empty-dir sweep must not remove durable scripts/ helper folders."""
+        dg = _load_lib()
+        scripts_tests = _isolate_env / "scripts" / "tests"
+        scripts_tests.mkdir(parents=True)
+        summary = dg.quick()
+        assert summary["empty_dirs"] == 0
+        assert scripts_tests.exists()
+
     def test_ordinary_file_returns_none(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "notes.md"


### PR DESCRIPTION
## Summary
- Prevent disk-cleanup from classifying durable `$HERMES_HOME/scripts/**` helper tests as disposable test artifacts.
- Preserve empty `scripts/` helper subdirectories during quick cleanup sweeps.
- Add regressions covering both the category filter and empty-dir sweep behavior.

## Verification
- `python3 -m pytest tests/plugins/test_disk_cleanup_plugin.py -q`
- Broader local run in the source checkout: `python3 -m pytest tests/plugins -q` (`1556 passed`)
- Tool/hook-adjacent local run: `python3 -m pytest tests/test_transform_tool_result_hook.py tests/tools/test_resolve_path.py tests/acp/test_tools.py -q` (`85 passed`)

## Notes
This was found because a persistent operator test under `$HERMES_HOME/scripts/tests/test_*.py` was deleted by session-end disk cleanup. `scripts/` is durable operator/helper state, not ephemeral scratch output.
