### PR TITLE
fix(gateway): reject relay inbound events claiming an unadvertised pl…

### DIFF
--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -277,7 +277,29 @@ class RelayAdapter(BasePlatformAdapter):
         self.supports_code_blocks = descriptor.markdown_dialect not in ("", "plain")
 
     async def _on_inbound(self, event) -> None:
-        """Bridge a connector-delivered MessageEvent into the normal adapter path."""
+        """Bridge a connector-delivered MessageEvent into the normal adapter path.
+
+        Reject events whose self-declared ``source.platform`` isn't one this
+        connection actually advertised at hello. Without this, a mis-stamped
+        (or malicious) platform value on a single inbound frame collides
+        build_session_key() with a different platform's real chat_id, since
+        the key is a pure function of the SessionSource fields and doesn't
+        know which transport delivered the event.
+        """
+        src = getattr(event, "source", None)
+        src_platform = getattr(src, "platform", None)
+        src_platform_value = getattr(src_platform, "value", src_platform)
+        if (
+            src_platform_value
+            and src_platform_value != "relay"
+            and not self._platform_is_fronted(src_platform_value)
+        ):
+            logger.warning(
+                "relay: rejecting inbound event claiming platform=%r (chat_id=%r) "
+                "— this connection never advertised that platform at hello",
+                src_platform_value, getattr(src, "chat_id", None),
+            )
+            return
         self._capture_scope(event)
         # Phase 3: a structured prompt answer resolves its waiting primitive
         # (approval/confirm/clarify) and is CONSUMED — it must not also

--- a/tests/gateway/relay/test_relay_adapter.py
+++ b/tests/gateway/relay/test_relay_adapter.py
@@ -563,3 +563,76 @@ async def test_get_chat_info_local_fallback_when_not_advertised():
     info = await a.get_chat_info("chan-1")
     assert info == {"name": "chan-1", "type": "dm"}
     assert t.calls == []
+
+
+def _make_event_with_platform(platform, chat_id="chat-1", user_id="user-1"):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    src = SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type="dm",
+        user_id=user_id,
+    )
+    return MessageEvent(text="hi", source=src, message_type=MessageType.TEXT)
+
+
+@pytest.mark.asyncio
+async def test_on_inbound_rejects_platform_not_advertised_at_hello():
+    """A relay-delivered event claiming a platform this connection never
+    advertised at hello must be rejected, not routed. Without this guard,
+    a mis-stamped (or malicious) platform value on a single inbound frame
+    collides build_session_key() with a different platform's real chat_id
+    — build_session_key() is a pure function of the SessionSource fields
+    and has no way to know which transport actually delivered the event."""
+    t = _CaptureTransport()
+    t._identities = [("discord", "app-1")]
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
+
+    routed = []
+    a.handle_message = lambda event: routed.append(event) or _async_none()
+
+    # This connection only fronts discord — an event claiming to be a real
+    # Telegram chat must not be routed through.
+    await a._on_inbound(_make_event_with_platform(Platform.TELEGRAM, chat_id="12345"))
+
+    assert routed == []
+
+
+@pytest.mark.asyncio
+async def test_on_inbound_allows_platform_advertised_at_hello():
+    """An event claiming a platform this connection DID advertise at hello
+    must still be routed normally — the guard must not break the
+    documented multi-platform-per-connection (N hellos) design."""
+    t = _CaptureTransport()
+    t._identities = [("discord", "app-1"), ("telegram", "app-2")]
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
+
+    routed = []
+    a.handle_message = lambda event: routed.append(event) or _async_none()
+
+    await a._on_inbound(_make_event_with_platform(Platform.TELEGRAM, chat_id="12345"))
+
+    assert len(routed) == 1
+
+
+@pytest.mark.asyncio
+async def test_on_inbound_allows_bare_relay_platform():
+    """The generic 'relay' platform (used when the connector doesn't tag a
+    concrete platform) must always pass through regardless of the
+    advertised identity set — it isn't impersonating a fronted platform."""
+    t = _CaptureTransport()
+    t._identities = [("discord", "app-1")]
+    a = RelayAdapter(PlatformConfig(), make_desc(platform="discord"), transport=t)
+
+    routed = []
+    a.handle_message = lambda event: routed.append(event) or _async_none()
+
+    await a._on_inbound(_make_event_with_platform(Platform.RELAY, chat_id="chan-1"))
+
+    assert len(routed) == 1
+
+
+async def _async_none():
+    return None


