### PR TITLE
fix(desktop): extend startup long-timeout to the whole boot data burst (supersedes #48518, #48526)

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import {
+  getProfiles,
+  getSessionMessages,
+  listAllProfileSessions,
+  listSessions
+} from './hermes'
+import { refreshActiveProfile } from './store/profile'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -42,6 +48,42 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith(
       expect.objectContaining({
         path: '/api/profiles/sessions?limit=50&offset=0&min_messages=1&archived=exclude&order=recent&profile=all',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
+  it('uses a longer timeout for profile listing during desktop startup', async () => {
+    api.mockResolvedValue({ profiles: [] })
+
+    await getProfiles()
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/profiles',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
+  it('uses a longer timeout for active profile refresh during desktop startup', async () => {
+    api
+      .mockResolvedValueOnce({ current: 'default' })
+      .mockResolvedValueOnce({ profiles: [] })
+
+    await refreshActiveProfile()
+
+    expect(api).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: '/api/profiles/active',
+        timeoutMs: 60_000
+      })
+    )
+    expect(api).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: '/api/profiles',
         timeoutMs: 60_000
       })
     )

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  getCronJobs,
+  getGlobalModelInfo,
+  getGlobalModelOptions,
+  getHermesConfig,
+  getHermesConfigDefaults,
   getProfiles,
   getSessionMessages,
+  getStatus,
   listAllProfileSessions,
   listSessions
 } from './hermes'
@@ -87,6 +93,37 @@ describe('Hermes REST session helpers', () => {
         timeoutMs: 60_000
       })
     )
+  })
+
+  it('gives the whole startup data burst the long timeout, not just profiles', async () => {
+    api.mockResolvedValue({})
+
+    const bootCalls: [() => Promise<unknown>, string][] = [
+      [getHermesConfig, '/api/config'],
+      [getHermesConfigDefaults, '/api/config/defaults'],
+      [getGlobalModelInfo, '/api/model/info'],
+      [() => getGlobalModelOptions(), '/api/model/options'],
+      [getCronJobs, '/api/cron/jobs']
+    ]
+
+    for (const [call, path] of bootCalls) {
+      api.mockClear()
+      await call()
+      expect(api).toHaveBeenCalledWith(expect.objectContaining({ path, timeoutMs: 60_000 }))
+    }
+  })
+
+  it('keeps the liveness poll on the short default so a dead backend fails fast', async () => {
+    api.mockResolvedValue({})
+    api.mockClear()
+
+    await getStatus()
+
+    // /api/status must NOT carry the long startup timeout — it is the runtime
+    // liveness probe and has to fail quickly when the backend drops.
+    const call = api.mock.calls[0]?.[0] as { path: string; timeoutMs?: number }
+    expect(call.path).toBe('/api/status')
+    expect(call.timeoutMs).toBeUndefined()
   })
 
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -47,6 +47,7 @@ import type {
   ToolsetInfo
 } from '@/types/hermes'
 
