### PR TITLE
feat(desktop): cap overlay inner-page width at 75rem

### DIFF
--- a/apps/desktop/src/app/layout-constants.ts
+++ b/apps/desktop/src/app/layout-constants.ts
@@ -12,6 +12,12 @@ export const PAGE_INSET_X = 'px-[clamp(1.25rem,4vw,4rem)]'
 // out to the gutter edges before re-applying PAGE_INSET_X.
 export const PAGE_INSET_NEG_X = '-mx-[clamp(1.25rem,4vw,4rem)]'
 
+// Readable cap for overlay "inner page" bodies (settings, command center). Wide
+// enough to breathe, tight enough that content doesn't sprawl on ultrawide
+// displays. Pair with `mx-auto w-full` to center within the pane. Literal string
+// for Tailwind's scanner (see PAGE_INSET_X note).
+export const PAGE_MAX_W = 'max-w-[75rem]'
+
 // Below this viewport width a docked sidebar leaves no room for content, so both
 // rails auto-collapse into the hover-reveal overlay. Single source of truth for
 // the responsive collapse point.

--- a/apps/desktop/src/app/overlays/overlay-split-layout.tsx
+++ b/apps/desktop/src/app/overlays/overlay-split-layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import type { IconComponent } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
-import { PAGE_INSET_X } from '../layout-constants'
+import { PAGE_INSET_X, PAGE_MAX_W } from '../layout-constants'
 
 interface OverlaySplitLayoutProps {
   children: ReactNode
@@ -64,7 +64,8 @@ export function OverlayMain({ children, className }: OverlayMainProps) {
   return (
     <main
       className={cn(
-        'flex min-h-0 flex-1 flex-col overflow-hidden bg-transparent pb-3 pt-[calc(var(--titlebar-height)/2+1rem)]',
+        'mx-auto flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-transparent pb-3 pt-[calc(var(--titlebar-height)/2+1rem)]',
+        PAGE_MAX_W,
         PAGE_INSET_X,
         className
       )}


### PR DESCRIPTION
## Summary
- Add shared `PAGE_MAX_W` (`max-w-[75rem]` ≈ 1200px) in `layout-constants`
- Apply it (with `mx-auto w-full`) to the `OverlayMain` primitive, so Settings and Command Center bodies cap at a readable width and center in the pane instead of sprawling on wide/ultrawide displays
- Follow-up to #57422, which removed the settings-only `max-w-4xl`; this reinstates a sane, wider cap at the shared primitive level

## Test plan
- [x] Wide/ultrawide window: Settings and Command Center content stops at ~1200px, centered in the pane
- [x] Narrow window: content still fills, inset (`PAGE_INSET_X`) intact, scroll works
- [x] Settings `px-0` override still wins (no double gutter); sidebar nav unaffected