### PR TITLE
fix(desktop): improve project rail resizing and tooltips

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -4,6 +4,7 @@ import { type NodeApi, type NodeRendererProps, type RowRendererProps, Tree, type
 
 import { TreeSkeleton } from '@/components/chat/skeletons'
 import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { cn } from '@/lib/utils'
 import { $repoChangeByPath, type RepoChangeKind } from '@/store/coding-status'
@@ -19,6 +20,7 @@ const ROW_HEIGHT = 22
 const INDENT = 10
 /** Fixed base inset (`px-6.5`) layered on top of arborist's depth indent. */
 const TREE_ROW_INSET = '17px'
+const PATH_TOOLTIP_CLASS = 'max-w-[42rem] whitespace-normal break-all text-left leading-snug'
 
 function withTreeInset(paddingLeft: number | string | undefined): string {
   if (typeof paddingLeft === 'number') {
@@ -327,7 +329,6 @@ function ProjectTreeRow({
         ...style,
         paddingLeft: withTreeInset(style.paddingLeft)
       }}
-      title={node.data.id}
     >
       {/* No chevron column — the folder icon (open/closed) already carries the
           expand state, so the extra glyph was pure noise. */}
@@ -347,7 +348,9 @@ function ProjectTreeRow({
       ) : (
         // Git decoration (VS Code-style): tint changed files; the explicit color
         // wins over the row's hover/selected text color, so it persists.
-        <span className={cn('min-w-0 flex-1 truncate', changeKind && CHANGE_TINT[changeKind])}>{node.data.name}</span>
+        <Tip className={PATH_TOOLTIP_CLASS} label={node.data.id} side="left">
+          <span className={cn('min-w-0 flex-1 truncate', changeKind && CHANGE_TINT[changeKind])}>{node.data.name}</span>
+        </Tip>
       )}
     </div>
   )

--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -40,6 +40,7 @@ import { pickRevealLabel } from '../file-actions'
 import { buildReviewFlatList, buildReviewTree, type ReviewTreeNode } from './tree-data'
 
 const INDENT = 12
+const PATH_TOOLTIP_CLASS = 'max-w-[42rem] whitespace-normal break-all text-left leading-snug'
 
 // Per git status letter: a tinted diff codicon so the file's nature reads at a
 // glance (added / modified / deleted / renamed / untracked).
@@ -215,9 +216,9 @@ function ReviewDirRow({
           name={open ? 'folder-opened' : 'folder'}
           size="0.8rem"
         />
-        <span className="min-w-0 flex-1 truncate" title={node.name}>
-          {node.name}
-        </span>
+        <Tip className={PATH_TOOLTIP_CLASS} label={node.id || node.name} side="left">
+          <span className="min-w-0 flex-1 truncate">{node.name}</span>
+        </Tip>
       </div>
       {open && node.children && (
         <ReviewNodeList animate={animate} depth={depth + 1} motion={useMotion} nodes={node.children} />
@@ -317,19 +318,20 @@ function ReviewFileRow({ node, depth }: { node: ReviewTreeNode; depth: number })
           event.dataTransfer.setData('text/plain', dragPath)
         }}
         style={rowStyle(depth)}
-        title={dragPath}
       >
         <Codicon className={cn('shrink-0', glyph.tone)} name={glyph.icon} size="0.8rem" />
         {/* Dir collapses first (huge shrink); the name only ellipsizes once the
             dir is gone — either way neither runs into the diff count. */}
         <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
-          <span className="min-w-0 shrink truncate" title={node.name}>
-            {node.name}
-          </span>
+          <Tip className={PATH_TOOLTIP_CLASS} label={file.path} side="left">
+            <span className="min-w-0 shrink truncate">{node.name}</span>
+          </Tip>
           {node.dir && (
-            <span className="min-w-0 shrink-[9999] truncate text-[0.68rem] text-(--ui-text-tertiary)" title={node.dir}>
-              {node.dir}
-            </span>
+            <Tip className={PATH_TOOLTIP_CLASS} label={file.path} side="left">
+              <span className="min-w-0 shrink-[9999] truncate text-[0.68rem] text-(--ui-text-tertiary)">
+                {node.dir}
+              </span>
+            </Tip>
           )}
         </span>
 

--- a/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
@@ -330,4 +330,32 @@ describe('PaneShell composition', () => {
 
     expect($paneStates.get().preview?.widthOverride).toBe(340)
   })
+
+  it('dragging a right-pane separator resolves a viewport max width', () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 })
+
+    const rendered = render(
+      <PaneShell>
+        <PaneMain>main</PaneMain>
+        <Pane id="preview" maxWidth="50vw" minWidth={220} resizable side="right" width="320px">
+          <span data-testid="preview-content">preview</span>
+        </Pane>
+      </PaneShell>
+    )
+
+    const paneCell = rendered.getByTestId('preview-content').parentElement
+
+    if (!(paneCell instanceof HTMLElement)) {
+      throw new Error('Expected pane cell element')
+    }
+
+    mockWidth(paneCell, 320)
+    const separator = rendered.getByLabelText('Resize preview')
+
+    fireEvent.pointerDown(separator, { clientX: 900, pointerId: 1 })
+    fireEvent.pointerMove(window, { clientX: 100 })
+    fireEvent.pointerUp(window, { clientX: 100 })
+
+    expect($paneStates.get().preview?.widthOverride).toBe(640)
+  })
 })

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -12,7 +12,7 @@ export const SIDEBAR_MAX_WIDTH = 360
 // want a narrow tree.
 export const FILE_BROWSER_DEFAULT_WIDTH = `${SIDEBAR_DEFAULT_WIDTH}px`
 export const FILE_BROWSER_MIN_WIDTH = '10rem'
-export const FILE_BROWSER_MAX_WIDTH = '20rem'
+export const FILE_BROWSER_MAX_WIDTH = '50vw'
 
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 


### PR DESCRIPTION
## Summary
- allow the desktop project/review rail to resize wider than the old fixed 20rem cap
- show full paths for truncated project tree and review file names with the app tooltip
- keep unrelated local package-lock changes out of the PR

## Tests
- npm run test:ui -- src/app/right-sidebar/index.test.tsx src/app/right-sidebar/review/tree-data.test.ts
- npm run typecheck
