### PR TITLE
fix(computer-use): guard None pid/window_id in list_windows parse (WSLg/X11 compatibility)

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1028,16 +1028,22 @@ class CuaDriverBackend(ComputerUseBackend):
             {"on_screen_only": True, "session": self._session_id},
         )
         raw_windows = (lw_out.get("structuredContent") or {}).get("windows") or []
+        # WSLg / X11 / Wayland backend windows can come back with pid=None
+        # (no host process — synthesized by the compositor or the WSLg bridge)
+        # and window_id=None. Keep the row but normalize to None so downstream
+        # filters can still match by app/title; drop rows that have neither
+        # pid nor window_id since they aren't actionable.
         windows = [
             {
                 "app_name": w.get("app_name", ""),
-                "pid": int(w["pid"]),
-                "window_id": int(w["window_id"]),
+                "pid": int(w["pid"]) if w.get("pid") is not None else None,
+                "window_id": int(w["window_id"]) if w.get("window_id") is not None else None,
                 "off_screen": not w.get("is_on_screen", True),
                 "title": w.get("title", ""),
-                "z_index": w.get("z_index", 0),
+                "z_index": w.get("z_index") if w.get("z_index") is not None else 0,
             }
             for w in raw_windows
+            if w.get("pid") is not None or w.get("window_id") is not None
         ]
         # Sort by z_index descending (lowest z_index = frontmost on macOS).
         windows.sort(key=lambda w: w["z_index"])


### PR DESCRIPTION
## Fix #56704 — computer_use capture crashes on Linux/WSL with int(None) on pid/window_id

### Problem

`CuaDriverBackend.capture()` crashes with `TypeError: int() argument must be ... not 'NoneType'` on any Linux/WSL install where cua-driver's `list_windows` returns null `pid` / `window_id` for synthesized X11/WSLg windows (panel, dock, WSLg bridge, `xwayland` itself).

This makes `computer_use` 100% unusable on WSL — `hermes computer-use doctor` reports all green, but every `capture()` call explodes.

### Reproduction

```
hermes-agent v2026.7.1 + cua-driver 0.6.8 + WSL2 Ubuntu 24.04

$ computer_use(action="capture", mode="som")
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'

  File ".../tools/computer_use/cua_backend.py", line 1031, in capture
    windows = [
  File ".../tools/computer_use/cua_backend.py", line 1034, in <listcomp>
    "pid": int(w["pid"]),
```

### Fix

Single-file, 9-line change in `tools/computer_use/cua_backend.py` (3 deletions, 9 insertions including comments). Guard `int(...)` with `None`-check; drop rows that have neither pid nor window_id.

```diff
+        # WSLg / X11 / Wayland backend windows can come back with pid=None
+        # (no host process — synthesized by the compositor or the WSLg bridge)
+        # and window_id=None. Keep the row but normalize to None so downstream
+        # filters can still match by app/title; drop rows that have neither
+        # pid nor window_id since they aren't actionable.
         windows = [
             {
                 "app_name": w.get("app_name", ""),
-                "pid": int(w["pid"]),
-                "window_id": int(w["window_id"]),
+                "pid": int(w["pid"]) if w.get("pid") is not None else None,
+                "window_id": int(w["window_id"]) if w.get("window_id") is not None else None,
                 "off_screen": not w.get("is_on_screen", True),
                 "title": w.get("title", ""),
-                "z_index": w.get("z_index", 0),
+                "z_index": w.get("z_index") if w.get("z_index") is not None else 0,
             }
             for w in raw_windows
+            if w.get("pid") is not None or w.get("window_id") is not None
         ]
```

### Why this is safe

- `int(x)` when `x is not None` is identical to the original behavior for the common case
- Rows that survive still keep `app_name` and `title`, so downstream app-name filters keep working
- macOS / native Linux X11 paths unaffected (no path changed)
- Minimal blast radius: only the list comprehension changed; nothing else in `capture()` was touched

### Test plan

- [x] Reproduced locally on WSL2 Ubuntu 24.04 + cua-driver 0.6.8 (stack trace matches issue)
- [ ] Re-run after fix: capture() returns window list, screenshot bytes present
- [ ] Add fixture + unit test for null-pid case
- [ ] `scripts/run_tests.sh` green

### Notes for reviewers

- Per CONTRIBUTING.md, this is a Tier 2 priority (cross-platform compatibility for Linux/WSL)
- Issue #56704 is currently unassigned; PR is referenced to claim the fix
- Author: xbc996 — happy to iterate on review feedback