### PR TITLE
fix(tools): guard computer_use against null pid/window_id from list_windows

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1133,6 +1133,49 @@ class TestElementLabelParsing:
         assert labels[15] == "Search"
 
 
+class TestParseWindowEntries:
+    """Regression for #56704: cua-driver ``list_windows`` may return non-application
+    windows (panels/docks/taskbars, common on the Linux/X11 alpha) with
+    ``pid``/``window_id`` set to null. ``_parse_window_entries`` must coerce
+    defensively and drop those untargetable entries instead of crashing the whole
+    enumeration on ``int(None)``.
+    """
+
+    def test_null_pid_or_window_id_entries_are_dropped_not_crashing(self):
+        from tools.computer_use.cua_backend import _parse_window_entries
+        raw = [
+            {"app_name": "Calculator", "pid": 4321, "window_id": 99, "z_index": 1},
+            {"app_name": "panel", "pid": None, "window_id": 12, "z_index": 0},   # X11 dock
+            {"app_name": "taskbar", "pid": 200, "window_id": None, "z_index": 0},
+        ]
+        windows = _parse_window_entries(raw)
+        # Only the fully-targetable application window survives; no TypeError.
+        assert len(windows) == 1
+        assert windows[0]["app_name"] == "Calculator"
+        assert windows[0]["pid"] == 4321
+        assert windows[0]["window_id"] == 99
+
+    def test_valid_entries_are_normalized_with_defaults(self):
+        from tools.computer_use.cua_backend import _parse_window_entries
+        # Stringified ids coerce; missing optional fields fall back to defaults.
+        raw = [{"pid": "17", "window_id": "42"}]
+        windows = _parse_window_entries(raw)
+        assert windows == [
+            {
+                "app_name": "",
+                "pid": 17,
+                "window_id": 42,
+                "off_screen": False,  # is_on_screen absent → defaults on-screen
+                "title": "",
+                "z_index": 0,
+            }
+        ]
+
+    def test_empty_input_returns_empty_list(self):
+        from tools.computer_use.cua_backend import _parse_window_entries
+        assert _parse_window_entries([]) == []
+
+
 class TestUpdateCheck:
     """cua_driver_update_check() / _nudge(): native `check-update --json`.
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -909,6 +909,53 @@ def _image_from_tool_result(out: Dict[str, Any]) -> tuple[Optional[str], Optiona
     return None, None
 
 
+def _coerce_window_int(value: Any) -> Optional[int]:
+    """Best-effort int coercion for cua-driver ``list_windows`` id fields.
+
+    Returns ``None`` when *value* is ``None`` or can't be parsed as an int,
+    so callers can skip malformed window entries instead of raising
+    ``TypeError`` on ``int(None)``.
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_window_entries(raw_windows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Normalize cua-driver ``list_windows`` entries into targetable window dicts.
+
+    cua-driver — notably the Linux/X11 alpha — surfaces non-application windows
+    (panels, docks, taskbars) with ``pid`` and/or ``window_id`` set to null.
+    Those can't be driven: ``get_window_state`` needs a pid and both it and
+    ``screenshot`` key off an integer window id. A single such entry used to
+    crash the whole enumeration via ``int(None)``, taking down capture of the
+    perfectly good application windows alongside it (NousResearch/hermes-agent#56704).
+
+    Coerce defensively and drop any entry missing a usable pid *and* window_id,
+    so one untargetable window can no longer poison the rest of the list.
+    """
+    windows: List[Dict[str, Any]] = []
+    for w in raw_windows:
+        pid = _coerce_window_int(w.get("pid"))
+        window_id = _coerce_window_int(w.get("window_id"))
+        if pid is None or window_id is None:
+            continue
+        windows.append(
+            {
+                "app_name": w.get("app_name", ""),
+                "pid": pid,
+                "window_id": window_id,
+                "off_screen": not w.get("is_on_screen", True),
+                "title": w.get("title", ""),
+                "z_index": w.get("z_index", 0),
+            }
+        )
+    return windows
+
+
 # ---------------------------------------------------------------------------
 # The backend itself
 # ---------------------------------------------------------------------------
@@ -1028,17 +1075,7 @@ class CuaDriverBackend(ComputerUseBackend):
             {"on_screen_only": True, "session": self._session_id},
         )
         raw_windows = (lw_out.get("structuredContent") or {}).get("windows") or []
-        windows = [
-            {
-                "app_name": w.get("app_name", ""),
-                "pid": int(w["pid"]),
-                "window_id": int(w["window_id"]),
-                "off_screen": not w.get("is_on_screen", True),
-                "title": w.get("title", ""),
-                "z_index": w.get("z_index", 0),
-            }
-            for w in raw_windows
-        ]
+        windows = _parse_window_entries(raw_windows)
         # Sort by z_index descending (lowest z_index = frontmost on macOS).
         windows.sort(key=lambda w: w["z_index"])
 
@@ -1433,15 +1470,7 @@ class CuaDriverBackend(ComputerUseBackend):
             {"on_screen_only": True, "session": self._session_id},
         )
         raw_windows = (lw_out.get("structuredContent") or {}).get("windows") or []
-        windows = [
-            {
-                "app_name": w.get("app_name", ""),
-                "pid": int(w["pid"]),
-                "window_id": int(w["window_id"]),
-                "z_index": w.get("z_index", 0),
-            }
-            for w in raw_windows
-        ]
+        windows = _parse_window_entries(raw_windows)
         windows.sort(key=lambda w: w["z_index"])
 
         app_lower = app.lower()


### PR DESCRIPTION
## What does this PR do?

`computer_use` capture crashes on Linux/WSL with:

```
TypeError: int() argument must be ... not 'NoneType'
```

whenever `cua-driver`'s `list_windows` returns a non-application window
(panel, dock, taskbar — common on the Linux/X11 alpha) with `pid` and/or
`window_id` set to `null`.

Both `capture()` and `focus_app()` normalize the window list by coercing
**every** entry eagerly:

```python
"pid": int(w["pid"]),
"window_id": int(w["window_id"]),
```

A single `null` id therefore raises `TypeError` inside the list
comprehension and takes down enumeration of the *other, perfectly good*
application windows — so capturing e.g. a Calculator window fails just
because a taskbar entry alongside it has no pid.

The fix factors the shared normalization into `_parse_window_entries()`,
coerces the id fields defensively, and drops any entry that lacks a usable
`pid` **and** `window_id` — those windows can't be passed to
`get_window_state` / `screenshot` anyway (both key off an integer window
id, and the AX path needs a pid). One untargetable window can no longer
poison the rest of the list. This also removes the duplicated
comprehension that existed at both call sites.

## Related Issue

Fixes #56704

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py`
  - New module-level helpers `_coerce_window_int()` and
    `_parse_window_entries()`.
  - `capture()` and `focus_app()` now call `_parse_window_entries()`
    instead of each rebuilding the window list with bare `int(w[...])`.
- `tests/tools/test_computer_use.py`
  - New `TestParseWindowEntries` covering: null `pid`/`window_id` entries
    dropped without raising, stringified ids coerced, optional fields
    defaulted, and empty input.

## How to Test

1. On Linux/WSL, run `computer_use(action="capture", mode="som")` in an
   environment where `list_windows` surfaces a panel/dock/taskbar with a
   `null` pid (X11). Before: `TypeError`; after: the untargetable window
   is skipped and application windows capture normally.
2. Unit: `pytest tests/tools/test_computer_use.py -q` — the new
   `TestParseWindowEntries::test_null_pid_or_window_id_entries_are_dropped_not_crashing`
   fails against the old code (`int(None)`) and passes with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/tools/test_computer_use.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux) — unit path

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the change is defensive and
  behavior-preserving on macOS/Windows (well-formed entries still parse
  identically); it only adds tolerance for the `null`-id windows seen on Linux/X11
- [x] I've updated tool descriptions/schemas — N/A (no behavior/schema change)
