### PR TITLE
fix(gateway): handle unresolved launchd uid homes

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2413,11 +2413,36 @@ def _launchd_user_home() -> Path:
     """Return the real macOS user home for launchd artifacts.
 
     Profile-mode Hermes often sets ``HOME`` to a profile-scoped directory, but
-    launchd user agents still live under the actual account home.
+    launchd user agents still live under the actual account home. Some
+    sandboxed macOS environments expose the real UID without making that UID
+    resolvable through ``pwd.getpwuid``; in that case prefer explicit or
+    conservative home-directory fallbacks over crashing launchd commands.
     """
     import pwd
 
-    return Path(pwd.getpwuid(os.getuid()).pw_dir)  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    override = os.environ.get("HERMES_LAUNCHD_HOME") or os.environ.get(
+        "HERMES_REAL_HOME"
+    )
+    if override:
+        return Path(override).expanduser()
+
+    try:
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except KeyError as exc:
+        home = os.environ.get("HOME")
+        if home and home.startswith("/Users/"):
+            return Path(home).expanduser()
+
+        hermes_home = os.environ.get("HERMES_HOME")
+        if hermes_home:
+            path = Path(hermes_home).expanduser()
+            if ".hermes" in path.parts:
+                return Path(*path.parts[: path.parts.index(".hermes")])
+
+        raise RuntimeError(
+            f"could not resolve launchd home for uid {os.getuid()}; "
+            "set HERMES_LAUNCHD_HOME=/Users/<user>"
+        ) from exc
 
 
 def get_launchd_plist_path() -> Path:

--- a/tests/hermes_cli/test_gateway_service_paths.py
+++ b/tests/hermes_cli/test_gateway_service_paths.py
@@ -1,6 +1,25 @@
 from unittest.mock import patch
 
 
+def test_launchd_user_home_uses_explicit_override(monkeypatch, tmp_path):
+    from hermes_cli.gateway import _launchd_user_home
+
+    monkeypatch.setenv("HERMES_LAUNCHD_HOME", str(tmp_path))
+
+    assert _launchd_user_home() == tmp_path
+
+
+def test_launchd_user_home_falls_back_to_home_when_pwd_lookup_fails(monkeypatch):
+    from hermes_cli.gateway import _launchd_user_home
+
+    monkeypatch.delenv("HERMES_LAUNCHD_HOME", raising=False)
+    monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+    monkeypatch.setenv("HOME", "/Users/example")
+
+    with patch("pwd.getpwuid", side_effect=KeyError("uid not found")):
+        assert _launchd_user_home().as_posix() == "/Users/example"
+
+
 def test_service_path_skips_nonexistent_node_modules(tmp_path):
     """Service PATH should not include node_modules/.bin if it doesn't exist."""
     from hermes_cli.gateway import _build_service_path_dirs


### PR DESCRIPTION
Fixes #57292.

Hermes launchd commands currently assume pwd.getpwuid(os.getuid()) always resolves the current UID on macOS. In sandboxed/app-hosted shells that can fail with KeyError even when HOME and HERMES_HOME are valid.

This adds explicit HERMES_LAUNCHD_HOME/HERMES_REAL_HOME support, conservative HOME/HERMES_HOME fallbacks, and focused tests for the unresolved-UID case.