### PR TITLE
fix(tools): keep shell snapshots owner-only

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -174,6 +174,32 @@ class TestAtomicSnapshotWrite:
         assert "$BASHPID" in boot
         assert ".tmp.$$" not in boot
 
+    def test_snapshot_writes_use_private_umask_after_user_command(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("echo hi", "/tmp")
+
+        assert "umask 077" in wrapped
+        assert wrapped.index("eval 'echo hi'") < wrapped.index("umask 077")
+        assert wrapped.index("umask 077") < wrapped.index("export -p >")
+
+    def test_init_session_bootstrap_uses_private_umask(self):
+        env = _TestableEnv()
+        captured = {}
+
+        def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+            captured["cmd"] = cmd_string
+            raise RuntimeError("stop after capture")
+
+        env._run_bash = fake_run_bash  # type: ignore[assignment]
+        try:
+            env.init_session()
+        except Exception:
+            pass
+        boot = captured.get("cmd", "")
+        assert "umask 077" in boot
+        assert boot.index("umask 077") < boot.index("export -p >")
+
 
 class TestAtomicSnapshotConcurrencyBehavioral:
     """Behavioral regression for #38249 — actually EXECUTES the generated
@@ -248,6 +274,57 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         self._run(script)
         out = self._run(f"cat {_q(snap)}")
         assert "export GOOD=1" in out.stdout, "good snapshot was destroyed by a failed export"
+
+
+class TestSnapshotFileModes:
+    """Snapshot metadata files are private without changing user command umask."""
+
+    def test_snapshot_and_cwd_files_are_0600(self, tmp_path):
+        import os
+        from pathlib import Path
+        import shutil
+        import stat
+        import subprocess
+        if not shutil.which("bash"):
+            import pytest
+            pytest.skip("bash required")
+
+        class ExecutableEnv(BaseEnvironment):
+            def __init__(self, temp_dir):
+                self._temp_dir = str(temp_dir)
+                super().__init__(cwd=str(temp_dir), timeout=10)
+
+            def get_temp_dir(self):
+                return self._temp_dir
+
+            def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+                proc = subprocess.Popen(
+                    ["/bin/bash", "-lc", cmd_string],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                    text=True,
+                    cwd=self.cwd,
+                )
+                proc.communicate(timeout=timeout)
+                return proc
+
+            def cleanup(self):
+                pass
+
+        old_umask = os.umask(0o022)
+        try:
+            env = ExecutableEnv(tmp_path)
+            env.init_session()
+
+            user_file = tmp_path / "user-created.txt"
+            env.execute(f"touch {user_file}")
+
+            assert stat.S_IMODE(user_file.stat().st_mode) == 0o644
+            assert stat.S_IMODE(Path(env._snapshot_path).stat().st_mode) == 0o600
+            assert stat.S_IMODE(Path(env._cwd_file).stat().st_mode) == 0o600
+        finally:
+            os.umask(old_umask)
 
 
 class TestExtractCwdFromOutput:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -395,6 +395,7 @@ class BaseEnvironment(ABC):
         # with ``$BASHPID`` left outside the quotes so it still expands.
         _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
         bootstrap = (
+            f"umask 077\n"
             f"export -p > {_snap_tmp}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
@@ -502,6 +503,9 @@ class BaseEnvironment(ABC):
         # Run the actual command
         parts.append(f"eval '{escaped}'")
         parts.append("__hermes_ec=$?")
+        # Restrict Hermes metadata files without changing the user's command
+        # umask. Snapshot files may contain env-carried secrets.
+        parts.append("umask 077")
 
         # Re-dump env vars to snapshot (atomic replacement to avoid races).
         # Chain mv on the export succeeding so a failed/partial dump never


### PR DESCRIPTION
## Summary

Salvages the security-relevant subset of https://github.com/NousResearch/hermes-agent/pull/20056 by making Hermes-owned shell snapshot and cwd metadata writes owner-only.

`BaseEnvironment` snapshots exported environment state before and after commands. Those files can include env-carried credentials, but current `origin/main` still writes them through the process umask, so a common `022` umask can leave them world-readable. This patch sets `umask 077` only around Hermes metadata writes while preserving the user's command umask.

This intentionally does not salvage the source PR's global `/tmp` orphan cleanup because deleting all matching snapshot files could interfere with concurrent Hermes processes.

## Source and Attribution

- Source PR: https://github.com/NousResearch/hermes-agent/pull/20056
- Related issue: https://github.com/NousResearch/hermes-agent/issues/48441
- Original author credited in git history: `Co-authored-by: Andrew Homeyer <andrew@hndl.app>`

## Policy and Validation

- [x] Read `SECURITY.md` and kept the change scoped to a local credential-disclosure hardening path.
- [x] Read `CONTRIBUTING.md` and kept the PR focused, with tests for the behavior change.
- [x] Confirmed current `origin/main` at `80a774f972b1b4dd127b87ccf3ff0b68bf3b356d` still has the unprotected `export -p` snapshot writes in `tools/environments/base.py`.
- [x] Confirmed the files involved in this fix did not change between the validated base `048270fa069ff6aa41c01b403ac1eeab34b29628` and current `origin/main`.
- [x] Ran CodeRabbit on the committed diff: no findings.
- [x] Ran `env HOME=/home/mac scripts/run_tests.sh -j 6 tests/tools/test_base_environment.py`: 29 passed.
- [x] Ran `env HOME=/home/mac scripts/run_tests.sh -j 6 --file-timeout 900`: 38,041 passed.

## Agent Disclosure

Model: GPT-5.5-xhigh

Harness: Codex

Human looked at and manually signed the commit.

The account owner loosely reviews my actions and receives the usual notifications from GitHub.
