### PR TITLE
fix(tui): confirm idle Ctrl+D exit

### DIFF
--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldPassThroughToGlobalHandler, shouldPreserveCtrlJNewline } from '../components/textInput.js'
+import {
+  isIdleExitHotkey,
+  shouldPassThroughToGlobalHandler,
+  shouldPreserveCtrlJNewline
+} from '../components/textInput.js'
 import { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } from '../lib/platform.js'
 
 const key = (overrides: Record<string, unknown> = {}) => ({ ctrl: false, meta: false, ...overrides }) as any
@@ -44,9 +48,20 @@ describe('shouldPassThroughToGlobalHandler', () => {
   it('always passes through non-voice global control keys', () => {
     expect(shouldPassThroughToGlobalHandler('c', key({ ctrl: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('x', key({ ctrl: true }))).toBe(true)
+    expect(shouldPassThroughToGlobalHandler('d', key({ ctrl: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ escape: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ tab: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageUp: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageDown: true }))).toBe(true)
+  })
+})
+
+describe('isIdleExitHotkey', () => {
+  it('recognizes Ctrl+D as an idle exit hotkey', () => {
+    expect(isIdleExitHotkey('d', key({ ctrl: true }))).toBe(true)
+  })
+
+  it('does not treat plain d as an idle exit hotkey', () => {
+    expect(isIdleExitHotkey('d', key())).toBe(false)
   })
 })

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -67,6 +67,47 @@ describe('handleIdleHotkeyExit', () => {
     expect(actions.sys).not.toHaveBeenCalled()
   })
 
+  it('requires a second confirmed idle exit hotkey press in normal terminals', () => {
+    const actions = { die: vi.fn(), sys: vi.fn() }
+    const lastPressedAt = { current: 0 }
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 1000,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).not.toHaveBeenCalled()
+    expect(actions.sys).toHaveBeenCalledWith('press Ctrl+D again to exit')
+    expect(lastPressedAt.current).toBe(1000)
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 2500,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms confirmed idle exit hotkeys after the confirmation window expires', () => {
+    const actions = { die: vi.fn(), sys: vi.fn() }
+    const lastPressedAt = { current: 1000 }
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 4001,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).not.toHaveBeenCalled()
+    expect(actions.sys).toHaveBeenCalledWith('press Ctrl+D again to exit')
+    expect(lastPressedAt.current).toBe(4001)
+  })
+
   it('asks the dashboard for a fresh chat instead of leaving a ghost session', () => {
     const actions = { die: vi.fn(), sys: vi.fn() }
     const requestDashboardNewSession = vi.fn()

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -24,18 +24,38 @@ import { getUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
+const IDLE_EXIT_CONFIRM_MS = 2000
+
+interface IdleHotkeyExitConfirmation {
+  hotkeyLabel?: string
+  lastPressedAt: { current: number }
+  now?: () => number
+  timeoutMs?: number
+}
 
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
 
 export function handleIdleHotkeyExit(
   actions: Pick<InputHandlerActions, 'die' | 'sys'>,
   dashboardTuiMode = DASHBOARD_TUI_MODE,
-  requestDashboardNewSession?: () => void
+  requestDashboardNewSession?: () => void,
+  confirmation?: IdleHotkeyExitConfirmation
 ) {
   if (!shouldAllowIdleHotkeyExit(dashboardTuiMode)) {
     requestDashboardNewSession?.()
 
     return actions.sys(DASHBOARD_NEW_SESSION_MESSAGE)
+  }
+
+  if (confirmation) {
+    const now = confirmation.now?.() ?? Date.now()
+    const timeoutMs = confirmation.timeoutMs ?? IDLE_EXIT_CONFIRM_MS
+
+    if (!confirmation.lastPressedAt.current || now - confirmation.lastPressedAt.current > timeoutMs) {
+      confirmation.lastPressedAt.current = now
+
+      return actions.sys(`press ${confirmation.hotkeyLabel ?? 'the exit hotkey'} again to exit`)
+    }
   }
 
   return actions.die()
@@ -105,6 +125,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   const isBlocked = useStore($isBlocked)
   const pagerPageSize = Math.max(5, (terminal.stdout?.rows ?? 24) - 6)
   const scrollIdleTimer = useRef<null | ReturnType<typeof setTimeout>>(null)
+  const idleExitConfirmAtRef = useRef(0)
 
   // Wheel accel ported from claude-code: inter-event timing drives step size,
   // direction flips reset. wheelStep (WHEEL_SCROLL_STEP) is the base; final
@@ -541,13 +562,22 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (isAction(key, ch, 'd')) {
-      return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {
-        gateway.gw.publishLocalEvent({
-          payload: { reason: 'idle_exit_hotkey' },
-          session_id: live.sid ?? undefined,
-          type: 'dashboard.new_session_requested'
-        })
-      })
+      if (cState.input || cState.inputBuf.length) {
+        return
+      }
+
+      return handleIdleHotkeyExit(
+        actions,
+        DASHBOARD_TUI_MODE,
+        () => {
+          gateway.gw.publishLocalEvent({
+            payload: { reason: 'idle_exit_hotkey' },
+            session_id: live.sid ?? undefined,
+            type: 'dashboard.new_session_requested'
+          })
+        },
+        { hotkeyLabel: isMac ? 'Cmd+D' : 'Ctrl+D', lastPressedAt: idleExitConfirmAtRef }
+      )
     }
 
     if (isAction(key, ch, 'l')) {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1348,12 +1348,16 @@ export const shouldPassThroughToGlobalHandler = (
 ): boolean =>
   (key.ctrl && input === 'c') ||
   (key.ctrl && input === 'x') ||
+  isIdleExitHotkey(input, key) ||
   key.tab ||
   (key.shift && key.tab) ||
   key.pageUp ||
   key.pageDown ||
   key.escape ||
   isVoiceToggleKey(key, input, voiceRecordKey)
+
+export const isIdleExitHotkey = (input: string, key: Key): boolean =>
+  input.toLowerCase() === 'd' && ((key.ctrl && !key.meta && key.super !== true) || isActionMod(key))
 
 export interface TextInputMouseApi {
   dragAt: (row: number, col: number) => void


### PR DESCRIPTION
## Summary

- require a second idle Ctrl+D / Cmd+D press before the standalone TUI exits
- route the idle-exit hotkey out of the focused composer so the first press is not inserted as `d`
- mirror the accidental-quit guard pattern used by Claude Code
- keep this intentionally narrower than readline delete-char semantics covered by #8478 / #21684

## Behavior

- Empty composer in normal TUI: first Ctrl+D/Cmd+D shows `press <key> again to exit`; second press within 2s exits.
- Non-empty composer: Ctrl+D/Cmd+D is consumed as a no-op so it neither exits nor inserts `d`.
- Dashboard embedded TUI: existing idle-hotkey behavior is preserved; it requests a fresh dashboard chat instead of exiting.

## Out of scope

This PR does not implement Ctrl+D delete-char/readline behavior. Existing work and discussion around that behavior lives in #8478 / #21684; this change is only an accidental-exit guard.

## Test plan

- `npm --prefix ui-tui test -- src/__tests__/useInputHandlers.test.ts src/__tests__/textInputPassThrough.test.ts`
- `npm --prefix ui-tui run typecheck`
