### PR TITLE
fix(inventory): handle dict entries in provider models lists for model selector

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -185,7 +185,11 @@ def build_models_payload(
         user_models: set[str] = set()
         for row in rows:
             if row.get("is_user_defined"):
-                user_models.update(m.lower() for m in (row.get("models") or []))
+                user_models.update(
+                    m.lower()
+                    for m in (row.get("models") or [])
+                    if isinstance(m, str)
+                )
         if user_models:
             for row in rows:
                 # A user's own configured provider is never an "aggregator
@@ -207,7 +211,7 @@ def build_models_payload(
                 if not _is_routing_aggregator(slug):
                     continue
                 original = row.get("models") or []
-                filtered = [m for m in original if m.lower() not in user_models]
+                filtered = [m for m in original if isinstance(m, str) and m.lower() not in user_models]
                 if len(filtered) < len(original):
                     row["models"] = filtered
                     row["total_models"] = len(filtered)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1966,8 +1966,13 @@ def list_authenticated_providers(
                         models_list.append(m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    # Guard: list entries may be dicts (hand-edited config
+                    # or legacy format with per-model metadata).  Extract
+                    # the model id string so downstream .lower() calls
+                    # never receive a dict.  (#57405)
+                    mid = m.get("id") if isinstance(m, dict) else m
+                    if isinstance(mid, str) and mid and mid not in models_list:
+                        models_list.append(mid)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.
@@ -2179,8 +2184,11 @@ def list_authenticated_providers(
                         groups[group_key]["models"].append(m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in groups[group_key]["models"]:
-                        groups[group_key]["models"].append(m)
+                    # Guard: list entries may be dicts (hand-edited config).
+                    # Extract the model id string.  (#57405)
+                    mid = m.get("id") if isinstance(m, dict) else m
+                    if isinstance(mid, str) and mid and mid not in groups[group_key]["models"]:
+                        groups[group_key]["models"].append(mid)
 
         _section4_emitted_slugs: set = set()
         _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()

--- a/tests/hermes_cli/test_model_dict_entries.py
+++ b/tests/hermes_cli/test_model_dict_entries.py
@@ -1,0 +1,201 @@
+"""Regression tests for dict entries in provider models lists.
+
+Issue #57405: Model selector crashes with
+'``dict`` object has no attribute ``lower``' when a provider's
+``models:`` config is a list of dicts (e.g. ``[{id: "gpt-4"}]``)
+instead of a flat list of strings.
+
+The models list is consumed by :func:`build_models_payload` which calls
+``m.lower()`` on every entry for deduplication.  If a dict slips through,
+the Desktop model selector and CLI ``hermes model`` both crash.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# model_switch: list_authenticated_providers
+# ---------------------------------------------------------------------------
+
+
+class TestListAuthenticatedProvidersDictModels:
+    """Section 3 (providers:) and Section 4 (custom_providers:) must
+    extract the ``id`` field from dict entries instead of appending
+    the raw dict to the models list."""
+
+    def test_providers_dict_with_list_of_dicts(self) -> None:
+        """providers: models is a list of dicts — extract id strings."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        user_providers = {
+            "my-proxy": {
+                "base_url": "https://proxy.example.com/v1",
+                "models": [
+                    {"id": "model-alpha", "context_length": 128_000},
+                    {"id": "model-beta", "context_length": 16_384},
+                ],
+            }
+        }
+
+        rows = list_authenticated_providers(
+            current_provider="my-proxy",
+            current_model="model-alpha",
+            current_base_url="https://proxy.example.com/v1",
+            user_providers=user_providers,
+            custom_providers=[],
+        )
+
+        proxy_rows = [r for r in rows if r.get("slug") == "my-proxy"]
+        assert proxy_rows, f"my-proxy not found in rows: {[r['slug'] for r in rows]}"
+        models = proxy_rows[0]["models"]
+        assert all(isinstance(m, str) for m in models), (
+            f"Non-string model entries: {[type(m).__name__ for m in models]}"
+        )
+        assert "model-alpha" in models
+        assert "model-beta" in models
+
+    def test_providers_dict_with_string_list(self) -> None:
+        """providers: models is a flat list of strings — still works."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        user_providers = {
+            "my-proxy": {
+                "base_url": "https://proxy.example.com/v1",
+                "models": ["model-x", "model-y"],
+            }
+        }
+
+        rows = list_authenticated_providers(
+            current_provider="my-proxy",
+            current_model="model-x",
+            current_base_url="https://proxy.example.com/v1",
+            user_providers=user_providers,
+            custom_providers=[],
+        )
+
+        proxy_rows = [r for r in rows if r.get("slug") == "my-proxy"]
+        assert proxy_rows
+        models = proxy_rows[0]["models"]
+        assert "model-x" in models
+        assert "model-y" in models
+
+    def test_providers_dict_with_keyed_dict(self) -> None:
+        """providers: models is a dict keyed by model id — still works."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        user_providers = {
+            "my-proxy": {
+                "base_url": "https://proxy.example.com/v1",
+                "models": {
+                    "model-p": {"context_length": 128_000},
+                    "model-q": {"context_length": 16_384},
+                },
+            }
+        }
+
+        rows = list_authenticated_providers(
+            current_provider="my-proxy",
+            current_model="model-p",
+            current_base_url="https://proxy.example.com/v1",
+            user_providers=user_providers,
+            custom_providers=[],
+        )
+
+        proxy_rows = [r for r in rows if r.get("slug") == "my-proxy"]
+        assert proxy_rows
+        models = proxy_rows[0]["models"]
+        assert "model-p" in models
+        assert "model-q" in models
+
+    def test_custom_providers_list_of_dicts(self) -> None:
+        """custom_providers: models is a list of dicts — extract id strings."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        custom_providers = [
+            {
+                "name": "My Ollama",
+                "base_url": "http://localhost:11434/v1",
+                "models": [
+                    {"id": "llama-4", "context_length": 8192},
+                    {"id": "qwen-3", "context_length": 32768},
+                ],
+            }
+        ]
+
+        rows = list_authenticated_providers(
+            current_provider="",
+            current_model="",
+            current_base_url="",
+            user_providers={},
+            custom_providers=custom_providers,
+        )
+
+        ollama_rows = [r for r in rows if "ollama" in r.get("slug", "").lower()]
+        assert ollama_rows, f"No ollama row found: {[r['slug'] for r in rows]}"
+        models = ollama_rows[0]["models"]
+        assert all(isinstance(m, str) for m in models), (
+            f"Non-string model entries: {[type(m).__name__ for m in models]}"
+        )
+        assert "llama-4" in models
+        assert "qwen-3" in models
+
+    def test_dict_entries_without_id_fall_through(self) -> None:
+        """Dicts without an 'id' key are silently skipped."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        user_providers = {
+            "my-proxy": {
+                "base_url": "https://proxy.example.com/v1",
+                "models": [
+                    {"name": "no-id-field"},
+                    "valid-model",
+                ],
+            }
+        }
+
+        rows = list_authenticated_providers(
+            current_provider="my-proxy",
+            current_model="valid-model",
+            current_base_url="https://proxy.example.com/v1",
+            user_providers=user_providers,
+            custom_providers=[],
+        )
+
+        proxy_rows = [r for r in rows if r.get("slug") == "my-proxy"]
+        assert proxy_rows
+        models = proxy_rows[0]["models"]
+        assert all(isinstance(m, str) for m in models)
+        assert "valid-model" in models
+        # The dict without 'id' should be skipped (not crash, not leak)
+        assert len(models) == 1
+
+
+# ---------------------------------------------------------------------------
+# inventory: build_models_payload dedup
+# ---------------------------------------------------------------------------
+
+
+class TestBuildModelsPayloadDictModels:
+    """build_models_payload dedup must not crash when models contain dicts."""
+
+    def test_build_payload_with_dict_models(self) -> None:
+        """End-to-end: build_models_payload survives dict entries."""
+        from hermes_cli.inventory import build_models_payload, load_picker_context
+
+        ctx = load_picker_context()
+        # Should not raise AttributeError on .lower()
+        payload = build_models_payload(
+            ctx,
+            include_unconfigured=True,
+            picker_hints=True,
+            canonical_order=True,
+        )
+        assert "providers" in payload
+        for provider in payload["providers"]:
+            for m in provider.get("models", []):
+                assert isinstance(m, str), (
+                    f"Non-string model in {provider['slug']}: "
+                    f"{type(m).__name__} = {repr(m)}"
+                )


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in the model selector dropdown when a provider's `models:` config contains dict entries instead of plain strings. When users hand-edit `config.yaml` with per-model metadata (e.g. `models: [{id: "gpt-4", context_length: 128000}]`), the dicts leak into the model list. Downstream dedup logic in `build_models_payload()` calls `.lower()` on every entry, causing `AttributeError: 'dict' object has no attribute 'lower'`.

The fix extracts the `id` field from dict entries at the source (`list_authenticated_providers()` Sections 3 and 4) and adds defensive type guards in the inventory dedup path.

## Related Issue

Fixes #57405

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: In Section 3 (`providers:` handling) and Section 4 (`custom_providers:` handling), when `cfg_models` is a list, extract `m.get("id")` from dict entries instead of appending the raw dict to the models list.
- `hermes_cli/inventory.py`: Add `isinstance(m, str)` guard in `build_models_payload()` dedup logic (lines 188 and 210) so non-string entries are filtered out instead of crashing.
- `tests/hermes_cli/test_model_dict_entries.py`: 5 regression tests covering list-of-dicts, flat string list, keyed dict, custom_providers list-of-dicts, and dicts without `id` field.

## How to Test

1. Add a `providers:` entry in `~/.hermes/config.yaml` with `models:` as a list of dicts:
   ```yaml
   providers:
     test:
       base_url: https://example.com/v1
       models:
         - id: model-a
           context_length: 128000
   ```
2. Open the Desktop model selector — it should load without crashing.
3. Run `pytest tests/hermes_cli/test_model_dict_entries.py -v` — all 5 tests should pass.
4. Verified locally: `build_models_payload()` returns all-string model entries with dict-in-list config.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction test output:
```
# Before fix: AttributeError: 'dict' object has no attribute 'lower'
# After fix:
PASS: test-provider models = ['model-a', 'model-b']
PASS: build_models_payload OK (38 providers)
PASS: string list models still work
```
