### PR TITLE
fix(desktop): hide Windows updater console during hand-off (#56884)

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2240,7 +2240,7 @@ async function applyUpdates(opts = {}) {
 
     // Detached so the updater outlives this process — it needs us GONE before
     // `hermes update` will run (the venv shim is locked while we live).
-    const child = spawn(updater, updaterArgs, {
+    const child = spawn(updater, updaterArgs, hiddenWindowsChildOptions({
       cwd: HERMES_HOME,
       env: {
         ...process.env,
@@ -2248,9 +2248,8 @@ async function applyUpdates(opts = {}) {
         PATH: pathWithHermesManagedNode(venvBin)
       },
       detached: true,
-      stdio: 'ignore',
-      windowsHide: false
-    })
+      stdio: 'ignore'
+    }))
     child.unref()
 
     rememberLog(`[updates] launched updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`)
@@ -2299,7 +2298,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
 
   await releaseBackendLockForUpdate(updateRoot)
 
-  const child = spawn(updater, updaterArgs, {
+  const child = spawn(updater, updaterArgs, hiddenWindowsChildOptions({
     cwd: HERMES_HOME,
     env: {
       ...process.env,
@@ -2307,9 +2306,8 @@ async function handOffWindowsBootstrapRecovery(reason) {
       PATH: pathWithHermesManagedNode(venvBin)
     },
     detached: true,
-    stdio: 'ignore',
-    windowsHide: false
-  })
+    stdio: 'ignore'
+  }))
   child.unref()
 
   rememberLog(

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -100,10 +100,15 @@ test('desktop backend teardown tree-kills Windows backend descendants', () => {
 test('intentional or interactive desktop child processes stay documented', () => {
   const source = readElectronFile('main.cjs')
 
-  assert.match(source, /windowsHide: false/)
   assert.match(source, /handOffWindowsBootstrapRecovery/)
   assert.match(source, /'--repair', '--branch'/)
   assert.match(source, /'--update', '--branch'/)
+  assert.doesNotMatch(source, /windowsHide: false/)
+  const updaterSpawns = [...source.matchAll(/spawn\(\s*updater,\s*updaterArgs/g)]
+  assert.equal(updaterSpawns.length, 2, 'expected both in-app update and bootstrap recovery updater spawns')
+  for (const match of updaterSpawns) {
+    requireHiddenChildOptions(source.slice(match.index), /spawn\(\s*updater,\s*updaterArgs/)
+  }
   assert.match(source, /nodePty\.spawn\(command, args/)
   assert.match(source, /spawn\('cmd\.exe', \['\/c', 'start'/)
 })


### PR DESCRIPTION
## Summary

- wrap `hermes-setup.exe` sp on Windows with `hiddenWindowsChildOptions()` so in-app update and bootstrap recovery no longer flash a visible console window
- remove the explicit `windowsHide: false` on both updater spawn sites in `applyUpdates()` and `handOffWindowsBootstrapRecovery()`

Fixes #56884

## Test plan

- [x] `node --test apps/desktop/electron/windows-child-process.test.cjs`
- [ ] On Windows: trigger Desktop in-app update and confirm no black console flash during `hermes-setup.exe --update`
