### PR TITLE
fix(state): preserve reasoning fields when forking sessions

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3092,6 +3092,30 @@ class SessionDB:
                 return content
         return content
 
+    @staticmethod
+    def _encode_json_field(value: Any) -> Optional[str]:
+        """Serialize a structured JSON column without double-encoding JSON text."""
+        if not value:
+            return None
+        if isinstance(value, str):
+            try:
+                json.loads(value)
+                return value
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return json.dumps(value)
+
+    @staticmethod
+    def _decode_json_field(value: Any, field_name: str) -> Any:
+        """Deserialize a JSON column, returning None on corrupt stored data."""
+        if not value:
+            return None
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Failed to deserialize %s, falling back to None", field_name)
+            return None
+
     def append_message(
         self,
         session_id: str,
@@ -3124,18 +3148,9 @@ class SessionDB:
         message by its platform-side identifier.
         """
         # Serialize structured fields to JSON before entering the write txn
-        reasoning_details_json = (
-            json.dumps(reasoning_details)
-            if reasoning_details else None
-        )
-        codex_items_json = (
-            json.dumps(codex_reasoning_items)
-            if codex_reasoning_items else None
-        )
-        codex_message_items_json = (
-            json.dumps(codex_message_items)
-            if codex_message_items else None
-        )
+        reasoning_details_json = self._encode_json_field(reasoning_details)
+        codex_items_json = self._encode_json_field(codex_reasoning_items)
+        codex_message_items_json = self._encode_json_field(codex_message_items)
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
@@ -3232,15 +3247,9 @@ class SessionDB:
             codex_message_items = (
                 msg.get("codex_message_items") if role == "assistant" else None
             )
-            reasoning_details_json = (
-                json.dumps(reasoning_details) if reasoning_details else None
-            )
-            codex_items_json = (
-                json.dumps(codex_reasoning_items) if codex_reasoning_items else None
-            )
-            codex_message_items_json = (
-                json.dumps(codex_message_items) if codex_message_items else None
-            )
+            reasoning_details_json = self._encode_json_field(reasoning_details)
+            codex_items_json = self._encode_json_field(codex_reasoning_items)
+            codex_message_items_json = self._encode_json_field(codex_message_items)
             tool_calls_json = json.dumps(tool_calls) if tool_calls else None
             # Accept either `platform_message_id` (new explicit name) or
             # `message_id` (yuanbao's existing convention on message dicts).
@@ -3428,6 +3437,14 @@ class SessionDB:
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
                     msg["tool_calls"] = []
+            if msg.get("role") == "assistant":
+                for field in (
+                    "reasoning_details",
+                    "codex_reasoning_items",
+                    "codex_message_items",
+                ):
+                    if msg.get(field):
+                        msg[field] = self._decode_json_field(msg[field], field)
             result.append(msg)
         return result
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import json
 import sqlite3
 import time
 import pytest
@@ -1160,6 +1161,49 @@ class TestMessageStorage:
         assert len(conv) == 1
         assert conv[0]["codex_reasoning_items"] == codex_items
         assert conv[0]["codex_reasoning_items"][0]["encrypted_content"] == "enc_blob_123"
+
+    def test_replace_messages_preserves_structured_reasoning_columns(self, db):
+        """Fork-style get_messages() -> replace_messages() must not double-encode reasoning JSON."""
+        db.create_session(session_id="src", source="cli")
+        db.create_session(session_id="fork", source="cli", parent_session_id="src")
+        reasoning_details = [
+            {"type": "reasoning.text", "text": "step one"},
+        ]
+        codex_reasoning_items = [
+            {"id": "rs_1", "type": "reasoning", "encrypted_content": "blob"},
+        ]
+        codex_message_items = [
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "done"}],
+            },
+        ]
+        db.append_message(
+            "src",
+            role="assistant",
+            content="done",
+            reasoning_details=reasoning_details,
+            codex_reasoning_items=codex_reasoning_items,
+            codex_message_items=codex_message_items,
+        )
+
+        db.replace_messages("fork", db.get_messages("src"))
+
+        fork_msg = db.get_messages_as_conversation("fork")[0]
+        assert fork_msg["reasoning_details"] == reasoning_details
+        assert fork_msg["codex_reasoning_items"] == codex_reasoning_items
+        assert fork_msg["codex_message_items"] == codex_message_items
+
+        stored = db._conn.execute(
+            "SELECT reasoning_details, codex_reasoning_items, codex_message_items "
+            "FROM messages WHERE session_id = ?",
+            ("fork",),
+        ).fetchone()
+        assert isinstance(json.loads(stored["reasoning_details"]), list)
+        assert isinstance(json.loads(stored["codex_reasoning_items"]), list)
+        assert isinstance(json.loads(stored["codex_message_items"]), list)
 
 
 # =========================================================================


### PR DESCRIPTION
Fixes #57240.

## Summary
- hydrate structured reasoning JSON columns in `get_messages()` alongside content/tool calls
- avoid double-encoding already-serialized reasoning JSON on message writes
- add a fork-style `get_messages() -> replace_messages()` regression covering `reasoning_details`, `codex_reasoning_items`, and `codex_message_items`

## Duplicate check
- checked open PRs for #57240, fork reasoning, `replace_messages`, and Codex reasoning item terms before opening
- no matching open PRs found

## Tests
- `.venv/bin/python -m pytest tests/test_hermes_state.py -q -k "reasoning_columns or reasoning_details or codex_reasoning_items or codex_message_items"`
- `.venv/bin/python -m pytest tests/test_hermes_state.py -q -k "MessageStorage"`
- `.venv/bin/python -m ruff check hermes_state.py tests/test_hermes_state.py`
- `scripts/run_tests.sh tests/test_hermes_state.py -q -k "MessageStorage"`