### PR TITLE
fix(matrix): stop classifying auth errors by substring match

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2236,13 +2236,17 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 if self._closing:
                     return
-                # Detect permanent auth/permission failures.
-                err_str = str(exc).lower()
-                if (
-                    "401" in err_str
-                    or "403" in err_str
-                    or "unauthorized" in err_str
-                    or "forbidden" in err_str
+                # Detect permanent auth/permission failures. Only trust the
+                # structured HTTP status / errcode from mautrix's own error
+                # types here — matching on str(exc) is unsafe because error
+                # bodies can be arbitrary HTML (e.g. a proxy error page)
+                # whose contents may coincidentally contain "401"/"403".
+                http_status = getattr(exc, "http_status", None)
+                errcode = (getattr(exc, "errcode", None) or "").upper()
+                if http_status in (401, 403) or errcode in (
+                    "M_UNKNOWN_TOKEN",
+                    "M_MISSING_TOKEN",
+                    "M_FORBIDDEN",
                 ):
                     logger.error(
                         "Matrix: permanent auth error: %s — stopping sync", exc


### PR DESCRIPTION
## Summary
- The matrix sync loop's permanent-auth-error detection matched `"401"`/`"403"`/`"unauthorized"`/`"forbidden"` against `str(exc)`, including the raw body of non-Matrix error responses.
- A transient reverse-proxy error page (returned when the homeserver briefly restarted) happened to contain the digits "401" inside an SVG path coordinate in its embedded logo. That falsely tripped the permanent-auth-error path and permanently killed the sync loop on what was actually a transient connection blip — the bot stayed disconnected for hours until the process was manually restarted, even though the homeserver was healthy again within seconds.
- This switches the check to use the structured `http_status`/`errcode` attributes that mautrix's own exception types (`MatrixRequestError` and subclasses) set for genuine Matrix API error responses, instead of substring-matching arbitrary exception text.

## Test plan
- [x] `python -m py_compile plugins/platforms/matrix/adapter.py`
- [ ] Run `scripts/run_tests.sh tests/` for matrix platform coverage, if any exists