### PR TITLE
fix(gateway): stop _ensure_windows_gateway_venv_imports leaking PYTHONPATH into global environment

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -202,10 +202,6 @@ def _ensure_windows_gateway_venv_imports() -> None:
         sys.path.insert(insert_at, site_entry)
 
         os.environ["VIRTUAL_ENV"] = str(resolved_venv)
-        pythonpath = [project_entry, site_entry]
-        if os.environ.get("PYTHONPATH"):
-            pythonpath.append(os.environ["PYTHONPATH"])
-        os.environ["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
         return
 
 

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -309,8 +309,9 @@ def test_windows_gateway_venv_imports_add_site_packages(monkeypatch, tmp_path):
     assert gateway_run.sys.path[:2] == [project_root, str(site_packages)]
     assert str(pth_extra) in gateway_run.sys.path
     assert gateway_run.os.environ["VIRTUAL_ENV"] == str(venv_dir.resolve())
-    pythonpath = gateway_run.os.environ["PYTHONPATH"].split(gateway_run.os.pathsep)
-    assert pythonpath[:3] == [project_root, str(site_packages), "already-there"]
+    # PYTHONPATH is no longer set globally — sys.path handles in-process
+    # imports and child-process spawners build their own PYTHONPATH explicitly.
+    assert gateway_run.os.environ["PYTHONPATH"] == "already-there"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Removes the global `os.environ["PYTHONPATH"]` assignment from `_ensure_windows_gateway_venv_imports()` in `gateway/run.py`. The function already patches `sys.path` (lines 194–202) which is sufficient for the gateway process itself. Setting `PYTHONPATH` globally causes every non-Hermes Python process launched from a Desktop session to inherit Hermes' venv paths, leading to version conflicts and GPU initialization failures.

## Related Issue

Fixes #57467

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Removed 4 lines that set `os.environ["PYTHONPATH"]` in `_ensure_windows_gateway_venv_imports()`. The `sys.path` patch and `VIRTUAL_ENV` assignment are kept.
- `tests/gateway/test_restart_drain.py`: Updated `test_windows_gateway_venv_imports_add_site_packages` to verify PYTHONPATH is no longer modified (remains at its pre-call value).

## How to Test

1. Run `python -m pytest tests/gateway/test_restart_drain.py::test_windows_gateway_venv_imports_add_site_packages -xvs` — should pass.
2. Run `python -m pytest tests/gateway/test_restart_drain.py -x` — all 24 tests should pass.
3. Run `python -m pytest tests/tools/test_windows_native_support.py -k windowless -x` — should pass (verifies `windowless_gateway_restart_spec` still sets PYTHONPATH in its subprocess-specific env overlay).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-only code path; no POSIX impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
