### PR TITLE
improve(hermes): sanitize cron context payloads

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -113,6 +113,26 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+_CRON_CONTEXT_PAYLOAD_HEADING_RE = re.compile(r"(?m)^## (Response|Error)\s*$")
+
+
+def _extract_cron_context_payload(output: str) -> str:
+    """Return the final response/error section from a saved cron artifact.
+
+    Saved cron markdown includes the original prompt before the model output.
+    Downstream ``context_from`` jobs should reason over the upstream result,
+    not inherit the upstream prompt or delivery instructions. Legacy files
+    without explicit sections are kept whole for backwards compatibility.
+    """
+    text = output.strip()
+    if not text:
+        return ""
+    matches = list(_CRON_CONTEXT_PAYLOAD_HEADING_RE.finditer(text))
+    if not matches:
+        return text
+    return text[matches[-1].start() :].strip()
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -2009,7 +2029,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 if not output_files:
                     continue  # silent skip — no output yet
-                latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                latest_output = _extract_cron_context_payload(
+                    output_files[0].read_text(encoding="utf-8")
+                )
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -102,6 +102,62 @@ class TestBuildJobPromptContextFrom:
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
+    def test_context_from_injects_response_payload_without_source_prompt(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            "# Cron Job: upstream\n\n"
+            "## Prompt\n"
+            "Do not leak this upstream prompt.\n\n"
+            "## Response\n"
+            "Validated actionable response only.\n",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Validate the prior output",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+
+        assert "Validated actionable response only." in prompt
+        assert "Do not leak this upstream prompt" not in prompt
+        assert "## Prompt" not in prompt
+
+    def test_context_from_injects_error_payload_without_source_prompt(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            "# Cron Job: upstream (FAILED)\n\n"
+            "## Prompt\n"
+            "Internal source prompt text.\n\n"
+            "## Error\n"
+            "RuntimeError: upstream failed cleanly\n",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Handle prior failure",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+
+        assert "RuntimeError: upstream failed cleanly" in prompt
+        assert "Internal source prompt text" not in prompt
+        assert "## Prompt" not in prompt
+
     def test_uses_most_recent_output(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt


### PR DESCRIPTION
## Summary
- extract only the final Response/Error section from saved cron artifacts before injecting context_from output
- preserve legacy artifacts without explicit sections unchanged
- add regression coverage for Response and Error artifacts so upstream prompts do not leak into downstream cron prompts

## Verification
- /Users/bryanmassenzo/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_cron_context_from.py -q
- /Users/bryanmassenzo/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_cron_context_from.py tests/cron/test_scheduler.py tests/cron/test_cron_no_agent.py -q

## Runtime note
- Deployed locally for trading-analyst Hermes and restarted ai.hermes.gateway-trading-analyst.
- Does not touch order placement, broker auth, sandbox mode, account settings, credentials, or kill-switch policy.