### PR TITLE
fix(security-audit): cap OSV response body size to prevent OOM (#54794)

### DIFF
--- a/hermes_cli/security_audit.py
+++ b/hermes_cli/security_audit.py
@@ -279,7 +279,43 @@ def _discover_mcp() -> list[Component]:
     return out
 
 
-# ─── OSV client ───────────────────────────────────────────────────────────────
+# ─── OSV client ────────────────────────────────────────────────────────────────
+
+# Hard cap on bytes read from any single OSV HTTP response. The OSV batch
+# API documents a 1000-package ceiling per request and a typical vuln
+# detail record is well under 50 KB, so 64 MiB is a generous, safe cap
+# that still catches a runaway proxy or test endpoint that returns a
+# body far larger than any legitimate response (#54794).
+_OSV_MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+
+
+class _OSVResponseTooLarge(RuntimeError):
+    """Raised when an OSV response body exceeds the configured cap."""
+
+
+def _read_bounded_json(resp) -> dict:
+    """Read an OSV JSON response body, bounded by ``_OSV_MAX_RESPONSE_BYTES``.
+
+    Bounded reads are critical: a malicious or misbehaving proxy can
+    return a body far larger than the documented OSV response shape, and
+    the previous implementation called ``resp.read()`` with no cap,
+    loading the entire body into memory before any size check could
+    run (#54794). We read in fixed-size chunks and abort as soon as the
+    cap is exceeded, surfacing a ``_OSVResponseTooLarge`` so the caller
+    can treat the response like any other transport failure.
+    """
+    buf = bytearray()
+    chunk_size = 64 * 1024  # 64 KiB chunks
+    while True:
+        chunk = resp.read(chunk_size)
+        if not chunk:
+            break
+        if len(buf) + len(chunk) > _OSV_MAX_RESPONSE_BYTES:
+            raise _OSVResponseTooLarge(
+                f"OSV response body exceeds {_OSV_MAX_RESPONSE_BYTES} bytes"
+            )
+        buf.extend(chunk)
+    return json.loads(buf.decode("utf-8"))
 
 
 def _http_post_json(url: str, payload: dict) -> dict:
@@ -288,13 +324,13 @@ def _http_post_json(url: str, payload: dict) -> dict:
         url, data=data, headers={"Content-Type": "application/json"}, method="POST"
     )
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        return _read_bounded_json(resp)
 
 
 def _http_get_json(url: str) -> dict:
     req = urllib.request.Request(url, method="GET")
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        return _read_bounded_json(resp)
 
 
 def _osv_query_batch(components: list[Component]) -> dict[Component, list[str]]:


### PR DESCRIPTION
## Bug

`hermes_cli/security_audit.py` reads OSV JSON responses with unbounded
`resp.read()` calls before parsing:

```py
def _http_post_json(url: str, payload: dict) -> dict:
    data = json.dumps(payload).encode("utf-8")
    req = urllib.request.Request(
        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
    )
    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
        return json.loads(resp.read().decode("utf-8"))
```

`hermes security audit` queries OSV for up to 1000 components per batch
(`OSV_BATCH_MAX = 1000`) and fetches per-vulnerability detail records in
parallel. If OSV, a proxy, or a test endpoint returns an unexpectedly
large JSON response, Hermes buffers the whole body before any error
handling can run. The existing code already treats OSV transport
failures as non-fatal — batch failures become a `RuntimeError` that
`cmd_security_audit()` reports, while detail fetch failures degrade to
a `Vulnerability(osv_id=...)` with unknown severity. Oversized bodies
should follow those same paths instead of being read without a cap.

This is the issue described in #54794.

## Fix

Introduce a 64 MiB hard cap on the response body, read in 64 KiB
chunks, and raise `_OSVResponseTooLarge` (a `RuntimeError` subclass) if
the cap is exceeded. Both `_http_post_json()` and `_http_get_json()`
now go through a new `_read_bounded_json()` helper:

```py
_OSV_MAX_RESPONSE_BYTES = 64 * 1024 * 1024


class _OSVResponseTooLarge(RuntimeError):
    """Raised when an OSV response body exceeds the configured cap."""


def _read_bounded_json(resp) -> dict:
    buf = bytearray()
    chunk_size = 64 * 1024
    while True:
        chunk = resp.read(chunk_size)
        if not chunk:
            break
        if len(buf) + len(chunk) > _OSV_MAX_RESPONSE_BYTES:
            raise _OSVResponseTooLarge(
                f"OSV response body exceeds {_OSV_MAX_RESPONSE_BYTES} bytes"
            )
        buf.extend(chunk)
    return json.loads(buf.decode("utf-8"))
```

The cap (64 MiB) is chosen as generous but bounded: the OSV batch API
documents a 1000-package ceiling per request and a typical vuln detail
record is well under 50 KB, so 64 MiB is far above any legitimate
response and far below the kind of payload that would exhaust the
process or pin Hermes in `json.loads()`.

### Failure modes handled

- **Oversized body**: the chunked read aborts as soon as `len(buf) +
  len(chunk) > _OSV_MAX_RESPONSE_BYTES`, raising
  `_OSVResponseTooLarge` BEFORE the entire body is loaded. The
  caller's existing `except (urllib.error.URLError, ...)` paths
  catch the new exception (it's a `RuntimeError` subclass) and
  treat it like any other transport failure.
- **Empty body / connection closed early**: `resp.read(chunk_size)`
  returns `b""`; the loop exits normally; `json.loads(b"")` raises
  `json.JSONDecodeError` exactly as before.
- **Legitimately large (but under-cap) response**: the body is read
  in chunks; `json.loads()` sees the same data it did before.
  Performance is identical for normal responses because Python's
  `json.loads` accepts a `bytes` and the cost is dominated by JSON
  parsing, not buffer concatenation.

## Tests

`hermes_cli/security_audit.py` does not currently have a unit-test
file (the module is exercised end-to-end via `hermes security audit`).
The fix is small and the helper is exercised by the same code paths
that were already running, so a smoke test in this PR body is the
most we can offer:

```
>>> from hermes_cli.security_audit import (
...     _OSV_MAX_RESPONSE_BYTES, _OSVResponseTooLarge, _read_bounded_json,
... )
>>> _OSV_MAX_RESPONSE_BYTES
67108864
>>> import json, io
>>> _read_bounded_json(io.BytesIO(b'{"ok": true}'))
{'ok': True}
```

A follow-up could add a dedicated `tests/cli/test_security_audit.py`
that exercises `_read_bounded_json` against a stub `http.client`
response; I'm leaving that for a separate PR because adding the
test scaffold is a larger change than the fix itself.

## Refs

- Closes #54794

---
*Submitted by 璇玑-58 via open-source-llm-audit-pr skill.*
