### PR TITLE
fix(kanban): inherit notify subscriptions for child tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2680,6 +2680,7 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -2700,6 +2701,47 @@ def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> l
     ).fetchall()
     present = {r["id"] for r in rows}
     return [p for p in parents if p not in present]
+
+
+def _inherit_notify_subs(
+    conn: sqlite3.Connection,
+    child_id: str,
+    parents: Iterable[str],
+    *,
+    created_at: Optional[int] = None,
+) -> None:
+    """Copy gateway notification subscriptions from parent tasks to a child.
+
+    The inherited subscription starts caught up to the child's current event
+    cursor. This makes manual `link_tasks(parent, existing_child)` safe: the
+    parent chat receives future child terminal events without replaying the
+    child's pre-link history.
+    """
+    parent_ids = tuple(dict.fromkeys(p for p in parents if p))
+    if not parent_ids:
+        return
+    row = conn.execute(
+        "SELECT COALESCE(MAX(id), 0) AS cursor FROM task_events WHERE task_id = ?",
+        (child_id,),
+    ).fetchone()
+    cursor = int(row["cursor"] if row is not None else 0)
+    placeholders = ",".join("?" * len(parent_ids))
+    conn.execute(
+        f"""
+        INSERT OR IGNORE INTO kanban_notify_subs
+            (task_id, platform, chat_id, thread_id, user_id,
+             notifier_profile, created_at, last_event_id)
+        SELECT ?, platform, chat_id, thread_id, user_id, notifier_profile, ?, ?
+          FROM kanban_notify_subs
+         WHERE task_id IN ({placeholders})
+        """,
+        (
+            child_id,
+            int(created_at if created_at is not None else time.time()),
+            cursor,
+            *parent_ids,
+        ),
+    )
 
 
 def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
@@ -2838,6 +2880,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},
         )
+        _inherit_notify_subs(conn, child_id, (parent_id,))
 
 
 def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
@@ -5132,6 +5175,7 @@ def decompose_triage_task(
                 conn, new_id, "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
             )
+            _inherit_notify_subs(conn, new_id, (task_id,), created_at=now)
             child_ids.append(new_id)
 
         # Link children to their sibling parents (within the decomposed graph).

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -26,6 +26,109 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def _assert_inherited_notify_sub(subs: list[dict]) -> None:
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat1"
+    assert subs[0]["thread_id"] == "topic1"
+    assert subs[0]["user_id"] == "user1"
+    assert subs[0]["notifier_profile"] == "default"
+
+
+def test_create_task_inherits_parent_notify_subscriptions(kanban_home):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="worker1")
+        kb.add_notify_sub(
+            conn,
+            task_id=parent,
+            platform="telegram",
+            chat_id="chat1",
+            thread_id="topic1",
+            user_id="user1",
+            notifier_profile="default",
+        )
+
+        child = kb.create_task(conn, title="child", parents=[parent], assignee="worker1")
+
+        subs = kb.list_notify_subs(conn, child)
+    finally:
+        conn.close()
+
+    _assert_inherited_notify_sub(subs)
+
+
+def test_link_tasks_inherits_parent_notify_subscriptions_without_replaying_old_child_events(kanban_home):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="worker1")
+        child = kb.create_task(conn, title="child", assignee="worker1")
+        with kb.write_txn(conn):
+            kb._append_event(conn, child, kind="blocked", payload={"reason": "old"})
+        kb.add_notify_sub(
+            conn,
+            task_id=parent,
+            platform="telegram",
+            chat_id="chat1",
+            thread_id="topic1",
+            user_id="user1",
+            notifier_profile="default",
+        )
+
+        kb.link_tasks(conn, parent, child)
+
+        subs = kb.list_notify_subs(conn, child)
+        _, old_events = kb.unseen_events_for_sub(
+            conn,
+            task_id=child,
+            platform="telegram",
+            chat_id="chat1",
+            thread_id="topic1",
+            kinds=["blocked"],
+        )
+    finally:
+        conn.close()
+
+    _assert_inherited_notify_sub(subs)
+    assert old_events == []
+
+
+def test_decompose_triage_task_inherits_root_notify_subscriptions(kanban_home):
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="triage root", triage=True, assignee="orchestrator")
+        kb.add_notify_sub(
+            conn,
+            task_id=root,
+            platform="telegram",
+            chat_id="chat1",
+            thread_id="topic1",
+            user_id="user1",
+            notifier_profile="default",
+        )
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "first child", "assignee": "worker1"},
+                {"title": "second child", "assignee": "worker2", "parents": [0]},
+            ],
+            author="triager",
+            auto_promote=False,
+        )
+
+        assert child_ids is not None
+        child_subs = [kb.list_notify_subs(conn, child_id) for child_id in child_ids]
+    finally:
+        conn.close()
+
+    assert len(child_subs) == 2
+    for subs in child_subs:
+        _assert_inherited_notify_sub(subs)
+
+
 @pytest.mark.asyncio
 async def test_notifier_unsubs_after_completed_event(kanban_home):
     """


### PR DESCRIPTION
## What does this PR do?

Inherits gateway Kanban notification subscriptions from parent tasks to child tasks, so a chat subscribed to the original task keeps receiving terminal updates when that task fans out into child work.

This covers all task-child creation paths in `hermes_cli.kanban_db`:

- `create_task(..., parents=[...])`
- `link_tasks(parent, child)`
- `decompose_triage_task(...)`

Inherited subscriptions start at the child's current task-event cursor. That matters for `link_tasks(parent, existing_child)`: the parent chat should receive future child terminal events, but should not replay the child's pre-link history.

## Related Issue

No public issue found in the duplicate/sibling search. This is a narrow correctness fix for Kanban notification continuity.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Adds `_inherit_notify_subs()` to copy parent `kanban_notify_subs` rows to child tasks.
  - Wires inheritance into parent-linked task creation, manual task linking, and triage decomposition.
  - Initializes inherited `last_event_id` to the child's current max event id to avoid replaying old child events.

- `tests/hermes_cli/test_kanban_notify.py`
  - Adds regression coverage for `create_task(..., parents=[...])` inheritance.
  - Adds regression coverage for `link_tasks()` inheritance without old child-event replay.
  - Adds regression coverage for `decompose_triage_task()` child notification inheritance.

## How to Test

RED check on current `origin/main` with the new tests only:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py -q -k 'inherits_parent_notify or decompose_triage_task_inherits or link_tasks_inherits'
# 3 failed: no inherited child subscriptions on current main
```

Verification after the fix:

```bash
python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_notify.py
scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py -q
python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_notify.py
python scripts/check-windows-footguns.py --diff origin/main
git diff --check
```

Observed result:

```text
407 tests passed, 0 failed
ruff: All checks passed
Windows footguns: none found
git diff --check: clean
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits: `fix(kanban): ...`.
- [x] I searched existing open and closed PRs/issues for duplicates.
- [x] The branch contains only this Kanban notification-inheritance fix.
- [ ] Full `pytest tests/ -q` not run; focused Kanban suites passed.
- [x] I've added tests for the change.
- [x] Tested on Linux/WSL.

### Documentation & Housekeeping

- [x] Documentation update: N/A, internal Kanban DB behavior.
- [x] `cli-config.yaml.example`: N/A, no config changes.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no workflow/architecture rule changes.
- [x] Cross-platform impact considered: pure Python/SQLite logic; Windows footgun check passed.
- [x] Tool descriptions/schemas: N/A, no tool schema changes.