### PR DESCRIPTION
## Summary
Fixes relay-delivered inbound events being able to claim any platform,
including one this connection never advertised at hello. Without this,
a mis-stamped platform value on a single inbound frame collides
build_session_key() with a different platform's real chat_id, since the
key is a pure function of the SessionSource fields and has no way to
know which transport actually delivered the event.

---

## Root cause
`_event_from_wire()` in `gateway/relay/ws_transport.py` builds a
`SessionSource` from the connector's wire payload, reading `platform`
fresh from each individual inbound event (`src.get("platform", "relay")`).
This function is a module-level function, not a method, so it has no
access to `self._platform` or `self._identities`, the set of
`(platform, bot_id)` pairs this specific WS connection actually
advertised during the hello handshake.

`RelayAdapter._on_inbound()`, the callback that receives events from the
transport, forwarded every event straight into `handle_message()`
without checking the claimed platform against anything. The comment on
`_bot_id_for()` documents that one relay connection can legitimately
front multiple platforms ("N hellos"), so there was no per-connection
single-platform invariant to fall back on either.

`build_session_key()` is a pure function of the `SessionSource` fields
and has no notion of which transport delivered the event. A relay event
with `source.platform="telegram"` and `source.chat_id` matching a real,
active Telegram chat produces the exact same session key a genuine
Telegram-adapter message for that chat would produce, so the event lands
in that chat's real, live session.

---

## Behavioral change
Before: `RelayAdapter._on_inbound()` routed every inbound event
regardless of its claimed platform, so a relay connector that (through a
bug or otherwise) sent an event tagged with a platform it never
advertised at hello could inject content into any other platform's
session for a matching chat_id.

After: `_on_inbound()` checks the claimed platform against the set of
platforms this specific connection advertised at hello
(`_platform_is_fronted()`, an existing helper). An event claiming a
platform outside that set is logged and dropped before reaching
`handle_message()`. The generic `"relay"` platform (used when the
connector doesn't tag a concrete platform) always passes through, since
it isn't impersonating a fronted platform. Events claiming any
advertised platform, including in a multi-platform ("N hellos")
connection, are unaffected.

---

## What changed
**`gateway/relay/adapter.py`**: `_on_inbound()` now reads
`event.source.platform`, and when it is set, not `"relay"`, and not
found in `_platform_is_fronted()`'s advertised identity set, logs a
warning with the claimed platform and chat_id and returns without
calling `handle_message()`.

**`tests/gateway/relay/test_relay_adapter.py`**: added
`test_on_inbound_rejects_platform_not_advertised_at_hello`,
`test_on_inbound_allows_platform_advertised_at_hello`, and
`test_on_inbound_allows_bare_relay_platform`, using the existing
`_CaptureTransport` test double with a configurable `_identities` set.

---

## What is NOT changed
- `_event_from_wire()` and the rest of `ws_transport.py` are untouched;
  the guard lives at the adapter layer, which already has access to the
  transport's advertised identity set through the existing
  `_platform_is_fronted()` helper
- `build_session_key()` and the rest of `gateway/session.py` are
  untouched
- The multi-platform-per-connection ("N hellos") design is preserved:
  any platform advertised at hello for this connection is still routed
  normally
- Outbound delivery and `_capture_scope()` are untouched
- All existing relay tests pass