### PR TITLE
fix(acp): pass agent.disabled_toolsets to AIAgent — config-disabled tools stay executable over ACP

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1793,7 +1793,11 @@ class HermesACPAgent(acp.Agent):
             toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
             )
-            tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
+            tools = get_tool_definitions(
+                enabled_toolsets=toolsets,
+                disabled_toolsets=getattr(state.agent, "disabled_toolsets", None),
+                quiet_mode=True,
+            )
             tool_view = SimpleNamespace(
                 tools=list(tools or []),
                 valid_tool_names={

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -637,6 +637,16 @@ class SessionManager:
             "model": model or default_model,
         }
 
+        # The CLI and gateway read agent.disabled_toolsets from config and
+        # pass it to AIAgent; without it the ACP tool-registry rebuild
+        # (server.py, get_tool_definitions) sees disabled_toolsets=None and
+        # config-disabled toolsets stay executable in editor sessions.
+        agent_cfg = config.get("agent")
+        if isinstance(agent_cfg, dict):
+            disabled_toolsets = agent_cfg.get("disabled_toolsets")
+            if disabled_toolsets:
+                kwargs["disabled_toolsets"] = list(disabled_toolsets)
+
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
             kwargs.update(

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1860,3 +1860,59 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+
+# ---------------------------------------------------------------------------
+# disabled_toolsets filter the ACP tool surface (real get_tool_definitions)
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledToolsetsFilterToolSurface:
+    """Config-disabled toolsets must be absent from ACP-generated definitions.
+
+    These run the real ``get_tool_definitions`` (no patching) so they cover
+    the actual filtering behavior, not just which kwargs were forwarded.
+    """
+
+    @staticmethod
+    def _listed_names(listing: str) -> set:
+        return {
+            line.strip().split(":", 1)[0]
+            for line in listing.splitlines()[1:]
+        }
+
+    def test_cmd_tools_strips_configured_disabled_toolsets(self, agent, mock_manager):
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent._memory_manager = None
+
+        state.agent.disabled_toolsets = None
+        baseline = agent._cmd_tools("", state)
+        assert baseline.startswith("Available tools"), baseline
+        assert "todo" in self._listed_names(baseline)
+
+        state.agent.disabled_toolsets = ["todo"]
+        filtered = agent._cmd_tools("", state)
+        assert filtered.startswith("Available tools"), filtered
+        assert "todo" not in self._listed_names(filtered)
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_rebuild_strips_configured_disabled_toolsets(
+        self, agent, mock_manager
+    ):
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent.disabled_toolsets = ["todo"]
+        state.agent.tools = []
+        state.agent.valid_tool_names = set()
+        state.agent._memory_manager = None
+
+        server = McpServerStdio(name="srv", command="/bin/test", args=[], env=[])
+
+        with patch("tools.mcp_tool.register_mcp_servers", return_value=[]):
+            await agent._register_session_mcp_servers(state, [server])
+
+        assert state.agent.valid_tool_names, "tool surface rebuild produced no tools"
+        assert "todo" not in state.agent.valid_tool_names

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -121,6 +121,59 @@ class TestCreateSession:
 
         assert state.agent.session_cwd == "/tmp/project"
 
+    @staticmethod
+    def _patch_make_agent_env(monkeypatch, config):
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr("acp_adapter.session.load_config", lambda: config, raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "openai_chat",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+    def test_make_agent_passes_configured_disabled_toolsets(self, monkeypatch):
+        # The CLI and gateway hand agent.disabled_toolsets to AIAgent, but the
+        # ACP path dropped it — config-disabled toolsets (e.g. todo) remained
+        # executable in editor/ACP sessions.
+        self._patch_make_agent_env(
+            monkeypatch,
+            {
+                "model": {"default": "fake-model", "provider": "fake-provider"},
+                "mcp_servers": {},
+                "agent": {"disabled_toolsets": ["todo", "browser"]},
+            },
+        )
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert state.agent.kwargs.get("disabled_toolsets") == ["todo", "browser"]
+
+    def test_make_agent_omits_disabled_toolsets_when_none_configured(self, monkeypatch):
+        self._patch_make_agent_env(
+            monkeypatch,
+            {
+                "model": {"default": "fake-model", "provider": "fake-provider"},
+                "mcp_servers": {},
+                "agent": {},
+            },
+        )
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert "disabled_toolsets" not in state.agent.kwargs
+
 
 
 


### PR DESCRIPTION
## Problem

`agent.disabled_toolsets` in `config.yaml` is honored by the CLI (`cli.py`: `CLI_CONFIG['agent'].get('disabled_toolsets')`) and the gateway (`gateway/run.py:12782`) — both pass it to `AIAgent`. The ACP adapter's `_make_agent` never does.

Consequence: `state.agent.disabled_toolsets` is always `None` on the ACP path, so the tool-registry rebuild in `acp_adapter/server.py` calls `get_tool_definitions(enabled_toolsets=..., disabled_toolsets=None)` and every tool in the enabled toolsets stays registered and executable — including toolsets the user explicitly disabled in config.

Observed live driving hermes over ACP: a `todo` tool call executed from a profile whose config lists `todo` in `agent.disabled_toolsets`.

Related family of reports on other surfaces: #36729 (WebUI), #54433 (desktop). This PR fixes the ACP surface. Sibling PR #57418 fixes the same construction gap for `fallback_model` (#18452) — `_make_agent` builds its kwargs from scratch and has drifted from what the CLI/gateway pass.

## Fix

Read `agent.disabled_toolsets` from the loaded config in `_make_agent` and pass it to `AIAgent`, mirroring the CLI and gateway. Guarded by an `isinstance` check consistent with the surrounding config handling.

## Verification

Two new tests in `tests/acp/test_session.py` (chain passes through when configured; key absent otherwise). Full file: 47 passed.

https://claude.ai/code/session_01YNvCUipheR7yx4VorUL2jW