### PR TITLE
fix(search): enforce hidden-dir exclusion consistently; add include_hidden opt-in; surface glob errors

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -401,6 +401,7 @@ class TestSearchHandler:
         mock_ops.search.assert_called_once_with(
             pattern="class", path="/src", target="files", file_glob="*.py",
             limit=10, offset=5, output_mode="count", context=2,
+            include_hidden=False,
         )
 
     @patch("tools.file_tools._get_file_ops")
@@ -416,6 +417,7 @@ class TestSearchHandler:
         mock_ops.search.assert_called_once_with(
             pattern="class", path="/src", target="files", file_glob=None,
             limit=1, offset=0, output_mode="content", context=0,
+            include_hidden=False,
         )
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_search_hidden_optin.py
+++ b/tests/tools/test_search_hidden_optin.py
@@ -1,0 +1,124 @@
+"""Hidden-dir search: consistent default exclusion + explicit ``include_hidden`` opt-in.
+
+Companion to ``test_search_hidden_dirs.py`` (#1558 — hidden caches can carry
+adversarial text, so search excludes dotdirs by default; that contract is kept).
+This file pins the two halves that were missing and sent a production agent into
+a 90-iteration retry loop hunting files that existed the whole time:
+
+1. **Consistency.** rg's own hidden pruning is glob-dependent — a ``-g`` glob is
+   also tested against directory *names* during traversal, so ``-g '*'``
+   descended into hidden trees (leaking exactly what #1558 excludes) while any
+   specific glob (``'*config*'``) pruned them and silently returned
+   ``{"total_count": 0}`` for files a ``'*'`` listing had just shown. The model
+   was told two contradicting answers about the same tree. Now one post-hoc
+   filter gives every pattern and backend the same answer.
+2. **Discoverability.** A caller that legitimately needs a dotdir (on agent
+   installs the whole working tree may live under one) has explicit paths:
+   ``include_hidden=true``, or passing the hidden directory as ``path=`` —
+   and a glob parse failure surfaces as an error instead of a silent 0.
+"""
+
+import shutil
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+
+
+requires_rg = pytest.mark.skipif(
+    shutil.which("rg") is None, reason="ripgrep not installed")
+
+
+@pytest.fixture
+def hidden_tree(tmp_path):
+    """A home-like tree whose real content lives under a hidden root."""
+    scripts = tmp_path / ".agenthome" / "skills" / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "preflight.py").write_text("print('needle_content')\n")
+    (tmp_path / ".agenthome" / "config.yaml").write_text("timezone: UTC\n")
+    (tmp_path / "VISIBLE.md").write_text("plain visible file\n")
+    return tmp_path
+
+
+def _ops(root):
+    return ShellFileOperations(LocalEnvironment(cwd=str(root)), cwd=str(root))
+
+
+# ---------------------------------------------------------------- consistency
+@requires_rg
+def test_bare_star_no_longer_leaks_hidden_files(hidden_tree):
+    """'-g *' matched the hidden dir NAME during traversal and listed its
+    files — contradicting every specific glob AND the #1558 exclusion."""
+    res = _ops(hidden_tree).search("*", path=str(hidden_tree), target="files")
+    assert not res.error
+    assert not any(".agenthome" in f for f in res.files)
+    assert any("VISIBLE.md" in f for f in res.files)
+
+
+@requires_rg
+def test_star_and_specific_glob_agree_about_hidden_files(hidden_tree):
+    """The gaslighting bug: the same tree gave two contradicting answers."""
+    ops = _ops(hidden_tree)
+    star = ops.search("*", path=str(hidden_tree), target="files")
+    specific = ops.search("*preflight*", path=str(hidden_tree), target="files")
+    star_hit = any("preflight.py" in f for f in star.files)
+    specific_hit = any("preflight.py" in f for f in specific.files)
+    assert star_hit == specific_hit == False  # noqa: E712 — agreement is the point
+
+
+# ---------------------------------------------------------------- the opt-in
+@requires_rg
+def test_include_hidden_finds_files_under_dotdirs(hidden_tree):
+    res = _ops(hidden_tree).search("*preflight*", path=str(hidden_tree),
+                                   target="files", include_hidden=True)
+    assert not res.error
+    assert any("preflight.py" in f for f in res.files)
+
+
+@requires_rg
+def test_include_hidden_content_search_reaches_dotdirs(hidden_tree):
+    ops = _ops(hidden_tree)
+    default = ops.search("needle_content", path=str(hidden_tree), target="content")
+    opted = ops.search("needle_content", path=str(hidden_tree), target="content",
+                       include_hidden=True)
+    assert default.total_count == 0        # #1558 default kept
+    assert opted.total_count >= 1
+
+
+@requires_rg
+def test_explicit_hidden_root_is_searched_without_the_flag(hidden_tree):
+    """Passing the dotdir as path= is the other sanctioned escape hatch."""
+    res = _ops(hidden_tree).search(
+        "*preflight*", path=str(hidden_tree / ".agenthome"), target="files")
+    assert not res.error
+    assert any("preflight.py" in f for f in res.files)
+
+
+# ------------------------------------------------------------- honest errors
+@requires_rg
+def test_files_glob_parse_error_is_surfaced_not_silent_zero(hidden_tree):
+    """A broken glob must be an error the model can react to — a silent
+    {"total_count": 0} reads as 'the file does not exist' and misleads."""
+    res = _ops(hidden_tree).search("[", path=str(hidden_tree), target="files")
+    assert res.error
+    assert not res.files
+
+
+# ------------------------------------------------------------- find fallback
+def test_find_fallback_matches_rg_semantics(hidden_tree, monkeypatch):
+    ops = _ops(hidden_tree)
+    monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "find")
+    default = ops.search("*preflight*", path=str(hidden_tree), target="files")
+    opted = ops.search("*preflight*", path=str(hidden_tree), target="files",
+                       include_hidden=True)
+    assert not any("preflight.py" in f for f in default.files)
+    assert any("preflight.py" in f for f in opted.files)
+
+
+def test_find_fallback_explicit_hidden_root(hidden_tree, monkeypatch):
+    ops = _ops(hidden_tree)
+    monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == "find")
+    res = ops.search("*preflight*", path=str(hidden_tree / ".agenthome"),
+                     target="files")
+    assert any("preflight.py" in f for f in res.files)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -487,7 +487,8 @@ class FileOperations(ABC):
     @abstractmethod
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0,
+               include_hidden: bool = False) -> SearchResult:
         """Search for content or files."""
         ...
 
@@ -1961,10 +1962,11 @@ class ShellFileOperations(FileOperations):
     
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0,
+               include_hidden: bool = False) -> SearchResult:
         """
         Search for content or files.
-        
+
         Args:
             pattern: Regex (for content) or glob pattern (for files)
             path: Directory/file to search (default: cwd)
@@ -1974,7 +1976,10 @@ class ShellFileOperations(FileOperations):
             offset: Skip first N results
             output_mode: "content", "files_only", or "count"
             context: Lines of context around matches
-        
+            include_hidden: Also search hidden directories/dotfiles. Off by
+                default (#1558 — hidden caches can carry adversarial text);
+                an explicit hidden *path* is always searched without it.
+
         Returns:
             SearchResult with matches or file list
         """
@@ -2017,30 +2022,60 @@ class ShellFileOperations(FileOperations):
             )
         
         if target == "files":
-            return self._search_files(pattern, path, limit, offset)
+            return self._search_files(pattern, path, limit, offset,
+                                      include_hidden=include_hidden)
         else:
-            return self._search_content(pattern, path, file_glob, limit, offset, 
-                                        output_mode, context)
+            return self._search_content(pattern, path, file_glob, limit, offset,
+                                        output_mode, context,
+                                        include_hidden=include_hidden)
     
-    def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
-        """Search for files by name pattern (glob-like)."""
+    @staticmethod
+    def _drop_hidden_descendants(files: List[str], search_root: str) -> List[str]:
+        """Drop paths with a hidden component BELOW ``search_root``.
+
+        The hidden filter is applied relative to the search root, so an
+        explicitly given hidden root (``path='.hermes/skills'``) stays
+        searchable while its hidden *descendants* remain excluded — the same
+        semantics for every backend (rg / find / grep), closing the rg quirk
+        where a bare ``-g '*'`` (which matches a hidden directory's *name*
+        during traversal) descended into trees that every specific glob
+        pruned: the two answers contradicted each other, and the ``'*'``
+        listing leaked exactly the hidden files #1558 excludes.
+        """
+        root = Path(search_root).resolve()
+        out = []
+        for file_path in files:
+            try:
+                rel_parts = Path(file_path).resolve().relative_to(root).parts
+            except (ValueError, OSError):
+                rel_parts = Path(file_path).parts
+            if any(p not in {".", ".."} and p.startswith(".") for p in rel_parts):
+                continue
+            out.append(file_path)
+        return out
+
+    def _search_files(self, pattern: str, path: str, limit: int, offset: int,
+                      include_hidden: bool = False) -> SearchResult:
+        """Search for files by name pattern (glob-like).
+
+        Hidden directories below the search root are excluded unless
+        ``include_hidden`` (#1558: hidden caches can carry adversarial text).
+        An explicitly given hidden root is always searched. The exclusion is
+        enforced CONSISTENTLY for every pattern and backend — see
+        ``_drop_hidden_descendants``.
+        """
         # Auto-prepend **/ for recursive search if not already present
         if not pattern.startswith('**/') and '/' not in pattern:
             search_pattern = pattern
         else:
             search_pattern = pattern.split('/')[-1]
 
-        search_root = Path(path)
-        has_hidden_path_ancestor = any(
-            part not in {".", ".."} and part.startswith(".")
-            for part in search_root.parts
-        )
-
-        # Prefer ripgrep: respects .gitignore, excludes hidden dirs by
-        # default, and has parallel directory traversal (~200x faster than
-        # find on wide trees).  Mirrors _search_content which already uses rg.
+        # Prefer ripgrep: respects .gitignore and has parallel directory
+        # traversal (~200x faster than find on wide trees).  Mirrors
+        # _search_content which already uses rg.
         if self._has_command('rg'):
-            return self._search_files_rg(search_pattern, path, limit, offset)
+            return self._search_files_rg(search_pattern, path, limit, offset,
+                                         include_hidden=include_hidden)
 
         # Fallback: find (slower, no .gitignore awareness)
         if not self._has_command('find'):
@@ -2050,27 +2085,19 @@ class ShellFileOperations(FileOperations):
                       "https://github.com/BurntSushi/ripgrep#installation"
             )
 
-        # Exclude hidden directories (matching ripgrep's default behavior).
-        hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
-        hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
-
-        # Use shell pagination for standard roots. For hidden roots, gather full
-        # output so we can re-apply hidden-descendant filtering while allowing
-        # explicit hidden-root searches.
-        pagination_expr = ""
-        if not has_hidden_path_ancestor:
-            pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
-
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-              f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
+        # Hidden filtering happens post-hoc in _drop_hidden_descendants (so an
+        # explicit hidden root works and semantics match the rg path); gather
+        # unpaginated output and page after filtering.
+        cmd = f"find {self._escape_shell_arg(path)} -type f -name {self._escape_shell_arg(search_pattern)} " \
+              f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn"
 
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-                        f"2>/dev/null | sort -rn{pagination_expr}"
+            cmd_simple = f"find {self._escape_shell_arg(path)} -type f -name {self._escape_shell_arg(search_pattern)} " \
+                        f"2>/dev/null | sort -rn"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
 
@@ -2084,37 +2111,39 @@ class ShellFileOperations(FileOperations):
             else:
                 files.append(line)
 
