### PR TITLE
fix(gateway): tolerate unresolved launchd user ids

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2416,7 +2416,14 @@ def _launchd_user_home() -> Path:
     Profile-mode Hermes often sets ``HOME`` to a profile-scoped directory, but
     launchd user agents still live under the actual account home.
     """
-    return Path(get_real_home())
+    home = Path(get_real_home())
+    if str(home) in {"/tmp", "/private/tmp"}:
+        raise RuntimeError(
+            "Could not resolve the real macOS user home for launchd artifacts. "
+            "Set HERMES_REAL_HOME to your account home directory, e.g. "
+            "HERMES_REAL_HOME=/Users/you."
+        )
+    return home
 
 
 def get_launchd_plist_path() -> Path:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -35,6 +35,7 @@ from hermes_cli.config import (
     save_env_value,
     write_platform_config_field,
 )
+from hermes_constants import get_real_home
 
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
@@ -2415,9 +2416,7 @@ def _launchd_user_home() -> Path:
     Profile-mode Hermes often sets ``HOME`` to a profile-scoped directory, but
     launchd user agents still live under the actual account home.
     """
-    import pwd
-
-    return Path(pwd.getpwuid(os.getuid()).pw_dir)  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    return Path(get_real_home())
 
 
 def get_launchd_plist_path() -> Path:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2469,12 +2469,52 @@ class TestProfileArg:
 
         monkeypatch.setattr(Path, "home", lambda: profile_home)
         monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.delenv("HOME", raising=False)
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
         monkeypatch.setattr(pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(machine_home)))
 
         plist_path = gateway_cli.get_launchd_plist_path()
 
         assert plist_path == machine_home / "Library" / "LaunchAgents" / "ai.hermes.gateway-orcha.plist"
+
+    def test_launchd_plist_path_falls_back_to_home_when_uid_lookup_fails(self, tmp_path, monkeypatch):
+        machine_home = tmp_path / "machine-home"
+        machine_home.mkdir()
+
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(machine_home))
+
+        def raise_key_error(uid):
+            raise KeyError(f"getpwuid(): uid not found: {uid}")
+
+        monkeypatch.setattr(pwd, "getpwuid", raise_key_error)
+
+        plist_path = gateway_cli.get_launchd_plist_path()
+
+        assert plist_path == machine_home / "Library" / "LaunchAgents" / "ai.hermes.gateway.plist"
+
+    def test_launchd_plist_path_uses_real_home_when_home_is_profile_home(self, tmp_path, monkeypatch):
+        profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
+        profile_home = profile_dir / "home"
+        real_home = tmp_path / "real-home"
+        profile_home.mkdir(parents=True)
+        real_home.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+
+        def raise_key_error(uid):
+            raise KeyError(f"getpwuid(): uid not found: {uid}")
+
+        monkeypatch.setattr(pwd, "getpwuid", raise_key_error)
+
+        plist_path = gateway_cli.get_launchd_plist_path()
+
+        assert plist_path == real_home / "Library" / "LaunchAgents" / "ai.hermes.gateway-orcha.plist"
 
 
 class TestRemapPathForUser:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2516,6 +2516,20 @@ class TestProfileArg:
 
         assert plist_path == real_home / "Library" / "LaunchAgents" / "ai.hermes.gateway-orcha.plist"
 
+    def test_launchd_plist_path_rejects_unresolved_tmp_home(self, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.delenv("HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: Path("/tmp"))
+
+        def raise_key_error(uid):
+            raise KeyError(f"getpwuid(): uid not found: {uid}")
+
+        monkeypatch.setattr(pwd, "getpwuid", raise_key_error)
+
+        with pytest.raises(RuntimeError, match="HERMES_REAL_HOME"):
+            gateway_cli.get_launchd_plist_path()
+
 
 class TestRemapPathForUser:
     """Unit tests for _remap_path_for_user()."""


### PR DESCRIPTION
Fixes #57292.

## Summary
- resolve macOS launchd user-agent paths through the existing `get_real_home()` helper instead of calling `pwd.getpwuid(os.getuid())` directly
- preserve profile-scoped plist names while avoiding profile `HOME` for LaunchAgents
- cover app-hosted/sandboxed shells where the UID cannot be resolved by `pwd.getpwuid`

## Duplicate check
- searched open PRs for `57292`, `launchd pwd getpwuid UID`, `_launchd_user_home`, `get_launchd_plist_path`, and `LaunchAgents pwd`
- no competing open PR found for this issue or code path

## Tests
- `.venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q -k "launchd_plist_path"`
- `.venv/bin/python -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -q -k "launchd_plist_path"`