### PR TITLE
fix(desktop): let settings content use full pane width

### DIFF
--- a/apps/desktop/src/app/settings/primitives.tsx
+++ b/apps/desktop/src/app/settings/primitives.tsx
@@ -11,9 +11,7 @@ import { PAGE_INSET_X } from '../layout-constants'
 export function SettingsContent({ children }: { children: ReactNode }) {
   return (
     <section className="min-h-0 overflow-hidden">
-      <div className={cn('h-full min-h-0 overflow-y-auto pb-20', PAGE_INSET_X)}>
-        <div className="mx-auto w-full max-w-4xl">{children}</div>
-      </div>
+      <div className={cn('h-full min-h-0 overflow-y-auto pb-20', PAGE_INSET_X)}>{children}</div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- Remove the `max-w-4xl` inner wrapper from `SettingsContent`, the shared primitive used by every settings page
- Settings panes now stretch to the available overlay width; horizontal inset from `PAGE_INSET_X` is unchanged

## Test plan
- [ ] Open settings on a wide window — content should reach the pane edges (minus inset), not stop at ~56rem
- [ ] Spot-check config, appearance, gateway, and sessions tabs for layout regressions
- [ ] Confirm narrow/mobile overlay still scrolls and reads cleanly