### PR TITLE
fix(dashboard): block .env files from managed-files API

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1184,6 +1184,20 @@ _FS_READDIR_HIDDEN = {
     "target",
     "venv",
 }
+
+# Filenames that must never be listed, read, or downloaded through the
+# managed-files API.  These typically contain credentials (API keys, tokens)
+# and exposing them through the dashboard file browser is a security leak —
+# see issue #57505.
+_SENSITIVE_FILENAMES: frozenset[str] = frozenset({
+    ".env",
+    ".env.local",
+    ".env.production",
+    ".env.development",
+    ".env.staging",
+    ".env.test",
+    ".env.backup",
+})
 _FS_DATA_URL_MAX_BYTES = 16 * 1024 * 1024
 _FS_TEXT_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 _FS_TEXT_PREVIEW_MAX_BYTES = 512 * 1024
@@ -1614,7 +1628,11 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
         raise HTTPException(status_code=400, detail="Path is not a directory")
 
     try:
-        entries = [_managed_file_entry(policy, child) for child in target.iterdir()]
+        entries = [
+            _managed_file_entry(policy, child)
+            for child in target.iterdir()
+            if child.name not in _SENSITIVE_FILENAMES
+        ]
     except PermissionError:
         raise HTTPException(status_code=403, detail="Directory is not readable")
     except OSError as exc:
@@ -1640,6 +1658,8 @@ async def read_managed_file(request: Request, path: str):
         raise HTTPException(status_code=404, detail="File not found")
     if not target.is_file():
         raise HTTPException(status_code=400, detail="Path is not a file")
+    if target.name in _SENSITIVE_FILENAMES:
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
 
     try:
         size = target.stat().st_size
@@ -1682,6 +1702,8 @@ async def download_managed_file(request: Request, path: str):
         raise HTTPException(status_code=404, detail="File not found")
     if not target.is_file():
         raise HTTPException(status_code=400, detail="Path is not a file")
