### PR TITLE
fix(docker): redact explicit env values in diagnostics (#57371)

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -440,6 +440,7 @@ def test_redact_docker_env_args_preserves_keys_only():
         "NO_VALUE",
         "--env=TOKEN=oauth-token",
         "-ePASSWORD=hunter2",
+        "-e=USERNAME=alice",
         "--env-file",
         "/tmp/env.list",
     ])
@@ -451,6 +452,7 @@ def test_redact_docker_env_args_preserves_keys_only():
         "NO_VALUE",
         "--env=TOKEN=***",
         "-ePASSWORD=***",
+        "-e=USERNAME=***",
         "--env-file",
         "/tmp/env.list",
     ]
@@ -473,6 +475,23 @@ def test_redact_subprocess_error_preserves_keys_only():
     assert "oauth-token" not in message
     assert "MY_SECRET=***" in message
     assert "--env=TOKEN=***" in message
+
+
+def test_redact_subprocess_error_preserves_tuple_commands():
+    cmd = (
+        "/usr/bin/docker",
+        "run",
+        "-e",
+        "MY_SECRET=sk-test-12345",
+        "python:3.11",
+    )
+    error = subprocess.CalledProcessError(125, cmd, stderr="daemon error")
+
+    message = docker_env._redact_subprocess_error(error)
+
+    assert "sk-test-12345" not in message
+    assert "MY_SECRET=***" in message
+    assert "('/usr/bin/docker'" in message
 
 
 def test_docker_env_values_are_redacted_from_logs(monkeypatch, caplog):

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -405,6 +405,123 @@ def test_egress_node_options_overrides_conflicting_ca_flag(monkeypatch):
     assert "--max-old-space-size=8192" in node_opts
 
 
