### PR TITLE
fix(state): cascade-delete compression continuations on session delete

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4728,6 +4728,25 @@ class SessionDB:
             if cursor.fetchone()[0] == 0:
                 return False
             removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
+            # Cascade-delete compression continuations — they are not
+            # independently meaningful and would reappear as listable root
+            # sessions if merely orphaned (#9314).
+            comp_rows = conn.execute(
+                "SELECT c.id FROM sessions c "
+                "JOIN sessions p ON p.id = c.parent_session_id "
+                "WHERE c.parent_session_id = ? AND p.end_reason = 'compression'",
+                (session_id,),
+            ).fetchall()
+            comp_ids = [r["id"] for r in comp_rows]
+            if comp_ids:
+                ph = ",".join("?" * len(comp_ids))
+                conn.execute(
+                    f"DELETE FROM messages WHERE session_id IN ({ph})", comp_ids
+                )
+                conn.execute(
+                    f"DELETE FROM sessions WHERE id IN ({ph})", comp_ids
+                )
+                removed_delegate_ids.extend(comp_ids)
             # Orphan remaining child sessions (branches, etc.) so FK is satisfied.
             conn.execute(
                 "UPDATE sessions SET parent_session_id = NULL "
@@ -4842,6 +4861,27 @@ class SessionDB:
 
             existing_placeholders = ",".join("?" * len(existing))
             removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
+            # Cascade-delete compression continuations — same rationale as
+            # delete_session(): orphaning them would reappear as listable
+            # root sessions (#9314).
+            ph_existing = ",".join("?" * len(existing))
+            comp_rows = conn.execute(
+                f"SELECT c.id FROM sessions c "
+                f"JOIN sessions p ON p.id = c.parent_session_id "
+                f"WHERE c.parent_session_id IN ({ph_existing}) "
+                f"AND p.end_reason = 'compression'",
+                existing,
+            ).fetchall()
+            comp_ids = [r["id"] for r in comp_rows]
+            if comp_ids:
+                ph_comp = ",".join("?" * len(comp_ids))
+                conn.execute(
+                    f"DELETE FROM messages WHERE session_id IN ({ph_comp})", comp_ids
+                )
+                conn.execute(
+                    f"DELETE FROM sessions WHERE id IN ({ph_comp})", comp_ids
+                )
+                removed_delegate_ids.extend(comp_ids)
             # Orphan remaining children whose parent is in the kill list so the
             # FK constraint stays satisfied. Pin children whose parent
             # is itself in the kill list rather than NULL-ing parents

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1775,6 +1775,59 @@ class TestDeleteAndExport:
     def test_delete_nonexistent(self, db):
         assert db.delete_session("nope") is False
 
+    def test_delete_session_cascades_compression_continuations(self, db):
+        """Deleting a compression root must cascade-delete its continuations,
+        not merely orphan them — orphaned continuations pass the
+        ``_LISTABLE_CHILD_SQL`` filter and reappear in the session list (#9314).
+        """
+        # Create a compression chain: root → continuation
+        db.create_session(session_id="root", source="cli")
+        db.append_message("root", role="user", content="Hello")
+        db.end_session("root", end_reason="compression")
+
+        db.create_session(
+            session_id="cont",
+            source="cli",
+            parent_session_id="root",
+        )
+        db.append_message("cont", role="user", content="Continued")
+
+        assert db.delete_session("root") is True
+        # Both the root and the compression continuation must be gone.
+        assert db.get_session("root") is None
+        assert db.get_session("cont") is None
+        assert db.message_count(session_id="root") == 0
+        assert db.message_count(session_id="cont") == 0
+
+    def test_delete_session_preserves_branch_children(self, db):
+        """Branch children (not compression continuations) must be orphaned,
+        not cascade-deleted, when their parent is deleted.
+        """
+        db.create_session(session_id="parent", source="cli")
+        db.append_message("parent", role="user", content="Hello")
+        db.end_session("parent", end_reason="branched")
+
+        db.create_session(
+            session_id="branch",
+            source="cli",
+            parent_session_id="parent",
+        )
+        # Set started_at after parent.ended_at so the legacy branch heuristic
+        # (_BRANCH_CHILD_SQL) recognises this as a branch child.
+        parent_ended = db.get_session("parent")["ended_at"]
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (parent_ended + 1, "branch"),
+        )
+        db._conn.commit()
+        db.append_message("branch", role="user", content="Branch content")
+
+        assert db.delete_session("parent") is True
+        assert db.get_session("parent") is None
+        # Branch child survives, orphaned.
+        assert db.get_session("branch") is not None
+        assert db.get_session("branch")["parent_session_id"] is None
+
     def test_resolve_session_id_exact(self, db):
         db.create_session(session_id="20260315_092437_c9a6ff", source="cli")
         assert db.resolve_session_id("20260315_092437_c9a6ff") == "20260315_092437_c9a6ff"
