### PR TITLE
fix(browser): block Camofox private-page interactions

### DIFF
--- a/tests/tools/test_browser_camofox_private_page_guard.py
+++ b/tests/tools/test_browser_camofox_private_page_guard.py
@@ -83,6 +83,30 @@ def test_private_page_blocks_camofox_reads(monkeypatch, _session, tool_call, act
     assert action_phrase in out["error"]
 
 
+@pytest.mark.parametrize(
+    ("tool_call", "action_phrase"),
+    [
+        (lambda: browser_camofox.camofox_click("e1", task_id="t1"), "click"),
+        (lambda: browser_camofox.camofox_type("e1", "hello", task_id="t1"), "type"),
+        (lambda: browser_camofox.camofox_press("Enter", task_id="t1"), "press"),
+    ],
+)
+def test_private_page_blocks_camofox_interactions(monkeypatch, _session, tool_call, action_phrase):
+    _block_active(monkeypatch)
+
+    def fail_post(*_args, **_kwargs):
+        raise AssertionError("Camofox interaction should not run on a private page")
+
+    monkeypatch.setattr(browser_camofox, "_post", fail_post)
+
+    out = json.loads(tool_call())
+
+    assert out["success"] is False
+    assert PRIVATE_URL in out["error"]
+    assert "private or internal address" in out["error"]
+    assert action_phrase in out["error"]
+
+
 def test_snapshot_still_runs_when_page_is_public(monkeypatch, _session):
     _public_page(monkeypatch)
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -653,6 +653,10 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
+        blocked = _camofox_private_page_block(session, task_id, "click")
+        if blocked:
+            return blocked
+
         # Strip @ prefix if present (our tool convention)
         clean_ref = ref.lstrip("@")
 
@@ -675,6 +679,10 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         session = _get_session(task_id)
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
+
+        blocked = _camofox_private_page_block(session, task_id, "type")
+        if blocked:
+            return blocked
 
         clean_ref = ref.lstrip("@")
 
@@ -744,6 +752,10 @@ def camofox_press(key: str, task_id: Optional[str] = None) -> str:
         session = _get_session(task_id)
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
+
+        blocked = _camofox_private_page_block(session, task_id, "press")
+        if blocked:
+            return blocked
 
         _post(
             f"/tabs/{session['tab_id']}/press",


### PR DESCRIPTION
## Summary

Camofox content-read tools already block private/internal pages before returning page state, but the Camofox interaction tools did not share the same guard.

`browser_click`, `browser_type`, and `browser_press` route directly into `camofox_click`, `camofox_type`, and `camofox_press` when Camofox is active. Those Camofox handlers called the backend immediately, even when the current Camofox tab was on a private/internal URL that the normal browser backend would block via `_blocked_private_page_action`.

That left the Camofox REST backend as a sibling bypass for the same private-page interaction boundary.

## Fix

Apply the existing `_camofox_private_page_block(...)` guard before Camofox sends click/type/press requests to the backend.

This keeps Camofox behavior aligned with the main browser backend:

- `browser_click` refuses to click on a private/internal page.
- `browser_type` refuses to type into a private/internal page.
- `browser_press` refuses to press keys on a private/internal page.

Snapshot, image extraction, and vision were already covered by the same Camofox private-page guard.

## Tests

Added regression coverage proving private-page Camofox interactions short-circuit before any backend `_post` call is made.

```text
python -m pytest tests/tools/test_browser_camofox_private_page_guard.py -q
8 passed

python -m pytest tests/tools/test_browser_camofox.py -q
30 passed