### PR TITLE
fix(desktop): autosave Mixture-of-Agents preset edits

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -298,23 +298,62 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     return moa.presets[selectedMoaPreset] || moa.presets[moa.default_preset] || Object.values(moa.presets)[0] || null
   }, [moa, selectedMoaPreset])
 
+  // Mirror of `moa` so inline edits compute the next state purely (outside the
+  // setState updater) and hand it straight to the debounced autosave.
+  const moaRef = useRef<MoaConfigResponse | null>(null)
+
+  useEffect(() => {
+    moaRef.current = moa
+  }, [moa])
+
+  const moaSaveTimer = useRef<number | null>(null)
+
+  useEffect(
+    () => () => {
+      if (moaSaveTimer.current) {
+        window.clearTimeout(moaSaveTimer.current)
+      }
+    },
+    []
+  )
+
+  // Quiet debounced persist for inline MoA edits — mirrors the config page's
+  // autosave so slot/aggregator tweaks save themselves, matching the
+  // preset-level ops (set default / add / delete) that already persist on
+  // click. No `applying` spinner, so selecting stays responsive.
+  const scheduleMoaSave = useCallback((next: MoaConfigResponse) => {
+    if (moaSaveTimer.current) {
+      window.clearTimeout(moaSaveTimer.current)
+    }
+
+    moaSaveTimer.current = window.setTimeout(() => {
+      void saveMoaModels(next)
+        .then(setMoa)
+        .catch(err => setError(err instanceof Error ? err.message : String(err)))
+    }, 600)
+  }, [])
+
   const updateMoaPreset = useCallback(
     (updater: (preset: NonNullable<typeof currentMoaPreset>) => NonNullable<typeof currentMoaPreset>) => {
-      setMoa(prev => {
-        if (!prev || !selectedMoaPreset || !prev.presets[selectedMoaPreset]) {
-          return prev
-        }
+      const prev = moaRef.current
 
-        return {
-          ...prev,
-          presets: {
-            ...prev.presets,
-            [selectedMoaPreset]: updater(prev.presets[selectedMoaPreset])
-          }
+      if (!prev || !selectedMoaPreset || !prev.presets[selectedMoaPreset]) {
+        return
+      }
+
+      const next: MoaConfigResponse = {
+        ...prev,
+        presets: {
+          ...prev.presets,
+          [selectedMoaPreset]: updater(prev.presets[selectedMoaPreset])
         }
-      })
+      }
+
+      moaRef.current = next
+      setMoa(next)
+      scheduleMoaSave(next)
     },
-    [selectedMoaPreset]
+    [scheduleMoaSave, selectedMoaPreset]
   )
 
   const updateMoaSlot = useCallback((slot: MoaModelSlot, patch: Partial<MoaModelSlot>): MoaModelSlot => {
@@ -841,12 +880,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       </section>
       {moa && currentMoaPreset && (
         <section>
-          <div className="mb-2.5 flex items-center justify-between">
-            <SectionHeading icon={Cpu} title="Mixture of Agents" />
-            <Button disabled={applying} onClick={() => void saveMoa(moa)} size="sm" variant="textStrong">
-              {applying ? m.applying : t.common.save}
-            </Button>
-          </div>
+          <SectionHeading icon={Cpu} title="Mixture of Agents" />
           <p className="mb-2 text-xs text-muted-foreground">
             Configure named presets that appear as models under the Mixture of Agents provider. The aggregator is the
             acting model.


### PR DESCRIPTION
## Summary
Unify save behavior in desktop settings: MoA was the one true outlier. Its preset-level ops (set default / add / delete) already persisted on click, but reference-model and aggregator **slot edits** sat behind a manual **Save** button. This debounce-persists slot/aggregator edits (600ms, mirroring the config page's autosave) and drops the redundant button, so Mixture-of-Agents is uniformly autosave.

## Save-behavior audit (`apps/desktop/`)
**Autosave (the norm):** `config-settings` (debounced 550ms), `notifications-settings`, `appearance-settings`, `pet-settings`, `model-settings` reasoning/fast toggles, `sessions-settings` default dir.

**Explicit save — correct by necessity (left as-is):**
- **Secrets/API keys** — `credential-key-ui`, `env-credentials`, `toolset-config-panel` (`EnvVarField`), secret fields in `provider-config-panel`. Masked + `is_set` semantics; can't autosave a half-typed key.
- **Restart/reconnect** — `gateway-settings` ("Save for restart" / "Save & reconnect"). Flips the live backend connection.
- **Freeform JSON** — `mcp-settings` server-JSON editor. Can't autosave invalid JSON mid-type.
- **Live-swap actions** — `model-settings` main-model **Apply** / aux **Change**. Swap the active model, not just store a pref.
- **Dialogs** (transactional) — profiles, cron, project-dialog, pet-rename.

**Outliers:**
1. **MoA slot edits** — fixed here.
2. **`provider-config-panel`** (memory provider) — non-secret select/text grouped with secrets under one Save. Left as-is; splitting would fragment one form into two save models for marginal gain.

## Test plan
- [ ] Settings → Model → Mixture of Agents: edit a reference-model provider/model, aggregator, add/remove a reference slot — changes persist without a Save button (reopen settings to confirm)
- [ ] Set default / add / delete preset still persist on click
- [ ] Rapid edits debounce to a single save; no save-loop or stale overwrite