### PR TITLE
fix(installer): quote browser env override paths

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -337,19 +337,26 @@ function Find-SystemBrowser {
     return $null
 }
 
+function ConvertTo-DotenvShellValue {
+    param([string]$Value)
+    $escaped = $Value -replace "'", "'\''"
+    return "'$escaped'"
+}
+
 function Write-BrowserEnv {
     param([string]$BrowserPath)
     if (-not (Test-Path $HermesHome)) {
         New-Item -ItemType Directory -Force -Path $HermesHome | Out-Null
     }
     $envFile = Join-Path $HermesHome ".env"
+    $line = "AGENT_BROWSER_EXECUTABLE_PATH=$(ConvertTo-DotenvShellValue $BrowserPath)"
     if (-not (Test-Path $envFile)) {
-        Set-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=$BrowserPath" -Encoding UTF8
+        Set-Content -Path $envFile -Value $line -Encoding UTF8
         return
     }
     $content = Get-Content $envFile -Raw -ErrorAction SilentlyContinue
     if ($content -and $content -match "AGENT_BROWSER_EXECUTABLE_PATH=") { return }
-    Add-Content -Path $envFile -Value "AGENT_BROWSER_EXECUTABLE_PATH=$BrowserPath" -Encoding UTF8
+    Add-Content -Path $envFile -Value $line -Encoding UTF8
 }
 
 function Install-AgentBrowser {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1877,11 +1877,11 @@ strip_snap_browser_override() {
     local env_file="$HERMES_HOME/.env"
 
     [ -f "$env_file" ] || return 0
-    grep -Eq '^AGENT_BROWSER_EXECUTABLE_PATH=/snap/' "$env_file" 2>/dev/null || return 0
+    grep -Eq "^AGENT_BROWSER_EXECUTABLE_PATH=(['\"])?/snap/" "$env_file" 2>/dev/null || return 0
 
     local tmp
     tmp="$(mktemp)" || return 0
-    if grep -Ev '^AGENT_BROWSER_EXECUTABLE_PATH=/snap/|^# Hermes Agent browser tools' "$env_file" > "$tmp"; then
+    if grep -Ev "^AGENT_BROWSER_EXECUTABLE_PATH=(['\"])?/snap/|^# Hermes Agent browser tools" "$env_file" > "$tmp"; then
         mv "$tmp" "$env_file"
         log_warn "Removed stale Snap browser override (AGENT_BROWSER_EXECUTABLE_PATH=/snap/...) from $env_file"
         log_info "Hermes will use the bundled Chromium instead."
@@ -1890,6 +1890,12 @@ strip_snap_browser_override() {
     else
         rm -f "$tmp"
     fi
+}
+
+quote_dotenv_shell_value() {
+    # Produce a POSIX-shell-sourceable .env value. Single quotes are literal in
+    # both shell and python-dotenv; embedded quotes use the standard '\'' splice.
+    printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
 }
 
 run_browser_install_with_timeout() {
@@ -2106,7 +2112,7 @@ configure_browser_env_from_system_browser() {
     {
         echo ""
         echo "# Hermes Agent browser tools — explicit browser override."
-        echo "AGENT_BROWSER_EXECUTABLE_PATH=$browser_path"
+        printf "AGENT_BROWSER_EXECUTABLE_PATH=%s\n" "$(quote_dotenv_shell_value "$browser_path")"
     } >> "$env_file"
     log_success "Configured browser tools to use $browser_path"
 }

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
 
 
 def test_install_script_does_not_autodetect_system_browser_on_path() -> None:
@@ -48,11 +49,56 @@ def test_install_script_strips_stale_snap_browser_override() -> None:
     text = INSTALL_SH.read_text()
 
     assert "strip_snap_browser_override()" in text
-    assert "^AGENT_BROWSER_EXECUTABLE_PATH=/snap/" in text
+    assert "^AGENT_BROWSER_EXECUTABLE_PATH=(['\\\"])?/snap/" in text
     # Both install paths invoke the migration before resolving a browser.
     assert text.count("strip_snap_browser_override") >= 3
     # A snap path is rejected by find_system_browser itself.
     assert "/snap/*) return 1 ;;" in text
+
+
+def test_install_script_quotes_browser_override_for_shell_source(tmp_path: Path) -> None:
+    """Spaced browser overrides written to .env must remain shell-sourceable."""
+    import subprocess
+
+    text = INSTALL_SH.read_text()
+    assert "quote_dotenv_shell_value()" in text
+    assert "AGENT_BROWSER_EXECUTABLE_PATH=%s" in text
+
+    start = text.index("quote_dotenv_shell_value() {")
+    end = text.index("\n}\n", start) + 3
+    helper = text[start:end]
+    browser_path = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    script = f"""
+set -eu
+{helper}
+env_file="$1"
+printf 'AGENT_BROWSER_EXECUTABLE_PATH=%s\\n' "$(quote_dotenv_shell_value "$2")" > "$env_file"
+set -a
+. "$env_file"
+set +a
+printf '%s' "$AGENT_BROWSER_EXECUTABLE_PATH"
+"""
+    env_file = tmp_path / ".env"
+    try:
+        proc = subprocess.run(
+            ["bash", "-c", script, "bash", str(env_file), browser_path],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout == browser_path
+    finally:
+        env_file.unlink(missing_ok=True)
+
+
+def test_install_ps1_quotes_browser_override_writer() -> None:
+    """Windows installer should not write a divergent bare .env value."""
+    text = INSTALL_PS1.read_text()
+
+    assert "ConvertTo-DotenvShellValue" in text
+    assert "AGENT_BROWSER_EXECUTABLE_PATH=$(ConvertTo-DotenvShellValue $BrowserPath)" in text
+    assert "AGENT_BROWSER_EXECUTABLE_PATH=$BrowserPath" not in text
 
 
 def test_playwright_installs_are_timeout_guarded() -> None:
@@ -289,4 +335,3 @@ def test_override_retry_skipped_on_unsupported_arch() -> None:
     r = _run_install_fn("ubuntu", "26.04", native_fails=True, arch="riscv64")
     assert len(r["runs"]) == 1, r["runs"]
     assert r["final_rc"] == 1
-


### PR DESCRIPTION
Fixes #57247.

## Summary
- quote `AGENT_BROWSER_EXECUTABLE_PATH` when installers persist explicit browser overrides to `.env`
- keep the stale Snap override cleanup working for quoted and unquoted values
- add regression coverage for shell-sourcing spaced browser paths plus the PowerShell writer shape

## Duplicate check
- checked open PRs for #57247 and `AGENT_BROWSER_EXECUTABLE_PATH` installer changes before opening
- only unrelated browser availability PR found (#48185)

## Tests
- `.venv/bin/python -m pytest tests/test_install_sh_browser_install.py -q -k "browser_override or snap"`
- `.venv/bin/python -m pytest tests/test_install_sh_browser_install.py -q`
- `.venv/bin/python -m ruff check tests/test_install_sh_browser_install.py`
- `scripts/run_tests.sh tests/test_install_sh_browser_install.py -q`

Note: `pwsh` is not installed in this local environment, so the PowerShell installer assertion is text-level coverage.