### PR TITLE
feat(mcp): headless client_credentials OAuth for HTTP MCP servers

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1281,6 +1281,16 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+#   # Headless machine-to-machine auth (no browser). Add via:
+#   #   hermes mcp add gateway --url https://gateway.internal/mcp --auth client_credentials
+#   gateway:
+#     url: https://gateway.internal/mcp
+#     auth: oauth
+#     oauth:
+#       grant: client_credentials
+#       client_id: my-client
+#       client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from .env — never inline
+#       scope: profile
 #
 # Sampling (server-initiated LLM requests) — enabled by default.
 # Per-server config under the 'sampling' key:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1083,6 +1083,16 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+#   # Headless machine-to-machine auth (no browser). Add via:
+#   #   hermes mcp add gateway --url https://gateway.internal/mcp --auth client_credentials
+#   gateway:
+#     url: https://gateway.internal/mcp
+#     auth: oauth
+#     oauth:
+#       grant: client_credentials
+#       client_id: my-client
+#       client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from .env — never inline
+#       scope: profile
 #
 # Sampling (server-initiated LLM requests) — enabled by default.
 # Per-server config under the 'sampling' key:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -150,10 +150,14 @@ def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
     return True, []
 
 
-def _env_key_for_server(name: str) -> str:
-    """Convert server name to an env-var key like ``MCP_MYSERVER_API_KEY``."""
-    suffix = re.sub(r"[^A-Za-z0-9_]", "_", name.upper()).strip("_")
-    return f"MCP_{suffix}_API_KEY"
+def _env_key_for_server(name: str, suffix: str = "API_KEY") -> str:
+    """Convert server name to an env-var key like ``MCP_MYSERVER_API_KEY``.
+
+    ``suffix`` selects the credential kind: ``API_KEY`` for header auth,
+    ``CLIENT_SECRET`` for the headless ``client_credentials`` grant.
+    """
+    name_part = re.sub(r"[^A-Za-z0-9_]", "_", name.upper()).strip("_")
+    return f"MCP_{name_part}_{suffix}"
 
 
 def _strip_bearer_prefix(token: str) -> str:
@@ -534,6 +538,41 @@ def cmd_mcp_add(args):
                 _info("Cancelled.")
                 return
 
+    elif url and auth_type == "client_credentials":
+        # Headless machine-to-machine: client_id + client_secret. The
+        # authorization server is discovered from the MCP server's
+        # protected-resource metadata; the secret is stored in .env and
+        # referenced via ${VAR} so it never lands in config.yaml.
+        print()
+        _info(f"Configuring client_credentials (M2M) auth for '{name}'")
+        client_id = getattr(args, "client_id", None) or _prompt("OAuth client_id")
+        if not client_id:
+            _error("client_credentials requires a client_id.")
+            return
+        secret_key = _env_key_for_server(name, "CLIENT_SECRET")
+        if get_env_value(secret_key):
+            _success(f"{secret_key}: already configured")
+        else:
+            client_secret = _prompt("OAuth client_secret", password=True)
+            if not client_secret:
+                _error("client_credentials requires a client_secret.")
+                return
+            save_env_value(secret_key, client_secret)
+            _success(f"Saved to {display_hermes_home()}/.env as {secret_key}")
+        scope = getattr(args, "scope", None)
+        if scope is None:
+            scope = _prompt("Scope (optional, space-separated)", default="")
+        oauth_cfg: Dict[str, Any] = {
+            "grant": "client_credentials",
+            "client_id": client_id,
+            "client_secret": f"${{{secret_key}}}",
+        }
+        if scope and scope.strip():
+            oauth_cfg["scope"] = scope.strip()
+        server_config["auth"] = "oauth"
+        server_config["oauth"] = oauth_cfg
+        _success("client_credentials configured (token minted on first connection)")
+
     elif url:
         # Prompt for API key / Bearer token for HTTP servers
         print()
@@ -770,7 +809,11 @@ def cmd_mcp_test(args):
     auth_type = cfg.get("auth", "")
     headers = cfg.get("headers", {})
     if auth_type == "oauth":
-        _info("Auth: OAuth 2.1 PKCE")
+        grant = str((cfg.get("oauth") or {}).get("grant", "")).strip().lower()
+        if grant == "client_credentials":
+            _info("Auth: OAuth client_credentials (headless M2M)")
+        else:
+            _info("Auth: OAuth 2.1 PKCE")
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
@@ -873,6 +916,22 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
                 "authentication did not complete."
             )
             print()
+            # A machine-to-machine server already has a client_id/secret, so
+            # the registration guidance below does not apply — and it would
+            # tell the operator to inline the secret in config.yaml, which is
+            # exactly what this grant exists to avoid.
+            from tools.mcp_oauth import is_m2m_grant
+
+            if is_m2m_grant(server_config.get("oauth")):
+                _info(
+                    "This server uses a headless machine-to-machine grant, so "
+                    "there is no authorization step to complete. The token "
+                    "exchange itself was refused — check the client_id, the "
+                    "client secret in the Hermes .env file, the requested "
+                    "scope, and the authorization server's policy for this "
+                    "client."
+                )
+                return False
             _info(
                 "Some providers (e.g. Google Drive, Atlassian) do not support "
                 "automatic client registration. For those you must create an "

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -150,10 +150,14 @@ def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
     return True, []
 
 
-def _env_key_for_server(name: str) -> str:
-    """Convert server name to an env-var key like ``MCP_MYSERVER_API_KEY``."""
-    suffix = re.sub(r"[^A-Za-z0-9_]", "_", name.upper()).strip("_")
-    return f"MCP_{suffix}_API_KEY"
+def _env_key_for_server(name: str, suffix: str = "API_KEY") -> str:
+    """Convert server name to an env-var key like ``MCP_MYSERVER_API_KEY``.
+
+    ``suffix`` selects the credential kind: ``API_KEY`` for header auth,
+    ``CLIENT_SECRET`` for the headless ``client_credentials`` grant.
+    """
+    name_part = re.sub(r"[^A-Za-z0-9_]", "_", name.upper()).strip("_")
+    return f"MCP_{name_part}_{suffix}"
 
 
 def _strip_bearer_prefix(token: str) -> str:
@@ -509,6 +513,41 @@ def cmd_mcp_add(args):
                 _info("Cancelled.")
                 return
 
+    elif url and auth_type == "client_credentials":
+        # Headless machine-to-machine: client_id + client_secret. The
+        # authorization server is discovered from the MCP server's
+        # protected-resource metadata; the secret is stored in .env and
+        # referenced via ${VAR} so it never lands in config.yaml.
+        print()
+        _info(f"Configuring client_credentials (M2M) auth for '{name}'")
+        client_id = getattr(args, "client_id", None) or _prompt("OAuth client_id")
+        if not client_id:
+            _error("client_credentials requires a client_id.")
+            return
+        secret_key = _env_key_for_server(name, "CLIENT_SECRET")
+        if get_env_value(secret_key):
+            _success(f"{secret_key}: already configured")
+        else:
+            client_secret = _prompt("OAuth client_secret", password=True)
+            if not client_secret:
+                _error("client_credentials requires a client_secret.")
+                return
+            save_env_value(secret_key, client_secret)
+            _success(f"Saved to {display_hermes_home()}/.env as {secret_key}")
+        scope = getattr(args, "scope", None)
+        if scope is None:
+            scope = _prompt("Scope (optional, space-separated)", default="")
+        oauth_cfg: Dict[str, Any] = {
+            "grant": "client_credentials",
+            "client_id": client_id,
+            "client_secret": f"${{{secret_key}}}",
+        }
+        if scope and scope.strip():
+            oauth_cfg["scope"] = scope.strip()
+        server_config["auth"] = "oauth"
+        server_config["oauth"] = oauth_cfg
+        _success("client_credentials configured (token minted on first connection)")
+
     elif url:
         # Prompt for API key / Bearer token for HTTP servers
         print()
@@ -745,7 +784,11 @@ def cmd_mcp_test(args):
     auth_type = cfg.get("auth", "")
     headers = cfg.get("headers", {})
     if auth_type == "oauth":
-        _info("Auth: OAuth 2.1 PKCE")
+        grant = str((cfg.get("oauth") or {}).get("grant", "")).strip().lower()
+        if grant == "client_credentials":
+            _info("Auth: OAuth client_credentials (headless M2M)")
+        else:
+            _info("Auth: OAuth 2.1 PKCE")
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
@@ -840,6 +883,22 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
                 "authentication did not complete."
             )
             print()
+            # A machine-to-machine server already has a client_id/secret, so
+            # the registration guidance below does not apply — and it would
+            # tell the operator to inline the secret in config.yaml, which is
+            # exactly what this grant exists to avoid.
+            from tools.mcp_oauth import is_m2m_grant
+
+            if is_m2m_grant(server_config.get("oauth")):
+                _info(
+                    "This server uses a headless machine-to-machine grant, so "
+                    "there is no authorization step to complete. The token "
+                    "exchange itself was refused — check the client_id, the "
+                    "client secret in the Hermes .env file, the requested "
+                    "scope, and the authorization server's policy for this "
+                    "client."
+                )
+                return False
             _info(
                 "Some providers (e.g. Google Drive, Atlassian) do not support "
                 "automatic client registration. For those you must create an "

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -58,7 +58,17 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         default=[],
         help="Arguments for stdio command; must be the last option",
     )
-    mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="Auth method")
+    mcp_add_p.add_argument(
+        "--auth",
+        choices=["oauth", "header", "client_credentials"],
+        help="Auth method (oauth = browser flow; client_credentials = headless M2M)",
+    )
+    mcp_add_p.add_argument(
+        "--client-id", help="OAuth client_id (for --auth client_credentials)"
+    )
+    mcp_add_p.add_argument(
+        "--scope", help="OAuth scope (for --auth client_credentials)"
+    )
     mcp_add_p.add_argument("--preset", help="Known MCP preset name")
     mcp_add_p.add_argument(
         "--connect-timeout",

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -206,6 +206,45 @@ class TestMcpAdd:
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
+    def test_add_client_credentials(self, capsys, monkeypatch):
+        """--auth client_credentials writes the oauth block + secret to .env."""
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [("list_items", "list items")],
+        )
+        # client_id + scope come from flags; only the secret is prompted.
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._prompt",
+            lambda q, password=False, default="": "s3cr3t" if "secret" in q.lower() else default,
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")  # accept all tools
+
+        from hermes_cli.mcp_config import cmd_mcp_add, get_env_value
+
+        cmd_mcp_add(
+            _make_args(
+                name="gw",
+                url="https://gw/mcp",
+                auth="client_credentials",
+                client_id="mcp-gateway",
+                scope="profile",
+            )
+        )
+
+        import yaml
+
+        from hermes_cli.config import get_config_path, load_config
+
+        srv = load_config()["mcp_servers"]["gw"]
+        assert srv["auth"] == "oauth"
+        assert srv["oauth"]["grant"] == "client_credentials"
+        assert srv["oauth"]["client_id"] == "mcp-gateway"
+        assert srv["oauth"]["scope"] == "profile"
+        # The secret is stored as a ${VAR} reference in config.yaml (resolved from
+        # .env at load time) — the literal secret never lands in config.yaml.
+        raw = yaml.safe_load(get_config_path().read_text())
+        assert raw["mcp_servers"]["gw"]["oauth"]["client_secret"] == "${MCP_GW_CLIENT_SECRET}"
+        assert get_env_value("MCP_GW_CLIENT_SECRET") == "s3cr3t"
 
     def test_add_stdio_server_with_env(self, tmp_path, capsys, monkeypatch):
         """Stdio servers can persist explicit environment variables."""
@@ -750,6 +789,42 @@ class TestMcpLogin:
         assert "no OAuth token was obtained" in out
         assert "Authenticated" not in out
         assert "client_id" in out
