### PR TITLE
fix: resolve TTS, Slack, TUI, and logging regressions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -573,7 +573,11 @@ def init_agent(
     # both live under ~/.hermes/logs/.  Idempotent, so gateway mode
     # (which creates a new AIAgent per message) won't duplicate handlers.
     from hermes_logging import setup_logging, setup_verbose_logging
-    setup_logging(hermes_home=_ra()._hermes_home)
+    # Resolve HERMES_HOME at agent-construction time rather than reusing
+    # run_agent's import-time snapshot. Pytest redirects HERMES_HOME after
+    # collection, so the frozen snapshot can otherwise attach log handlers to
+    # the user's real profile (#57118).
+    setup_logging()
 
     if agent.verbose_logging:
         setup_verbose_logging()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,6 +15,7 @@ import re
 import socket as _socket
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from abc import ABC, abstractmethod
@@ -4965,8 +4966,19 @@ class BasePlatformAdapter(ABC):
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
+                            # This adapter-level path runs outside the agent-turn
+                            # contextvars that text_to_speech_tool normally uses
+                            # to infer the platform. Pass an explicit extension so
+                            # Telegram voice replies become real Ogg/Opus bubbles.
+                            audio_ext = "ogg" if self.platform == Platform.TELEGRAM else "mp3"
+                            audio_path = os.path.join(
+                                tempfile.gettempdir(),
+                                "hermes_voice",
+                                f"tts_reply_{uuid.uuid4().hex[:12]}.{audio_ext}",
+                            )
+                            os.makedirs(os.path.dirname(audio_path), exist_ok=True)
                             tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                                text_to_speech_tool, text=speech_text, output_path=audio_path
                             )
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")

--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -451,6 +451,17 @@ def render_blocks(
                     elif om:
                         items.append((_indent_level(om.group(1)), True, om.group(3)))
                         i += 1
+                    elif lines[i].strip() == "" and items:
+                        # Slack restarts numbering for each rich_text_list block.
+                        # Keep markdown lists grouped across blank spacer lines
+                        # when the next nonblank line is another list marker.
+                        j = i + 1
+                        while j < n and lines[j].strip() == "":
+                            j += 1
+                        if j < n and (_BULLET_RE.match(lines[j]) or _ORDERED_RE.match(lines[j])):
+                            i = j
+                        else:
+                            break
                     elif lines[i].strip() and lines[i].startswith((" ", "\t")) and items:
                         # continuation line of the previous item
                         indent, ordered, txt = items[-1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,11 @@ test runner at ``scripts/run_tests.sh``.
 """
 
 import asyncio
+import atexit
 import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -30,6 +33,17 @@ import pytest
 PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+# Pytest imports test modules during collection before function-scoped fixtures
+# can redirect HERMES_HOME. Give import-time get_hermes_home() consumers a
+# process-local sandbox immediately so collection can never bind log/env paths
+# to the developer's live Hermes profile (#57118). Individual tests still get
+# their own per-test HERMES_HOME in _hermetic_environment below.
+_COLLECTION_HERMES_HOME = Path(tempfile.mkdtemp(prefix="hermes_pytest_collection_"))
+for _subdir in ("sessions", "cron", "memories", "skills", "logs"):
+    (_COLLECTION_HERMES_HOME / _subdir).mkdir(parents=True, exist_ok=True)
+os.environ["HERMES_HOME"] = str(_COLLECTION_HERMES_HOME)
+atexit.register(shutil.rmtree, _COLLECTION_HERMES_HOME, ignore_errors=True)
 
 
 # ── Per-file process isolation ──────────────────────────────────────────────

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -71,6 +71,20 @@ class TestNestedLists:
         assert "ordered" in styles
         assert "bullet" in styles
 
+    def test_ordered_list_with_blank_lines_stays_one_numbered_group(self):
+        md = "1. Alpha\n\n2. Beta\n\n3. Gamma"
+        blocks = render_blocks(md)
+        assert blocks is not None
+        rich = [b for b in blocks if b["type"] == "rich_text"]
+        ordered_lists = [
+            e
+            for b in rich
+            for e in b["elements"]
+            if e["type"] == "rich_text_list" and e["style"] == "ordered"
+        ]
+        assert len(ordered_lists) == 1
+        assert len(ordered_lists[0]["elements"]) == 3
+
 
 class TestInlineFormatting:
     def test_link_becomes_link_element(self):

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -6,9 +6,10 @@ Telegram (where Bot-API sendAudio only accepts MP3/M4A and .ogg/.opus
 only renders as a voice bubble when explicitly flagged) and via
 ``GatewayRunner._deliver_media_from_response``.
 """
-
+import json
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -118,6 +119,43 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
         audio_path=str(media_file),
         metadata={"notify": True},
     )
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_auto_tts_requests_telegram_ogg_voice_output(tmp_path, monkeypatch):
+    adapter = _MediaRoutingAdapter()
+    adapter._auto_tts_enabled_chats.add("chat-1")
+    adapter._message_handler = AsyncMock(return_value="hello from voice reply")
+    adapter.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="voice"))
+    adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="text"))
+    event = _event()
+    event.message_type = MessageType.VOICE
+    requested_paths: list[str] = []
+
+    def fake_tts(*, text, output_path):
+        requested_paths.append(output_path)
+        assert text == "hello from voice reply"
+        assert output_path.endswith(".ogg")
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_bytes(b"OggS fake opus")
+        return json.dumps({
+            "success": True,
+            "file_path": output_path,
+            "provider": "edge",
+            "voice_compatible": True,
+        })
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), \
+            patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_tts):
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert requested_paths
+    adapter.send_voice.assert_awaited_once()
+    send_voice_args = adapter.send_voice.await_args
+    assert send_voice_args is not None
+    assert send_voice_args.kwargs["audio_path"].endswith(".ogg")
     adapter.send_document.assert_not_awaited()
 
 

