### PR TITLE
feat(bluebubbles): message editing via Private API (enables streamed live-edit previews)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -202,6 +202,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # Edits consumed per sent-message guid (Apple caps iMessage edits
+        # at 5 per message within 15 minutes). LRU-capped like _guid_cache.
+        self._edit_counts: OrderedDict[str, int] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -278,6 +281,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             server_data = (info or {}).get("data", {})
             self._private_api_enabled = bool(server_data.get("private_api"))
             self._helper_connected = bool(server_data.get("helper_connected"))
+            # Message editing rides the Private API.  Expose support
+            # dynamically (instance attribute shadows the class default) so
+            # the stream consumer, which reads SUPPORTS_MESSAGE_EDITING via
+            # getattr at message time, only streams when the helper can
+            # actually deliver edits.
+            self.SUPPORTS_MESSAGE_EDITING = bool(
+                self._private_api_enabled and self._helper_connected
+            )
             logger.info(
                 "[bluebubbles] connected to %s (private_api=%s, helper=%s)",
                 self.server_url,
@@ -767,6 +778,75 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Tapback reactions
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Message editing (Private API) — enables Telegram-style streamed
+    # previews via the gateway stream consumer.
+    # ------------------------------------------------------------------
+
+    # Apple caps iMessage edits at 5 per message within a 15-minute window.
+    _EDIT_BUDGET = 5
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Edit a previously sent iMessage via the BlueBubbles Private API.
+
+        Preview (non-finalize) edits stop one short of Apple's 5-edit cap so
+        the final answer always has an edit slot left; over-budget preview
+        edits succeed as no-ops (the bubble stops updating until finalize).
+        A finalize call with no budget left delivers the answer as a fresh
+        message instead of being dropped.
+        """
+        if not (self._private_api_enabled and self._helper_connected and self.client):
+            return SendResult(
+                success=False,
+                error="BlueBubbles message editing requires the Private API helper",
+            )
+        if not message_id:
+            return SendResult(success=False, error="edit_message: missing message_id")
+
+        used = self._edit_counts.get(message_id, 0)
+        if not finalize and used >= self._EDIT_BUDGET - 1:
+            return SendResult(success=True, message_id=message_id)
+        if finalize and used >= self._EDIT_BUDGET:
+            return await self.send(chat_id, content)
+
+        text = self.format_message(content)
+        chunks = self.truncate_message(text)
+        first, rest = chunks[0], chunks[1:]
+        payload = {
+            "editedMessage": first,
+            "backwardsCompatibilityMessage": first,
+            "partIndex": 0,
+        }
+        encoded = quote(message_id, safe="")
+        try:
+            res = await self._api_post(f"/api/v1/message/{encoded}/edit", payload)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+        data = (res or {}).get("data") or {}
+        new_id = str(data.get("guid") or message_id)
+        self._edit_counts.pop(message_id, None)
+        self._edit_counts[new_id] = used + 1
+        while len(self._edit_counts) > _GUID_CACHE_SIZE:
+            self._edit_counts.popitem(last=False)
+        last = SendResult(success=True, message_id=new_id, raw_response=res)
+        # Overflow past MAX_TEXT_LENGTH: edit holds the first chunk and the
+        # tail goes out as follow-up messages, mirroring the Telegram
+        # adapter's split-and-deliver contract (subsequent edits then target
+        # the returned last message id).
+        for chunk in rest:
+            tail = await self.send(chat_id, chunk)
+            if tail.success and tail.message_id:
+                last = tail
+        return last
 
     # ------------------------------------------------------------------
     # Chat info

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -178,6 +178,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # Edits consumed per sent-message guid (Apple caps iMessage edits
+        # at 5 per message within 15 minutes). LRU-capped like _guid_cache.
+        self._edit_counts: OrderedDict[str, int] = OrderedDict()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -254,6 +257,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             server_data = (info or {}).get("data", {})
             self._private_api_enabled = bool(server_data.get("private_api"))
             self._helper_connected = bool(server_data.get("helper_connected"))
+            # Message editing rides the Private API.  Expose support
+            # dynamically (instance attribute shadows the class default) so
+            # the stream consumer, which reads SUPPORTS_MESSAGE_EDITING via
+            # getattr at message time, only streams when the helper can
+            # actually deliver edits.
+            self.SUPPORTS_MESSAGE_EDITING = bool(
+                self._private_api_enabled and self._helper_connected
+            )
             logger.info(
                 "[bluebubbles] connected to %s (private_api=%s, helper=%s)",
                 self.server_url,
@@ -743,6 +754,75 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Tapback reactions
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Message editing (Private API) — enables Telegram-style streamed
+    # previews via the gateway stream consumer.
+    # ------------------------------------------------------------------
+
+    # Apple caps iMessage edits at 5 per message within a 15-minute window.
+    _EDIT_BUDGET = 5
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Edit a previously sent iMessage via the BlueBubbles Private API.
+
+        Preview (non-finalize) edits stop one short of Apple's 5-edit cap so
+        the final answer always has an edit slot left; over-budget preview
+        edits succeed as no-ops (the bubble stops updating until finalize).
+        A finalize call with no budget left delivers the answer as a fresh
+        message instead of being dropped.
+        """
+        if not (self._private_api_enabled and self._helper_connected and self.client):
+            return SendResult(
+                success=False,
+                error="BlueBubbles message editing requires the Private API helper",
+            )
+        if not message_id:
+            return SendResult(success=False, error="edit_message: missing message_id")
+
+        used = self._edit_counts.get(message_id, 0)
+        if not finalize and used >= self._EDIT_BUDGET - 1:
+            return SendResult(success=True, message_id=message_id)
+        if finalize and used >= self._EDIT_BUDGET:
+            return await self.send(chat_id, content)
+
+        text = self.format_message(content)
+        chunks = self.truncate_message(text)
+        first, rest = chunks[0], chunks[1:]
+        payload = {
+            "editedMessage": first,
+            "backwardsCompatibilityMessage": first,
+            "partIndex": 0,
+        }
+        encoded = quote(message_id, safe="")
+        try:
+            res = await self._api_post(f"/api/v1/message/{encoded}/edit", payload)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+        data = (res or {}).get("data") or {}
+        new_id = str(data.get("guid") or message_id)
+        self._edit_counts.pop(message_id, None)
+        self._edit_counts[new_id] = used + 1
+        while len(self._edit_counts) > _GUID_CACHE_SIZE:
+            self._edit_counts.popitem(last=False)
+        last = SendResult(success=True, message_id=new_id, raw_response=res)
+        # Overflow past MAX_TEXT_LENGTH: edit holds the first chunk and the
+        # tail goes out as follow-up messages, mirroring the Telegram
+        # adapter's split-and-deliver contract (subsequent edits then target
+        # the returned last message id).
+        for chunk in rest:
+            tail = await self.send(chat_id, chunk)
+            if tail.success and tail.message_id:
+                last = tail
+        return last
 
     # ------------------------------------------------------------------
     # Chat info

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -837,16 +837,55 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._edit_counts[new_id] = used + 1
         while len(self._edit_counts) > _GUID_CACHE_SIZE:
             self._edit_counts.popitem(last=False)
-        last = SendResult(success=True, message_id=new_id, raw_response=res)
         # Overflow past MAX_TEXT_LENGTH: edit holds the first chunk and the
         # tail goes out as follow-up messages, mirroring the Telegram
         # adapter's split-and-deliver contract (subsequent edits then target
         # the returned last message id).
+        continuation_ids: List[str] = []
+        delivered_chunks: List[str] = [first]
+        prev_id = new_id
         for chunk in rest:
             tail = await self.send(chat_id, chunk)
-            if tail.success and tail.message_id:
-                last = tail
-        return last
+            if not (tail.success and tail.message_id):
+                # Continuation failed — the user has the edited first chunk
+                # plus however many tails landed, but NOT the full response.
+                # Reporting success here would let the stream consumer mark a
+                # clipped answer as delivered and suppress fallback delivery,
+                # so surface the partial-delivery contract instead.
+                logger.warning(
+                    "[bluebubbles] Overflow split: stopped at %d/%d chunks delivered",
+                    1 + len(continuation_ids),
+                    len(chunks),
+                )
+                return SendResult(
+                    success=False,
+                    message_id=prev_id,
+                    error="overflow_continuation_failed",
+                    retryable=True,
+                    raw_response={
+                        "partial_overflow": True,
+                        "delivered_chunks": 1 + len(continuation_ids),
+                        "total_chunks": len(chunks),
+                        "last_message_id": prev_id,
+                        "delivered_prefix": "".join(delivered_chunks),
+                        "continuation_message_ids": tuple(continuation_ids),
+                    },
+                    continuation_message_ids=tuple(continuation_ids),
+                )
+            tail_id = str(tail.message_id)
+            continuation_ids.append(tail_id)
+            delivered_chunks.append(chunk)
+            prev_id = tail_id
+
+        # ``message_id`` is the LAST visible bubble so subsequent edits target
+        # the most recent chunk; the consumer only adopts it when
+        # ``continuation_message_ids`` is populated.
+        return SendResult(
+            success=True,
+            message_id=prev_id,
+            raw_response=res,
+            continuation_message_ids=tuple(continuation_ids),
+        )
 
     # ------------------------------------------------------------------
     # Chat info

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -813,16 +813,55 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._edit_counts[new_id] = used + 1
         while len(self._edit_counts) > _GUID_CACHE_SIZE:
             self._edit_counts.popitem(last=False)
-        last = SendResult(success=True, message_id=new_id, raw_response=res)
         # Overflow past MAX_TEXT_LENGTH: edit holds the first chunk and the
         # tail goes out as follow-up messages, mirroring the Telegram
         # adapter's split-and-deliver contract (subsequent edits then target
         # the returned last message id).
+        continuation_ids: List[str] = []
+        delivered_chunks: List[str] = [first]
+        prev_id = new_id
         for chunk in rest:
             tail = await self.send(chat_id, chunk)
-            if tail.success and tail.message_id:
-                last = tail
-        return last
+            if not (tail.success and tail.message_id):
+                # Continuation failed — the user has the edited first chunk
+                # plus however many tails landed, but NOT the full response.
+                # Reporting success here would let the stream consumer mark a
+                # clipped answer as delivered and suppress fallback delivery,
+                # so surface the partial-delivery contract instead.
+                logger.warning(
+                    "[bluebubbles] Overflow split: stopped at %d/%d chunks delivered",
+                    1 + len(continuation_ids),
+                    len(chunks),
+                )
+                return SendResult(
+                    success=False,
+                    message_id=prev_id,
+                    error="overflow_continuation_failed",
+                    retryable=True,
+                    raw_response={
+                        "partial_overflow": True,
+                        "delivered_chunks": 1 + len(continuation_ids),
+                        "total_chunks": len(chunks),
+                        "last_message_id": prev_id,
+                        "delivered_prefix": "".join(delivered_chunks),
+                        "continuation_message_ids": tuple(continuation_ids),
+                    },
+                    continuation_message_ids=tuple(continuation_ids),
+                )
+            tail_id = str(tail.message_id)
+            continuation_ids.append(tail_id)
+            delivered_chunks.append(chunk)
+            prev_id = tail_id
+
+        # ``message_id`` is the LAST visible bubble so subsequent edits target
+        # the most recent chunk; the consumer only adopts it when
+        # ``continuation_message_ids`` is populated.
+        return SendResult(
+            success=True,
+            message_id=prev_id,
+            raw_response=res,
+            continuation_message_ids=tuple(continuation_ids),
+        )
 
     # ------------------------------------------------------------------
     # Chat info

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.bluebubbles import MAX_TEXT_LENGTH
 
 
 def _make_adapter(monkeypatch, **extra):
@@ -438,3 +439,93 @@ class TestBlueBubblesWebhookRegistration:
         assert len(deleted_ids) == 2
 
 
+class TestBlueBubblesEditOverflow:
+    """Oversized edits split across the original bubble + follow-up sends.
+
+    ``GatewayStreamConsumer`` only adopts the returned last-visible
+    ``message_id`` when ``continuation_message_ids`` is populated
+    (``gateway/stream_consumer.py``), so an overflowing edit must report every
+    continuation id or later edits keep targeting the original bubble and
+    duplicate the tail.
+    """
+
+    @staticmethod
+    def _ready(adapter):
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        adapter.client = object()
+
+    @pytest.mark.asyncio
+    async def test_edit_overflow_reports_continuation_ids_and_last_id(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        self._ready(adapter)
+
+        async def fake_api_post(path, payload):
+            return {"data": {"guid": "edited-guid"}}
+
+        adapter._api_post = fake_api_post
+
+        sent = []
+
+        async def fake_send(chat_id, chunk, **kwargs):
+            from gateway.platforms.base import SendResult
+
+            sent.append(chunk)
+            return SendResult(success=True, message_id=f"tail-{len(sent)}")
+
+        adapter.send = fake_send
+
+        content = "x" * (MAX_TEXT_LENGTH * 3)
+        result = await adapter.edit_message("chat", "orig-guid", content)
+
+        assert result.success is True
+        # message_id must be the LAST visible bubble so later edits target it.
+        assert result.message_id == f"tail-{len(sent)}"
+        # Every continuation id is reported, in send order.
+        assert result.continuation_message_ids == tuple(
+            f"tail-{i + 1}" for i in range(len(sent))
+        )
+        assert len(sent) >= 1
+
+    @pytest.mark.asyncio
+    async def test_edit_overflow_tail_failure_reports_partial_delivery(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        self._ready(adapter)
+
+        async def fake_api_post(path, payload):
+            return {"data": {"guid": "edited-guid"}}
+
+        adapter._api_post = fake_api_post
+
+        calls = []
+
+        async def failing_send(chat_id, chunk, **kwargs):
+            from gateway.platforms.base import SendResult
+
+            calls.append(chunk)
+            if len(calls) == 1:
+                return SendResult(success=True, message_id="tail-1")
+            return SendResult(success=False, error="imessage send failed")
+
+        adapter.send = failing_send
+
+        content = "x" * (MAX_TEXT_LENGTH * 3)
+        result = await adapter.edit_message("chat", "orig-guid", content)
+
+        # A dropped tail must NOT be reported as a delivered response.
+        assert result.success is False
+        assert result.error == "overflow_continuation_failed"
+        assert result.continuation_message_ids == ("tail-1",)
+        assert result.message_id == "tail-1"
+        raw = result.raw_response or {}
+        assert raw.get("partial_overflow") is True
+        assert raw.get("delivered_chunks") == 2
+        assert raw.get("last_message_id") == "tail-1"
+        # ``delivered_prefix`` must be a true prefix of the formatted text:
+        # the consumer gates tail recovery on ``text.startswith(prefix)``
+        # (gateway/stream_consumer.py). BlueBubbles' truncate_message omits
+        # the "(1/3)" pagination suffixes Telegram has to strip, so joining
+        # the delivered chunks is enough.
+        delivered_prefix = raw.get("delivered_prefix")
+        assert delivered_prefix
+        assert adapter.format_message(content).startswith(delivered_prefix)


### PR DESCRIPTION
## What

Adds message-editing support to the BlueBubbles (iMessage) platform adapter, which enables Telegram-style edit-based live streaming of responses on iMessage.

- Implements `edit_message()` using the BlueBubbles Private API endpoint `POST /api/v1/message/:guid/edit` with `{editedMessage, backwardsCompatibilityMessage, partIndex}`.
- `SUPPORTS_MESSAGE_EDITING` becomes a dynamic instance attribute, set in `connect()` and true only when the server reports `private_api && helper_connected`. Since the gateway stream consumer reads the flag via `getattr` at message time, it automatically gains edit-based streamed previews on iMessage when — and only when — the helper can actually deliver edits. No gateway changes needed.

## Edit budget

Apple caps iMessage edits at 5 per message within 15 minutes. The adapter tracks edits consumed per sent-message guid (LRU-capped alongside `_guid_cache`):

- Preview (non-finalize) edits stop one short of the cap, reserving the last slot for the final answer.
- Over-budget preview edits return success as no-ops (the bubble simply stops updating until finalize).
- A finalize call with no budget left falls back to sending a fresh message rather than dropping the answer.

## Overflow

Content past `MAX_TEXT_LENGTH` follows the Telegram adapter's split-and-deliver contract: the edit holds the first chunk, the tail is sent as follow-up messages, and the `message_id` of the last visible message is returned so subsequent edits target it.

## Verification

- Payload shape and endpoint verified against the BlueBubbles server source (`messageRouter.ts` `editMessage` handler).
- Tested for no-regression with the helper disconnected on a live gateway (flag stays false, adapter behaves as before).
- The live edit path itself is pending Private API helper access on my server, so it has not been exercised end-to-end yet.

## Out of scope

Tapback send support is intentionally not included in this PR.
