### PR TITLE
fix: decode Windows install subprocess output as UTF-8

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -18,7 +18,6 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-
 from hermes_cli.config import (
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
@@ -33,6 +32,12 @@ from tools.tool_backend_helpers import fal_key_is_configured
 from utils import base_url_hostname, is_truthy_value
 
 logger = logging.getLogger(__name__)
+
+
+def subprocess_text_kwargs():
+    if sys.platform == "win32":
+        return {"encoding": "utf-8", "errors": "replace"}
+    return {}
 
 # Platforms already warned about an all-invalid platform_toolsets list, so the
 # runtime check in _get_platform_tools warns once per platform instead of on
@@ -641,6 +646,7 @@ def _pip_install(
                 [uv_bin, "pip", "install", *args],
                 capture_output=capture_output, text=True, timeout=timeout,
                 env=uv_env,
+                **subprocess_text_kwargs(),
             )
             if result.returncode == 0:
                 return result
@@ -655,6 +661,7 @@ def _pip_install(
         probe = subprocess.run(
             pip_cmd + ["--version"],
             capture_output=True, text=True, timeout=15,
+            **subprocess_text_kwargs(),
         )
         if probe.returncode != 0:
             raise FileNotFoundError("pip not in venv")
@@ -663,6 +670,7 @@ def _pip_install(
             subprocess.run(
                 [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                 capture_output=True, text=True, timeout=120, check=True,
+                **subprocess_text_kwargs(),
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             # Synthesize a result so callers see a clean failure path.
@@ -674,6 +682,7 @@ def _pip_install(
     return subprocess.run(
         pip_cmd + ["install", *args],
         capture_output=capture_output, text=True, timeout=timeout,
+        **subprocess_text_kwargs(),
     )
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
 import logging
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -26,6 +27,29 @@ from hermes_cli.tools_config import (
     _visible_providers,
     tools_command,
 )
+
+
+def test_pip_install_uses_explicit_text_encoding(monkeypatch):
+    import hermes_cli.tools_config as tc
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+    monkeypatch.setattr(
+        tc.shutil, "which", lambda name: "uv" if name == "uv" else None
+    )
+    monkeypatch.setattr(tc.subprocess, "run", fake_run)
+    monkeypatch.setattr(tc.sys, "platform", "win32")
+
+    result = tc._pip_install(["demo==1"])
+
+    assert result.returncode == 0
+    assert calls
+    assert calls[0][1]["encoding"] == "utf-8"
+    assert calls[0][1]["errors"] == "replace"
 
 
 def test_agent_disabled_toolsets_suppresses_across_platforms():

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -13,6 +13,8 @@ call is mocked — we never actually shell out during unit tests.
 from __future__ import annotations
 
 
+import subprocess
+
 import pytest
 
 import tools.lazy_deps as ld
@@ -404,3 +406,46 @@ class TestRefreshActiveFeatures:
         result = ld.refresh_active_features()
         assert result["a.ok"] == "current"
         assert result["b.fail"].startswith("failed:")
+
+
+class TestPipInstallSubprocessEncoding:
+    def test_uv_install_uses_explicit_text_encoding(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+        monkeypatch.setattr(
+            ld.shutil, "which", lambda name: "uv" if name == "uv" else None
+        )
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+
+        result = ld._venv_pip_install(("demo==1",))
+
+        assert result.success is True
+        assert calls
+        assert calls[0][1]["encoding"] == "utf-8"
+        assert calls[0][1]["errors"] == "replace"
+
+    def test_pip_fallback_uses_explicit_text_encoding(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+        monkeypatch.setattr(ld.shutil, "which", lambda name: None)
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+
+        result = ld._venv_pip_install(("demo==1",))
+
+        assert result.success is True
+        assert len(calls) == 2
+        for _, kwargs in calls:
+            assert kwargs["encoding"] == "utf-8"
+            assert kwargs["errors"] == "replace"

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -82,6 +82,12 @@ from typing import Any, Callable, Optional
 logger = logging.getLogger(__name__)
 
 
+def subprocess_text_kwargs():
+    if sys.platform == "win32":
+        return {"encoding": "utf-8", "errors": "replace"}
+    return {}
+
+
 # =============================================================================
 # Allowlist of lazy-installable backends.
 #
@@ -650,6 +656,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
                     capture_output=True, text=True, timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
+                    **subprocess_text_kwargs(),
                 )
                 if r.returncode == 0:
                     if target is not None:
@@ -666,6 +673,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pip_cmd + ["--version"],
                 capture_output=True, text=True, timeout=15,
                 stdin=subprocess.DEVNULL,
+                **subprocess_text_kwargs(),
             )
             if probe.returncode != 0:
                 raise FileNotFoundError("pip not in venv")
@@ -675,6 +683,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                     capture_output=True, text=True, timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
+                    **subprocess_text_kwargs(),
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 return _InstallResult(False, "",
@@ -685,6 +694,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 pip_cmd + ["install", *target_args, *constraint_args, *specs],
                 capture_output=True, text=True, timeout=timeout,
                 stdin=subprocess.DEVNULL,
+                **subprocess_text_kwargs(),
             )
             if r.returncode == 0 and target is not None:
                 _activate_target_on_syspath(target)


### PR DESCRIPTION
## Summary

- decode captured install subprocess output as UTF-8 with replacement on Windows
- apply the same subprocess text handling to lazy backend refresh installs and CLI tool installs
- add focused regression coverage for the uv and pip install paths

## Why

On Windows, `subprocess.run(..., text=True)` decodes captured stdout/stderr with the process locale by default. On systems whose ANSI code page is not UTF-8, install helpers can crash while reading child output when tools such as uv, pip, npm, or postinstall scripts emit UTF-8 symbols.

This was observed during `hermes update` while refreshing lazy backends: the backend install itself could continue or fail normally, but Python reader threads raised `UnicodeDecodeError` before Hermes could report the install result cleanly. The bug class is not specific to one language environment; it can affect Windows users on non-UTF-8 locale/code-page combinations such as cp932, cp936, cp949, cp1252, and similar setups.

## Change

This keeps POSIX behavior unchanged. On Windows only, the affected install helpers pass `encoding="utf-8"` and `errors="replace"` whenever they capture text output from install subprocesses. Replacement is intentional here: install logs are diagnostic text, and Hermes should preserve the command result instead of letting log decoding crash the refresh flow.

Related: #43402 was a similar closed, unmerged attempt. This PR keeps the diff limited to the install helper call paths and focused tests.

## Validation

- `python -m pytest tests\tools\test_lazy_deps.py tests\hermes_cli\test_tools_config.py -q` -> 172 passed
- `python -m py_compile hermes_cli\tools_config.py tools\lazy_deps.py tests\hermes_cli\test_tools_config.py tests\tools\test_lazy_deps.py`
- `git diff --check HEAD~1`