### PR TITLE
fix(copilot): gate Openai-Intent header on Responses API model support

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3951,7 +3951,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         from hermes_cli.copilot_auth import copilot_request_headers
 
         async_kwargs["default_headers"] = copilot_request_headers(
-            is_agent_turn=True, is_vision=is_vision
+            is_agent_turn=True, is_vision=is_vision, model=model
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
@@ -4255,7 +4255,7 @@ def resolve_provider_client(
             elif base_url_host_matches(custom_base, "githubcopilot.com"):
                 from hermes_cli.copilot_auth import copilot_request_headers
                 extra["default_headers"] = copilot_request_headers(
-                    is_agent_turn=True, is_vision=is_vision
+                    is_agent_turn=True, is_vision=is_vision, model=final_model
                 )
             elif base_url_host_matches(custom_base, "integrate.api.nvidia.com"):
                 extra["default_headers"] = build_nvidia_nim_headers(custom_base)
@@ -4513,7 +4513,7 @@ def resolve_provider_client(
             from hermes_cli.copilot_auth import copilot_request_headers
 
             headers.update(copilot_request_headers(
-                is_agent_turn=True, is_vision=is_vision
+                is_agent_turn=True, is_vision=is_vision, model=final_model
             ))
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             headers.update(build_nvidia_nim_headers(base_url))

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -440,18 +440,32 @@ def copilot_request_headers(
     *,
     is_agent_turn: bool = True,
     is_vision: bool = False,
+    model: str | None = None,
 ) -> dict[str, str]:
     """Build the standard headers for Copilot API requests.
 
     Replicates the header set used by opencode and the Copilot CLI.
+
+    When *model* is provided, the ``Openai-Intent: conversation-edits``
+    header is only included for models that support the Responses API
+    (GPT-5+, excluding gpt-5-mini).  Non-GPT models (Claude, Gemini,
+    etc.) use Chat Completions and must NOT carry this header — the
+    Copilot gateway rejects them with HTTP 400 otherwise.
     """
     headers: dict[str, str] = {
         "Editor-Version": "vscode/1.104.1",
         "User-Agent": "HermesAgent/1.0",
         "Copilot-Integration-Id": "vscode-chat",
-        "Openai-Intent": "conversation-edits",
         "x-initiator": "agent" if is_agent_turn else "user",
     }
+    # Only include Openai-Intent for models that need Responses API.
+    # When no model is known, include it for backward compatibility.
+    if model is None:
+        headers["Openai-Intent"] = "conversation-edits"
+    else:
+        from hermes_cli.models import _should_use_copilot_responses_api
+        if _should_use_copilot_responses_api(model):
+            headers["Openai-Intent"] = "conversation-edits"
     if is_vision:
         headers["Copilot-Vision-Request"] = "true"
 

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -421,9 +421,10 @@ class TestResolveVisionMainFirst:
 
         captured = {}
 
-        def fake_headers(*, is_agent_turn=False, is_vision=False):
+        def fake_headers(*, is_agent_turn=False, is_vision=False, model=None):
             captured["is_agent_turn"] = is_agent_turn
             captured["is_vision"] = is_vision
+            captured["model"] = model
             return {"Copilot-Vision-Request": "true"} if is_vision else {}
 
         with patch(
@@ -439,7 +440,7 @@ class TestResolveVisionMainFirst:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             return_value={
                 "provider": "copilot",
-                "api_key": "copilot-api-token",
+                "api_key": "***",
                 "base_url": "https://api.githubcopilot.com",
             },
         ), patch(
@@ -456,7 +457,7 @@ class TestResolveVisionMainFirst:
         assert provider == "copilot"
         assert client is mock_client
         assert model == "configured-copilot-model"
-        assert captured == {"is_agent_turn": True, "is_vision": True}
+        assert captured == {"is_agent_turn": True, "is_vision": True, "model": "configured-copilot-model"}
         assert mock_openai.call_args.kwargs["default_headers"]["Copilot-Vision-Request"] == "true"
 
     def test_text_copilot_does_not_set_vision_header(self, monkeypatch):
@@ -465,9 +466,10 @@ class TestResolveVisionMainFirst:
 
         captured = {}
 
-        def fake_headers(*, is_agent_turn=False, is_vision=False):
+        def fake_headers(*, is_agent_turn=False, is_vision=False, model=None):
             captured["is_agent_turn"] = is_agent_turn
             captured["is_vision"] = is_vision
+            captured["model"] = model
             return {"Copilot-Vision-Request": "true"} if is_vision else {}
 
         with patch(
@@ -476,7 +478,7 @@ class TestResolveVisionMainFirst:
             "hermes_cli.auth.resolve_api_key_provider_credentials",
             return_value={
                 "provider": "copilot",
-                "api_key": "copilot-api-token",
+                "api_key": "***",
                 "base_url": "https://api.githubcopilot.com",
             },
         ), patch(
@@ -492,7 +494,7 @@ class TestResolveVisionMainFirst:
 
         assert client is mock_client
         assert model == "gpt-5-mini"
-        assert captured == {"is_agent_turn": True, "is_vision": False}
+        assert captured == {"is_agent_turn": True, "is_vision": False, "model": "gpt-5-mini"}
         assert "default_headers" not in mock_openai.call_args.kwargs
 
     def test_main_unavailable_vision_falls_through_to_aggregators(self):

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -137,6 +137,33 @@ class TestRequestHeaders:
         headers = copilot_request_headers()
         assert "Copilot-Vision-Request" not in headers
 
+    def test_openai_intent_included_when_no_model(self):
+        """Backward compat: model=None includes Openai-Intent."""
+        from hermes_cli.copilot_auth import copilot_request_headers
+        headers = copilot_request_headers()
+        assert headers["Openai-Intent"] == "conversation-edits"
+
+    def test_openai_intent_included_for_gpt5(self):
+        """GPT-5+ models need Responses API, include Openai-Intent."""
+        from hermes_cli.copilot_auth import copilot_request_headers
+        headers = copilot_request_headers(model="gpt-5.4")
+        assert headers["Openai-Intent"] == "conversation-edits"
+
+    def test_openai_intent_excluded_for_non_gpt(self):
+        """Non-GPT models (Claude, Gemini) use Chat Completions."""
+        from hermes_cli.copilot_auth import copilot_request_headers
+        for model in ("claude-sonnet-4.6", "gemini-3.1-pro-preview", "gpt-4o"):
+            headers = copilot_request_headers(model=model)
+            assert "Openai-Intent" not in headers, (
+                f"Openai-Intent should be absent for {model}"
+            )
+
+    def test_openai_intent_excluded_for_gpt5_mini(self):
+        """gpt-5-mini uses Chat Completions, not Responses API."""
+        from hermes_cli.copilot_auth import copilot_request_headers
+        headers = copilot_request_headers(model="gpt-5-mini")
+        assert "Openai-Intent" not in headers
+
 
 class TestCopilotDefaultHeaders:
     """The models.py copilot_default_headers uses copilot_auth."""


### PR DESCRIPTION
## What does this PR do?

Makes the `Openai-Intent: conversation-edits` header conditional on the target model when building Copilot API request headers. Non-GPT models (Claude, Gemini, etc.) use Chat Completions and do not support the Responses API — sending this header causes the GitHub Copilot gateway to reject them with HTTP 400 (`unsupported_api_for_model`).

The fix reuses the existing `_should_use_copilot_responses_api()` model ID pattern (GPT-5+, excluding gpt-5-mini) that already governs `CodexAuxiliaryClient` wrapping, so the header and the client wrapping are now consistently gated on the same condition.

## Related Issue

Fixes #57395

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/copilot_auth.py`: Added optional `model` parameter to `copilot_request_headers()`. When provided, `Openai-Intent: conversation-edits` is only included for GPT-5+ models. When `model=None` (backward compat), the header is always included.
- `agent/auxiliary_client.py`: Updated all 3 call sites (`_to_async_client`, custom base_url path, main `resolve_provider_client` path) to pass `model=final_model`/`model=model` so the header is correctly gated per-model.
- `tests/hermes_cli/test_copilot_auth.py`: Added 4 regression tests covering GPT-5 (included), non-GPT models (excluded), gpt-5-mini (excluded), and backward-compat no-model (included).

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_copilot_auth.py::TestRequestHeaders -q` — all 9 tests should pass (4 new + 5 existing).
2. Verify `copilot_request_headers(model="claude-sonnet-4.6")` does NOT contain `Openai-Intent`, while `copilot_request_headers(model="gpt-5.4")` does.
3. Verify `copilot_request_headers()` (no model arg) still includes `Openai-Intent` for backward compatibility.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_copilot_auth.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