+export const STARTUP_PROFILE_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
@@ -702,7 +703,8 @@ export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
 
 export function getProfiles(): Promise<ProfilesResponse> {
   return window.hermesDesktop.api<ProfilesResponse>({
-    path: '/api/profiles'
+    path: '/api/profiles',
+    timeoutMs: STARTUP_PROFILE_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -47,7 +47,18 @@ import type {
   ToolsetInfo
 } from '@/types/hermes'
 
-export const STARTUP_PROFILE_REQUEST_TIMEOUT_MS = 60_000
+// Desktop startup fires a burst of read-only data calls (config, profiles,
+// model info/options, cron) the moment the backend passes readiness. On a
+// profile-heavy or remote install these can each take tens of seconds — e.g.
+// /api/profiles runs list_profiles(), which does a recursive skill-tree walk
+// per profile — so the 15s default (DEFAULT_FETCH_TIMEOUT_MS in hardening.cjs)
+// times out a backend that is alive-but-busy, surfacing as a spurious
+// "Timed out connecting to Hermes backend" that hangs the UI (#48504).
+//
+// Give the boot burst a generous per-call timeout instead of raising the
+// global default: interactive/runtime calls and the liveness poll (/api/status)
+// keep the short default so a genuinely-dead backend is still detected fast.
+export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
@@ -288,7 +299,8 @@ export function renameSession(
 export function getGlobalModelInfo(): Promise<ModelInfoResponse> {
   return window.hermesDesktop.api<ModelInfoResponse>({
     ...profileScoped(),
-    path: '/api/model/info'
+    path: '/api/model/info',
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 
@@ -334,7 +346,8 @@ export function getLogs(params: {
 export function getHermesConfig(): Promise<HermesConfig> {
   return window.hermesDesktop.api<HermesConfig>({
     ...profileScoped(),
-    path: '/api/config'
+    path: '/api/config',
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 
@@ -348,7 +361,8 @@ export function getHermesConfigRecord(): Promise<HermesConfigRecord> {
 export function getHermesConfigDefaults(): Promise<HermesConfigRecord> {
   return window.hermesDesktop.api<HermesConfigRecord>({
     ...profileScoped(),
-    path: '/api/config/defaults'
+    path: '/api/config/defaults',
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 
@@ -639,7 +653,8 @@ export function testMessagingPlatform(platformId: string): Promise<MessagingPlat
 
 export function getCronJobs(): Promise<CronJob[]> {
   return window.hermesDesktop.api<CronJob[]>({
-    path: '/api/cron/jobs'
+    path: '/api/cron/jobs',
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 
@@ -704,7 +719,7 @@ export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
 export function getProfiles(): Promise<ProfilesResponse> {
   return window.hermesDesktop.api<ProfilesResponse>({
     path: '/api/profiles',
-    timeoutMs: STARTUP_PROFILE_REQUEST_TIMEOUT_MS
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 
@@ -761,7 +776,8 @@ export function getUsageAnalytics(days = 30): Promise<AnalyticsResponse> {
 export function getGlobalModelOptions(opts?: { refresh?: boolean }): Promise<ModelOptionsResponse> {
   return window.hermesDesktop.api<ModelOptionsResponse>({
     ...profileScoped(),
-    path: opts?.refresh ? '/api/model/options?refresh=1' : '/api/model/options'
+    path: opts?.refresh ? '/api/model/options?refresh=1' : '/api/model/options',
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,6 +1,6 @@
 import { atom, computed } from 'nanostores'
 
-import { getProfiles, setApiRequestProfile } from '@/hermes'
+import { getProfiles, setApiRequestProfile, STARTUP_PROFILE_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { queryClient } from '@/lib/query-client'
 import {
   arraysEqual,
@@ -110,7 +110,10 @@ interface ActiveProfileResponse {
 // Best-effort: failures (backend not up yet) leave the prior values intact.
 export async function refreshActiveProfile(): Promise<void> {
   try {
-    const res = await window.hermesDesktop.api<ActiveProfileResponse>({ path: '/api/profiles/active' })
+    const res = await window.hermesDesktop.api<ActiveProfileResponse>({
+      path: '/api/profiles/active',
+      timeoutMs: STARTUP_PROFILE_REQUEST_TIMEOUT_MS
+    })
 
     setActiveProfile(res.current || 'default')
   } catch {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,6 +1,6 @@
 import { atom, computed } from 'nanostores'
 
-import { getProfiles, setApiRequestProfile, STARTUP_PROFILE_REQUEST_TIMEOUT_MS } from '@/hermes'
+import { getProfiles, setApiRequestProfile, STARTUP_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { queryClient } from '@/lib/query-client'
 import {
   arraysEqual,
@@ -112,7 +112,7 @@ export async function refreshActiveProfile(): Promise<void> {
   try {
     const res = await window.hermesDesktop.api<ActiveProfileResponse>({
       path: '/api/profiles/active',
-      timeoutMs: STARTUP_PROFILE_REQUEST_TIMEOUT_MS
+      timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
     })
 
     setActiveProfile(res.current || 'default')


### PR DESCRIPTION
## Summary

Fixes the Desktop `Timed out connecting to Hermes backend after 15000ms` hang on profile-heavy / remote installs (#48504), consolidating the two open approaches into one.

The desktop fires a burst of read-only data calls the moment the backend passes readiness. On a profile-heavy or remote install several of these legitimately take tens of seconds while the backend is **alive but busy** — e.g. `GET /api/profiles` runs `list_profiles()`, which does a recursive skill-tree walk per profile (~6s for 16 profiles cold, and `/api/profiles/sessions` runs it again). The 15s `DEFAULT_FETCH_TIMEOUT_MS` then aborts a working backend, surfacing as the spurious "Timed out connecting…" that hangs the UI.

## Why this supersedes both open PRs

- **#48518** (@Tranquil-Flow) gave `getProfiles` + `refreshActiveProfile` a 60s per-call timeout — the right *mechanism* (matches the existing `SESSION_LIST_REQUEST_TIMEOUT_MS` precedent) and the profile-scaled calls, but the boot burst has **other** 15s calls it doesn't cover.
- **#48526** (@HeLLGURD / YapBi) raised the **global** `DEFAULT_FETCH_TIMEOUT_MS` 15s→60s — complete coverage, but it also (a) regresses *runtime* failure detection to 60s for every interactive call and (b) slows the boot readiness probe `waitForHermes` (which uses the same default per attempt).

This PR takes the surgical per-call mechanism from #48518 and extends it to the whole boot burst — `/api/config`, `/api/config/defaults`, `/api/model/info`, `/api/model/options`, `/api/cron/jobs`, plus the profile calls #48518 already covered — while **leaving the global default and the `/api/status` liveness poll at the fast 15s**. So a genuinely-dead backend still fails fast at runtime, `waitForHermes` is untouched, and the alive-but-busy startup no longer false-times-out.

Tranquil-Flow's commit is carried as the base (authorship preserved); both authors credited via `Co-authored-by`.

## What is / isn't bumped

| Call | Timeout | Rationale |
|---|---|---|
| `/api/profiles`, `/api/profiles/active` | 60s | profile-scaled (list_profiles) |
| `/api/config`, `/api/config/defaults` | 60s | boot config burst |
| `/api/model/info`, `/api/model/options` | 60s | gateway-open burst |
| `/api/cron/jobs` | 60s | boot refreshSessions burst |
| `/api/*/sessions` | 60s | already (unchanged) |
| **`/api/status`** | **15s (default)** | liveness poll — must fail fast |
| all interactive/runtime calls | 15s (default) | fast failure preserved |

## Validation

- `vitest src/hermes.test.ts` — 7/7 (adds a boot-burst-coverage test + a guard that `/api/status` keeps the short default)
- `vitest src/store/profile.test.ts` — 7/7
- `tsc --noEmit` clean, eslint clean

Fixes #48504.

Co-authored-by: YapBi <129007007+HeLLGURD@users.noreply.github.com>
Co-authored-by: Tranquil-Flow <66773372+Tranquil-Flow@users.noreply.github.com>