### PR TITLE
fix(tui_gateway): back off notification poller when session is busy

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7937,11 +7937,19 @@ def _notification_poller_loop(
             _emit("status.update", sid, {"kind": "process", "text": text})
             _emitted.add(_dedup_key)
 
+        _requeued = False
         with session["history_lock"]:
             if session.get("running"):
                 process_registry.completion_queue.put(evt)
-                continue
-            session["running"] = True
+                _requeued = True
+            else:
+                session["running"] = True
+        if _requeued:
+            # Back off before re-polling: the re-queued event keeps the queue
+            # non-empty, so without a sleep this loop spins at full speed
+            # (100% CPU, GIL churn) for as long as the session stays busy.
+            time.sleep(0.25)
+            continue
 
         rid = f"__notif__{int(time.time() * 1000)}"
         try:


### PR DESCRIPTION
## Bug

`_notification_poller_loop` in `tui_gateway/server.py` spins at 100% CPU for as long as a session stays busy while a completion event for it sits in `completion_queue`.

The busy-session branch re-queues the event and immediately re-polls it with no back-off:

```python
with session["history_lock"]:
    if session.get("running"):
        process_registry.completion_queue.put(evt)
        continue  # queue is now non-empty -> get(timeout=0.5) returns instantly
    session["running"] = True
```

Since the re-queued event keeps the queue non-empty, `completion_queue.get(timeout=0.5)` at the top of the loop returns immediately, so the loop degenerates into `get -> format_process_notification -> put -> get -> ...` at full speed.

## Observed impact (production, Python 3.13)

- One thread pegged at ~97-100% CPU (`top -H`), ~1,100 `futex` calls/s and **zero** `nanosleep` under `strace` — pure userspace spin with GIL churn.
- `py-spy dump` consistently showed this thread as the only `active+gil` one, inside `format_process_notification` / `queue.put` / `Condition.notify`.
- The dashboard's asyncio event loop (same process) starved: `/api/status` went from ~0.14s to 3-6s with intermittent 10s timeouts, recovering only when the busy session went idle.

Trigger: a long-running agent turn (e.g. a multi-hour terminal-tool command) + any background process completion for that session. `notify_on_complete`/watch events make this easy to hit.

## Fix

Mirror the 0.1s back-off that the foreign-session branch just above already uses: re-queue, then sleep 0.25s **outside** `history_lock` before re-polling. Notification latency for a busy session changes by at most 0.25s per cycle; idle-session dispatch is unaffected.

The drain loop after the stop signal is not affected (its busy branch `break`s out instead of continuing).
