### PR TITLE
fix(desktop): stage file attachments under HERMES_HOME on Docker (#57413)

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -349,9 +349,15 @@ async def _default_url_fetcher(url: str) -> str:
 
 
 def _resolve_path(cwd: Path, target: str, *, allowed_root: Path | None = None) -> Path:
-    path = Path(os.path.expanduser(target))
-    if not path.is_absolute():
-        path = cwd / path
+    from hermes_constants import resolve_desktop_attachment_ref
+
+    mapped = resolve_desktop_attachment_ref(target)
+    if mapped is not None:
+        path = mapped
+    else:
+        path = Path(os.path.expanduser(target))
+        if not path.is_absolute():
+            path = cwd / path
     resolved = path.resolve()
     if allowed_root is not None:
         try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1259,9 +1259,15 @@ def _fs_path(raw_path: str) -> Path:
             if parsed.netloc and parsed.netloc not in {"", "localhost"}:
                 raise ValueError
             raw = urllib.request.url2pathname(parsed.path)
-        candidate = Path(raw).expanduser()
-        if not candidate.is_absolute():
-            candidate = Path.cwd() / candidate
+        from hermes_constants import resolve_desktop_attachment_ref
+
+        mapped = resolve_desktop_attachment_ref(raw)
+        if mapped is not None:
+            candidate = mapped
+        else:
+            candidate = Path(raw).expanduser()
+            if not candidate.is_absolute():
+                candidate = Path.cwd() / candidate
         return candidate.resolve(strict=False)
     except (OSError, RuntimeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid path")

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -150,6 +150,48 @@ def get_default_hermes_root() -> Path:
     return env_path
 
 
+DESKTOP_ATTACHMENTS_REF_PREFIX = ".hermes/desktop-attachments"
+
+
+def get_desktop_attachments_dir() -> Path:
+    """Return the gateway directory for Desktop-uploaded file attachments."""
+    return get_hermes_home() / "desktop-attachments"
+
+
+def resolve_desktop_attachment_ref(raw: str) -> Path | None:
+    """Map a ``.hermes/desktop-attachments/...`` ref to a path under HERMES_HOME.
+
+    Desktop stages remote uploads under ``$HERMES_HOME/desktop-attachments/``,
+    but keeps the historical ``@file:.hermes/desktop-attachments/...`` ref shape
+    so session transcripts stay stable. Resolve that alias against HERMES_HOME,
+    not the session cwd (which may be the read-only Docker install tree).
+    """
+    text = str(raw or "").strip().replace("\\", "/")
+    prefix = DESKTOP_ATTACHMENTS_REF_PREFIX
+    if text == prefix:
+        return get_desktop_attachments_dir()
+    if not text.startswith(f"{prefix}/"):
+        return None
+    suffix = text[len(prefix) + 1 :]
+    if not suffix or ".." in Path(suffix).parts:
+        return None
+    return get_desktop_attachments_dir() / suffix
+
+
+def format_desktop_attachment_ref(target: Path) -> str | None:
+    """Return the canonical ``.hermes/desktop-attachments/...`` ref for *target*."""
+    resolved = target.resolve()
+    root = get_desktop_attachments_dir().resolve()
+    try:
+        rel = resolved.relative_to(root)
+    except ValueError:
+        return None
+    if rel.parts and ".." in rel.parts:
+        return None
+    suffix = rel.as_posix()
+    return f"{DESKTOP_ATTACHMENTS_REF_PREFIX}/{suffix}" if suffix else DESKTOP_ATTACHMENTS_REF_PREFIX
+
+
 def _get_packaged_data_dir(name: str) -> Path | None:
     """Return an installed data-files directory if one exists.
 

--- a/tests/hermes_cli/test_desktop_attachments_paths.py
+++ b/tests/hermes_cli/test_desktop_attachments_paths.py
@@ -1,0 +1,84 @@
+"""Regression tests for #57413 — desktop attachment paths must use HERMES_HOME."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_constants import (
+    format_desktop_attachment_ref,
+    get_desktop_attachments_dir,
+    resolve_desktop_attachment_ref,
+)
+
+pytest.importorskip("starlette.testclient")
+from starlette.testclient import TestClient
+
+from hermes_cli import web_server
+
+
+@pytest.fixture
+def client(monkeypatch):
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    test_client = TestClient(web_server.app)
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        if previous_auth_required is None:
+            try:
+                delattr(web_server.app.state, "auth_required")
+            except AttributeError:
+                pass
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+def test_get_desktop_attachments_dir_uses_hermes_home(monkeypatch, tmp_path):
+    home = tmp_path / "data"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    assert get_desktop_attachments_dir() == home / "desktop-attachments"
+
+
+def test_resolve_desktop_attachment_ref_maps_under_hermes_home(monkeypatch, tmp_path):
+    home = tmp_path / "data"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    resolved = resolve_desktop_attachment_ref(".hermes/desktop-attachments/report.txt")
+    assert resolved == home / "desktop-attachments" / "report.txt"
+    assert resolve_desktop_attachment_ref("../secrets") is None
+
+
+def test_format_desktop_attachment_ref_round_trip(monkeypatch, tmp_path):
+    home = tmp_path / "data"
+    target = home / "desktop-attachments" / "report.txt"
+    target.parent.mkdir(parents=True)
+    target.write_text("ok", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    ref = format_desktop_attachment_ref(target)
+    assert ref == ".hermes/desktop-attachments/report.txt"
+    assert resolve_desktop_attachment_ref(ref) == target.resolve()
+
+
+def test_fs_read_text_resolves_desktop_attachment_alias(client, tmp_path, monkeypatch):
+    """GET /api/fs/read-text must not join .hermes/desktop-attachments against cwd."""
+    data_home = tmp_path / "data"
+    data_home.mkdir()
+    install_cwd = tmp_path / "opt" / "hermes"
+    install_cwd.mkdir(parents=True)
+    attachment = data_home / "desktop-attachments" / "report.txt"
+    attachment.parent.mkdir(parents=True)
+    attachment.write_text("hello", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(data_home))
+    monkeypatch.chdir(install_cwd)
+
+    resp = client.get(
+        "/api/fs/read-text",
+        params={"path": ".hermes/desktop-attachments/report.txt"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["text"] == "hello"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4061,7 +4061,9 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
             }
         )
 
-        stored = workspace / ".hermes" / "desktop-attachments" / "report.txt"
+        from hermes_constants import get_desktop_attachments_dir
+
+        stored = get_desktop_attachments_dir() / "report.txt"
         assert resp["result"]["attached"] is True
         assert resp["result"]["uploaded"] is True
         assert resp["result"]["path"] == str(stored)
@@ -4094,7 +4096,9 @@ def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, 
             }
         )
 
