### PR TITLE
fix(browser): block Camofox input on private pages

### DIFF
--- a/tests/tools/test_browser_camofox_private_page_guard.py
+++ b/tests/tools/test_browser_camofox_private_page_guard.py
@@ -83,6 +83,34 @@ def test_private_page_blocks_camofox_reads(monkeypatch, _session, tool_call, act
     assert action_phrase in out["error"]
 
 
+@pytest.mark.parametrize(
+    ("tool_call", "action_phrase"),
+    [
+        (lambda: browser_camofox.camofox_click("@e1", task_id="t1"), "click"),
+        (
+            lambda: browser_camofox.camofox_type("@e1", "do-not-send-this", task_id="t1"),
+            "type",
+        ),
+        (lambda: browser_camofox.camofox_press("Enter", task_id="t1"), "press"),
+    ],
+)
+def test_private_page_blocks_camofox_input_actions(monkeypatch, _session, tool_call, action_phrase):
+    _block_active(monkeypatch)
+
+    def fail_post(*_args, **_kwargs):
+        raise AssertionError("Camofox action HTTP call should not run on a private page")
+
+    monkeypatch.setattr(browser_camofox, "_post", fail_post)
+
+    out = json.loads(tool_call())
+
+    assert out["success"] is False
+    assert PRIVATE_URL in out["error"]
+    assert "private or internal address" in out["error"]
+    assert action_phrase in out["error"]
+    assert "do-not-send-this" not in json.dumps(out)
+
+
 def test_snapshot_still_runs_when_page_is_public(monkeypatch, _session):
     _public_page(monkeypatch)
 
@@ -96,6 +124,29 @@ def test_snapshot_still_runs_when_page_is_public(monkeypatch, _session):
 
     assert out["success"] is True
     assert out["element_count"] == 1
+
+
+def test_camofox_click_still_runs_when_page_is_public(monkeypatch, _session):
+    _public_page(monkeypatch)
+    calls = []
+
+    def fake_post(path, body=None, timeout=None):
+        calls.append((path, body, timeout))
+        return {"url": "https://example.test/"}
+
+    monkeypatch.setattr(browser_camofox, "_post", fake_post)
+
+    out = json.loads(browser_camofox.camofox_click("@e1", task_id="t1"))
+
+    assert out["success"] is True
+    assert out["clicked"] == "e1"
+    assert calls == [
+        (
+            "/tabs/tab-1/click",
+            {"userId": "user-1", "ref": "e1"},
+            None,
+        )
+    ]
 
 
 def test_guard_inactive_does_not_probe(monkeypatch, _session):

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -653,6 +653,10 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
+        blocked = _camofox_private_page_block(session, task_id, "click")
+        if blocked:
+            return blocked
+
         # Strip @ prefix if present (our tool convention)
         clean_ref = ref.lstrip("@")
 
@@ -675,6 +679,10 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         session = _get_session(task_id)
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
+
+        blocked = _camofox_private_page_block(session, task_id, "type")
+        if blocked:
+            return blocked
 
         clean_ref = ref.lstrip("@")
 
@@ -744,6 +752,10 @@ def camofox_press(key: str, task_id: Optional[str] = None) -> str:
         session = _get_session(task_id)
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
+
+        blocked = _camofox_private_page_block(session, task_id, "press")
+        if blocked:
+            return blocked
 
         _post(
             f"/tabs/{session['tab_id']}/press",


### PR DESCRIPTION
## Summary

This extends the Camofox private-page guard to input actions (`camofox_click`, `camofox_type`, and `camofox_press`).

## Why

Recent browser hardening closed the private/internal-page boundary for the main browser tools and for Camofox read tools such as snapshot, image extraction, and vision. However, Camofox input actions still posted directly to the Camofox backend when the current page was a private/internal URL.

On a non-local Camofox backend, that means an agent could interact with an intranet or cloud-metadata-adjacent page that the terminal itself cannot reach. Even without reading the page back, clicks, typing, and key presses can mutate internal/admin state or submit forms.

## Changes

- Reuse the existing `_camofox_private_page_block()` helper before:
  - `camofox_click`
  - `camofox_type`
  - `camofox_press`
- Keep public-page and guard-inactive behavior unchanged.
- Add regression coverage proving private-page input actions short-circuit before any Camofox POST is sent.

## Tests

```text
python -m pytest tests/tools/test_browser_camofox_private_page_guard.py -q --timeout-method=thread
9 passed

python -m ruff check tools/browser_camofox.py tests/tools/test_browser_camofox_private_page_guard.py