### PR TITLE
fix(providers): pass extra headers to model discovery (#57336 salvage)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4609,11 +4609,9 @@ def _normalize_custom_provider_entry(
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).
     # Values may carry credentials (e.g. CF-Access-Client-Secret) — never
     # log them anywhere downstream.
-    extra_headers = entry.get("extra_headers")
-    if isinstance(extra_headers, dict) and extra_headers:
-        normalized["extra_headers"] = {
-            str(k): str(v) for k, v in extra_headers.items() if v is not None
-        }
+    normalized_headers = normalize_extra_headers(entry.get("extra_headers"))
+    if normalized_headers:
+        normalized["extra_headers"] = normalized_headers
 
     ssl_ca_cert = entry.get("ssl_ca_cert")
     if isinstance(ssl_ca_cert, str) and ssl_ca_cert.strip():
@@ -4796,6 +4794,23 @@ def apply_custom_provider_tls_to_client_kwargs(
         client_kwargs["ssl_verify"] = tls["ssl_verify"]
 
 
+def normalize_extra_headers(extra_headers: Any) -> Dict[str, str]:
+    """Normalize a raw ``extra_headers`` value into a ``dict[str, str]``.
+
+    Stringifies keys and values and drops entries whose value is ``None``.
+    Returns ``{}`` for non-dict or empty inputs. This is the single shared
+    normalizer for per-provider ``extra_headers`` across config normalization,
+    runtime resolution, client construction, and live ``/models`` discovery.
+
+    SECURITY: header values routinely carry credentials (Cloudflare Access
+    service tokens, proxy auth, custom bearer schemes). Callers must never
+    log the returned values.
+    """
+    if not isinstance(extra_headers, dict) or not extra_headers:
+        return {}
+    return {str(k): str(v) for k, v in extra_headers.items() if v is not None}
+
+
 def get_custom_provider_extra_headers(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
@@ -4827,12 +4842,7 @@ def get_custom_provider_extra_headers(
         entry_url = (entry.get("base_url") or "").rstrip("/").lower()
         if not entry_url or entry_url != target_url:
             continue
-        extra_headers = entry.get("extra_headers")
-        if isinstance(extra_headers, dict) and extra_headers:
-            return {
-                str(k): str(v) for k, v in extra_headers.items() if v is not None
-            }
-        return {}
+        return normalize_extra_headers(entry.get("extra_headers"))
     return {}
 
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 from hermes_cli.providers import (
     ProviderDef,
@@ -1362,6 +1362,19 @@ import threading as _threading  # noqa: E402
 _picker_prewarm_done = _threading.Event()
 
 
+def _extra_headers_from_config(entry: Any) -> dict[str, str]:
+    if not isinstance(entry, dict):
+        return {}
+    headers = entry.get("extra_headers")
+    if not isinstance(headers, dict) or not headers:
+        return {}
+    return {
+        str(key): str(value)
+        for key, value in headers.items()
+        if value is not None
+    }
+
+
 def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
     """Warm the provider-models disk cache in a background daemon thread.
 
@@ -1993,7 +2006,11 @@ def list_authenticated_providers(
             if should_probe:
                 try:
                     from hermes_cli.models import fetch_api_models
-                    live_models = fetch_api_models(api_key, api_url)
+                    live_models = fetch_api_models(
+                        api_key,
+                        api_url,
+                        headers=_extra_headers_from_config(ep_cfg) or None,
+                    )
                     if live_models:
                         models_list = live_models
                 except Exception:
@@ -2130,10 +2147,13 @@ def list_authenticated_providers(
                     "api_key": api_key,
                     "models": [],
                     "discover_models": discover,
+                    "extra_headers": _extra_headers_from_config(entry),
                 }
             else:
                 if api_key and not groups[group_key].get("api_key"):
                     groups[group_key]["api_key"] = api_key
+                if not groups[group_key].get("extra_headers"):
+                    groups[group_key]["extra_headers"] = _extra_headers_from_config(entry)
                 # If any entry in this group opts out of discovery,
                 # honour that for the whole grouped row.
                 if not discover:
@@ -2240,7 +2260,11 @@ def list_authenticated_providers(
                 try:
                     from hermes_cli.models import fetch_api_models
 
-                    live_models = fetch_api_models(api_key, api_url)
+                    live_models = fetch_api_models(
+                        api_key,
+                        api_url,
+                        headers=grp.get("extra_headers") or None,
+                    )
                     if live_models:
                         grp["models"] = live_models
                         grp["total_models"] = len(live_models)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1365,14 +1365,9 @@ _picker_prewarm_done = _threading.Event()
 def _extra_headers_from_config(entry: Any) -> dict[str, str]:
     if not isinstance(entry, dict):
         return {}
-    headers = entry.get("extra_headers")
-    if not isinstance(headers, dict) or not headers:
-        return {}
-    return {
-        str(key): str(value)
-        for key, value in headers.items()
-        if value is not None
-    }
+    from hermes_cli.config import normalize_extra_headers
+
+    return normalize_extra_headers(entry.get("extra_headers"))
 
 
 def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
@@ -2126,7 +2121,16 @@ def list_authenticated_providers(
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
 
-            group_key = (api_url, credential_identity, api_mode)
+            # Per-provider extra_headers participate in the group identity:
+            # two entries sharing (api_url, credential, api_mode) but declaring
+            # different headers are distinct endpoints (e.g. different tenants
+            # behind one proxy URL, routed by header) and must probe /models
+            # with their own headers rather than collapsing into one row and
+            # silently adopting whichever header set was seen first.
+            entry_extra_headers = _extra_headers_from_config(entry)
+            headers_identity = tuple(sorted(entry_extra_headers.items()))
+
+            group_key = (api_url, credential_identity, api_mode, headers_identity)
             if group_key not in groups:
                 # Strip per-model suffix so "Ollama — GLM 5.1" becomes
                 # "Ollama" for the grouped row. Em dash is the convention
@@ -2147,13 +2151,13 @@ def list_authenticated_providers(
                     "api_key": api_key,
                     "models": [],
                     "discover_models": discover,
-                    "extra_headers": _extra_headers_from_config(entry),
+                    "extra_headers": entry_extra_headers,
                 }
             else:
                 if api_key and not groups[group_key].get("api_key"):
                     groups[group_key]["api_key"] = api_key
-                if not groups[group_key].get("extra_headers"):
-                    groups[group_key]["extra_headers"] = _extra_headers_from_config(entry)
+                # extra_headers is part of group_key, so every entry in this
+                # group already carries identical headers — nothing to merge.
                 # If any entry in this group opts out of discovery,
                 # honour that for the whole grouped row.
                 if not discover:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3501,13 +3501,9 @@ def probe_api_models(
     if isinstance(request_headers, dict):
         # Per-provider custom headers can contain auth/proxy secrets. Merge
         # last so endpoint-specific config wins, and never log the values.
-        headers.update(
-            {
-                str(key): str(value)
-                for key, value in request_headers.items()
-                if value is not None
-            }
-        )
+        from hermes_cli.config import normalize_extra_headers
+
+        headers.update(normalize_extra_headers(request_headers))
 
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3451,6 +3451,7 @@ def probe_api_models(
     base_url: Optional[str],
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
+    request_headers: Optional[dict[str, str]] = None,
 ) -> dict[str, Any]:
     """Probe a ``/models`` endpoint with light URL heuristics.
 
@@ -3497,6 +3498,16 @@ def probe_api_models(
         headers["Authorization"] = f"Bearer {api_key}"
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
+    if isinstance(request_headers, dict):
+        # Per-provider custom headers can contain auth/proxy secrets. Merge
+        # last so endpoint-specific config wins, and never log the values.
+        headers.update(
+            {
+                str(key): str(value)
+                for key, value in request_headers.items()
+                if value is not None
+            }
+        )
 
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"
@@ -3529,13 +3540,20 @@ def fetch_api_models(
     base_url: Optional[str],
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
+    headers: Optional[dict[str, str]] = None,
 ) -> Optional[list[str]]:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
 
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
     """
-    return probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get("models")
+    return probe_api_models(
+        api_key,
+        base_url,
+        timeout=timeout,
+        api_mode=api_mode,
+        request_headers=headers,
+    ).get("models")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -31,7 +31,11 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
-from hermes_cli.config import get_compatible_custom_providers, load_config
+from hermes_cli.config import (
+    get_compatible_custom_providers,
+    load_config,
+    normalize_extra_headers,
+)
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_int
 
@@ -597,11 +601,9 @@ def _lift_extra_headers(entry: Dict[str, Any], result: Dict[str, Any]) -> None:
     SECURITY: header values routinely carry credentials (Cloudflare Access
     service tokens, proxy auth, custom bearer schemes). Never log them.
     """
-    extra_headers = entry.get("extra_headers")
-    if isinstance(extra_headers, dict) and extra_headers:
-        result["extra_headers"] = {
-            str(k): str(v) for k, v in extra_headers.items() if v is not None
-        }
+    extra_headers = normalize_extra_headers(entry.get("extra_headers"))
+    if extra_headers:
+        result["extra_headers"] = extra_headers
 
 
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -4,11 +4,14 @@ PR #3526 salvage — user-configurable extra HTTP headers on LLM API calls
 (reverse proxies, gateways, custom auth such as Cloudflare Access tokens).
 """
 
+import json
+
 from hermes_cli.config import (
     _normalize_custom_provider_entry,
     apply_custom_provider_extra_headers_to_client_kwargs,
     get_custom_provider_extra_headers,
 )
+from hermes_cli import models as models_mod
 
 
 def test_normalize_entry_keeps_extra_headers():
@@ -125,3 +128,43 @@ def test_apply_extra_headers_noop_without_match():
         custom_providers=providers,
     )
     assert "default_headers" not in client_kwargs
+
+
+def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"data": [{"id": "proxy-model"}]}).encode()
+
+    def fake_urlopen(request, timeout=0):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        captured["headers"] = {
+            key.lower(): value
+            for key, value in request.header_items()
+        }
+        return FakeResponse()
+
+    monkeypatch.setattr(models_mod.urllib.request, "urlopen", fake_urlopen)
+
+    models = models_mod.fetch_api_models(
+        "proxy-key",
+        "https://llm.internal.example.com/v1",
+        headers={
+            "sleeve-harness": "hermes",
+            "sleeve-base-url": "http://localhost:8081/v1",
+        },
+    )
+
+    assert models == ["proxy-model"]
+    assert captured["url"] == "https://llm.internal.example.com/v1/models"
+    assert captured["headers"]["authorization"] == "Bearer proxy-key"
+    assert captured["headers"]["sleeve-harness"] == "hermes"
+    assert captured["headers"]["sleeve-base-url"] == "http://localhost:8081/v1"

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -10,8 +10,21 @@ from hermes_cli.config import (
     _normalize_custom_provider_entry,
     apply_custom_provider_extra_headers_to_client_kwargs,
     get_custom_provider_extra_headers,
+    normalize_extra_headers,
 )
 from hermes_cli import models as models_mod
+
+
+def test_normalize_extra_headers_stringifies_and_drops_none():
+    assert normalize_extra_headers({"X-Int": 7, "X-Str": "v", "X-None": None}) == {
+        "X-Int": "7",
+        "X-Str": "v",
+    }
+
+
+def test_normalize_extra_headers_rejects_non_dict_and_empty():
+    for bad in (None, "x", 42, ["a"], {}):
+        assert normalize_extra_headers(bad) == {}
 
 
 def test_normalize_entry_keeps_extra_headers():

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -643,8 +643,8 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
 
     calls = []
 
-    def fake_fetch_api_models(api_key, base_url):
-        calls.append((api_key, base_url))
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
         return ["gateway-model-a", "gateway-model-b", "gateway-model-c"]
 
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
@@ -679,15 +679,70 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
     )
 
     assert gateway_prov is not None, "Custom provider group not found in results"
-    assert calls == [("sk-gateway-key", "https://gateway.example.com/v1")], (
-        "fetch_api_models must be called with the custom provider's credentials"
-    )
+    assert calls == [
+        ("sk-gateway-key", "https://gateway.example.com/v1", {"headers": None})
+    ], "fetch_api_models must be called with the custom provider's credentials"
     assert gateway_prov["models"] == [
         "gateway-model-a",
         "gateway-model-b",
         "gateway-model-c",
     ], "Live models must replace the static subset"
     assert gateway_prov["total_models"] == 3
+
+
+def test_custom_provider_live_model_probe_uses_extra_headers(monkeypatch):
+    """custom_providers[].extra_headers must apply to live /models probes."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["gateway-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        custom_providers=[
+            {
+                "name": "LLM Proxy",
+                "api_key": "local-key",
+                "base_url": "http://localhost:8081/v1",
+                "extra_headers": {
+                    "sleeve-harness": "hermes",
+                    "sleeve-base-url": "http://localhost:8081/v1",
+                },
+            }
+        ],
+        max_models=50,
+    )
+
+    gateway_prov = next(
+        (
+            p
+            for p in providers
+            if p.get("api_url") == "http://localhost:8081/v1"
+        ),
+        None,
+    )
+
+    assert gateway_prov is not None
+    assert calls == [
+        (
+            "local-key",
+            "http://localhost:8081/v1",
+            {
+                "headers": {
+                    "sleeve-harness": "hermes",
+                    "sleeve-base-url": "http://localhost:8081/v1",
+                }
+            },
+        )
+    ]
+    assert gateway_prov["models"] == ["gateway-model"]
 
 
 def test_custom_providers_discover_models_false_keeps_explicit_subset(monkeypatch):
@@ -704,8 +759,8 @@ def test_custom_providers_discover_models_false_keeps_explicit_subset(monkeypatc
 
     calls = []
 
-    def fake_fetch_api_models(api_key, base_url):
-        calls.append((api_key, base_url))
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
         return ["gateway-model-a", "gateway-model-b", "gateway-model-c"]
 
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
@@ -760,8 +815,8 @@ def test_custom_providers_discover_models_false_string_is_normalised(monkeypatch
 
     calls = []
 
-    def fake_fetch_api_models(api_key, base_url):
-        calls.append((api_key, base_url))
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
         return ["live-a", "live-b"]
 
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -745,6 +745,60 @@ def test_custom_provider_live_model_probe_uses_extra_headers(monkeypatch):
     assert gateway_prov["models"] == ["gateway-model"]
 
 
+def test_same_endpoint_different_extra_headers_not_collapsed(monkeypatch):
+    """Entries sharing (api_url, credential, api_mode) but declaring different
+    extra_headers must NOT collapse into one picker row — each is a distinct
+    header-authenticated endpoint (e.g. per-tenant routing behind one proxy)
+    and must probe /models with its own headers."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs.get("headers")))
+        # Return a per-tenant model list keyed by the routing header so we can
+        # assert each row got its OWN probe rather than a shared one.
+        tenant = (kwargs.get("headers") or {}).get("X-Tenant", "none")
+        return [f"model-{tenant}"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        custom_providers=[
+            {
+                "name": "Proxy Tenant A",
+                "api_key": "shared-key",
+                "base_url": "http://localhost:8081/v1",
+                "extra_headers": {"X-Tenant": "a"},
+            },
+            {
+                "name": "Proxy Tenant B",
+                "api_key": "shared-key",
+                "base_url": "http://localhost:8081/v1",
+                "extra_headers": {"X-Tenant": "b"},
+            },
+        ],
+        max_models=50,
+    )
+
+    rows = [
+        p for p in providers if p.get("api_url") == "http://localhost:8081/v1"
+    ]
+    # Two distinct rows, not one collapsed row.
+    assert len(rows) == 2, f"expected 2 rows, got {len(rows)}: {rows}"
+
+    # Each tenant was probed with its OWN header set (order-independent).
+    assert ("shared-key", "http://localhost:8081/v1", {"X-Tenant": "a"}) in calls
+    assert ("shared-key", "http://localhost:8081/v1", {"X-Tenant": "b"}) in calls
+
+    # Each row surfaces the model list its own headers unlocked.
+    models_by_row = {tuple(r["models"]) for r in rows}
+    assert models_by_row == {("model-a",), ("model-b",)}
+
+
 def test_custom_providers_discover_models_false_keeps_explicit_subset(monkeypatch):
     """Custom providers (section 4) with ``discover_models: false`` must keep
     their explicit ``models:`` subset instead of replacing it with live

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -144,8 +144,8 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
 
     calls = []
 
-    def fake_fetch_api_models(api_key, base_url):
-        calls.append((api_key, base_url))
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
         return ["old-configured-model", "new-live-model"]
 
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
@@ -175,9 +175,60 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
     )
 
     assert user_prov is not None
-    assert calls == [("sk-test", "http://127.0.0.1:3000/api/v1")]
+    assert calls == [("sk-test", "http://127.0.0.1:3000/api/v1", {"headers": None})]
     assert user_prov["models"] == ["old-configured-model", "new-live-model"]
     assert user_prov["total_models"] == 2
+
+
+def test_user_provider_live_model_probe_uses_extra_headers(monkeypatch):
+    """providers.<name>.extra_headers must also apply to live /models probes."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["live-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    providers = list_authenticated_providers(
+        current_provider="llm-proxy",
+        user_providers={
+            "llm-proxy": {
+                "name": "LLM Proxy",
+                "base_url": "http://localhost:8081/v1",
+                "api_key": "local-key",
+                "extra_headers": {
+                    "sleeve-harness": "hermes",
+                    "sleeve-base-url": "http://localhost:8081/v1",
+                },
+            }
+        },
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "llm-proxy"),
+        None,
+    )
+
+    assert user_prov is not None
+    assert calls == [
+        (
+            "local-key",
+            "http://localhost:8081/v1",
+            {
+                "headers": {
+                    "sleeve-harness": "hermes",
+                    "sleeve-base-url": "http://localhost:8081/v1",
+                }
+            },
+        )
+    ]
+    assert user_prov["models"] == ["live-model"]
 
 
 def test_list_authenticated_providers_dict_models_without_default_model(monkeypatch):
@@ -1063,10 +1114,11 @@ def test_section3_probes_no_key_endpoint_without_explicit_models(monkeypatch):
 
     probed = {}
 
-    def _fake_fetch(api_key, api_url):
+    def _fake_fetch(api_key, api_url, **kwargs):
         probed["called"] = True
         probed["api_key"] = api_key
         probed["api_url"] = api_url
+        probed["kwargs"] = kwargs
         return ["live-model-1", "live-model-2", "live-model-3"]
 
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", _fake_fetch)
@@ -1088,6 +1140,7 @@ def test_section3_probes_no_key_endpoint_without_explicit_models(monkeypatch):
 
     assert probed.get("called") is True, "no-key bare endpoint should be probed"
     assert probed["api_key"] == ""
+    assert probed["kwargs"] == {"headers": None}
     row = next(p for p in providers if p["slug"] == "local-llamacpp")
     assert row["models"] == ["live-model-1", "live-model-2", "live-model-3"]
     assert row["total_models"] == 3
@@ -1099,7 +1152,7 @@ def test_section3_skips_probe_when_no_key_but_explicit_models(monkeypatch):
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
 
-    def _fail_fetch(api_key, api_url):
+    def _fail_fetch(api_key, api_url, **kwargs):
         raise AssertionError("should not probe when explicit models are set")
 
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", _fail_fetch)


### PR DESCRIPTION
## Summary

Custom-provider `extra_headers` now reach the live `/v1/models` discovery path, so a proxy that requires custom auth headers (Cloudflare Access, gateway tokens) returns its model list in the picker — not just on chat calls.

Salvage of #57336 by @helix4u, cherry-picked onto current `main` (authorship preserved) with two review findings fixed on top.

Follow-up to #57038, which wired `extra_headers` into chat/API client construction but left `fetch_api_models()` / `probe_api_models()` (the model picker's live discovery) sending no custom headers.

## Changes

- `hermes_cli/models.py` — `probe_api_models()` / `fetch_api_models()` accept caller headers, merged **last** so endpoint-specific config wins over the SDK's `Authorization`/`User-Agent`/copilot defaults. Never logged. *(@helix4u)*
- `hermes_cli/model_switch.py` — picker threads `extra_headers` from both `providers:` and `custom_providers:` entries into live discovery. *(@helix4u)*
- **Follow-up (W1):** picker grouped rows by `(api_url, credential, api_mode)` but not `extra_headers`, so two entries sharing a URL+credential yet declaring different headers (per-tenant routing behind one proxy) collapsed into one row and probed with whichever header set came first (order-dependent). Header identity now participates in the group key; distinct header-authed endpoints stay separate. Dead first-non-empty merge branch removed.
- **Follow-up (W2):** the `extra_headers` stringify+None-filter comprehension existed in 5 copies (config.py ×2, runtime_provider.py, model_switch.py, models.py). Extracted one shared `hermes_cli.config.normalize_extra_headers`; all sites call it.

## Validation

| Check | Result |
| --- | --- |
| Targeted suite (extra_headers + model_switch + user_providers + runtime_provider_resolution) | ✅ 223 passed |
| New: `normalize_extra_headers` unit tests | ✅ |
| New: regression — two same-endpoint entries w/ different headers stay distinct, each probes with its own headers | ✅ |
| `ruff check` on all touched files | ✅ clean |
| Cherry-picked onto current `origin/main`, @helix4u authorship preserved | ✅ |

Closes #57336. Original by @helix4u — cherry-picked to preserve authorship.
