### PR TITLE
fix(agent): max-iterations exit demands an honest failure report, not a success-shaped summary

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1502,9 +1502,15 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
 
     summary_request = (
-        "You've reached the maximum number of tool-calling iterations allowed. "
-        "Please provide a final response summarizing what you've found and accomplished so far, "
-        "without calling any more tools."
+        "You've reached the maximum number of tool-calling iterations allowed — the "
+        "task did NOT run to completion. Provide a final response, without calling "
+        "any more tools, that: (1) states plainly WHAT YOU COULD NOT DO and, if "
+        "known, why (which tool calls kept failing or returned nothing); (2) reports "
+        "only results you actually verified — do not present partial work as "
+        "success, do not guess or fabricate numbers or outcomes; (3) suggests what "
+        "would unblock the task (a missing file/path, a permission, a different "
+        "tool). If you genuinely completed the user-visible goal before hitting the "
+        "limit, say so and summarize it briefly."
     )
     messages.append({"role": "user", "content": summary_request})
 


### PR DESCRIPTION
## Summary

`handle_max_iterations` asks the model to *"provide a final response summarizing what you've found and accomplished so far"*. For a turn that just exhausted its entire iteration budget **without completing**, that wording invites confabulation — the model is prompted to present accomplishments it may not have.

We observed this in production: a cron turn spent all 90 iterations on fruitless `search_files` retries (see #57366 for that root cause), then — prompted by this fallback — delivered a confident *"I successfully loaded and reviewed …"* summary to the end user, describing work that never happened. The user-facing failure mode of a runaway isn't just the cost; it's the **fabricated success report at the end**.

## Change

Reword the summary request to demand an honest exit: state that the task did **not** run to completion; say plainly what could not be done and which calls kept failing; report only verified results (no presenting partial work as success, no guessed numbers); suggest what would unblock the task. An explicit carve-out keeps the happy case intact: if the user-visible goal genuinely finished before the limit, say so and summarize briefly.

One string change; no behavior/API change. The turn-finalizer tests covering this path pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)