-        stored = workspace / ".hermes" / "desktop-attachments" / "outside.txt"
+        from hermes_constants import get_desktop_attachments_dir
+
+        stored = get_desktop_attachments_dir() / "outside.txt"
         assert resp["result"]["attached"] is True
         assert resp["result"]["uploaded"] is True
         assert resp["result"]["ref_text"] == "@file:.hermes/desktop-attachments/outside.txt"
@@ -4130,7 +4134,9 @@ def test_file_attach_uses_in_workspace_file_without_copying(monkeypatch, tmp_pat
         assert resp["result"]["uploaded"] is False
         assert resp["result"]["ref_text"] == "@file:data/exam.csv"
         # No copy: nothing staged under desktop-attachments.
-        assert not (workspace / ".hermes" / "desktop-attachments").exists()
+        from hermes_constants import get_desktop_attachments_dir
+
+        assert not get_desktop_attachments_dir().exists()
     finally:
         server._sessions.pop("sid", None)
 
@@ -4189,6 +4195,47 @@ def test_file_attach_quotes_ref_with_spaces(monkeypatch, tmp_path):
 
         assert resp["result"]["attached"] is True
         assert resp["result"]["ref_text"] == "@file:`.hermes/desktop-attachments/my exam schedule.csv`"
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_file_attach_stages_under_hermes_home_when_cwd_is_read_only_install(monkeypatch, tmp_path):
+    """Docker: cwd may be the read-only install tree (/opt/hermes), not HERMES_HOME."""
+    data_home = tmp_path / "data"
+    data_home.mkdir()
+    install_cwd = tmp_path / "opt" / "hermes"
+    install_cwd.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(data_home))
+    monkeypatch.chdir(install_cwd)
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._detect_file_drop = lambda raw: None
+    fake_cli._split_path_input = lambda raw: (raw, "")
+    fake_cli._resolve_attachment_path = lambda raw: None
+
+    server._sessions["sid"] = _session(cwd=str(install_cwd))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "file.attach",
+                "params": {
+                    "session_id": "sid",
+                    "path": "/Users/alice/Downloads/report.txt",
+                    "name": "report.txt",
+                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+                },
+            }
+        )
+
+        stored = data_home / "desktop-attachments" / "report.txt"
+        assert resp["result"]["attached"] is True
+        assert resp["result"]["uploaded"] is True
+        assert resp["result"]["path"] == str(stored)
+        assert stored.read_text(encoding="utf-8") == "hello world"
+        assert not (install_cwd / ".hermes").exists()
     finally:
         server._sessions.pop("sid", None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_constants import (
+    format_desktop_attachment_ref,
+    get_desktop_attachments_dir,
     get_hermes_home,
     get_hermes_home_override,
     reset_hermes_home_override,
@@ -9341,16 +9343,21 @@ def _format_ref_value(value: str) -> str:
 
 def _attachment_ref_path(session: dict, target: Path) -> str:
     """Workspace-relative path for an attachment, or the absolute path if outside."""
+    resolved = target.resolve()
+    staged_ref = format_desktop_attachment_ref(resolved)
+    if staged_ref is not None:
+        return staged_ref
     workspace = Path(_session_cwd(session)).resolve()
     try:
-        rel = target.resolve().relative_to(workspace)
+        rel = resolved.relative_to(workspace)
         return str(rel).replace(os.sep, "/")
     except ValueError:
-        return str(target.resolve())
+        return str(resolved)
 
 
 def _desktop_attachment_dir(session: dict) -> Path:
-    root = Path(_session_cwd(session)).resolve() / ".hermes" / "desktop-attachments"
+    del session  # attachments are profile-scoped, not workspace-scoped
+    root = get_desktop_attachments_dir()
     root.mkdir(parents=True, exist_ok=True)
     return root
 


### PR DESCRIPTION
## Summary
- Desktop `file.attach` staged uploads under `<session cwd>/.hermes/desktop-attachments`, which on Docker is often the read-only install tree (`/opt/hermes`) → `Permission denied: /opt/hermes/.hermes`.
- Stage attachments under `$HERMES_HOME/desktop-attachments` instead, and resolve `.hermes/desktop-attachments/...` refs against HERMES_HOME for preview (`/api/fs/read-text`) and `@file:` expansion.

Fixes #57413

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_desktop_attachments_paths.py -q`
- [x] `scripts/run_tests.sh tests/test_tui_gateway_server.py -k file_attach -q`