### PR TITLE
fix(desktop): persist active profile after startup refresh

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -102,6 +102,7 @@ import {
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import { setPrimaryDesktopProfile } from './profile-set-routing'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -7699,17 +7700,14 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
 })
 
 ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
-ipcMain.handle('hermes:profile:set', async (_event, name) => {
-  const next = writeActiveDesktopProfile(name)
-
-  // Switching profiles is a backend re-home: relaunch the dashboard under the
-  // new HERMES_HOME. Pool backends keep their own homes, so only the primary
-  // is torn down.
-  await teardownPrimaryBackendAndWait()
-  mainWindow?.reload()
-
-  return { profile: next }
-})
+ipcMain.handle('hermes:profile:set', async (_event, name) =>
+  setPrimaryDesktopProfile(name, {
+    primaryProfileKey,
+    writeActiveDesktopProfile,
+    teardownPrimaryBackendAndWait,
+    reloadMainWindow: () => mainWindow?.reload()
+  })
+)
 
 ipcMain.on('hermes:previewShortcutActive', (_event, active) => {
   previewShortcutActive = Boolean(active)

--- a/apps/desktop/electron/profile-set-routing.test.ts
+++ b/apps/desktop/electron/profile-set-routing.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { setPrimaryDesktopProfile } from './profile-set-routing'
+
+test('setting the existing primary profile persists without teardown or reload', async () => {
+  const teardownPrimaryBackendAndWait = vi.fn(async () => undefined)
+  const reloadMainWindow = vi.fn()
+
+  const result = await setPrimaryDesktopProfile('keo', {
+    primaryProfileKey: () => 'keo',
+    writeActiveDesktopProfile: () => 'keo',
+    teardownPrimaryBackendAndWait,
+    reloadMainWindow
+  })
+
+  assert.deepEqual(result, { profile: 'keo' })
+  assert.equal(teardownPrimaryBackendAndWait.mock.calls.length, 0)
+  assert.equal(reloadMainWindow.mock.calls.length, 0)
+})
+
+test('switching the primary profile tears down before reloading', async () => {
+  const effects: string[] = []
+
+  const result = await setPrimaryDesktopProfile('keo', {
+    primaryProfileKey: () => 'default',
+    writeActiveDesktopProfile: () => 'keo',
+    teardownPrimaryBackendAndWait: async () => {
+      effects.push('teardown')
+    },
+    reloadMainWindow: () => {
+      effects.push('reload')
+    }
+  })
+
+  assert.deepEqual(result, { profile: 'keo' })
+  assert.deepEqual(effects, ['teardown', 'reload'])
+})

--- a/apps/desktop/electron/profile-set-routing.ts
+++ b/apps/desktop/electron/profile-set-routing.ts
@@ -1,0 +1,22 @@
+export interface SetPrimaryDesktopProfileDeps {
+  primaryProfileKey: () => string
+  writeActiveDesktopProfile: (name: unknown) => null | string
+  teardownPrimaryBackendAndWait: () => Promise<void>
+  reloadMainWindow: () => void
+}
+
+export async function setPrimaryDesktopProfile(
+  name: unknown,
+  deps: SetPrimaryDesktopProfileDeps
+): Promise<{ profile: null | string }> {
+  const previous = deps.primaryProfileKey()
+  const next = deps.writeActiveDesktopProfile(name)
+  const nextKey = next || 'default'
+
+  if (nextKey !== previous) {
+    await deps.teardownPrimaryBackendAndWait()
+    deps.reloadMainWindow()
+  }
+
+  return { profile: next }
+}

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -13,12 +13,21 @@ const resetStarmapGraph = vi.fn()
 vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForProfile }))
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
-  setApiRequestProfile: vi.fn()
+  setApiRequestProfile: vi.fn(),
+  STARTUP_REQUEST_TIMEOUT_MS: 60_000
 }))
 vi.mock('@/lib/query-client', () => ({ queryClient: { invalidateQueries: vi.fn() } }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, $profiles, ensureGatewayProfile, refreshProfiles } = await import('./profile')
+const {
+  $activeGatewayProfile,
+  $activeProfile,
+  $profiles,
+  ensureGatewayProfile,
+  refreshActiveProfile,
+  refreshProfiles
+} = await import('./profile')
+
 const { $connection } = await import('./session')
 const { queryClient } = await import('@/lib/query-client')
 const { getProfiles } = await import('@/hermes')
@@ -40,21 +49,42 @@ const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
   ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
 
 const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
+const api = vi.fn()
+const getDesktopProfile = vi.fn()
+const setDesktopProfile = vi.fn()
 
 beforeEach(() => {
+  api.mockReset()
+  getDesktopProfile.mockReset()
+  setDesktopProfile.mockReset()
   getConnection.mockReset()
   ensureGatewayForProfile.mockClear()
+  api.mockResolvedValue({ current: 'default' })
+  getDesktopProfile.mockResolvedValue({ profile: 'default' })
+  setDesktopProfile.mockResolvedValue({ profile: 'default' })
   $gateway.set({ id: 'live-socket' })
+  $activeProfile.set('default')
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
   $profiles.set([])
-  vi.stubGlobal('window', { hermesDesktop: { getConnection } })
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      api,
+      getConnection,
+      profile: {
+        get: getDesktopProfile,
+        set: setDesktopProfile
+      }
+    }
+  })
   vi.mocked(queryClient.invalidateQueries).mockClear()
   resetStarmapGraph.mockClear()
 })
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  Reflect.deleteProperty(window, 'hermesDesktop')
   $connection.set(null)
 })
 