@@ -1792,6 +1845,28 @@ class TestDeleteAndExport:
         db.create_session(session_id="20260315_092437_c9a6ff", source="cli")
         db.create_session(session_id="20260315X092437_c9a6ff", source="cli")
         assert db.resolve_session_id("20260315_092437") == "20260315_092437_c9a6ff"
+
+    def test_delete_sessions_cascades_compression_continuations(self, db):
+        """Bulk delete must also cascade-delete compression continuations."""
+        db.create_session(session_id="root1", source="cli")
+        db.append_message("root1", role="user", content="Hello")
+        db.end_session("root1", end_reason="compression")
+
+        db.create_session(
+            session_id="cont1",
+            source="cli",
+            parent_session_id="root1",
+        )
+        db.append_message("cont1", role="user", content="Continued")
+
+        db.create_session(session_id="root2", source="cli")
+        db.append_message("root2", role="user", content="World")
+
+        count = db.delete_sessions(["root1", "root2"])
+        assert count == 2
+        assert db.get_session("root1") is None
+        assert db.get_session("cont1") is None
+        assert db.get_session("root2") is None
 
     def test_export_session(self, db):
         db.create_session(session_id="s1", source="cli", model="test")


### PR DESCRIPTION
## What does this PR do?

When a session with compression continuations is deleted via the Web Dashboard (or bulk delete), the `delete_session()` / `delete_sessions()` methods orphaned compression child sessions by setting `parent_session_id → NULL` instead of cascade-deleting them. Orphaned compression continuations then passed the `_LISTABLE_CHILD_SQL` filter (`parent_session_id IS NULL`) and reappeared in the session list as standalone root sessions — making it look like the deleted session came back.

The fix adds a cascade-delete step for compression continuations before the orphan step, matching the existing pattern for delegate subagent children. Branch children are still orphaned (not deleted) since they represent independent user-created branches.

## Related Issue

Fixes #9314

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py` — `delete_session()`: added compression-continuation cascade-delete before the orphan step. Children whose parent has `end_reason='compression'` are now deleted along with their messages, matching the delegate-children pattern.
- `hermes_state.py` — `delete_sessions()` (bulk): same cascade-delete logic applied for consistency.
- `tests/test_hermes_state.py` — Added 3 regression tests:
  - `test_delete_session_cascades_compression_continuations`: verifies compression continuations are deleted with the root
  - `test_delete_session_preserves_branch_children`: verifies branch children are still orphaned (not cascade-deleted)
  - `test_delete_sessions_cascades_compression_continuations`: verifies bulk delete also cascades

## How to Test

1. Run `pytest tests/test_hermes_state.py::TestDeleteAndExport -xvs` — all 13 tests should pass
2. Run `pytest tests/test_hermes_state.py -q` — all 306 tests should pass (no regressions)
3. Manual verification: create a session, let auto-compression produce a continuation, delete the root session from the Web Dashboard, navigate away and back — the continuation should not reappear

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