+def test_egress_node_options_preserves_operator_tuning(monkeypatch):
+    """Non-conflicting operator NODE_OPTIONS survive the egress append-merge."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(
+        docker_env, "_egress_proxy_args_for_docker",
+        lambda: ([], {"_HERMES_EGRESS_NODE_OPTIONS_APPEND": "--use-openssl-ca"}, []),
+    )
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(env={"NODE_OPTIONS": "--max-old-space-size=4096"})
+
+    node_opts = (_node_options_from_run(calls) or "").split()
+    assert "--use-openssl-ca" in node_opts
+    assert "--max-old-space-size=4096" in node_opts
+
+
+def test_docker_env_appears_in_init_env_args(monkeypatch):
+    """Explicit docker_env values should appear in _build_init_env_args."""
+    env = _make_execute_only_env()
+    env._env = {"MY_VAR": "my_value"}
+
+    args = env._build_init_env_args()
+    args_str = " ".join(args)
+
+    assert "MY_VAR=my_value" in args_str
+
+
+def test_redact_docker_env_args_preserves_keys_only():
+    redacted = docker_env._redact_docker_env_args([
+        "-e",
+        "MY_SECRET=sk-test-12345",
+        "--env",
+        "NO_VALUE",
+        "--env=TOKEN=oauth-token",
+        "-ePASSWORD=hunter2",
+        "--env-file",
+        "/tmp/env.list",
+    ])
+
+    assert redacted == [
+        "-e",
+        "MY_SECRET=***",
+        "--env",
+        "NO_VALUE",
+        "--env=TOKEN=***",
+        "-ePASSWORD=***",
+        "--env-file",
+        "/tmp/env.list",
+    ]
+
+
+def test_redact_subprocess_error_preserves_keys_only():
+    cmd = [
+        "/usr/bin/docker",
+        "run",
+        "-e",
+        "MY_SECRET=sk-test-12345",
+        "--env=TOKEN=oauth-token",
+        "python:3.11",
+    ]
+    error = subprocess.CalledProcessError(125, cmd, stderr="daemon error")
+
+    message = docker_env._redact_subprocess_error(error)
+
+    assert "sk-test-12345" not in message
+    assert "oauth-token" not in message
+    assert "MY_SECRET=***" in message
+    assert "--env=TOKEN=***" in message
+
+
+def test_docker_env_values_are_redacted_from_logs(monkeypatch, caplog):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    with caplog.at_level(logging.DEBUG, logger="tools.environments.docker"):
+        _make_dummy_env(
+            env={"MY_SECRET": "sk-test-12345"},
+            persist_across_processes=False,
+        )
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "sk-test-12345" not in log_text
+    assert "MY_SECRET=***" in log_text
+
+    run_args = _run_args_from_calls(calls)
+    assert "MY_SECRET=sk-test-12345" in run_args
+
+
+def test_docker_run_failure_redacts_env_values_from_logs(monkeypatch, caplog):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+
+    def _run(cmd, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            sub = cmd[1]
+            if sub == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if sub == "run":
+                raise subprocess.CalledProcessError(125, cmd, stderr="daemon error")
+            if sub == "rm":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.docker"):
+        with pytest.raises(subprocess.CalledProcessError):
+            _make_dummy_env(
+                env={"MY_SECRET": "sk-test-12345"},
+                persist_across_processes=False,
+            )
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "sk-test-12345" not in log_text
+    assert "MY_SECRET=***" in log_text
+
+
 def test_forward_env_overrides_docker_env_in_init_args(monkeypatch):
     """docker_forward_env should override docker_env for the same key."""
     env = _make_execute_only_env(forward_env=["MY_KEY"])
@@ -1364,6 +1481,105 @@ def test_s6_image_skips_docker_init_and_mounts_run_exec(monkeypatch):
 # ---------------------------------------------------------------------------
 # Out-of-band container removal recovery (issue #36266, PR #36631)
 # ---------------------------------------------------------------------------
+
+
+def test_is_container_gone_matches_removal_errors(monkeypatch):
+    """``_is_container_gone`` recognizes the docker errors that mean the
+    container no longer exists, and does NOT match ordinary command failures.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    _mock_subprocess_run(monkeypatch)
+    env = _make_dummy_env()
+
+    # Positive: the daemon's "container gone" phrasings.
+    assert env._is_container_gone(
+        "Error response from daemon: No such container: hermes-abc123"
+    )
+    assert env._is_container_gone("Error: No such container: deadbeef")
+    assert env._is_container_gone(
+        "Error response from daemon: Container abc is not running"
+    )
+
+    # Control / negative: a real command failure must NOT be misclassified as
+    # the container being gone — otherwise every non-zero exit would trigger a
+    # spurious container recreation.
+    assert not env._is_container_gone("bash: nonsuch: command not found")
+    assert not env._is_container_gone("Traceback (most recent call last): ...")
+    assert not env._is_container_gone("")
+    assert not env._is_container_gone("permission denied")
+
+
+def test_recreate_container_failure_redacts_env_values_from_logs(monkeypatch, caplog):
+    env = docker_env.DockerEnvironment.__new__(docker_env.DockerEnvironment)
+    env._container_id = "old-container-id"
+    env._labels = {
+        "hermes-agent": "1",
+        "hermes-task-id": "task",
+        "hermes-profile": "default",
+    }
+    env._image = "python:3.11"
+    env._image_uses_s6_init = False
+    env._all_run_args = ["-e", "MY_SECRET=sk-test-12345"]
+    env._docker_exe = "/usr/bin/docker"
+    env.cwd = "/root"
+
+    monkeypatch.setattr(
+        docker_env.DockerEnvironment,
+        "_find_reusable_container",
+        lambda self, task_label, profile_label, egress_mode: None,
+    )
+
+    def _run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(125, cmd, stderr="daemon error")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    with caplog.at_level(logging.ERROR, logger="tools.environments.docker"):
+        assert env._recreate_container() is False
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "sk-test-12345" not in log_text
+    assert "MY_SECRET=***" in log_text
+
+
+def test_execute_recovers_from_out_of_band_removal(monkeypatch):
+    """When a persistent container is removed out-of-band, ``execute`` detects
+    the "No such container" error, recreates the container, and retries once —
+    returning success transparently.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    _mock_subprocess_run(monkeypatch)
+    env = _make_dummy_env(
+        persistent_filesystem=True,
+        persist_across_processes=True,
+    )
+
+    # First execute() sees a dead container; second (post-recovery) succeeds.
+    outputs = iter([
+        {"output": "Error response from daemon: No such container: hermes-x", "returncode": 1},
+        {"output": "ok", "returncode": 0},
+    ])
+
+    def _fake_super_execute(self, command, cwd="", **kwargs):
+        return next(outputs)
+
+    recreate_calls = []
+
+    def _fake_recreate(self):
+        recreate_calls.append(True)
+        self._container_id = "recovered-container-id"
+        return True
+
+    monkeypatch.setattr(docker_env.BaseEnvironment, "execute", _fake_super_execute)
+    monkeypatch.setattr(
+        docker_env.DockerEnvironment, "_recreate_container", _fake_recreate
+    )
+
+    result = env.execute("echo hi")
+
+    assert recreate_calls == [True], "recovery should have been attempted exactly once"
+    assert result.get("returncode") == 0, f"expected success after recovery, got {result!r}"
+    assert result.get("output") == "ok"
 
 
 def test_execute_does_not_recover_when_not_persistent(monkeypatch):

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1809,3 +1809,135 @@ def test_docker_env_warnings_never_echo_values(caplog):
     with caplog.at_level(logging.WARNING, logger="tools.environments.docker"):
         docker_env._normalize_env_dict({"TOKEN": ["sk-live-value"], "OK": "1"})
     assert "TOKEN" in caplog.text and "sk-live-value" not in caplog.text
+
+
+def test_redact_docker_env_args_preserves_keys_only():
+    redacted = docker_env._redact_docker_env_args([
+        "-e",
+        "MY_SECRET=sk-test-12345",
+        "--env",
+        "NO_VALUE",
+        "--env=TOKEN=oauth-token",
+        "-ePASSWORD=hunter2",
+        "-e=USERNAME=alice",
+        "--env-file",
+        "/tmp/env.list",
+    ])
+
+    assert redacted == [
+        "-e",
+        "MY_SECRET=***",
+        "--env",
+        "NO_VALUE",
+        "--env=TOKEN=***",
+        "-ePASSWORD=***",
+        "-e=USERNAME=***",
+        "--env-file",
+        "/tmp/env.list",
+    ]
+
+@pytest.mark.parametrize("shape", [list, tuple])
+@pytest.mark.parametrize("error_type", [subprocess.CalledProcessError, subprocess.TimeoutExpired])
+def test_redact_subprocess_error_preserves_keys_only(shape, error_type):
+    cmd = [
+        "/usr/bin/docker",
+        "run",
+        "-e",
+        "MY_SECRET=sk-test-12345",
+        "--env=TOKEN=oauth-token",
+        "python:3.11",
+    ]
+    cmd = shape(cmd)
+    error = (error_type(125, cmd, output="stdout-secret", stderr="stderr-secret")
+             if error_type is subprocess.CalledProcessError else
+             error_type(cmd, 120, output="stdout-secret", stderr="stderr-secret"))
+
+    message = docker_env._redact_subprocess_error(error)
+    assert error.cmd is cmd
+    assert error.output == "stdout-secret" and error.stderr == "stderr-secret"
+    assert "stdout-secret" not in message and "stderr-secret" not in message
+
+    assert "sk-test-12345" not in message
+    assert "oauth-token" not in message
+    assert "MY_SECRET=***" in message
+    assert "--env=TOKEN=***" in message
+
+
+def test_docker_env_values_are_redacted_from_logs(monkeypatch, caplog):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    with caplog.at_level(logging.DEBUG, logger="tools.environments.docker"):
+        _make_dummy_env(
+            extra_args=["-e", "MY_SECRET=sk-test-12345"],
+            persist_across_processes=False,
+        )
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "sk-test-12345" not in log_text
+    assert "MY_SECRET=***" in log_text
+
+    run_args = _run_args_from_calls(calls)
+    assert "MY_SECRET=sk-test-12345" in run_args
+
+def test_docker_run_failure_redacts_env_values_from_logs(monkeypatch, caplog):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+
+    def _run(cmd, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            sub = cmd[1]
+            if sub == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if sub == "run":
+                raise subprocess.CalledProcessError(125, cmd, stderr="daemon error")
+            if sub == "rm":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    with caplog.at_level(logging.WARNING, logger="tools.environments.docker"):
+        with pytest.raises(subprocess.CalledProcessError):
+            _make_dummy_env(
+                extra_args=["-e", "MY_SECRET=sk-test-12345"],
+                persist_across_processes=False,
+            )
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "sk-test-12345" not in log_text
+    assert "MY_SECRET=***" in log_text
+
+def test_recreate_container_failure_redacts_env_values_from_logs(monkeypatch, caplog):
+    env = docker_env.DockerEnvironment.__new__(docker_env.DockerEnvironment)
+    env._container_id = "old-container-id"
+    env._labels = {
+        "hermes-agent": "1",
+        "hermes-task-id": "task",
+        "hermes-profile": "default",
+    }
+    env._image = "python:3.11"
+    env._image_uses_s6_init = False
+    env._all_run_args = ["-e", "MY_SECRET=sk-test-12345"]
+    env._docker_exe = "/usr/bin/docker"
+    env.cwd = "/root"
+    env._snap_compat = False
+    env._run_env_values = {}
+
+    monkeypatch.setattr(
+        docker_env.DockerEnvironment,
+        "_find_reusable_container",
+        lambda self, task_label, profile_label, egress_mode: None,
+    )
+
+    def _run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(125, cmd, stderr="daemon error")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    with caplog.at_level(logging.ERROR, logger="tools.environments.docker"):
+        assert env._recreate_container() is False
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "sk-test-12345" not in log_text
+    assert "MY_SECRET=***" in log_text

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -119,6 +119,9 @@ def _redact_docker_env_args(args: list[str]) -> list[str]:
         if arg.startswith("--env="):
             redacted.append("--env=" + _redact_env_assignment(arg[len("--env="):]))
             continue
+        if arg.startswith("-e="):
+            redacted.append("-e=" + _redact_env_assignment(arg[len("-e="):]))
+            continue
         if arg.startswith("-e") and "=" in arg:
             redacted.append("-e" + _redact_env_assignment(arg[2:]))
             continue
@@ -133,7 +136,8 @@ def _redact_subprocess_error(error: BaseException) -> str:
     if isinstance(cmd, (list, tuple)):
         raw_cmd = [str(arg) for arg in cmd]
         redacted_cmd = _redact_docker_env_args(raw_cmd)
-        message = message.replace(repr(raw_cmd), repr(redacted_cmd))
+        rendered_cmd = tuple(redacted_cmd) if isinstance(cmd, tuple) else redacted_cmd
+        message = message.replace(repr(cmd), repr(rendered_cmd))
     return message
 
 
@@ -1506,14 +1510,10 @@ class DockerEnvironment(BaseEnvironment):
                 image,
                 "sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
             ]
-<<<<<<< HEAD
-            logger.debug("Starting container: %s", ' '.join(run_cmd))
-=======
             logger.debug(
                 "Starting container: %s",
                 " ".join(_redact_docker_env_args(run_cmd)),
             )
->>>>>>> 87376706b (fix(docker): redact env values from run logs)
             try:
                 result = subprocess.run(
                     run_cmd,

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -96,6 +96,47 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
     return normalized
 
 
+def _redact_env_assignment(value: str) -> str:
+    if "=" not in value:
+        return value
+    key, _secret = value.split("=", 1)
+    return f"{key}=***"
+
+
+def _redact_docker_env_args(args: list[str]) -> list[str]:
+    """Return a copy of docker args with ``-e KEY=VALUE`` values redacted."""
+    redacted: list[str] = []
+    redact_next = False
+    for arg in args:
+        if redact_next:
+            redacted.append(_redact_env_assignment(arg))
+            redact_next = False
+            continue
+        if arg in {"-e", "--env"}:
+            redacted.append(arg)
+            redact_next = True
+            continue
+        if arg.startswith("--env="):
+            redacted.append("--env=" + _redact_env_assignment(arg[len("--env="):]))
+            continue
+        if arg.startswith("-e") and "=" in arg:
+            redacted.append("-e" + _redact_env_assignment(arg[2:]))
+            continue
+        redacted.append(arg)
+    return redacted
+
+
+def _redact_subprocess_error(error: BaseException) -> str:
+    """Format a subprocess exception without exposing docker env values."""
+    message = str(error)
+    cmd = getattr(error, "cmd", None)
+    if isinstance(cmd, (list, tuple)):
+        raw_cmd = [str(arg) for arg in cmd]
+        redacted_cmd = _redact_docker_env_args(raw_cmd)
+        message = message.replace(repr(raw_cmd), repr(redacted_cmd))
+    return message
+
+
 def _load_hermes_env_vars() -> dict[str, str]:
     """Load ~/.hermes/.env values without failing Docker command execution."""
     try:
@@ -1336,7 +1377,7 @@ class DockerEnvironment(BaseEnvironment):
             + env_args
             + validated_extra
         )
-        logger.info("Docker run_args: %s", all_run_args)
+        logger.info("Docker run_args: %s", _redact_docker_env_args(all_run_args))
 
         # Start the container directly via `docker run -d`.
         container_name = f"hermes-{uuid.uuid4().hex[:8]}"
@@ -1465,7 +1506,14 @@ class DockerEnvironment(BaseEnvironment):
                 image,
                 "sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
             ]
+<<<<<<< HEAD
             logger.debug("Starting container: %s", ' '.join(run_cmd))
+=======
+            logger.debug(
+                "Starting container: %s",
+                " ".join(_redact_docker_env_args(run_cmd)),
+            )
+>>>>>>> 87376706b (fix(docker): redact env values from run logs)
             try:
                 result = subprocess.run(
                     run_cmd,
@@ -1485,7 +1533,7 @@ class DockerEnvironment(BaseEnvironment):
                 # re-raising. See #7439.
                 logger.warning(
                     "docker run failed for %s, cleaning up orphaned container: %s",
-                    container_name, e,
+                    container_name, _redact_subprocess_error(e),
                 )
                 subprocess.run(
                     [self._docker_exe, "rm", "-f", container_name],
@@ -1659,7 +1707,10 @@ class DockerEnvironment(BaseEnvironment):
                     self._container_id = cid
                     logger.info("Recovery: restarted container %s", cid[:12])
                 except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                    logger.warning("Recovery: failed to start container %s: %s", cid[:12], e)
+                    logger.warning(
+                        "Recovery: failed to start container %s: %s",
+                        cid[:12], _redact_subprocess_error(e),
+                    )
 
         # 2. No reusable container — create a fresh one.
         if not self._container_id:
@@ -1694,7 +1745,10 @@ class DockerEnvironment(BaseEnvironment):
                     new_name, self._container_id[:12],
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
-                logger.error("Recovery: failed to create new container: %s", e)
+                logger.error(
+                    "Recovery: failed to create new container: %s",
+                    _redact_subprocess_error(e),
+                )
                 return False
 
         # 3. Re-initialize session snapshot in the (re)created container.

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -80,6 +80,51 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
     return normalized
 
 
+def _redact_env_assignment(value: str) -> str:
+    if "=" not in value:
+        return value
+    key, _secret = value.split("=", 1)
+    return f"{key}=***"
+
+
+def _redact_docker_env_args(args: list[str]) -> list[str]:
+    """Return a copy of docker args with ``-e KEY=VALUE`` values redacted."""
+    redacted: list[str] = []
+    redact_next = False
+    for arg in args:
+        if redact_next:
+            redacted.append(_redact_env_assignment(arg))
+            redact_next = False
+            continue
+        if arg in {"-e", "--env"}:
+            redacted.append(arg)
+            redact_next = True
+            continue
+        if arg.startswith("--env="):
+            redacted.append("--env=" + _redact_env_assignment(arg[len("--env="):]))
+            continue
+        if arg.startswith("-e="):
+            redacted.append("-e=" + _redact_env_assignment(arg[len("-e="):]))
+            continue
+        if arg.startswith("-e") and "=" in arg:
+            redacted.append("-e" + _redact_env_assignment(arg[2:]))
+            continue
+        redacted.append(arg)
+    return redacted
+
+
+def _redact_subprocess_error(error: BaseException) -> str:
+    """Format a subprocess exception without exposing docker env values."""
+    message = str(error)
+    cmd = getattr(error, "cmd", None)
+    if isinstance(cmd, (list, tuple)):
+        raw_cmd = [str(arg) for arg in cmd]
+        redacted_cmd = _redact_docker_env_args(raw_cmd)
+        rendered_cmd = tuple(redacted_cmd) if isinstance(cmd, tuple) else redacted_cmd
+        message = message.replace(repr(cmd), repr(rendered_cmd))
+    return message
+
+
 # Module-level binding: tests patch ``docker._load_hermes_env_vars`` to fake the .env file.
 _load_hermes_env_vars = load_hermes_env_vars
 
@@ -571,7 +616,7 @@ class DockerEnvironment(BaseEnvironment):
         all_run_args = (
             security_args + user_args + writable_args + resource_args
             + egress_host_args + volume_args + env_args + validated_extra)
-        logger.info("Docker run_args: %s", all_run_args)
+        logger.info("Docker run_args: %s", _redact_docker_env_args(all_run_args))
 
         # Labels identify hermes containers to the orphan reaper (hermes-agent=1),
         # cross-process reuse (task-id/profile) and operators. The reuse identity
@@ -782,13 +827,13 @@ class DockerEnvironment(BaseEnvironment):
         removed by name before re-raising."""
         container_name = f"hermes-{uuid.uuid4().hex[:8]}"
         run_cmd = self._run_command(container_name, cwd)
