### PR TITLE
fix(tui): skip full lockfile check in monorepo to avoid spurious npm installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1488,6 +1488,13 @@ def _tui_need_npm_install(root: Path) -> bool:
     ink = ws_root / "node_modules" / "@hermes" / "ink" / "package.json"
     if not ink.is_file():
         return True
+    if ws_root != root:
+        # Monorepo: ``npm install --workspace ui-tui`` only installs the
+        # TUI workspace, not apps/desktop or other workspaces.  The full
+        # lockfile comparison below would flag every other-workspace
+        # package as "missing" and trigger a reinstall on every launch.
+        # @hermes/ink presence is a sufficient canary.
+        return False
     if not lock.is_file():
         return False
     marker = ws_root / "node_modules" / ".package-lock.json"


### PR DESCRIPTION
_tui_need_npm_install compared all workspace packages in package-lock.json (~1380 packages) against the installed marker from a --workspace ui-tui scoped install (~670 packages). Since the scoped install intentionally skips apps/desktop and other workspaces, the check flagged hundreds of packages as missing every launch, triggering npm install --workspace ui-tui on every `hermes --tui` invocation.

When in a monorepo (workspace root != tui dir), trust @hermes/ink presence as a sufficient canary instead of running the full lockfile comparison.

### Before
Every `hermes --tui` → Spurious npm install (1-3s delay).

### After
`hermes --tui` launches immediately when deps are installed.