### PR TITLE
fix(gateway): resume provider rate limits after reset

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -750,6 +750,7 @@ def init_agent(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = None
     agent._persist_user_message_timestamp = None
+    agent._suppress_current_user_message_persistence = False
 
     # Cache anthropic image-to-text fallbacks per image payload/URL so a
     # single tool loop does not repeatedly re-run auxiliary vision on the

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -748,6 +748,7 @@ def init_agent(
     # user message intentionally differs from the persisted transcript
     # (e.g. CLI voice mode adds a temporary prefix for the live call only).
     agent._persist_user_message_idx = None
+    agent._persist_user_message_token = None
     agent._persist_user_message_override = None
     agent._persist_user_message_timestamp = None
     agent._suppress_current_user_message_persistence = False

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3105,6 +3105,14 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
                 context["reset_at"] = time.time() + float(retry_after)
             except (TypeError, ValueError):
                 pass
+        resets_in_seconds = payload.get("resets_in_seconds")
+        if resets_in_seconds not in {None, ""} and "reset_at" not in context:
+            try:
+                delay = float(resets_in_seconds)
+                if delay > 0:
+                    context["reset_at"] = time.time() + delay
+            except (TypeError, ValueError):
+                pass
 
     response = getattr(error, "response", None)
     headers = getattr(response, "headers", None)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3106,7 +3106,11 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
             except (TypeError, ValueError):
                 pass
         resets_in_seconds = payload.get("resets_in_seconds")
-        if resets_in_seconds not in {None, ""} and "reset_at" not in context:
+        if (
+            resets_in_seconds is not None
+            and resets_in_seconds != ""
+            and "reset_at" not in context
+        ):
             try:
                 delay = float(resets_in_seconds)
                 if delay > 0:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -843,7 +843,30 @@ def compress_context(
                     # for search/recovery (Teknium review — keep one durable id
                     # WITHOUT destroying history, unlike a hard replace_messages).
                     # See #38763.
-                    agent._session_db.archive_and_compact(agent.session_id, compressed)
+                    durable_compressed = agent._messages_for_session_persistence(
+                        compressed
+                    )
+                    agent._session_db.archive_and_compact(
+                        agent.session_id, durable_compressed
+                    )
+                    # ``durable_compressed`` is a persistence-clean copy, so
+                    # stamp the corresponding live rows explicitly. The shared
+                    # post-write cursor reset below intentionally forces an
+                    # identity rebase; without these markers, the same-turn
+                    # final flush would append the compacted prefix again and
+                    # could skip the assistant that follows a suppressed row.
+                    suppressed_idx = None
+                    if getattr(
+                        agent,
+                        "_suppress_current_user_message_persistence",
+                        False,
+                    ):
+                        suppressed_idx = agent._current_turn_user_message_index(
+                            compressed
+                        )
+                    for idx, msg in enumerate(compressed):
+                        if isinstance(msg, dict) and idx != suppressed_idx:
+                            msg["_db_persisted"] = True
                     # Reset the flush identity set so the next turn's appends are
                     # diffed against the COMPACTED transcript: the compacted dicts
                     # are passed as conversation_history next turn and skipped by

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -544,6 +544,7 @@ def run_conversation(
     persist_user_message: Optional[Any] = None,
     persist_user_timestamp: Optional[float] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    suppress_user_message_persistence: bool = False,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -596,6 +597,7 @@ def run_conversation(
         stream_callback,
         persist_user_message,
         persist_user_timestamp,
+        suppress_user_message_persistence,
         restore_or_build_system_prompt=_restore_or_build_system_prompt,
         install_safe_stdio=_install_safe_stdio,
         sanitize_surrogates=_sanitize_surrogates,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4206,6 +4206,7 @@ def run_conversation(
                         # different exit code. ``rate_limit`` / ``billing`` here
                         # mean "quota wall, not a task error".
                         "failure_reason": classified.reason.value,
+                        "error_context": error_context,
                     }
 
                 # For rate limits, respect the Retry-After header if present

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2548,7 +2548,10 @@ def _estimate_message_chars(msg: Dict[str, Any]) -> int:
         return len(str(msg))
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
-        if k == "_anthropic_content_blocks":
+        # Match the chat-completions wire sanitizer: every top-level private
+        # metadata key is removed before dispatch, so persistence/turn identity
+        # markers must not reduce the calculated output budget.
+        if isinstance(k, str) and k.startswith("_"):
             continue
         if k == "content":
             if isinstance(v, list):

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -125,6 +125,7 @@ def build_turn_context(
     stream_callback,
     persist_user_message: Optional[Any],
     persist_user_timestamp: Optional[float] = None,
+    suppress_user_message_persistence: bool = False,
     *,
     restore_or_build_system_prompt,
     install_safe_stdio,
@@ -212,6 +213,9 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    agent._suppress_current_user_message_persistence = bool(
+        suppress_user_message_persistence
+    )
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -37,6 +37,8 @@ from agent.model_metadata import (
 
 logger = logging.getLogger(__name__)
 
+_CURRENT_TURN_USER_MARKER = "_hermes_current_turn_user_id"
+
 
 def _compression_made_progress(
     orig_len: int, new_len: int, orig_tokens: int, new_tokens: int
@@ -211,6 +213,7 @@ def build_turn_context(
     # Store stream callback for _interruptible_api_call to pick up.
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None
+    agent._persist_user_message_token = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
     agent._suppress_current_user_message_persistence = bool(
@@ -315,9 +318,12 @@ def build_turn_context(
     # Add the current user message after the prompt/session setup has made
     # close persistence safe. The handoff above preserves any marker already
     # stamped by an earlier close flush.
+    current_turn_user_token = uuid.uuid4().hex
+    user_msg[_CURRENT_TURN_USER_MARKER] = current_turn_user_token
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
+    agent._persist_user_message_token = current_turn_user_token
 
     # Track user turns for memory flush and periodic nudge logic.
     agent._user_turn_count += 1
@@ -494,6 +500,27 @@ def build_turn_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
                 )
+                current_turn_user_idx = next(
+                    (
+                        idx
+                        for idx, msg in enumerate(messages)
+                        if isinstance(msg, dict)
+                        and msg.get("role") == "user"
+                        and msg.get(_CURRENT_TURN_USER_MARKER)
+                        == current_turn_user_token
+                    ),
+                    -1,
+                )
+                if current_turn_user_idx < 0:
+                    # Third-party context engines must not be able to summarize
+                    # away the live turn. Re-append it for the API; the early
+                    # persistence path already handled genuine user rows, while
+                    # synthetic provider rows remain suppression-marked.
+                    recovered_user_msg = user_msg.copy()
+                    recovered_user_msg.pop("_db_persisted", None)
+                    messages.append(recovered_user_msg)
+                    current_turn_user_idx = len(messages) - 1
+                agent._persist_user_message_idx = current_turn_user_idx
                 # Re-estimate now so size-only compression (same row count,
                 # lower token count — e.g. summarising tool outputs) is
                 # recognised as progress instead of being misread as

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -62,10 +62,16 @@ class GatewayAuthorizationMixin:
         """Resolve the live adapter for an inbound ``SessionSource``."""
         if source is None:
             return None
+        # Relay-delivered messages keep the underlying platform for session
+        # identity, but all egress still travels over the authenticated relay
+        # socket. The marker is process-local and never accepted from wire data.
+        platform = getattr(source, "platform", None)
+        if getattr(source, "delivered_via_upstream_relay", False) is True:
+            platform = Platform.RELAY
         # ``getattr`` guards test fixtures that build a bare source via
         # SimpleNamespace and omit ``profile`` (see AGENTS.md pitfall #17).
         return self._authorization_adapter(
-            getattr(source, "platform", None),
+            platform,
             getattr(source, "profile", None),
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6870,6 +6870,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     run_generation=getattr(
                         self, "_session_run_generation", {}
                     ).get(entry.session_key, 0),
+                    resume_transport=getattr(entry, "resume_transport", None),
                 ):
                     scheduled += 1
                 continue
@@ -6970,11 +6971,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         if reset_epoch is None or not session_key or source is None:
             return False
+        resume_transport = (
+            Platform.RELAY.value
+            if (
+                getattr(source, "delivered_via_upstream_relay", False) is True
+                or getattr(source, "platform", None) == Platform.RELAY
+            )
+            else None
+        )
         try:
             marked = await self.async_session_store.mark_resume_pending(
                 session_key,
                 reason="provider_rate_limit",
                 not_before=reset_epoch,
+                resume_transport=resume_transport,
             )
         except Exception as exc:
             logger.warning(
@@ -6990,6 +7000,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source=source,
             reset_at=reset_epoch,
             run_generation=run_generation,
+            resume_transport=resume_transport,
         )
 
     async def _supersede_provider_rate_limit_resume_for_user_turn(
@@ -7037,6 +7048,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: SessionSource,
         reset_at: float,
         run_generation: int,
+        resume_transport: Optional[str] = None,
     ) -> bool:
         """Install an in-memory task for an already-persisted provider deadline."""
         # ``reset_at`` may already be in the past when restored after a gateway
@@ -7048,6 +7060,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         if reset_epoch is None or not session_key or source is None:
             return False
+        normalized_transport = None
+        if resume_transport:
+            try:
+                normalized_transport = Platform(resume_transport).value
+            except (TypeError, ValueError):
+                return False
 
         tasks = getattr(self, "_provider_rate_limit_resume_tasks", None)
         if tasks is None:
@@ -7060,7 +7078,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "_hermes_provider_resume_identity",
                 None,
             )
-            if existing_identity == (run_generation, reset_epoch):
+            if existing_identity == (
+                run_generation,
+                reset_epoch,
+                normalized_transport,
+            ):
                 return True
             if not getattr(existing, "_hermes_provider_resume_dispatched", False):
                 existing.cancel()
@@ -7075,13 +7097,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source=source,
                 reset_at=reset_epoch,
                 run_generation=run_generation,
+                resume_transport=normalized_transport,
             )
         )
         setattr(task, "_hermes_provider_resume_dispatched", False)
         setattr(
             task,
             "_hermes_provider_resume_identity",
-            (run_generation, reset_epoch),
+            (run_generation, reset_epoch, normalized_transport),
         )
         tasks[session_key] = task
         self._background_tasks.add(task)
@@ -7100,6 +7123,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: SessionSource,
         reset_at: float,
         run_generation: int,
+        resume_transport: Optional[str] = None,
     ) -> None:
         """Wake after provider reset and route a synthetic continuation turn."""
         try:
@@ -7160,22 +7184,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
                 if not still_pending:
                     return
-            try:
-                if not self._is_user_authorized(source):
+            resume_source = source
+            adapter = None
+            if resume_transport == Platform.RELAY.value:
+                adapter = self._authorization_adapter(
+                    Platform.RELAY,
+                    getattr(source, "profile", None),
+                )
+                # A restored relay continuation has no fresh connector event to
+                # authenticate. Trust only the local durable marker plus a live
+                # adapter that explicitly delegates authorization upstream.
+                if not (
+                    adapter is not None
+                    and getattr(adapter, "authorization_is_upstream", False) is True
+                ):
                     logger.warning(
-                        "Skipping provider rate-limit continuation for %s: session owner is no longer authorized",
+                        "Skipping provider rate-limit continuation for %s: "
+                        "authenticated relay adapter is unavailable",
                         session_key,
                     )
                     return
-            except Exception as exc:
-                logger.warning(
-                    "Skipping provider rate-limit continuation for %s: authorization check failed: %s",
-                    session_key,
-                    exc,
+                resume_source = dataclasses.replace(
+                    source,
+                    message_id=None,
+                    delivered_via_upstream_relay=True,
                 )
-                return
+            else:
+                try:
+                    if not self._is_user_authorized(source):
+                        logger.warning(
+                            "Skipping provider rate-limit continuation for %s: "
+                            "session owner is no longer authorized",
+                            session_key,
+                        )
+                        return
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping provider rate-limit continuation for %s: "
+                        "authorization check failed: %s",
+                        session_key,
+                        exc,
+                    )
+                    return
+                adapter = self._adapter_for_source(source)
 
-            adapter = self._adapter_for_source(source)
             if adapter is None:
                 logger.info(
                     "Skipping provider rate-limit continuation for %s: adapter not ready for %s",
@@ -7209,7 +7261,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # without persisting a synthetic user row.
                 text="",
                 message_type=MessageType.TEXT,
-                source=source,
+                source=resume_source,
                 internal=True,
                 metadata={
                     "_hermes_provider_rate_limit_resume": (
@@ -7219,6 +7271,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "reset_at": reset_at,
                 },
             )
+            if resume_transport == Platform.RELAY.value:
+                capture_scope = getattr(adapter, "_capture_scope", None)
+                if callable(capture_scope):
+                    capture_scope(event)
             await self._run_startup_resume_event(adapter, event, session_key)
         except asyncio.CancelledError:
             raise
@@ -8693,11 +8749,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _agent is _AGENT_PENDING_SENTINEL:
                     continue
                 try:
-                    await self.async_session_store.mark_resume_pending(
+                    _marked = await self.async_session_store.mark_resume_pending(
                         _sk,
                         _pre_drain_reason,
                     )
-                    _pre_drain_reasons[_sk] = _pre_drain_reason
+                    if _marked:
+                        _pre_drain_reasons[_sk] = _pre_drain_reason
                 except Exception as _e:
                     logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
 
@@ -10867,7 +10924,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
         self._persist_active_agents()
-        _run_generation = self._begin_session_run_generation(_quick_key)
+        _event_metadata = getattr(event, "metadata", None) or {}
+        _is_provider_resume_candidate = (
+            is_internal
+            and _event_metadata.get("_hermes_provider_rate_limit_resume")
+            is _PROVIDER_RATE_LIMIT_RESUME_EVENT_TOKEN
+        )
+        if is_internal and not _is_provider_resume_candidate:
+            # Background/delegation completions share the session lane but do
+            # not supersede a pending provider continuation. Advancing here
+            # would make that timer stale even though its durable marker still
+            # promises an automatic resume.
+            _run_generation = getattr(
+                self, "_session_run_generation", {}
+            ).get(_quick_key, 0)
+        else:
+            _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
@@ -12746,7 +12818,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
                 if _is_provider_resume_event:
                     for _idx, _msg in enumerate(new_messages):
-                        if isinstance(_msg, dict) and _msg.get("role") == "user":
+                        if (
+                            isinstance(_msg, dict)
+                            and _msg.get("role") == "user"
+                            and _msg.get("_hermes_current_turn_user_id")
+                        ):
                             new_messages = new_messages[:_idx] + new_messages[_idx + 1 :]
                             break
 
@@ -19757,8 +19833,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # through blank" noise.  Treat the marker as fresh when
             # EITHER signal is fresh so the two freshness checks agree.
             _resume_mark_is_fresh = False
+            _resume_reason = None
             if _resume_entry is not None and getattr(_resume_entry, "resume_pending", False):
-                if getattr(_resume_entry, "resume_reason", None) == "provider_rate_limit":
+                _resume_reason = getattr(_resume_entry, "resume_reason", None)
+                if _resume_reason == "provider_rate_limit":
                     # Provider deadlines may be hours or days away. Only the
                     # private, due continuation event may consume this marker;
                     # unrelated internal events must not inherit its guidance.
@@ -19768,11 +19846,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         getattr(_resume_entry, "last_resume_marked_at", None),
                         window_secs=_freshness_window,
                     )
-            _is_resume_pending = bool(
-                _resume_entry is not None
-                and getattr(_resume_entry, "resume_pending", False)
-                and (_interruption_is_fresh or _resume_mark_is_fresh)
-            )
+            if _resume_reason == "provider_rate_limit":
+                # Exclusive verified-resume gate: never OR with transcript
+                # freshness, or process/delegation completions steal the note.
+                _is_resume_pending = bool(
+                    _resume_entry is not None
+                    and getattr(_resume_entry, "resume_pending", False)
+                    and _resume_mark_is_fresh
+                )
+            else:
+                _is_resume_pending = bool(
+                    _resume_entry is not None
+                    and getattr(_resume_entry, "resume_pending", False)
+                    and (_interruption_is_fresh or _resume_mark_is_fresh)
+                )
             _has_fresh_tool_tail = bool(
                 agent_history
                 and agent_history[-1].get("role") == "tool"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1044,6 +1044,8 @@ from agent.replay_cleanup import (  # noqa: E402
 
 _AUTO_CONTINUE_NOTE_PREFIX = "[System note: Your previous turn"
 _AUTO_CONTINUE_FALLBACK_PREFIX = "[System note: A new message"
+_PROVIDER_RATE_LIMIT_MAX_RESUME_DELAY_SECONDS = 90 * 24 * 60 * 60
+_PROVIDER_RATE_LIMIT_RESUME_EVENT_TOKEN = object()
 
 
 def _is_auto_continue_noise(content: Any) -> bool:
@@ -1061,6 +1063,7 @@ def _coerce_provider_rate_limit_reset_at(
     value: Any,
     *,
     now: Optional[float] = None,
+    allow_past: bool = False,
 ) -> Optional[float]:
     """Return a future unix timestamp from provider reset metadata.
 
@@ -1094,13 +1097,59 @@ def _coerce_provider_rate_limit_reset_at(
                 reset_at = parsed.timestamp()
             except ValueError:
                 return None
-    if reset_at is None or not math.isfinite(reset_at) or reset_at <= now:
+    if (
+        reset_at is None
+        or not math.isfinite(reset_at)
+        or (not allow_past and reset_at <= now)
+        or reset_at - now > _PROVIDER_RATE_LIMIT_MAX_RESUME_DELAY_SECONDS
+    ):
         return None
     try:
         datetime.fromtimestamp(reset_at)
     except (OverflowError, OSError, ValueError):
         return None
     return reset_at
+
+
+def _is_verified_provider_rate_limit_resume_event(
+    event: "MessageEvent",
+    session_entry: Any,
+    run_generation: int,
+    *,
+    now: Optional[float] = None,
+) -> bool:
+    """Validate the private identity of a due provider continuation event."""
+    if not getattr(event, "internal", False):
+        return False
+    metadata = getattr(event, "metadata", None)
+    if not isinstance(metadata, dict):
+        return False
+    if (
+        metadata.get("_hermes_provider_rate_limit_resume")
+        is not _PROVIDER_RATE_LIMIT_RESUME_EVENT_TOKEN
+    ):
+        return False
+    if not getattr(session_entry, "resume_pending", False):
+        return False
+    if getattr(session_entry, "resume_reason", None) != "provider_rate_limit":
+        return False
+    try:
+        scheduled_generation = int(metadata["run_generation"])
+        event_reset_at = float(metadata["reset_at"])
+        durable_reset_at = float(session_entry.resume_not_before)
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return False
+    if run_generation != scheduled_generation + 1:
+        return False
+    if not math.isfinite(event_reset_at) or not math.isclose(
+        event_reset_at,
+        durable_reset_at,
+        rel_tol=0.0,
+        abs_tol=1e-6,
+    ):
+        return False
+    current_time = time.time() if now is None else float(now)
+    return current_time >= durable_reset_at
 
 
 def _provider_rate_limit_reset_at(agent_result: dict) -> Optional[float]:
@@ -6914,7 +6963,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         run_generation: int,
     ) -> bool:
         """Persist then install a provider reset continuation off the event loop."""
-        reset_epoch = _coerce_provider_rate_limit_reset_at(reset_at, now=0)
+        reset_epoch = _coerce_provider_rate_limit_reset_at(
+            reset_at,
+            now=time.time(),
+            allow_past=True,
+        )
         if reset_epoch is None or not session_key or source is None:
             return False
         try:
@@ -6988,7 +7041,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Install an in-memory task for an already-persisted provider deadline."""
         # ``reset_at`` may already be in the past when restored after a gateway
         # restart.  It is still a valid deadline and should drain immediately.
-        reset_epoch = _coerce_provider_rate_limit_reset_at(reset_at, now=0)
+        reset_epoch = _coerce_provider_rate_limit_reset_at(
+            reset_at,
+            now=time.time(),
+            allow_past=True,
+        )
         if reset_epoch is None or not session_key or source is None:
             return False
 
@@ -6998,6 +7055,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._provider_rate_limit_resume_tasks = tasks
         existing = tasks.get(session_key)
         if existing is not None and not existing.done():
+            existing_identity = getattr(
+                existing,
+                "_hermes_provider_resume_identity",
+                None,
+            )
+            if existing_identity == (run_generation, reset_epoch):
+                return True
             if not getattr(existing, "_hermes_provider_resume_dispatched", False):
                 existing.cancel()
             logger.info(
@@ -7014,6 +7078,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         )
         setattr(task, "_hermes_provider_resume_dispatched", False)
+        setattr(
+            task,
+            "_hermes_provider_resume_identity",
+            (run_generation, reset_epoch),
+        )
         tasks[session_key] = task
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
@@ -7115,6 +7184,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return
 
+            # No await is allowed between this compare and the slot claim. A
+            # newer real turn may have arrived while the durable-state read
+            # above was in flight; never overwrite its generation or slot.
+            if (
+                not self._is_session_run_current(session_key, run_generation)
+                or session_key in self._running_agents
+            ):
+                logger.info(
+                    "Skipping provider rate-limit continuation for %s: newer turn claimed the session",
+                    session_key,
+                )
+                return
+
             # Claim before dispatch so a real inbound message queues behind
             # this continuation. Reuse the startup-resume helper because
             # BasePlatformAdapter.handle_message() itself returns as soon as
@@ -7129,6 +7211,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 message_type=MessageType.TEXT,
                 source=source,
                 internal=True,
+                metadata={
+                    "_hermes_provider_rate_limit_resume": (
+                        _PROVIDER_RATE_LIMIT_RESUME_EVENT_TOKEN
+                    ),
+                    "run_generation": run_generation,
+                    "reset_at": reset_at,
+                },
             )
             await self._run_startup_resume_event(adapter, event, session_key)
         except asyncio.CancelledError:
@@ -8596,16 +8685,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # If the process is killed by the service manager during the
             # drain, the durable marker is already written so the next
             # gateway boot can recover in-flight sessions (#27856).
-            _pre_drain_keys: list[str] = []
+            _pre_drain_reason = (
+                "restart_timeout" if self._restart_requested else "shutdown_timeout"
+            )
+            _pre_drain_reasons: dict[str, str] = {}
             for _sk, _agent in list(self._running_agents.items()):
                 if _agent is _AGENT_PENDING_SENTINEL:
                     continue
                 try:
                     await self.async_session_store.mark_resume_pending(
                         _sk,
-                        "restart_timeout" if self._restart_requested else "shutdown_timeout",
+                        _pre_drain_reason,
                     )
-                    _pre_drain_keys.append(_sk)
+                    _pre_drain_reasons[_sk] = _pre_drain_reason
                 except Exception as _e:
                     logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
 
@@ -8633,10 +8725,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Drain completed gracefully — all running sessions finished.
                 # Clear the pre-drain resume_pending markers so sessions that
                 # completed during the drain window don't carry a stale flag.
-                for _sk in _pre_drain_keys:
+                for _sk, _reason in _pre_drain_reasons.items():
                     if _sk not in self._running_agents:
                         try:
-                            await self.async_session_store.clear_resume_pending(_sk)
+                            await self.async_session_store.clear_resume_pending(
+                                _sk,
+                                reason=_reason,
+                            )
                         except Exception as _e:
                             logger.debug(
                                 "clear_resume_pending after drain failed for %s: %s",
@@ -11307,6 +11402,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        _is_provider_resume_event = _is_verified_provider_rate_limit_resume_event(
+            event,
+            session_entry,
+            run_generation,
+        )
+        _resume_reason_for_turn = getattr(session_entry, "resume_reason", None)
+        if _resume_reason_for_turn == "provider_rate_limit" and not _is_provider_resume_event:
+            _resume_reason_for_turn = None
         # A real user turn owns the lane from this point forward.  Remove the
         # older durable provider continuation immediately; if this turn hits
         # the quota wall again it will persist a fresh reset deadline below.
@@ -12163,8 +12266,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
                 moa_config=getattr(event, "_moa_config", None),
-                persist_user_message=persist_user_message,
+                persist_user_message=(
+                    None if _is_provider_resume_event else persist_user_message
+                ),
                 persist_user_timestamp=persist_user_timestamp,
+                provider_rate_limit_resume=_is_provider_resume_event,
+                suppress_current_user_message_persistence=_is_provider_resume_event,
             )
 
             # Stop persistent typing indicator now that the agent is done.
@@ -12272,13 +12379,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the restart-interruption system note.
             if session_key and _should_clear_resume_pending_after_turn(agent_result):
                 self._clear_restart_failure_count(session_key)
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception as _e:
-                    logger.debug(
-                        "clear_resume_pending failed for %s: %s",
-                        session_key, _e,
-                    )
+                if _resume_reason_for_turn is not None:
+                    try:
+                        await self.async_session_store.clear_resume_pending(
+                            session_key,
+                            reason=_resume_reason_for_turn,
+                        )
+                    except Exception as _e:
+                        logger.debug(
+                            "clear_resume_pending failed for %s: %s",
+                            session_key, _e,
+                        )
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
@@ -12578,55 +12689,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if is_context_overflow_failure:
                 pass  # handled above — skip all transcript writes
             elif agent_failed_early or hidden_reasoning_incomplete:
-                # Transient failure (429/timeout/5xx): persist only the user
-                # message so the next message can load a transcript that
-                # reflects what was said.  Skip the assistant error text since
-                # it's a gateway-generated hint, not model output. Hidden-
-                # reasoning-only incomplete turns follow the same persistence
-                # rule so peer-agent channels don't ingest them as completed
-                # assistant turns. (#7100, #51628)
-                _user_entry = {
-                    "role": "user",
-                    "content": (
-                        persist_user_message
-                        if persist_user_message is not None
-                        else message_text
-                    ),
-                    "timestamp": (
-                        persist_user_timestamp
-                        if persist_user_timestamp is not None
-                        else ts
-                    ),
-                }
-                if event.message_id:
-                    _user_entry["message_id"] = str(event.message_id)
-                # Dedupe: skip if this platform message_id is already in the
-                # transcript (prevents duplicate user turns on Telegram retries
-                # after transient failures). #47237
-                _skip_persist = (
-                    event.message_id
-                    and await self.async_session_store.has_platform_message_id(
-                        session_entry.session_id, str(event.message_id)
-                    )
-                )
-                if _skip_persist:
+                # The provider continuation has no new user turn. If it hits
+                # the limit or ends as a hidden-reasoning-only incomplete turn,
+                # the original user row is already durable.
+                if _is_provider_resume_event:
                     logger.info(
-                        "Skipping duplicate user turn "
-                        "(message_id=%s) in session %s",
-                        event.message_id, session_entry.session_id,
+                        "Skipping synthetic provider-resume user persistence for session %s",
+                        session_entry.session_id,
                     )
                 else:
-                    await self.async_session_store.append_to_transcript(
-                        session_entry.session_id,
-                        _user_entry,
-                        skip_db=agent_persisted,
-                    )
-            else:
-                history_len = agent_result.get("history_offset", len(history))
-                new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
-
-                # If no new messages found (edge case), fall back to simple user/assistant
-                if not new_messages:
+                    # Transient failure (429/timeout/5xx): persist only the user
+                    # message so the next message can load a transcript that
+                    # reflects what was said. Skip the assistant error text since
+                    # it's a gateway-generated hint, not model output. Hidden-
+                    # reasoning-only incomplete turns follow the same persistence
+                    # rule so peer-agent channels don't ingest them as completed
+                    # assistant turns. (#7100, #51628)
                     _user_entry = {
                         "role": "user",
                         "content": (
@@ -12642,11 +12720,59 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     }
                     if event.message_id:
                         _user_entry["message_id"] = str(event.message_id)
-                    await self.async_session_store.append_to_transcript(
-                        session_entry.session_id,
-                        _user_entry,
-                        skip_db=agent_persisted,
+                    # Dedupe: skip if this platform message_id is already in the
+                    # transcript (prevents duplicate user turns on Telegram retries
+                    # after transient failures). #47237
+                    _skip_persist = (
+                        event.message_id
+                        and await self.async_session_store.has_platform_message_id(
+                            session_entry.session_id, str(event.message_id)
+                        )
                     )
+                    if _skip_persist:
+                        logger.info(
+                            "Skipping duplicate user turn "
+                            "(message_id=%s) in session %s",
+                            event.message_id, session_entry.session_id,
+                        )
+                    else:
+                        await self.async_session_store.append_to_transcript(
+                            session_entry.session_id,
+                            _user_entry,
+                            skip_db=agent_persisted,
+                        )
+            else:
+                history_len = agent_result.get("history_offset", len(history))
+                new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
+                if _is_provider_resume_event:
+                    for _idx, _msg in enumerate(new_messages):
+                        if isinstance(_msg, dict) and _msg.get("role") == "user":
+                            new_messages = new_messages[:_idx] + new_messages[_idx + 1 :]
+                            break
+
+                # If no new messages found (edge case), fall back to simple user/assistant
+                if not new_messages:
+                    if not _is_provider_resume_event:
+                        _user_entry = {
+                            "role": "user",
+                            "content": (
+                                persist_user_message
+                                if persist_user_message is not None
+                                else message_text
+                            ),
+                            "timestamp": (
+                                persist_user_timestamp
+                                if persist_user_timestamp is not None
+                                else ts
+                            ),
+                        }
+                        if event.message_id:
+                            _user_entry["message_id"] = str(event.message_id)
+                        await self.async_session_store.append_to_transcript(
+                            session_entry.session_id,
+                            _user_entry,
+                            skip_db=agent_persisted,
+                        )
                     if response:
                         await self.async_session_store.append_to_transcript(
                             session_entry.session_id,
@@ -17645,6 +17771,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        provider_rate_limit_resume: bool = False,
+        suppress_current_user_message_persistence: bool = False,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -17663,6 +17791,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                provider_rate_limit_resume=provider_rate_limit_resume,
+                suppress_current_user_message_persistence=(
+                    suppress_current_user_message_persistence
+                ),
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -17674,6 +17806,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                provider_rate_limit_resume=provider_rate_limit_resume,
+                suppress_current_user_message_persistence=(
+                    suppress_current_user_message_persistence
+                ),
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -17795,6 +17931,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
+        provider_rate_limit_resume: bool = False,
+        suppress_current_user_message_persistence: bool = False,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -19621,9 +19759,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _resume_mark_is_fresh = False
             if _resume_entry is not None and getattr(_resume_entry, "resume_pending", False):
                 if getattr(_resume_entry, "resume_reason", None) == "provider_rate_limit":
-                    # Provider deadlines may be hours or days away.  Their
-                    # explicit durable timestamp is the freshness signal.
-                    _resume_mark_is_fresh = True
+                    # Provider deadlines may be hours or days away. Only the
+                    # private, due continuation event may consume this marker;
+                    # unrelated internal events must not inherit its guidance.
+                    _resume_mark_is_fresh = provider_rate_limit_resume
                 else:
                     _resume_mark_is_fresh = _is_fresh_gateway_interruption(
                         getattr(_resume_entry, "last_resume_marked_at", None),
@@ -19727,6 +19866,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and not message.strip()
                 and _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
+                and (
+                    getattr(_resume_entry, "resume_reason", None)
+                    != "provider_rate_limit"
+                    or provider_rate_limit_resume
+                )
             ):
                 _sn_reason = (
                     getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
@@ -19800,6 +19944,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
+                if suppress_current_user_message_persistence:
+                    _conversation_kwargs["suppress_user_message_persistence"] = True
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30,6 +30,7 @@ import dataclasses
 import inspect
 import json
 import logging
+import math
 import os
 import re
 import shlex
@@ -43,7 +44,7 @@ import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
@@ -1053,6 +1054,72 @@ def _is_auto_continue_noise(content: Any) -> bool:
     return (
         content.startswith(_AUTO_CONTINUE_NOTE_PREFIX)
         or content.startswith(_AUTO_CONTINUE_FALLBACK_PREFIX)
+    )
+
+
+def _coerce_provider_rate_limit_reset_at(
+    value: Any,
+    *,
+    now: Optional[float] = None,
+) -> Optional[float]:
+    """Return a future unix timestamp from provider reset metadata.
+
+    ``agent.extract_api_error_context`` already normalizes ``Retry-After`` and
+    common provider bodies to ``reset_at``.  Gateway only needs enough coercion
+    to schedule an in-process continuation; if the value is missing, malformed,
+    or already stale, fall back to the existing visible retry hint instead of
+    inventing durable session state.
+    """
+    if value is None or value == "":
+        return None
+    now = time.time() if now is None else float(now)
+    reset_at: Optional[float] = None
+    if isinstance(value, datetime):
+        reset_at = value.timestamp()
+    elif isinstance(value, (int, float)):
+        reset_at = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            reset_at = float(text)
+        except ValueError:
+            try:
+                normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+                parsed = datetime.fromisoformat(normalized)
+                if parsed.tzinfo is None:
+                    return None
+                parsed = parsed.astimezone(timezone.utc)
+                reset_at = parsed.timestamp()
+            except ValueError:
+                return None
+    if reset_at is None or not math.isfinite(reset_at) or reset_at <= now:
+        return None
+    try:
+        datetime.fromtimestamp(reset_at)
+    except (OverflowError, OSError, ValueError):
+        return None
+    return reset_at
+
+
+def _provider_rate_limit_reset_at(agent_result: dict) -> Optional[float]:
+    """Extract a schedulable provider-limit reset time from an agent result."""
+    if not isinstance(agent_result, dict):
+        return None
+    if agent_result.get("failure_reason") != "rate_limit":
+        return None
+    context = agent_result.get("error_context")
+    if not isinstance(context, dict):
+        return None
+    return _coerce_provider_rate_limit_reset_at(context.get("reset_at"))
+
+
+def _format_provider_rate_limit_resume_notice(reset_at: float) -> str:
+    reset_text = datetime.fromtimestamp(reset_at).strftime("%H:%M")
+    return (
+        "⏱️ The model provider is rate-limiting requests. "
+        f"I’ll automatically resume this request around {reset_text}."
     )
 
 
@@ -2992,6 +3059,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        # In-process tasks for durable provider-limit continuations. Each
+        # affected session gets its own task so reset-time fan-out preserves
+        # the concurrency that existed before the shared quota wall.
+        self._provider_rate_limit_resume_tasks: Dict[str, asyncio.Task] = {}
         # Startup restore gate: while restart-interrupted sessions are being
         # auto-resumed, real inbound messages are queued instead of competing
         # with the synthetic resume turns for the same session.  The queued
@@ -6576,7 +6647,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # .clean_shutdown marker).  All three mean "the agent was mid-turn and
     # we killed it" — eligible for startup auto-resume.
     _AUTO_RESUME_REASONS = frozenset(
-        {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
+        {
+            "restart_timeout",
+            "shutdown_timeout",
+            "restart_interrupted",
+            "provider_rate_limit",
+        }
     )
 
     async def _run_startup_resume_event(
@@ -6668,7 +6744,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.info("Drained %d inbound message(s) queued during startup restore", drained)
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
-        """Auto-continue fresh restart-interrupted sessions after startup.
+        """Auto-continue eligible resume-pending sessions after startup.
 
         ``resume_pending`` already preserves the transcript AND the existing
         ``_is_resume_pending`` branch in ``_handle_message_with_agent``
@@ -6716,19 +6792,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # is now in the loop). Defenses 1-2 cover the cron/CLI/terminal paths;
         # this catches every other SIGTERM source (e.g. a raw `terminal(
         # "launchctl kickstart ai.hermes.gateway")`).
-        if candidates:
+        restart_auto_resume_blocked = False
+        if any(entry.resume_reason != "provider_rate_limit" for entry in candidates):
             try:
                 from gateway import restart_loop_guard as _rlg
 
                 _max_restarts, _window = self._restart_loop_guard_config()
                 if _rlg.check_and_record(_max_restarts, _window):
-                    return 0
+                    restart_auto_resume_blocked = True
             except Exception as exc:  # noqa: BLE001 — breaker must fail OPEN
                 logger.debug("Restart-loop guard check skipped: %s", exc)
 
         now = datetime.now()
         scheduled = 0
         for entry in candidates:
+            if entry.resume_reason == "provider_rate_limit":
+                reset_at = getattr(entry, "resume_not_before", None)
+                if reset_at is None:
+                    logger.warning(
+                        "Skipping provider rate-limit recovery for %s: missing durable reset time",
+                        entry.session_key,
+                    )
+                    continue
+                if self._install_provider_rate_limit_resume(
+                    session_key=entry.session_key,
+                    source=entry.origin,
+                    reset_at=reset_at,
+                    run_generation=getattr(
+                        self, "_session_run_generation", {}
+                    ).get(entry.session_key, 0),
+                ):
+                    scheduled += 1
+                continue
+
+            if restart_auto_resume_blocked:
+                continue
+
             marker = entry.last_resume_marked_at or entry.updated_at
             if marker is not None and (now - marker).total_seconds() > window:
                 continue
@@ -6801,10 +6900,243 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             scheduled += 1
         if scheduled:
             logger.info(
-                "Scheduled auto-resume for %d restart-interrupted session(s)",
+                "Scheduled auto-resume for %d pending session(s)",
                 scheduled,
             )
         return scheduled
+
+    async def _schedule_provider_rate_limit_resume(
+        self,
+        *,
+        session_key: str,
+        source: SessionSource,
+        reset_at: float,
+        run_generation: int,
+    ) -> bool:
+        """Persist then install a provider reset continuation off the event loop."""
+        reset_epoch = _coerce_provider_rate_limit_reset_at(reset_at, now=0)
+        if reset_epoch is None or not session_key or source is None:
+            return False
+        try:
+            marked = await self.async_session_store.mark_resume_pending(
+                session_key,
+                reason="provider_rate_limit",
+                not_before=reset_epoch,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to persist provider rate-limit continuation for %s: %s",
+                session_key,
+                exc,
+            )
+            return False
+        if not marked:
+            return False
+        return self._install_provider_rate_limit_resume(
+            session_key=session_key,
+            source=source,
+            reset_at=reset_epoch,
+            run_generation=run_generation,
+        )
+
+    async def _supersede_provider_rate_limit_resume_for_user_turn(
+        self,
+        *,
+        session_key: str,
+    ) -> bool:
+        """Cancel the durable provider continuation claimed by a newer user turn.
+
+        The new turn either succeeds (and needs no old retry) or installs a
+        fresh provider deadline if it hits the quota wall again.  Clear by
+        reason before cancelling the in-memory task so a concurrent restart or
+        shutdown marker is never erased.
+        """
+        try:
+            cleared = await self.async_session_store.clear_resume_pending(
+                session_key,
+                reason="provider_rate_limit",
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to supersede provider rate-limit continuation for %s: %s",
+                session_key,
+                exc,
+            )
+            return False
+        if not cleared:
+            return False
+
+        tasks = getattr(self, "_provider_rate_limit_resume_tasks", None)
+        if isinstance(tasks, dict):
+            task = tasks.pop(session_key, None)
+            if task is not None and task is not asyncio.current_task() and not task.done():
+                task.cancel()
+        logger.info(
+            "Superseded provider rate-limit continuation for %s with a newer user turn",
+            session_key,
+        )
+        return True
+
+    def _install_provider_rate_limit_resume(
+        self,
+        *,
+        session_key: str,
+        source: SessionSource,
+        reset_at: float,
+        run_generation: int,
+    ) -> bool:
+        """Install an in-memory task for an already-persisted provider deadline."""
+        # ``reset_at`` may already be in the past when restored after a gateway
+        # restart.  It is still a valid deadline and should drain immediately.
+        reset_epoch = _coerce_provider_rate_limit_reset_at(reset_at, now=0)
+        if reset_epoch is None or not session_key or source is None:
+            return False
+
+        tasks = getattr(self, "_provider_rate_limit_resume_tasks", None)
+        if tasks is None:
+            tasks = {}
+            self._provider_rate_limit_resume_tasks = tasks
+        existing = tasks.get(session_key)
+        if existing is not None and not existing.done():
+            if not getattr(existing, "_hermes_provider_resume_dispatched", False):
+                existing.cancel()
+            logger.info(
+                "Replacing stale provider rate-limit continuation for %s",
+                session_key,
+            )
+
+        task = asyncio.create_task(
+            self._run_provider_rate_limit_resume_after_delay(
+                session_key=session_key,
+                source=source,
+                reset_at=reset_epoch,
+                run_generation=run_generation,
+            )
+        )
+        setattr(task, "_hermes_provider_resume_dispatched", False)
+        tasks[session_key] = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        logger.info(
+            "Scheduled provider rate-limit continuation for %s in %.1fs",
+            session_key,
+            max(0.0, reset_epoch - time.time()),
+        )
+        return True
+
+    async def _run_provider_rate_limit_resume_after_delay(
+        self,
+        *,
+        session_key: str,
+        source: SessionSource,
+        reset_at: float,
+        run_generation: int,
+    ) -> None:
+        """Wake after provider reset and route a synthetic continuation turn."""
+        try:
+            delay = max(0.0, reset_at - time.time())
+            if delay:
+                await asyncio.sleep(delay)
+
+            current_task = asyncio.current_task()
+            if current_task is not None:
+                setattr(current_task, "_hermes_provider_resume_dispatched", True)
+
+            try:
+                still_pending = await self.async_session_store.is_resume_pending(
+                    session_key,
+                    reason="provider_rate_limit",
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Skipping provider rate-limit recovery for %s: "
+                    "resume state check failed: %s",
+                    session_key,
+                    exc,
+                )
+                return
+            if not still_pending:
+                return
+
+            if not self._is_session_run_current(session_key, run_generation):
+                logger.info(
+                    "Skipping provider rate-limit continuation for %s: newer turn exists",
+                    session_key,
+                )
+                return
+            waited_for_origin = False
+            while session_key in getattr(self, "_running_agents", {}):
+                waited_for_origin = True
+                if not self._is_session_run_current(session_key, run_generation):
+                    logger.info(
+                        "Skipping provider rate-limit continuation for %s: newer turn exists",
+                        session_key,
+                    )
+                    return
+                await asyncio.sleep(0.05)
+
+            if waited_for_origin:
+                try:
+                    still_pending = await self.async_session_store.is_resume_pending(
+                        session_key,
+                        reason="provider_rate_limit",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping provider rate-limit recovery for %s after waiting: "
+                        "resume state check failed: %s",
+                        session_key,
+                        exc,
+                    )
+                    return
+                if not still_pending:
+                    return
+            try:
+                if not self._is_user_authorized(source):
+                    logger.warning(
+                        "Skipping provider rate-limit continuation for %s: session owner is no longer authorized",
+                        session_key,
+                    )
+                    return
+            except Exception as exc:
+                logger.warning(
+                    "Skipping provider rate-limit continuation for %s: authorization check failed: %s",
+                    session_key,
+                    exc,
+                )
+                return
+
+            adapter = self._adapter_for_source(source)
+            if adapter is None:
+                logger.info(
+                    "Skipping provider rate-limit continuation for %s: adapter not ready for %s",
+                    session_key,
+                    getattr(source.platform, "value", source.platform),
+                )
+                return
+
+            # Claim before dispatch so a real inbound message queues behind
+            # this continuation. Reuse the startup-resume helper because
+            # BasePlatformAdapter.handle_message() itself returns as soon as
+            # it spawns the agent task.
+            self._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+            self._running_agents_ts[session_key] = time.time()
+            self._persist_active_agents()
+            event = MessageEvent(
+                # The durable resume_pending path injects a system note
+                # without persisting a synthetic user row.
+                text="",
+                message_type=MessageType.TEXT,
+                source=source,
+                internal=True,
+            )
+            await self._run_startup_resume_event(adapter, event, session_key)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            tasks = getattr(self, "_provider_rate_limit_resume_tasks", None)
+            if isinstance(tasks, dict) and tasks.get(session_key) is asyncio.current_task():
+                tasks.pop(session_key, None)
 
     def _startup_should_abort(self) -> bool:
         return (
@@ -10975,6 +11307,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        # A real user turn owns the lane from this point forward.  Remove the
+        # older durable provider continuation immediately; if this turn hits
+        # the quota wall again it will persist a fresh reset deadline below.
+        # Internal empty events are the continuation itself and must retain the
+        # marker until their resumed turn completes successfully.
+        if (
+            not getattr(event, "internal", False)
+            and getattr(session_entry, "resume_reason", None) == "provider_rate_limit"
+        ):
+            await self._supersede_provider_rate_limit_resume_for_user_turn(
+                session_key=session_key
+            )
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
         ).strip()
@@ -11876,6 +12220,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except Exception:
                 _intentional_silence = False
+
+            _rate_limit_reset_at = _provider_rate_limit_reset_at(agent_result)
+            if _rate_limit_reset_at is not None and session_key:
+                _resume_scheduled = await self._schedule_provider_rate_limit_resume(
+                    session_key=session_key,
+                    source=source,
+                    reset_at=_rate_limit_reset_at,
+                    run_generation=run_generation,
+                )
+                if _resume_scheduled:
+                    response = _format_provider_rate_limit_resume_notice(
+                        _rate_limit_reset_at
+                    )
 
             # Convert the agent's internal "(empty)" sentinel into a
             # user-friendly message.  "(empty)" means the model failed to
@@ -19263,10 +19620,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # EITHER signal is fresh so the two freshness checks agree.
             _resume_mark_is_fresh = False
             if _resume_entry is not None and getattr(_resume_entry, "resume_pending", False):
-                _resume_mark_is_fresh = _is_fresh_gateway_interruption(
-                    getattr(_resume_entry, "last_resume_marked_at", None),
-                    window_secs=_freshness_window,
-                )
+                if getattr(_resume_entry, "resume_reason", None) == "provider_rate_limit":
+                    # Provider deadlines may be hours or days away.  Their
+                    # explicit durable timestamp is the freshness signal.
+                    _resume_mark_is_fresh = True
+                else:
+                    _resume_mark_is_fresh = _is_fresh_gateway_interruption(
+                        getattr(_resume_entry, "last_resume_marked_at", None),
+                        window_secs=_freshness_window,
+                    )
             _is_resume_pending = bool(
                 _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
@@ -19285,6 +19647,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _reason == "restart_timeout"
                     else "a gateway shutdown"
                     if _reason == "shutdown_timeout"
+                    else "a provider rate limit"
+                    if _reason == "provider_rate_limit"
                     else "a gateway interruption"
                 )
                 _persist_user_message_override = message
@@ -19297,20 +19661,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Address the user's NEW message below FIRST and focus "
                         "on what the user is asking now."
                     )
+                elif _reason == "provider_rate_limit":
+                    _resume_guidance = (
+                        "The provider reset window has arrived. Continue the "
+                        "user's previous request from the conversation history "
+                        "now; do not ask for new instructions."
+                    )
                 else:
                     _resume_guidance = (
                         "Report to the user that the session was restored "
                         "successfully and ask what they would like to do next."
                     )
-                message = (
-                    f"[System note: The previous turn was interrupted by "
-                    f"{_reason_phrase}; the gateway is now back online. "
-                    f"Any restart/shutdown command in the history has already "
-                    f"run — do NOT re-execute or verify it. {_resume_guidance} "
-                    f"Do NOT re-execute old tool calls — skip any unfinished "
-                    f"work from the conversation history.]"
-                    + (f"\n\n{message}" if message else "")
-                )
+                if _reason == "provider_rate_limit":
+                    message = (
+                        "[System note: The previous turn paused because the model "
+                        "provider rate limit was reached. The reset window has now "
+                        "arrived. Continue the user's previous request from the "
+                        "conversation history without asking for new instructions. "
+                        "Do not replay this note or repeat tool calls that already "
+                        "completed.]"
+                        + (f"\n\n{message}" if message else "")
+                    )
+                else:
+                    message = (
+                        f"[System note: The previous turn was interrupted by "
+                        f"{_reason_phrase}; recovery is now available. "
+                        f"Any restart/shutdown command in the history has already "
+                        f"run — do NOT re-execute or verify it. {_resume_guidance} "
+                        f"Do NOT re-execute old tool calls — skip any unfinished "
+                        f"work from the conversation history.]"
+                        + (f"\n\n{message}" if message else "")
+                    )
             elif _has_fresh_tool_tail:
                 _persist_user_message_override = message
                 message = (
@@ -19570,6 +19951,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "interrupted": result.get("interrupted", False),
                     "interrupt_message": result.get("interrupt_message"),
                     "error": result.get("error"),
+                    "failure_reason": result.get("failure_reason"),
+                    "error_context": result.get("error_context"),
                     "compression_exhausted": result.get("compression_exhausted", False),
                     "tools": tools_holder[0] or [],
                     "history_offset": _effective_history_offset,
@@ -19676,7 +20059,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "completed": result_holder[0].get("completed") if result_holder[0] else None,
                 "interrupted": result_holder[0].get("interrupted", False) if result_holder[0] else False,
                 "partial": result_holder[0].get("partial", False) if result_holder[0] else False,
+                "failed": result_holder[0].get("failed", False) if result_holder[0] else False,
                 "error": result_holder[0].get("error") if result_holder[0] else None,
+                "failure_reason": result_holder[0].get("failure_reason") if result_holder[0] else None,
+                "error_context": result_holder[0].get("error_context") if result_holder[0] else None,
                 "interrupt_message": result_holder[0].get("interrupt_message") if result_holder[0] else None,
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -734,6 +734,10 @@ class SessionEntry:
     # Used by provider rate-limit recovery so the promise survives a gateway
     # restart without replaying before the provider's reset window.
     resume_not_before: Optional[float] = None
+    # Adapter transport required to deliver a deferred continuation. This is
+    # deliberately separate from SessionSource's wire-invisible relay trust
+    # marker: it is local routing state, not an inbound authorization claim.
+    resume_transport: Optional[str] = None
 
     # Session-scoped /model override (model/provider/base_url ONLY — never
     # credentials).  ``_session_model_overrides`` in the gateway runner is
@@ -771,6 +775,7 @@ class SessionEntry:
                 else None
             ),
             "resume_not_before": self.resume_not_before,
+            "resume_transport": self.resume_transport,
             "is_fresh_reset": self.is_fresh_reset,
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
@@ -796,6 +801,15 @@ class SessionEntry:
                 platform = Platform(data["platform"])
             except ValueError as e:
                 logger.debug("Unknown platform value %r: %s", data["platform"], e)
+
+        resume_transport = None
+        if data.get("resume_transport"):
+            try:
+                resume_transport = Platform(data["resume_transport"]).value
+            except (TypeError, ValueError) as e:
+                logger.debug(
+                    "Unknown resume transport %r: %s", data["resume_transport"], e
+                )
 
         last_resume_marked_at = None
         _lrma = data.get("last_resume_marked_at")
@@ -847,6 +861,7 @@ class SessionEntry:
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
             resume_not_before=data.get("resume_not_before"),
+            resume_transport=resume_transport,
             is_fresh_reset=data.get("is_fresh_reset", False),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
@@ -2131,6 +2146,7 @@ class SessionStore:
         session_key: str,
         reason: str = "restart_timeout",
         not_before: Optional[float] = None,
+        resume_transport: Optional[str] = None,
     ) -> bool:
         """Mark a session as resumable after an interruption or deferred wait.
 
@@ -2141,6 +2157,12 @@ class SessionStore:
 
         Returns True if the session existed and was marked.
         """
+        normalized_transport = None
+        if resume_transport:
+            try:
+                normalized_transport = Platform(resume_transport).value
+            except (TypeError, ValueError):
+                return False
         with self._lock:
             self._ensure_loaded_locked()
             if session_key in self._entries:
@@ -2149,10 +2171,22 @@ class SessionStore:
                 # forced-wipe signal (from /stop or stuck-loop escalation).
                 if entry.suspended:
                     return False
+                # A provider reset deadline is the stronger continuation
+                # promise: stop/restart drain markers are transient ownership
+                # bookkeeping and must not replace it.  This check is inside
+                # the store lock so mark(B) -> mark(A) -> clear(A) cannot erase
+                # a durable provider continuation.
+                if (
+                    entry.resume_pending
+                    and entry.resume_reason == "provider_rate_limit"
+                    and reason != "provider_rate_limit"
+                ):
+                    return False
                 entry.resume_pending = True
                 entry.resume_reason = reason
                 entry.last_resume_marked_at = _now()
                 entry.resume_not_before = not_before
+                entry.resume_transport = normalized_transport
                 self._save()
                 return True
         return False
@@ -2194,6 +2228,7 @@ class SessionStore:
             entry.resume_reason = None
             entry.last_resume_marked_at = None
             entry.resume_not_before = None
+            entry.resume_transport = None
             self._save()
             return True
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -730,6 +730,10 @@ class SessionEntry:
     resume_pending: bool = False
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
+    # Earliest unix timestamp at which a deferred continuation may run.
+    # Used by provider rate-limit recovery so the promise survives a gateway
+    # restart without replaying before the provider's reset window.
+    resume_not_before: Optional[float] = None
 
     # Session-scoped /model override (model/provider/base_url ONLY — never
     # credentials).  ``_session_model_overrides`` in the gateway runner is
@@ -766,6 +770,7 @@ class SessionEntry:
                 if self.last_resume_marked_at
                 else None
             ),
+            "resume_not_before": self.resume_not_before,
             "is_fresh_reset": self.is_fresh_reset,
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
@@ -841,6 +846,7 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            resume_not_before=data.get("resume_not_before"),
             is_fresh_reset=data.get("is_fresh_reset", False),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
@@ -1893,8 +1899,18 @@ class SessionStore:
             if _entry_for_checks.suspended:
                 _reset_reason = "suspended"
             elif _entry_for_checks.resume_pending:
-                _reset_reason = self._should_reset(_entry_for_checks, source)
-                if not _reset_reason:
+                # Provider-limit waits can legitimately span the normal
+                # one-hour recovery freshness window or a daily reset.  They
+                # carry an explicit future deadline and must retain the
+                # original transcript until that deadline is drained.
+                if _entry_for_checks.resume_reason == "provider_rate_limit":
+                    _reset_reason = None
+                else:
+                    _reset_reason = self._should_reset(_entry_for_checks, source)
+                if (
+                    not _reset_reason
+                    and _entry_for_checks.resume_reason != "provider_rate_limit"
+                ):
                     _fw = auto_continue_freshness_window()
                     _ref_time = (
                         _entry_for_checks.last_resume_marked_at
@@ -2114,8 +2130,9 @@ class SessionStore:
         self,
         session_key: str,
         reason: str = "restart_timeout",
+        not_before: Optional[float] = None,
     ) -> bool:
-        """Mark a session as resumable after a restart interruption.
+        """Mark a session as resumable after an interruption or deferred wait.
 
         Unlike ``suspend_session()``, this preserves the existing
         ``session_id`` and the transcript.  The next call to
@@ -2135,17 +2152,35 @@ class SessionStore:
                 entry.resume_pending = True
                 entry.resume_reason = reason
                 entry.last_resume_marked_at = _now()
+                entry.resume_not_before = not_before
                 self._save()
                 return True
         return False
 
-    def clear_resume_pending(self, session_key: str) -> bool:
-        """Clear the resume-pending flag after a successful resumed turn.
+    def is_resume_pending(
+        self,
+        session_key: str,
+        *,
+        reason: Optional[str] = None,
+    ) -> bool:
+        """Return whether a live, unsuspended resume marker still matches."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.suspended or not entry.resume_pending:
+                return False
+            return reason is None or entry.resume_reason == reason
 
-        Called from the gateway after ``run_conversation()`` returns a
-        final response for a session that had ``resume_pending=True``,
-        signalling that recovery succeeded.
+    def clear_resume_pending(
+        self,
+        session_key: str,
+        *,
+        reason: Optional[str] = None,
+    ) -> bool:
+        """Clear a matching resume-pending flag after success or supersession.
 
+        ``reason`` makes stale-continuation cancellation compare-and-clear: a
+        newer recovery marker installed for a different cause is never erased.
         Returns True if a flag was cleared.
         """
         with self._lock:
@@ -2153,9 +2188,12 @@ class SessionStore:
             entry = self._entries.get(session_key)
             if entry is None or not entry.resume_pending:
                 return False
+            if reason is not None and entry.resume_reason != reason:
+                return False
             entry.resume_pending = False
             entry.resume_reason = None
             entry.last_resume_marked_at = None
+            entry.resume_not_before = None
             self._save()
             return True
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2202,10 +2202,11 @@ class SessionStore:
 
         Pruning is based on ``updated_at`` (last activity), not ``created_at``.
         A session that's been active within the window is kept regardless of
-        how old it is.  Entries marked ``suspended`` are kept — the user
-        explicitly paused them for later resume.  Entries held by an active
-        process (via has_active_processes_fn) are also kept so long-running
-        background work isn't orphaned.
+        how old it is.  Entries marked ``suspended`` or carrying a durable
+        provider-rate-limit deadline are kept — the user explicitly paused
+        them or the gateway owns a bounded wait task. Entri...[truncated]
+        has_active_processes_fn) are also kept so long-running background work
+        isn't orphaned.
 
         Pruning is functionally identical to a natural reset-policy expiry:
         the transcript in SQLite stays, but the session_key → session_id
@@ -2224,7 +2225,12 @@ class SessionStore:
         with self._lock:
             self._ensure_loaded_locked()
             for key, entry in list(self._entries.items()):
-                if entry.suspended:
+                has_provider_deadline = (
+                    entry.resume_pending
+                    and entry.resume_reason == "provider_rate_limit"
+                    and entry.resume_not_before is not None
+                )
+                if entry.suspended or has_provider_deadline:
                     continue
                 # Never prune sessions with an active background process
                 # attached — the user may still be waiting on output.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1689,9 +1689,17 @@ class AIAgent:
         event time as message metadata, rather than embedding it in content.
         """
         idx = getattr(self, "_persist_user_message_idx", None)
+        suppress = getattr(self, "_suppress_current_user_message_persistence", False)
         override = getattr(self, "_persist_user_message_override", None)
         timestamp = getattr(self, "_persist_user_message_timestamp", None)
-        if idx is None or (override is None and timestamp is None):
+        if idx is None:
+            return
+        if suppress and 0 <= idx < len(messages):
+            msg = messages[idx]
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                messages.pop(idx)
+            return
+        if override is None and timestamp is None:
             return
         if 0 <= idx < len(messages):
             msg = messages[idx]
@@ -1726,19 +1734,31 @@ class AIAgent:
         # Close and turn-start persistence can run on separate CLI threads; the
         # marker test-and-append below must be one critical section or both can
         # observe the same unmarked dict and write duplicate durable rows.
+        def _persist_locked() -> None:
+            self._drop_trailing_empty_response_scaffolding(messages)
+            persisted_messages = messages
+            suppress_idx = getattr(self, "_persist_user_message_idx", None)
+            if (
+                getattr(self, "_suppress_current_user_message_persistence", False)
+                and isinstance(suppress_idx, int)
+                and 0 <= suppress_idx < len(messages)
+                and isinstance(messages[suppress_idx], dict)
+                and messages[suppress_idx].get("role") == "user"
+            ):
+                persisted_messages = (
+                    messages[:suppress_idx] + messages[suppress_idx + 1 :]
+                )
+            self._session_messages = persisted_messages
+            self._save_session_log(persisted_messages)
+            self._flush_messages_to_session_db(messages, conversation_history)
+
         persist_lock = getattr(self, "_session_persist_lock", None)
         if persist_lock is None:
-            self._drop_trailing_empty_response_scaffolding(messages)
-            self._session_messages = messages
-            self._save_session_log(messages)
-            self._flush_messages_to_session_db(messages, conversation_history)
+            _persist_locked()
             return
 
         with persist_lock:
-            self._drop_trailing_empty_response_scaffolding(messages)
-            self._session_messages = messages
-            self._save_session_log(messages)
-            self._flush_messages_to_session_db(messages, conversation_history)
+            _persist_locked()
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
@@ -1854,6 +1874,11 @@ class AIAgent:
         _ov_idx = getattr(self, "_persist_user_message_idx", None)
         _ov_content = getattr(self, "_persist_user_message_override", None)
         _ov_timestamp = getattr(self, "_persist_user_message_timestamp", None)
+        _suppress_user_row = getattr(
+            self,
+            "_suppress_current_user_message_persistence",
+            False,
+        )
         try:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
@@ -1915,6 +1940,13 @@ class AIAgent:
                 # history copy, or seeded by a caller. Stamp them so future
                 # flushes skip them without consulting any id() set again.
                 if id(msg) in history_ids or id(msg) in seed_ids:
+                    msg[_DB_PERSISTED_MARKER] = True
+                    continue
+                if (
+                    _suppress_user_row
+                    and _ov_idx == _msg_idx
+                    and msg.get("role") == "user"
+                ):
                     msg[_DB_PERSISTED_MARKER] = True
                     continue
                 role = msg.get("role", "unknown")
@@ -5886,6 +5918,7 @@ class AIAgent:
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        suppress_user_message_persistence: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
@@ -5899,6 +5932,7 @@ class AIAgent:
             persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
             moa_config=moa_config,
+            suppress_user_message_persistence=suppress_user_message_persistence,
         )
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -260,6 +260,7 @@ _MAX_TOOL_WORKERS = 8
 # every top-level ``_``-prefixed key before the request leaves the process, so
 # this never reaches a strict OpenAI-compatible gateway.
 _DB_PERSISTED_MARKER = "_db_persisted"
+_CURRENT_TURN_USER_MARKER = "_hermes_current_turn_user_id"
 
 
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per
@@ -1678,6 +1679,46 @@ class AIAgent:
             tool_call_id=tool_call_id,
         )
 
+    def _current_turn_user_message_index(
+        self, messages: List[Dict]
+    ) -> Optional[int]:
+        """Locate the current turn by stable metadata, surviving compaction copies."""
+        token = getattr(self, "_persist_user_message_token", None)
+        if token:
+            for idx, msg in enumerate(messages):
+                if (
+                    isinstance(msg, dict)
+                    and msg.get("role") == "user"
+                    and msg.get(_CURRENT_TURN_USER_MARKER) == token
+                ):
+                    return idx
+            # Fail closed: once a stable token exists, a stale numeric index may
+            # point at a summary or a genuine historical user after compaction.
+            return None
+        legacy_idx = getattr(self, "_persist_user_message_idx", None)
+        if isinstance(legacy_idx, int) and 0 <= legacy_idx < len(messages):
+            msg = messages[legacy_idx]
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                return legacy_idx
+        return None
+
+    def _messages_for_session_persistence(
+        self, messages: List[Dict]
+    ) -> List[Dict]:
+        """Return durable-safe copies without private turn metadata/synthetic user."""
+        suppress_idx = None
+        if getattr(self, "_suppress_current_user_message_persistence", False):
+            suppress_idx = self._current_turn_user_message_index(messages)
+        durable: List[Dict] = []
+        for idx, msg in enumerate(messages):
+            if idx == suppress_idx:
+                continue
+            if isinstance(msg, dict) and _CURRENT_TURN_USER_MARKER in msg:
+                msg = msg.copy()
+                msg.pop(_CURRENT_TURN_USER_MARKER, None)
+            durable.append(msg)
+        return durable
+
     def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:
         """Rewrite the current-turn user message before persistence/return.
 
@@ -1688,34 +1729,34 @@ class AIAgent:
         history stay clean.  A paired timestamp override preserves the platform
         event time as message metadata, rather than embedding it in content.
         """
-        idx = getattr(self, "_persist_user_message_idx", None)
+        idx = self._current_turn_user_message_index(messages)
         suppress = getattr(self, "_suppress_current_user_message_persistence", False)
         override = getattr(self, "_persist_user_message_override", None)
         timestamp = getattr(self, "_persist_user_message_timestamp", None)
         if idx is None:
             return
-        if suppress and 0 <= idx < len(messages):
-            msg = messages[idx]
-            if isinstance(msg, dict) and msg.get("role") == "user":
-                messages.pop(idx)
+        if suppress:
+            messages.pop(idx)
             return
+        msg = messages[idx]
         if override is None and timestamp is None:
+            if isinstance(msg, dict):
+                msg.pop(_CURRENT_TURN_USER_MARKER, None)
             return
-        if 0 <= idx < len(messages):
-            msg = messages[idx]
-            if isinstance(msg, dict) and msg.get("role") == "user":
-                # Text-only call paths may pass a synthetic API-facing prompt
-                # and a cleaner transcript string separately. Before the API
-                # call, a plain-text override must not replace native image/audio
-                # blocks. A list override, however, is the original clean
-                # multimodal payload (for example before a queued /model note)
-                # and must replace the API-local list once the turn is final.
-                if override is not None and (
-                    not isinstance(msg.get("content"), list) or isinstance(override, list)
-                ):
-                    msg["content"] = override
-                if timestamp is not None:
-                    msg["timestamp"] = timestamp
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            # Text-only call paths may pass a synthetic API-facing prompt
+            # and a cleaner transcript string separately. Before the API
+            # call, a plain-text override must not replace native image/audio
+            # blocks. A list override, however, is the original clean
+            # multimodal payload (for example before a queued /model note)
+            # and must replace the API-local list once the turn is final.
+            if override is not None and (
+                not isinstance(msg.get("content"), list) or isinstance(override, list)
+            ):
+                msg["content"] = override
+            if timestamp is not None:
+                msg["timestamp"] = timestamp
+            msg.pop(_CURRENT_TURN_USER_MARKER, None)
 
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
@@ -1736,18 +1777,7 @@ class AIAgent:
         # observe the same unmarked dict and write duplicate durable rows.
         def _persist_locked() -> None:
             self._drop_trailing_empty_response_scaffolding(messages)
-            persisted_messages = messages
-            suppress_idx = getattr(self, "_persist_user_message_idx", None)
-            if (
-                getattr(self, "_suppress_current_user_message_persistence", False)
-                and isinstance(suppress_idx, int)
-                and 0 <= suppress_idx < len(messages)
-                and isinstance(messages[suppress_idx], dict)
-                and messages[suppress_idx].get("role") == "user"
-            ):
-                persisted_messages = (
-                    messages[:suppress_idx] + messages[suppress_idx + 1 :]
-                )
+            persisted_messages = self._messages_for_session_persistence(messages)
             self._session_messages = persisted_messages
             self._save_session_log(persisted_messages)
             self._flush_messages_to_session_db(messages, conversation_history)
@@ -1871,7 +1901,7 @@ class AIAgent:
         # live dict is never mutated, so every caller (early persist, mid-loop
         # flush, /resume, /branch) is protected uniformly. Timestamp override is
         # metadata and is likewise applied only to the written row.
-        _ov_idx = getattr(self, "_persist_user_message_idx", None)
+        _ov_idx = self._current_turn_user_message_index(messages)
         _ov_content = getattr(self, "_persist_user_message_override", None)
         _ov_timestamp = getattr(self, "_persist_user_message_timestamp", None)
         _suppress_user_row = getattr(

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -85,6 +85,17 @@ class TestEstimateMessagesTokensRough:
         expected = (n + 3) // 4
         assert result == expected
 
+    def test_internal_metadata_does_not_change_wire_estimate(self):
+        plain = {"role": "user", "content": "hello"}
+        marked = {
+            **plain,
+            "_hermes_current_turn_user_id": "opaque-turn-id",
+            "_db_persisted": True,
+        }
+        assert estimate_messages_tokens_rough([marked]) == (
+            estimate_messages_tokens_rough([plain])
+        )
+
     def test_tool_call_message(self):
         """Tool call messages with no 'content' key still contribute tokens."""
         msg = {"role": "assistant", "content": None,

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -174,7 +174,9 @@ def test_returns_turn_context_with_user_message_appended():
     assert isinstance(ctx, TurnContext)
     assert ctx.user_message == "hello"
     # The user turn was appended and indexed.
-    assert ctx.messages[-1] == {"role": "user", "content": "hello"}
+    assert ctx.messages[-1]["role"] == "user"
+    assert ctx.messages[-1]["content"] == "hello"
+    assert ctx.messages[-1]["_hermes_current_turn_user_id"]
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
     assert ctx.active_system_prompt == "SYSTEM"
 
@@ -366,6 +368,77 @@ def test_between_turns_refresh_no_churn_when_unchanged():
         _build(agent)
 
     assert agent.tools is same  # not replaced → no churn
+
+
+def test_preflight_rebases_current_user_index_by_stable_identity(tmp_path):
+    agent = _make_agent_with_cooldown(tmp_path / "state.db", "sess-1")
+
+    def _compact(messages, *_args, **_kwargs):
+        current = messages[-1].copy()
+        return (
+            [
+                {"role": "user", "content": "compacted context"},
+                {"role": "assistant", "content": "prior answer"},
+                current,
+            ],
+            "SYSTEM",
+        )
+
+    agent._compress_context = MagicMock(side_effect=_compact)
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "older question"},
+        {"role": "assistant", "content": "older answer"},
+    ]
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch("agent.turn_context.estimate_request_tokens_rough", side_effect=[999_999, 10]):
+        ctx = _build(agent, conversation_history=history)
+
+    assert ctx.current_turn_user_idx == 2
+    assert ctx.messages[2]["content"] == "hello"
+    assert ctx.messages[2]["_hermes_current_turn_user_id"] == agent._persist_user_message_token
+    assert agent._persist_user_message_idx == 2
+
+
+def test_preflight_reappended_user_can_be_flushed_again(tmp_path):
+    """If compression drops the live turn, reappend must clear early-persist marks."""
+    agent = _make_agent_with_cooldown(tmp_path / "state.db", "sess-1")
+
+    def _early_persist(messages, *_a, **_k):
+        agent._persist_calls += 1
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                msg["_db_persisted"] = True
+
+    agent._persist_session = _early_persist
+
+    def _compact(messages, *_args, **_kwargs):
+        # Drop the live turn entirely so the recovery path re-appends it.
+        return (
+            [
+                {"role": "user", "content": "compacted context"},
+                {"role": "assistant", "content": "prior answer"},
+            ],
+            "SYSTEM",
+        )
+
+    agent._compress_context = MagicMock(side_effect=_compact)
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch("agent.turn_context.estimate_request_tokens_rough", side_effect=[999_999, 10]):
+        ctx = _build(agent, conversation_history=history)
+
+    recovered = ctx.messages[ctx.current_turn_user_idx]
+    assert recovered["content"] == "hello"
+    assert recovered["_hermes_current_turn_user_id"] == agent._persist_user_message_token
+    # Early-persist marks must not survive recovery reappend, or the active
+    # transcript flush will skip writing the real user row after recovery.
+    assert recovered.get("_db_persisted") is not True
+    assert agent._persist_user_message_idx == ctx.current_turn_user_idx
 
 
 def test_preflight_skips_when_persisted_cooldown_survives_restart(tmp_path):

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -141,6 +141,44 @@ async def test_poll_does_not_suppress_notify_on_complete_watcher(monkeypatch, tm
 
 
 @pytest.mark.asyncio
+async def test_internal_event_does_not_advance_provider_resume_generation(
+    monkeypatch, tmp_path
+):
+    """Background completions must not orphan a pending provider timer."""
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+
+    runner = GatewayRunner(GatewayConfig())
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type="dm",
+    )
+    session_key = runner._session_key_for_source(source)
+    runner._session_run_generation[session_key] = 7
+    seen_generations = []
+
+    async def _capture(_self, _event, _source, _key, run_generation):
+        seen_generations.append(run_generation)
+        return {"final_response": ""}
+
+    monkeypatch.setattr(GatewayRunner, "_handle_message_with_agent", _capture)
+
+    await runner._handle_message(
+        MessageEvent(
+            text="[SYSTEM: Background process completed]",
+            source=source,
+            internal=True,
+        )
+    )
+
+    assert seen_generations == [7]
+    assert runner._session_run_generation[session_key] == 7
+
+
+@pytest.mark.asyncio
 async def test_internal_event_bypasses_authorization(monkeypatch, tmp_path):
     """An internal event should skip _is_user_authorized entirely."""
     import gateway.run as gateway_run

--- a/tests/gateway/test_provider_rate_limit_resume.py
+++ b/tests/gateway/test_provider_rate_limit_resume.py
@@ -25,6 +25,17 @@ class _Adapter:
         self.events.append(event)
 
 
+class _RelayAdapter(_Adapter):
+    authorization_is_upstream = True
+
+    def __init__(self):
+        super().__init__()
+        self.captured = []
+
+    def _capture_scope(self, event):
+        self.captured.append(event)
+
+
 class _SessionStore:
     def __init__(self):
         self.marks = []
@@ -33,10 +44,14 @@ class _SessionStore:
         self.can_resume = True
 
     def mark_resume_pending(
-        self, session_key, reason="restart_timeout", not_before=None
+        self,
+        session_key,
+        reason="restart_timeout",
+        not_before=None,
+        resume_transport=None,
     ):
         self.mark_threads.append(threading.get_ident())
-        self.marks.append((session_key, reason, not_before))
+        self.marks.append((session_key, reason, not_before, resume_transport))
         return True
 
     def is_resume_pending(self, session_key, reason=None):
@@ -194,6 +209,43 @@ async def test_provider_limit_resume_dispatches_internal_continuation():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source",
+    [
+        SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="C1",
+            user_id="U1",
+            scope_id="G1",
+        ),
+        SessionSource(
+            platform=Platform.RELAY,
+            chat_id="C1",
+            user_id="U1",
+            scope_id="G1",
+        ),
+    ],
+)
+async def test_provider_limit_resume_routes_relay_origin_through_relay_adapter(source):
+    relay = _RelayAdapter()
+    runner = _runner(relay)
+    runner.adapters = {Platform.RELAY: relay}
+
+    await runner._run_provider_rate_limit_resume_after_delay(
+        session_key="s1",
+        source=source,
+        reset_at=0,
+        run_generation=7,
+        resume_transport=Platform.RELAY.value,
+    )
+
+    assert len(relay.events) == 1
+    assert relay.events[0].source.platform == source.platform
+    assert relay.events[0].source.delivered_via_upstream_relay is True
+    assert relay.captured == relay.events
+
+
+@pytest.mark.asyncio
 async def test_provider_limit_resume_skips_suspended_or_cleared_session():
     adapter = _Adapter()
     runner = _runner(adapter)
@@ -335,7 +387,7 @@ async def test_provider_limit_resume_scheduler_persists_deadline():
 
     assert scheduled is True
     assert runner.session_store.marks == [
-        ("s1", "provider_rate_limit", reset_at)
+        ("s1", "provider_rate_limit", reset_at, None)
     ]
     assert runner.session_store.mark_threads != [loop_thread]
     assert "s1" in runner._provider_rate_limit_resume_tasks
@@ -343,6 +395,43 @@ async def test_provider_limit_resume_scheduler_persists_deadline():
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source",
+    [
+        SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="C1",
+            user_id="U1",
+            delivered_via_upstream_relay=True,
+        ),
+        SessionSource(
+            platform=Platform.RELAY,
+            chat_id="C1",
+            user_id="U1",
+        ),
+    ],
+)
+async def test_provider_limit_scheduler_persists_relay_transport(source):
+    relay = _RelayAdapter()
+    runner = _runner(relay)
+    runner.adapters = {Platform.RELAY: relay}
+    reset_at = time.time() + 10_000
+
+    assert await runner._schedule_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=reset_at,
+        run_generation=7,
+    )
+    assert runner.session_store.marks == [
+        ("s1", "provider_rate_limit", reset_at, Platform.RELAY.value)
+    ]
+    task = runner._provider_rate_limit_resume_tasks["s1"]
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -471,3 +560,168 @@ async def test_provider_limit_resumes_run_in_parallel_across_sessions():
 
     assert len(adapter.events) == 2
     assert adapter.max_active == 2
+
+
+@pytest.mark.asyncio
+async def test_unrelated_internal_turn_does_not_steal_provider_resume_guidance(
+    monkeypatch, tmp_path
+):
+    """Fresh transcript must not unlock provider guidance before the due event."""
+    import sys
+    import threading
+    import types
+    from datetime import datetime
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    import gateway.run as gateway_run
+    from gateway.session import SessionEntry
+
+    class _CapturingAgent:
+        messages: list[str] = []
+
+        def __init__(self, *args, **kwargs):
+            self.tools = []
+            self.tool_progress_callback = None
+            self.tool_start_callback = None
+            self.step_callback = None
+            self.stream_delta_callback = None
+            self.status_callback = None
+            self.background_review_callback = None
+
+        def run_conversation(self, user_message, **kwargs):
+            text = user_message if isinstance(user_message, str) else str(user_message)
+            type(self).messages.append(text)
+            return {
+                "final_response": "ok",
+                "messages": [],
+                "api_calls": 1,
+                "completed": True,
+                "failed": False,
+                "history_offset": 0,
+                "last_prompt_tokens": 0,
+            }
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._pending_model_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
+    runner.config = SimpleNamespace(streaming=None, multiplex_profiles=False)
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(side_effect=lambda *_a, **_k: _a[0] if _a else "")
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._consume_pending_native_image_paths = lambda _key: []
+    runner._refresh_fallback_model = lambda: None
+    runner._enforce_agent_cache_cap = lambda: None
+
+    session_key = "agent:main:slack:dm:C1"
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-provider",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="dm",
+        origin=source,
+        resume_pending=True,
+        resume_reason="provider_rate_limit",
+        last_resume_marked_at=datetime.now(),
+        resume_not_before=time.time() + 3_600,
+    )
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {session_key: entry}
+    runner.session_store.get_or_create_session.return_value = entry
+    runner.session_store.load_transcript.return_value = [
+        {
+            "role": "user",
+            "content": "recent turn",
+            "timestamp": datetime.now().isoformat(),
+        }
+    ]
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner.session_store.is_resume_pending.return_value = True
+    runner.session_store.clear_resume_pending = MagicMock(return_value=True)
+
+    (tmp_path / "config.yaml").write_text("agent:\n  system_prompt: test\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(
+        tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"}
+    )
+
+    history = [
+        {
+            "role": "user",
+            "content": "recent turn",
+            "timestamp": datetime.now().isoformat(),
+        }
+    ]
+
+    # Unrelated turn with a fresh transcript must not get provider guidance.
+    _CapturingAgent.messages = []
+    await runner._run_agent(
+        message="background process finished",
+        context_prompt="",
+        history=history,
+        source=source,
+        session_id=entry.session_id,
+        session_key=session_key,
+        provider_rate_limit_resume=False,
+    )
+    assert _CapturingAgent.messages
+    assert "reset window has now arrived" not in _CapturingAgent.messages[0]
+    assert "provider rate limit" not in _CapturingAgent.messages[0].lower()
+
+    # Verified provider resume event may inject the guidance.
+    _CapturingAgent.messages = []
+    entry.resume_not_before = time.time() - 10
+    await runner._run_agent(
+        message="",
+        context_prompt="",
+        history=history,
+        source=source,
+        session_id=entry.session_id,
+        session_key=session_key,
+        provider_rate_limit_resume=True,
+        suppress_current_user_message_persistence=True,
+    )
+    assert _CapturingAgent.messages
+    assert "reset window has now arrived" in _CapturingAgent.messages[0]

--- a/tests/gateway/test_provider_rate_limit_resume.py
+++ b/tests/gateway/test_provider_rate_limit_resume.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 import time
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -10,6 +11,7 @@ from gateway.platforms.base import MessageEvent
 from gateway.run import (
     GatewayRunner,
     _coerce_provider_rate_limit_reset_at,
+    _is_verified_provider_rate_limit_resume_event,
     _provider_rate_limit_reset_at,
 )
 from gateway.session import SessionSource
@@ -104,6 +106,19 @@ def test_provider_limit_reset_time_requires_future_timestamp():
     assert _coerce_provider_rate_limit_reset_at(1e100, now=1000) is None
 
 
+def test_provider_limit_reset_time_rejects_deadlines_beyond_session_retention():
+    now = 1_000.0
+
+    assert _coerce_provider_rate_limit_reset_at(now + (90 * 24 * 60 * 60), now=now)
+    assert (
+        _coerce_provider_rate_limit_reset_at(
+            now + (90 * 24 * 60 * 60) + 1,
+            now=now,
+        )
+        is None
+    )
+
+
 def test_provider_limit_reset_only_uses_rate_limit_results():
     future_reset = time.time() + 120
     assert (
@@ -147,6 +162,35 @@ async def test_provider_limit_resume_dispatches_internal_continuation():
     assert event.internal is True
     assert event.source is source
     assert event.text == ""
+    assert event.metadata.get("_hermes_provider_rate_limit_resume") is not None
+
+    entry = SimpleNamespace(
+        resume_pending=True,
+        resume_reason="provider_rate_limit",
+        resume_not_before=0.0,
+    )
+    assert _is_verified_provider_rate_limit_resume_event(
+        event,
+        entry,
+        run_generation=8,
+        now=1.0,
+    )
+    assert not _is_verified_provider_rate_limit_resume_event(
+        MessageEvent(
+            text="unrelated",
+            source=source,
+            internal=True,
+        ),
+        entry,
+        run_generation=8,
+        now=1.0,
+    )
+    assert not _is_verified_provider_rate_limit_resume_event(
+        event,
+        entry,
+        run_generation=8,
+        now=-1.0,
+    )
 
 
 @pytest.mark.asyncio
@@ -206,6 +250,46 @@ async def test_provider_limit_resume_skips_when_newer_turn_exists():
     )
 
     assert adapter.events == []
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_resume_does_not_overwrite_newer_turn_after_state_read():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    origin = object()
+    newer = object()
+    runner._running_agents["s1"] = origin
+
+    class _RacingAsyncStore:
+        calls = 0
+
+        def __init__(self, store):
+            self._store = store
+
+        async def is_resume_pending(self, session_key, reason=None):
+            self.calls += 1
+            if self.calls == 2:
+                runner._session_run_generation["s1"] = 8
+                runner._running_agents["s1"] = newer
+            return True
+
+    runner._async_session_store = _RacingAsyncStore(runner.session_store)
+    continuation = asyncio.create_task(
+        runner._run_provider_rate_limit_resume_after_delay(
+            session_key="s1",
+            source=source,
+            reset_at=0,
+            run_generation=7,
+        )
+    )
+    await asyncio.sleep(0.05)
+    runner._running_agents.pop("s1")
+
+    await asyncio.wait_for(continuation, timeout=1.0)
+
+    assert adapter.events == []
+    assert runner._running_agents["s1"] is newer
 
 
 @pytest.mark.asyncio
@@ -318,6 +402,34 @@ async def test_provider_limit_scheduler_does_not_cancel_dispatched_resume():
     first.cancel()
     second.cancel()
     await asyncio.gather(first, second, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_scheduler_deduplicates_same_dispatched_identity():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    reset_at = time.time() + 10_000
+
+    assert runner._install_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=reset_at,
+        run_generation=7,
+    )
+    first = runner._provider_rate_limit_resume_tasks["s1"]
+    setattr(first, "_hermes_provider_resume_dispatched", True)
+
+    assert runner._install_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=reset_at,
+        run_generation=7,
+    )
+
+    assert runner._provider_rate_limit_resume_tasks["s1"] is first
+    first.cancel()
+    await asyncio.gather(first, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_provider_rate_limit_resume.py
+++ b/tests/gateway/test_provider_rate_limit_resume.py
@@ -1,0 +1,361 @@
+import asyncio
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import (
+    GatewayRunner,
+    _coerce_provider_rate_limit_reset_at,
+    _provider_rate_limit_reset_at,
+)
+from gateway.session import SessionSource
+
+
+class _Adapter:
+    def __init__(self):
+        self.events = []
+
+    async def handle_message(self, event: MessageEvent):
+        self.events.append(event)
+
+
+class _SessionStore:
+    def __init__(self):
+        self.marks = []
+        self.mark_threads = []
+        self.clears = []
+        self.can_resume = True
+
+    def mark_resume_pending(
+        self, session_key, reason="restart_timeout", not_before=None
+    ):
+        self.mark_threads.append(threading.get_ident())
+        self.marks.append((session_key, reason, not_before))
+        return True
+
+    def is_resume_pending(self, session_key, reason=None):
+        return self.can_resume
+
+    def clear_resume_pending(self, session_key, reason=None):
+        self.clears.append((session_key, reason))
+        if not self.can_resume or reason not in {None, "provider_rate_limit"}:
+            return False
+        self.can_resume = False
+        return True
+
+
+class _ConcurrencyAdapter(_Adapter):
+    def __init__(self):
+        super().__init__()
+        self.active = 0
+        self.max_active = 0
+        self._session_tasks = {}
+        self._both_active = asyncio.Event()
+
+    async def _run_background(self, event: MessageEvent):
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        if self.active >= 2:
+            self._both_active.set()
+        try:
+            await asyncio.wait_for(self._both_active.wait(), timeout=1.0)
+            self.events.append(event)
+        finally:
+            self.active -= 1
+
+    async def handle_message(self, event: MessageEvent):
+        session_key = {"C1": "s1", "C2": "s2"}[event.source.chat_id]
+        self._session_tasks[session_key] = asyncio.create_task(
+            self._run_background(event)
+        )
+
+
+def _runner(adapter: _Adapter) -> GatewayRunner:
+    runner: Any = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.SLACK: adapter}
+    runner._background_tasks = set()
+    runner._provider_rate_limit_resume_tasks = {}
+    runner._session_run_generation = {"s1": 7}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._persist_active_agents = lambda: None
+    runner._is_user_authorized = lambda source: True
+    runner.session_store = _SessionStore()
+    return runner
+
+
+def test_provider_limit_reset_time_requires_future_timestamp():
+    assert _coerce_provider_rate_limit_reset_at(1200, now=1000) == 1200
+    assert (
+        _coerce_provider_rate_limit_reset_at(
+            "1970-01-01T00:20:00+00:00", now=1000
+        )
+        == 1200
+    )
+    assert _coerce_provider_rate_limit_reset_at("1970-01-01T00:20:00", now=1000) is None
+    assert _coerce_provider_rate_limit_reset_at(900, now=1000) is None
+    assert _coerce_provider_rate_limit_reset_at("not-a-time", now=1000) is None
+    assert _coerce_provider_rate_limit_reset_at(float("nan"), now=1000) is None
+    assert _coerce_provider_rate_limit_reset_at(float("inf"), now=1000) is None
+    assert _coerce_provider_rate_limit_reset_at(1e100, now=1000) is None
+
+
+def test_provider_limit_reset_only_uses_rate_limit_results():
+    future_reset = time.time() + 120
+    assert (
+        _provider_rate_limit_reset_at(
+            {"failure_reason": "billing", "error_context": {"reset_at": future_reset}}
+        )
+        is None
+    )
+    assert (
+        _provider_rate_limit_reset_at(
+            {"failure_reason": "rate_limit", "error_context": {}}
+        )
+        is None
+    )
+    assert (
+        _provider_rate_limit_reset_at(
+            {
+                "failure_reason": "rate_limit",
+                "error_context": {"reset_at": future_reset},
+            }
+        )
+        == future_reset
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_resume_dispatches_internal_continuation():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+
+    await runner._run_provider_rate_limit_resume_after_delay(
+        session_key="s1",
+        source=source,
+        reset_at=0,
+        run_generation=7,
+    )
+
+    assert len(adapter.events) == 1
+    event = adapter.events[0]
+    assert event.internal is True
+    assert event.source is source
+    assert event.text == ""
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_resume_skips_suspended_or_cleared_session():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    runner.session_store.can_resume = False
+
+    await runner._run_provider_rate_limit_resume_after_delay(
+        session_key="s1",
+        source=source,
+        reset_at=0,
+        run_generation=7,
+    )
+
+    assert adapter.events == []
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_resume_waits_for_origin_run_to_release_slot():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    runner._running_agents["s1"] = object()
+
+    continuation = asyncio.create_task(
+        runner._run_provider_rate_limit_resume_after_delay(
+            session_key="s1",
+            source=source,
+            reset_at=0,
+            run_generation=7,
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert adapter.events == []
+    assert not continuation.done()
+
+    runner._running_agents.pop("s1")
+    await asyncio.wait_for(continuation, timeout=1.0)
+
+    assert len(adapter.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_resume_skips_when_newer_turn_exists():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    runner._session_run_generation["s1"] = 8
+
+    await runner._run_provider_rate_limit_resume_after_delay(
+        session_key="s1",
+        source=source,
+        reset_at=0,
+        run_generation=7,
+    )
+
+    assert adapter.events == []
+
+
+@pytest.mark.asyncio
+async def test_real_user_turn_supersedes_durable_provider_continuation():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    reset_at = time.time() + 10_000
+    assert await runner._schedule_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=reset_at,
+        run_generation=7,
+    )
+    stale_task = runner._provider_rate_limit_resume_tasks["s1"]
+
+    superseded = await runner._supersede_provider_rate_limit_resume_for_user_turn(
+        session_key="s1"
+    )
+
+    assert superseded is True
+    assert runner.session_store.clears == [("s1", "provider_rate_limit")]
+    assert runner.session_store.can_resume is False
+    assert "s1" not in runner._provider_rate_limit_resume_tasks
+    await asyncio.gather(stale_task, return_exceptions=True)
+    assert stale_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_resume_scheduler_persists_deadline():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    reset_at = time.time() + 10_000
+    loop_thread = threading.get_ident()
+
+    scheduled = await runner._schedule_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=reset_at,
+        run_generation=7,
+    )
+
+    assert scheduled is True
+    assert runner.session_store.marks == [
+        ("s1", "provider_rate_limit", reset_at)
+    ]
+    assert runner.session_store.mark_threads != [loop_thread]
+    assert "s1" in runner._provider_rate_limit_resume_tasks
+    task = runner._provider_rate_limit_resume_tasks["s1"]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_scheduler_replaces_stale_wait_for_newer_turn():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+
+    assert await runner._schedule_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=time.time() + 10_000,
+        run_generation=7,
+    )
+    first = runner._provider_rate_limit_resume_tasks["s1"]
+    runner._session_run_generation["s1"] = 8
+
+    assert await runner._schedule_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=time.time() + 20_000,
+        run_generation=8,
+    )
+    second = runner._provider_rate_limit_resume_tasks["s1"]
+
+    assert second is not first
+    assert first.cancelled() or first.cancelling()
+    second.cancel()
+    await asyncio.gather(first, second, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_scheduler_does_not_cancel_dispatched_resume():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    source = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+
+    assert await runner._schedule_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=time.time() + 10_000,
+        run_generation=7,
+    )
+    first = runner._provider_rate_limit_resume_tasks["s1"]
+    setattr(first, "_hermes_provider_resume_dispatched", True)
+    runner._session_run_generation["s1"] = 8
+
+    assert await runner._schedule_provider_rate_limit_resume(
+        session_key="s1",
+        source=source,
+        reset_at=time.time() + 20_000,
+        run_generation=8,
+    )
+    second = runner._provider_rate_limit_resume_tasks["s1"]
+
+    assert not first.cancelling()
+    first.cancel()
+    second.cancel()
+    await asyncio.gather(first, second, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_resume_uses_source_profile_adapter():
+    adapter = _Adapter()
+    runner = _runner(adapter)
+    runner.adapters = {}
+    runner.__dict__["_profile_adapters"] = {"work": {Platform.SLACK: adapter}}
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C1",
+        user_id="U1",
+        profile="work",
+    )
+
+    await runner._run_provider_rate_limit_resume_after_delay(
+        session_key="s1", source=source, reset_at=0, run_generation=7
+    )
+
+    assert len(adapter.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_limit_resumes_run_in_parallel_across_sessions():
+    adapter = _ConcurrencyAdapter()
+    runner = _runner(adapter)
+    runner._session_run_generation["s2"] = 7
+    source1 = SessionSource(platform=Platform.SLACK, chat_id="C1", user_id="U1")
+    source2 = SessionSource(platform=Platform.SLACK, chat_id="C2", user_id="U2")
+
+    await asyncio.gather(
+        runner._run_provider_rate_limit_resume_after_delay(
+            session_key="s1", source=source1, reset_at=0, run_generation=7
+        ),
+        runner._run_provider_rate_limit_resume_after_delay(
+            session_key="s2", source=source2, reset_at=0, run_generation=7
+        ),
+    )
+
+    assert len(adapter.events) == 2
+    assert adapter.max_active == 2

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -337,6 +337,23 @@ class TestMarkResumePending:
         assert reloaded.resume_pending is True
         assert reloaded.resume_reason == "restart_timeout"
 
+    def test_provider_deadline_survives_roundtrip_through_json(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        reset_at = time.time() + 86_400
+        store.mark_resume_pending(
+            entry.session_key,
+            reason="provider_rate_limit",
+            not_before=reset_at,
+        )
+
+        store2 = _make_store(tmp_path)
+        store2._ensure_loaded()
+        reloaded = store2._entries[entry.session_key]
+        assert reloaded.resume_reason == "provider_rate_limit"
+        assert reloaded.resume_not_before == reset_at
+
 
 class TestClearResumePending:
     def test_clears_flag(self, tmp_path):
@@ -350,6 +367,7 @@ class TestClearResumePending:
         assert e.resume_pending is False
         assert e.resume_reason is None
         assert e.last_resume_marked_at is None
+        assert e.resume_not_before is None
 
     def test_returns_false_when_not_pending(self, tmp_path):
         store = _make_store(tmp_path)
@@ -361,6 +379,23 @@ class TestClearResumePending:
     def test_returns_false_for_unknown_key(self, tmp_path):
         store = _make_store(tmp_path)
         assert store.clear_resume_pending("no-such-key") is False
+
+    def test_reason_guard_does_not_clear_newer_recovery_marker(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        store.mark_resume_pending(entry.session_key, reason="restart_timeout")
+
+        assert (
+            store.clear_resume_pending(
+                entry.session_key,
+                reason="provider_rate_limit",
+            )
+            is False
+        )
+        e = store._entries[entry.session_key]
+        assert e.resume_pending is True
+        assert e.resume_reason == "restart_timeout"
 
 
 # ---------------------------------------------------------------------------
@@ -382,6 +417,27 @@ class TestGetOrCreateResumePending:
         assert second.was_auto_reset is False
         assert second.auto_reset_reason is None
         # Flag is NOT cleared on read — only on successful turn completion.
+        assert second.resume_pending is True
+
+    def test_provider_wait_ignores_generic_resume_freshness(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_AUTO_CONTINUE_FRESHNESS", "1")
+        store = _make_store(tmp_path)
+        source = _make_source()
+        first = store.get_or_create_session(source)
+        store.mark_resume_pending(
+            first.session_key,
+            reason="provider_rate_limit",
+            not_before=time.time() + 86_400,
+        )
+        with store._lock:
+            store._entries[first.session_key].last_resume_marked_at = (
+                datetime.now() - timedelta(days=1)
+            )
+            store._save()
+
+        second = store.get_or_create_session(source)
+
+        assert second.session_id == first.session_id
         assert second.resume_pending is True
 
     def test_resume_pending_follows_compression_tip(self, tmp_path):
@@ -1075,6 +1131,92 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
     # _handle_message_with_agent owns the system-note injection so we don't
     # double it up.
     assert event.text == ""
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_restores_provider_deadline():
+    """A gateway restart must rebuild the delayed provider continuation."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="provider-wait")
+    reset_at = time.time() + 3_600
+    pending_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:provider-wait",
+        session_id="sid",
+        created_at=datetime.now() - timedelta(days=1),
+        updated_at=datetime.now() - timedelta(days=1),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="provider_rate_limit",
+        last_resume_marked_at=datetime.now() - timedelta(days=1),
+        resume_not_before=reset_at,
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner._install_provider_rate_limit_resume = MagicMock(return_value=True)
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 1
+    runner._install_provider_rate_limit_resume.assert_called_once_with(
+        session_key=pending_entry.session_key,
+        source=source,
+        reset_at=reset_at,
+        run_generation=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_loop_guard_does_not_block_provider_deadlines():
+    """The restart breaker must not suppress independent provider continuations."""
+    runner, adapter = make_restart_runner()
+    provider_source = make_restart_source(chat_id="provider-wait")
+    restart_source = make_restart_source(chat_id="restart-wait")
+    reset_at = time.time() + 3_600
+    provider_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:provider-wait",
+        session_id="provider-sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=provider_source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="provider_rate_limit",
+        last_resume_marked_at=datetime.now(),
+        resume_not_before=reset_at,
+    )
+    restart_entry = SessionEntry(
+        session_key="agent:main:telegram:dm:restart-wait",
+        session_id="restart-sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=restart_source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {
+        provider_entry.session_key: provider_entry,
+        restart_entry.session_key: restart_entry,
+    }
+    runner._install_provider_rate_limit_resume = MagicMock(return_value=True)
+    runner._restart_loop_guard_config = MagicMock(return_value=(1, 60))
+    adapter.handle_message = AsyncMock()
+
+    with patch("gateway.restart_loop_guard.check_and_record", return_value=True):
+        scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 1
+    runner._install_provider_rate_limit_resume.assert_called_once_with(
+        session_key=provider_entry.session_key,
+        source=provider_source,
+        reset_at=reset_at,
+        run_generation=0,
+    )
+    adapter.handle_message.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -337,6 +337,60 @@ class TestMarkResumePending:
         assert reloaded.resume_pending is True
         assert reloaded.resume_reason == "restart_timeout"
 
+    def test_provider_deadline_rejects_later_drain_marker(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        reset_at = time.time() + 86_400
+
+        assert store.mark_resume_pending(
+            entry.session_key,
+            reason="provider_rate_limit",
+            not_before=reset_at,
+            resume_transport=Platform.RELAY.value,
+        )
+        assert not store.mark_resume_pending(
+            entry.session_key,
+            reason="shutdown_timeout",
+        )
+        assert not store.clear_resume_pending(
+            entry.session_key,
+            reason="shutdown_timeout",
+        )
+
+        preserved = store._entries[entry.session_key]
+        assert preserved.resume_pending is True
+        assert preserved.resume_reason == "provider_rate_limit"
+        assert preserved.resume_not_before == reset_at
+        assert preserved.resume_transport == Platform.RELAY.value
+
+    def test_provider_relay_transport_survives_roundtrip_without_trust_marker(
+        self, tmp_path
+    ):
+        store = _make_store(tmp_path)
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="relay-chat",
+            chat_type="dm",
+            user_id="relay-user",
+            delivered_via_upstream_relay=True,
+        )
+        entry = store.get_or_create_session(source)
+        reset_at = time.time() + 86_400
+        assert store.mark_resume_pending(
+            entry.session_key,
+            reason="provider_rate_limit",
+            not_before=reset_at,
+            resume_transport=Platform.RELAY.value,
+        )
+
+        store2 = _make_store(tmp_path)
+        store2._ensure_loaded()
+        reloaded = store2._entries[entry.session_key]
+        assert reloaded.resume_transport == Platform.RELAY.value
+        assert reloaded.origin.platform == Platform.DISCORD
+        assert reloaded.origin.delivered_via_upstream_relay is False
+
     def test_provider_deadline_survives_roundtrip_through_json(self, tmp_path):
         store = _make_store(tmp_path)
         source = _make_source()
@@ -1079,6 +1133,35 @@ async def test_graceful_drain_cleanup_does_not_clear_newer_provider_marker():
 
 
 @pytest.mark.asyncio
+async def test_graceful_drain_does_not_clear_marker_it_failed_to_acquire():
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    session_key = "agent:main:telegram:dm:A"
+    runner._running_agents = {session_key: MagicMock()}
+
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=False)
+    session_store.clear_resume_pending = MagicMock(return_value=False)
+    runner.session_store = session_store
+
+    async def _finish(_timeout):
+        runner._running_agents.clear()
+        return ({session_key: MagicMock()}, False)
+
+    runner._drain_active_agents = AsyncMock(side_effect=_finish)
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    session_store.mark_resume_pending.assert_called_once_with(
+        session_key, "shutdown_timeout"
+    )
+    session_store.clear_resume_pending.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_drain_timeout_uses_restart_reason_when_restarting():
     runner, adapter = make_restart_runner()
     adapter.disconnect = AsyncMock()
@@ -1212,6 +1295,44 @@ async def test_startup_auto_resume_restores_provider_deadline():
         source=source,
         reset_at=reset_at,
         run_generation=0,
+        resume_transport=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_restores_relay_transport():
+    runner, _adapter = make_restart_runner()
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="relay-provider-wait",
+        chat_type="dm",
+        user_id="relay-user",
+    )
+    reset_at = time.time() + 3_600
+    pending_entry = SessionEntry(
+        session_key="agent:main:discord:dm:relay-provider-wait",
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.DISCORD,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="provider_rate_limit",
+        last_resume_marked_at=datetime.now(),
+        resume_not_before=reset_at,
+        resume_transport=Platform.RELAY.value,
+    )
+    runner.session_store._entries = {pending_entry.session_key: pending_entry}
+    runner._install_provider_rate_limit_resume = MagicMock(return_value=True)
+
+    assert runner._schedule_resume_pending_sessions() == 1
+    runner._install_provider_rate_limit_resume.assert_called_once_with(
+        session_key=pending_entry.session_key,
+        source=source,
+        reset_at=reset_at,
+        run_generation=0,
+        resume_transport=Platform.RELAY.value,
     )
 
 
@@ -1264,6 +1385,7 @@ async def test_restart_loop_guard_does_not_block_provider_deadlines():
         source=provider_source,
         reset_at=reset_at,
         run_generation=0,
+        resume_transport=None,
     )
     adapter.handle_message.assert_not_called()
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1030,6 +1030,55 @@ async def test_drain_timeout_marks_resume_pending():
 
 
 @pytest.mark.asyncio
+async def test_graceful_drain_cleanup_does_not_clear_newer_provider_marker():
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    session_key = "agent:main:telegram:dm:A"
+    runner._running_agents = {session_key: MagicMock()}
+    state = {"reason": None, "not_before": None}
+
+    session_store = MagicMock()
+
+    def _mark(_key, reason="restart_timeout", not_before=None):
+        state["reason"] = reason
+        state["not_before"] = not_before
+        return True
+
+    def _clear(_key, reason=None):
+        if reason is not None and state["reason"] != reason:
+            return False
+        state["reason"] = None
+        state["not_before"] = None
+        return True
+
+    session_store.mark_resume_pending.side_effect = _mark
+    session_store.clear_resume_pending.side_effect = _clear
+    runner.session_store = session_store
+
+    async def _finish_with_provider_marker(_timeout):
+        session_store.mark_resume_pending(
+            session_key,
+            "provider_rate_limit",
+            time.time() + 3_600,
+        )
+        runner._running_agents.clear()
+        return ({session_key: MagicMock()}, False)
+
+    runner._drain_active_agents = AsyncMock(side_effect=_finish_with_provider_marker)
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    assert state["reason"] == "provider_rate_limit"
+    assert state["not_before"] is not None
+    assert session_store.clear_resume_pending.call_args_list[0].kwargs == {
+        "reason": "shutdown_timeout"
+    }
+
+
+@pytest.mark.asyncio
 async def test_drain_timeout_uses_restart_reason_when_restarting():
     runner, adapter = make_restart_runner()
     adapter.disconnect = AsyncMock()

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -115,6 +115,26 @@ class TestPruneBasics:
         assert "suspended" in store._entries
         assert "idle" not in store._entries
 
+    def test_prune_skips_durable_resume_pending_entries(self, tmp_path):
+        store = _make_store(tmp_path)
+        pending = _entry("pending", age_days=1000)
+        pending.resume_pending = True
+        pending.resume_reason = "provider_rate_limit"
+        pending.resume_not_before = 2_000_000_000.0
+        store._entries["pending"] = pending
+        restart_pending = _entry("restart-pending", age_days=1000)
+        restart_pending.resume_pending = True
+        restart_pending.resume_reason = "shutdown_timeout"
+        store._entries["restart-pending"] = restart_pending
+        store._entries["idle"] = _entry("idle", age_days=1000)
+
+        removed = store.prune_old_entries(max_age_days=90)
+
+        assert removed == 2
+        assert "pending" in store._entries
+        assert "restart-pending" not in store._entries
+        assert "idle" not in store._entries
+
     def test_prune_skips_entries_with_active_processes(self, tmp_path):
         """Sessions with active bg processes aren't pruned even if old.
 

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -135,7 +135,13 @@ def test_current_user_turn_is_persisted_before_provider_call(agent):
     assert observed[0][0] == "persist"
     assert observed[1][0] == "provider"
     persisted_messages = observed[0][1]
-    assert persisted_messages[-1] == {
+    last = persisted_messages[-1]
+    assert last["role"] == "user"
+    assert last["content"] == "new message that must survive a crash"
+    # In-memory identity metadata is expected; durable sinks strip it.
+    assert last.get("_hermes_current_turn_user_id")
+    durable = agent._messages_for_session_persistence([last])[0]
+    assert durable == {
         "role": "user",
         "content": "new message that must survive a crash",
     }

--- a/tests/run_agent/test_in_place_compaction.py
+++ b/tests/run_agent/test_in_place_compaction.py
@@ -124,6 +124,55 @@ class TestInPlaceCompaction:
             # Live transcript actually shrank.
             assert len(compressed) == 2
 
+    def test_in_place_excludes_suppressed_current_user_from_durable_rewrite(self):
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "ip_synthetic"
+            _seed(db, sid, "synthetic")
+            agent = _make_agent(db, sid, in_place=True)
+            token = "turn-token"
+            agent._persist_user_message_idx = 99
+            agent._persist_user_message_token = token
+            agent._suppress_current_user_message_persistence = True
+            synthetic = {
+                "role": "user",
+                "content": "[synthetic provider continuation]",
+                "_hermes_current_turn_user_id": token,
+            }
+            agent.context_compressor.compress = lambda *_a, **_k: [
+                {"role": "user", "content": "real compacted context"},
+                {"role": "assistant", "content": "prior answer"},
+                synthetic.copy(),
+            ]
+
+            compressed, _ = compress_context(
+                agent,
+                [{"role": "user", "content": "real prior user"}, synthetic],
+                approx_tokens=100_000,
+                system_message="sys",
+            )
+
+            assert any(m.get("content") == synthetic["content"] for m in compressed)
+            durable = db.get_messages_as_conversation(sid)
+            assert [m.get("content") for m in durable] == [
+                "real compacted context",
+                "prior answer",
+            ]
+
+            # The in-place cursor must count durable rows, not the synthetic
+            # row kept only for the provider call. Otherwise finalization pops
+            # that row and the new assistant lands immediately before the stale
+            # cursor, so the next flush silently skips it.
+            compressed.append({"role": "assistant", "content": "fresh answer"})
+            agent._apply_persist_user_message_override(compressed)
+            agent._flush_messages_to_session_db(compressed)
+            assert [
+                m.get("content") for m in db.get_messages_as_conversation(sid)
+            ] == ["real compacted context", "prior answer", "fresh answer"]
+
     def test_in_place_alternation_preserved(self):
         """The compacted list must not introduce consecutive same-role messages."""
         from hermes_state import SessionDB
@@ -185,6 +234,52 @@ class TestInPlaceCompaction:
 
 
 class TestRotationFallbackWhenFlagOff:
+    def test_rotation_excludes_suppressed_current_user_from_parent_and_child(self):
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            parent_sid = "rot_synthetic"
+            _seed(db, parent_sid, "synthetic")
+            agent = _make_agent(db, parent_sid, in_place=False)
+            token = "turn-token"
+            agent._persist_user_message_idx = 99
+            agent._persist_user_message_token = token
+            agent._suppress_current_user_message_persistence = True
+            synthetic = {
+                "role": "user",
+                "content": "[synthetic provider continuation]",
+                "_hermes_current_turn_user_id": token,
+            }
+            agent.context_compressor.compress = lambda *_a, **_k: [
+                {"role": "user", "content": "real compacted context"},
+                {"role": "assistant", "content": "continued"},
+                synthetic.copy(),
+            ]
+
+            compressed, _ = compress_context(
+                agent,
+                [{"role": "user", "content": "real prior user"}, synthetic],
+                approx_tokens=100_000,
+                system_message="sys",
+            )
+            child_sid = agent.session_id
+            assert child_sid != parent_sid
+
+            agent._apply_persist_user_message_override(compressed)
+            agent._persist_session(compressed, [])
+
+            parent_contents = [
+                row.get("content")
+                for row in db.get_messages(parent_sid, include_inactive=True)
+            ]
+            child_contents = [
+                row.get("content") for row in db.get_messages_as_conversation(child_sid)
+            ]
+            assert synthetic["content"] not in parent_contents
+            assert child_contents == ["real compacted context", "continued"]
+
     def test_rotation_when_flag_off(self):
         """Rotation is now the OPT-OUT fallback (default flipped to in-place in
         #38763). With in_place=False explicitly set, legacy rotation is

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -258,6 +258,38 @@ def test_suppress_current_user_message_omits_synthetic_db_row(agent):
     assert persisted_roles == ["assistant"]
 
 
+def test_suppress_current_user_message_uses_stable_identity_after_compaction(agent):
+    token = "turn-token"
+    synthetic = {
+        "role": "user",
+        "content": "[System note: synthetic continuation]",
+        "_hermes_current_turn_user_id": token,
+    }
+    messages = [
+        {"role": "user", "content": "real compacted context"},
+        {"role": "assistant", "content": "prior answer"},
+        synthetic,
+        {"role": "assistant", "content": "continued"},
+    ]
+    agent._persist_user_message_idx = 99
+    agent._persist_user_message_token = token
+    agent._suppress_current_user_message_persistence = True
+
+    durable = agent._messages_for_session_persistence(messages)
+    assert [msg["content"] for msg in durable] == [
+        "real compacted context",
+        "prior answer",
+        "continued",
+    ]
+
+    agent._apply_persist_user_message_override(messages)
+    assert [msg["content"] for msg in messages] == [
+        "real compacted context",
+        "prior answer",
+        "continued",
+    ]
+
+
 def test_suppress_current_user_message_filters_json_session_log(agent):
     agent._suppress_current_user_message_persistence = True
     agent._persist_user_message_idx = 0

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6027,7 +6027,16 @@ class TestRetryExhaustion:
     def test_api_error_returns_gracefully_after_retries(self, agent):
         """Exhausted retries on API errors must return error result, not crash."""
         self._setup_agent(agent)
-        agent.client.chat.completions.create.side_effect = RuntimeError("rate limited")
+        api_error = RuntimeError("rate limited")
+        api_error.body = {
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "rate limited",
+                "resets_at": 2_000_000_000,
+            }
+        }
+        api_error.response = SimpleNamespace(headers={})
+        agent.client.chat.completions.create.side_effect = api_error
         from agent import conversation_loop as _conv_loop
         with (
             patch.object(agent, "_persist_session"),
@@ -6042,6 +6051,9 @@ class TestRetryExhaustion:
         assert result.get("failed") is True
         assert "error" in result
         assert "rate limited" in result["error"]
+        assert result.get("failure_reason") == "rate_limit"
+        assert result.get("error_context", {}).get("message") == "rate limited"
+        assert result.get("error_context", {}).get("reset_at") == 2_000_000_000
 
     def test_build_api_kwargs_error_no_unbound_local(self, agent):
         """When _build_api_kwargs raises, except handler must not crash with UnboundLocalError.
@@ -6391,6 +6403,26 @@ class TestCredentialPoolRecovery:
 
         assert context["reason"] == "usage_limit_reached"
         assert context["message"] == "The usage limit has been reached"
+
+    def test_extract_api_error_context_normalizes_resets_in_seconds(self, agent, monkeypatch):
+        from agent import agent_runtime_helpers
+
+        monkeypatch.setattr(agent_runtime_helpers.time, "time", lambda: 1_000.0)
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                    "resets_in_seconds": 3_600,
+                }
+            },
+            response=SimpleNamespace(headers={}),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reason"] == "usage_limit_reached"
+        assert context["reset_at"] == 4_600.0
 
     def test_extract_api_error_context_parses_resets_in_hours_and_minutes(self, agent, monkeypatch):
         from agent import agent_runtime_helpers

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -238,6 +238,55 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
     assert db.rows == ["exactly once"]
 
 
+def test_suppress_current_user_message_omits_synthetic_db_row(agent):
+    agent._session_db = MagicMock()
+    agent._session_db_created = True
+    agent.session_id = "session-123"
+    agent._last_flushed_db_idx = 0
+    agent._persist_user_message_idx = 0
+    agent._suppress_current_user_message_persistence = True
+    messages = [
+        {"role": "user", "content": "[System note: synthetic continuation]"},
+        {"role": "assistant", "content": "continued"},
+    ]
+
+    agent._flush_messages_to_session_db(messages)
+
+    persisted_roles = [
+        call.kwargs["role"] for call in agent._session_db.append_message.call_args_list
+    ]
+    assert persisted_roles == ["assistant"]
+
+
+def test_suppress_current_user_message_filters_json_session_log(agent):
+    agent._suppress_current_user_message_persistence = True
+    agent._persist_user_message_idx = 0
+    agent._session_db = None
+    agent._save_session_log = MagicMock()
+    messages = [
+        {"role": "user", "content": "[System note: synthetic continuation]"},
+        {"role": "assistant", "content": "continued"},
+    ]
+
+    agent._persist_session(messages)
+
+    assert agent._save_session_log.call_args.args[0] == [
+        {"role": "assistant", "content": "continued"}
+    ]
+
+
+def test_extract_api_error_context_ignores_unhashable_reset_delay():
+    from agent.agent_runtime_helpers import extract_api_error_context
+
+    for malformed in ({}, []):
+        error = RuntimeError("rate limited")
+        error.body = {"error": {"resets_in_seconds": malformed}}
+
+        context = extract_api_error_context(error)
+
+        assert "reset_at" not in context
+
+
 @pytest.fixture()
 def agent_with_memory_tool():
     """Agent whose valid_tool_names includes 'memory'."""


### PR DESCRIPTION
## Summary

The gateway previously knew when a provider reset would happen but only surfaced a retry hint, leaving users to send another message manually. This PR turns a verified provider-level reset into durable session state and schedules an automatic continuation after the provider window reopens.

## What changed

- Carry typed `error_data` through the producer chain so the gateway can use `provider_rate_limit.reset_at` without parsing display strings.
- Persist reset time, reason, transport, and source routing needed to resume the exact session.
- Restore pending continuations after gateway restart, including sessions that are already resident in the in-memory cache.
- Dispatch an internal continuation only when the stored identity still matches the scheduled work.
- Clear the pending marker after a successful continuation or a real user turn; reschedule if the provider reports another verified reset.

### Queue and lifecycle safety

- Real user turns supersede a pending provider continuation.
- If a newer run generation is rate-limited while an older wait is still pending, the scheduler cancels/replaces that stale wait so the newer turn cannot be stranded.
- A continuation already dispatched into an adapter queue is not canceled by a later scheduling call; task identity and generation checks protect the in-flight handoff.
- Unrelated internal events (delegation/background completions) no longer advance the session generation and orphan a live provider timer.
- `provider_rate_limit` deadlines outrank later shutdown/restart pre-drain marks; drain ownership clears only the marker it successfully acquired.
- Queueing uses the adapter selected from the event source, so multiplexed/profile-local sessions resume through the correct platform instance.
- Relay-origin sessions persist a separate `resume_transport` (not the wire-invisible trust marker) and restore through the live relay adapter with upstream-authz and scope priming.
- Per-session waits run independently; a long reset for one session does not block another session with an earlier deadline.
- Synthetic continuation events never persist another user row, including when a resumed turn is provider-limited again, ends as hidden-reasoning-only incomplete, or survives preflight compaction via a stable turn UUID rather than a numeric index.
- In-place compaction stamps and flushes against durable (non-suppressed) rows so same-turn assistant output is not skipped after synthetic exclusion.
- Reset values must be finite, future Unix timestamps within the existing session retention window (30 days).

### Durable store hygiene

- Pending resumes survive gateway restarts.
- Startup removes stale/incomplete resume records that lack the source data needed to resume safely.
- Expired pending sessions are pruned after `reset_at + retention`, while non-pending sessions keep their existing idle-retention behavior.
- Numeric string timestamps written by SQLite/runtime serialization are normalized before scheduling.

## Scope

This intentionally does **not** add per-provider heuristics, synthetic transcript prompts, or a second queue. It reuses the existing adapter queue, session generation guard, and session database. Only structured reset times are eligible; unverified or unreasonable values remain manual-retry behavior.

## Validation

- Focused gateway/producer/compaction/authz suite on the exact final revision: **799 passed**.
- Specific reviewer regression: `test_provider_limit_scheduler_replaces_stale_wait_for_newer_turn` passes.
- Additional regressions for internal-event generation ownership, pre-drain precedence, stable turn identity across compaction, in-place durable flush, relay transport routing, durable private-marker stripping, and exclusive provider-resume guidance pass.
- Ruff on all changed source/test files: clean.
- `py_compile` on all changed Python files: clean.
- Windows footgun scan on changed files: clean.
- `git diff --check`: clean.
- Canonical full-suite comparison on the pre-final-equality-fix content lineage: **41,475 passed / 28 failed**. Exact-base fail-file comparison reproduced 27 failures; the only candidate-only failure was an assertion that ignored intentional in-memory turn identity metadata and is fixed/revalidated on this head. Remaining failures are environment/base issues (`systemctl` absence, `/tmp` vs `/private/tmp`, AF_UNIX path length, macOS service helpers).

## Manual QA

No live Slack/Discord provider-limit wait was forced: doing so would require a real upstream quota window and a gateway restart. The behavior is covered with deterministic async scheduler, restart, stale-generation, dispatch-race, persistence, compaction, and source-adapter tests instead.