-        logger.debug("Starting container: %s", ' '.join(run_cmd))
+        logger.debug("Starting container: %s", ' '.join(_redact_docker_env_args(run_cmd)))
         try:
             result = run_capture(
                 run_cmd, timeout=120, check=True,  # image pull may take a while
                 env=self._docker_client_env(self._run_env_values))
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            logger.warning("docker run failed for %s, cleaning up orphaned container: %s", container_name, e)
+            logger.warning("docker run failed for %s, cleaning up orphaned container: %s", container_name, _redact_subprocess_error(e))
             subprocess.run(
                 [self._docker_exe, "rm", "-f", container_name],
                 capture_output=True, timeout=10, stdin=subprocess.DEVNULL)
@@ -906,7 +951,7 @@ class DockerEnvironment(BaseEnvironment):
                 self._container_id = result.stdout.strip()
                 logger.info("Recovery: created fresh container %s (%s)", new_name, self._container_id[:12])
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
-                logger.error("Recovery: failed to create new container: %s", e)
+                logger.error("Recovery: failed to create new container: %s", _redact_subprocess_error(e))
                 return False
 
         try:


### PR DESCRIPTION
## Summary

Redact explicit Docker environment assignments in diagnostic copies of run arguments and startup/recovery exceptions. Keep variable names visible and preserve the real subprocess arguments.

