### PR TITLE
feat(kanban): decomposer graph discipline — explicit dependency rule + mechanical-check guidance

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -92,10 +92,14 @@ Rules:
     and the system will route to the default_assignee.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
-  - The LAST task must be a verify/acceptance task that lists every other
-    task in "parents": run the test suite, check the promised artifacts
-    exist, and confirm the ORIGINAL request is fully satisfied. Every
-    fanout ends with this gate.
+  - Overall acceptance is owned by the ROOT task: when every child is done
+    it returns to its orchestrator to judge completion, so do not add a
+    child whose only job is to re-judge the original request. DO add a
+    task that executes mechanical checks the work produces (run the new
+    test suite, build, confirm promised artifacts exist), with the
+    producing tasks as its "parents" — that puts pass/fail evidence in
+    the graph instead of leaving claims for the root review to take on
+    faith.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -80,6 +80,9 @@ Rules:
   - "parents" is a list of INDICES (0-based) into this same "tasks" list,
     expressing actual data dependencies. Tasks with no parents run in
     PARALLEL. Tasks with parents wait until every parent completes.
+  - A task that consumes another task's output MUST list that task in
+    "parents". A test or documentation task with no parents is dispatched
+    immediately and runs before the code it covers exists.
   - Prefer parallelism. If two tasks can be done independently, give
     them no parents so the dispatcher fans them out at once.
   - Use 2-6 tasks for normal work. Don't create 20 tiny tasks. Don't
@@ -89,6 +92,10 @@ Rules:
     and the system will route to the default_assignee.
   - Each child task body is what a fresh worker will read with no other
     context — be specific about goal, approach, and acceptance criteria.
+  - The LAST task must be a verify/acceptance task that lists every other
+    task in "parents": run the test suite, check the promised artifacts
+    exist, and confirm the ORIGINAL request is fully satisfied. Every
+    fanout ends with this gate.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:


### PR DESCRIPTION
Two additions to the decomposer `_SYSTEM_PROMPT`, motivated by benching the same fanout request across three models (nemotron-nano, qwen3-next-80b, nex-n2-pro; then a 5x-per-model consistency pass on the top two):

1. **Dependency MUST-rule**: the existing 'expressing actual data dependencies' wording is too weak — one finalist let test/doc tasks float parentless in 3/5 runs, so the dispatcher would start them before the code they cover exists.

2. **Mechanical-check guidance** (reworked after review): the fan-out already has a final acceptance owner — the root task returns to its orchestrator when every child completes — so the prompt now names the root as that owner and tells the model NOT to add a child that re-judges the request. What the bench showed models never produce, and what this asks for, is narrower: when the work yields mechanically checkable output (a test suite, a build, promised artifacts), add a task that executes those checks, parented on the producing tasks, so the root review gets pass/fail evidence instead of workers' claims. It is model guidance, not a claimed structural invariant.

Both are graph discipline, not workflow opinions: a fanout whose consumers can start before their producers is an incorrect graph, and one whose mechanical checks nobody runs leaves the acceptance owner judging on faith.