+    if target.name in _SENSITIVE_FILENAMES:
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
 
     try:
         size = target.stat().st_size

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1189,15 +1189,9 @@ _FS_READDIR_HIDDEN = {
 # managed-files API.  These typically contain credentials (API keys, tokens)
 # and exposing them through the dashboard file browser is a security leak —
 # see issue #57505.
-_SENSITIVE_FILENAMES: frozenset[str] = frozenset({
-    ".env",
-    ".env.local",
-    ".env.production",
-    ".env.development",
-    ".env.staging",
-    ".env.test",
-    ".env.backup",
-})
+def _is_sensitive_filename(name: str) -> bool:
+    """Return True for ``.env`` and any ``.env.<suffix>`` variant."""
+    return name == ".env" or name.startswith(".env.")
 _FS_DATA_URL_MAX_BYTES = 16 * 1024 * 1024
 _FS_TEXT_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 _FS_TEXT_PREVIEW_MAX_BYTES = 512 * 1024
@@ -1631,7 +1625,7 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
         entries = [
             _managed_file_entry(policy, child)
             for child in target.iterdir()
-            if child.name not in _SENSITIVE_FILENAMES
+            if not _is_sensitive_filename(child.name)
         ]
     except PermissionError:
         raise HTTPException(status_code=403, detail="Directory is not readable")
@@ -1658,7 +1652,7 @@ async def read_managed_file(request: Request, path: str):
         raise HTTPException(status_code=404, detail="File not found")
     if not target.is_file():
         raise HTTPException(status_code=400, detail="Path is not a file")
-    if target.name in _SENSITIVE_FILENAMES:
+    if _is_sensitive_filename(target.name):
         raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
 
     try:
@@ -1702,7 +1696,7 @@ async def download_managed_file(request: Request, path: str):
         raise HTTPException(status_code=404, detail="File not found")
     if not target.is_file():
         raise HTTPException(status_code=400, detail="Path is not a file")
-    if target.name in _SENSITIVE_FILENAMES:
+    if _is_sensitive_filename(target.name):
         raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
 
     try:

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -494,7 +494,7 @@ def test_sensitive_env_files_hidden_from_listing(forced_files_client):
     """Regression test for #57505: .env files must not appear in directory listings."""
     client, root = forced_files_client
 
-    # Create a regular file and a .env file.
+    # Create a regular file and .env variants including shorthand suffixes.
     root.mkdir(parents=True, exist_ok=True)
     regular = root / "config.txt"
     regular.write_text("safe content")
@@ -502,6 +502,8 @@ def test_sensitive_env_files_hidden_from_listing(forced_files_client):
     env_file.write_text("SECRET_KEY=abc123")
     env_local = root / ".env.local"
     env_local.write_text("LOCAL_SECRET=def456")
+    env_prod = root / ".env.prod"
+    env_prod.write_text("PROD_SECRET=ghi789")
 
     listing = client.get("/api/files", params={"path": str(root)})
     assert listing.status_code == 200
@@ -509,6 +511,7 @@ def test_sensitive_env_files_hidden_from_listing(forced_files_client):
     assert "config.txt" in names
     assert ".env" not in names
     assert ".env.local" not in names
+    assert ".env.prod" not in names
 
 
 def test_sensitive_env_files_blocked_read(forced_files_client):
@@ -533,3 +536,15 @@ def test_sensitive_env_files_blocked_download(forced_files_client):
 
     resp = client.get("/api/files/download", params={"path": str(env_file)})
     assert resp.status_code == 403
+
+
+def test_sensitive_env_suffix_variants_blocked(forced_files_client):
+    """Regression: .env.<suffix> shorthand variants (e.g. .env.prod) must also be blocked."""
+    client, root = forced_files_client
+
+    root.mkdir(parents=True, exist_ok=True)
+    for suffix in ("prod", "dev", "staging.local", "ci"):
+        p = root / f".env.{suffix}"
+        p.write_text(f"SECRET_{suffix}=abc123")
+        assert client.get("/api/files/read", params={"path": str(p)}).status_code == 403
+        assert client.get("/api/files/download", params={"path": str(p)}).status_code == 403

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -488,3 +488,48 @@ def test_stream_upload_cleans_temp_on_cancellation(forced_files_client):
     # ... and no .upload temp file was left behind.
     leftovers = [p.name for p in target.parent.iterdir() if ".upload" in p.name]
     assert leftovers == [], f"temp upload files leaked on cancellation: {leftovers}"
+
+
+def test_sensitive_env_files_hidden_from_listing(forced_files_client):
+    """Regression test for #57505: .env files must not appear in directory listings."""
+    client, root = forced_files_client
+
+    # Create a regular file and a .env file.
+    root.mkdir(parents=True, exist_ok=True)
+    regular = root / "config.txt"
+    regular.write_text("safe content")
+    env_file = root / ".env"
+    env_file.write_text("SECRET_KEY=abc123")
+    env_local = root / ".env.local"
+    env_local.write_text("LOCAL_SECRET=def456")
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+    names = [e["name"] for e in listing.json()["entries"]]
+    assert "config.txt" in names
+    assert ".env" not in names
+    assert ".env.local" not in names
+
+
+def test_sensitive_env_files_blocked_read(forced_files_client):
+    """Regression test for #57505: .env files must not be readable."""
+    client, root = forced_files_client
+
+    root.mkdir(parents=True, exist_ok=True)
+    env_file = root / ".env"
+    env_file.write_text("SECRET_KEY=abc123")
+
+    resp = client.get("/api/files/read", params={"path": str(env_file)})
+    assert resp.status_code == 403
+
+
+def test_sensitive_env_files_blocked_download(forced_files_client):
+    """Regression test for #57505: .env files must not be downloadable."""
+    client, root = forced_files_client
+
+    root.mkdir(parents=True, exist_ok=True)
+    env_file = root / ".env"
+    env_file.write_text("SECRET_KEY=abc123")
+
+    resp = client.get("/api/files/download", params={"path": str(env_file)})
+    assert resp.status_code == 403


### PR DESCRIPTION
## What does this PR do?

Blocks the dashboard managed-files API from listing, reading, or downloading sensitive credential files (`.env`, `.env.local`, etc.). Previously, when the dashboard was run with a bind-mounted Hermes home directory (e.g. `docker run -v ~/.hermes:/opt/data`), the Files tab could browse and download `.env` files containing API keys and tokens.

## Related Issue

Fixes #57505

## Type of Change

- [x] 🔒 Security fix
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Added `_SENSITIVE_FILENAMES` frozenset containing `.env` and common variants. Filtered these filenames from `list_managed_files()` directory listings and added 403 guards to `read_managed_file()` and `download_managed_file()`.
- `tests/hermes_cli/test_web_server_files.py`: Added 3 regression tests verifying `.env` files are hidden from listings, blocked from read, and blocked from download.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_web_server_files.py -q` — all 19 tests should pass (including the 3 new regression tests).
2. Manual: start the dashboard with `hermes dashboard`, navigate to the Files tab, verify `.env` files do not appear in directory listings.
3. Manual: attempt to directly access `/api/files/read?path=.../.env` — should return 403.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_web_server_files.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — security fix with regression tests.
