### PR TITLE
fix(desktop): coalesce thought fragments

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -11,6 +11,7 @@ import {
   chatMessageText,
   type GatewayEventPayload,
   reasoningPart,
+  replaceReasoningPart,
   renderMediaTags,
   upsertToolPart
 } from '@/lib/chat-messages'
@@ -273,7 +274,7 @@ export function useMessageStream({
           }
 
           if (replace) {
-            return [...parts.filter(part => part.type !== 'reasoning'), reasoningPart(delta)]
+            return replaceReasoningPart(parts, delta)
           }
 
           return appendReasoningPart(parts, delta)

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -6,6 +6,7 @@ import {
   appendReasoningPart,
   chatMessageText,
   preserveLocalAssistantErrors,
+  replaceReasoningPart,
   renderMediaTags,
   toChatMessages,
   upsertToolPart
@@ -67,6 +68,17 @@ describe('toChatMessages', () => {
     expect(assistantMessages[0].parts.filter(part => part.type === 'tool-call')).toHaveLength(2)
     expect(chatMessageText(assistantMessages[0])).toContain("Let me also check if there's a top-level lint workflow.")
     expect(chatMessageText(assistantMessages[0])).toContain('Now let me check git status and commit.')
+  })
+
+  it('coalesces consecutive stored assistant reasoning rows into one thought part', () => {
+    const messages = toChatMessages([
+      { role: 'assistant', content: '', reasoning_content: 'first thought ', timestamp: 1 },
+      { role: 'assistant', content: '', reasoning_content: 'second thought', timestamp: 2 }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(p => p.type)).toEqual(['reasoning'])
+    expect((messages[0].parts[0] as { text: string }).text).toBe('first thought second thought')
   })
 
   it('hides attached context payloads from user message display', () => {
@@ -219,6 +231,31 @@ describe('interleaved reasoning/text coalescing', () => {
     expect(parts.map(p => p.type)).toEqual(['reasoning', 'tool-call', 'reasoning'])
     expect((parts[0] as { text: string }).text).toBe('before tool')
     expect((parts[2] as { text: string }).text).toBe('after tool')
+  })
+
+  it('replaces reasoning fragments in the current stream segment in place', () => {
+    let parts: ChatMessagePart[] = appendReasoningPart([], 'The complete thought')
+    parts = appendAssistantTextPart(parts, 'Answer in progress.')
+    parts = appendReasoningPart(parts, 'The complete ')
+    parts = appendReasoningPart(parts, 'thought')
+
+    parts = replaceReasoningPart(parts, 'The complete thought.')
+
+    expect(parts.map(p => p.type)).toEqual(['reasoning', 'text'])
+    expect((parts[0] as { text: string }).text).toBe('The complete thought.')
+    expect((parts[1] as { text: string }).text).toBe('Answer in progress.')
+  })
+
+  it('does not replace reasoning from a previous tool-bounded segment', () => {
+    let parts: ChatMessagePart[] = appendReasoningPart([], 'before tool')
+    parts = upsertToolPart(parts, { name: 'read_file', tool_id: 'tc-1' }, 'complete')
+    parts = appendReasoningPart(parts, 'partial after tool')
+
+    parts = replaceReasoningPart(parts, 'settled after tool')
+
+    expect(parts.map(p => p.type)).toEqual(['reasoning', 'tool-call', 'reasoning'])
+    expect((parts[0] as { text: string }).text).toBe('before tool')
+    expect((parts[2] as { text: string }).text).toBe('settled after tool')
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -234,6 +234,61 @@ export function appendReasoningPart(parts: ChatMessagePart[], delta: string): Ch
   return appendStreamPart(parts, 'reasoning', delta).parts
 }
 
+export function replaceReasoningPart(parts: ChatMessagePart[], text: string): ChatMessagePart[] {
+  const next: ChatMessagePart[] = []
+  let inserted = false
+  let boundary = -1
+
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i]
+
+    if (part.type !== 'text' && part.type !== 'reasoning') {
+      boundary = i
+      break
+    }
+  }
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i]
+
+    if (i <= boundary) {
+      next.push(part)
+      continue
+    }
+
+    if (part.type === 'reasoning') {
+      if (!inserted) {
+        next.push(reasoningPart(text))
+        inserted = true
+      }
+
+      continue
+    }
+
+    next.push(part)
+  }
+
+  if (!inserted) {
+    next.push(reasoningPart(text))
+  }
+
+  return next
+}
+
+function appendAssistantParts(parts: ChatMessagePart[], incoming: ChatMessagePart[]): ChatMessagePart[] {
+  return incoming.reduce<ChatMessagePart[]>((next, part) => {
+    if (part.type === 'reasoning') {
+      return appendReasoningPart(next, part.text)
+    }
+
+    if (part.type === 'text') {
+      return appendAssistantTextPart(next, part.text)
+    }
+
+    return [...next, part]
+  }, parts)
+}
+
 export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
   const { index, parts: next } = appendStreamPart(parts, 'text', delta)
   const part = next[index]
@@ -720,7 +775,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       return false
     }
 
-    active.parts = [...active.parts, ...parts]
+    active.parts = appendAssistantParts(active.parts, parts)
     active.timestamp = timestamp ?? active.timestamp
 
     return true
@@ -820,9 +875,11 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
 
       const currentHasToolCall = parts.some(part => part.type === 'tool-call')
       const activeHasToolCall = Boolean(activeAssistant?.parts.some(part => part.type === 'tool-call'))
+      const currentHasReasoning = parts.some(part => part.type === 'reasoning')
+      const activeHasReasoning = Boolean(activeAssistant?.parts.some(part => part.type === 'reasoning'))
 
-      if (activeAssistant && (currentHasToolCall || activeHasToolCall)) {
-        activeAssistant.parts = [...activeAssistant.parts, ...parts]
+      if (activeAssistant && (currentHasToolCall || activeHasToolCall || currentHasReasoning || activeHasReasoning)) {
+        activeAssistant.parts = appendAssistantParts(activeAssistant.parts, parts)
         activeAssistant.timestamp = message.timestamp ?? activeAssistant.timestamp
 
         return


### PR DESCRIPTION
## What does this PR do?
Fixes #57077.

Desktop could render one assistant thought/reasoning response as multiple Thought entries when reasoning arrived or hydrated in fragments. This PR keeps final reasoning replacement segment-aware and coalesces consecutive stored assistant reasoning rows into one assistant message/Thought part.

## Changes Made
- Add a segment-aware reasoning replacement helper so final reasoning snapshots update the current reasoning part in place.
- Reuse streaming coalescing when appending stored assistant parts during hydration.
- Merge consecutive stored assistant reasoning rows into one assistant bubble when they belong to the same assistant response.
- Add regression tests for stored reasoning coalescing and segment-aware replacement.

## How to Test
- npm run test:ui --workspace apps/desktop -- chat-messages.test.ts

Result:
- Test Files: 1 passed (1)
- Tests: 32 passed (32)

## Checklist
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've run the targeted test locally