### PR TITLE
fix(simplex): guard media delivery paths

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -823,10 +823,9 @@ class SimplexAdapter(BasePlatformAdapter):
         waiting for one would serialise all outbound traffic behind a
         30-second timeout.
         """
-        _voice_exts = {".ogg", ".mp3", ".wav", ".m4a", ".opus"}
-        media_paths = re.findall(r"MEDIA:(\S+)", content)
-        if media_paths:
-            content = re.sub(r"MEDIA:\S+", "", content).strip()
+        media_files, cleaned_content = self.extract_media(content)
+        media_files = self.filter_media_delivery_paths(media_files)
+        content = cleaned_content.strip()
 
         if content:
             corr_id = self._make_corr_id()
@@ -842,8 +841,7 @@ class SimplexAdapter(BasePlatformAdapter):
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 
-        for path in media_paths:
-            is_voice = os.path.splitext(path)[1].lower() in _voice_exts
+        for path, is_voice in media_files:
             if is_voice:
                 media_result = await self.send_voice(chat_id, path)
             else:
@@ -1012,8 +1010,10 @@ class SimplexAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a document/file attachment."""
-        if not Path(file_path).exists():
+        safe_path = self.validate_media_delivery_path(file_path)
+        if not safe_path:
             return SendResult(success=False, error="File not found")
+        file_path = safe_path
 
         composed = json.dumps(
             [
@@ -1051,8 +1051,10 @@ class SimplexAdapter(BasePlatformAdapter):
         a downloadable file; the structured ``/_send`` form with
         ``msgContent.type == "voice"`` produces the voice-note player.
         """
-        if not Path(audio_path).exists():
+        safe_path = self.validate_media_delivery_path(audio_path)
+        if not safe_path:
             return SendResult(success=False, error="Voice file not found")
+        audio_path = safe_path
 
         composed = json.dumps(
             [

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -264,6 +264,46 @@ async def test_send_when_ws_not_connected_does_not_crash():
     assert result.success is True  # send() always returns success — fire-and-forget
 
 
+@pytest.mark.asyncio
+async def test_send_filters_media_tags_through_delivery_guard(monkeypatch):
+    """MEDIA tags must not bypass the shared media-delivery path guard."""
+    from gateway.config import PlatformConfig
+    import gateway.platforms.base as base
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    monkeypatch.setattr(base, "validate_media_delivery_path", lambda _path: None)
+
+    result = await adapter.send("contact-42", "before MEDIA:/home/user/.ssh/id_rsa after")
+
+    mock_ws.send.assert_called_once()
+    payload = json.loads(mock_ws.send.call_args[0][0])
+    assert payload["cmd"] == "@contact-42 before MEDIA:/home/user/.ssh/id_rsa after"
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_send_document_refuses_unvalidated_paths(monkeypatch):
+    """Direct document sends should also refuse paths outside the delivery guard."""
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    send_command = AsyncMock()
+    adapter._send_command = send_command  # type: ignore[method-assign]
+    monkeypatch.setattr(adapter, "validate_media_delivery_path", lambda _path: None)
+
+    result = await adapter.send_document("contact-42", "/home/user/.ssh/id_rsa")
+
+    assert result.success is False
+    assert send_command.await_count == 0
+
+
 # ---------------------------------------------------------------------------
 # 8. Inbound: filter own-echo by corrId prefix
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This routes SimpleX `MEDIA:<path>` handling through the shared Hermes media-delivery guard before sending native attachments.

## Why

Most gateway delivery paths use `BasePlatformAdapter.extract_media()` plus `filter_media_delivery_paths()` before uploading model-emitted local files. That guard blocks credential/system paths and enforces the stricter allowlist/recency policy when configured.

The SimpleX adapter had its own `re.findall(r"MEDIA:(\S+)")` parser inside `send()`, then called `send_document()` / `send_voice()` directly. That bypassed the shared delivery validation for model-emitted `MEDIA:` tags.

## Changes

- Replace SimpleX's local `MEDIA:` regex extraction with `self.extract_media()`.
- Apply `self.filter_media_delivery_paths()` before any SimpleX attachment send.
- Add backstop validation inside `send_document()`.
- Add backstop validation inside `send_voice()`.
- Add regression coverage for blocked `MEDIA:` paths and direct document sends.

## Tests

```text
python -m pytest tests/gateway/test_simplex_plugin.py -k "send_filters_media_tags_through_delivery_guard or send_document_refuses_unvalidated_paths or test_send_dm or test_send_group" -q --timeout-method=thread
4 passed, 28 deselected

python -m pytest tests/gateway/test_simplex_plugin.py -q --timeout-method=thread
32 passed

python -m ruff check plugins/platforms/simplex/adapter.py tests/gateway/test_simplex_plugin.py