### PR TITLE
fix(web): guard extract provider final URLs

### DIFF
--- a/tests/tools/test_web_tools_truncate.py
+++ b/tests/tools/test_web_tools_truncate.py
@@ -129,6 +129,41 @@ class TestEndToEnd:
         assert "para 0 " in content
         assert "para 2999 " in content
 
+    def test_web_extract_blocks_non_firecrawl_private_final_url(self, monkeypatch):
+        class FakeProvider:
+            name = "fake"
+            display_name = "Fake"
+
+            def supports_extract(self):
+                return True
+
+            async def extract(self, urls, **kwargs):
+                return [{
+                    "url": "http://169.254.169.254/latest/meta-data/",
+                    "title": "Metadata",
+                    "content": "metadata credentials",
+                    "raw_content": "metadata credentials",
+                    "metadata": {"sourceURL": "http://169.254.169.254/latest/meta-data/"},
+                }]
+
+        async def safe_only_requested(url):
+            return url == "https://example.com/redirect"
+
+        with patch("tools.web_tools._ensure_web_plugins_loaded"), \
+             patch("tools.web_tools._get_extract_backend", return_value="fake"), \
+             patch("tools.web_tools.async_is_safe_url", new=safe_only_requested), \
+             patch("tools.web_tools._store_full_text") as store_full_text, \
+             patch("agent.web_search_registry.get_provider", return_value=FakeProvider()):
+            result = json.loads(asyncio.new_event_loop().run_until_complete(
+                wt.web_extract_tool(["https://example.com/redirect"], char_limit=5000)
+            ))
+
+        item = result["results"][0]
+        assert item["url"] == "http://169.254.169.254/latest/meta-data/"
+        assert item["content"] == ""
+        assert "private or internal network" in item["error"]
+        store_full_text.assert_not_called()
+
 
 def _make_awaitable(value):
     async def _coro(*a, **k):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -463,6 +463,32 @@ def _truncate_with_footer(
     return model_text, True
 
 
+def _result_final_url(result: Dict[str, Any]) -> str:
+    """Return the provider-reported final URL for an extract result."""
+    url = str(result.get("url") or "").strip()
+    metadata = result.get("metadata")
+    if isinstance(metadata, dict):
+        url = str(metadata.get("sourceURL") or metadata.get("url") or url).strip()
+    return normalize_url_for_request(url) if url else ""
+
+
+async def _apply_extract_final_url_guard(results: List[Dict[str, Any]]) -> None:
+    """Block provider results whose final URL is private/internal."""
+    for result in results:
+        if result.get("error"):
+            continue
+        final_url = _result_final_url(result)
+        if not final_url:
+            continue
+        if await async_is_safe_url(final_url):
+            result["url"] = final_url
+            continue
+        result["url"] = final_url
+        result["content"] = ""
+        result["raw_content"] = ""
+        result["error"] = "Blocked: final URL targets a private or internal network address"
+
+
 
 # ─── Exa / Parallel inline helpers — moved into plugins ──────────────────────
 # After PR #25182, the exa client + search/extract and parallel client +
@@ -771,6 +797,8 @@ async def web_extract_tool(
                 results = await asyncio.to_thread(
                     provider.extract, safe_urls, format=format
                 )
+
+            await _apply_extract_final_url_guard(results)
 
         # Merge any SSRF-blocked results back in
         if ssrf_blocked:


### PR DESCRIPTION
## Summary

This adds a shared post-provider final URL guard to `web_extract_tool()`.

## Why

`web_extract_tool()` preflights the requested URLs before dispatching to the configured extract backend. Firecrawl also has its own provider-local final URL check after redirects. However, the shared dispatcher did not enforce the same invariant for other extract providers or third-party plugin providers.

That leaves a sibling path where a requested public URL can pass the initial SSRF check, but the provider result reports a different final URL such as a private/internal or cloud metadata address. The dispatcher would then continue processing the returned content, including the truncate-and-store path for large pages.

## Changes

- Add `_result_final_url()` to normalize provider-reported final URLs from `result["url"]` and `metadata.sourceURL`.
- Add `_apply_extract_final_url_guard()` after provider dispatch and before truncation/storage.
- If a final URL is private/internal, clear `content` / `raw_content` and return a blocked error for that result.
- Preserve the final URL on allowed results so downstream response shaping remains canonical.
- Add regression coverage for a non-Firecrawl provider result that redirects to a cloud metadata URL and ensure `_store_full_text()` is not called.

## Tests

```text
python -m pytest tests/tools/test_web_tools_truncate.py::TestEndToEnd::test_web_extract_blocks_non_firecrawl_private_final_url tests/tools/test_web_tools_truncate.py::TestEndToEnd::test_web_extract_truncates_large_page_no_llm -q --timeout-method=thread
2 passed

python -m pytest tests/tools/test_website_policy.py::TestWebToolPolicy::test_web_extract_blocks_firecrawl_unsafe_final_url tests/tools/test_website_policy.py::TestWebToolPolicy::test_web_extract_blocks_redirected_final_url tests/tools/test_web_tools_truncate.py -q --timeout-method=thread
15 passed

python -m ruff check tools/web_tools.py tests/tools/test_web_tools_truncate.py