### PR TITLE
fix(dashboard-auth): skip OAuth redirect for password-only providers in auto-SSO

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -182,9 +182,15 @@ def _auto_sso_response(request: Request) -> Response | None:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None
 
-    from hermes_cli.dashboard_auth.prefix import prefix_from_request
-
     provider = providers[0]
+
+    # Password-only providers (e.g. basic auth) don't have an OAuth flow;
+    # /auth/login?provider=<name> would raise NotImplementedError.
+    # Fall through to the server-rendered /login page instead.
+    if getattr(provider, "supports_password", False):
+        return None
+
+    from hermes_cli.dashboard_auth.prefix import prefix_from_request
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
## Problem

The `_auto_sso_response` middleware redirects unauthenticated requests to `/auth/login?provider=<name>` when exactly one session provider is registered. This works for OAuth providers but raises `NotImplementedError` for password-only providers (e.g. basic auth).

When basic auth is the only configured provider and the dashboard is accessed via a non-loopback address (e.g. Tailscale IP, LAN IP), every page load results in a 500 error:

```
NotImplementedError: BasicAuthProvider is password-only; there is no OAuth redirect flow.
The login page POSTs to /auth/password-login instead.
```

Access via loopback (e.g. `http://localhost:9119`) works because loopback connections bypass auth entirely via `should_require_auth()`.

## Root cause

`_auto_sso_response` checks `len(providers) == 1` but doesn't verify the provider supports OAuth before redirecting to `/auth/login`. For password-only providers, `start_login()` is a stub that raises `NotImplementedError` — the correct endpoint is `/auth/password-login` (POST), and the login page renders a credential form.

## Fix

Add a check: when the single session provider has `supports_password=True`, return `None` so the request falls through to the server-rendered `/login` page, which renders the credential form for password-only providers.

```python
provider = providers[0]

# Password-only providers (e.g. basic auth) don't have an OAuth flow;
# /auth/login?provider=<name> would raise NotImplementedError.
# Fall through to the server-rendered /login page instead.
if getattr(provider, "supports_password", False):
    return None
```

## Testing

- Access via non-loopback with only basic auth: now shows login form ✅
- Access via loopback: unchanged (auth bypassed) ✅
- OAuth-only providers (nous, self_hosted): unchanged (auto-SSO still works) ✅
- Mixed providers (basic + OAuth): unchanged (already returns None for 2+ providers) ✅