### PR TITLE
fix: skip auto-SSO redirect for password-only dashboard providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,11 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers (e.g. dashboard_auth/basic) do not implement
+    # OAuth start_login and must use /login -> /auth/password-login.
+    # Auto-SSO should only fire for redirect-capable providers.
+    if bool(getattr(provider, "supports_password", False)):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
## Summary
- prevent dashboard auto-SSO middleware from redirecting to `/auth/login` when the only provider is password-based (`basic`)
- fall back to `/login` for password providers so users authenticate via `/auth/password-login`

## Root cause
`_auto_sso_response()` assumed the single auth provider supports OAuth redirect login. For `basic` provider this is false, so `/auth/login?provider=basic` raised `NotImplementedError` and returned HTTP 500.

## Fix
- in `hermes_cli/dashboard_auth/middleware.py`, short-circuit auto-SSO when `provider.supports_password` is true

## Verification
- `GET /` now returns `302 /login?next=%2F` (instead of `/auth/login?provider=basic...`)
- `GET /login` returns `200` and renders the sign-in page
- reproduced and validated on LAN bind (`--host 0.0.0.0 --port 9119`)

## User impact
Fixes dashboard "Internal Server Error" on first load when basic auth is enabled and dashboard is exposed beyond loopback.
