### PR TITLE
fix(desktop): stop macOS Tahoe misplacing the traffic lights

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3861,6 +3861,20 @@ function getWindowButtonPosition() {
   return mainWindow?.getWindowButtonPosition?.() || WINDOW_BUTTON_POSITION
 }
 
+// macOS product major (26 = Tahoe), or null off macOS. Static per boot, so cache
+// it. The renderer uses this to widen the left titlebar cluster's offset past
+// Tahoe's larger traffic lights.
+let macOSMajorCache
+function getMacOSMajor() {
+  if (macOSMajorCache !== undefined) return macOSMajorCache
+  macOSMajorCache = null
+  if (IS_MAC) {
+    const major = Number.parseInt(process.getSystemVersion?.() ?? '', 10)
+    if (Number.isFinite(major)) macOSMajorCache = major
+  }
+  return macOSMajorCache
+}
+
 function getNativeOverlayWidth() {
   return computeNativeOverlayWidth({ isWindows: IS_WINDOWS, isWsl: IS_WSL, isMac: IS_MAC })
 }
@@ -3868,6 +3882,7 @@ function getNativeOverlayWidth() {
 function getWindowState() {
   return {
     isFullscreen: Boolean(mainWindow?.isFullScreen?.()),
+    macOSMajor: getMacOSMajor(),
     nativeOverlayWidth: getNativeOverlayWidth(),
     windowButtonPosition: getWindowButtonPosition()
   }

--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -86,7 +86,11 @@ export function AppShell({
   // pop-out) is a compact side panel — none of them carry the full titlebar
   // tool cluster. Gate on isSecondaryWindow, never the narrower new-session flag.
   const hideTitlebarControls = isSecondaryWindow()
-  const titlebarControls = titlebarControlsPosition(connection?.windowButtonPosition, isFullscreen)
+  const titlebarControls = titlebarControlsPosition(
+    connection?.windowButtonPosition,
+    isFullscreen,
+    connection?.macOSMajor ?? null
+  )
   // Width Windows/WSLg reserve for the native min/max/close overlay (zero on
   // macOS, where window controls sit on the left and are reported via
   // windowButtonPosition instead). The right tool cluster has to clear them.

--- a/apps/desktop/src/app/shell/titlebar.test.ts
+++ b/apps/desktop/src/app/shell/titlebar.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  MACOS_TAHOE_MAJOR,
   TITLEBAR_CONTROL_OFFSET_X,
+  TITLEBAR_CONTROL_OFFSET_X_TAHOE,
   TITLEBAR_EDGE_INSET,
   TITLEBAR_FALLBACK_WINDOW_BUTTON_X,
   titlebarControlsPosition
@@ -10,6 +12,18 @@ import {
 describe('titlebarControlsPosition', () => {
   it('offsets controls from visible traffic lights', () => {
     expect(titlebarControlsPosition({ x: 24, y: 10 }).left).toBe(24 + TITLEBAR_CONTROL_OFFSET_X)
+  })
+
+  it('keeps the pre-Tahoe offset on older macOS', () => {
+    expect(titlebarControlsPosition({ x: 24, y: 10 }, false, MACOS_TAHOE_MAJOR - 1).left).toBe(
+      24 + TITLEBAR_CONTROL_OFFSET_X
+    )
+  })
+
+  it('widens the offset on macOS Tahoe (26+) to clear the larger traffic lights', () => {
+    expect(titlebarControlsPosition({ x: 24, y: 10 }, false, MACOS_TAHOE_MAJOR).left).toBe(
+      24 + TITLEBAR_CONTROL_OFFSET_X_TAHOE
+    )
   })
 
   it('pins to the edge when macOS fullscreen hides traffic lights', () => {

--- a/apps/desktop/src/app/shell/titlebar.ts
+++ b/apps/desktop/src/app/shell/titlebar.ts
@@ -4,6 +4,12 @@ export const TITLEBAR_HEIGHT = 34
 export const MACOS_TRAFFIC_LIGHTS_HEIGHT = 14
 export const TITLEBAR_ICON_SIZE = 12
 export const TITLEBAR_CONTROL_OFFSET_X = 74
+// macOS Tahoe (26+) enlarged the traffic lights, so the pre-Tahoe cluster width
+// no longer clears them and our left tools overlap. Electron only reports the
+// cluster's origin (not its width), so we can't measure the delta — gate a wider
+// offset on the OS major instead. Pre-Tahoe stays byte-identical.
+export const TITLEBAR_CONTROL_OFFSET_X_TAHOE = 88
+export const MACOS_TAHOE_MAJOR = 26
 export const TITLEBAR_CONTROL_HEIGHT = 22
 export const TITLEBAR_CONTROLS_TOP = (TITLEBAR_HEIGHT - TITLEBAR_CONTROL_HEIGHT) / 2
 export const TITLEBAR_FALLBACK_WINDOW_BUTTON_X = 24
@@ -29,7 +35,8 @@ export const titlebarHeaderShadowClass =
 
 export function titlebarControlsPosition(
   windowButtonPosition: HermesConnection['windowButtonPosition'] | undefined,
-  isFullscreen = false
+  isFullscreen = false,
+  macOSMajor: number | null = null
 ) {
   const top = Math.max(0, TITLEBAR_CONTROLS_TOP)
 
@@ -41,8 +48,13 @@ export function titlebarControlsPosition(
     return { left: TITLEBAR_EDGE_INSET, top }
   }
 
+  const offset =
+    macOSMajor !== null && macOSMajor >= MACOS_TAHOE_MAJOR
+      ? TITLEBAR_CONTROL_OFFSET_X_TAHOE
+      : TITLEBAR_CONTROL_OFFSET_X
+
   return {
-    left: (windowButtonPosition?.x ?? TITLEBAR_FALLBACK_WINDOW_BUTTON_X) + TITLEBAR_CONTROL_OFFSET_X,
+    left: (windowButtonPosition?.x ?? TITLEBAR_FALLBACK_WINDOW_BUTTON_X) + offset,
     top
   }
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -356,6 +356,9 @@ export interface HermesConnection {
   isFullscreen: boolean
   mode?: 'local' | 'remote'
   authMode?: 'oauth' | 'token'
+  // macOS product major (26 = Tahoe); null off macOS. Widens the left titlebar
+  // cluster offset past Tahoe's larger traffic lights.
+  macOSMajor?: number | null
   nativeOverlayWidth: number
   source?: 'env' | 'local' | 'settings'
   token: string
@@ -374,6 +377,7 @@ export interface HermesTitleBarTheme {
 
 export interface HermesWindowState {
   isFullscreen: boolean
+  macOSMajor?: number | null
   nativeOverlayWidth: number
   windowButtonPosition: { x: number; y: number } | null
 }


### PR DESCRIPTION
## Summary
On **macOS Tahoe** the left titlebar tools overlap the native traffic lights. Root cause is [electron#49183](https://github.com/electron/electron/issues/49183): when `titleBarOverlay` carries a **nonzero `height`**, `setWindowButtonPosition()` miscalculates the traffic-light position on Tahoe, so the lights don't land at our configured inset (`x:24`) and collide with the left tool cluster.

We hit it exactly — on macOS we pass `titleBarOverlay: { height: 34 }` + `setWindowButtonPosition({x:24})` (Electron 40).

## Fix
- On macOS **Tahoe (Darwin 25+)** pass `titleBarOverlay` **height `0`** — the value confirmed unaffected in #49183. Pre-Tahoe keeps the full `34` (byte-identical).
- The renderer already paints its own `-webkit-app-region:drag` strips (`app-shell.tsx`), so a `0` overlay height costs no draggable area; native lights are positioned via `trafficLightPosition`/`setWindowButtonPosition` regardless.
- Gate on the **truthful Darwin kernel major** (`os.release()` → `25` = Tahoe), *not* `process.getSystemVersion()`, which macOS reports as `16` **or** `26` depending on the build SDK (Apple's compat-versioning trick).
- Logic extracted to `macTitleBarOverlayHeight()` in the pure `titlebar-overlay-width.cjs`, with `node:test` coverage.

## Why not just bump Electron?
The upstream fix ([electron#51989](https://github.com/electron/electron/pull/51989)) is **still an open, unmerged PR** — not in 40.10.6 or any 41/42/43 release — and it's native code inside the prebuilt Electron binary, so it can't be cherry-picked app-side. This app-level workaround is the only remedy available today. (Superseded my earlier offset-bump approach, which targeted the wrong axis and used the unreliable product-version check.)

## Test plan
- [ ] macOS Tahoe (26+): traffic lights sit at the normal inset; left titlebar tools no longer overlap them
- [ ] macOS ≤ 15 (Sequoia): titlebar/overlay unchanged
- [ ] Window dragging still works on Tahoe (renderer drag strips)
- [ ] Windows/Linux/WSLg: overlay unaffected (non-mac branch untouched)
- [x] `node --test apps/desktop/electron/titlebar-overlay-width.test.cjs` passes