### PR TITLE
fix(auxiliary): cap OpenRouter max tokens

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5745,7 +5745,12 @@ def _build_call_kwargs(
         # models reject it entirely with error 1210). Omitting it sidesteps all of
         # those wire-format quirks at once.
         #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
+        # OpenRouter is an exception: when omitted, its chat-completions
+        # default can be the model's full output ceiling (for example 65536),
+        # which turns small auxiliary calls like title generation into
+        # avoidable credit-limit failures. Preserve the caller's explicit cap.
+        #
+        # The other exception is the Anthropic Messages wire (MiniMax and any
         # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
         # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
         # there.
@@ -5763,8 +5768,13 @@ def _build_call_kwargs(
             _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
+        _is_openrouter = (
+            _provider_norm == "openrouter"
+            or base_url_host_matches(_effective_base, "openrouter.ai")
+        )
         if (
-            _is_anthropic_compat_endpoint(provider, _effective_base)
+            _is_openrouter
+            or _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim
         ):
             kwargs["max_tokens"] = max_tokens

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -185,7 +185,6 @@ class TestBuildCallKwargsMaxTokens:
             ("copilot", "gpt-5.4", "https://api.githubcopilot.com"),
             ("copilot", "gpt-5.5", "https://api.githubcopilot.com"),
             ("custom", "gpt-5", "https://api.openai.com/v1"),
-            ("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1"),
             ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1"),
             ("custom", "qwen", "http://localhost:8080/v1"),
             ("zai", "glm-4v-flash", "https://open.bigmodel.cn/api/paas/v4"),
@@ -222,6 +221,26 @@ class TestBuildCallKwargsMaxTokens:
             base_url=base_url,
         )
         assert kwargs["max_tokens"] == 1234
+        assert "max_completion_tokens" not in kwargs
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            ("openrouter", "https://openrouter.ai/api/v1"),
+            ("custom", "https://openrouter.ai/api/v1"),
+        ],
+    )
+    def test_keeps_max_tokens_for_openrouter(self, provider, base_url):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model="anthropic/claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "title this"}],
+            max_tokens=500,
+            base_url=base_url,
+        )
+        assert kwargs["max_tokens"] == 500
         assert "max_completion_tokens" not in kwargs
 
     def test_keeps_max_tokens_for_nvidia_nim(self):


### PR DESCRIPTION
Fixes #56901.

## Problem
Small auxiliary calls, especially title generation, pass an explicit output cap such as `max_tokens=500`. When auto fallback reaches OpenRouter, `_build_call_kwargs()` currently omits that cap because OpenRouter is treated like generic OpenAI-compatible chat completions. OpenRouter can then apply the model full-output default (for example 65536), causing confusing credit-limit errors on a task that asked for only a few hundred tokens.

## Root Cause
The auxiliary client intentionally omits `max_tokens` for most OpenAI-compatible providers to avoid providers that reject the parameter. The exception list covered Anthropic-compatible endpoints and NVIDIA NIM, but not OpenRouter, even though the adjacent `auxiliary_max_tokens_param()` path already treats OpenRouter as a provider that should keep `max_tokens`.

## Fix
- Preserve explicit `max_tokens` when the resolved provider is OpenRouter or the effective base URL is `openrouter.ai`.
- Keep the existing omit behavior for Copilot, OpenAI-compatible custom endpoints, Nous, local endpoints, and ZAI.
- Add regression coverage for both direct OpenRouter and a custom provider pointed at OpenRouter.

## Tests
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q`
- `.venv/bin/ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`