Current main already forwards normal `docker_env` values through the Docker client's environment using name-only flags. The remaining exposure is in explicit `docker_extra_args`, which still accepts `-e KEY=VALUE`, `--env KEY=VALUE`, `--env=KEY=VALUE`, `-eKEY=VALUE`, and `-e=KEY=VALUE`. This PR covers those spellings without changing forwarding or execution.

## Attribution

Related source report: #5332. Preserve Dusk's attribution and Teknium's concrete key-retention and tuple-formatting corrections in the commit trailers. Unrelated historical test additions already covered by current behavior are excluded from this focused change.

## Validation

Six diagnostic regressions failed on the current base before the fix. Afterward, all 74 Docker environment tests pass through `scripts/run_tests.sh`. Coverage includes real constructor/startup/recovery logging, preserved executable argv, name-only forwarding, list/tuple exception commands, timeout errors, and unchanged exception stdout/stderr. Ruff and whitespace checks pass.

Not checked: full repository suite, live Docker daemon, native Windows/macOS, or CodeRabbit (self-authored PR without a P0/P1 review route). This is log formatting, not a change to the exceptions propagated to callers or the explicit arguments exposed by the host process.

## Agent disclosure

Original preparation: GPT-5.5-xhigh in Codex; earlier correction: GPT-5.6-sol-xhigh in Codex. Maintenance: GPT-6 in Codex desktop (parent reasoning level unavailable). The account owner loosely reviews these actions and receives the usual GitHub notifications.