--- a/tests/run_agent/test_hermes_home_logging_isolation.py
+++ b/tests/run_agent/test_hermes_home_logging_isolation.py
@@ -1,0 +1,65 @@
+"""Regression coverage for pytest log isolation (#57118)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_aiagent_logging_uses_current_home_after_run_agent_import(tmp_path):
+    old_home = tmp_path / "old-home"
+    new_home = tmp_path / "new-home"
+    old_home.mkdir()
+    new_home.mkdir()
+    marker = "pytest-hermes-home-isolation-marker"
+    script = textwrap.dedent(
+        """
+        import logging
+        import os
+        import sys
+        from pathlib import Path
+
+        old_home = Path(sys.argv[1])
+        new_home = Path(sys.argv[2])
+        marker = sys.argv[3]
+
+        os.environ["HERMES_HOME"] = str(old_home)
+        import run_agent
+        assert Path(run_agent._hermes_home) == old_home
+
+        os.environ["HERMES_HOME"] = str(new_home)
+        agent = run_agent.AIAgent(
+            api_key=os.environ["OPENROUTER_API_KEY"],
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        logging.getLogger("run_agent").info(marker)
+
+        old_log = old_home / "logs" / "agent.log"
+        new_log = new_home / "logs" / "agent.log"
+        assert new_log.exists(), new_log
+        assert marker in new_log.read_text(encoding="utf-8")
+        assert not old_log.exists() or marker not in old_log.read_text(encoding="utf-8")
+        assert agent is not None
+        """
+    )
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+        "OPENROUTER_API_KEY": "test-key",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(old_home), str(new_home), marker],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4242,6 +4242,21 @@ def test_commands_catalog_includes_tui_mouse_command():
     assert "/mouse" in tui_pairs
 
 
+def test_commands_catalog_tui_local_commands_override_cli_aliases():
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    assert resp is not None
+    result = resp["result"]
+    assert result is not None
+    pairs = dict(result["pairs"])
+    canon = result["canon"]
+
+    assert pairs["/compact"] == "Toggle compact display mode"
+    assert canon["/compact"] == "/compact"
+
+
 def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,6 +1,8 @@
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import Mock
+from types import SimpleNamespace
 
 import pytest
 
@@ -68,3 +70,76 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_edge_explicit_ogg_writes_temp_mp3_then_converts_to_target(tmp_path, monkeypatch):
+    out = tmp_path / "speech.ogg"
+    saved_paths: list[str] = []
+    convert_calls: list[tuple[str, str]] = []
+
+    class FakeCommunicate:
+        def __init__(self, text: str, **kwargs):
+            assert text == "hello"
+            assert kwargs["voice"] == tts_tool.DEFAULT_EDGE_VOICE
+
+        async def save(self, path: str) -> None:
+            saved_paths.append(path)
+            Path(path).write_bytes(b"mp3 bytes")
+
+    def fake_convert(input_path: str, output_path: str | None = None) -> str:
+        assert output_path == str(out)
+        assert output_path is not None
+        assert input_path != str(out)
+        assert input_path.endswith(".mp3")
+        convert_calls.append((input_path, output_path))
+        out.write_bytes(b"OggS converted")
+        return str(out)
+
+    monkeypatch.setattr(
+        tts_tool,
+        "_import_edge_tts",
+        lambda: SimpleNamespace(Communicate=FakeCommunicate),
+    )
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", fake_convert)
+
+    result = asyncio.run(tts_tool._generate_edge_tts("hello", str(out), {}))
+
+    assert result == str(out)
+    assert out.read_bytes().startswith(b"OggS")
+    assert len(saved_paths) == 1
+    assert saved_paths[0] != str(out)
+    assert not Path(saved_paths[0]).exists()
+    assert convert_calls == [(saved_paths[0], str(out))]
+
+
+def test_telegram_explicit_ogg_for_non_native_provider_is_transcoded(tmp_path, monkeypatch):
+    out = tmp_path / "speech.ogg"
+    convert_calls: list[tuple[str, str | None]] = []
+
+    def fake_generate_piper(_text: str, output_path: str, _tts_config: dict) -> str:
+        assert output_path == str(out)
+        Path(output_path).write_bytes(b"OggS fake vorbis")
+        return output_path
+
+    def fake_convert(input_path: str, output_path: str | None = None) -> str:
+        assert output_path is not None
+        assert input_path != str(out)
+        assert output_path != str(out)
+        convert_calls.append((input_path, output_path))
+        Path(output_path).write_bytes(b"OggS opus")
+        return output_path
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "piper"})
+    monkeypatch.setattr(tts_tool, "_import_piper", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_piper_tts", fake_generate_piper)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", fake_convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{out}"
+    assert out.read_bytes() == b"OggS opus"
+    assert len(convert_calls) == 1

--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -42,10 +42,13 @@ def server():
     }):
         import importlib
         mod = importlib.import_module("tui_gateway.server")
+        methods_snapshot = dict(mod._methods)
         yield mod
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
+        mod._methods.clear()
+        mod._methods.update(methods_snapshot)
 
 
 @pytest.fixture()

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -29,18 +29,20 @@ def server():
     }):
         import importlib
         mod = importlib.import_module("tui_gateway.server")
+        methods_snapshot = dict(mod._methods)
         yield mod
         # Reset module-level session state without re-importing. importlib.reload
         # would re-register the module's atexit hooks (ThreadPoolExecutor
         # shutdown, _shutdown_sessions); the duplicates race the stderr
         # buffer at interpreter shutdown and surface as Fatal Python error:
-        # _enter_buffered_busy. Clearing the per-session dicts gives the
-        # next test a clean slate; _methods is NOT cleared because it's
-        # populated at module import time and re-registration only happens
-        # via reload (which we don't do).
+        # _enter_buffered_busy. Restore _methods from a per-test snapshot so
+        # RPC handler monkeypatches in this protocol module do not leak into
+        # later server tests in the same pytest process.
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
+        mod._methods.clear()
+        mod._methods.update(methods_snapshot)
 
 
 @pytest.fixture()

--- a/tests/tui_gateway/test_undo_command.py
+++ b/tests/tui_gateway/test_undo_command.py
@@ -42,12 +42,15 @@ def server(hermes_home):
         },
     ):
         mod = importlib.import_module("tui_gateway.server")
+        methods_snapshot = dict(mod._methods)
         yield mod
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
         mod._methods.clear()
-        importlib.reload(mod)
+        mod._methods.update(methods_snapshot)
+        setattr(mod, "_db", None)
+        setattr(mod, "_db_error", None)
 
 
 @pytest.fixture()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -394,6 +394,19 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "piper",
 })
 
+# Providers in this set do not produce native Ogg/Opus for Telegram voice
+# bubbles.  Even if they were asked to write a .ogg file, it may be MP3 bytes
+# or Ogg/Vorbis, so post-process through ffmpeg/libopus before tagging it as a
+# native voice message.
+BUILTIN_TTS_OPUS_TRANSCODE_PROVIDERS = frozenset({
+    "edge",
+    "minimax",
+    "xai",
+    "neutts",
+    "kittentts",
+    "piper",
+})
+
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
 COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
@@ -891,12 +904,23 @@ def _has_ffmpeg() -> bool:
     return shutil.which("ffmpeg") is not None
 
 
-def _convert_to_opus(mp3_path: str) -> Optional[str]:
+def _is_ogg_container(path: str) -> bool:
+    """Return True when *path* starts with the Ogg container magic bytes."""
+    try:
+        with open(path, "rb") as f:
+            return f.read(4) == b"OggS"
+    except OSError:
+        return False
+
+
+def _convert_to_opus(input_path: str, output_path: Optional[str] = None) -> Optional[str]:
     """
-    Convert an MP3 file to OGG Opus format for Telegram voice bubbles.
+    Convert an audio file to OGG Opus format for Telegram voice bubbles.
 
     Args:
-        mp3_path: Path to the input MP3 file.
+        input_path: Path to the input audio file.
+        output_path: Optional explicit .ogg destination. Defaults to replacing
+            the input suffix with .ogg.
 
     Returns:
         Path to the .ogg file, or None if conversion fails.
@@ -904,10 +928,10 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     if not _has_ffmpeg():
         return None
 
-    ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+    ogg_path = output_path or input_path.rsplit(".", 1)[0] + ".ogg"
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
+            ["ffmpeg", "-i", input_path, "-acodec", "libopus",
              "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
@@ -917,8 +941,9 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
             logger.warning("ffmpeg conversion failed with return code %d: %s", 
                           result.returncode, result.stderr.decode('utf-8', errors='ignore')[:200])
             return None
-        if os.path.exists(ogg_path) and os.path.getsize(ogg_path) > 0:
+        if os.path.exists(ogg_path) and os.path.getsize(ogg_path) > 0 and _is_ogg_container(ogg_path):
             return ogg_path
+        logger.warning("ffmpeg conversion did not produce a valid OGG file: %s", ogg_path)
     except subprocess.TimeoutExpired:
         logger.warning("ffmpeg OGG conversion timed out after 30s")
     except FileNotFoundError:
@@ -926,6 +951,47 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     except Exception as e:
         logger.warning("ffmpeg OGG conversion failed: %s", e, exc_info=True)
     return None
+
+
+def _ensure_opus_voice_file(input_path: str, output_path: Optional[str] = None) -> Optional[str]:
+    """Convert *input_path* to an Ogg/Opus voice file.
+
+    Unlike ``_convert_to_opus``, this helper safely handles the common
+    adapter-auto-TTS case where the provider was already asked to write the
+    final ``.ogg`` path.  Those bytes may still be MP3 or Ogg/Vorbis, and
+    ffmpeg cannot reliably read and write the same path in-place, so copy the
+    source and replace the final path only after a successful libopus encode.
+    """
+    final_path = output_path or input_path.rsplit(".", 1)[0] + ".ogg"
+    if os.path.abspath(input_path) != os.path.abspath(final_path):
+        if output_path is None:
+            return _convert_to_opus(input_path)
+        return _convert_to_opus(input_path, final_path)
+
+    source_tmp: Optional[str] = None
+    output_tmp: Optional[str] = None
+    try:
+        fd, source_tmp = tempfile.mkstemp(
+            prefix="hermes_tts_opus_src_",
+            suffix=Path(input_path).suffix or ".audio",
+        )
+        os.close(fd)
+        shutil.copyfile(input_path, source_tmp)
+
+        fd, output_tmp = tempfile.mkstemp(prefix="hermes_tts_opus_out_", suffix=".ogg")
+        os.close(fd)
+        converted = _convert_to_opus(source_tmp, output_tmp)
+        if not converted:
+            return None
+        shutil.move(converted, final_path)
+        return final_path if _is_ogg_container(final_path) else None
+    finally:
+        for tmp_path in (source_tmp, output_tmp):
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
 
 
 # ===========================================================================
@@ -953,8 +1019,30 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
         pct = round((speed - 1.0) * 100)
         kwargs["rate"] = f"{pct:+d}%"
 
+    edge_output_path = output_path
+    temp_mp3: Optional[str] = None
+    if output_path.lower().endswith(".ogg"):
+        fd, temp_mp3 = tempfile.mkstemp(prefix="hermes_edge_tts_", suffix=".mp3")
+        os.close(fd)
+        edge_output_path = temp_mp3
+
     communicate = _edge_tts.Communicate(text, **kwargs)
-    await communicate.save(output_path)
+    try:
+        await communicate.save(edge_output_path)
+
+        if temp_mp3 is not None:
+            converted = _convert_to_opus(temp_mp3, output_path)
+            if not converted:
+                raise RuntimeError(
+                    "Edge TTS produced MP3 audio, but ffmpeg could not convert it "
+                    "to Ogg/Opus for the requested .ogg output_path"
+                )
+    finally:
+        if temp_mp3 is not None:
+            try:
+                os.remove(temp_mp3)
+            except OSError:
+                pass
     return output_path
 
 
@@ -2397,12 +2485,8 @@ def text_to_speech_tool(
                     if opus_path:
                         file_str = opus_path
                 voice_compatible = file_str.endswith(".ogg")
-        elif (
-            want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
-            and not file_str.endswith(".ogg")
-        ):
-            opus_path = _convert_to_opus(file_str)
+        elif want_opus and provider in BUILTIN_TTS_OPUS_TRANSCODE_PROVIDERS:
+            opus_path = _ensure_opus_voice_file(file_str)
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11237,6 +11237,10 @@ def _(rid, params: dict) -> dict:
 
         for name, desc, cat in _TUI_EXTRA:
             all_pairs.append([name, desc])
+            # TUI-local commands intentionally win over CLI aliases in the TUI
+            # catalog. Example: CLI exposes /compact as an alias for /compress,
+            # while the TUI has a local /compact display toggle.
+            canon[name.lower()] = name
             if cat not in cat_map:
                 cat_map[cat] = []
                 cat_order.append(cat)


### PR DESCRIPTION
## Summary
- Fix Edge TTS explicit `.ogg` requests by generating a temporary MP3, ffmpeg-converting to Ogg/Opus, validating `OggS`, and reporting voice-compatible media only for valid Ogg output.
- Fix Telegram/gateway auto-TTS routing so Telegram voice replies request explicit `.ogg` voice output.
- Preserve Slack ordered-list grouping across blank spacer lines instead of restarting numbering in separate rich_text_list blocks.
- Keep TUI-local `/compact` command metadata ahead of CLI aliases, and isolate TUI RPC monkeypatch state across protocol/undo/GIL-starvation tests.
- Resolve agent log paths from the active `HERMES_HOME` at agent construction time and add subprocess regression coverage.

Refs #57048 #57049 #57068 #57070 #57076 #57118

## Test plan
- `scripts/run_tests.sh tests/gateway/test_tts_media_routing.py tests/tools/test_tts_opus_routing.py tests/gateway/test_slack_block_kit.py tests/run_agent/test_hermes_home_logging_isolation.py tests/test_tui_gateway_server.py tests/tui_gateway/test_protocol.py tests/tui_gateway/test_undo_command.py tests/tui_gateway/test_inline_rpc_gil_starvation.py -v --tb=short` -> 431 passed, 1 known unrelated failure: `tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint`.
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -v --tb=short -k 'commands_catalog_tui_local_commands_override_cli_aliases or not browser_manage_connect_default_local_reports_launch_hint'` -> 303 passed.
- `.venv/bin/python -m compileall -q agent gateway plugins tools tui_gateway ... touched tests` -> passed.
- `.venv/bin/ruff check <touched Python files/tests>` -> passed.
- `git diff --check` -> passed.
- `npm run typecheck --prefix ui-tui` -> passed.
- `npm run typecheck --prefix web` -> passed.
- Real Edge TTS probe: `text_to_speech_tool('test', output_path='/tmp/hermes_edge_rebased_probe.ogg')` -> success, provider=edge, `voice_compatible=true`, `magic=b'OggS'`, size 13071.

## Known unrelated follow-ups
- Browser launch-hint test failure is pre-existing/unrelated to this diff; Kanban follow-up `t_d79bc9a4` already exists.
- Frontend lint debt in `ui-tui`/`web` is pre-existing/untouched; Kanban follow-up `t_ea240d32` already exists.
