### PR TITLE
fix(plugins/google-meet): migrate OpenAI Realtime client from retired beta to GA protocol

### DIFF
--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -78,9 +78,11 @@ class RealtimeSession:
         """Open WS and send session.update with voice+instructions."""
         connect = _require_websockets()
         url = f"{REALTIME_URL}?model={self.model}"
+        # GA protocol only: the beta interface (OpenAI-Beta: realtime=v1) was
+        # retired 2026-05-07; sending the header now gets the socket closed
+        # with beta_api_shape_disabled (4000).
         headers = [
             ("Authorization", f"Bearer {self.api_key}"),
-            ("OpenAI-Beta", "realtime=v1"),
         ]
         # websockets.sync.client.connect accepts either additional_headers=
         # (newer) or extra_headers= depending on version; try the newer
@@ -90,15 +92,23 @@ class RealtimeSession:
         except TypeError:
             self._ws = connect(url, extra_headers=headers)
 
+        # GA session shape: type is required, modalities/formats moved under
+        # output_modalities and audio.{input,output}.format. 24 kHz PCM16
+        # matches what the audio bridge downstream expects (beta pcm16 default).
         self._send_json(
             {
                 "type": "session.update",
                 "session": {
-                    "voice": self.voice,
+                    "type": "realtime",
                     "instructions": self.instructions,
-                    "modalities": ["audio", "text"],
-                    "output_audio_format": "pcm16",
-                    "input_audio_format": "pcm16",
+                    "output_modalities": ["audio"],
+                    "audio": {
+                        "input": {"format": {"type": "audio/pcm", "rate": 24000}},
+                        "output": {
+                            "format": {"type": "audio/pcm", "rate": 24000},
+                            "voice": self.voice,
+                        },
+                    },
                 },
             }
         )
@@ -135,12 +145,9 @@ class RealtimeSession:
                 },
             }
         )
-        self._send_json(
-            {
-                "type": "response.create",
-                "response": {"modalities": ["audio"]},
-            }
-        )
+        # Output modalities come from the GA session config; response.create
+        # takes no per-response modalities override here.
+        self._send_json({"type": "response.create"})
 
         bytes_written = 0
         sink_fp = None
@@ -166,7 +173,8 @@ class RealtimeSession:
                 if not isinstance(frame, dict):
                     continue
                 ftype = frame.get("type")
-                if ftype == "response.audio.delta":
+                # GA event name (beta's response.audio.delta no longer exists).
+                if ftype == "response.output_audio.delta":
                     b64 = frame.get("delta") or frame.get("audio") or ""
                     if b64 and sink_fp is not None:
                         try:
@@ -188,9 +196,9 @@ class RealtimeSession:
                 elif ftype == "error":
                     err = frame.get("error") or frame
                     raise RuntimeError(f"realtime error: {err}")
-                # All other frames (response.created, response.output_item.*,
-                # response.audio_transcript.delta, rate_limits.updated, ...)
-                # are ignored for v2.
+                # All other frames (response.output_item.*, response.output_
+                # audio_transcript.delta, rate_limits.updated, ...) are
+                # ignored for v2.
         finally:
             if sink_fp is not None:
                 sink_fp.close()

--- a/tests/plugins/test_google_meet_realtime.py
+++ b/tests/plugins/test_google_meet_realtime.py
@@ -97,24 +97,26 @@ def test_connect_sends_session_update_with_voice_and_instructions(monkeypatch):
     )
     sess.connect()
 
-    # Auth + beta headers set.
+    # Auth header set; the retired beta header must NOT be sent (the GA
+    # endpoint closes the socket with beta_api_shape_disabled if it is).
     assert captured["url"].startswith("wss://api.openai.com/v1/realtime")
     assert "model=gpt-realtime" in captured["url"]
     headers = captured["headers"] or []
     hdict = dict(headers)
     assert hdict.get("Authorization") == "Bearer sk-test"
-    assert hdict.get("OpenAI-Beta") == "realtime=v1"
+    assert "OpenAI-Beta" not in hdict
 
-    # First frame sent must be session.update with the right shape.
+    # First frame sent must be a GA-shaped session.update.
     assert len(ws.sent) == 1
     update = ws.sent[0]
     assert update["type"] == "session.update"
     s = update["session"]
-    assert s["voice"] == "verse"
+    assert s["type"] == "realtime"
     assert s["instructions"] == "Be brief."
