### PR TITLE
fix(windows): prevent UnicodeDecodeError in subprocess calls with encoding=utf-8

### DIFF
--- a/skills/creative/comfyui/scripts/auto_fix_deps.py
+++ b/skills/creative/comfyui/scripts/auto_fix_deps.py
@@ -51,7 +51,7 @@ def run_cmd(cmd: list[str], *, dry_run: bool = False) -> tuple[int, str]:
     if dry_run:
         return 0, "[dry-run]"
     log(f"$ {' '.join(cmd)}")
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False)
     out = (proc.stdout or "") + (proc.stderr or "")
     return proc.returncode, out
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -648,7 +648,8 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             try:
                 r = subprocess.run(
                     [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
-                    capture_output=True, text=True, timeout=timeout, env=uv_env,
+                    capture_output=True, text=True, encoding="utf-8", errors="replace",
+                    timeout=timeout, env=uv_env,
                     stdin=subprocess.DEVNULL,
                 )
                 if r.returncode == 0:
@@ -664,7 +665,8 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         try:
             probe = subprocess.run(
                 pip_cmd + ["--version"],
-                capture_output=True, text=True, timeout=15,
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+                timeout=15,
                 stdin=subprocess.DEVNULL,
             )
             if probe.returncode != 0:
@@ -673,7 +675,8 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             try:
                 subprocess.run(
                     [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                    capture_output=True, text=True, timeout=120, check=True,
+                    capture_output=True, text=True, encoding="utf-8", errors="replace",
+                    timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
@@ -683,7 +686,8 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
         try:
             r = subprocess.run(
                 pip_cmd + ["install", *target_args, *constraint_args, *specs],
-                capture_output=True, text=True, timeout=timeout,
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+                timeout=timeout,
                 stdin=subprocess.DEVNULL,
             )
             if r.returncode == 0 and target is not None:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1188,7 +1188,7 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
+        subprocess.run(command, check=True, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
         return converted_path, None
     except subprocess.TimeoutExpired:
         logger.error("ffmpeg conversion timed out for %s", file_path)
@@ -1234,9 +1234,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
+                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
+                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1861,7 +1861,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
         "--device", device,
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+    result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120, stdin=subprocess.DEVNULL)
     if result.returncode != 0:
         stderr = result.stderr.strip()
         # Filter out the "OK:" line from stderr


### PR DESCRIPTION
## Problem

On Windows CJK systems (zh-CN, ja-JP, ko-KR), `subprocess.run(..., text=True)` defaults to `locale.getpreferredencoding()` — GBK on Chinese Windows. When child processes (pip, uv, ffmpeg, ffprobe, local STT) emit UTF-8 output containing bytes that are un-decodable as GBK, the `_readerthread` silently crashes with `UnicodeDecodeError`, and stdout/stderr is entirely lost.

## Symptoms

- `hermes update` shows **`UnicodeDecodeError: 'gbk' codec can't decode byte`** during lazy-backend refresh phase
- `platform.matrix` falsely reports `pip install failed` (actually a cascading failure from the crashed reader thread)
- TTS/STT error reporting silently drops diagnostic output
- ComfyUI dependency resolution produces corrupted output

## Fix

Add `encoding="utf-8", errors="replace"` to all `subprocess.run(..., text=True)` calls in Windows-reachable code paths. Non-decodable bytes are substituted with `\ufffd` (�) rather than crashing the reader thread.

## Files changed

| File | Calls fixed | Context |
|------|-------------|---------|
| `tools/lazy_deps.py` | 4 | uv/pip install, ensurepip, probe — the main trigger of the reported bug |
| `tools/tts_tool.py` | 1 | ffprobe duration probe |
| `tools/transcription_tools.py` | 3 | ffmpeg conversion + local STT commands |
| `skills/creative/comfyui/scripts/auto_fix_deps.py` | 1 | pip install inside ComfyUI dep resolver |

## Notes

- Test files are excluded — they don't run in production CJK environments.
- The same issue exists in `tools/voice_mode.py` (Termux/Android) and `tools/environments/singularity.py` (Linux only) — those are left alone as they target non-Windows platforms.
- Linux/macOS are unaffected (`text=True` defaults to UTF-8 there).