### PR TITLE
fix(acp): pass configured fallback chain to AIAgent — model failover was broken over ACP

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -637,6 +637,19 @@ class SessionManager:
             "model": model or default_model,
         }
 
+        # The CLI and gateway pass the configured fallback chain to AIAgent;
+        # without it the ACP path gets an empty chain, so a rate-limited or
+        # unreachable primary provider stalls the turn in the retry loop
+        # instead of failing over (#18452).
+        try:
+            from hermes_cli.fallback_config import get_fallback_chain
+
+            fallback_chain = get_fallback_chain(config)
+            if fallback_chain:
+                kwargs["fallback_model"] = fallback_chain
+        except Exception:
+            logger.debug("ACP session: failed to load fallback chain", exc_info=True)
+
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
             kwargs.update(

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -121,6 +121,64 @@ class TestCreateSession:
 
         assert state.agent.session_cwd == "/tmp/project"
 
+    @staticmethod
+    def _patch_make_agent_env(monkeypatch, config):
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr("acp_adapter.session.load_config", lambda: config, raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "openai_chat",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+    def test_make_agent_passes_configured_fallback_chain(self, monkeypatch):
+        # Regression for #18452: the CLI and gateway hand the configured
+        # fallback chain to AIAgent, but the ACP path dropped it — so a
+        # rate-limited primary provider stalled in the retry loop instead
+        # of failing over.
+        self._patch_make_agent_env(
+            monkeypatch,
+            {
+                "model": {"default": "fake-model", "provider": "fake-provider"},
+                "mcp_servers": {},
+                "fallback_providers": [
+                    {"model": "backup-model", "provider": "backup-provider"},
+                ],
+            },
+        )
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        chain = state.agent.kwargs.get("fallback_model")
+        assert chain, "ACP agent must receive the configured fallback chain"
+        assert chain[0]["model"] == "backup-model"
+        assert chain[0]["provider"] == "backup-provider"
+
+    def test_make_agent_omits_fallback_when_none_configured(self, monkeypatch):
+        self._patch_make_agent_env(
+            monkeypatch,
+            {
+                "model": {"default": "fake-model", "provider": "fake-provider"},
+                "mcp_servers": {},
+            },
+        )
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert "fallback_model" not in state.agent.kwargs
+
 
 
 


### PR DESCRIPTION
Fixes #18452.

## Problem

The CLI (`cli.py` via `get_fallback_chain`) and the gateway both pass the configured fallback chain to `AIAgent(fallback_model=...)`. The ACP adapter's `_make_agent` never did — its kwargs dict has no `fallback_model` key — so every ACP agent runs with `_fallback_chain = []`.

Consequence: when the primary provider rate-limits (429), overloads, or drops, the conversation-loop's eager-failover path (`conversation_loop.py`, the `_should_fallback` block) finds an empty chain and falls through to the retry loop instead — the turn stalls for 60s+ per retry. Model failover is silently broken in every editor/ACP integration (Zed, Obsidian, VS Code, JetBrains…), exactly as #18452 reports.

Hit this in production driving hermes as a voice-assistant brain over ACP: a Cerebras 429 froze the spoken turn in `Retrying API call in 60.0s (attempt 1/3)` despite a configured NVIDIA fallback.

## Fix

Load the chain in `_make_agent` with `hermes_cli.fallback_config.get_fallback_chain(config)` — the same helper the CLI uses, so `fallback_providers` and legacy `fallback_model` entries both work — and pass it as `fallback_model` when non-empty. Guarded by try/except mirroring the surrounding provider-resolution style.

## Verification

- Two new tests in `tests/acp/test_session.py`: the chain reaches `AIAgent` kwargs when configured; the key is absent when not. Full file: 47 passed.
- Live before/after on the ACP path: before — `Retrying API call in 60.0s`; after — `⚠️ Rate limited — switching to fallback provider...` and the turn completes on the fallback model.

https://claude.ai/code/session_01YNvCUipheR7yx4VorUL2jW