### PR TITLE
fix(slack): keep blank-line-separated ordered lists in one rich_text_list (#57076)

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -451,10 +451,22 @@ def render_blocks(
                         indent, ordered, txt = items[-1]
                         items[-1] = (indent, ordered, txt + " " + lines[i].strip())
                         i += 1
-                    elif not lines[i].strip():
-                        # blank line — soft separator within a list run;
-                        # skip so that ordered items stay in one rich_text_list.
-                        i += 1
+                    elif not lines[i].strip() and items:
+                        # Blank line inside a list run. LLM-authored ordered
+                        # lists commonly separate items with a blank line; if
+                        # the next non-blank line is another list item, treat
+                        # the blank(s) as a soft separator and keep the run
+                        # going so the items stay in one rich_text_list (Slack
+                        # numbers each list independently, so splitting would
+                        # restart every item at "1."). Otherwise the blank
+                        # ends the list.
+                        j = i + 1
+                        while j < n and not lines[j].strip():
+                            j += 1
+                        if j < n and (_BULLET_RE.match(lines[j]) or _ORDERED_RE.match(lines[j])):
+                            i = j
+                        else:
+                            break
                     else:
                         break
                 blocks.append(_list_block(items))

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -55,6 +55,11 @@ _QUOTE_RE = re.compile(r"^\s{0,3}>\s?(.*)$")
 _TABLE_SEP_RE = re.compile(r"^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)+\|?\s*$")
 
 
+def _is_list_line(line: str) -> bool:
+    """True if ``line`` is a markdown list item (bullet or ordered)."""
+    return bool(_BULLET_RE.match(line) or _ORDERED_RE.match(line))
+
+
 def _indent_level(spaces: str) -> int:
     """Map leading whitespace to a nesting level (2 spaces or 1 tab per level)."""
     width = 0
@@ -434,7 +439,7 @@ def render_blocks(
                 continue
 
             # List group (bullets + ordered, with nesting)
-            if _BULLET_RE.match(line) or _ORDERED_RE.match(line):
+            if _is_list_line(line):
                 flush_para()
                 items: List[Tuple[int, bool, str]] = []
                 while i < n:
@@ -463,7 +468,7 @@ def render_blocks(
                         j = i + 1
                         while j < n and not lines[j].strip():
                             j += 1
-                        if j < n and (_BULLET_RE.match(lines[j]) or _ORDERED_RE.match(lines[j])):
+                        if j < n and _is_list_line(lines[j]):
                             i = j
                         else:
                             break

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -451,6 +451,10 @@ def render_blocks(
                         indent, ordered, txt = items[-1]
                         items[-1] = (indent, ordered, txt + " " + lines[i].strip())
                         i += 1
+                    elif not lines[i].strip():
+                        # blank line — soft separator within a list run;
+                        # skip so that ordered items stay in one rich_text_list.
+                        i += 1
                     else:
                         break
                 blocks.append(_list_block(items))

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -106,6 +106,31 @@ class TestInlineFormatting:
         items = lists[0]["elements"]
         assert len(items) == 3
 
+    def test_blank_separated_mixed_list_matches_contiguous_layout(self):
+        """A blank line between different list kinds must render like the
+        contiguous form: one rich_text block whose sub-lists split only on
+        (indent, ordered) changes — not a separate block per item.
+        """
+        rich = [b for b in render_blocks("1. a\n\n- b") if b["type"] == "rich_text"]
+        # Single rich_text block (matches contiguous "1. a\n- b"), two sub-lists
+        assert len(rich) == 1
+        styles = [e["style"] for e in rich[0]["elements"] if e["type"] == "rich_text_list"]
+        assert styles == ["ordered", "bullet"]
+
+    def test_blank_line_before_paragraph_ends_the_list(self):
+        """A blank line followed by non-list content must still end the run,
+        so a list → paragraph → list sequence stays three separate blocks.
+        """
+        blocks = render_blocks("1. a\n\nsome paragraph text\n\n1. b")
+        lists = [
+            e
+            for b in blocks
+            for e in b.get("elements", [])
+            if e.get("type") == "rich_text_list"
+        ]
+        # Two independent single-item lists, not one merged three-item list
+        assert [len(e["elements"]) for e in lists] == [1, 1]
+
 
 class TestTables:
     def test_pipe_table_renders_native_table_block(self):

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -90,6 +90,22 @@ class TestInlineFormatting:
         ]
         assert styled, "expected a bold-styled text element in the list item"
 
+    def test_blank_line_separated_ordered_items_stay_in_one_list(self):
+        """Regression: blank lines between ordered items must not reset numbering.
+
+        Slack numbers each rich_text_list independently.  If blank lines break
+        the list run, N items produce N separate lists each starting at 1.
+        See: https://github.com/NousResearch/hermes-agent/issues/57076
+        """
+        md = "1. alpha\n\n1. beta\n\n1. gamma"
+        blocks = render_blocks(md)
+        rich = [b for b in blocks if b["type"] == "rich_text"][0]
+        lists = [e for e in rich["elements"] if e["type"] == "rich_text_list"]
+        # Must be ONE list with 3 items, not 3 separate single-item lists
+        assert len(lists) == 1
+        items = lists[0]["elements"]
+        assert len(items) == 3
+
 
 class TestTables:
     def test_pipe_table_renders_native_table_block(self):


### PR DESCRIPTION
## Summary
Blank-line-separated ordered lists now render as one continuous `rich_text_list` in Slack, so numbering stays 1, 2, 3 instead of 1, 1, 1.

Root cause: with `rich_blocks: true`, `render_blocks()` in `plugins/platforms/slack/block_kit.py` broke the list-run loop on any blank line, so each blank-separated item became its own single-item `rich_text_list`. Slack numbers each list independently, so N items rendered as N lists each restarting at "1." Blank lines between items are the normal shape of LLM-authored content, so this hit real output.

Salvage of #57107 by @liuhao1024 (first submitter, cherry-picked with authorship preserved), plus a follow-up commit refining the blank-line handling to a next-item lookahead guard and adding boundary regression tests.

## Changes
- `plugins/platforms/slack/block_kit.py`: inside the list-run loop, a blank line continues the run only when the next non-blank line is another list item; otherwise it ends the list. This keeps a list → paragraph → list sequence as three separate blocks and renders mixed/nested blank-separated lists identically to their contiguous form (one `rich_text` block, sub-lists split by `(indent, ordered)`).
- `tests/gateway/test_slack_block_kit.py`: regression tests for the blank-separated ordered case (#57107), the mixed blank-separated layout, and the list → paragraph → list boundary.

## Validation
| Input | Before | After |
|---|---|---|
| `1. a` / blank / `1. b` / blank / `1. c` | 3 lists → renders 1, 1, 1 | 1 list, 3 items → 1, 2, 3 |
| `1. a` / `2. b` / `3. c` (contiguous) | 1 list | 1 list (unchanged) |
| `1. a` / blank / `- b` | 3 blocks | 1 block, ordered+bullet sub-lists (matches contiguous) |
| `1. a` / blank / paragraph / blank / `1. b` | 3 blocks | 3 blocks (paragraph preserved) |

`tests/gateway/test_slack_block_kit.py`: 22 passed. Ruff clean. E2E verified through the real `render_blocks` path.

Closes #57076

Credit: @liuhao1024 (#57107). Duplicate PRs for the same issue: #57138 (@kyssta-exe), #57144 (@msh01), #57204 (@ms-alan).