-        # For explicit hidden roots, find's path-based filtering excludes every
-        # file under the hidden path. Apply descendant filtering after command
-        # execution so only the explicit root ancestry is bypassed.
-        if has_hidden_path_ancestor:
-            normalized_root = search_root.resolve()
-            filtered_files = []
-            for file_path in files:
-                try:
-                    rel_parts = Path(file_path).resolve().relative_to(normalized_root).parts
-                except ValueError:
-                    rel_parts = Path(file_path).parts
-                if any(part not in {".", ".."} and part.startswith(".") for part in rel_parts):
-                    continue
-                filtered_files.append(file_path)
-            files = filtered_files[offset:offset + limit]
-        # pagination for standard roots is already applied in shell
+        if not include_hidden:
+            files = self._drop_hidden_descendants(files, path)
+        page = files[offset:offset + limit]
 
         return SearchResult(
-            files=files,
+            files=page,
             total_count=len(files),
             truncated=bool(limit_reason),
             limit_reason=limit_reason,
         )
 
-    def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+    def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int,
+                         include_hidden: bool = False) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
 
-        rg --files respects .gitignore and excludes hidden directories by
-        default, and uses parallel directory traversal for ~200x speedup
-        over find on wide trees.  Results are sorted by modification time
-        (most recently edited first) when rg >= 13.0 supports --sortr.
+        rg --files respects .gitignore and uses parallel directory traversal
+        for ~200x speedup over find on wide trees.  Results are sorted by
+        modification time (most recently edited first) when rg >= 13.0
+        supports --sortr.
+
+        ``--hidden`` is always passed and the hidden filter applied POST-HOC
+        (``_drop_hidden_descendants``, skipped when ``include_hidden``): rg's
+        own hidden pruning is glob-dependent — a ``-g`` glob is also tested
+        against directory *names* during traversal, so a bare ``'*'``
+        descended into hidden trees (leaking exactly what #1558 excludes)
+        while a specific glob (``'*config*'``) pruned them, silently
+        returning 0 for files that a ``'*'`` listing had just shown. One
+        filter, every pattern, same answer; an explicit hidden root stays
+        searchable either way.
+
+        Diagnostics are surfaced rather than discarded: a glob parse error
+        (or any rg failure) must reach the model as an error, not read as
+        "no files matched".
         """
         # rg --files -g uses glob patterns; wrap bare names so they match
         # at any depth (equivalent to find -name).
@@ -2123,47 +2152,62 @@ class ShellFileOperations(FileOperations):
         else:
             glob_pattern = pattern
 
-        fetch_limit = limit + offset
+        # Over-fetch when we filter post-hoc so a hidden-heavy prefix can't
+        # starve the visible page (bounded; no unbounded slurp).
+        fetch_limit = (limit + offset) if include_hidden else max((limit + offset) * 4, 200)
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"rg --files --hidden --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
+            f"{self._escape_shell_arg(path)} "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
-        all_files = [f for f in stdout.strip().split('\n') if f]
+        diagnostics, payload = _split_tool_diagnostics(stdout)
+        all_files = [f for f in payload.strip().split('\n') if f]
 
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"rg --files --hidden -g {self._escape_shell_arg(glob_pattern)} "
+                f"{self._escape_shell_arg(path)} "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
-            all_files = [f for f in stdout.strip().split('\n') if f]
+            diagnostics, payload = _split_tool_diagnostics(stdout)
+            all_files = [f for f in payload.strip().split('\n') if f]
 
+        if not all_files and diagnostics and not limit_reason:
+            # Pure failure (e.g. a glob parse error): surface it. A silent 0
+            # here reads as "the file does not exist" and misleads the model.
+            return SearchResult(error=f"Search failed: {diagnostics}")
+
+        truncated_fetch = len(all_files) >= fetch_limit
+        if not include_hidden:
+            all_files = self._drop_hidden_descendants(all_files, path)
         page = all_files[offset:offset + limit]
 
         return SearchResult(
             files=page,
             total_count=len(all_files),
-            truncated=len(all_files) >= fetch_limit or bool(limit_reason),
+            truncated=truncated_fetch or bool(limit_reason),
             limit_reason=limit_reason,
         )
     
     def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                        limit: int, offset: int, output_mode: str, context: int,
+                        include_hidden: bool = False) -> SearchResult:
         """Search for content inside files (grep-like)."""
         # Try ripgrep first (fast), fallback to grep (slower but works)
         if self._has_command('rg'):
             result = self._search_with_rg(pattern, path, file_glob, limit, offset,
-                                          output_mode, context)
+                                          output_mode, context,
+                                          include_hidden=include_hidden)
         elif self._has_command('grep'):
             result = self._search_with_grep(pattern, path, file_glob, limit, offset,
-                                            output_mode, context)
+                                            output_mode, context,
+                                            include_hidden=include_hidden)
         else:
             # Neither rg nor grep available (Windows without Git Bash, etc.)
             return SearchResult(
@@ -2174,9 +2218,17 @@ class ShellFileOperations(FileOperations):
         return _maybe_warn_line_oriented_newline_pattern(result, pattern)
     
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
-        """Search using ripgrep."""
+                        limit: int, offset: int, output_mode: str, context: int,
+                        include_hidden: bool = False) -> SearchResult:
+        """Search using ripgrep.
+
+        Hidden directories are skipped by rg's default (#1558) unless the
+        caller opts in with ``include_hidden``; an explicitly given hidden
+        root is searched by rg either way. ``.gitignore`` still applies.
+        """
         cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
+        if include_hidden:
+            cmd_parts.append("--hidden")
         
         # Add context if requested
         if context > 0:
@@ -2300,13 +2352,16 @@ class ShellFileOperations(FileOperations):
             )
     
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
-                          limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                          limit: int, offset: int, output_mode: str, context: int,
+                          include_hidden: bool = False) -> SearchResult:
         """Fallback search using grep."""
         cmd_parts = ["grep", "-rnH"]  # -H forces filename even for single-file searches
-        
+
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.
-        cmd_parts.append("--exclude-dir='.*'")
+        # Skipped when the caller explicitly opts in via include_hidden.
+        if not include_hidden:
+            cmd_parts.append("--exclude-dir='.*'")
         
         # Add context if requested
         if context > 0:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1759,6 +1759,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
+                include_hidden: bool = False,
                 task_id: str = "default") -> str:
     """Search for content or files."""
     try:
@@ -1775,6 +1776,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             file_glob or "",
             limit,
             offset,
+            include_hidden,
         )
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
@@ -1809,7 +1811,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
             pattern=pattern, path=path, target=target, file_glob=file_glob,
-            limit=limit, offset=offset, output_mode=output_mode, context=context
+            limit=limit, offset=offset, output_mode=output_mode, context=context,
+            include_hidden=include_hidden,
         )
         omitted = _filter_read_blocked_search_results(result, task_id)
         if hasattr(result, 'matches'):
@@ -1822,6 +1825,21 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             result_dict["_omitted"] = (
                 f"{omitted} result(s) omitted because they target credential, "
                 "token, cache, or secret-bearing environment files."
+            )
+
+        if (not include_hidden
+                and not result_dict.get("error")
+                and result_dict.get("total_count") == 0):
+            # A silent 0 gaslights the model when the target lives under a
+            # dotdir (on agent installs the whole working tree may): say WHY
+            # nothing matched and name the escape hatches (#1558 keeps hidden
+            # exclusion the default; discoverability was the missing half).
+            result_dict["_note"] = (
+                "0 matches. Hidden directories below the search root are not "
+                "searched by default — if the target may live under a dotdir "
+                "(e.g. ~/.hermes), retry with include_hidden=true or pass that "
+                "directory as path=. If you already have an absolute path, use "
+                "read_file directly instead of searching."
             )
 
         if count >= 3:
@@ -1939,7 +1957,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. Hidden directories (dotdirs) below the search root are NOT searched unless include_hidden=true — an explicitly hidden path (e.g. path='.hermes/skills') is always searched.\n\nContent search (target='content'): Regex search inside files (regex syntax — a glob like '*foo*' is a regex ERROR here; write 'foo'). Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1950,7 +1968,8 @@ SEARCH_FILES_SCHEMA = {
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0},
+            "include_hidden": {"type": "boolean", "description": "Also search hidden directories/dotfiles below the search root (default false). Use when the target may live under a dotdir; an explicitly hidden path= is searched without this.", "default": False}
         },
         "required": ["pattern"]
     }
@@ -2008,7 +2027,8 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"), context=args.get("context", 0),
+        include_hidden=bool(args.get("include_hidden", False)), task_id=tid)
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)


### PR DESCRIPTION
## Summary

`search_files`' hidden-directory exclusion (#1558 — hidden caches can carry adversarial text) is enforced **inconsistently** on the ripgrep path, and the inconsistency both re-opens the #1558 leak and sends models into retry loops:

- ripgrep tests a `-g` glob against directory **names** during traversal, so a bare `'*'` matches hidden dirs and **descends into them** — surfacing exactly the files #1558 excludes;
- while any specific glob (`'*config*'`, the schema's own example) prunes the same trees and silently returns `{"total_count": 0}`;
- and glob parse errors were discarded by `2>/dev/null`, so a broken pattern also read as "no files matched".

On installs whose working tree lives under a hidden root (an agent home like `~/.hermes`), the model gets **two contradicting answers about the same tree**: a `'*'` listing shows files that every specific search then denies exist. We watched a production Gemini-Flash cron burn its full 90-iteration budget varying glob patterns against that contradiction (72 silent zeros; the identical-args loop-breakers never fired because every retry was a *different* pattern). Full write-up with the session record available on request.

Repro (rg 14.1.0, tree under a dotdir):

```
$ rg --files -g '*'          .   | head        # lists ./.hermes/… (hidden leak)
$ rg --files -g '*preflight*' .                # (empty, exit 0 — same tree)
$ rg --files --hidden -g '*preflight*' .       # 3 hits
```

## Changes (keeping #1558's default)

1. **Consistency** — the hidden filter is applied post-hoc relative to the search root (`_drop_hidden_descendants`) for every pattern and backend (rg + find): `'*'` no longer leaks hidden files, and a specific glob no longer contradicts it. An explicitly hidden `path=` stays searchable (matching the find fallback's existing explicit-hidden-root behavior).
2. **Opt-in** — a new `include_hidden` parameter (schema-documented, default `false`) searches dotdirs deliberately, on files and content targets, for rg + find + grep fallbacks. `.gitignore` semantics unchanged (so `.hub`'s `.ignore` belt still applies even with the flag).
3. **Honest failures** — rg diagnostics are surfaced instead of discarded (a glob parse error returns an error, not a silent 0), and a legitimate 0-hit carries a `_note` explaining the hidden-exclusion default and the escape hatches, so a model doesn't conclude "the file does not exist" about a file it was just shown in a listing.

## Tests

- New `tests/tools/test_search_hidden_optin.py`: the `'*'`-leak closure, star-vs-specific agreement, `include_hidden` on files + content, explicit-hidden-root without the flag, glob-error surfacing, find-fallback parity.
- The two search-handler contract assertions in `test_file_tools.py` extended with the new kwarg.
- The existing #1558 suite (`test_search_hidden_dirs.py`) and the search error-guard suite pass unchanged; a full `test_file_tools.py` + `test_file_operations.py` run shows zero regressions vs the clean base.

## Notes

- In model traffic we captured, the model followed the schema's documented examples exactly — the contradiction was environmental, not model error. The `_note` in change 3 is what turns a dead-end retry loop into a recoverable decision.
- Sibling PR #57285 (per-job cron `max_turns`) bounds the blast radius of any remaining loop; this PR removes this loop's cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
