### PR TITLE
refactor(desktop): simplify remote path picker condition

### DIFF
--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -174,11 +174,7 @@ export async function desktopFileDiff(repoRoot: string, filePath: string): Promi
 export async function selectDesktopPaths(options?: HermesSelectPathsOptions): Promise<string[]> {
   const desktop = bridge()
 
-  if (!isDesktopFsRemoteMode()) {
-    return desktop.selectPaths(options)
-  }
-
-  if (!options?.directories) {
+  if (!isDesktopFsRemoteMode() || !options?.directories) {
     return desktop.selectPaths(options)
   }
 


### PR DESCRIPTION
## Summary
- simplify `selectDesktopPaths` by combining the local-mode and remote-file branches into one condition
- preserve the upstream behavior: local Electron picker for file/image selection, remote picker for directories

## Test
- npm run test:ui -- src/lib/desktop-fs.test.ts

## Note
This PR originally fixed remote file attachments, but upstream `c19bfb5` has since restored that behavior. After rebasing, this PR is now a tiny cleanup on top of that fix.
