### PR TITLE
fix: skip symlink resolution for non-local terminal backends (#52823)

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -307,9 +307,19 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
+
+    On non-local terminal backends (Docker, SSH, Modal, etc.) symlinks are
+    NOT resolved because the path refers to the remote filesystem, not the
+    host.  This prevents macOS host symlinks (e.g. /home →
+    /System/Volumes/Data/home) from corrupting paths destined for a Linux
+    container.
     """
     p = Path(_expand_tilde(filepath))
     if p.is_absolute():
+        # Non-local backends — skip host-side symlink resolution (issue #52823)
+        terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower()
+        if terminal_env and terminal_env != "local":
+            return p
         return p.resolve()
     return (_resolve_base_dir(task_id) / p).resolve()
 


### PR DESCRIPTION
Fixes #52823

## Problem

On macOS 10.15+, `/home` is a symlink to `/System/Volumes/Data/home`. When `TERMINAL_ENV` is non-local (docker, ssh, modal, etc.), paths refer to the remote filesystem but `_resolve_path_for_task()` calls `Path.resolve()` unconditionally, following host-side symlinks and corrupting the path (e.g. `/home/user/file.txt` → `/System/Volumes/Data/home/user/file.txt`).

## Fix

Check `TERMINAL_ENV` in `_resolve_path_for_task()`: if the backend is non-local, skip `Path.resolve()` for absolute paths. Relative paths and local backend behavior are unchanged.

## Testing

- Manual: `TERMINAL_ENV=docker` → absolute paths no longer follow symlinks
- Existing behavior preserved for local backend (`TERMINAL_ENV` unset or `local`)
- All existing tests for path resolution should pass unchanged