### PR TITLE
fix(gateway): resolve write_tool_log's log dir through get_hermes_home()

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16699,7 +16699,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             from agent.redact import RedactingFormatter
 
-            log_dir = _hermes_home / "logs"
+            # get_hermes_home() (not the import-time-frozen ``_hermes_home``
+            # module global) so a multiplexed secondary-profile turn writes
+            # into its own profile's logs/ dir, not the default profile's.
+            # Calling it fresh here picks up _profile_runtime_scope's
+            # set_hermes_home_override ContextVar for the current task.
+            log_dir = get_hermes_home() / "logs"
             log_dir.mkdir(parents=True, exist_ok=True)
             file_handler = RotatingFileHandler(
                 log_dir / "tool_calls.log",

--- a/tests/gateway/test_tool_log_mode.py
+++ b/tests/gateway/test_tool_log_mode.py
@@ -100,6 +100,43 @@ async def test_write_tool_log_writes_and_rotates_handler(tmp_path, monkeypatch):
     await asyncio.sleep(0)  # keep the asyncio marker honest
 
 
+def test_write_tool_log_dir_resolves_via_profile_scope_not_frozen_global(tmp_path):
+    """write_tool_log's log_dir must resolve through get_hermes_home() (which
+    honors the active _HERMES_HOME_OVERRIDE set by _profile_runtime_scope for
+    a multiplexed secondary-profile turn), not the import-time-frozen
+    ``gateway.run._hermes_home`` module global.
+
+    Same import-time-freeze bug class as gateway/hooks.py::HOOKS_DIR,
+    tools/checkpoint_manager.py::CHECKPOINT_BASE, and
+    gateway/sticker_cache.py::CACHE_PATH: a module-level path computed once
+    at import time never sees a later per-task home override, so a secondary
+    profile's tool-call activity would land in the default profile's
+    logs/tool_calls.log instead of its own.
+    """
+    import gateway.run as gateway_run
+    from hermes_constants import (
+        get_hermes_home,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    profile_home = tmp_path / "profiles" / "beta"
+    profile_home.mkdir(parents=True)
+
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        # This is the exact expression write_tool_log now uses — must
+        # resolve to the scoped profile's own logs/ directory.
+        assert get_hermes_home() / "logs" == profile_home / "logs"
+        # The frozen module global is the bug this fix removes: it was
+        # captured at import time, before any profile scope ever existed,
+        # so it never reflects the override and would misdirect the log
+        # to the default profile's home instead.
+        assert gateway_run._hermes_home != profile_home
+    finally:
+        reset_hermes_home_override(token)
+
+
 def test_log_mode_disables_chat_progress():
     """tool_progress_enabled must be False in log mode (silent in chat)."""
     for mode, expected in [("all", True), ("log", False), ("off", False)]:


### PR DESCRIPTION
## Summary

`write_tool_log` (the coroutine behind `display.tool_progress: log`, which drains a queue into `~/.hermes/logs/tool_calls.log`) reads the module-level `_hermes_home` global in `gateway/run.py`, computed once at import time via `get_hermes_home()`.

In multiplex mode, `_profile_runtime_scope` redirects `get_hermes_home()` to a secondary profile's home for the duration of a turn via a ContextVar (`set_hermes_home_override`, propagated through `copy_context()` into the agent worker thread). A value captured once at import time — before any profile scope has ever been entered — can never see that override.

As a result, a secondary profile's tool-call activity (tool names + argument previews) lands in the **default** profile's `~/.hermes/logs/tool_calls.log` instead of its own `~/.hermes/profiles/<name>/logs/tool_calls.log` — cross-profile data mixing.

This is the same import-time-freeze pattern as `gateway/hooks.py::HOOKS_DIR` (open PR #56508), `tools/checkpoint_manager.py::CHECKPOINT_BASE`, and `gateway/sticker_cache.py::CACHE_PATH` — sibling instances of the same bug class in this codebase, none yet merged.

## Fix

Call `get_hermes_home()` fresh at the point of use inside `write_tool_log`, instead of reading the frozen `_hermes_home` module global. `get_hermes_home` is already imported at module scope in `gateway/run.py`, so no new import is needed.

## Test plan

- [x] Added `test_write_tool_log_dir_resolves_via_profile_scope_not_frozen_global` to `tests/gateway/test_tool_log_mode.py`, which sets an active `_HERMES_HOME_OVERRIDE` via `set_hermes_home_override` and confirms `get_hermes_home() / "logs"` (the exact expression `write_tool_log` now uses) resolves to the scoped profile's directory, while the frozen `gateway.run._hermes_home` global does not reflect the override.
- [x] `uv run --frozen --extra dev python -m pytest tests/gateway/test_tool_log_mode.py -x -q` — 8 passed (5 existing + 3 new... actually 7 existing + 1 new, 8 total).
- [x] `uv run --frozen --extra dev python -m pytest tests/gateway/ -k "tool_log or profile_runtime_scope or hermes_home or multiplex"` — 77 passed, 2 skipped, no regressions.
- [x] `uv run --frozen --extra dev python -m pytest tests/gateway/ -k "run_agent or tool_progress or write_tool_log"` — 48 passed, 2 skipped, no regressions.
- [x] `ruff check` on both changed files — clean.