-    assert set(s["modalities"]) == {"audio", "text"}
-    assert s["output_audio_format"] == "pcm16"
-    assert s["input_audio_format"] == "pcm16"
+    assert s["output_modalities"] == ["audio"]
+    assert s["audio"]["output"]["voice"] == "verse"
+    assert s["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
+    assert s["audio"]["output"]["format"] == {"type": "audio/pcm", "rate": 24000}
 
 
 # ---------------------------------------------------------------------------
@@ -130,8 +132,8 @@ def test_speak_sends_create_and_response_and_writes_audio(monkeypatch, tmp_path)
 
     recv_frames = [
         {"type": "response.created"},
-        {"type": "response.audio.delta", "delta": b64},
-        {"type": "response.audio.delta", "delta": base64.b64encode(b"more").decode()},
+        {"type": "response.output_audio.delta", "delta": b64},
+        {"type": "response.output_audio.delta", "delta": base64.b64encode(b"more").decode()},
         {"type": "response.done"},
     ]
     ws = _FakeWS(recv_frames=recv_frames)
@@ -151,8 +153,9 @@ def test_speak_sends_create_and_response_and_writes_audio(monkeypatch, tmp_path)
     assert item["content"][0]["type"] == "input_text"
     assert item["content"][0]["text"] == "Hello everyone."
 
-    resp = ws.sent[2]["response"]
-    assert resp["modalities"] == ["audio"]
+    # GA response.create carries no per-response modalities override; output
+    # modalities come from the session config.
+    assert "response" not in ws.sent[2]
 
     # Audio file got decoded + appended bytes.
     data = sink.read_bytes()


### PR DESCRIPTION
## What does this PR do?

Fixes OpenAI Realtime voice being broken in the `google_meet` plugin. OpenAI retired the beta Realtime interface on **2026-05-07** — connecting with the `OpenAI-Beta: realtime=v1` header now gets the websocket closed with `beta_api_shape_disabled` (code 4000), so realtime mode fails at connect.

Removing the header alone is not enough (an earlier revision of #37781 tried that): dropping it opts the connection into the **GA protocol**, which also renamed the session config shape and the audio streaming event. A header-only fix connects but stays silent — the GA server streams `response.output_audio.delta`, which the old event loop (listening for beta's `response.audio.delta`) ignores, so `speak()` writes 0 audio bytes while reporting `ok=True`.

This PR completes the GA migration:

- drop the retired `OpenAI-Beta: realtime=v1` header
- send GA-shaped `session.update`: `session.type: "realtime"`, `output_modalities`, `audio.{input,output}.format` objects (`{"type": "audio/pcm", "rate": 24000}` — same 24 kHz PCM16 the audio bridge already expects), voice under `audio.output`
- send plain `response.create` (output modalities come from the session config)
- read the GA audio event `response.output_audio.delta`

## Related Issue

Split out of #37781 (which now carries only the Meet locale fix) per the one-logical-change-per-PR guideline.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/google_meet/realtime/openai_client.py` — header removal, GA `session.update` / `response.create` payloads, GA audio event name
- `tests/plugins/test_google_meet_realtime.py` — assert the GA session shape, assert the beta header is absent, fake-WS frames use the GA event name

## How to Test

1. `pytest tests/plugins/test_google_meet_realtime.py -q` → 9 passed
2. Live (needs `OPENAI_API_KEY`): instantiate `RealtimeSession`, `connect()`, `speak("Say hi.")` — see log below
3. In-meeting: `HERMES_MEET_MODE=realtime` join a meeting and ask the bot to speak

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs (supersedes the realtime half of #37781)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the full `tests/plugins/` tree locally (all pass); `tests/gateway`/`tests/integration`/`tests/acp_adapter` need optional deps not in my env (aiohttp etc.) — relying on CI for those
- [x] I've added tests for my changes
- [x] I've tested on my platform: Arch Linux (kernel 7.0.9), Python 3.13

### Documentation & Housekeeping

- [x] Docs — N/A (no user-facing API change; internal protocol migration)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure websocket protocol change)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Live run of the migrated client against `wss://api.openai.com/v1/realtime?model=gpt-realtime`:

```
connect: OK
speak ok: True | bytes_written: 508800 | sink size: 508800
```

Raw GA event probe (same endpoint, no beta header, GA session.update accepted):

```
event types seen: {
 "session.created": 1, "session.updated": 1,
 "conversation.item.added": 2, "conversation.item.done": 2,
 "response.created": 1, "response.output_item.added": 1,
 "response.content_part.added": 1,
 "response.output_audio_transcript.delta": 2,
 "response.output_audio.delta": 23,
 "response.output_audio.done": 1, "response.done": 1
}
decoded audio bytes: 278400
```

Note `response.output_audio.delta` — the beta name `response.audio.delta` never fires on GA, which is why a header-only fix produces a mute bot. References: [Realtime GA migration guide](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/realtime-audio-preview-api-migration-guide), [OpenAI Realtime WebSocket docs](https://developers.openai.com/api/docs/guides/realtime-websocket).
