### PR TITLE
fix(dashboard-auth): catch NotImplementedError in auth_login for password-only providers

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -195,6 +195,16 @@ async def auth_login(request: Request, provider: str, next: str = ""):
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
+    except NotImplementedError:
+        # Password-only providers (e.g. BasicAuthProvider) do not support
+        # OAuth redirect flows.  Redirect to the server-rendered login
+        # page instead of crashing with a 500.
+        from urllib.parse import quote
+
+        next_path = request.query_params.get("next", "")
+        safe = _validate_post_login_target(next_path)
+        target = f"/login?next={quote(safe, safe='')}" if safe else "/login"
+        return RedirectResponse(url=target, status_code=302)
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,


### PR DESCRIPTION
## Problem

When only `dashboard.basic_auth` is configured (no OAuth provider), navigating to `GET /auth/login?provider=basic` crashes with an **HTTP 500** — no error page, no redirect, just "Internal Server Error".

The root cause: `BasicAuthProvider.start_login()` intentionally raises `NotImplementedError` because password-only providers have no OAuth redirect flow. The `auth_login` route catches `ProviderError` but not `NotImplementedError`.

This is reproducible from any mobile browser that bookmarks or auto-completes the `/auth/login?provider=basic` URL, or when the auth gate lands on a password-only setup.

## Fix

Catch `NotImplementedError` in `auth_login()` and redirect to the server-rendered `/login` page, which correctly renders the password form for providers with `supports_password=True`. The `next=` parameter is preserved through the redirect.

## Steps to reproduce

1. Configure only `dashboard.basic_auth` in `config.yaml` (no OAuth)
2. Start dashboard: `hermes dashboard --host 0.0.0.0 --port 9119`
3. From a remote browser (not localhost), navigate to `http://<ip>:9119/auth/login?provider=basic`
4. **Before:** HTTP 500, "Internal Server Error"
5. **After:** 302 redirect to `/login` -> password form renders correctly

## Testing

Verified locally with:
- `curl -s -o /dev/null -w "%{http_code}" http://localhost:9119/auth/login?provider=basic` -> 302 (was 500)
- `curl -s -o /dev/null -w "%{redirect_url}" "http://localhost:9119/auth/login?provider=basic&next=/projects"` -> `/login?next=%2Fprojects` (next= preserved)
- Full login flow from iPhone (Safari/Arc Search) via Tailscale -> works
