### PR TITLE
test(tools): add unit tests for has_traversal_component

### DIFF
--- a/tests/tools/test_path_security.py
+++ b/tests/tools/test_path_security.py
@@ -1,0 +1,44 @@
+"""Unit tests for has_traversal_component (tools/path_security.py).
+
+has_traversal_component is a pure, I/O-free guard used by skills_tool,
+tts_tool, file_tools, and skill_manager_tool to reject path-traversal
+attempts before expensive resolution. These tests pin its contract: it
+flags ".." only as a whole path component, never as a substring, and
+treats "." / "..." as non-traversal.
+
+All inputs use forward slashes and relative paths so pathlib parses them
+identically on POSIX and Windows.
+"""
+
+import pytest
+
+from tools.path_security import has_traversal_component
+
+
+class TestHasTraversalComponent:
+    @pytest.mark.parametrize("path_str", [
+        "a/../b", "../etc/passwd", "..", "foo/bar/..", "../../secret",
+    ])
+    def test_traversal_component_detected(self, path_str):
+        assert has_traversal_component(path_str) is True
+
+    @pytest.mark.parametrize("path_str", [
+        "a/b/c", "safe/path.txt", "config.yaml", "dir/sub/file",
+    ])
+    def test_clean_paths_pass(self, path_str):
+        assert has_traversal_component(path_str) is False
+
+    @pytest.mark.parametrize("path_str", ["a/b..c/d", "file..txt", "ab..cd"])
+    def test_double_dot_substring_is_not_traversal(self, path_str):
+        # ".." must match a whole path component, not appear as a substring.
+        assert has_traversal_component(path_str) is False
+
+    @pytest.mark.parametrize("path_str", ["...", "a/.../b"])
+    def test_triple_dot_is_not_traversal(self, path_str):
+        assert has_traversal_component(path_str) is False
+
+    def test_current_dir_is_not_traversal(self):
+        assert has_traversal_component("./a") is False
+
+    def test_empty_string_is_not_traversal(self):
+        assert has_traversal_component("") is False


### PR DESCRIPTION
﻿## What does this PR do?

Adds unit test coverage for `has_traversal_component` in `tools/path_security.py`. This pure, I/O-free helper is used by `skills_tool`, `tts_tool`, `file_tools`, and `skill_manager_tool` to reject path-traversal attempts before expensive path resolution — but the module had no tests.

The tests pin the function's contract:
- A `..` path **component** is flagged (`a/../b`, `../etc/passwd`, `..`, `foo/bar/..`)
- Clean relative paths pass (`a/b/c`, `safe/path.txt`, `config.yaml`)
- `..` as a **substring** is NOT flagged (`a/b..c/d`, `file..txt`) — it must be a whole component
- Triple-dot is not traversal (`...`, `a/.../b`)
- Current-dir `.` is not traversal (`./a`)
- Empty string is not traversal

## Type of Change

- [x] Test coverage (no production code changed)

## Why

`has_traversal_component` is a security guard on a path boundary used across four tools. Without a test, a future "simplification" to something like `".." in path_str` would introduce false positives (e.g. `file..txt`) and pass silently. The substring-vs-component cases lock the intended behavior in place.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_path_security.py -v
```

## Notes

- 1 new file, no production code touched. Pure input→output assertions — no mocks, no network, no filesystem.
- All inputs use forward slashes and relative paths so `pathlib` parses them identically on POSIX and Windows.
- Follows the existing style of `tests/tools/test_ansi_strip.py`.
