### PR TITLE
fix(plugins): allow symlinks in plugin directory

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -87,7 +87,10 @@ def _sanitize_plugin_name(
     """Validate a plugin name and return the safe target path inside *plugins_dir*.
 
     Raises ``ValueError`` if the name contains path-traversal sequences or would
-    resolve outside the plugins directory.
+    resolve outside the plugins directory.  Direct symlinks whose entry lives
+    inside *plugins_dir* are accepted without resolving their target — this
+    preserves the common developer workflow of symlinking a plugin from a
+    project checkout into ``~/.hermes/plugins/``.
 
     ``allow_subdir=True`` permits a single forward slash inside *name* so
     category-namespaced plugin keys like ``observability/langfuse`` or
@@ -117,7 +120,18 @@ def _sanitize_plugin_name(
         if bad in name:
             raise ValueError(f"Invalid plugin name '{name}': must not contain '{bad}'.")
 
-    target = (plugins_dir / name).resolve()
+    entry = plugins_dir / name
+
+    # Symlinks: the entry itself lives inside *plugins_dir* (guaranteed by the
+    # string checks above).  Return the unresolved path so callers operate on
+    # the link, not its external target.  This preserves the common developer
+    # workflow of symlinking a plugin from a project checkout into
+    # ``~/.hermes/plugins/``.
+    if entry.is_symlink():
+        return entry
+
+    # Non-symlinks: resolve and verify containment (defense-in-depth).
+    target = entry.resolve()
     plugins_resolved = plugins_dir.resolve()
 
     if target == plugins_resolved:

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -95,6 +95,39 @@ class TestSanitizePluginName:
         target = _sanitize_plugin_name("a/b/c", tmp_path, allow_subdir=True)
         assert target.is_relative_to(tmp_path.resolve())
 
+    # ── symlink handling ──
+
+    def test_symlink_to_external_dir_accepted(self, tmp_path):
+        """Symlinks whose entry lives inside plugins_dir are accepted."""
+        external = tmp_path / "external-project"
+        external.mkdir()
+        (external / "plugin.yaml").write_text("name: my-plugin\n")
+        (tmp_path / "my-plugin").symlink_to(external)
+        target = _sanitize_plugin_name("my-plugin", tmp_path)
+        # Returns the unresolved symlink path, not the target
+        assert target == tmp_path / "my-plugin"
+        assert target.is_symlink()
+
+    def test_symlink_returns_unresolved_path(self, tmp_path):
+        """Symlink result is the link itself, not its resolved target."""
+        external = tmp_path / "project" / "plugin"
+        external.parent.mkdir(parents=True)
+        external.mkdir()
+        (tmp_path / "my-plugin").symlink_to(external)
+        target = _sanitize_plugin_name("my-plugin", tmp_path)
+        assert target != external.resolve()
+        assert target == tmp_path / "my-plugin"
+
+    def test_symlink_with_allow_subdir(self, tmp_path):
+        """Symlinks work with allow_subdir=True."""
+        external = tmp_path / "external-cat" / "plugin"
+        external.parent.mkdir(parents=True)
+        external.mkdir()
+        (tmp_path / "cat").mkdir()
+        (tmp_path / "cat" / "plugin").symlink_to(external)
+        target = _sanitize_plugin_name("cat/plugin", tmp_path, allow_subdir=True)
+        assert target.is_symlink()
+
 
 # ── _resolve_git_url ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Fixes a regression introduced by the path-traversal security guard (PR #46435) that prevents symlinked plugins from being discovered or enabled. When a user installs a plugin as a symlink (e.g., `ln -s ~/projects/my-plugin ~/.hermes/plugins/my-plugin`), the guard's `.resolve()` call follows the symlink, sees the target is outside `~/.hermes/plugins/`, and raises `ValueError`.

## Related Issue

Fixes #57385

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/plugins_cmd.py`: In `_sanitize_plugin_name()`, check `is_symlink()` before calling `.resolve()`. For symlinks whose entry lives inside `plugins_dir` (guaranteed by the preceding string checks for `..`, `/`, `\`), return the unresolved symlink path instead of following it to the target. Non-symlink paths retain the existing resolve-and-verify defense-in-depth check.
- `tests/hermes_cli/test_plugins_cmd.py`: Added 3 regression tests — symlink-to-external-dir accepted, unresolved return value, and `allow_subdir` interaction.

## How to Test

1. `python -m pytest tests/hermes_cli/test_plugins_cmd.py::TestSanitizePluginName -v` — all 17 tests should pass, including the 3 new symlink tests.
2. Manual: create a symlink `ln -s ~/some-project ~/.hermes/plugins/test-plugin` (where `test-plugin/` contains a `plugin.yaml`), then run `hermes plugins list` — the symlinked plugin should appear.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
