### PR TITLE
fix(browser): apply private-page guard to browser_cdp frame_id routing

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -430,6 +430,70 @@ def test_runtime_evaluate_blocked_when_current_page_is_private(monkeypatch):
     assert calls == []
 
 
+def test_frame_id_route_blocked_when_current_page_is_private(monkeypatch):
+    """frame_id routing (OOPIF via supervisor) must not bypass the guard
+    applied to the stateless path — same private-page boundary either way."""
+    supervisor_calls = []
+
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: PRIVATE_URL)
+
+    def fake_supervisor_route(**kwargs):
+        supervisor_calls.append(kwargs)
+        return json.dumps({"success": True, "result": {"value": "private data"}})
+
+    monkeypatch.setattr(
+        browser_cdp_tool, "_browser_cdp_via_supervisor", fake_supervisor_route
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.body.innerText"},
+            frame_id="frame-1",
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert "private or internal address" in result["error"]
+    assert supervisor_calls == []
+
+
+def test_frame_id_route_allowed_when_page_is_not_private(monkeypatch):
+    """Sanity check: the new guard call must not block ordinary frame_id
+    routing when the current page isn't private."""
+    supervisor_calls = []
+
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+    monkeypatch.setattr(bt, "_current_page_private_url", lambda task_id: None)
+
+    def fake_supervisor_route(**kwargs):
+        supervisor_calls.append(kwargs)
+        return json.dumps({"success": True, "result": {"value": "ok"}})
+
+    monkeypatch.setattr(
+        browser_cdp_tool, "_browser_cdp_via_supervisor", fake_supervisor_route
+    )
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Runtime.evaluate",
+            params={"expression": "document.title"},
+            frame_id="frame-1",
+            task_id="task-1",
+        )
+    )
+
+    assert result.get("success") is True
+    assert len(supervisor_calls) == 1
+
+
 def test_page_navigate_to_private_url_blocked_before_cdp(monkeypatch):
     calls = []
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -428,6 +428,15 @@ def browser_cdp(
 
     # --- Route iframe-scoped calls through the supervisor ---------------
     if frame_id:
+        # Same private-page/SSRF boundary as the stateless path below —
+        # frame_id routing must not become the sibling bypass for it.
+        blocked = _browser_cdp_private_guard(
+            task_id=effective_task_id,
+            method=method,
+            params=params or {},
+        )
+        if blocked:
+            return blocked
         return _browser_cdp_via_supervisor(
             task_id=effective_task_id,
             frame_id=frame_id,


### PR DESCRIPTION
## Summary

`browser_cdp`'s `frame_id` (OOPIF) routing path returns early via `_browser_cdp_via_supervisor(...)` before `_browser_cdp_private_guard(...)` ever runs. The stateless path (no `frame_id`) a few lines below correctly calls the guard before dispatching. This means a cloud browser that has navigated to a private/internal URL can still have its content read via `browser_cdp(method="Runtime.evaluate", ..., frame_id="...")`, even though the identical call without `frame_id` is correctly blocked.

This is the same private-page/SSRF boundary that `browser_snapshot`, `browser_console`, `browser_eval`, and the stateless `browser_cdp` path already enforce (see the guard series in `_browser_cdp_private_guard`'s own docstring: "raw CDP calls ... must not become the sibling bypass for the guarded browser tools").

## Fix

Call the same `_browser_cdp_private_guard(...)` used by the stateless path before dispatching to `_browser_cdp_via_supervisor(...)`, so both routing modes share one boundary. No other behavior changes.

## Test plan

- [x] Added `test_frame_id_route_blocked_when_current_page_is_private` — confirms a `frame_id` call is blocked (and the supervisor is never reached) when the current page is private, mirroring the existing stateless-path test.
- [x] Added `test_frame_id_route_allowed_when_page_is_not_private` — sanity check that ordinary `frame_id` routing still works when the page isn't private.
- [x] `uv run --frozen --extra dev python -m pytest tests/tools/test_browser_cdp_tool.py -x -q` — 25 passed.
- [x] `uv run --frozen --extra dev python -m pytest tests/tools/ -k browser -q` — 514 passed, 23 skipped (unrelated), no regressions.
- [x] `ruff check` on both changed files — clean.