### PR TITLE
fix(installer): self-repair corrupt desktop npm tree

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2734,6 +2734,55 @@ _restore_electron_dist_with_fallback() {
         || { [ -z "${ELECTRON_MIRROR:-}" ] && _restore_electron_dist "$install_dir" "$DESKTOP_ELECTRON_FALLBACK_MIRROR"; }
 }
 
+_desktop_run_logged() {
+    local log_file="$1"
+    shift
+
+    set +e
+    "$@" 2>&1 | tee -a "$log_file"
+    local rc=${PIPESTATUS[0]}
+    set -e
+    return "$rc"
+}
+
+_desktop_workspace_npm_install_attempt() {
+    local install_dir="$1"
+    local timeout_budget="$2"
+    local log_file="$3"
+    local deps_start deps_remaining
+
+    : > "$log_file"
+    deps_start=$(date +%s)
+    if _desktop_run_logged "$log_file" run_with_timeout "$timeout_budget" bash -c 'cd "$1" && npm ci' _ "$install_dir"; then
+        return 0
+    fi
+
+    deps_remaining=$(( timeout_budget - ($(date +%s) - deps_start) ))
+    [ "$deps_remaining" -lt 30 ] && deps_remaining=30
+    _desktop_run_logged "$log_file" run_with_timeout "$deps_remaining" bash -c 'cd "$1" && npm install' _ "$install_dir"
+}
+
+_desktop_npm_log_has_tree_corruption() {
+    local log_file="$1"
+    [ -f "$log_file" ] || return 1
+
+    grep -Eiq 'ENOTEMPTY|directory not empty, rename .*node_modules|node_modules/\.[^[:space:]/]+-[^[:space:]/]+' "$log_file"
+}
+
+_purge_desktop_npm_artifacts() {
+    local install_dir="$1"
+    local desktop_dir="$install_dir/apps/desktop"
+
+    log_warn "Detected a corrupted desktop dependency tree; clearing generated npm/build artifacts and retrying once..."
+    log_info "Removing: $install_dir/node_modules, $desktop_dir/node_modules, $desktop_dir/dist, $desktop_dir/release"
+    rm -rf \
+        "$install_dir/node_modules" \
+        "$desktop_dir/node_modules" \
+        "$desktop_dir/dist" \
+        "$desktop_dir/release" \
+        2>/dev/null || true
+}
+
 # Build apps/desktop into a launchable native app. Mirrors install.ps1's
 # Install-Desktop: a root-level npm install so the apps/* workspace resolves
 # the desktop's own deps (Electron ~150MB), then `npm run pack`