+
+    def test_login_failure_on_m2m_skips_registration_guidance(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A failed M2M login must not tell the operator to inline the secret.
+
+        The registration guidance exists for servers that reject RFC 7591 and
+        need a hand-made OAuth client. A client_credentials server already has
+        one — printing that advice would recommend pasting the secret into
+        config.yaml, which is precisely what this grant avoids.
+        """
+        _seed_config(tmp_path, {
+            "gateway": {
+                "url": "https://gateway.internal/mcp",
+                "auth": "oauth",
+                "oauth": {
+                    "grant": "client_credentials",
+                    "client_id": "cid",
+                    "client_secret": "${MCP_GATEWAY_CLIENT_SECRET}",
+                },
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, cfg, connect_timeout=30: [("list_items", "d")],
+        )
+        # No token file is created → _oauth_tokens_present() returns False.
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="gateway"))
+        out = capsys.readouterr().out
+
+        assert "no OAuth token was obtained" in out
+        assert "machine-to-machine grant" in out
+        assert "<your-oauth-client-secret>" not in out
+        assert "do not support" not in out
 
     def test_login_genuine_success_with_token(self, tmp_path, capsys, monkeypatch):
         """Probe lists tools AND a token exists → report real success."""

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -220,6 +220,46 @@ class TestMcpAdd:
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
+    def test_add_client_credentials(self, capsys, monkeypatch):
+        """--auth client_credentials writes the oauth block + secret to .env."""
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [("list_items", "list items")],
+        )
+        # client_id + scope come from flags; only the secret is prompted.
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._prompt",
+            lambda q, password=False, default="": "s3cr3t" if "secret" in q.lower() else default,
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")  # accept all tools
+
+        from hermes_cli.mcp_config import cmd_mcp_add, get_env_value
+
+        cmd_mcp_add(
+            _make_args(
+                name="gw",
+                url="https://gw/mcp",
+                auth="client_credentials",
+                client_id="mcp-gateway",
+                scope="profile",
+            )
+        )
+
+        import yaml
+
+        from hermes_cli.config import get_config_path, load_config
+
+        srv = load_config()["mcp_servers"]["gw"]
+        assert srv["auth"] == "oauth"
+        assert srv["oauth"]["grant"] == "client_credentials"
+        assert srv["oauth"]["client_id"] == "mcp-gateway"
+        assert srv["oauth"]["scope"] == "profile"
+        # The secret is stored as a ${VAR} reference in config.yaml (resolved from
+        # .env at load time) — the literal secret never lands in config.yaml.
+        raw = yaml.safe_load(get_config_path().read_text())
+        assert raw["mcp_servers"]["gw"]["oauth"]["client_secret"] == "${MCP_GW_CLIENT_SECRET}"
+        assert get_env_value("MCP_GW_CLIENT_SECRET") == "s3cr3t"
+
     def test_add_stdio_server(self, tmp_path, capsys, monkeypatch):
         """Add a stdio server."""
         fake_tools = [FakeTool("search", "Search repos")]
@@ -921,6 +961,42 @@ class TestMcpLogin:
         assert "no OAuth token was obtained" in out
         assert "Authenticated" not in out
         assert "client_id" in out
+
+    def test_login_failure_on_m2m_skips_registration_guidance(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A failed M2M login must not tell the operator to inline the secret.
+
+        The registration guidance exists for servers that reject RFC 7591 and
+        need a hand-made OAuth client. A client_credentials server already has
+        one — printing that advice would recommend pasting the secret into
+        config.yaml, which is precisely what this grant avoids.
+        """
+        _seed_config(tmp_path, {
+            "gateway": {
+                "url": "https://gateway.internal/mcp",
+                "auth": "oauth",
+                "oauth": {
+                    "grant": "client_credentials",
+                    "client_id": "cid",
+                    "client_secret": "${MCP_GATEWAY_CLIENT_SECRET}",
+                },
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, cfg, connect_timeout=30: [("list_items", "d")],
+        )
+        # No token file is created → _oauth_tokens_present() returns False.
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="gateway"))
+        out = capsys.readouterr().out
+
+        assert "no OAuth token was obtained" in out
+        assert "machine-to-machine grant" in out
+        assert "<your-oauth-client-secret>" not in out
+        assert "do not support" not in out
 
     def test_login_genuine_success_with_token(self, tmp_path, capsys, monkeypatch):
         """Probe lists tools AND a token exists → report real success."""

--- a/tests/tools/test_mcp_oauth_client_credentials.py
+++ b/tests/tools/test_mcp_oauth_client_credentials.py
@@ -1,0 +1,338 @@
+"""Tests for the headless client_credentials (M2M) MCP OAuth grant.
+
+Covers the ``oauth.grant: client_credentials`` path in ``tools/mcp_oauth.py``
+and ``tools/mcp_oauth_manager.py``: it wires the MCP SDK's headless
+``ClientCredentialsOAuthProvider`` so a daemon can authenticate to an
+OAuth-fronted MCP gateway with no browser, no callback, and no interactive
+re-auth.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+
+from tools import mcp_oauth as mo
+from tools import mcp_oauth_manager as mgr
+
+
+@pytest.fixture
+def reset_manager():
+    """Isolate the process-global MCPOAuthManager singleton.
+
+    Reset on both sides: entries registered here would otherwise outlive the
+    test and leak into the rest of the session.
+    """
+    mgr.reset_manager_for_tests()
+    yield
+    mgr.reset_manager_for_tests()
+
+
+def _cfg(**over):
+    cfg = {
+        "grant": "client_credentials",
+        "client_id": "mcp-gateway",
+        "client_secret": "s3cr3t",
+        "scope": "profile",
+    }
+    cfg.update(over)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Grant classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsM2MGrant:
+    def test_client_credentials_selected(self):
+        assert mo.is_m2m_grant({"grant": "client_credentials"}) is True
+
+    def test_case_and_whitespace_insensitive(self):
+        assert mo.is_m2m_grant({"grant": " Client_Credentials "}) is True
+
+    def test_non_m2m_grants(self):
+        # Spelling out the interactive grant is allowed: it means "the default".
+        assert mo.is_m2m_grant({"grant": "authorization_code"}) is False
+        assert mo.is_m2m_grant({"client_id": "x"}) is False
+        assert mo.is_m2m_grant(None) is False
+        assert mo.is_m2m_grant({}) is False
+
+    @pytest.mark.parametrize("bad", ["client-credentials", "clientcredentials",
+                                     "private_key_jwt", "device_code"])
+    def test_unknown_grant_raises_instead_of_falling_back(self, bad):
+        """A typo must not silently become the interactive flow.
+
+        Falling through would answer a headless deployment with "run
+        `hermes mcp login` interactively first" — advice impossible to follow
+        on the very machine the operator is configuring.
+        """
+        with pytest.raises(ValueError, match="Unknown MCP OAuth grant"):
+            mo.is_m2m_grant({"grant": bad})
+
+
+# ---------------------------------------------------------------------------
+# SDK generation compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestScopeKwargCompat:
+    """The scope keyword changed name between the two SDK generations.
+
+    mcp 1.x took ``scopes=``; mcp 2.0 renamed it to ``scope=``. Passing the
+    wrong spelling is a TypeError at construction, so on a headless
+    deployment every M2M server would fail to authenticate at startup. These
+    pins are what makes an SDK bump a visible test failure instead of a live
+    outage.
+    """
+
+    def test_kwarg_follows_the_installed_sdk_signature(self):
+        import inspect
+
+        params = inspect.signature(
+            ClientCredentialsOAuthProvider.__init__
+        ).parameters
+        expected = "scopes" if "scopes" in params else "scope"
+
+        kwargs = mo._client_credentials_scope_kwarg("profile")
+
+        assert kwargs == {expected: "profile"}
+        # Whatever the spelling, it must be one the SDK actually accepts.
+        assert expected in params
+
+    def test_none_scope_is_still_passed_through(self):
+        kwargs = mo._client_credentials_scope_kwarg(None)
+        assert list(kwargs.values()) == [None]
+
+    def test_configured_scope_reaches_the_client_metadata(self, monkeypatch, tmp_path):
+        """End-to-end pin: the config scope must survive the kwarg translation."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg()
+        cfg["scope"] = "gateway.read gateway.write"
+
+        p = mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+        assert p.context.client_metadata.scope == "gateway.read gateway.write"
+        assert p._fixed_client_info.scope == "gateway.read gateway.write"
+        assert p._configured_scope == "gateway.read gateway.write"
+
+
+# ---------------------------------------------------------------------------
+# Provider construction
+# ---------------------------------------------------------------------------
+
+
+class TestClientCredentials:
+    def test_builds_headless_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider("gw", "https://gw/mcp", _cfg())
+
+        assert isinstance(p, ClientCredentialsOAuthProvider)
+        assert p.context.client_metadata.grant_types == ["client_credentials"]
+        assert p.context.client_metadata.scope == "profile"
+        assert p._fixed_client_info.client_id == "mcp-gateway"
+        assert p._fixed_client_info.client_secret == "s3cr3t"
+        # Headless: base __init__ constructed with no redirect/callback handlers.
+        assert p.context.redirect_handler is None
+        assert p.context.callback_handler is None
+
+    def test_default_auth_method_is_basic(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider("gw", "https://gw/mcp", _cfg())
+        assert p.context.client_metadata.token_endpoint_auth_method == "client_secret_basic"
+
+    def test_auth_method_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider(
+            "gw", "https://gw/mcp", _cfg(token_endpoint_auth_method="client_secret_post")
+        )
+        assert p.context.client_metadata.token_endpoint_auth_method == "client_secret_post"
+
+    def test_missing_client_secret_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg()
+        del cfg["client_secret"]
+        with pytest.raises(ValueError, match="client_secret"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+    def test_missing_client_id_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg()
+        del cfg["client_id"]
+        with pytest.raises(ValueError, match="client_id"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+    @pytest.mark.parametrize("bad", ["mtls", "private_key_jwt", "none"])
+    def test_bad_auth_method_raises(self, monkeypatch, tmp_path, bad):
+        """Only the two supported methods are accepted.
+
+        Matched on Hermes' own wording: pydantic also rejects some values, and
+        its ValidationError subclasses ValueError with the field name in the
+        message — so a loose match would pass even with our check deleted.
+        ``private_key_jwt`` and ``none`` are accepted by pydantic, so only our
+        check can reject them.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with pytest.raises(
+            ValueError, match=r"must be 'client_secret_basic' or 'client_secret_post'"
+        ):
+            mo.build_client_credentials_provider(
+                "gw", "https://gw/mcp", _cfg(token_endpoint_auth_method=bad)
+            )
+
+    def test_unresolved_env_placeholder_is_rejected(self, monkeypatch, tmp_path):
+        """An unset ${VAR} must never be sent to the authorization server.
+
+        Interpolation leaves an unset reference as its own literal, which is
+        truthy — so the emptiness check above does not catch it and the
+        placeholder would be base64'd into the Basic header, disclosing the
+        variable name off-host for an opaque invalid_client.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg(client_secret="${MCP_GW_CLIENT_SECRET}")
+        with pytest.raises(ValueError, match="unresolved placeholder"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+    def test_raises_when_sdk_extension_missing(self, monkeypatch, tmp_path):
+        """On an SDK without the extension: fail loudly, never return None.
+
+        Returning None would leave the caller connecting with no Authorization
+        header at all — which fails later and further away, or silently
+        "succeeds" against a server that lists tools unauthenticated.
+
+        ``_HermesClientCredentialsProvider`` only exists when the extension
+        imported, so the guard must also come *before* the constructor is
+        touched; deleting the attribute makes a mis-ordered guard raise
+        NameError instead of our error.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mo, "_M2M_AVAILABLE", False)
+        monkeypatch.delattr(mo, "_HermesClientCredentialsProvider", raising=False)
+
+        with pytest.raises(mo.OAuthGrantUnavailableError, match=r"mcp>=1\.26\.0"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", _cfg())
+
+
+class TestDispatch:
+    def test_dispatch_client_credentials(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_m2m_provider("gw", "https://gw/mcp", _cfg())
+        # Our thin subclass — still the SDK provider, only the
+        # client_secret_post body is corrected. See _HermesClientCredentialsProvider.
+        assert type(p) is mo._HermesClientCredentialsProvider
+        assert isinstance(p, ClientCredentialsOAuthProvider)
+
+    def test_dispatch_unknown_grant_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with pytest.raises(ValueError, match="Unknown M2M oauth grant"):
+            mo.build_m2m_provider("gw", "https://gw/mcp", {"grant": "authorization_code"})
+
+
+class TestBuildOAuthAuthHeadless:
+    def test_m2m_bypasses_non_interactive_guard(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Force a non-interactive env: the browser path would raise
+        # OAuthNonInteractiveError; the M2M path must not.
+        monkeypatch.setattr(mo, "_is_interactive", lambda: False)
+        p = mo.build_oauth_auth("gw", "https://gw/mcp", _cfg())
+        assert isinstance(p, ClientCredentialsOAuthProvider)
+
+
+# ---------------------------------------------------------------------------
+# Manager wiring
+# ---------------------------------------------------------------------------
+
+
+class TestManagerWiring:
+    def test_build_provider_uses_sdk_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mo, "_is_interactive", lambda: False)
+        entry = mgr._ProviderEntry(server_url="https://gw/mcp", oauth_config=_cfg())
+        provider = mgr.get_manager()._build_provider("gw", entry)
+        assert type(provider) is mo._HermesClientCredentialsProvider
+        assert isinstance(provider, ClientCredentialsOAuthProvider)
+
+    def test_is_m2m(self, monkeypatch, tmp_path, reset_manager):
+        """Register through the public path, then read back.
+
+        Deliberately NOT seeding ``_entries`` directly: entries are keyed by
+        (hermes_home, server_name) via ``_key``, and a test that both writes
+        and reads through ``_key`` only proves ``is_m2m`` agrees with itself.
+        Going through ``get_or_build_provider`` is what makes it catch a
+        divergence between the code that registers entries and the code that
+        looks them up — the exact shape of the bug this method already had.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Interactive so the browser server registers too; constructing its
+        # provider opens nothing (a browser would only open on a request).
+        monkeypatch.setattr(mo, "_is_interactive", lambda: True)
+        manager = mgr.get_manager()
+
+        manager.get_or_build_provider("gw", "https://gw/mcp", _cfg())
+        manager.get_or_build_provider(
+            "browser", "https://b/mcp", {"client_id": "x"}
+        )
+
+        assert manager.is_m2m("gw") is True
+        assert manager.is_m2m("browser") is False
+        assert manager.is_m2m("never-seen") is False
+
+    def test_auth_failure_message_is_wired_to_the_registered_grant(
+        self, monkeypatch, tmp_path, reset_manager
+    ):
+        """The manager lookup must actually drive the message the model sees.
+
+        ``_needs_reauth_error`` is easy to test with a hand-passed literal,
+        which proves nothing about production: what matters is that
+        ``_handle_auth_error_and_retry`` asks the manager and gets the right
+        answer for a server registered the normal way.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mo, "_is_interactive", lambda: True)
+        from tools.mcp_tool import _needs_reauth_error
+
+        manager = mgr.get_manager()
+        manager.get_or_build_provider("gw", "https://gw/mcp", _cfg())
+        manager.get_or_build_provider(
+            "browser", "https://b/mcp", {"client_id": "x"}
+        )
+
+        m2m = json.loads(
+            _needs_reauth_error("gw", m2m=manager.is_m2m("gw"))
+        )
+        interactive = json.loads(
+            _needs_reauth_error("browser", m2m=manager.is_m2m("browser"))
+        )
+        assert m2m["m2m"] is True
+        assert "hermes mcp login" not in m2m["error"]
+        assert "m2m" not in interactive
+        assert "hermes mcp login browser" in interactive["error"]
+
+
+# ---------------------------------------------------------------------------
+# Auth-failure message: M2M vs interactive
+# ---------------------------------------------------------------------------
+
+
+class TestReauthMessage:
+    def test_m2m_message_does_not_prompt_login(self):
+        from tools.mcp_tool import _needs_reauth_error
+
+        payload = json.loads(_needs_reauth_error("gw", m2m=True))
+        assert payload["m2m"] is True
+        assert payload["needs_reauth"] is True
+        assert "credential/config" in payload["error"]
+        # The M2M branch must never send the model down the re-auth path: a
+        # fresh mint produces the same rejected token.
+        assert "Re-authenticating will NOT help" in payload["error"]
+        assert "hermes mcp login" not in payload["error"]
+
+    def test_interactive_message_prompts_login(self):
+        from tools.mcp_tool import _needs_reauth_error
+
+        payload = json.loads(_needs_reauth_error("gh", m2m=False))
+        assert "m2m" not in payload
+        assert "hermes mcp login gh" in payload["error"]

--- a/tests/tools/test_mcp_oauth_client_credentials.py
+++ b/tests/tools/test_mcp_oauth_client_credentials.py
@@ -1,0 +1,292 @@
+"""Tests for the headless client_credentials (M2M) MCP OAuth grant.
+
+Covers the ``oauth.grant: client_credentials`` path in ``tools/mcp_oauth.py``
+and ``tools/mcp_oauth_manager.py``: it wires the MCP SDK's headless
+``ClientCredentialsOAuthProvider`` so a daemon can authenticate to an
+OAuth-fronted MCP gateway with no browser, no callback, and no interactive
+re-auth.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+
+from tools import mcp_oauth as mo
+from tools import mcp_oauth_manager as mgr
+
+
+@pytest.fixture
+def reset_manager():
+    """Isolate the process-global MCPOAuthManager singleton.
+
+    Reset on both sides: entries registered here would otherwise outlive the
+    test and leak into the rest of the session.
+    """
+    mgr.reset_manager_for_tests()
+    yield
+    mgr.reset_manager_for_tests()
+
+
+def _cfg(**over):
+    cfg = {
+        "grant": "client_credentials",
+        "client_id": "mcp-gateway",
+        "client_secret": "s3cr3t",
+        "scope": "profile",
+    }
+    cfg.update(over)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Grant classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsM2MGrant:
+    def test_client_credentials_selected(self):
+        assert mo.is_m2m_grant({"grant": "client_credentials"}) is True
+
+    def test_case_and_whitespace_insensitive(self):
+        assert mo.is_m2m_grant({"grant": " Client_Credentials "}) is True
+
+    def test_non_m2m_grants(self):
+        # Spelling out the interactive grant is allowed: it means "the default".
+        assert mo.is_m2m_grant({"grant": "authorization_code"}) is False
+        assert mo.is_m2m_grant({"client_id": "x"}) is False
+        assert mo.is_m2m_grant(None) is False
+        assert mo.is_m2m_grant({}) is False
+
+    @pytest.mark.parametrize("bad", ["client-credentials", "clientcredentials",
+                                     "private_key_jwt", "device_code"])
+    def test_unknown_grant_raises_instead_of_falling_back(self, bad):
+        """A typo must not silently become the interactive flow.
+
+        Falling through would answer a headless deployment with "run
+        `hermes mcp login` interactively first" — advice impossible to follow
+        on the very machine the operator is configuring.
+        """
+        with pytest.raises(ValueError, match="Unknown MCP OAuth grant"):
+            mo.is_m2m_grant({"grant": bad})
+
+
+# ---------------------------------------------------------------------------
+# Provider construction
+# ---------------------------------------------------------------------------
+
+
+class TestClientCredentials:
+    def test_builds_headless_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider("gw", "https://gw/mcp", _cfg())
+
+        assert isinstance(p, ClientCredentialsOAuthProvider)
+        assert p.context.client_metadata.grant_types == ["client_credentials"]
+        assert p.context.client_metadata.scope == "profile"
+        assert p._fixed_client_info.client_id == "mcp-gateway"
+        assert p._fixed_client_info.client_secret == "s3cr3t"
+        # Headless: base __init__ constructed with no redirect/callback handlers.
+        assert p.context.redirect_handler is None
+        assert p.context.callback_handler is None
+
+    def test_default_auth_method_is_basic(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider("gw", "https://gw/mcp", _cfg())
+        assert p.context.client_metadata.token_endpoint_auth_method == "client_secret_basic"
+
+    def test_auth_method_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_client_credentials_provider(
+            "gw", "https://gw/mcp", _cfg(token_endpoint_auth_method="client_secret_post")
+        )
+        assert p.context.client_metadata.token_endpoint_auth_method == "client_secret_post"
+
+    def test_missing_client_secret_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg()
+        del cfg["client_secret"]
+        with pytest.raises(ValueError, match="client_secret"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+    def test_missing_client_id_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg()
+        del cfg["client_id"]
+        with pytest.raises(ValueError, match="client_id"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+    @pytest.mark.parametrize("bad", ["mtls", "private_key_jwt", "none"])
+    def test_bad_auth_method_raises(self, monkeypatch, tmp_path, bad):
+        """Only the two supported methods are accepted.
+
+        Matched on Hermes' own wording: pydantic also rejects some values, and
+        its ValidationError subclasses ValueError with the field name in the
+        message — so a loose match would pass even with our check deleted.
+        ``private_key_jwt`` and ``none`` are accepted by pydantic, so only our
+        check can reject them.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with pytest.raises(
+            ValueError, match=r"must be 'client_secret_basic' or 'client_secret_post'"
+        ):
+            mo.build_client_credentials_provider(
+                "gw", "https://gw/mcp", _cfg(token_endpoint_auth_method=bad)
+            )
+
+    def test_unresolved_env_placeholder_is_rejected(self, monkeypatch, tmp_path):
+        """An unset ${VAR} must never be sent to the authorization server.
+
+        Interpolation leaves an unset reference as its own literal, which is
+        truthy — so the emptiness check above does not catch it and the
+        placeholder would be base64'd into the Basic header, disclosing the
+        variable name off-host for an opaque invalid_client.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _cfg(client_secret="${MCP_GW_CLIENT_SECRET}")
+        with pytest.raises(ValueError, match="unresolved placeholder"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", cfg)
+
+    def test_raises_when_sdk_extension_missing(self, monkeypatch, tmp_path):
+        """On an SDK without the extension: fail loudly, never return None.
+
+        Returning None would leave the caller connecting with no Authorization
+        header at all — which fails later and further away, or silently
+        "succeeds" against a server that lists tools unauthenticated.
+
+        ``_HermesClientCredentialsProvider`` only exists when the extension
+        imported, so the guard must also come *before* the constructor is
+        touched; deleting the attribute makes a mis-ordered guard raise
+        NameError instead of our error.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mo, "_M2M_AVAILABLE", False)
+        monkeypatch.delattr(mo, "_HermesClientCredentialsProvider", raising=False)
+
+        with pytest.raises(mo.OAuthGrantUnavailableError, match=r"mcp>=1\.26\.0"):
+            mo.build_client_credentials_provider("gw", "https://gw/mcp", _cfg())
+
+
+class TestDispatch:
+    def test_dispatch_client_credentials(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        p = mo.build_m2m_provider("gw", "https://gw/mcp", _cfg())
+        # Our thin subclass — still the SDK provider, only the
+        # client_secret_post body is corrected. See _HermesClientCredentialsProvider.
+        assert type(p) is mo._HermesClientCredentialsProvider
+        assert isinstance(p, ClientCredentialsOAuthProvider)
+
+    def test_dispatch_unknown_grant_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with pytest.raises(ValueError, match="Unknown M2M oauth grant"):
+            mo.build_m2m_provider("gw", "https://gw/mcp", {"grant": "authorization_code"})
+
+
+class TestBuildOAuthAuthHeadless:
+    def test_m2m_bypasses_non_interactive_guard(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Force a non-interactive env: the browser path would raise
+        # OAuthNonInteractiveError; the M2M path must not.
+        monkeypatch.setattr(mo, "_is_interactive", lambda: False)
+        p = mo.build_oauth_auth("gw", "https://gw/mcp", _cfg())
+        assert isinstance(p, ClientCredentialsOAuthProvider)
+
+
+# ---------------------------------------------------------------------------
+# Manager wiring
+# ---------------------------------------------------------------------------
+
+
+class TestManagerWiring:
+    def test_build_provider_uses_sdk_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mo, "_is_interactive", lambda: False)
+        entry = mgr._ProviderEntry(server_url="https://gw/mcp", oauth_config=_cfg())
+        provider = mgr.get_manager()._build_provider("gw", entry)
+        assert type(provider) is mo._HermesClientCredentialsProvider
+        assert isinstance(provider, ClientCredentialsOAuthProvider)
+
+    def test_is_m2m(self, monkeypatch, tmp_path, reset_manager):
+        """Register through the public path, then read back.
+
+        Deliberately NOT seeding ``_entries`` directly: entries are keyed by
+        (hermes_home, server_name) via ``_key``, and a test that both writes
+        and reads through ``_key`` only proves ``is_m2m`` agrees with itself.
+        Going through ``get_or_build_provider`` is what makes it catch a
+        divergence between the code that registers entries and the code that
+        looks them up — the exact shape of the bug this method already had.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Interactive so the browser server registers too; constructing its
+        # provider opens nothing (a browser would only open on a request).
+        monkeypatch.setattr(mo, "_is_interactive", lambda: True)
+        manager = mgr.get_manager()
+
+        manager.get_or_build_provider("gw", "https://gw/mcp", _cfg())
+        manager.get_or_build_provider(
+            "browser", "https://b/mcp", {"client_id": "x"}
+        )
+
+        assert manager.is_m2m("gw") is True
+        assert manager.is_m2m("browser") is False
+        assert manager.is_m2m("never-seen") is False
+
+    def test_auth_failure_message_is_wired_to_the_registered_grant(
+        self, monkeypatch, tmp_path, reset_manager
+    ):
+        """The manager lookup must actually drive the message the model sees.
+
+        ``_needs_reauth_error`` is easy to test with a hand-passed literal,
+        which proves nothing about production: what matters is that
+        ``_handle_auth_error_and_retry`` asks the manager and gets the right
+        answer for a server registered the normal way.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(mo, "_is_interactive", lambda: True)
+        from tools.mcp_tool import _needs_reauth_error
+
+        manager = mgr.get_manager()
+        manager.get_or_build_provider("gw", "https://gw/mcp", _cfg())
+        manager.get_or_build_provider(
+            "browser", "https://b/mcp", {"client_id": "x"}
+        )
+
+        m2m = json.loads(
+            _needs_reauth_error("gw", m2m=manager.is_m2m("gw"))
+        )
+        interactive = json.loads(
+            _needs_reauth_error("browser", m2m=manager.is_m2m("browser"))
+        )
+        assert m2m["m2m"] is True
+        assert "hermes mcp login" not in m2m["error"]
+        assert "m2m" not in interactive
+        assert "hermes mcp login browser" in interactive["error"]
+
+
+# ---------------------------------------------------------------------------
+# Auth-failure message: M2M vs interactive
+# ---------------------------------------------------------------------------
+
+
+class TestReauthMessage:
+    def test_m2m_message_does_not_prompt_login(self):
+        from tools.mcp_tool import _needs_reauth_error
+
+        payload = json.loads(_needs_reauth_error("gw", m2m=True))
+        assert payload["m2m"] is True
+        assert payload["needs_reauth"] is True
+        assert "credential/config" in payload["error"]
+        # The M2M branch must never send the model down the re-auth path: a
+        # fresh mint produces the same rejected token.
+        assert "Re-authenticating will NOT help" in payload["error"]
+        assert "hermes mcp login" not in payload["error"]
+
+    def test_interactive_message_prompts_login(self):
+        from tools.mcp_tool import _needs_reauth_error
+
+        payload = json.loads(_needs_reauth_error("gh", m2m=False))
+        assert "m2m" not in payload
+        assert "hermes mcp login gh" in payload["error"]

--- a/tests/tools/test_mcp_oauth_client_credentials_integration.py
+++ b/tests/tools/test_mcp_oauth_client_credentials_integration.py
@@ -1,0 +1,441 @@
+"""End-to-end integration test for the headless ``client_credentials`` grant.
+
+The unit tests in ``test_mcp_oauth_client_credentials.py`` cover construction
+and dispatch. This module covers the runtime path: the **real** MCP SDK
+provider built by ``tools.mcp_oauth.build_oauth_auth``, driven by a **real**
+``AsyncClient`` from the SDK's own HTTP stack, against a **real** HTTP server
+on loopback. Nothing is mocked — no ``MockTransport``, no patched SDK
+internals.
+
+The sequence exercised is the one the feature promises:
+
+    GET  /mcp                      -> 401 + WWW-Authenticate: resource_metadata
+    GET  <that metadata URL>       -> authorization_servers
+    GET  .well-known/oauth-authorization-server -> token_endpoint
+    POST /token                    (grant_type=client_credentials)
+    GET  /mcp                      (Authorization: Bearer <minted>) -> 200
+
+The protected-resource metadata is served **only** at an unguessable path
+advertised in ``WWW-Authenticate``, so the RFC 9728 hint is load-bearing: if
+the client ignored it, the SDK's well-known fallbacks would 404 and discovery
+would fail. The fake authorization server also verifies the client credentials
+it is sent, so "the flow completed" means the request was actually acceptable.
+
+Hermetic: an ephemeral port on 127.0.0.1, torn down with the context manager.
+No outbound network, no sleeps, no wall-clock dependence.
+"""
+
+from __future__ import annotations
+
+import base64
+import http.server
+import json
+import socketserver
+import sys
+import threading
+from contextlib import contextmanager
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from tools import mcp_oauth as mo
+from tools.mcp_tool import sdk_httpx
+
+# The provider is an ``httpx.Auth`` subclass built by the MCP SDK, and mcp 2.0
+# moved that stack from ``httpx`` to ``httpx2``. A client from the other
+# distribution rejects it outright ("Invalid \"auth\" argument"), so this
+# harness has to drive it with the same flavour the SDK hands its own
+# transports — which is exactly what tools/mcp_tool.py does at runtime.
+# Resolving it here keeps the test honest on either SDK generation.
+httpx = sdk_httpx()
+
+CLIENT_ID = "test-client"
+CLIENT_SECRET = "s3cr3t"
+# Deliberately unguessable: reachable only via the WWW-Authenticate hint.
+PRM_PATH = "/oauth-metadata/9f3c1a/resource"
+
+
+class _ASState:
+    """Mutable state shared with the request handler (per-server instance)."""
+
+    def __init__(self) -> None:
+        self.port: int = 0
+        self.requests: list[tuple[str, str]] = []   # (method, path)
+        self.token_bodies: list[dict] = []          # parsed /token form bodies
+        self.token_raw_bodies: list[str] = []       # unparsed, to spot repeats
+        self.token_auth_headers: list[str | None] = []
+        self.resource_auth_headers: list[str | None] = []
+        self.issued: list[str] = []                 # access tokens handed out
+        self.revoked: set[str] = set()
+        self.mint_count = 0
+        self.reject_credentials = False
+
+    @property
+    def base(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def valid(self, token: str | None) -> bool:
+        return bool(token) and token in self.issued and token not in self.revoked
+
+    def credentials_ok(self, form: dict, auth_header: str | None) -> bool:
+        """Accept either RFC 6749 client authentication method, and only those."""
+        if self.reject_credentials:
+            return False
+        if auth_header and auth_header.startswith("Basic "):
+            expected = base64.b64encode(
+                f"{CLIENT_ID}:{CLIENT_SECRET}".encode()
+            ).decode()
+            return auth_header == f"Basic {expected}"
+        # client_secret_post: BOTH fields are required to identify the client.
+        return (
+            form.get("client_id") == CLIENT_ID
+            and form.get("client_secret") == CLIENT_SECRET
+        )
+
+
+def _handler_cls(state: _ASState):
+    class _H(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *args):  # silence stderr noise in test output
+            pass
+
+        # -- helpers ------------------------------------------------------
+        def _json(self, status: int, payload: dict, headers: dict | None = None):
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            for k, v in (headers or {}).items():
+                self.send_header(k, v)
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _bearer(self) -> str | None:
+            raw = self.headers.get("Authorization")
+            if raw and raw.startswith("Bearer "):
+                return raw[len("Bearer "):]
+            return None
+
+        # -- routes -------------------------------------------------------
+        def do_GET(self):
+            path = urlparse(self.path).path
+            state.requests.append(("GET", path))
+
+            if path == "/mcp":
+                state.resource_auth_headers.append(self.headers.get("Authorization"))
+                if state.valid(self._bearer()):
+                    return self._json(200, {"ok": True})
+                return self._json(
+                    401,
+                    {"error": "unauthorized"},
+                    {"WWW-Authenticate": (
+                        f'Bearer resource_metadata="{state.base}{PRM_PATH}"'
+                    )},
+                )
+
+            if path == PRM_PATH:
+                return self._json(200, {
+                    # Deliberately NOT the canonical server URL: asserting this
+                    # value in the token request proves the resource came from
+                    # the discovered document, not from the configured URL.
+                    "resource": f"{state.base}/",
+                    "authorization_servers": [state.base],
+                })
+
+            if path == "/.well-known/oauth-authorization-server":
+                return self._json(200, {
+                    "issuer": state.base,
+                    "authorization_endpoint": f"{state.base}/authorize",
+                    "token_endpoint": f"{state.base}/token",
+                    "grant_types_supported": ["client_credentials"],
+                    "response_types_supported": ["code"],
+                })
+
+            return self._json(404, {"error": "not_found"})
+
+        def do_POST(self):
+            path = urlparse(self.path).path
+            state.requests.append(("POST", path))
+
+            if path == "/token":
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length).decode()
+                form = {k: v[0] for k, v in parse_qs(raw).items()}
+                auth_header = self.headers.get("Authorization")
+                state.token_raw_bodies.append(raw)
+                state.token_bodies.append(form)
+                state.token_auth_headers.append(auth_header)
+
+                # This grant issues no refresh_token, so the client must never
+                # try to redeem one.
+                if form.get("grant_type") != "client_credentials":
+                    return self._json(400, {"error": "unsupported_grant_type"})
+                if not state.credentials_ok(form, auth_header):
+                    return self._json(401, {"error": "invalid_client"})
+
+                state.mint_count += 1
+                token = f"access-token-{state.mint_count}"
+                state.issued.append(token)
+                return self._json(200, {
+                    "access_token": token,
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                })
+
+            # Dynamic client registration must never be reached: the grant
+            # supplies client_id/client_secret up front.
+            return self._json(500, {"error": "unexpected_endpoint"})
+
+    return _H
+
+
+@contextmanager
+def _auth_server():
+    """Run the fake resource + authorization server on loopback."""
+    state = _ASState()
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), _handler_cls(state))
+    state.port = httpd.server_address[1]
+    thread = threading.Thread(
+        target=httpd.serve_forever, kwargs={"poll_interval": 0.05}, daemon=True
+    )
+    thread.start()
+    try:
+        yield state
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+def _provider(state: _ASState, monkeypatch, **overrides):
+    """Build the real provider through Hermes' own config path."""
+    # Belt and braces: if the M2M branch ever regressed, the interactive
+    # provider would try to open a browser and block on a callback server.
+    # Forcing non-interactive turns that into a loud failure, not a hang.
+    monkeypatch.setattr(mo, "_is_interactive", lambda: False)
+    cfg = {
+        "grant": "client_credentials",
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        **overrides,
+    }
+    auth = mo.build_oauth_auth("gw", f"{state.base}/mcp", cfg)
+    assert auth is not None, "SDK client_credentials extension unavailable"
+    return auth
+
+
+def _paths(state: _ASState) -> list[str]:
+    return [p for _, p in state.requests]
+
+
+def _assert_subsequence(actual: list[str], expected: list[str]) -> None:
+    """Assert *expected* appears in order within *actual*.
+
+    A subsequence rather than equality: the load-bearing hops must all happen
+    in order, but the SDK is free to try additional discovery fallbacks
+    without that counting as a Hermes regression.
+    """
+    remaining = list(expected)
+    for path in actual:
+        if remaining and path == remaining[0]:
+            remaining.pop(0)
+    assert not remaining, (
+        f"missing {remaining} in order; actual sequence was {actual}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_401_discovery_token_exchange_and_authenticated_retry(
+    tmp_path, monkeypatch
+):
+    """The full runtime path, asserted request by request."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        auth = _provider(state, monkeypatch)
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+        # 1. Unauthenticated probe, both discovery hops, exchange, retry.
+        _assert_subsequence(_paths(state), [
+            "/mcp",
+            PRM_PATH,
+            "/.well-known/oauth-authorization-server",
+            "/token",
+            "/mcp",
+        ])
+
+        # 2. Dynamic client registration is skipped entirely.
+        assert "/register" not in _paths(state)
+
+        # 3. A real client_credentials exchange, accepted by the server.
+        assert len(state.token_bodies) == 1
+        body = state.token_bodies[0]
+        assert body["grant_type"] == "client_credentials"
+        # Credentials travel in the Authorization header, not the body.
+        assert "client_secret" not in body
+        expected = base64.b64encode(
+            f"{CLIENT_ID}:{CLIENT_SECRET}".encode()
+        ).decode()
+        assert state.token_auth_headers[0] == f"Basic {expected}"
+        # The resource comes from the discovered PRM document, not from the
+        # configured server URL (the fake advertises a different value).
+        assert body["resource"] == f"{state.base}/"
+
+        # 4. First call carried no credentials; the retry carries the minted
+        #    token — this is what proves the retry re-authenticated.
+        assert state.resource_auth_headers[0] is None
+        assert state.resource_auth_headers[1] == f"Bearer {state.issued[0]}"
+
+
+@pytest.mark.asyncio
+async def test_configured_scope_reaches_the_token_request(tmp_path, monkeypatch):
+    """``oauth.scope`` must survive the SDK's scope-selection strategy.
+
+    The flow assigns its own scope choice (WWW-Authenticate scope, else the
+    metadata's ``scopes_supported``, else nothing) over ``client_metadata``
+    before every authorization — so a scope set at construction is otherwise
+    dropped, and the documented ``--scope`` flag would do nothing. Here the
+    fake advertises no scopes at all, so anything in the body can only have
+    come from the configuration.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        auth = _provider(state, monkeypatch, scope="gateway.read gateway.write")
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200
+        assert state.token_bodies[0]["scope"] == "gateway.read gateway.write"
+
+
+@pytest.mark.asyncio
+async def test_client_secret_post_sends_both_credentials_in_the_body(
+    tmp_path, monkeypatch
+):
+    """``client_secret_post`` puts BOTH credentials in the form body.
+
+    RFC 6749 §2.3.1: a client authenticating this way must send ``client_id``
+    *and* ``client_secret`` in the request body. The 1.x SDK sent only the
+    secret, leaving the authorization server unable to identify the caller
+    (modelcontextprotocol/python-sdk#2128); 2.x fixes it in
+    ``prepare_token_auth`` (#2185), which is why Hermes no longer carries a
+    repair of its own. This is the guard on that removal: the fake rejects a
+    body without ``client_id``, so an SDK that regressed here would fail the
+    test loudly instead of reaching an authorization server as
+    ``invalid_client``.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        auth = _provider(
+            state, monkeypatch, token_endpoint_auth_method="client_secret_post"
+        )
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200
+        body = state.token_bodies[0]
+        assert body["client_id"] == CLIENT_ID
+        assert body["client_secret"] == CLIENT_SECRET
+        assert body["grant_type"] == "client_credentials"
+        # Credentials are in the body for this method, never duplicated as Basic.
+        assert state.token_auth_headers[0] is None
+        # The rebuilt body must not corrupt the rest of the exchange.
+        assert body["resource"] == f"{state.base}/"
+        assert state.resource_auth_headers[-1] == f"Bearer {state.issued[0]}"
+
+
+@pytest.mark.asyncio
+async def test_reserved_characters_survive_the_form_encoding(tmp_path, monkeypatch):
+    """Form-encoding the token body must not corrupt the credentials.
+
+    A secret containing characters that are meaningful in a form-encoded
+    payload (``&``, ``=``, ``+``, ``%``, spaces, non-ASCII) is where encoding
+    goes wrong. The fake server compares the decoded values byte for byte and
+    answers ``invalid_client`` on any mismatch, so corruption fails the test
+    rather than going unnoticed. Hermes reads real secrets from ``${VAR}``, so
+    an operator can perfectly well hold one of these.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    nasty = "a+b=c%20d&e f/g?h#ié中~_-.*"
+    # The fake server validates against this module-level constant.
+    monkeypatch.setattr(sys.modules[__name__], "CLIENT_SECRET", nasty)
+
+    with _auth_server() as state:
+        auth = _provider(
+            state,
+            monkeypatch,
+            client_secret=nasty,
+            token_endpoint_auth_method="client_secret_post",
+        )
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200          # server accepted the creds
+        body = state.token_bodies[0]
+        assert body["client_secret"] == nasty
+        assert body["client_id"] == CLIENT_ID
+        assert body["grant_type"] == "client_credentials"
+
+
+@pytest.mark.asyncio
+async def test_rejected_token_is_reminted_without_a_refresh_token(
+    tmp_path, monkeypatch
+):
+    """A rejected token triggers a fresh mint — never a refresh_token grant.
+
+    ``client_credentials`` responses carry no ``refresh_token``, so recovery
+    can only be a new exchange. The fake answers 400 to any other grant_type,
+    so an attempted refresh would fail the run rather than pass silently.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        auth = _provider(state, monkeypatch)
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            first = await client.get(f"{state.base}/mcp")
+            assert first.status_code == 200
+
+            # The server revokes it (rotated secret, restarted gateway, …).
+            state.revoked.add(state.issued[0])
+
+            second = await client.get(f"{state.base}/mcp")
+
+        assert second.status_code == 200
+        assert state.mint_count == 2
+        assert state.issued[0] != state.issued[1]
+        assert state.resource_auth_headers[-1] == f"Bearer {state.issued[1]}"
+        assert all(
+            b["grant_type"] == "client_credentials" for b in state.token_bodies
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejected_credentials_surface_as_an_error(tmp_path, monkeypatch):
+    """Bad credentials fail loudly instead of hanging or looping.
+
+    This is the failure the M2M auth-failure message exists for: the exchange
+    itself is refused, so there is nothing to retry.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        state.reject_credentials = True
+        auth = _provider(state, monkeypatch)
+
+        with pytest.raises(Exception) as excinfo:
+            async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+                await client.get(f"{state.base}/mcp")
+
+        assert "invalid_client" in str(excinfo.value)
+        assert state.mint_count == 0
+        assert "/register" not in _paths(state)

--- a/tests/tools/test_mcp_oauth_client_credentials_integration.py
+++ b/tests/tools/test_mcp_oauth_client_credentials_integration.py
@@ -1,0 +1,471 @@
+"""End-to-end integration test for the headless ``client_credentials`` grant.
+
+The unit tests in ``test_mcp_oauth_client_credentials.py`` cover construction
+and dispatch. This module covers the runtime path: the **real** MCP SDK
+provider built by ``tools.mcp_oauth.build_oauth_auth``, driven by a **real**
+``httpx.AsyncClient``, against a **real** HTTP server on loopback. Nothing is
+mocked — no ``MockTransport``, no patched SDK internals.
+
+The sequence exercised is the one the feature promises:
+
+    GET  /mcp                      -> 401 + WWW-Authenticate: resource_metadata
+    GET  <that metadata URL>       -> authorization_servers
+    GET  .well-known/oauth-authorization-server -> token_endpoint
+    POST /token                    (grant_type=client_credentials)
+    GET  /mcp                      (Authorization: Bearer <minted>) -> 200
+
+The protected-resource metadata is served **only** at an unguessable path
+advertised in ``WWW-Authenticate``, so the RFC 9728 hint is load-bearing: if
+the client ignored it, the SDK's well-known fallbacks would 404 and discovery
+would fail. The fake authorization server also verifies the client credentials
+it is sent, so "the flow completed" means the request was actually acceptable.
+
+Hermetic: an ephemeral port on 127.0.0.1, torn down with the context manager.
+No outbound network, no sleeps, no wall-clock dependence.
+"""
+
+from __future__ import annotations
+
+import base64
+import http.server
+import json
+import socketserver
+import sys
+import threading
+from contextlib import contextmanager
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from tools import mcp_oauth as mo
+
+CLIENT_ID = "test-client"
+CLIENT_SECRET = "s3cr3t"
+# Deliberately unguessable: reachable only via the WWW-Authenticate hint.
+PRM_PATH = "/oauth-metadata/9f3c1a/resource"
+
+
+class _ASState:
+    """Mutable state shared with the request handler (per-server instance)."""
+
+    def __init__(self) -> None:
+        self.port: int = 0
+        self.requests: list[tuple[str, str]] = []   # (method, path)
+        self.token_bodies: list[dict] = []          # parsed /token form bodies
+        self.token_raw_bodies: list[str] = []       # unparsed, to spot repeats
+        self.token_auth_headers: list[str | None] = []
+        self.resource_auth_headers: list[str | None] = []
+        self.issued: list[str] = []                 # access tokens handed out
+        self.revoked: set[str] = set()
+        self.mint_count = 0
+        self.reject_credentials = False
+
+    @property
+    def base(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def valid(self, token: str | None) -> bool:
+        return bool(token) and token in self.issued and token not in self.revoked
+
+    def credentials_ok(self, form: dict, auth_header: str | None) -> bool:
+        """Accept either RFC 6749 client authentication method, and only those."""
+        if self.reject_credentials:
+            return False
+        if auth_header and auth_header.startswith("Basic "):
+            expected = base64.b64encode(
+                f"{CLIENT_ID}:{CLIENT_SECRET}".encode()
+            ).decode()
+            return auth_header == f"Basic {expected}"
+        # client_secret_post: BOTH fields are required to identify the client.
+        return (
+            form.get("client_id") == CLIENT_ID
+            and form.get("client_secret") == CLIENT_SECRET
+        )
+
+
+def _handler_cls(state: _ASState):
+    class _H(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *args):  # silence stderr noise in test output
+            pass
+
+        # -- helpers ------------------------------------------------------
+        def _json(self, status: int, payload: dict, headers: dict | None = None):
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            for k, v in (headers or {}).items():
+                self.send_header(k, v)
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _bearer(self) -> str | None:
+            raw = self.headers.get("Authorization")
+            if raw and raw.startswith("Bearer "):
+                return raw[len("Bearer "):]
+            return None
+
+        # -- routes -------------------------------------------------------
+        def do_GET(self):
+            path = urlparse(self.path).path
+            state.requests.append(("GET", path))
+
+            if path == "/mcp":
+                state.resource_auth_headers.append(self.headers.get("Authorization"))
+                if state.valid(self._bearer()):
+                    return self._json(200, {"ok": True})
+                return self._json(
+                    401,
+                    {"error": "unauthorized"},
+                    {"WWW-Authenticate": (
+                        f'Bearer resource_metadata="{state.base}{PRM_PATH}"'
+                    )},
+                )
+
+            if path == PRM_PATH:
+                return self._json(200, {
+                    # Deliberately NOT the canonical server URL: asserting this
+                    # value in the token request proves the resource came from
+                    # the discovered document, not from the configured URL.
+                    "resource": f"{state.base}/",
+                    "authorization_servers": [state.base],
+                })
+
+            if path == "/.well-known/oauth-authorization-server":
+                return self._json(200, {
+                    "issuer": state.base,
+                    "authorization_endpoint": f"{state.base}/authorize",
+                    "token_endpoint": f"{state.base}/token",
+                    "grant_types_supported": ["client_credentials"],
+                    "response_types_supported": ["code"],
+                })
+
+            return self._json(404, {"error": "not_found"})
+
+        def do_POST(self):
+            path = urlparse(self.path).path
+            state.requests.append(("POST", path))
+
+            if path == "/token":
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length).decode()
+                form = {k: v[0] for k, v in parse_qs(raw).items()}
+                auth_header = self.headers.get("Authorization")
+                state.token_raw_bodies.append(raw)
+                state.token_bodies.append(form)
+                state.token_auth_headers.append(auth_header)
+
+                # This grant issues no refresh_token, so the client must never
+                # try to redeem one.
+                if form.get("grant_type") != "client_credentials":
+                    return self._json(400, {"error": "unsupported_grant_type"})
+                if not state.credentials_ok(form, auth_header):
+                    return self._json(401, {"error": "invalid_client"})
+
+                state.mint_count += 1
+                token = f"access-token-{state.mint_count}"
+                state.issued.append(token)
+                return self._json(200, {
+                    "access_token": token,
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                })
+
+            # Dynamic client registration must never be reached: the grant
+            # supplies client_id/client_secret up front.
+            return self._json(500, {"error": "unexpected_endpoint"})
+
+    return _H
+
+
+@contextmanager
+def _auth_server():
+    """Run the fake resource + authorization server on loopback."""
+    state = _ASState()
+    httpd = socketserver.TCPServer(("127.0.0.1", 0), _handler_cls(state))
+    state.port = httpd.server_address[1]
+    thread = threading.Thread(
+        target=httpd.serve_forever, kwargs={"poll_interval": 0.05}, daemon=True
+    )
+    thread.start()
+    try:
+        yield state
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+def _provider(state: _ASState, monkeypatch, **overrides):
+    """Build the real provider through Hermes' own config path."""
+    # Belt and braces: if the M2M branch ever regressed, the interactive
+    # provider would try to open a browser and block on a callback server.
+    # Forcing non-interactive turns that into a loud failure, not a hang.
+    monkeypatch.setattr(mo, "_is_interactive", lambda: False)
+    cfg = {
+        "grant": "client_credentials",
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        **overrides,
+    }
+    auth = mo.build_oauth_auth("gw", f"{state.base}/mcp", cfg)
+    assert auth is not None, "SDK client_credentials extension unavailable"
+    return auth
+
+
+def _paths(state: _ASState) -> list[str]:
+    return [p for _, p in state.requests]
+
+
+def _assert_subsequence(actual: list[str], expected: list[str]) -> None:
+    """Assert *expected* appears in order within *actual*.
+
+    A subsequence rather than equality: the load-bearing hops must all happen
+    in order, but the SDK is free to try additional discovery fallbacks
+    without that counting as a Hermes regression.
+    """
+    remaining = list(expected)
+    for path in actual:
+        if remaining and path == remaining[0]:
+            remaining.pop(0)
+    assert not remaining, (
+        f"missing {remaining} in order; actual sequence was {actual}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_401_discovery_token_exchange_and_authenticated_retry(
+    tmp_path, monkeypatch
+):
+    """The full runtime path, asserted request by request."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        auth = _provider(state, monkeypatch)
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+        # 1. Unauthenticated probe, both discovery hops, exchange, retry.
+        _assert_subsequence(_paths(state), [
+            "/mcp",
+            PRM_PATH,
+            "/.well-known/oauth-authorization-server",
+            "/token",
+            "/mcp",
+        ])
+
+        # 2. Dynamic client registration is skipped entirely.
+        assert "/register" not in _paths(state)
+
+        # 3. A real client_credentials exchange, accepted by the server.
+        assert len(state.token_bodies) == 1
+        body = state.token_bodies[0]
+        assert body["grant_type"] == "client_credentials"
+        # Credentials travel in the Authorization header, not the body.
+        assert "client_secret" not in body
+        expected = base64.b64encode(
+            f"{CLIENT_ID}:{CLIENT_SECRET}".encode()
+        ).decode()
+        assert state.token_auth_headers[0] == f"Basic {expected}"
+        # The resource comes from the discovered PRM document, not from the
+        # configured server URL (the fake advertises a different value).
+        assert body["resource"] == f"{state.base}/"
+
+        # 4. First call carried no credentials; the retry carries the minted
+        #    token — this is what proves the retry re-authenticated.
+        assert state.resource_auth_headers[0] is None
+        assert state.resource_auth_headers[1] == f"Bearer {state.issued[0]}"
+
+
+@pytest.mark.asyncio
+async def test_configured_scope_reaches_the_token_request(tmp_path, monkeypatch):
+    """``oauth.scope`` must survive the SDK's scope-selection strategy.
+
+    The flow assigns its own scope choice (WWW-Authenticate scope, else the
+    metadata's ``scopes_supported``, else nothing) over ``client_metadata``
+    before every authorization — so a scope set at construction is otherwise
+    dropped, and the documented ``--scope`` flag would do nothing. Here the
+    fake advertises no scopes at all, so anything in the body can only have
+    come from the configuration.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        auth = _provider(state, monkeypatch, scope="gateway.read gateway.write")
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200
+        assert state.token_bodies[0]["scope"] == "gateway.read gateway.write"
+
+
+@pytest.mark.asyncio
+async def test_client_secret_post_sends_both_credentials_in_the_body(
+    tmp_path, monkeypatch
+):
+    """``client_secret_post`` puts BOTH credentials in the form body.
+
+    RFC 6749 §2.3.1: a client authenticating this way must send ``client_id``
+    *and* ``client_secret`` in the request body. The pinned SDK sends only the
+    secret, leaving the authorization server unable to identify the caller
+    (modelcontextprotocol/python-sdk#2128, fixed on 2.x by #2185 but never
+    backported to the 1.x line). ``_HermesClientCredentialsProvider`` re-adds
+    it. The fake rejects a body without ``client_id``, so this fails loudly
+    rather than merely observing a missing field.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        auth = _provider(
+            state, monkeypatch, token_endpoint_auth_method="client_secret_post"
+        )
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200
+        body = state.token_bodies[0]
+        assert body["client_id"] == CLIENT_ID
+        assert body["client_secret"] == CLIENT_SECRET
+        assert body["grant_type"] == "client_credentials"
+        # Credentials are in the body for this method, never duplicated as Basic.
+        assert state.token_auth_headers[0] is None
+        # The rebuilt body must not corrupt the rest of the exchange.
+        assert body["resource"] == f"{state.base}/"
+        assert state.resource_auth_headers[-1] == f"Bearer {state.issued[0]}"
+
+
+@pytest.mark.asyncio
+async def test_reserved_characters_survive_the_body_rewrite(tmp_path, monkeypatch):
+    """Re-encoding the form body must not corrupt the credentials.
+
+    The ``client_secret_post`` fix parses and re-encodes the request body, so a
+    secret containing characters that are meaningful in a form-encoded payload
+    (``&``, ``=``, ``+``, ``%``, spaces, non-ASCII) is where a naive rewrite
+    would break. The fake server compares the decoded values byte for byte and
+    answers ``invalid_client`` on any mismatch, so corruption fails the test
+    rather than going unnoticed.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    nasty = "a+b=c%20d&e f/g?h#ié中~_-.*"
+    # The fake server validates against this module-level constant.
+    monkeypatch.setattr(sys.modules[__name__], "CLIENT_SECRET", nasty)
+
+    with _auth_server() as state:
+        auth = _provider(
+            state,
+            monkeypatch,
+            client_secret=nasty,
+            token_endpoint_auth_method="client_secret_post",
+        )
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200          # server accepted the creds
+        body = state.token_bodies[0]
+        assert body["client_secret"] == nasty
+        assert body["client_id"] == CLIENT_ID
+        assert body["grant_type"] == "client_credentials"
+
+
+@pytest.mark.asyncio
+async def test_client_id_is_not_duplicated_once_the_sdk_emits_it(
+    tmp_path, monkeypatch
+):
+    """The override is a no-op when the SDK already supplies ``client_id``.
+
+    Simulates the fixed SDK (2.x, PR #2185) so the idempotence guard is
+    actually exercised: without it the body would carry ``client_id`` twice
+    after an SDK upgrade, which some authorization servers reject.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from mcp.client.auth.oauth2 import OAuthContext
+
+    original = OAuthContext.prepare_token_auth
+
+    def _fixed(self, data, headers=None):
+        data, headers = original(self, data, headers)
+        if (
+            self.client_info
+            and self.client_info.token_endpoint_auth_method == "client_secret_post"
+        ):
+            data["client_id"] = self.client_info.client_id
+        return data, headers
+
+    monkeypatch.setattr(OAuthContext, "prepare_token_auth", _fixed)
+
+    with _auth_server() as state:
+        auth = _provider(
+            state, monkeypatch, token_endpoint_auth_method="client_secret_post"
+        )
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            response = await client.get(f"{state.base}/mcp")
+
+        assert response.status_code == 200
+        assert state.token_bodies[0]["client_id"] == CLIENT_ID
+        # Count on the RAW body: parse_qs collapses a repeated key, so a
+        # duplicate would be invisible in the parsed form.
+        assert state.token_raw_bodies[0].count("client_id=") == 1
+
+
+@pytest.mark.asyncio
+async def test_rejected_token_is_reminted_without_a_refresh_token(
+    tmp_path, monkeypatch
+):
+    """A rejected token triggers a fresh mint — never a refresh_token grant.
+
+    ``client_credentials`` responses carry no ``refresh_token``, so recovery
+    can only be a new exchange. The fake answers 400 to any other grant_type,
+    so an attempted refresh would fail the run rather than pass silently.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        auth = _provider(state, monkeypatch)
+
+        async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+            first = await client.get(f"{state.base}/mcp")
+            assert first.status_code == 200
+
+            # The server revokes it (rotated secret, restarted gateway, …).
+            state.revoked.add(state.issued[0])
+
+            second = await client.get(f"{state.base}/mcp")
+
+        assert second.status_code == 200
+        assert state.mint_count == 2
+        assert state.issued[0] != state.issued[1]
+        assert state.resource_auth_headers[-1] == f"Bearer {state.issued[1]}"
+        assert all(
+            b["grant_type"] == "client_credentials" for b in state.token_bodies
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejected_credentials_surface_as_an_error(tmp_path, monkeypatch):
+    """Bad credentials fail loudly instead of hanging or looping.
+
+    This is the failure the M2M auth-failure message exists for: the exchange
+    itself is refused, so there is nothing to retry.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with _auth_server() as state:
+        state.reject_credentials = True
+        auth = _provider(state, monkeypatch)
+
+        with pytest.raises(Exception) as excinfo:
+            async with httpx.AsyncClient(auth=auth, timeout=10.0) as client:
+                await client.get(f"{state.base}/mcp")
+
+        assert "invalid_client" in str(excinfo.value)
+        assert state.mint_count == 0
+        assert "/register" not in _paths(state)

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -2,9 +2,10 @@
 """
 MCP OAuth 2.1 Client Support
 
-Implements the browser-based OAuth 2.1 authorization code flow with PKCE
-for MCP servers that require OAuth authentication instead of static bearer
-tokens.
+Implements the browser-based OAuth 2.1 authorization code flow with PKCE for
+MCP servers that require OAuth authentication instead of static bearer tokens,
+plus a headless ``client_credentials`` grant for machine-to-machine servers
+(selected with ``oauth.grant``; see the M2M section further down).
 
 Uses the MCP Python SDK's ``OAuthClientProvider`` (an ``httpx.Auth`` subclass)
 which handles discovery, client identification, PKCE, token exchange,
@@ -31,6 +32,8 @@ Configuration in config.yaml::
         url: "https://mcp.example.com/mcp"
         auth: oauth
         oauth:                                  # all fields optional
+          grant: client_credentials             # headless M2M; omit = browser
+          token_endpoint_auth_method: client_secret_basic   # or _post (M2M)
           client_id: "pre-registered-id"        # skip dynamic registration
           client_secret: "secret"               # confidential clients only
           scope: "read write"                   # default: server-provided
@@ -44,6 +47,7 @@ Configuration in config.yaml::
 
 import asyncio
 import contextvars
+import inspect
 import json
 import logging
 import os
@@ -137,6 +141,44 @@ try:
 except ImportError:
     AnyUrl = None  # type: ignore[assignment, misc]
 
+# Machine-to-machine OAuth via the SDK's headless client_credentials extension
+# (mcp>=1.26): the client authenticates with client_id + client_secret — no
+# browser, no callback — and the SDK re-mints on expiry (no refresh_token
+# needed). Optional import so the module still loads on older SDKs.
+_M2M_AVAILABLE = False
+try:
+    from mcp.client.auth.extensions.client_credentials import (
+        ClientCredentialsOAuthProvider,
+    )
+
+    _M2M_AVAILABLE = True
+except ImportError:
+    logger.debug(
+        "MCP client_credentials extension not available -- M2M MCP auth disabled"
+    )
+
+
+def _client_credentials_scope_kwarg(scope: "str | None") -> dict:
+    """The scope keyword ``ClientCredentialsOAuthProvider`` accepts, per SDK.
+
+    mcp 2.0 renamed the constructor keyword from ``scopes`` to ``scope`` — the
+    field it feeds, ``OAuthClientMetadata.scope``, was singular all along. The
+    wrong spelling is a ``TypeError`` at construction, and on a headless
+    deployment that means every machine-to-machine MCP server fails to
+    authenticate at startup rather than degrading. Read the signature instead
+    of inferring it from a version number, matching the posture of
+    ``tools.mcp_tool.sdk_httpx`` for the same 1.x/2.x split.
+    """
+    if not _M2M_AVAILABLE:
+        return {}
+    try:
+        params = inspect.signature(
+            ClientCredentialsOAuthProvider.__init__
+        ).parameters
+    except (TypeError, ValueError):  # pragma: no cover — defensive
+        return {"scope": scope}
+    return {"scopes" if "scopes" in params else "scope": scope}
+
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -145,6 +187,15 @@ except ImportError:
 
 class OAuthNonInteractiveError(RuntimeError):
     """Raised when OAuth requires browser interaction in a non-interactive env."""
+
+
+class OAuthGrantUnavailableError(RuntimeError):
+    """Raised when a configured OAuth grant needs SDK support that is absent.
+
+    Deliberately fatal: returning None here would leave the caller connecting
+    with no ``Authorization`` header at all, which fails later and further away
+    — or, against a server that lists tools unauthenticated, appears to succeed.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -1876,6 +1927,180 @@ def humanize_oauth_registration_error(
     )
 
 
+# ---------------------------------------------------------------------------
+# Machine-to-machine (headless client_credentials grant)
+#
+# ``grant: client_credentials`` — client_id + client_secret, via the MCP SDK's
+# ``ClientCredentialsOAuthProvider``. Selected via ``oauth.grant``; default
+# (absent) keeps the interactive authorization_code flow below unchanged. The
+# provider mints reactively on the first 401 and re-mints on expiry inside the
+# SDK's own httpx flow (no refresh_token, no proactive path): unlike
+# authorization_code, ``is_token_valid()`` gates nothing extra for this grant.
+#
+# The only Hermes-side behaviour is the ``client_secret_post`` fix below.
+# ---------------------------------------------------------------------------
+
+M2M_GRANT_CLIENT_CREDENTIALS = "client_credentials"
+_M2M_GRANTS = frozenset({M2M_GRANT_CLIENT_CREDENTIALS})
+# Spelling the interactive grant out is allowed and simply means "the default".
+_INTERACTIVE_GRANTS = frozenset({"authorization_code"})
+# Mirrors mcp_tool._ENV_VAR_PATTERN: an unset ${VAR} keeps its placeholder.
+_UNRESOLVED_ENV_REF = re.compile(r"\$\{[^}]+\}")
+
+
+def _grant_of(oauth_config: dict | None) -> str:
+    if not oauth_config:
+        return ""
+    return str(oauth_config.get("grant", "")).strip().lower()
+
+
+def is_m2m_grant(oauth_config: dict | None) -> bool:
+    """True when the oauth block requests a headless machine-to-machine grant.
+
+    Raises ValueError for a ``grant`` that is present but unrecognised. Falling
+    through to the interactive flow instead would answer a typo'd headless
+    config with "run `hermes mcp login` interactively first" — advice that is
+    impossible to follow on the deployment the operator is configuring.
+    """
+    grant = _grant_of(oauth_config)
+    if not grant:
+        return False
+    if grant in _M2M_GRANTS:
+        return True
+    if grant in _INTERACTIVE_GRANTS:
+        return False
+    raise ValueError(
+        f"Unknown MCP OAuth grant {grant!r}. Supported: "
+        f"{', '.join(sorted(_M2M_GRANTS | _INTERACTIVE_GRANTS))}. "
+        "Omit 'oauth.grant' for the interactive flow."
+    )
+
+
+def _require_client_id(cfg: dict, grant: str) -> str:
+    client_id = cfg.get("client_id")
+    if not client_id:
+        raise ValueError(f"MCP OAuth grant '{grant}' requires 'oauth.client_id'.")
+    return client_id
+
+
+if _M2M_AVAILABLE:
+
+    class _HermesClientCredentialsProvider(ClientCredentialsOAuthProvider):
+        """SDK provider that keeps the operator's configured scope authoritative.
+
+        The SDK's auth flow runs a scope-selection strategy before *every*
+        authorization — ``WWW-Authenticate`` scope, else the protected-resource
+        metadata's ``scopes_supported``, else the authorization server's — and
+        assigns the result over ``client_metadata.scope``
+        (``mcp.client.auth.oauth2``, "Step 3"). ``get_client_metadata_scopes``
+        never consults the scope the client was constructed with, so a scope
+        set from ``oauth.scope`` would never reach the token request.
+
+        For a machine-to-machine client that is the wrong precedence: the
+        operator picked a scope deliberately, and a scope the server advertises
+        must not silently widen it. Re-applying it in the exchange is the only
+        seam available downstream — the selection assigns onto ``OAuthContext``,
+        not onto the provider, so there is nothing else to override.
+
+        Previously this class also repaired the ``client_secret_post`` token
+        body, which the SDK sent with a ``client_secret`` and no ``client_id``
+        (RFC 6749 §2.3.1 requires both; strict servers answered
+        ``invalid_client``). That is fixed upstream in
+        modelcontextprotocol/python-sdk#2185 (issue #2128) and shipped in the
+        2.x line Hermes pins, whose ``prepare_token_auth`` emits ``client_id``
+        itself — so the repair was dropped rather than carried as dead code.
+        ``client_secret_basic`` was never affected either way: there the
+        credentials ride in the Authorization header, which the SDK gets right.
+        """
+
+        def __init__(self, *args, scope: str | None = None, **kwargs) -> None:
+            super().__init__(
+                *args, **_client_credentials_scope_kwarg(scope), **kwargs
+            )
+            self._configured_scope = scope
+
+        async def _exchange_token_client_credentials(self):
+            if self._configured_scope:
+                # Undo the flow's scope selection: explicit config wins.
+                self.context.client_metadata.scope = self._configured_scope
+            return await super()._exchange_token_client_credentials()
+
+
+def build_client_credentials_provider(
+    server_name: str,
+    server_url: str,
+    oauth_config: dict,
+) -> "ClientCredentialsOAuthProvider | None":
+    """Build a headless client_credentials M2M OAuth provider for an MCP server.
+
+    Shared by :func:`build_oauth_auth` and the manager's ``_build_provider`` so
+    both construction paths behave identically. The shared secret is read from
+    ``oauth.client_secret`` — resolve it from a secret via ``${VAR}``; never
+    inline a literal.
+
+    Raises OAuthGrantUnavailableError if the SDK's client_credentials extension
+    is unavailable.
+    """
+    if not _M2M_AVAILABLE:
+        raise OAuthGrantUnavailableError(
+            f"MCP server '{server_name}' is configured for the "
+            "'client_credentials' grant, but this MCP SDK has no "
+            "client_credentials extension. Install 'mcp>=1.26.0'."
+        )
+
+    cfg = dict(oauth_config or {})
+    client_id = _require_client_id(cfg, M2M_GRANT_CLIENT_CREDENTIALS)
+    client_secret = cfg.get("client_secret")
+    if not client_secret:
+        raise ValueError(
+            "MCP OAuth grant 'client_credentials' requires 'oauth.client_secret' "
+            "(resolve it from a secret via ${VAR}; do not inline a literal)."
+        )
+    # An unresolved ``${VAR}`` survives interpolation as its own literal, which
+    # is truthy — so without this the placeholder itself would be sent to the
+    # authorization server as the secret, disclosing the variable name off-host
+    # and returning an opaque invalid_client.
+    if _UNRESOLVED_ENV_REF.search(str(client_secret)):
+        raise ValueError(
+            f"MCP OAuth 'oauth.client_secret' for '{server_name}' still contains "
+            f"an unresolved placeholder ({client_secret}). Set that variable in "
+            "the Hermes .env file."
+        )
+    auth_method = str(
+        cfg.get("token_endpoint_auth_method", "client_secret_basic")
+    ).strip()
+    if auth_method not in ("client_secret_basic", "client_secret_post"):
+        raise ValueError(
+            "MCP OAuth 'token_endpoint_auth_method' must be 'client_secret_basic' "
+            f"or 'client_secret_post' (got {auth_method!r})."
+        )
+    return _HermesClientCredentialsProvider(
+        server_url=server_url,
+        storage=HermesTokenStorage(server_name),
+        client_id=client_id,
+        client_secret=client_secret,
+        token_endpoint_auth_method=auth_method,
+        scope=cfg.get("scope"),
+    )
+
+
+def build_m2m_provider(
+    server_name: str,
+    server_url: str,
+    oauth_config: dict,
+) -> "OAuthClientProvider":
+    """Dispatch to the M2M provider for the configured ``oauth.grant``.
+
+    Raises OAuthGrantUnavailableError if the SDK extension is unavailable, and
+    ValueError for an absent/unknown M2M grant (callers gate with
+    :func:`is_m2m_grant` first, which rejects an unknown grant of its own).
+    """
+    grant = _grant_of(oauth_config)
+    if grant == M2M_GRANT_CLIENT_CREDENTIALS:
+        return build_client_credentials_provider(server_name, server_url, oauth_config)
+    raise ValueError(f"Unknown M2M oauth grant: {grant!r}")
+
+
 def build_oauth_auth(
     server_name: str,
     server_url: str,
@@ -1910,6 +2135,11 @@ def build_oauth_auth(
     apply_oauth_provider_defaults(
         cfg, server_name=server_name, server_url=server_url
     )
+
+    # Headless M2M grant: no browser, no callback, no interactivity gate.
+    if is_m2m_grant(cfg):
+        return build_m2m_provider(server_name, server_url, cfg)
+
     storage = HermesTokenStorage(server_name)
 
     if not _is_interactive() and not storage.has_cached_tokens():

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -2,9 +2,10 @@
 """
 MCP OAuth 2.1 Client Support
 
-Implements the browser-based OAuth 2.1 authorization code flow with PKCE
-for MCP servers that require OAuth authentication instead of static bearer
-tokens.
+Implements the browser-based OAuth 2.1 authorization code flow with PKCE for
+MCP servers that require OAuth authentication instead of static bearer tokens,
+plus a headless ``client_credentials`` grant for machine-to-machine servers
+(selected with ``oauth.grant``; see the M2M section further down).
 
 Uses the MCP Python SDK's ``OAuthClientProvider`` (an ``httpx.Auth`` subclass)
 which handles discovery, dynamic client registration, PKCE, token exchange,
@@ -25,6 +26,8 @@ Configuration in config.yaml::
         url: "https://mcp.example.com/mcp"
         auth: oauth
         oauth:                                  # all fields optional
+          grant: client_credentials             # headless M2M; omit = browser
+          token_endpoint_auth_method: client_secret_basic   # or _post (M2M)
           client_id: "pre-registered-id"        # skip dynamic registration
           client_secret: "secret"               # confidential clients only
           scope: "read write"                   # default: server-provided
@@ -51,7 +54,7 @@ from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse
 from hermes_constants import secure_parent_dir
 
 logger = logging.getLogger(__name__)
@@ -79,6 +82,22 @@ try:
 except ImportError:
     AnyUrl = None  # type: ignore[assignment, misc]
 
+# Machine-to-machine OAuth via the SDK's headless client_credentials extension
+# (mcp>=1.26): the client authenticates with client_id + client_secret — no
+# browser, no callback — and the SDK re-mints on expiry (no refresh_token
+# needed). Optional import so the module still loads on older SDKs.
+_M2M_AVAILABLE = False
+try:
+    from mcp.client.auth.extensions.client_credentials import (
+        ClientCredentialsOAuthProvider,
+    )
+
+    _M2M_AVAILABLE = True
+except ImportError:
+    logger.debug(
+        "MCP client_credentials extension not available -- M2M MCP auth disabled"
+    )
+
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -87,6 +106,15 @@ except ImportError:
 
 class OAuthNonInteractiveError(RuntimeError):
     """Raised when OAuth requires browser interaction in a non-interactive env."""
+
+
+class OAuthGrantUnavailableError(RuntimeError):
+    """Raised when a configured OAuth grant needs SDK support that is absent.
+
+    Deliberately fatal: returning None here would leave the caller connecting
+    with no ``Authorization`` header at all, which fails later and further away
+    — or, against a server that lists tools unauthenticated, appears to succeed.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -1129,6 +1157,210 @@ def _maybe_preregister_client(
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 
+# ---------------------------------------------------------------------------
+# Machine-to-machine (headless client_credentials grant)
+#
+# ``grant: client_credentials`` — client_id + client_secret, via the MCP SDK's
+# ``ClientCredentialsOAuthProvider``. Selected via ``oauth.grant``; default
+# (absent) keeps the interactive authorization_code flow below unchanged. The
+# provider mints reactively on the first 401 and re-mints on expiry inside the
+# SDK's own httpx flow (no refresh_token, no proactive path): unlike
+# authorization_code, ``is_token_valid()`` gates nothing extra for this grant.
+#
+# The only Hermes-side behaviour is the ``client_secret_post`` fix below.
+# ---------------------------------------------------------------------------
+
+M2M_GRANT_CLIENT_CREDENTIALS = "client_credentials"
+_M2M_GRANTS = frozenset({M2M_GRANT_CLIENT_CREDENTIALS})
+# Spelling the interactive grant out is allowed and simply means "the default".
+_INTERACTIVE_GRANTS = frozenset({"authorization_code"})
+# Mirrors mcp_tool._ENV_VAR_PATTERN: an unset ${VAR} keeps its placeholder.
+_UNRESOLVED_ENV_REF = re.compile(r"\$\{[^}]+\}")
+
+
+def _grant_of(oauth_config: dict | None) -> str:
+    if not oauth_config:
+        return ""
+    return str(oauth_config.get("grant", "")).strip().lower()
+
+
+def is_m2m_grant(oauth_config: dict | None) -> bool:
+    """True when the oauth block requests a headless machine-to-machine grant.
+
+    Raises ValueError for a ``grant`` that is present but unrecognised. Falling
+    through to the interactive flow instead would answer a typo'd headless
+    config with "run `hermes mcp login` interactively first" — advice that is
+    impossible to follow on the deployment the operator is configuring.
+    """
+    grant = _grant_of(oauth_config)
+    if not grant:
+        return False
+    if grant in _M2M_GRANTS:
+        return True
+    if grant in _INTERACTIVE_GRANTS:
+        return False
+    raise ValueError(
+        f"Unknown MCP OAuth grant {grant!r}. Supported: "
+        f"{', '.join(sorted(_M2M_GRANTS | _INTERACTIVE_GRANTS))}. "
+        "Omit 'oauth.grant' for the interactive flow."
+    )
+
+
+def _require_client_id(cfg: dict, grant: str) -> str:
+    client_id = cfg.get("client_id")
+    if not client_id:
+        raise ValueError(f"MCP OAuth grant '{grant}' requires 'oauth.client_id'.")
+    return client_id
+
+
+if _M2M_AVAILABLE:
+    import httpx
+
+    class _HermesClientCredentialsProvider(ClientCredentialsOAuthProvider):
+        """SDK provider with the ``client_secret_post`` body made compliant.
+
+        The SDK's ``prepare_token_auth()`` appends only ``client_secret`` for
+        ``client_secret_post``, so a client_credentials token request carries a
+        secret but no client identifier and the authorization server cannot
+        tell which client is calling — RFC 6749 §2.3.1 requires both, and
+        strict servers answer ``invalid_client``.
+
+        Fixed upstream in modelcontextprotocol/python-sdk#2185 (issue #2128),
+        but only on ``main`` (the 2.x line): the 1.x maintenance branch this
+        project pins was never backported, so 1.26.0 *and* the current 1.28.1
+        are both affected. Note that upstream deliberately fixed the shared
+        ``prepare_token_auth`` rather than this exchange method (PRs #2140 and
+        #2213, which patched the method, were rejected) — but that helper hangs
+        off ``OAuthContext``, not off the provider, so overriding the exchange
+        is the only seam available downstream.
+
+        Deliberately written to no-op: once the SDK emits ``client_id`` itself,
+        the field is already present and the request is returned untouched.
+        ``client_secret_basic`` is never affected — there the credentials ride
+        in the Authorization header, which the SDK gets right.
+
+        It also re-applies the configured ``oauth.scope``. The SDK's auth flow
+        runs its scope-selection strategy (``WWW-Authenticate`` scope, else the
+        metadata's ``scopes_supported``, else nothing) and assigns the result
+        over ``client_metadata.scope`` *before* every authorization, so a scope
+        set at construction never reaches the token request. For a
+        machine-to-machine client the operator's configured scope is
+        authoritative — a server-advertised scope must not silently widen it.
+        """
+
+        def __init__(self, *args, scopes: str | None = None, **kwargs) -> None:
+            super().__init__(*args, scopes=scopes, **kwargs)
+            self._configured_scope = scopes
+
+        async def _exchange_token_client_credentials(self) -> "httpx.Request":
+            if self._configured_scope:
+                # Undo the flow's scope selection: explicit config wins.
+                self.context.client_metadata.scope = self._configured_scope
+
+            request = await super()._exchange_token_client_credentials()
+
+            client_info = self.context.client_info
+            if (
+                client_info is None
+                or client_info.token_endpoint_auth_method != "client_secret_post"
+            ):
+                return request
+
+            content_type = request.headers.get("content-type", "")
+            if not content_type.startswith("application/x-www-form-urlencoded"):
+                return request  # Not a form body — nothing safe to rewrite.
+
+            fields = parse_qsl(request.content.decode(), keep_blank_values=True)
+            if any(key == "client_id" for key, _ in fields):
+                return request  # SDK fixed upstream — nothing to do.
+
+            fields.append(("client_id", client_info.client_id))
+            # Drop Content-Length: httpx recomputes it for the new body.
+            headers = {
+                key: value
+                for key, value in request.headers.items()
+                if key.lower() != "content-length"
+            }
+            return httpx.Request(
+                "POST", request.url, content=urlencode(fields), headers=headers
+            )
+
+
+def build_client_credentials_provider(
+    server_name: str,
+    server_url: str,
+    oauth_config: dict,
+) -> "ClientCredentialsOAuthProvider | None":
+    """Build a headless client_credentials M2M OAuth provider for an MCP server.
+
+    Shared by :func:`build_oauth_auth` and the manager's ``_build_provider`` so
+    both construction paths behave identically. The shared secret is read from
+    ``oauth.client_secret`` — resolve it from a secret via ``${VAR}``; never
+    inline a literal.
+
+    Raises OAuthGrantUnavailableError if the SDK's client_credentials extension
+    is unavailable.
+    """
+    if not _M2M_AVAILABLE:
+        raise OAuthGrantUnavailableError(
+            f"MCP server '{server_name}' is configured for the "
+            "'client_credentials' grant, but this MCP SDK has no "
+            "client_credentials extension. Install 'mcp>=1.26.0'."
+        )
+
+    cfg = dict(oauth_config or {})
+    client_id = _require_client_id(cfg, M2M_GRANT_CLIENT_CREDENTIALS)
+    client_secret = cfg.get("client_secret")
+    if not client_secret:
+        raise ValueError(
+            "MCP OAuth grant 'client_credentials' requires 'oauth.client_secret' "
+            "(resolve it from a secret via ${VAR}; do not inline a literal)."
+        )
+    # An unresolved ``${VAR}`` survives interpolation as its own literal, which
+    # is truthy — so without this the placeholder itself would be sent to the
+    # authorization server as the secret, disclosing the variable name off-host
+    # and returning an opaque invalid_client.
+    if _UNRESOLVED_ENV_REF.search(str(client_secret)):
+        raise ValueError(
+            f"MCP OAuth 'oauth.client_secret' for '{server_name}' still contains "
+            f"an unresolved placeholder ({client_secret}). Set that variable in "
+            "the Hermes .env file."
+        )
+    auth_method = str(
+        cfg.get("token_endpoint_auth_method", "client_secret_basic")
+    ).strip()
+    if auth_method not in ("client_secret_basic", "client_secret_post"):
+        raise ValueError(
+            "MCP OAuth 'token_endpoint_auth_method' must be 'client_secret_basic' "
+            f"or 'client_secret_post' (got {auth_method!r})."
+        )
+    return _HermesClientCredentialsProvider(
+        server_url=server_url,
+        storage=HermesTokenStorage(server_name),
+        client_id=client_id,
+        client_secret=client_secret,
+        token_endpoint_auth_method=auth_method,
+        scopes=cfg.get("scope"),
+    )
+
+
+def build_m2m_provider(
+    server_name: str,
+    server_url: str,
+    oauth_config: dict,
+) -> "OAuthClientProvider":
+    """Dispatch to the M2M provider for the configured ``oauth.grant``.
+
+    Raises OAuthGrantUnavailableError if the SDK extension is unavailable, and
+    ValueError for an absent/unknown M2M grant (callers gate with
+    :func:`is_m2m_grant` first, which rejects an unknown grant of its own).
+    """
+    grant = _grant_of(oauth_config)
+    if grant == M2M_GRANT_CLIENT_CREDENTIALS:
+        return build_client_credentials_provider(server_name, server_url, oauth_config)
+    raise ValueError(f"Unknown M2M oauth grant: {grant!r}")
+
+
 def build_oauth_auth(
     server_name: str,
     server_url: str,
@@ -1158,6 +1390,11 @@ def build_oauth_auth(
         return None
 
     cfg = dict(oauth_config or {})  # copy — we mutate _resolved_port
+
+    # Headless M2M grant: no browser, no callback, no interactivity gate.
+    if is_m2m_grant(cfg):
+        return build_m2m_provider(server_name, server_url, cfg)
+
     storage = HermesTokenStorage(server_name)
 
     if not _is_interactive() and not storage.has_cached_tokens():

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -654,7 +654,9 @@ class MCPOAuthManager:
             _maybe_preregister_client,
             _make_callback_waiter,
             _make_redirect_handler,
+            build_m2m_provider,
             cimd_provider_kwargs,
+            is_m2m_grant,
             token_request_user_agent,
         )
 
@@ -667,6 +669,14 @@ class MCPOAuthManager:
         apply_oauth_provider_defaults(
             cfg, server_name=server_name, server_url=entry.server_url
         )
+
+        # Headless M2M grant (client_credentials): no browser, no callback, no
+        # interactivity gate. The SDK's provider mints on the first 401 and
+        # re-mints on expiry (client_credentials — no refresh_token) inside
+        # its own httpx auth flow, so nothing extra is needed here.
+        if is_m2m_grant(cfg):
+            return build_m2m_provider(server_name, entry.server_url, cfg)
+
         storage = HermesTokenStorage(server_name)
 
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
@@ -708,6 +718,23 @@ class MCPOAuthManager:
             token_user_agent=token_request_user_agent(cfg),
             **cimd_provider_kwargs(cfg),
         )
+
+    def is_m2m(
+        self,
+        server_name: str,
+        hermes_home: str | Path | None = None,
+    ) -> bool:
+        """True when this server uses a headless machine-to-machine grant.
+
+        Used to tailor the auth-failure message: an M2M server has no browser
+        ``hermes mcp login`` flow, so prompting for one would be wrong.
+        """
+        entry = self._entries.get(self._key(server_name, hermes_home))
+        if entry is None:
+            return False
+        from tools.mcp_oauth import is_m2m_grant
+
+        return is_m2m_grant(entry.oauth_config)
 
     def remove(
         self,

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -540,12 +540,22 @@ class MCPOAuthManager:
             _maybe_preregister_client,
             _make_callback_waiter,
             _make_redirect_handler,
+            build_m2m_provider,
+            is_m2m_grant,
         )
 
         if not _OAUTH_AVAILABLE:
             return None
 
         cfg = dict(entry.oauth_config or {})
+
+        # Headless M2M grant (client_credentials): no browser, no callback, no
+        # interactivity gate. The SDK's provider mints on the first 401 and
+        # re-mints on expiry (client_credentials — no refresh_token) inside
+        # its own httpx auth flow, so nothing extra is needed here.
+        if is_m2m_grant(cfg):
+            return build_m2m_provider(server_name, entry.server_url, cfg)
+
         storage = HermesTokenStorage(server_name)
 
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
@@ -581,6 +591,23 @@ class MCPOAuthManager:
             callback_handler=callback_handler,
             timeout=float(cfg.get("timeout", 300)),
         )
+
+    def is_m2m(
+        self,
+        server_name: str,
+        hermes_home: str | Path | None = None,
+    ) -> bool:
+        """True when this server uses a headless machine-to-machine grant.
+
+        Used to tailor the auth-failure message: an M2M server has no browser
+        ``hermes mcp login`` flow, so prompting for one would be wrong.
+        """
+        entry = self._entries.get(self._key(server_name, hermes_home))
+        if entry is None:
+            return False
+        from tools.mcp_oauth import is_m2m_grant
+
+        return is_m2m_grant(entry.oauth_config)
 
     def remove(
         self,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3787,6 +3787,43 @@ def _is_auth_error(exc: BaseException) -> bool:
     return True
 
 
+def _needs_reauth_error(server_name: str, *, m2m: bool) -> str:
+    """Build the structured auth-failure payload returned to the model.
+
+    ``m2m`` servers (client_credentials) have no interactive authorization step
+    — the SDK already re-mints on 401, so reaching this point means a freshly
+    minted token was rejected (bad client_id / client secret / scope / gateway
+    audience or group policy). Steer the model at the credentials, not at a
+    re-auth that would mint the same rejected token again.
+    """
+    if m2m:
+        return json.dumps({
+            "error": (
+                f"MCP server '{server_name}' rejected a freshly minted token "
+                f"(machine-to-machine auth). This is a credential/config issue, "
+                f"not a session expiry — check the OAuth client_id, client "
+                f"secret, scopes, and the gateway's audience/group policy. "
+                f"Re-authenticating will NOT help: this grant has no "
+                f"interactive step and mints a new token on every attempt. "
+                f"Do NOT retry this tool."
+            ),
+            "needs_reauth": True,
+            "m2m": True,
+            "server": server_name,
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "error": (
+            f"MCP server '{server_name}' requires re-authentication. "
+            f"Run `hermes mcp login {server_name}` (or delete the tokens "
+            f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
+            f"this tool — ask the user to re-authenticate."
+        ),
+        "needs_reauth": True,
+        "server": server_name,
+    }, ensure_ascii=False)
+
+
 def _handle_auth_error_and_retry(
     server_name: str,
     exc: BaseException,
@@ -3881,16 +3918,7 @@ def _handle_auth_error_and_retry(
     # needs_reauth error. Bumps the circuit breaker so the model stops
     # retrying the tool.
     _bump_server_error(server_name)
-    return json.dumps({
-        "error": (
-            f"MCP server '{server_name}' requires re-authentication. "
-            f"Run `hermes mcp login {server_name}` (or delete the tokens "
-            f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
-            f"this tool — ask the user to re-authenticate."
-        ),
-        "needs_reauth": True,
-        "server": server_name,
-    }, ensure_ascii=False)
+    return _needs_reauth_error(server_name, m2m=manager.is_m2m(server_name))
 
 
 # Substrings (lower-cased match) that indicate the MCP server rejected

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4647,6 +4647,39 @@ def _is_auth_error(exc: BaseException) -> bool:
     return True
 
 
+def _needs_reauth_error(server_name: str, *, m2m: bool) -> str:
+    """Build the structured auth-failure payload returned to the model.
+
+    ``m2m`` servers (client_credentials) have no interactive authorization step
+    — the SDK already re-mints on 401, so reaching this point means a freshly
+    minted token was rejected (bad client_id / client secret / scope / gateway
+    audience or group policy). Steer the model at the credentials, not at a
+    re-auth that would mint the same rejected token again.
+    """
+    if m2m:
+        return tool_error(
+            f"MCP server '{server_name}' rejected a freshly minted token "
+            f"(machine-to-machine auth). This is a credential/config issue, "
+            f"not a session expiry — check the OAuth client_id, client "
+            f"secret, scopes, and the gateway's audience/group policy. "
+            f"Re-authenticating will NOT help: this grant has no "
+            f"interactive step and mints a new token on every attempt. "
+            f"Do NOT retry this tool.",
+            needs_reauth=True,
+            m2m=True,
+            server=server_name,
+        )
+
+    return tool_error(
+        f"MCP server '{server_name}' requires re-authentication. "
+        f"Run `hermes mcp login {server_name}` (or delete the tokens "
+        f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
+        f"this tool — ask the user to re-authenticate.",
+        needs_reauth=True,
+        server=server_name,
+    )
+
+
 def _handle_auth_error_and_retry(
     server_name: str,
     exc: BaseException,
@@ -4741,14 +4774,7 @@ def _handle_auth_error_and_retry(
     # needs_reauth error. Bumps the circuit breaker so the model stops
     # retrying the tool.
     _bump_server_error(server_name)
-    return tool_error(
-        f"MCP server '{server_name}' requires re-authentication. "
-        f"Run `hermes mcp login {server_name}` (or delete the tokens "
-        f"file under ~/.hermes/mcp-tokens/ and restart). Do NOT retry "
-        f"this tool — ask the user to re-authenticate.",
-        needs_reauth=True,
-        server=server_name,
-    )
+    return _needs_reauth_error(server_name, m2m=manager.is_m2m(server_name))
 
 
 # Substrings (lower-cased match) that indicate the MCP server rejected

--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -34,7 +34,7 @@ Hermes prints the exact port it bound to on the `Waiting for callback on ...` li
 | Provider | Loopback port | Tunnel needed? |
 |----------|---------------|----------------|
 | Spotify | `43827` (default) | Yes, when Hermes is remote |
-| MCP servers (`auth: oauth`) | auto-picked per server | Yes, when Hermes is remote (or paste redirect URL) |
+| MCP servers (`auth: oauth`) | auto-picked per server | Yes, when Hermes is remote (or paste redirect URL). No tunnel at all when the server supports the headless [`client_credentials`](../user-guide/features/mcp.md#headless-machine-to-machine-servers-client_credentials) grant |
 | `xai-oauth` (Grok SuperGrok) | n/a | No — device code flow |
 | `anthropic` (Claude Pro/Max) | n/a | No — paste-the-code flow |
 | `openai-codex` (ChatGPT Plus/Pro) | n/a | No — device code flow |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1389,7 +1389,8 @@ Manage MCP (Model Context Protocol) server configurations and run Hermes as an M
 | `catalog` | List Nous-approved MCPs (plain text, scriptable). |
 | `install <name>` | Install a catalog entry (e.g. `hermes mcp install n8n`). |
 | `serve [-v\|--verbose]` | Run Hermes as an MCP server — expose conversations to other agents. |
-| `add <name> [--url URL] [--command CMD] [--auth oauth\|header] [--args ...]` | Add a custom MCP server with automatic tool discovery. `--args` passes the remaining argv to the stdio command, so put it last. |
+| `add <name> [--url URL] [--command CMD] [--auth oauth\|header\|client_credentials] [--args ...]` | Add a custom MCP server with automatic tool discovery. `--args` passes the remaining argv to the stdio command, so put it last. `--auth client_credentials` sets up headless machine-to-machine OAuth (see `--client-id` / `--scope` below). |
+| `add … --auth client_credentials [--client-id ID] [--scope SCOPE]` | Headless M2M OAuth: no browser. Prompts for the client secret and stores it in `~/.hermes/.env`, referencing it from config as `${VAR}`. |
 | `remove <name>` (alias: `rm`) | Remove an MCP server from config. |
 | `list` (alias: `ls`) | List configured MCP servers. |
 | `test <name>` | Test connection to an MCP server. |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1330,7 +1330,8 @@ Manage MCP (Model Context Protocol) server configurations and run Hermes as an M
 | `catalog` | List Nous-approved MCPs (plain text, scriptable). |
 | `install <name>` | Install a catalog entry (e.g. `hermes mcp install n8n`). |
 | `serve [-v\|--verbose]` | Run Hermes as an MCP server — expose conversations to other agents. |
-| `add <name> [--url URL] [--command CMD] [--auth oauth\|header] [--args ...]` | Add a custom MCP server with automatic tool discovery. `--args` passes the remaining argv to the stdio command, so put it last. |
+| `add <name> [--url URL] [--command CMD] [--auth oauth\|header\|client_credentials] [--args ...]` | Add a custom MCP server with automatic tool discovery. `--args` passes the remaining argv to the stdio command, so put it last. `--auth client_credentials` sets up headless machine-to-machine OAuth (see `--client-id` / `--scope` below). |
+| `add … --auth client_credentials [--client-id ID] [--scope SCOPE]` | Headless M2M OAuth: no browser. Prompts for the client secret and stores it in `~/.hermes/.env`, referencing it from config as `${VAR}`. |
 | `remove <name>` (alias: `rm`) | Remove an MCP server from config. |
 | `list` (alias: `ls`) | List configured MCP servers. |
 | `test <name>` | Test connection to an MCP server. |

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -64,7 +64,8 @@ mcp_servers:
 | `idle_timeout_seconds` | number | stdio | Optional stdio server recycle after idle time (`0` disables). May also live under a `lifecycle:` mapping |
 | `max_lifetime_seconds` | number | stdio | Optional stdio server recycle after age (`0` disables). May also live under a `lifecycle:` mapping |
 | `tools` | mapping | both | Filtering and utility-tool policy |
-| `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
+| `auth` | string | HTTP | Authentication method. Set to `oauth` for OAuth 2.1 — interactive PKCE by default, or headless machine-to-machine via `oauth.grant` |
+| `oauth` | mapping | HTTP | OAuth settings. See [OAuth 2.1 authentication](#oauth-21-authentication) for the interactive flow, [Machine-to-machine](#machine-to-machine-client_credentials) for the headless grant |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
 | `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`). Form-mode requests route through the approval surface; URL-mode is declined (see MCP guide) |
 | `trust` | string | both | Trust tier: `full` (default) or `untrusted`. On an `untrusted` server, every write-capable tool call (any tool without a `readOnlyHint: true` annotation) requires user approval through the standard approval surface before it runs. `readOnlyHint` is a server-supplied *hint* — a lying server can at most skip approval for tools it claims are read-only, never gain extra access — so mark any server you don't fully control as `untrusted`. Unrecognized values are treated as `untrusted` (fail-closed) |
@@ -378,6 +379,45 @@ mcp_servers:
 `client_metadata_url` must be an HTTPS URL with a path (no bare origin, no fragment, no userinfo, no `.`/`..` segments) that returns `200` and `Content-Type: application/json` with **no redirect** — authorization servers are forbidden from following redirects when fetching it. Hermes still pins its callback to the same `27890`–`27894` range, so a self-hosted document must declare all ten loopback URIs (`http://127.0.0.1:<port>/callback` and `http://localhost:<port>/callback` for each port), and its `client_id` must be its own URL.
 
 `user_agent` replaces the HTTP library's default `User-Agent` on **token-endpoint requests only** (authorization-code exchange and refresh) — some authorization servers and WAFs reject the default `python-httpx/...` value there. It never applies to MCP traffic or OAuth discovery, and no other token-request headers are configurable. Empty or null values are ignored.
+
+
+### Machine-to-machine (`client_credentials`)
+
+The interactive flow above needs a human at first connect. For a **headless**
+deployment (a daemon/gateway with no browser), set `oauth.grant:
+client_credentials` to use the SDK's client-credentials extension: the client
+authenticates with a client ID + shared secret — no browser, no callback. Keep
+the secret in a secret store and reference it via `${VAR}`; never inline it.
+
+You can also add this server with the CLI wizard:
+`hermes mcp add gateway --url https://gateway.internal/mcp --auth client_credentials`
+(it prompts for the client ID, secret, and scope).
+
+```yaml
+mcp_servers:
+  gateway:
+    url: "https://gateway.internal/mcp"
+    auth: oauth
+    oauth:
+      grant: client_credentials
+      client_id: "my-client"
+      client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from ~/.hermes/.env — never inline
+      scope: "profile"
+      # token_endpoint_auth_method: client_secret_basic   # or client_secret_post (default: basic)
+```
+
+Behavior:
+- Fully headless: no browser, no local callback server, no interactivity gate
+- The token is a client-credentials access token, **re-minted automatically on
+  expiry** — the SDK re-runs the exchange on a 401 (no `refresh_token` required)
+- The authorization server is discovered from the MCP server's protected-resource
+  metadata (RFC 9728) — no token endpoint to configure by hand
+- An explicitly configured `scope` is authoritative — a scope advertised by the
+  server does not override it
+- The secret is referenced (env var), never stored in config; an unresolved
+  `${VAR}` is rejected up front rather than sent as the secret
+- If a *freshly minted* token is rejected, the error points at the client
+  credentials / scopes / gateway policy — there is no interactive re-auth
 
 ## Add to Hermes link
 

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -59,7 +59,8 @@ mcp_servers:
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
 | `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |
 | `tools` | mapping | both | Filtering and utility-tool policy |
-| `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
+| `auth` | string | HTTP | Authentication method. Set to `oauth` for OAuth 2.1 — interactive PKCE by default, or headless machine-to-machine via `oauth.grant` |
+| `oauth` | mapping | HTTP | OAuth settings. See [OAuth 2.1 authentication](#oauth-21-authentication) for the interactive flow, [Machine-to-machine](#machine-to-machine-client_credentials) for the headless grant |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
 
 ## `tools` policy keys
@@ -290,3 +291,41 @@ Behavior:
 - Tokens are persisted to `~/.hermes/mcp-tokens/<server>.json` and reused across sessions
 - Token refresh is automatic; re-authorization only happens when refresh fails
 - Only applies to HTTP/StreamableHTTP transport (`url`-based servers)
+
+### Machine-to-machine (`client_credentials`)
+
+The interactive flow above needs a human at first connect. For a **headless**
+deployment (a daemon/gateway with no browser), set `oauth.grant:
+client_credentials` to use the SDK's client-credentials extension: the client
+authenticates with a client ID + shared secret — no browser, no callback. Keep
+the secret in a secret store and reference it via `${VAR}`; never inline it.
+
+You can also add this server with the CLI wizard:
+`hermes mcp add gateway --url https://gateway.internal/mcp --auth client_credentials`
+(it prompts for the client ID, secret, and scope).
+
+```yaml
+mcp_servers:
+  gateway:
+    url: "https://gateway.internal/mcp"
+    auth: oauth
+    oauth:
+      grant: client_credentials
+      client_id: "my-client"
+      client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from ~/.hermes/.env — never inline
+      scope: "profile"
+      # token_endpoint_auth_method: client_secret_basic   # or client_secret_post (default: basic)
+```
+
+Behavior:
+- Fully headless: no browser, no local callback server, no interactivity gate
+- The token is a client-credentials access token, **re-minted automatically on
+  expiry** — the SDK re-runs the exchange on a 401 (no `refresh_token` required)
+- The authorization server is discovered from the MCP server's protected-resource
+  metadata (RFC 9728) — no token endpoint to configure by hand
+- An explicitly configured `scope` is authoritative — a scope advertised by the
+  server does not override it
+- The secret is referenced (env var), never stored in config; an unresolved
+  `${VAR}` is rejected up front rather than sent as the secret
+- If a *freshly minted* token is rejected, the error points at the client
+  credentials / scopes / gateway policy — there is no interactive re-auth

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -255,6 +255,8 @@ mcp_servers:
 Or: `hermes mcp install figma`, then `hermes mcp login figma`.
 :::
 
+This section covers the **interactive** flow — a human approves in a browser once. If the server instead issues you a client ID and secret (typical for an internal gateway), skip to [Headless machine-to-machine servers](#headless-machine-to-machine-servers-client_credentials): that flow never opens a browser at all.
+
 ```yaml
 mcp_servers:
   linear:
@@ -280,7 +282,7 @@ mcp_servers:
       redirect_uri: "https://oauth.example.ts.net/callback"
 ```
 
-For fully headless gateways (messaging bot, no interactive terminal at all), the optional [`mcp-oauth-remote-gateway` skill](../skills/optional/mcp/mcp-mcp-oauth-remote-gateway.md) walks the agent through completing the flow manually and writing tokens where Hermes expects them.
+For fully headless gateways (messaging bot, no interactive terminal at all), the optional [`mcp-oauth-remote-gateway` skill](../skills/optional/mcp/mcp-mcp-oauth-remote-gateway.md) walks the agent through completing the flow manually and writing tokens where Hermes expects them. That workaround is only needed when the server *requires* the interactive grant — if it can issue you a client ID and secret, use [`client_credentials`](#headless-machine-to-machine-servers-client_credentials) instead and no manual step is involved.
 
 **Pitfall — WAF rejects `127.0.0.1` redirect URIs.** A few providers front their authorization server with a WAF that 403s any authorize request whose query string contains a literal `127.0.0.1` (Reclaim.ai's AWS API Gateway is a known example — every attempt returns `{"message":"Forbidden"}` before reaching the OAuth app). Set `oauth.redirect_host: localhost` to use `http://localhost:<port>/callback` instead; the callback listener still binds `127.0.0.1` either way.
 
@@ -301,6 +303,45 @@ mcp_servers:
 Then run `hermes mcp login googledrive` — with the pre-registered client, Hermes skips registration and runs the normal browser authorization flow.
 
 **Pitfall — config auto-reload race.** When you edit `~/.hermes/config.yaml` from inside a running Hermes session, the CLI auto-reloads MCP connections with a 30s timeout. That's not enough for an interactive OAuth flow. Add the entry, then run `hermes mcp login <server>` from a fresh terminal — it waits the full 5 minutes for you to complete auth.
+
+### Headless machine-to-machine servers (`client_credentials`)
+
+The flow above needs a human at a browser once. That is a problem for a deployment with no browser at all — a gateway, a daemon, a messaging bot on a server. When the MCP server can issue you a **client ID and secret** (typical for an internal or self-hosted gateway), set `oauth.grant: client_credentials` and Hermes authenticates machine-to-machine: no browser, no callback listener, no interactive gate.
+
+Add it with the wizard:
+
+```bash
+hermes mcp add gateway --url https://gateway.internal/mcp --auth client_credentials
+```
+
+It prompts for the client ID, the secret, and an optional scope. The secret is written to `~/.hermes/.env` and referenced from `config.yaml` as `${VAR}`, so it never lands in the config file:
+
+```yaml
+mcp_servers:
+  gateway:
+    url: "https://gateway.internal/mcp"
+    auth: oauth
+    oauth:
+      grant: client_credentials
+      client_id: "my-client"
+      client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from ~/.hermes/.env
+      scope: "profile"
+```
+
+What changes compared with the interactive flow:
+
+- **Nothing to approve.** The first request goes out unauthenticated; the server answers `401`, Hermes discovers the authorization server from the protected-resource metadata it points at (RFC 9728), exchanges the client credentials for an access token, and replays the request. All of it without a prompt.
+- **No `refresh_token`.** The grant does not use one — the token is simply minted again when it expires. There is no stale-refresh failure mode and nothing to re-authorize.
+- **Tokens are still cached** at `~/.hermes/mcp-tokens/<server>.json` (0600), exactly as for the interactive flow, so a restart reuses a valid token instead of minting a new one.
+- **No interactive re-auth.** `hermes mcp login <server>` still works and forces a fresh mint (useful after you change scopes or rotate the secret), but it will not open a browser.
+- **`hermes mcp test <server>`** reports `Auth: OAuth client_credentials (headless M2M)` so you can tell the two modes apart.
+- **The configured `scope` is authoritative.** Whatever the server advertises, Hermes requests exactly the scope you set — it is never silently widened. If the server needs a different one, set it here.
+
+**Rotating the secret.** Re-running `hermes mcp add` keeps the value already in `~/.hermes/.env` — it will not prompt again. To rotate, edit `MCP_<SERVER>_CLIENT_SECRET` in that file, then run `hermes mcp login <server>` to discard the cached token and mint a new one.
+
+**Troubleshooting.** If a tool call comes back saying the server rejected a *freshly minted* token, it is not a session expiry — re-authenticating would mint the same token again. Check the client ID and secret, the scopes you requested, and the audience or group policy on the gateway side.
+
+See the [MCP Config Reference](../../reference/mcp-config-reference.md#machine-to-machine-client_credentials) for the `client_credentials` keys, including `token_endpoint_auth_method`.
 
 ## mTLS / client certificates
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -213,6 +213,8 @@ Use HTTP servers when:
 
 Most hosted MCP servers (Linear, Sentry, Atlassian, Asana, Figma, Stripe, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, dynamic client registration, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.
 
+This section covers the **interactive** flow — a human approves in a browser once. If the server instead issues you a client ID and secret (typical for an internal gateway), skip to [Headless machine-to-machine servers](#headless-machine-to-machine-servers-client_credentials): that flow never opens a browser at all.
+
 ```yaml
 mcp_servers:
   linear:
@@ -238,7 +240,7 @@ mcp_servers:
       redirect_uri: "https://oauth.example.ts.net/callback"
 ```
 
-For fully headless gateways (messaging bot, no interactive terminal at all), the optional [`mcp-oauth-remote-gateway` skill](../skills/optional/mcp/mcp-mcp-oauth-remote-gateway.md) walks the agent through completing the flow manually and writing tokens where Hermes expects them.
+For fully headless gateways (messaging bot, no interactive terminal at all), the optional [`mcp-oauth-remote-gateway` skill](../skills/optional/mcp/mcp-mcp-oauth-remote-gateway.md) walks the agent through completing the flow manually and writing tokens where Hermes expects them. That workaround is only needed when the server *requires* the interactive grant — if it can issue you a client ID and secret, use [`client_credentials`](#headless-machine-to-machine-servers-client_credentials) instead and no manual step is involved.
 
 **Pitfall — WAF rejects `127.0.0.1` redirect URIs.** A few providers front their authorization server with a WAF that 403s any authorize request whose query string contains a literal `127.0.0.1` (Reclaim.ai's AWS API Gateway is a known example — every attempt returns `{"message":"Forbidden"}` before reaching the OAuth app). Set `oauth.redirect_host: localhost` to use `http://localhost:<port>/callback` instead; the callback listener still binds `127.0.0.1` either way.
 
@@ -259,6 +261,45 @@ mcp_servers:
 Then run `hermes mcp login googledrive` — with the pre-registered client, Hermes skips registration and runs the normal browser authorization flow.
 
 **Pitfall — config auto-reload race.** When you edit `~/.hermes/config.yaml` from inside a running Hermes session, the CLI auto-reloads MCP connections with a 30s timeout. That's not enough for an interactive OAuth flow. Add the entry, then run `hermes mcp login <server>` from a fresh terminal — it waits the full 5 minutes for you to complete auth.
+
+### Headless machine-to-machine servers (`client_credentials`)
+
+The flow above needs a human at a browser once. That is a problem for a deployment with no browser at all — a gateway, a daemon, a messaging bot on a server. When the MCP server can issue you a **client ID and secret** (typical for an internal or self-hosted gateway), set `oauth.grant: client_credentials` and Hermes authenticates machine-to-machine: no browser, no callback listener, no interactive gate.
+
+Add it with the wizard:
+
+```bash
+hermes mcp add gateway --url https://gateway.internal/mcp --auth client_credentials
+```
+
+It prompts for the client ID, the secret, and an optional scope. The secret is written to `~/.hermes/.env` and referenced from `config.yaml` as `${VAR}`, so it never lands in the config file:
+
+```yaml
+mcp_servers:
+  gateway:
+    url: "https://gateway.internal/mcp"
+    auth: oauth
+    oauth:
+      grant: client_credentials
+      client_id: "my-client"
+      client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from ~/.hermes/.env
+      scope: "profile"
+```
+
+What changes compared with the interactive flow:
+
+- **Nothing to approve.** The first request goes out unauthenticated; the server answers `401`, Hermes discovers the authorization server from the protected-resource metadata it points at (RFC 9728), exchanges the client credentials for an access token, and replays the request. All of it without a prompt.
+- **No `refresh_token`.** The grant does not use one — the token is simply minted again when it expires. There is no stale-refresh failure mode and nothing to re-authorize.
+- **Tokens are still cached** at `~/.hermes/mcp-tokens/<server>.json` (0600), exactly as for the interactive flow, so a restart reuses a valid token instead of minting a new one.
+- **No interactive re-auth.** `hermes mcp login <server>` still works and forces a fresh mint (useful after you change scopes or rotate the secret), but it will not open a browser.
+- **`hermes mcp test <server>`** reports `Auth: OAuth client_credentials (headless M2M)` so you can tell the two modes apart.
+- **The configured `scope` is authoritative.** Whatever the server advertises, Hermes requests exactly the scope you set — it is never silently widened. If the server needs a different one, set it here.
+
+**Rotating the secret.** Re-running `hermes mcp add` keeps the value already in `~/.hermes/.env` — it will not prompt again. To rotate, edit `MCP_<SERVER>_CLIENT_SECRET` in that file, then run `hermes mcp login <server>` to discard the cached token and mint a new one.
+
+**Troubleshooting.** If a tool call comes back saying the server rejected a *freshly minted* token, it is not a session expiry — re-authenticating would mint the same token again. Check the client ID and secret, the scopes you requested, and the audience or group policy on the gateway side.
+
+See the [MCP Config Reference](../../reference/mcp-config-reference.md#machine-to-machine-client_credentials) for the `client_credentials` keys, including `token_endpoint_auth_method`.
 
 ## mTLS / client certificates
 


### PR DESCRIPTION
## What does this PR do?

Adds non-interactive OAuth 2.0 **`client_credentials`** auth for HTTP MCP servers, so a **headless** Hermes deployment (a gateway/daemon with no browser) can authenticate to an OAuth-fronted MCP server without the interactive PKCE browser flow.

Today `auth: oauth` only supports the interactive `authorization_code` + PKCE flow, which needs a human at first connect. `tools/mcp_oauth_manager.py` explicitly refuses to proceed in a non-interactive environment with no cached tokens, so a machine-to-machine server behind an OAuth gateway simply cannot be reached from a daemon. This wires the MCP SDK's own `ClientCredentialsOAuthProvider` behind a new `oauth.grant: client_credentials`.

This has been running in a production deployment (an internal MCP gateway fronted by an identity provider, `client_credentials` + a service account): token minted at runtime, group-scoped RBAC enforced by the gateway, tools served.

## Related Issue / prior art

No open issue. Two earlier `client_credentials` proposals are open but stalled: #30613 and #46488 (the latter labeled `duplicate`). This PR is a different approach, not a third attempt at the same one:

|  | #30613 / #46488 | This PR |
|---|---|---|
| Token exchange | hand-rolled minter (#46488 adds a new `tools/mcp_client_credentials.py`) | the SDK's `ClientCredentialsOAuthProvider`, already shipped in the pinned `mcp` |
| Token endpoint | configured by hand (#46488 hardcodes a per-vendor default) | discovered from the server's protected-resource metadata (RFC 9728) — nothing to configure |
| Config surface | a new top-level `auth:` value | `auth: oauth` + `oauth.grant`, so the existing `oauth.*` keys keep working |
| Token storage | in-memory (#46488) | the existing `HermesTokenStorage`, so `hermes mcp login/reauth`, the cache-invalidation hook and the 401 handler all apply unchanged |

The practical consequence of riding the SDK provider is that this touches very little: no new module, no second auth lane to keep in sync with the interactive one.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/mcp_oauth.py` — `is_m2m_grant` / `build_client_credentials_provider` / `build_m2m_provider`; the M2M grant is routed in `build_oauth_auth` before the interactivity gate.
- `tools/mcp_oauth_manager.py` — M2M branch in `_build_provider`, plus an `is_m2m` accessor.
- `tools/mcp_tool.py` — grant-aware auth-failure message: this grant has no interactive step, so a rejected *freshly minted* token points at credentials/scopes/gateway policy rather than at a re-auth that would mint the same token again.
- `hermes_cli/subcommands/mcp.py`, `hermes_cli/mcp_config.py` — `hermes mcp add --auth client_credentials` wizard (`--client-id` / `--scope`; prompts for the secret, stores it in `.env`, references it as `${VAR}`); `hermes mcp test` shows the M2M auth mode.
- Docs — the two surfaces flagged in review (below), plus `mcp-config-reference.md`, a pointer from the OAuth-over-SSH guide, and `cli-config.yaml.example`.
- Tests — unit coverage plus a hermetic integration test (below).

Behavior: fully headless (no browser, no callback listener); tokens are re-minted on expiry (this grant issues no `refresh_token`); the secret is referenced via `${VAR}`, never written to config. Default (grant absent) keeps the interactive flow byte-for-byte unchanged.

## Review feedback addressed

Both items from the automated review:

- **Documentation.** `website/docs/reference/cli-commands.md` (the `hermes mcp add` auth list) and `website/docs/user-guide/features/mcp.md` (which described `auth: oauth` as browser-PKCE only) are updated. While there I also fixed the `auth` row in `mcp-config-reference.md`, which still claimed "OAuth 2.1 with PKCE", and added a pointer from `guides/oauth-over-ssh.md`, since that is where a headless operator lands.
- **Integration test.** `tests/tools/test_mcp_oauth_client_credentials_integration.py` drives the real SDK provider through a real client from the SDK's own HTTP stack against a real HTTP server on an ephemeral loopback port — no `MockTransport`, no patched SDK internals. It asserts the full runtime sequence (401 → protected-resource metadata → authorization-server metadata → token exchange → authenticated retry), that dynamic client registration is never reached, that both client-authentication methods and the configured scope land correctly, and that a rejected token is re-minted rather than refreshed. The protected-resource document is served only at an unguessable path advertised in `WWW-Authenticate`, so the RFC 9728 hint is load-bearing rather than incidentally satisfied by the SDK's well-known fallback.

Writing that test surfaced two real defects. One was ours, and it is the reason this PR still carries a provider subclass:

- **`oauth.scope` never reached the token request.** The SDK's auth flow runs its scope-selection strategy and assigns the result over `client_metadata.scope` before *every* authorization, so a scope set at construction was always discarded — the `--scope` flag was inert. The configured scope is now re-applied before the exchange and is authoritative: a scope advertised by the server does not silently widen it.

The other was an upstream SDK bug on the 1.x line, since fixed and shipped in the 2.x line this repo pins; the workaround this PR used to carry has been dropped. See the subclass section below.

I also made four failure modes explicit rather than silent, per the project's "surface failures early" rule: an unknown `oauth.grant` is rejected instead of falling through to the browser flow (which would tell a headless deployment to run `hermes mcp login`); a missing SDK extension raises instead of returning `None`, which left the caller connecting with no `Authorization` header at all; an unresolved `${VAR}` is rejected instead of being sent as the secret; and a failed `hermes mcp login` on an M2M server no longer prints the client-registration guidance, which recommended inlining the secret in `config.yaml`.

## Why there is a provider subclass

One thin subclass remains, for one reason, so it is worth being explicit about it.

The SDK's auth flow applies a scope-selection strategy before *every* authorization: it assigns `get_client_metadata_scopes(...)` over `client_metadata.scope`, and that helper reads the `WWW-Authenticate` scope, then the protected-resource metadata's `scopes_supported`, then the authorization server's — **never the scope the client was constructed with**. A configured `oauth.scope` therefore never reaches the token request, which is what made the `--scope` flag inert before this PR.

For a machine-to-machine client that is the wrong precedence. The operator picked the scope deliberately, and a scope the server merely advertises must not silently widen it. The subclass re-applies the configured value before the exchange. The selection assigns onto `OAuthContext` rather than onto the provider, so overriding the exchange is the only seam available to a downstream consumer — happy to take a different shape if you would rather expose one.

The subclass also reads the scope keyword from the installed constructor signature instead of inferring it from a version number: mcp 2.0 renamed the `ClientCredentialsOAuthProvider` argument from `scopes` to `scope`, and the wrong spelling is a `TypeError` at construction. On a headless deployment that means every M2M server fails to authenticate at startup rather than degrading, so it seemed worth resolving the way `sdk_httpx()` already resolves the 1.x/2.x HTTP-stack split. It also keeps the extra installable at either generation.

**What used to be here.** An earlier revision of this PR carried a second workaround: under `token_endpoint_auth_method: client_secret_post` the 1.x SDK put only `client_secret` in the token body and never `client_id`, so the authorization server could not identify the caller (RFC 6749 §2.3.1 requires both; strict servers answered `invalid_client`). That is modelcontextprotocol/python-sdk#2128, closed by #2185, which landed on `main` and shipped in the 2.x line this repo now pins — `prepare_token_auth` emits `client_id` itself. The workaround has been dropped rather than carried as dead code. The integration test that covered it stays, reframed as the guard on that removal: an SDK regressing here fails the test loudly instead of surfacing as `invalid_client` against a live authorization server.

## Known limitation (pre-existing, not introduced here)

`_handle_auth_error_and_retry` treats every `OAuthTokenError` as an auth failure, and the SDK raises that for *any* non-200 from the token endpoint — 5xx included. So a transient authorization-server outage is reported to the model as a credential problem and trips the circuit breaker. The interactive path has the same misclassification today (it advises `hermes mcp login`), so I left it alone rather than widen this PR; happy to follow up separately if you'd like it fixed.

## How to Test

Config-only:

```yaml
mcp_servers:
  gateway:
    url: https://your-gateway/mcp
    auth: oauth
    oauth:
      grant: client_credentials
      client_id: my-client
      client_secret: "${MCP_GATEWAY_CLIENT_SECRET}"   # from .env
      scope: profile
```

…or the wizard: `hermes mcp add gateway --url https://your-gateway/mcp --auth client_credentials`

Automated (no network required):

```
pytest tests/tools/test_mcp_oauth_client_credentials.py \
       tests/tools/test_mcp_oauth_client_credentials_integration.py \
       tests/hermes_cli/test_mcp_config.py -q
```

Regression across the MCP OAuth surface (`tests/tools/test_mcp_oauth*.py`, `test_mcp_tool.py`, `tests/hermes_cli/test_mcp_*.py`): 19 files, 328 passed, 0 failed. `ruff check` clean. Re-measured on this rebase, against `mcp==2.0.0`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(mcp):`)
- [x] I searched for existing PRs (see prior art above)
- [x] My PR contains **only** changes related to this feature
- [x] I've run the tests and they pass

