### PR TITLE
fix(desktop): stop macOS Tahoe misplacing the traffic lights

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -21,6 +21,7 @@ const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
+const os = require('node:os')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -45,7 +46,10 @@ const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-ma
 const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-env.cjs')
 const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
 const { readWslWindowsClipboardImage } = require('./wsl-clipboard-image.cjs')
-const { nativeOverlayWidth: computeNativeOverlayWidth } = require('./titlebar-overlay-width.cjs')
+const {
+  nativeOverlayWidth: computeNativeOverlayWidth,
+  macTitleBarOverlayHeight
+} = require('./titlebar-overlay-width.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { readLiveUpdateMarker } = require('./update-marker.cjs')
 const {
@@ -160,6 +164,9 @@ const IS_PACKAGED = app.isPackaged
 const IS_MAC = process.platform === 'darwin'
 const IS_WINDOWS = process.platform === 'win32'
 const IS_WSL = isWslEnvironment()
+// Truthful macOS kernel major (Tahoe = 25). Product version lies (16 vs 26) per
+// build SDK, so gate Tahoe workarounds on Darwin instead.
+const DARWIN_MAJOR = IS_MAC ? Number.parseInt(os.release(), 10) || 0 : 0
 const APP_ROOT = app.getAppPath()
 
 function hiddenWindowsChildOptions(options = {}) {
@@ -532,7 +539,10 @@ const TITLEBAR_OVERLAY_COLOR = 'rgba(1, 0, 0, 0)'
 
 function getTitleBarOverlayOptions() {
   if (IS_MAC) {
-    return { height: TITLEBAR_HEIGHT }
+    // Tahoe (Darwin 25+) misplaces the traffic lights when the overlay has a
+    // nonzero height (electron#49183); 0 there keeps them at the configured
+    // inset. See macTitleBarOverlayHeight.
+    return { height: macTitleBarOverlayHeight({ darwinMajor: DARWIN_MAJOR, titlebarHeight: TITLEBAR_HEIGHT }) }
   }
 
   // WSLg paints WCO via the RDP host's own min/max/close, so requesting

--- a/apps/desktop/electron/titlebar-overlay-width.cjs
+++ b/apps/desktop/electron/titlebar-overlay-width.cjs
@@ -21,4 +21,23 @@ function nativeOverlayWidth({ isWindows = false, isWsl = false, isMac = false } 
   return OVERLAY_FALLBACK_WIDTH
 }
 
-module.exports = { OVERLAY_FALLBACK_WIDTH, nativeOverlayWidth }
+// macOS Tahoe ships as Darwin 25 (Sequoia is 24); the Darwin number is truthful,
+// unlike the product version which macOS reports as 16 or 26 depending on the
+// build SDK.
+const MACOS_TAHOE_DARWIN_MAJOR = 25
+
+/**
+ * Height (px) to pass to `titleBarOverlay` on macOS. Tahoe (Darwin 25+)
+ * miscalculates the native traffic-light position when the overlay carries a
+ * nonzero height (electron#49183), shoving the lights into the left titlebar
+ * tools. Return 0 there so `setWindowButtonPosition` lands them at the configured
+ * inset; the renderer paints its own drag strips, so nothing is lost. Pre-Tahoe
+ * keeps the full titlebar height, byte-identical.
+ *
+ * @param {{ darwinMajor?: number, titlebarHeight?: number }} opts
+ */
+function macTitleBarOverlayHeight({ darwinMajor = 0, titlebarHeight = 0 } = {}) {
+  return darwinMajor >= MACOS_TAHOE_DARWIN_MAJOR ? 0 : titlebarHeight
+}
+
+module.exports = { MACOS_TAHOE_DARWIN_MAJOR, OVERLAY_FALLBACK_WIDTH, macTitleBarOverlayHeight, nativeOverlayWidth }

--- a/apps/desktop/electron/titlebar-overlay-width.test.cjs
+++ b/apps/desktop/electron/titlebar-overlay-width.test.cjs
@@ -1,7 +1,12 @@
 const assert = require('node:assert/strict')
 const test = require('node:test')
 
-const { OVERLAY_FALLBACK_WIDTH, nativeOverlayWidth } = require('./titlebar-overlay-width.cjs')
+const {
+  MACOS_TAHOE_DARWIN_MAJOR,
+  OVERLAY_FALLBACK_WIDTH,
+  macTitleBarOverlayHeight,
+  nativeOverlayWidth
+} = require('./titlebar-overlay-width.cjs')
 
 // This static reservation is only the pre-layout FALLBACK. Once laid out the
 // renderer reads the exact width from navigator.windowControlsOverlay
@@ -33,4 +38,17 @@ test('macOS uses traffic lights, not a WCO overlay, so it reserves nothing', () 
 
 test('the fallback width is a sane positive pixel value', () => {
   assert.ok(Number.isInteger(OVERLAY_FALLBACK_WIDTH) && OVERLAY_FALLBACK_WIDTH > 0)
+})
+
+test('pre-Tahoe keeps the full titlebar overlay height', () => {
+  assert.equal(macTitleBarOverlayHeight({ darwinMajor: MACOS_TAHOE_DARWIN_MAJOR - 1, titlebarHeight: 34 }), 34)
+})
+
+test('Tahoe (Darwin 25+) drops the overlay height to 0 to avoid electron#49183', () => {
+  assert.equal(macTitleBarOverlayHeight({ darwinMajor: MACOS_TAHOE_DARWIN_MAJOR, titlebarHeight: 34 }), 0)
+  assert.equal(macTitleBarOverlayHeight({ darwinMajor: MACOS_TAHOE_DARWIN_MAJOR + 1, titlebarHeight: 34 }), 0)
+})
+
+test('macTitleBarOverlayHeight tolerates missing args (unknown platform → 0)', () => {
+  assert.equal(macTitleBarOverlayHeight(), 0)
 })


### PR DESCRIPTION
Reopens the fix from #57446 (that PR got closed while still referencing an orphaned earlier commit after a force-push; the branch now carries the corrected fix below).

## Summary
On **macOS Tahoe** the left titlebar tools overlap the native traffic lights. Root cause is [electron#49183](https://github.com/electron/electron/issues/49183): when `titleBarOverlay` carries a **nonzero `height`**, `setWindowButtonPosition()` miscalculates the traffic-light position on Tahoe, so the lights don't land at our configured inset (`x:24`) and collide with the left tool cluster.

We hit it exactly — on macOS we pass `titleBarOverlay: { height: 34 }` + `setWindowButtonPosition({x:24})` (Electron 40).

## Fix
- On macOS **Tahoe (Darwin 25+)** pass `titleBarOverlay` **height `0`** — the value confirmed unaffected in electron#49183. Pre-Tahoe keeps the full `34` (byte-identical).
- The renderer already paints its own `-webkit-app-region:drag` strips (`app-shell.tsx`), so a `0` overlay height costs no draggable area; native lights are positioned via `trafficLightPosition`/`setWindowButtonPosition` regardless.
- Gate on the **truthful Darwin kernel major** (`os.release()` → `25` = Tahoe), *not* `process.getSystemVersion()`, which macOS reports as `16` **or** `26` depending on the build SDK (Apple's compat-versioning trick).
- Logic extracted to `macTitleBarOverlayHeight()` in the pure `titlebar-overlay-width.cjs`, with `node:test` coverage.

## Why not just bump Electron?
The upstream fix ([electron#51989](https://github.com/electron/electron/pull/51989)) is **still an open, unmerged PR** — not in 40.10.6 or any 41/42/43 release — and it's native code inside the prebuilt Electron binary, so it can't be cherry-picked app-side. This app-level workaround is the only remedy available today.

## Test plan
- [ ] macOS Tahoe (26+): traffic lights sit at the normal inset; left titlebar tools no longer overlap them
- [ ] macOS ≤ 15 (Sequoia): titlebar/overlay unchanged
- [ ] Window dragging still works on Tahoe (renderer drag strips)
- [ ] Windows/Linux/WSLg: overlay unaffected (non-mac branch untouched)
- [x] `node --test apps/desktop/electron/titlebar-overlay-width.test.cjs` passes