### PR TITLE
fix: ignore inactive systemd manager defaults

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -361,30 +361,47 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
         return None
 
     # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
-    # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # on which manager actually owns the unit.  ``systemctl --user show`` can
+    # return manager defaults for a nonexistent unit with rc=0, so do not trust
+    # a TimeoutStopUSec value unless the unit has a real FragmentPath or is
+    # active under that manager.
     timeout_us: Optional[int] = None
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl",
+                    *flag,
+                    "show",
+                    unit_name,
+                    "--property=TimeoutStopUSec",
+                    "--property=FragmentPath",
+                    "--property=ActiveState",
+                ],
                 capture_output=True, text=True, timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+
+        props: Dict[str, str] = {}
         for line in result.stdout.splitlines():
-            if line.startswith("TimeoutStopUSec="):
-                value = line.split("=", 1)[1].strip()
-                # Try numeric microseconds first
-                if value.isdigit():
-                    timeout_us = int(value)
-                else:
-                    timeout_us = _parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    break
+            if "=" in line:
+                key, value = line.split("=", 1)
+                props[key] = value.strip()
+
+        fragment_path = props.get("FragmentPath", "")
+        active_state = props.get("ActiveState", "")
+        if not fragment_path and active_state not in {"active", "activating", "deactivating"}:
+            continue
+
+        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        value = props.get("TimeoutStopUSec", "")
+        if value.isdigit():
+            timeout_us = int(value)
+        else:
+            timeout_us = _parse_systemd_duration_to_us(value)
         if timeout_us is not None:
             break
 

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import builtins
+import io
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -248,3 +251,81 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_ignores_inactive_manager_default_for_nonexistent_user_unit(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/self/cgroup":
+                return io.StringIO("0::/system.slice/hermes-gateway.service\n")
+            return real_open(path, *args, **kwargs)
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "--user" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=(
+                        "TimeoutStopUSec=1min 30s\n"
+                        "FragmentPath=\n"
+                        "ActiveState=inactive\n"
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "TimeoutStopUSec=3min 30s\n"
+                    "FragmentPath=/etc/systemd/system/hermes-gateway.service\n"
+                    "ActiveState=active\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["timeout_stop_sec"] == 210.0
+        assert result["mismatch"] is False
+        assert calls[0][1] == "--user"
+        assert "--user" not in calls[1]
+
+    def test_accepts_active_user_unit_without_fragment_path(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/self/cgroup":
+                return io.StringIO("0::/user.slice/hermes-gateway.service\n")
+            return real_open(path, *args, **kwargs)
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "TimeoutStopUSec=3min 30s\n"
+                    "FragmentPath=\n"
+                    "ActiveState=active\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["timeout_stop_sec"] == 210.0
+        assert result["mismatch"] is False


### PR DESCRIPTION
## Summary
- Ignore `systemctl --user show` timeout defaults when the user manager does not actually own the gateway unit.
- Fall back to the system manager when the user-manager result has no `FragmentPath` and is inactive.
- Add regression coverage for system-owned gateway units and active user units.

## Test Plan
- `venv/bin/python -m pytest tests/gateway/test_shutdown_forensics.py tests/gateway/test_shutdown_cache_cleanup.py tests/gateway/test_gateway_shutdown.py -q -o 'addopts='`

## Context
On systems where the Hermes gateway runs as a system service, `systemctl --user show hermes-gateway.service` can still return rc=0 with the user manager's default `TimeoutStopUSec=1min 30s` for a nonexistent/inactive user unit. That produced a false stale-unit warning even when the real system unit had the correct `TimeoutStopSec=210`.
