### PR TITLE
fix(mattermost): root DM thread sessions at the first post

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -870,9 +870,10 @@ class MattermostAdapter(BasePlatformAdapter):
         if (
             not thread_id
             and self._reply_mode == "thread"
-            and channel_type_raw != "D"
             and post_id
         ):
+            # Top-level posts (DMs included) root their own thread so the
+            # session that answers the first message is the thread's session.
             thread_id = post_id
 
         # Determine message type.


### PR DESCRIPTION
## Problem

With `MATTERMOST_REPLY_MODE=thread`, a top-level **DM** post is handled with `thread_id=None`, while the user's replies inside the bot's answer thread carry `root_id`. Since session keys include the thread id, the thread's messages land in a **different, fresh session** than the one that answered the opening message — the agent visibly loses the context of the first message in the conversation it itself started.

Channels don't have this problem because the handler already roots top-level channel posts at their own post id in thread mode; the `channel_type_raw != "D"` guard excluded DMs from that behavior.

## Fix

Treat top-level DM posts as their own thread root in thread reply mode, matching the existing channel behavior. The session that answers the first message is then the same session that handles every in-thread reply.

One behavioral consequence (intended): each new top-level DM message starts its own thread/session — thread-per-conversation semantics, consistent with how thread mode already works in channels.

## Testing

Live-tested on a self-hosted Mattermost 11.7 instance: DM the bot → bot replies in a thread rooted at the message → replies inside that thread retain full context of the opening message. Flat mode (`reply_mode=off`) is unaffected (guard still requires thread mode).
