### PR TITLE
fix(gateway): keep runtime files in process home

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_process_hermes_home
 from typing import Any, Optional
 from utils import atomic_json_write
 
@@ -36,29 +36,34 @@ _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
+_gateway_lock_path: Path | None = None
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
 
 
-def _get_pid_path() -> Path:
+def _get_pid_path(*, process_scope: bool = False) -> Path:
     """Return the path to the gateway PID file, respecting HERMES_HOME."""
-    home = get_hermes_home()
+    home = get_process_hermes_home() if process_scope else get_hermes_home()
     return home / "gateway.pid"
 
 
-def _get_gateway_lock_path(pid_path: Optional[Path] = None) -> Path:
+def _get_gateway_lock_path(
+    pid_path: Optional[Path] = None,
+    *,
+    process_scope: bool = False,
+) -> Path:
     """Return the path to the runtime gateway lock file."""
     if pid_path is not None:
         return pid_path.with_name(_GATEWAY_LOCK_FILENAME)
-    home = get_hermes_home()
+    home = get_process_hermes_home() if process_scope else get_hermes_home()
     return home / _GATEWAY_LOCK_FILENAME
 
 
-def _get_runtime_status_path() -> Path:
+def _get_runtime_status_path(*, process_scope: bool = False) -> Path:
     """Return the persisted runtime health/status file path."""
-    return _get_pid_path().with_name(_RUNTIME_STATUS_FILE)
+    return _get_pid_path(process_scope=process_scope).with_name(_RUNTIME_STATUS_FILE)
 
 
 def _get_lock_dir() -> Path:
@@ -665,11 +670,11 @@ def acquire_gateway_runtime_lock() -> bool:
     Unlike the PID file, the lock is owned by the live process itself. If the
     process dies abruptly, the OS releases the lock automatically.
     """
-    global _gateway_lock_handle
+    global _gateway_lock_handle, _gateway_lock_path
     if _gateway_lock_handle is not None:
         return True
 
-    path = _get_gateway_lock_path()
+    path = _get_gateway_lock_path(process_scope=True)
     path.parent.mkdir(parents=True, exist_ok=True)
     handle = open(path, "a+", encoding="utf-8")
     if not _try_acquire_file_lock(handle):
@@ -677,16 +682,18 @@ def acquire_gateway_runtime_lock() -> bool:
         return False
     _write_gateway_lock_record(handle)
     _gateway_lock_handle = handle
+    _gateway_lock_path = path
     return True
 
 
 def release_gateway_runtime_lock() -> None:
     """Release the gateway runtime lock when owned by this process."""
-    global _gateway_lock_handle
+    global _gateway_lock_handle, _gateway_lock_path
     handle = _gateway_lock_handle
     if handle is None:
         return
     _gateway_lock_handle = None
+    _gateway_lock_path = None
     _release_file_lock(handle)
     try:
         handle.close()
@@ -698,7 +705,7 @@ def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     """Return True when some process currently owns the gateway runtime lock."""
     global _gateway_lock_handle
     resolved_lock_path = lock_path or _get_gateway_lock_path()
-    if _gateway_lock_handle is not None and resolved_lock_path == _get_gateway_lock_path():
+    if _gateway_lock_handle is not None and resolved_lock_path == _gateway_lock_path:
         return True
 
     if not resolved_lock_path.exists():
@@ -724,7 +731,7 @@ def write_pid_file() -> None:
     invocations race: exactly one process wins and the rest get
     FileExistsError.
     """
-    path = _get_pid_path()
+    path = _get_pid_path(process_scope=True)
     path.parent.mkdir(parents=True, exist_ok=True)
     record = json.dumps(_build_pid_record())
     try:
@@ -755,7 +762,7 @@ def write_runtime_status(
     served_profiles: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
-    path = _get_runtime_status_path()
+    path = _get_runtime_status_path(process_scope=True)
     payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
     payload.setdefault("platforms", {})
@@ -915,7 +922,7 @@ def remove_pid_file() -> None:
     PID file (invisible to ``get_running_pid()``).
     """
     try:
-        path = _get_pid_path()
+        path = _get_pid_path(process_scope=True)
         record = _read_json_file(path)
         if record is not None:
             try:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -110,6 +110,22 @@ def get_hermes_home() -> Path:
     return _get_platform_default_hermes_home()
 
 
+def get_process_hermes_home() -> Path:
+    """Return the process-scoped Hermes home, ignoring context-local overrides.
+
+    ``get_hermes_home()`` deliberately honors ``set_hermes_home_override()`` so
+    one gateway process can serve individual profile turns with isolated config,
+    memory, and skills. Process-owned runtime identity files are different:
+    ``gateway.pid``, ``gateway.lock``, and ``gateway_state.json`` belong to the
+    launched process's HERMES_HOME, not to whichever profile context is active
+    on a worker thread at write time.
+    """
+    val = os.environ.get("HERMES_HOME", "").strip()
+    if val:
+        return Path(val)
+    return _get_platform_default_hermes_home()
+
+
 def get_default_hermes_root() -> Path:
     """Return the root Hermes directory for profile-level operations.
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from gateway import status
 
 
@@ -20,6 +21,35 @@ class TestGatewayPidState:
         assert payload["kind"] == "hermes-gateway"
         assert isinstance(payload["argv"], list)
         assert payload["argv"]
+
+    def test_process_runtime_files_ignore_profile_context_override(self, tmp_path, monkeypatch):
+        """Gateway pid/lock/state files belong to the launched process home.
+
+        Multiplexed profile turns use a context-local Hermes-home override for
+        config/memory isolation. A turn-boundary status write under that context
+        must not move the gateway's process identity files into a profile dir.
+        """
+        process_home = tmp_path / "default"
+        profile_home = process_home / "profiles" / "cfo"
+        process_home.mkdir(parents=True)
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(process_home))
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            assert status.acquire_gateway_runtime_lock() is True
+            status.write_pid_file()
+            status.write_runtime_status(gateway_state="running", active_agents=1)
+        finally:
+            status.release_gateway_runtime_lock()
+            reset_hermes_home_override(token)
+
+        assert (process_home / "gateway.lock").exists()
+        assert (process_home / "gateway.pid").exists()
+        assert (process_home / "gateway_state.json").exists()
+        assert not (profile_home / "gateway.lock").exists()
+        assert not (profile_home / "gateway.pid").exists()
+        assert not (profile_home / "gateway_state.json").exists()
 
     def test_write_pid_file_is_atomic_against_concurrent_writers(self, tmp_path, monkeypatch):
         """Regression: two concurrent --replace invocations must not both win.


### PR DESCRIPTION
Fixes #56986.

## Problem
Gateway runtime identity files (`gateway.pid`, `gateway.lock`, `gateway_state.json`) can be written while a multiplexed profile turn has installed a context-local `HERMES_HOME` override. That moves process-level status into a named profile directory even though the gateway was launched from the default/process home.

## Root Cause
`gateway.status` derived all default runtime paths from `get_hermes_home()`. That helper is correct for config, memory, skills, and profile-scoped reads, but it intentionally honors `set_hermes_home_override()`. Runtime identity writes need the launched process home instead.

## Fix
- Add `get_process_hermes_home()` for process-owned state that must ignore context-local profile overrides.
- Route gateway pid/status writes, removal, and the owned runtime lock through the process-scoped home.
- Track the actual owned lock path so a root gateway lock does not make same-process profile lock probes look active.
- Add regression coverage for pid/lock/status writes under an active profile override.

## Tests
- `scripts/run_tests.sh tests/gateway/test_status.py -q`
- `scripts/run_tests.sh tests/test_hermes_constants.py tests/test_profile_isolation_runtime.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py -q`
- `.venv/bin/ruff check hermes_constants.py gateway/status.py tests/gateway/test_status.py`