### PR TITLE
feat(agent): config.yaml override for background-review prompts

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -157,6 +157,10 @@ def _digest_history(messages_snapshot: List[Dict], tail: int = 24) -> List[Dict]
 # the user-message that the forked review agent receives.  AIAgent exposes
 # them as class attributes (``_MEMORY_REVIEW_PROMPT`` etc.) for back-compat;
 # the actual text lives here so future edits are one-place.
+#
+# Users can override any of these via ``agent.review_prompts.{memory,skill,
+# combined}`` in config.yaml — see ``_resolve_review_prompt`` below for the
+# full resolution chain.
 _MEMORY_REVIEW_PROMPT = (
     "Review the conversation above and consider saving to memory if appropriate.\n\n"
     "Focus on:\n"
@@ -602,6 +606,15 @@ def _run_review_in_thread(
 
     review_agent = None
     review_messages: List[Dict] = []
+    # Empty-prompt short-circuit: the config-resolved prompt can be ""
+    # when the user explicitly turns off this review variant. The
+    # original sentinel was supposed to skip the fork entirely; rather
+    # than spawn an agent that receives a sub-minimal user message
+    # (still consumes a model call), we never enter the try block.
+    # Must run BEFORE _resolve_review_runtime(agent) etc., since those
+    # touch live agent attributes that we want to leave untouched.
+    if not prompt:
+        return
     try:
         # Silence stdout/stderr for THIS worker thread only.  A process-global
         # ``contextlib.redirect_stdout(devnull)`` here would also blank
@@ -869,6 +882,80 @@ def _run_review_in_thread(
             pass
 
 
+# Mapping from config-side review-prompt key (``agent.review_prompts.*`` in
+# config.yaml) to the module-level constants and the matching agent-attribute
+# names. Centralising the mapping keeps ``_resolve_review_prompt`` tiny and
+# means adding a new review kind only needs one edit here.
+_REVIEW_PROMPT_BY_KIND: Dict[str, str] = {
+    "memory": "_MEMORY_REVIEW_PROMPT",
+    "skill": "_SKILL_REVIEW_PROMPT",
+    "combined": "_COMBINED_REVIEW_PROMPT",
+}
+
+
+def _resolve_review_prompt(agent: Any, kind: str) -> str:
+    """Pick the review prompt to send to the forked review agent.
+
+    Resolution order (first hit wins):
+
+      1. ``agent.<attr>`` — a per-instance override set by tests or by a
+         subclass. Wins on any non-empty value. Back-compat path with
+         the existing ``getattr(agent, "_MEMORY_REVIEW_PROMPT", ...)``
+         fallback pattern.
+      2. ``agent.review_prompts.<kind>`` in ``config.yaml`` — the new
+         override slot. ``None`` / missing key → fall through. An empty
+         string (``""``) is treated as an explicit "this review kind is
+         off" signal: ``spawn_background_review_thread`` short-circuits
+         and the forked agent never spawns, saving the model call.
+      3. The module-level constant for that kind — the unchanged default.
+
+    Pure read against ``agent``. The config read is wrapped in a narrow
+    ``except (ImportError, OSError, ValueError)`` so a misconfigured
+    user gets a ``logger.warning`` line and falls through to the module
+    constant rather than crashing the review thread.
+    """
+    attr_name = _REVIEW_PROMPT_BY_KIND.get(kind)
+    if attr_name is None:
+        # Unknown kind — caller bug. Don't raise: a bad probe into the
+        # review API shouldn't kill the user's turn.
+        return _MEMORY_REVIEW_PROMPT
+    # 1. Per-instance override (test patches, agent subclassing).
+    try:
+        per_instance = getattr(agent, attr_name)
+    except AttributeError:
+        per_instance = None
+    if per_instance:
+        return per_instance
+    # 2. config.yaml override (None / missing = fall through). We narrow
+    # the except to the realistic failure modes a misconfigured user can
+    # hit (yaml parse error, missing file, bad JSON) — anything else is a
+    # bug we'd rather see than swallow.
+    cfg = None
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except (ImportError, OSError, ValueError) as exc:
+        # ImportError: hermes_cli.config unavailable in odd contexts.
+        # OSError: user config file unreadable.
+        # ValueError: yaml/json parse error in the user's config.
+        logger.warning(
+            "background_review: could not read config (%s); "
+            "falling back to module-level prompt constants",
+            exc,
+        )
+    if isinstance(cfg, dict):
+        agent_cfg = cfg.get("agent")
+        if isinstance(agent_cfg, dict):
+            rp_cfg = agent_cfg.get("review_prompts")
+            if isinstance(rp_cfg, dict):
+                override = rp_cfg.get(kind)
+                if override is not None:
+                    return override
+    # 3. Module-level constant — preserved verbatim so legacy callers
+    # that import ``AIAgent._SKILL_REVIEW_PROMPT`` see the same text.
+    return globals()[attr_name]
+
+
 def spawn_background_review_thread(
     agent: Any,
     messages_snapshot: List[Dict],
@@ -881,15 +968,17 @@ def spawn_background_review_thread(
     owns the actual ``threading.Thread`` construction so test-level patches
     of ``run_agent.threading.Thread`` keep working.
     """
-    # Pick the right prompt based on which triggers fired.  Allow per-agent
-    # override (the prompts moved to module-level constants but old code paths
-    # that set agent._MEMORY_REVIEW_PROMPT etc. directly keep working).
+    # Pick the right prompt based on which triggers fired. Resolution chain
+    # (see ``_resolve_review_prompt``): agent instance attribute → config.yaml
+    # ``agent.review_prompts.{kind}`` → module-level constant here. The
+    # existing per-agent override path is preserved so legacy test patches
+    # that set ``agent._MEMORY_REVIEW_PROMPT`` etc. keep working.
     if review_memory and review_skills:
-        prompt = getattr(agent, "_COMBINED_REVIEW_PROMPT", _COMBINED_REVIEW_PROMPT)
+        prompt = _resolve_review_prompt(agent, "combined")
     elif review_memory:
-        prompt = getattr(agent, "_MEMORY_REVIEW_PROMPT", _MEMORY_REVIEW_PROMPT)
+        prompt = _resolve_review_prompt(agent, "memory")
     else:
-        prompt = getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
+        prompt = _resolve_review_prompt(agent, "skill")
 
     def _target() -> None:
         _run_review_in_thread(agent, messages_snapshot, prompt)
@@ -901,6 +990,7 @@ __all__ = [
     "_MEMORY_REVIEW_PROMPT",
     "_SKILL_REVIEW_PROMPT",
     "_COMBINED_REVIEW_PROMPT",
+    "_resolve_review_prompt",
     "spawn_background_review_thread",
     "summarize_background_review_actions",
     "build_memory_write_metadata",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -638,6 +638,46 @@ agent:
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
 
+  # Override the background-review prompts the forked review agent receives
+  # after each turn. Each value here REPLACES the module-level constant for
+  # that review kind. Leave a field unset (null / missing) to keep the
+  # shipped default — these are *opt-in* overrides, not new defaults.
+  #
+  # Resolution chain (first hit wins):
+  #   1. agent instance attribute (per-subclass / per-test override)
+  #   2. this config block
+  #   3. module-level constant in `agent/background_review.py`
+  #
+  # Use ``memory``  to retune what counts as memory-worthy.
+  # Use ``skill``   to retune the skill-create / patch / library-shape ladder.
+  # Use ``combined`` when both review kinds fire in the same fork.
+  # Set a field to "" (empty string) to disable that review variant
+  # explicitly — the fork will skip work for that kind.
+  #
+  # Safety: this only changes the user-message the background review fork
+  # receives. The main-conversation system prompt and per-conversation prompt
+  # cache are untouched (per AGENTS.md "Per-conversation prompt caching is
+  # sacred"). Three reasons it is NOT a new core tool:
+  #   - The escape-hatch is per-turn and only fires from one call site
+  #     (`agent._spawn_background_review`). It does not ship on every API
+  #     call.
+  # - Override applies to a prompt that the existing review fork already
+  #   consumes; nothing new fires when the override is unset.
+  # review_prompts:
+  #   memory: |
+  #     Review the conversation above. Save ONLY durable user facts to memory
+  #     (persona, preferences, persistent environment facts). One-shot tool
+  #     failures and transient task notes do NOT belong in memory.
+  #     If nothing qualifies, say "Nothing to save." and stop.
+  #   skill: |
+  #     Update the skill library. Be active on durable lessons only:
+  #     technique, recurring user preference, or wrong/outdated skill.
+  #     Skip session-one-off fixes and environment failures.
+  #   combined: |
+  #     Two things. Memory: durable user facts only. Skills: durable lessons
+  #     from this session. Skip one-offs on both sides.
+  #     "Nothing to save." is fine when both criteria are empty.
+
   # After the agent edits code without fresh passing verification, nudge it to
   # verify before finishing. The default "auto" enables it on interactive
   # coding surfaces (CLI, TUI, desktop) and programmatic callers, and disables

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -928,6 +928,28 @@ DEFAULT_CONFIG = {
         # Set a positive value in config.yaml only if you explicitly want a
         # grace window on /restart (and keep it well under TimeoutStopSec).
         "restart_drain_timeout": 0,
+        # Background-review prompt overrides — let users tune the
+        # memory/skill/combined review forks without forking Hermes.
+        # Each value (None = unset) replaces the module-level constant in
+        # ``agent.background_review`` for that review kind only. Set a
+        # non-empty string to override. Set ``""`` (empty string) to
+        # disable that review variant explicitly — ``spawn_background_
+        # review_thread`` short-circuits and skips the fork entirely,
+        # saving the model call. Resolution order:
+        #   1. agent instance attribute (``agent._MEMORY_REVIEW_PROMPT`` etc.)
+        #   2. this config block
+        #   3. module-level constant in ``agent.background_review``
+        # Override ONLY changes the prompt the background review fork
+        # receives — the main-conversation system prompt and prompt cache
+        # are never touched (per AGENTS.md "Per-conversation prompt caching
+        # is sacred"). Use ``memory`` to retune memory-write criteria,
+        # ``skill`` to retune skill-create / patch / library-shape rules,
+        # ``combined`` when both review kinds fire in the same fork.
+        "review_prompts": {
+            "memory": None,
+            "skill": None,
+            "combined": None,
+        },
         # Max app-level retry attempts for API errors (connection drops,
         # provider timeouts, 5xx, etc.) before the agent surfaces the
         # failure.  The OpenAI SDK already does its own low-level retries

--- a/tests/run_agent/test_review_prompt_override.py
+++ b/tests/run_agent/test_review_prompt_override.py
@@ -1,0 +1,384 @@
+"""Behavior tests for ``agent.review_prompts`` config override.
+
+Asserts the *resolution chain* (agent instance attribute > config.yaml >
+module-level constant), not snapshot text. These are *behavior contracts*:
+
+  - None / missing config block       → module-level constant (no behavior change)
+  - config override set              → that override string flows through
+  - config override = ""             → empty string is preserved (explicit "off")
+  - agent instance attr set          → wins over config override
+  - unknown kind                     → caller bug does not crash the resolve
+
+The override only changes the user message the background review fork
+receives. The main-conversation system prompt and prompt cache are never
+touched (per AGENTS.md "Per-conversation prompt caching is sacred").
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from agent.background_review import (
+    _MEMORY_REVIEW_PROMPT,
+    _SKILL_REVIEW_PROMPT,
+    _COMBINED_REVIEW_PROMPT,
+    _resolve_review_prompt,
+    _REVIEW_PROMPT_BY_KIND,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeAgent:
+    """Minimal stand-in for AIAgent — just enough surface for the resolver."""
+
+    def __init__(self, **overrides: str) -> None:
+        for k, v in overrides.items():
+            setattr(self, k, v)
+
+
+def _set_config_review_prompts(tmp_config, **values):
+    """Return a context manager that, on enter, calls ``tmp_config(dict)``
+    with an existing real config merged with our review_prompts overrides.
+    On exit, monkeypatch (set up by pytest's ``monkeypatch`` fixture inside
+    ``tmp_config``) is automatically undone by pytest.
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx():
+        from hermes_cli.config import load_config
+        real = load_config()
+        merged = dict(real)
+        agent_cfg = dict(merged.get("agent", {}) or {})
+        rp = dict(agent_cfg.get("review_prompts", {}) or {})
+        for k, v in values.items():
+            if v is _SENTINEL_UNSET:
+                rp.pop(k, None)
+            elif v is None:
+                # Explicit None in user config — store as None so the resolver
+                # sees "this slot is set but to default". (The resolver
+                # treats None the same as missing, so behaviour is preserved.)
+                rp[k] = None
+            else:
+                rp[k] = v
+        agent_cfg["review_prompts"] = rp
+        merged["agent"] = agent_cfg
+        tmp_config(merged)
+        yield merged
+
+    return _ctx()
+
+
+_SENTINEL_UNSET = object()
+
+
+@pytest.fixture
+def tmp_config(monkeypatch):
+    """Force ``hermes_cli.config.load_config`` to return a chosen dict.
+
+    Patches the *attribute* ``load_config`` on the module that
+    ``_resolve_review_prompt`` lazy-imports. The lazy-import pattern
+    (``from hermes_cli.config import load_config`` inside the function)
+    means we patch the symbol *on that module*, not the local binding.
+    """
+
+    def _apply(value: Dict[str, Any]) -> None:
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: value)
+
+    yield _apply
+
+
+# ---------------------------------------------------------------------------
+# 1. Defaults — no change in behaviour when override is unset.
+# ---------------------------------------------------------------------------
+
+class TestDefaultsPreserved:
+    """When ``agent.review_prompts`` is None / missing, the resolver must
+    return the verbatim module-level constant for each kind. This is the
+    regression guard for existing users."""
+
+    def test_memory_default_is_module_constant(self, tmp_config):
+        # Block any value from reaching the resolver.
+        with _set_config_review_prompts(tmp_config):
+            assert _resolve_review_prompt(_FakeAgent(), "memory") == _MEMORY_REVIEW_PROMPT
+
+    def test_skill_default_is_module_constant(self, tmp_config):
+        with _set_config_review_prompts(tmp_config):
+            assert _resolve_review_prompt(_FakeAgent(), "skill") == _SKILL_REVIEW_PROMPT
+
+    def test_combined_default_is_module_constant(self, tmp_config):
+        with _set_config_review_prompts(tmp_config):
+            assert _resolve_review_prompt(_FakeAgent(), "combined") == _COMBINED_REVIEW_PROMPT
+
+    def test_default_config_has_review_prompts_block(self):
+        """The DEFAULT_CONFIG dict exposes the three slots as a contract."""
+        from hermes_cli.config import DEFAULT_CONFIG
+        rp = DEFAULT_CONFIG["agent"]["review_prompts"]
+        assert set(rp.keys()) == {"memory", "skill", "combined"}
+        # All three are None by default (unset).
+        assert rp["memory"] is None
+        assert rp["skill"] is None
+        assert rp["combined"] is None
+
+
+# ---------------------------------------------------------------------------
+# 2. config.yaml override flows through.
+# ---------------------------------------------------------------------------
+
+class TestConfigOverride:
+    """Setting a field in config.yaml replaces the module constant."""
+
+    def test_memory_override_replaces_module_constant(self, tmp_config):
+        custom = "MEMORY OVERRIDE: only save cross-session persona facts."
+        with _set_config_review_prompts(tmp_config, memory=custom):
+            out = _resolve_review_prompt(_FakeAgent(), "memory")
+        assert out == custom
+        assert out != _MEMORY_REVIEW_PROMPT  # and IS different from default
+
+    def test_skill_override_replaces_module_constant(self, tmp_config):
+        custom = "SKILL OVERRIDE: patch loaded skill first, then references."
+        with _set_config_review_prompts(tmp_config, skill=custom):
+            out = _resolve_review_prompt(_FakeAgent(), "skill")
+        assert out == custom
+        assert out != _SKILL_REVIEW_PROMPT  # and IS different from default
+
+    def test_combined_override_replaces_module_constant(self, tmp_config):
+        custom = "COMBINED OVERRIDE: nothing qualifies? just say so and exit."
+        with _set_config_review_prompts(tmp_config, combined=custom):
+            out = _resolve_review_prompt(_FakeAgent(), "combined")
+        assert out == custom
+
+    def test_per_kind_overrides_are_independent(self, tmp_config):
+        """Overriding one kind must not leak into the others."""
+        mem_override = "ONLY memory facts."
+        with _set_config_review_prompts(tmp_config, memory=mem_override):
+            assert _resolve_review_prompt(_FakeAgent(), "memory") == mem_override
+            assert _resolve_review_prompt(_FakeAgent(), "skill") == _SKILL_REVIEW_PROMPT
+            assert _resolve_review_prompt(_FakeAgent(), "combined") == _COMBINED_REVIEW_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty-string override = explicit "off" sentinel.
+# ---------------------------------------------------------------------------
+
+class TestEmptyStringIsPreserved:
+    """An empty-string override is a valid "review off" signal and must not
+    be coerced to ``None`` / dropped. The fork exits early when the prompt
+    is empty; collapsing it to the default would silently disable the
+    override."""
+
+    def test_empty_memory_kept_verbatim(self, tmp_config):
+        with _set_config_review_prompts(tmp_config, memory=""):
+            assert _resolve_review_prompt(_FakeAgent(), "memory") == ""
+
+    def test_empty_skill_kept_verbatim(self, tmp_config):
+        with _set_config_review_prompts(tmp_config, skill=""):
+            assert _resolve_review_prompt(_FakeAgent(), "skill") == ""
+
+
+# ---------------------------------------------------------------------------
+# 4. Resolution chain — instance attribute wins over config.
+# ---------------------------------------------------------------------------
+
+class TestInstanceAttrWinsOverConfig:
+    """The resolver must keep the existing ``getattr(agent, ...)`` back-compat
+    path working, AND make it win over the new config block — same precedence
+    the original code had."""
+
+    def test_instance_attr_wins_for_memory(self, tmp_config):
+        instance_text = "INSTANCE memory override"
+        with _set_config_review_prompts(tmp_config, memory="CONFIG memory"):
+            agent = _FakeAgent(_MEMORY_REVIEW_PROMPT=instance_text)
+            assert _resolve_review_prompt(agent, "memory") == instance_text
+
+    def test_instance_attr_wins_for_skill(self, tmp_config):
+        instance_text = "INSTANCE skill override"
+        with _set_config_review_prompts(tmp_config, skill="CONFIG skill"):
+            agent = _FakeAgent(_SKILL_REVIEW_PROMPT=instance_text)
+            assert _resolve_review_prompt(agent, "skill") == instance_text
+
+    def test_instance_attr_wins_for_combined(self, tmp_config):
+        instance_text = "INSTANCE combined override"
+        with _set_config_review_prompts(tmp_config, combined="CONFIG combined"):
+            agent = _FakeAgent(_COMBINED_REVIEW_PROMPT=instance_text)
+            assert _resolve_review_prompt(agent, "combined") == instance_text
+
+
+# ---------------------------------------------------------------------------
+# 5. Robustness — bad config layouts must not crash the fork.
+# ---------------------------------------------------------------------------
+
+class TestBadConfigFallsBack:
+    """The review fork runs in a daemon thread — exceptions here are
+    swallowed by the ``except Exception`` guards in turn_finalizer and
+    the forked thread silently dies. Better to fall back to the module
+    constant than to crash."""
+
+    def test_non_dict_review_prompts_falls_through(self, tmp_config):
+        """If a user pastes a string into agent.review_prompts by mistake,
+        we must not crash — fall through to the module constant."""
+        from hermes_cli.config import DEFAULT_CONFIG
+        # Build a dict where agent.review_prompts is a string, not a dict.
+        bad_config = dict(DEFAULT_CONFIG)
+        bad_config["agent"] = dict(bad_config["agent"])
+        bad_config["agent"]["review_prompts"] = "oops i pasted a string"
+        tmp_config(bad_config)
+        assert _resolve_review_prompt(_FakeAgent(), "memory") == _MEMORY_REVIEW_PROMPT
+        assert _resolve_review_prompt(_FakeAgent(), "skill") == _SKILL_REVIEW_PROMPT
+        assert _resolve_review_prompt(_FakeAgent(), "combined") == _COMBINED_REVIEW_PROMPT
+
+    def test_unknown_kind_returns_memory_constant(self):
+        """Unknown kind should return SOMETHING rather than raise — the
+        resolver must not crash the review thread on a caller bug."""
+        out = _resolve_review_prompt(_FakeAgent(), "nonsense_kind")
+        # Lands on _MEMORY_REVIEW_PROMPT (the resolver's documented fallback
+        # for unknown kinds). Whatever it is must be a non-empty string.
+        assert isinstance(out, str) and out
+
+
+# ---------------------------------------------------------------------------
+# 6. spawn_background_review_thread wires the resolved prompt through.
+# ---------------------------------------------------------------------------
+
+class TestSpawnUsesResolver:
+    """The end-to-end behaviour: a non-empty override reaches the spawned
+    thread; an unset override preserves the default; an empty override
+    passes through unchanged."""
+
+    def test_skill_review_uses_config_override(self, tmp_config):
+        from agent.background_review import spawn_background_review_thread
+        custom = "SKILL OVERRIDE: prefer patches to skills/"
+        with _set_config_review_prompts(tmp_config, skill=custom):
+            _, prompt = spawn_background_review_thread(
+                agent=_FakeAgent(),  # no instance attr → falls through to config
+                messages_snapshot=[],
+                review_memory=False,
+                review_skills=True,
+            )
+        assert prompt == custom
+
+    def test_combined_review_uses_config_override(self, tmp_config):
+        from agent.background_review import spawn_background_review_thread
+        custom = "COMBINED OVERRIDE: none of this is memory-worthy."
+        with _set_config_review_prompts(tmp_config, combined=custom):
+            _, prompt = spawn_background_review_thread(
+                agent=_FakeAgent(),
+                messages_snapshot=[],
+                review_memory=True,
+                review_skills=True,
+            )
+        assert prompt == custom
+
+    def test_spawn_preserves_empty_override(self, tmp_config):
+        """An empty-string override is meaningful (review off). The spawn
+        function must not collapse it to the default — that would silently
+        re-enable a review the user explicitly disabled."""
+        from agent.background_review import spawn_background_review_thread
+        with _set_config_review_prompts(tmp_config, memory=""):
+            _, prompt = spawn_background_review_thread(
+                agent=_FakeAgent(),
+                messages_snapshot=[],
+                review_memory=True,
+                review_skills=False,
+            )
+        assert prompt == ""
+
+    def test_empty_prompt_short_circuits_review_fork(self, tmp_config):
+        """Reviewer fix: an empty prompt must skip the forked agent
+        entirely — not just emit a sub-minimal user message. Without
+        this guard, ``review_agent.run_conversation`` still fires a
+        model call when the user explicitly said "review off".
+
+        The resolver reads ``agent._MEMORY_REVIEW_PROMPT`` (priority 1
+        in the resolve chain), so the only way to exercise the actual
+        ``_run_review_in_thread`` guard without exploding there is to
+        provide a sentinel that returns ``None`` from that attr (so
+        the resolver falls through to config → config says "" → empty
+        prompt propagates) and then explodes on any *other* attribute
+        — the explosion marks "we built the review agent", and the
+        test passes iff the explosion never fires (early return ran
+        before the agent was ever constructed).
+        """
+        from agent.background_review import spawn_background_review_thread
+
+        touched = {"after_target": False}
+
+        class _SentinelAgent:
+            """Behaves during resolver read, then explodes later.
+
+            The resolver wants ``agent._MEMORY_REVIEW_PROMPT`` —
+            returning ``None`` lets it fall through to config. Once the
+            resolver returns "" from config, the spawn function builds
+            ``_target`` and returns. ``_target()`` calls
+            ``_run_review_in_thread``, which checks ``if not prompt:
+            return`` BEFORE touching any agent attribute. If the guard
+            is in place, no explosion; if it's gone, we'd see
+            ``touched["after_target"] = True`` set by _run_review_in_thread
+            reaching the agent-construction code path.
+            """
+
+            _MEMORY_REVIEW_PROMPT = None
+
+            def __getattr__(self, name):
+                # The resolver only reads _MEMORY_REVIEW_PROMPT, which
+                # is set as a class attr above. ANY other attribute
+                # access means we've reached the run_conversation /
+                # review-agent-construction code path. Mark + raise.
+                touched["after_target"] = True
+                raise AssertionError(
+                    f"empty-prompt review reached the build-review-agent "
+                    f"code path (attr={name}); the early-return guard in "
+                    f"_run_review_in_thread should have skipped this"
+                )
+
+        with _set_config_review_prompts(tmp_config, memory=""):
+            target, prompt = spawn_background_review_thread(
+                agent=_SentinelAgent(),
+                messages_snapshot=[],
+                review_memory=True,
+                review_skills=False,
+            )
+        assert prompt == ""
+        target()  # must early-return without reaching _SentinelAgent attrs
+        assert touched["after_target"] is False, (
+            "review fork reached the build-review-agent code path — "
+            "the empty-prompt short-circuit in _run_review_in_thread "
+            "is missing or was bypassed"
+        )
+
+    def test_spawn_uses_instance_attr_first(self, tmp_config):
+        """When an instance attr is set, it wins over both config and
+        module constant — this is the back-compat path for existing tests
+        that monkey-patch ``AIAgent._SKILL_REVIEW_PROMPT`` etc."""
+        from agent.background_review import spawn_background_review_thread
+        instance_text = "INSTANCE skill — back-compat path"
+        with _set_config_review_prompts(tmp_config, skill="CONFIG skill"):
+            agent = _FakeAgent(_SKILL_REVIEW_PROMPT=instance_text)
+            _, prompt = spawn_background_review_thread(
+                agent=agent,
+                messages_snapshot=[],
+                review_memory=False,
+                review_skills=True,
+            )
+        assert prompt == instance_text
+
+
+# ---------------------------------------------------------------------------
+# 7. Mapping table — every declared kind has a corresponding prompt constant.
+# ---------------------------------------------------------------------------
+
+def test_review_prompt_mapping_covers_all_kinds():
+    """The mapping table is the single source of truth for kind→attr.
+
+    Adding a new review kind must require an edit here; if you add a kind
+    but forget the mapping, ``_resolve_review_prompt`` quietly falls back
+    to _MEMORY_REVIEW_PROMPT, which is wrong-and-silent. Lock it down.
+    """
+    expected_attrs = {"_MEMORY_REVIEW_PROMPT", "_SKILL_REVIEW_PROMPT", "_COMBINED_REVIEW_PROMPT"}
+    actual_attrs = set(_REVIEW_PROMPT_BY_KIND.values())
+    assert actual_attrs == expected_attrs


### PR DESCRIPTION
## Summary

Add `agent.review_prompts.{memory, skill, combined}` config knobs so users can override the prompts the forked background-review agent receives without forking Hermes.

Resolution chain (first hit wins):
1. `agent._MEMORY_REVIEW_PROMPT` / `_SKILL_REVIEW_PROMPT` / `_COMBINED_REVIEW_PROMPT` instance attr (back-compat — preserves the existing `getattr(agent, ...)` pattern that `test_review_prompt_class_first.py` and others rely on)
2. `agent.review_prompts.<kind>` in `config.yaml`
3. The module-level constant in `agent/background_review.py`

Defaults are preserved (all three new slots are `None`), so this is opt-in. An empty-string override acts as an explicit "review off" sentinel: `_run_review_in_thread` short-circuits before any review-agent construction, skipping the model call.

The override only changes the user message the background review fork receives. Main-conversation system prompt and per-conversation prompt cache are untouched (per AGENTS.md: "Per-conversation prompt caching is sacred").

## Why this is not speculative infrastructure

- The escape-hatch is per-turn and only fires from one call site (`agent._spawn_background_review`). It does not ship on every API call.
- The override path mirrors the existing `auxiliary.background_review.*` config pattern (auxiliary model routing for the same review fork) — same shape, same auditability.
- The config and resolve chain have one source of truth: `_REVIEW_PROMPT_BY_KIND` mapping plus `_resolve_review_prompt(agent, kind)`. Adding a fourth review kind is one edit there.
- Override applies to a prompt that the existing review fork already consumes; nothing new fires when the override is unset.

## Files

- `hermes_cli/config.py` — `agent.review_prompts: {memory: None, skill: None, combined: None}` added to `DEFAULT_CONFIG` under `agent:` (3 new fields, all None).
- `agent/background_review.py` — new `_REVIEW_PROMPT_BY_KIND` mapping + new `_resolve_review_prompt(agent, kind)` helper. The 3 `getattr(agent, ..., _CONSTANT)` calls in `spawn_background_review_thread` are replaced with the helper. `_run_review_in_thread` gains an early-return when the resolved prompt is empty so an explicit "off" sentinel actually skips the fork. The config-read `except` is narrowed to `(ImportError, OSError, ValueError)` and a `logger.warning(...)` line is emitted on hit so misconfigured users get feedback rather than silent fallback.
- `cli-config.yaml.example` — documented the override keys, the resolution order, the "review off" empty-string sentinel, and the cache-safety guarantee. Three worked examples included (commented out) for memory / skill / combined retunings.
- `tests/run_agent/test_review_prompt_override.py` — 21 behavior-contract tests covering: defaults preserved (no behavior change when override unset), config override flows through, empty-string sentinel preserved AND short-circuits the fork, instance attr wins over config, per-kind overrides are independent, bad config layouts fall back without crashing, and `_resolve_review_prompt` mapping-table invariant.

## Cache safety

Verifier:
- `_resolve_review_prompt` reads only config and returns a string.
- `spawn_background_review_thread` passes that string as the `user_message` argument to `review_agent.run_conversation(...)` on the forked review agent.
- The fork pins the parent's `_cached_system_prompt` (background_review.py:716) and inherits the parent's runtime + toolsets.
- Main-conversation system prompt and provider prefix cache are not touched in any code path.

The early-return short-circuit for empty prompts lives in `_run_review_in_thread` BEFORE any review-agent construction, so an "off" sentinel saves both the agent build cost and the model call.

## Test plan

Existing baseline (46+8 tests, all reading `AIAgent._SKILL_REVIEW_PROMPT` etc. as class attributes via the `from agent.background_review import (...)` re-export) is preserved bit-for-bit:

```
$ uv run --frozen pytest tests/run_agent/test_review_prompt_class_first.py \
    tests/run_agent/test_background_review.py \
    tests/run_agent/test_background_review_cache_parity.py \
    tests/run_agent/test_background_review_toolset_restriction.py \
    tests/run_agent/test_background_review_summary.py \
    tests/run_agent/test_background_review_cost_controls.py \
    tests/run_agent/test_review_prompt_override.py -q
75 passed in 3.21s
```

54 baseline + 21 new behavior-contract tests, all passing.

## Notes for reviewer

- I considered making this an env-var override, but went with `config.yaml` to comply with AGENTS.md ("All behavioral settings — timeouts, thresholds, feature flags, display prefs — go in `config.yaml`"). Nothing in this PR adds a `HERMES_*` env var.
- The new tests assert resolution contracts (which string flows through for which input), not literal prompt text. No change-detector tests.
- The `_resolve_review_prompt` helper is pure-read against `agent` (no mutation, no instance writes) and reads config lazily — keeps the review fork's hot path off any new I/O.
