### PR TITLE
fix(gateway): use getattr for exception chain traversal in _is_transient_network_error

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -267,7 +267,7 @@ def _is_transient_network_error(exc: BaseException) -> bool:
         name = type(cur).__name__
         if name in transient_class_names:
             return True
-        cur = cur.__cause__ or cur.__context__
+        cur = getattr(cur, "__cause__", None) or getattr(cur, "__context__", None)
     return False
 
 

--- a/tests/gateway/test_loop_exception_handler.py
+++ b/tests/gateway/test_loop_exception_handler.py
@@ -83,6 +83,25 @@ def test_transient_classifier_rejects_unrelated_errors():
         assert _is_transient_network_error(exc) is False
 
 
+def test_transient_classifier_handles_traceback_exception_in_chain():
+    """TracebackException objects in the exception chain don't crash the walker.
+
+    ``traceback.TracebackException`` lacks ``__cause__`` / ``__context__``
+    instance attributes (they live on the *captured* chain, not as direct
+    attrs).  The walker must use ``getattr()`` to avoid ``AttributeError``.
+    """
+    import traceback
+
+    tbe = traceback.TracebackException.from_exception(
+        ConnectError("connection refused")
+    )
+    # TracebackException objects don't have __cause__ as an instance attr
+    assert not hasattr(tbe, "__cause__") or tbe.__cause__ is None
+
+    # Must not raise AttributeError — should return False (no transient name)
+    assert _is_transient_network_error(tbe) is False
+
+
 def test_transient_classifier_unwraps_cause_chain():
     """A NetworkError wrapping a ConnectError is still classified."""
     inner = ConnectError("connection refused")


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` crash in `_is_transient_network_error()` when the exception chain contains a `traceback.TracebackException` object instead of a live exception instance.

`TracebackException` objects (which appear in asyncio exception handler chains or when PTB formats exception context) don't have `__cause__` / `__context__` as direct instance attributes. The existing code accessed them with `cur.__cause__`, which raises `AttributeError` and masks the real network error during Telegram reconnect — preventing the reconnect ladder from recovering.

The fix uses `getattr()` with `None` default, matching the safe pattern already used in the Telegram adapter at lines 878 and 913 of the same codebase.

## Related Issue

Fixes #57298

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Changed `cur.__cause__ or cur.__context__` to `getattr(cur, "__cause__", None) or getattr(cur, "__context__", None)` in `_is_transient_network_error()` (line 270)
- `tests/gateway/test_loop_exception_handler.py`: Added `test_transient_classifier_handles_traceback_exception_in_chain` — verifies that a `TracebackException` object in the exception chain doesn't crash the walker

## How to Test

1. Run `python -m pytest tests/gateway/test_loop_exception_handler.py -v` — all 15 tests should pass, including the new `test_transient_classifier_handles_traceback_exception_in_chain`
2. The new test creates a `traceback.TracebackException` from a `ConnectError` and passes it to `_is_transient_network_error()` — before the fix this would raise `AttributeError: 'TracebackException' object has no attribute '__cause__'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_loop_exception_handler.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
