### PR TITLE
fix(status): flag platform tokens visible only to the shell, not .env

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -60,6 +60,40 @@ def _format_iso_timestamp(value) -> str:
     return parsed.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
+def _dotenv_key_names() -> set[str]:
+    """Return the set of env-var names assigned a non-empty value in ~/.hermes/.env.
+
+    The managed backends (launchd / systemd / the desktop-spawned ``serve``
+    process) load credentials from this file — NOT from an interactive shell's
+    exports. ``hermes status`` runs in a terminal, so ``os.getenv`` reflects the
+    shell's environment, which can include exported keys the managed backend
+    never sees. Comparing against this set lets status flag that mismatch —
+    same trap ``hermes debug share`` (dump.py) flags for its own key list.
+    """
+    try:
+        env_path = get_env_path()
+        text = env_path.read_text(encoding="utf-8", errors="ignore")
+    except (OSError, UnicodeError):
+        return set()
+
+    names: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.lower().startswith("export "):
+            line = line[len("export "):].lstrip()
+        name, _, value = line.partition("=")
+        name = name.strip()
+        # A bare `KEY=` (empty value) is effectively unset for the backend.
+        if name and value.strip().strip("'\""):
+            names.add(name)
+    return names
+
+
+_SHELL_ONLY_SUFFIX = " (shell only — not in .env; managed/desktop backend may not see it)"
+
+
 def _configured_model_label(config: dict) -> str:
     """Return the configured default model from config.yaml."""
     model_cfg = config.get("model")
@@ -453,21 +487,29 @@ def show_status(args):
         "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
     }
 
+    dotenv_keys = _dotenv_key_names()
+
     for name, (token_var, home_var) in platforms.items():
         token = os.getenv(token_var, "")
         has_token = bool(token)
-        
+
         home_channel = ""
         if home_var:
             home_channel = os.getenv(home_var, "")
         # Back-compat: QQBot home channel was renamed from QQ_HOME_CHANNEL to QQBOT_HOME_CHANNEL
         if not home_channel and home_var == "QQBOT_HOME_CHANNEL":
             home_channel = os.getenv("QQ_HOME_CHANNEL", "")
-        
+
         status = "configured" if has_token else "not configured"
         if home_channel:
             status += f" (home: {home_channel})"
-        
+        # Set in this (shell) process but absent from ~/.hermes/.env: a managed
+        # backend (launchd/systemd/desktop `serve`) loads .env, not the login
+        # shell, so it likely can't see this token even though status reads
+        # "configured" here.
+        if has_token and token_var not in dotenv_keys:
+            status += _SHELL_ONLY_SUFFIX
+
         print(f"  {name:<12}  {check_mark(has_token)} {status}")
 
     # Plugin-registered platforms
@@ -573,7 +615,12 @@ def show_status(args):
                     timeout=10
                 )
                 ok = response.status_code == 200
-                print(f"  OpenRouter:   {check_mark(ok)} {'reachable' if ok else f'error ({response.status_code})'}")
+                suffix = (
+                    _SHELL_ONLY_SUFFIX
+                    if "OPENROUTER_API_KEY" not in _dotenv_key_names()
+                    else ""
+                )
+                print(f"  OpenRouter:   {check_mark(ok)} {'reachable' if ok else f'error ({response.status_code})'}{suffix}")
             except Exception as e:
                 print(f"  OpenRouter:   {check_mark(False)} error: {e}")
         

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -15,6 +15,64 @@ def test_show_status_all_does_not_print_tavily_key_value(monkeypatch, capsys, tm
     assert sentinel not in output
 
 
+def _platform_line(out: str, label: str) -> str:
+    for line in out.splitlines():
+        if line.strip().startswith(f"{label} "):
+            return line
+    raise AssertionError(f"no {label!r} platform line in status output:\n{out}")
+
+
+def test_show_status_flags_shell_only_platform_token(monkeypatch, capsys, tmp_path):
+    """A platform token exported in the shell but absent from ~/.hermes/.env
+    is invisible to the launchd/systemd/desktop-spawned managed backend —
+    status must flag the mismatch instead of printing a bare "configured"
+    (same trap `hermes debug share` / dump.py already flags for API keys)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("OPENROUTER_API_KEY=sk-or-xxxx\n")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "shell-only-token")
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    line = _platform_line(capsys.readouterr().out, "Telegram")
+    assert "configured" in line
+    assert "shell only" in line
+    assert ".env" in line
+
+
+def test_show_status_does_not_flag_platform_token_present_in_dotenv(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=in-dotenv-token\n")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "in-dotenv-token")
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    line = _platform_line(capsys.readouterr().out, "Telegram")
+    assert "configured" in line
+    assert "shell only" not in line
+
+
+def test_show_status_deep_flags_shell_only_openrouter_key(monkeypatch, capsys, tmp_path):
+    """The OpenRouter deep-connectivity check reads the shell's env var too —
+    it must flag the same shell-vs-.env mismatch even though the live
+    reachability probe itself succeeds."""
+    import httpx
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("OTHER_KEY=1\n")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-shell-only")
+
+    class _FakeResponse:
+        status_code = 200
+
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: _FakeResponse())
+
+    show_status(SimpleNamespace(all=True, deep=True))
+
+    line = _platform_line(capsys.readouterr().out, "OpenRouter:")
+    assert "reachable" in line
+    assert "shell only" in line
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary

`hermes status` reads messaging-platform tokens and the OpenRouter deep-connectivity check via `os.getenv` — the invoking terminal's environment. But the managed backends (launchd / systemd / the desktop-spawned `serve` process) load credentials from `~/.hermes/.env`, not the login shell.

A token exported in the shell but absent from `.env` is invisible to the managed backend, yet `status` prints a bare `configured` (or, for OpenRouter's deep check, `reachable` — the live probe genuinely succeeds using the shell's key) with no indication that the backend actually running the gateway won't see it. This is the exact same class of trap `#89acc1960` (`fix(dump): flag API keys visible only to the shell, not the managed backend`) just fixed for `hermes debug share`'s API-key list, down to the real-world symptom it documents: a platform or provider looking "configured" in status while gated off for the actual running gateway.

## Fix

Port `dump.py`'s `_dotenv_key_names()` helper (reads `~/.hermes/.env`, returns the set of non-empty-value keys) into `status.py`, and apply it at the two `os.getenv`-based checks that display a boolean "configured"/"reachable" state without any indication of *which* process would actually see the value:

1. The messaging-platforms loop (Telegram, Discord, Slack, etc.) — appends `(shell only — not in .env; managed/desktop backend may not see it)` when a token is set in-process but missing from `.env`.
2. The OpenRouter deep-connectivity check — same annotation, since the live reachability probe uses the shell's key even though the backend may not have it.

## Test plan

- [x] Added `test_show_status_flags_shell_only_platform_token`, `test_show_status_does_not_flag_platform_token_present_in_dotenv`, and `test_show_status_deep_flags_shell_only_openrouter_key` to `tests/hermes_cli/test_status.py`, mirroring the existing `test_dump_env_visibility.py` pattern.
- [x] `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_status.py -x -q` — 20 passed (17 existing + 3 new).
- [x] `uv run --frozen --extra dev python -m pytest tests/hermes_cli/ -k status -q` — 193 passed, 3 skipped, no regressions.
- [x] `ruff check` on both changed files — clean.