### PR TITLE
fix(mcp): reap orphaned subprocesses before spawning new ones on retry (#57355)

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -199,6 +199,68 @@ class TestStdioPidTracking:
         with _lock:
             assert fake_pid not in _orphan_stdio_pids
 
+    def test_run_stdio_reaps_orphans_before_spawn(self):
+        """_run_stdio kills orphaned PIDs from prior failed attempts (#57355)."""
+        from tools.mcp_tool import (
+            _kill_orphaned_mcp_children,
+            _orphan_stdio_pids,
+            _stdio_pids,
+            _stdio_pgids,
+            _lock,
+            MCPServerTask,
+        )
+        from unittest.mock import patch, MagicMock, AsyncMock
+
+        # Seed an orphan PID that belongs to a prior failed connection.
+        fake_pid = 999999997
+        with _lock:
+            _orphan_stdio_pids.add(fake_pid)
+
+        server = MCPServerTask.__new__(MCPServerTask)
+        server.name = "test-zombie-reap"
+        server._ready = MagicMock()
+        server._shutdown_event = MagicMock()
+        server._shutdown_event.is_set.return_value = True
+        server._reconnect_event = MagicMock()
+        server._sampling = None
+        server._elicitation = None
+        server._registered_tool_names = []
+
+        config = {"command": "echo", "args": ["hello"]}
+
+        import asyncio
+
+        async def _run():
+            # _run_stdio should reap orphans before it gets to the
+            # stdio_client spawn.  Patch the OSV check (local import)
+            # and stdio_client so no real subprocess is spawned.
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._build_safe_env", return_value={}), \
+                 patch("tools.mcp_tool._resolve_stdio_command",
+                       return_value=("echo", {})), \
+                 patch("tools.mcp_tool._write_stderr_log_header"), \
+                 patch("tools.mcp_tool._get_mcp_stderr_log",
+                       return_value=None), \
+                 patch("tools.mcp_tool.check_package_for_malware",
+                       return_value=None, create=True), \
+                 patch("tools.osv_check.check_package_for_malware",
+                       return_value=None):
+                # Patch stdio_client to raise so the test exits quickly
+                cm = MagicMock()
+                cm.__aenter__ = AsyncMock(side_effect=RuntimeError("test"))
+                cm.__aexit__ = AsyncMock(return_value=False)
+                with patch("tools.mcp_tool.stdio_client", return_value=cm):
+                    try:
+                        await server._run_stdio(config)
+                    except Exception:
+                        pass
+
+        asyncio.run(_run())
+
+        # The orphan must have been reaped before the spawn attempt.
+        with _lock:
+            assert fake_pid not in _orphan_stdio_pids
+
 
 # ---------------------------------------------------------------------------
 # Fix 2b: stdio descendant reaping via process group (issue #23799)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1852,6 +1852,13 @@ class MCPServerTask:
         if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
             sampling_kwargs["message_handler"] = self._make_message_handler()
 
+        # Reap any orphaned subprocesses from a prior failed connection
+        # attempt before spawning a new one.  Without this, each retry in
+        # the run() reconnect loop spawns a fresh process pair while the
+        # previous failed pair lingers — leading to rapid zombie
+        # accumulation (see #57355).
+        _kill_orphaned_mcp_children()
+
         # Snapshot child PIDs before spawning so we can track the new one.
         pids_before = _snapshot_child_pids()
         new_pids: set = set()


### PR DESCRIPTION
## What does this PR do?

When an MCP stdio subprocess fails to connect (token expiry, port contention, timeout), the `run()` reconnect loop retries with exponential backoff. Each retry calls `_run_stdio()` which spawns a **new** process pair, but the previous failed pair was only *detected* as orphaned (added to `_orphan_stdio_pids`) — never actually killed before the next spawn. This causes rapid zombie accumulation: 5 failed attempts × 2 processes each = 10 orphans all competing for the same port, making reconnection impossible without manual `pkill`.

This PR adds a `_kill_orphaned_mcp_children()` call at the top of `_run_stdio()`, before the `_snapshot_child_pids()` baseline, so any orphans from prior failed attempts are reaped before a new subprocess is spawned.

## Related Issue

Fixes #57355

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Add `_kill_orphaned_mcp_children()` call at the beginning of `_run_stdio()` (before `_snapshot_child_pids()` baseline) to reap orphaned processes from prior failed connection attempts before spawning new ones
- `tests/tools/test_mcp_stability.py`: Add `test_run_stdio_reaps_orphans_before_spawn` — seeds `_orphan_stdio_pids` with a fake PID, runs `_run_stdio()` with mocked internals, verifies the orphan is reaped

## How to Test

1. Run `pytest tests/tools/test_mcp_stability.py -xvs` — all 23 tests should pass, including the new `test_run_stdio_reaps_orphans_before_spawn`
2. Configure an MCP server using `npx mcp-remote` (stdio mode) and let the connection fail (e.g., block the port or let OAuth token expire)
3. Trigger reconnection via `/reload-mcp` or circuit-breaker auto-recovery
4. Run `pgrep -fa "mcp-remote"` — only the latest process pair should be present, not accumulated orphans from prior attempts

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_mcp_stability.py -q` and all tests pass (23/23)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The `_kill_orphaned_mcp_children()` function is already well-tested (SIGTERM→SIGKILL escalation, pgid-based killpg, dead-PID handling). The new test verifies it's called at the right point in `_run_stdio()` — before the subprocess spawn baseline, not after.