@@ -112,6 +142,34 @@ describe('profile-scoped cache invalidation', () => {
 
     expect(queryClient.invalidateQueries).toHaveBeenCalled()
     expect(resetStarmapGraph).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('refreshActiveProfile persistence (#57283)', () => {
+  it('persists the backend active profile when the desktop preference is unset', async () => {
+    api
+      .mockResolvedValueOnce({ current: 'keo' })
+      .mockResolvedValueOnce({ profiles: [profile('default', true), profile('keo')] })
+    getDesktopProfile.mockResolvedValueOnce({ profile: null })
+    setDesktopProfile.mockResolvedValueOnce({ profile: 'keo' })
+
+    await refreshActiveProfile()
+
+    expect($activeProfile.get()).toBe('keo')
+    expect(getDesktopProfile).toHaveBeenCalled()
+    expect(setDesktopProfile).toHaveBeenCalledWith('keo')
+  })
+
+  it('does not rewrite an existing desktop profile preference', async () => {
+    api
+      .mockResolvedValueOnce({ current: 'keo' })
+      .mockResolvedValueOnce({ profiles: [profile('default', true), profile('keo')] })
+    getDesktopProfile.mockResolvedValueOnce({ profile: 'keo' })
+
+    await refreshActiveProfile()
+
+    expect($activeProfile.get()).toBe('keo')
+    expect(setDesktopProfile).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -115,7 +115,19 @@ export async function refreshActiveProfile(): Promise<void> {
       timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
     })
 
-    setActiveProfile(res.current || 'default')
+    const current = normalizeProfileKey(res.current)
+    setActiveProfile(current)
+
+    try {
+      const stored = await window.hermesDesktop.profile.get()
+
+      if (!stored.profile) {
+        await window.hermesDesktop.profile.set(current)
+      }
+    } catch {
+      // Profile persistence is best-effort; the visible active profile is still
+      // updated from the backend response above.
+    }
   } catch {
     // Backend may not be ready; keep the last known value.
   }


### PR DESCRIPTION
## Summary

Fixes #57283.

When the desktop renderer refreshes `/api/profiles/active`, it now backfills the Electron main-process active profile preference if that preference is unset. That makes the profile sticky for future desktop launches, so `startHermes()` can pin the local backend with `--profile <name>` instead of falling back to the legacy sticky `~/.hermes/active_profile` / default profile path.

The `hermes:profile:set` IPC now avoids tearing down and reloading the primary backend when the requested profile already matches the primary profile. This keeps startup backfill from causing a reload loop while still preserving the existing reload behavior for real profile switches.

## Duplicate audit

Before opening this PR I checked the current open PR list for:

- `57283`
- `active-profile`
- `desktop profile`
- `profile preference`
- `profile persistence`
- `refreshActiveProfile`
- `hermes:profile:set`

No open PR matched this issue or mechanism.

## Tests

- `npm exec --workspace apps/desktop -- vitest run --environment jsdom src/store/profile.test.ts`
- `npm exec --workspace apps/desktop -- eslint src/store/profile.ts src/store/profile.test.ts electron/main.cjs`