@@ -2789,19 +2838,33 @@ install_desktop() {
     #    the remaining seconds to the fallback (min 30s so it still gets a real
     #    attempt if `npm ci` failed fast rather than stalling).
     log_info "Installing desktop workspace dependencies (includes Electron ~150MB, 1-3min)..."
-    local _deps_start _deps_remaining
-    _deps_start=$(date +%s)
-    if run_with_timeout "$DESKTOP_BUILD_TIMEOUT" bash -c 'cd "$1" && npm ci' _ "$INSTALL_DIR"; then
+    local _deps_log _deps_ok=false
+    _deps_log="$(mktemp "${TMPDIR:-/tmp}/hermes-desktop-npm.XXXXXX.log")"
+    if _desktop_workspace_npm_install_attempt "$INSTALL_DIR" "$DESKTOP_BUILD_TIMEOUT" "$_deps_log"; then
+        _deps_ok=true
+    elif _desktop_npm_log_has_tree_corruption "$_deps_log"; then
+        _purge_desktop_npm_artifacts "$INSTALL_DIR"
+        if _desktop_workspace_npm_install_attempt "$INSTALL_DIR" "$DESKTOP_BUILD_TIMEOUT" "$_deps_log"; then
+            _deps_ok=true
+        fi
+    fi
+
+    if [ "$_deps_ok" = true ]; then
         log_success "Desktop workspace dependencies installed"
-    elif _deps_remaining=$(( DESKTOP_BUILD_TIMEOUT - ($(date +%s) - _deps_start) )); \
-         [ "$_deps_remaining" -lt 30 ] && _deps_remaining=30; \
-         run_with_timeout "$_deps_remaining" bash -c 'cd "$1" && npm install' _ "$INSTALL_DIR"; then
-        log_success "Desktop workspace dependencies installed"
+        rm -f "$_deps_log" 2>/dev/null || true
     elif _electron_pkg_staged_missing_dist "$INSTALL_DIR"; then
         log_warn "Desktop dependency install failed with a missing Electron dist; attempting self-heal..."
         _restore_electron_dist_with_fallback "$INSTALL_DIR" || true
+        rm -f "$_deps_log" 2>/dev/null || true
     else
         log_error "Desktop workspace npm install failed"
+        if _desktop_npm_log_has_tree_corruption "$_deps_log"; then
+            log_info "npm reported a corrupted node_modules rename (for example ENOTEMPTY while"
+            log_info "renaming node_modules/<package> to node_modules/.<package>-*). The installer"
+            log_info "already removed generated desktop dependency/build artifacts and retried once."
+            log_info "If this persists, quit all Hermes/Node/npm processes and remove generated artifacts manually:"
+            log_info "  rm -rf \"$INSTALL_DIR/node_modules\" \"$desktop_dir/node_modules\" \"$desktop_dir/dist\" \"$desktop_dir/release\""
+        fi
         # Common cause: a previous 'sudo npm'/'sudo npx' left root-owned files in
         # ~/.npm, so this non-root install can't write the shared cache. npm hides
         # it behind a confusing EEXIST / "File exists" message while the real errno
@@ -2812,6 +2875,7 @@ install_desktop() {
         log_info "  sudo chown -R \"\$(id -un)\" ~/.npm && npm cache verify"
         log_info "Then re-run this installer, or build manually:"
         log_info "  cd \"$INSTALL_DIR\" && npm ci && cd apps/desktop && npm run pack"
+        rm -f "$_deps_log" 2>/dev/null || true
         return 1
     fi
 

--- a/tests/test_install_sh_desktop_npm_repair.py
+++ b/tests/test_install_sh_desktop_npm_repair.py
@@ -1,0 +1,211 @@
+"""Behavioral regression coverage for desktop installer npm tree self-repair."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _desktop_install_functions() -> str:
+    """Extract the installer functions needed for an isolated shell fixture.
+
+    The assertions below execute the real functions with a stubbed ``npm``;
+    this helper keeps the test from running install.sh's top-level installer.
+    """
+    source = INSTALL_SH.read_text()
+    function_names = (
+        "_desktop_run_logged",
+        "_desktop_workspace_npm_install_attempt",
+        "_desktop_npm_log_has_tree_corruption",
+        "_purge_desktop_npm_artifacts",
+        "install_desktop",
+    )
+    functions = []
+    for name in function_names:
+        match = re.search(
+            rf"^{re.escape(name)}\(\) \{{.*?^\}}",
+            source,
+            re.MULTILINE | re.DOTALL,
+        )
+        assert match is not None, f"could not extract {name}() from install.sh"
+        functions.append(match.group(0))
+    return "\n\n".join(functions)
+
+
+def _run_desktop_install(tmp_path: Path, npm_mode: str) -> dict[str, object]:
+    """Run ``install_desktop`` against a controlled npm failure fixture."""
+    install_dir = tmp_path / "install"
+    desktop_dir = install_dir / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}")
+    lockfile = install_dir / "package-lock.json"
+    lockfile.write_text('{"lockfileVersion": 3}')
+
+    artifacts = (
+        install_dir / "node_modules",
+        desktop_dir / "node_modules",
+        desktop_dir / "dist",
+        desktop_dir / "release",
+    )
+    for artifact in artifacts:
+        artifact.mkdir()
+        (artifact / "sentinel").write_text("generated")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    runlog = tmp_path / "npm-runs.log"
+    eventlog = tmp_path / "installer-events.log"
+    npm = bin_dir / "npm"
+    npm.write_text(
+        """#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "$*" >> "$RUNLOG"
+calls=$(wc -l < "$RUNLOG")
+
+case "$NPM_MODE" in
+  repaired)
+    if [ "$calls" -lt 3 ]; then
+      printf '%s\\n' 'npm ERR! code ENOTEMPTY' >&2
+      printf '%s\\n' 'npm ERR! directory not empty, rename node_modules/pkg to node_modules/.pkg-abc' >&2
+      exit 1
+    fi
+    if [ ! -e "$INSTALL_DIR/node_modules" ] \\
+       && [ ! -e "$INSTALL_DIR/apps/desktop/node_modules" ] \\
+       && [ ! -e "$INSTALL_DIR/apps/desktop/dist" ] \\
+       && [ ! -e "$INSTALL_DIR/apps/desktop/release" ]; then
+      printf '%s\\n' 'cleanup-observed' >> "$RUNLOG"
+      exit 0
+    fi
+    printf '%s\\n' 'cleanup-not-observed' >> "$RUNLOG"
+    exit 1
+    ;;
+  persistent-corruption)
+    printf '%s\\n' 'npm ERR! code ENOTEMPTY' >&2
+    printf '%s\\n' 'npm ERR! directory not empty, rename node_modules/pkg to node_modules/.pkg-abc' >&2
+    exit 1
+    ;;
+  ordinary-failure)
+    printf '%s\\n' 'npm ERR! code ECONNRESET' >&2
+    exit 1
+    ;;
+esac
+"""
+    )
+    npm.chmod(0o755)
+
+    shell = f"""
+set -u
+INSTALL_DIR={shlex.quote(str(install_dir))}
+DESKTOP_BUILD_TIMEOUT=60
+OS=linux
+RUNLOG={shlex.quote(str(runlog))}
+EVENTLOG={shlex.quote(str(eventlog))}
+NPM_MODE={shlex.quote(npm_mode)}
+export INSTALL_DIR RUNLOG NPM_MODE
+PATH={shlex.quote(str(bin_dir))}:$PATH
+
+log_info() {{ printf 'INFO:%s\\n' "$*" >> "$EVENTLOG"; }}
+log_warn() {{ printf 'WARN:%s\\n' "$*" >> "$EVENTLOG"; }}
+log_error() {{ printf 'ERROR:%s\\n' "$*" >> "$EVENTLOG"; }}
+log_success() {{ printf 'SUCCESS:%s\\n' "$*" >> "$EVENTLOG"; }}
+check_node() {{ :; }}
+run_with_timeout() {{ local _timeout="$1"; shift; "$@"; }}
+_electron_pkg_staged_missing_dist() {{ return 1; }}
+_restore_electron_dist_with_fallback() {{ return 1; }}
+_electron_dist_ok() {{ return 1; }}
+_desktop_pack() {{
+    mkdir -p "$INSTALL_DIR/apps/desktop/release/linux-unpacked"
+    : > "$INSTALL_DIR/apps/desktop/release/linux-unpacked/Hermes"
+    chmod +x "$INSTALL_DIR/apps/desktop/release/linux-unpacked/Hermes"
+    printf '%s\n' 'pack' >> "$EVENTLOG"
+}}
+clear_electron_build_cache() {{ :; }}
+_restore_electron_dist() {{ return 1; }}
+restore_dirty_lockfiles() {{ :; }}
+
+{_desktop_install_functions()}
+
+if install_desktop; then
+    result=0
+else
+    result=$?
+fi
+printf 'RESULT=%s\n' "$result"
+"""
+    completed = subprocess.run(
+        ["bash", "-c", shell],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ),
+    )
+    result_line = next(
+        (line for line in completed.stdout.splitlines() if line.startswith("RESULT=")),
+        None,
+    )
+    assert result_line is not None, (
+        "desktop installer fixture did not report a result:\n"
+        f"stdout={completed.stdout}\nstderr={completed.stderr}"
+    )
+    result = int(result_line.split("=", 1)[1])
+    return {
+        "returncode": completed.returncode,
+        "result": result,
+        "npm_runs": runlog.read_text().splitlines(),
+        "events": eventlog.read_text().splitlines(),
+        "artifacts": artifacts,
+        "lockfile": lockfile,
+        "stderr": completed.stderr,
+    }
+
+
+def test_enotempty_clears_generated_artifacts_then_retries_once(tmp_path: Path) -> None:
+    result = _run_desktop_install(tmp_path, "repaired")
+
+    assert result["returncode"] == 0, result["stderr"]
+    assert result["result"] == 0
+    assert result["npm_runs"] == ["ci", "install", "ci", "cleanup-observed"]
+    assert all(not artifact.exists() for artifact in result["artifacts"][:3])
+    assert result["artifacts"][3].is_dir(), (
+        "the successful desktop build recreates release/"
+    )
+    assert result["lockfile"].read_text() == '{"lockfileVersion": 3}'
+    assert any(
+        "clearing generated npm/build artifacts and retrying once" in event
+        for event in result["events"]
+    )
+
+
+def test_non_corruption_failure_does_not_clear_or_retry(tmp_path: Path) -> None:
+    result = _run_desktop_install(tmp_path, "ordinary-failure")
+
+    assert result["returncode"] == 0, result["stderr"]
+    assert result["result"] == 1
+    assert result["npm_runs"] == ["ci", "install"]
+    assert all(artifact.exists() for artifact in result["artifacts"])
+    assert not any(
+        "clearing generated npm/build artifacts" in event for event in result["events"]
+    )
+
+
+def test_persistent_enotempty_reports_manual_repair_guidance(tmp_path: Path) -> None:
+    result = _run_desktop_install(tmp_path, "persistent-corruption")
+
+    assert result["returncode"] == 0, result["stderr"]
+    assert result["result"] == 1
+    assert result["npm_runs"] == ["ci", "install", "ci", "install"]
+    assert all(not artifact.exists() for artifact in result["artifacts"])
+    assert any(
+        "already removed generated desktop dependency/build artifacts and retried once"
+        in event
+        for event in result["events"]
+    )
+    assert any(
+        "quit all Hermes/Node/npm processes" in event for event in result["events"]
+    )


### PR DESCRIPTION
What does this PR do?

Fixes a Desktop bootstrap failure mode where npm can exit with ENOTEMPTY while renaming a package directory under node_modules, but Hermes only surfaces a generic “install did not finish” / exit code 1 failure.

The installer now captures desktop npm install output while still streaming it to the installer log, detects the npm tree-corruption pattern, clears only generated desktop dependency/build artifacts, and retries once. If the retry still fails, it prints specific recovery guidance instead of leaving the user to infer the fix from npm internals.

Related Issue

Fixes #57408

Type of Change

* 🐛 Bug fix (non-breaking change that fixes an issue)
* ✨ New feature (non-breaking change that adds functionality)
* 🔒 Security fix
* 📝 Documentation update
* ✅ Tests (adding or improving test coverage)
* ♻️ Refactor (no behavior change)
* 🎯 New skill (bundled or hub)

Changes Made

* scripts/install.sh: add a logged desktop npm install helper that preserves npm exit status while streaming output.
* scripts/install.sh: detect ENOTEMPTY / directory-not-empty rename failures under node_modules.
* scripts/install.sh: remove only generated desktop npm/build artifacts for that corruption class, then retry once.
* scripts/install.sh: add persistent-failure guidance that explains the detected npm corruption class.
* tests/test_install_sh_desktop_npm_repair.py: add regression coverage for output capture, corruption detection, safe artifact cleanup, retry ordering, and actionable error text.

How to Test

1. Run bash syntax validation for scripts/install.sh.
2. Run the targeted installer regression tests:
    * tests/test_install_sh_desktop_npm_repair.py
    * tests/test_install_sh_browser_install.py
3. Confirm all targeted tests pass.

Verified locally:

bash -n scripts/install.sh
./scripts/run_tests.sh tests/test_install_sh_desktop_npm_repair.py tests/test_install_sh_browser_install.py
20 tests passed, 0 failed

Checklist

Code

* I’ve read the Contributing Guide / repo instructions.
* My commit messages follow Conventional Commits.
* I searched for existing PRs/issues to make sure this isn’t a duplicate.
* My PR contains only changes related to this fix.
* I’ve run pytest tests/ -q and all tests pass. Targeted installer tests passed instead.
* I’ve added tests for my changes.
* I’ve tested on my platform: Linux dev workspace for installer static/regression tests; bug was diagnosed from macOS Desktop bootstrap logs.

Documentation & Housekeeping

* I’ve updated relevant documentation (README, docs/, docstrings) — N/A.
* I’ve updated cli-config.yaml.example if I added/changed config keys — N/A.
* I’ve updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A.
* I’ve considered cross-platform impact (Windows, macOS) per the compatibility guide.
* I’ve updated tool descriptions/schemas if I changed tool behavior — N/A.

For New Skills

N/A. This PR does not add or modify skills.

Screenshots / Logs

Targeted verification output:

20 tests passed, 0 failed