### PR TITLE
feat(compression): add codex_gpt55_autoraise_notice flag

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -86,6 +86,19 @@ def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
     )
 
 
+def _codex_gpt55_autoraise_notice_enabled(compression_cfg: Dict[str, Any]) -> bool:
+    """Return whether the Codex gpt-5.5 autoraise notice should be user-visible.
+
+    ``codex_gpt55_autoraise`` controls the behavior; this flag controls only
+    the UX notice. Keeping these separate lets long-running gateway sessions
+    keep the safer/later 85% trigger without sending a platform chat message on
+    every fresh agent/session.
+    """
+    return str(
+        compression_cfg.get("codex_gpt55_autoraise_notice", True)
+    ).lower() in {"true", "1", "yes", "on"}
+
+
 def _normalized_custom_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -1407,6 +1420,7 @@ def init_agent(
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
     ).lower() in {"true", "1", "yes"}
+    _codex_gpt55_autoraise_notice = _codex_gpt55_autoraise_notice_enabled(_compression_cfg)
     agent._compression_threshold_autoraised = None
     try:
         from agent.auxiliary_client import (
@@ -1864,7 +1878,7 @@ def init_agent(
         # gateway users get the same text replayed via _compression_warning on
         # turn 1 (set below, after the warning slot is initialized).
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
+        if _autoraise and compression_enabled and _codex_gpt55_autoraise_notice:
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
     # Check immediately so CLI users see the warning at startup.
@@ -1875,7 +1889,7 @@ def init_agent(
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
     _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
+    if _autoraise and compression_enabled and _codex_gpt55_autoraise_notice:
         agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1358,6 +1358,9 @@ DEFAULT_CONFIG = {
                                       # exact route is affected — gpt-5.5 on OpenAI's
                                       # direct API, OpenRouter, and Copilot keep the
                                       # global threshold regardless.
+        "codex_gpt55_autoraise_notice": True,
+                                      # When False, keep the 85% Codex gpt-5.5 trigger but
+                                      # suppress the user-visible startup/gateway notice.
         "in_place": True,             # When True, compaction rewrites the message
                                       # list and rebuilds the system prompt WITHOUT
                                       # rotating the session id — the conversation

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -1,0 +1,67 @@
+"""Tests for the Codex gpt-5.5 autoraise notice UX switch.
+
+The autoraise behavior and its user-facing notice are intentionally separate:
+Codex gpt-5.5 should still compact at 85%, while gateway/CLI notices can be
+suppressed for long-running chat sessions where the notice is noise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _make_codex_gpt55_agent(compression_cfg: dict, tmp_path: Path) -> Any:
+    cfg = {
+        "compression": compression_cfg,
+        "memory": {"memory_enabled": False, "user_profile_enabled": False},
+    }
+    db = SessionDB(db_path=tmp_path / "state.db")
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        return AIAgent(
+            api_key="test-key",
+            provider="openai-codex",
+            base_url="https://api.openai.com/v1",
+            model="gpt-5.5",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=db,
+        )
+
+
+def test_codex_gpt55_notice_can_be_suppressed_without_disabling_autoraise(tmp_path: Path) -> None:
+    agent = _make_codex_gpt55_agent(
+        {
+            "enabled": True,
+            "threshold": 0.50,
+            "codex_gpt55_autoraise": True,
+            "codex_gpt55_autoraise_notice": False,
+        },
+        tmp_path,
+    )
+
+    assert getattr(agent, "_compression_threshold_autoraised") == {"from": 0.50, "to": 0.85}
+    assert agent.context_compressor.context_length == 272_000
+    assert agent.context_compressor.threshold_tokens == 231_200
+    assert getattr(agent, "_compression_warning") is None
+
+
+def test_codex_gpt55_notice_defaults_visible_for_existing_users(tmp_path: Path) -> None:
+    agent = _make_codex_gpt55_agent(
+        {
+            "enabled": True,
+            "threshold": 0.50,
+            "codex_gpt55_autoraise": True,
+        },
+        tmp_path,
+    )
+
+    warning = getattr(agent, "_compression_warning")
+    assert getattr(agent, "_compression_threshold_autoraised") == {"from": 0.50, "to": 0.85}
+    assert warning is not None
+    assert "auto-compaction was raised to 85%" in warning


### PR DESCRIPTION
## Summary

`compression.codex_gpt55_autoraise` raises the compaction trigger to 85% for gpt-5.5 on Codex OAuth. The accompanying UX notice is currently printed on **every fresh agent/session** — once via `print()` for CLI users and once replayed through `status_callback` for gateway platforms.

For gateway-heavy installs (messaging platforms + many cron sessions per day), this notice becomes recurring noise in user-facing chats.

This PR adds `compression.codex_gpt55_autoraise_notice` (default: `true`, preserving current behavior). When set to `false`:

- the safer/raised 85% trigger is **kept** (behavior and UX are decoupled)
- the notice is not printed at CLI startup
- the notice is not stashed into `agent._compression_warning` for platform replay

## Changes

- `agent/agent_init.py`: new `_codex_gpt55_autoraise_notice_enabled()` helper; both notice emission sites now check the flag
- `hermes_cli/config.py`: new `compression.codex_gpt55_autoraise_notice` default + comment
- `tests/agent/test_codex_gpt55_autoraise_notice.py`: covers flag on/off paths

## Testing

```
$ python -m pytest tests/agent/test_codex_gpt55_autoraise_notice.py -o 'addopts=' -q
2 passed
```

Running in production on a Telegram/Slack/Discord gateway install since May 2026 with `codex_gpt55_autoraise_notice: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBLFizAHnjBKWFHbRHcfFN
