### PR TITLE
fix: persist rotated compression transcripts

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -84,6 +84,14 @@ LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 # poisoning every subsequent request in the session — a bare key like
 # "is_compressed_summary" would reach the wire and trip exactly that.
 COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+_PERSISTENCE_MARKER_KEYS = {"_db_persisted"}
+
+
+def _copy_for_compressed_transcript(message: Dict[str, Any]) -> Dict[str, Any]:
+    copied = message.copy()
+    for key in _PERSISTENCE_MARKER_KEYS:
+        copied.pop(key, None)
+    return copied
 
 # Appended to every standalone summary message (and to the merged-into-tail
 # prefix) so the model has an unambiguous "summary ends here" boundary.
@@ -2834,7 +2842,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # Phase 4: Assemble compressed message list
         compressed = []
         for i in range(compress_start):
-            msg = messages[i].copy()
+            msg = _copy_for_compressed_transcript(messages[i])
             if i == 0 and msg.get("role") == "system":
                 existing = msg.get("content")
                 _compression_note = "[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work. Your persistent memory (MEMORY.md, USER.md) remains fully authoritative regardless of compaction.]"
@@ -2907,7 +2915,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             })
 
         for i in range(compress_end, n_messages):
-            msg = messages[i].copy()
+            msg = _copy_for_compressed_transcript(messages[i])
             if _merge_summary_into_tail and i == compress_end:
                 # Merge the summary into the first tail message, but place
                 # the END MARKER at the very end so the model sees an

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -191,6 +191,51 @@ class TestFlushAfterCompression:
                 "final answer",
             ]
 
+    def test_rotation_compression_drops_persisted_markers_before_child_flush(self):
+        from agent.context_compressor import ContextCompressor
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = self._make_agent(db)
+            original_messages = [
+                {"role": "system", "content": "system", "_db_persisted": True},
+                {"role": "user", "content": "head user", "_db_persisted": True},
+                {"role": "assistant", "content": "head assistant", "_db_persisted": True},
+                {"role": "user", "content": "middle user 1", "_db_persisted": True},
+                {"role": "assistant", "content": "middle assistant 1", "_db_persisted": True},
+                {"role": "user", "content": "middle user 2", "_db_persisted": True},
+                {"role": "assistant", "content": "middle assistant 2", "_db_persisted": True},
+                {"role": "user", "content": "middle user 3", "_db_persisted": True},
+                {"role": "assistant", "content": "tail assistant", "_db_persisted": True},
+                {"role": "user", "content": "tail user", "_db_persisted": True},
+            ]
+
+            compressor = ContextCompressor(
+                model="test/model",
+                quiet_mode=True,
+                protect_first_n=3,
+                protect_last_n=2,
+                config_context_length=100_000,
+            )
+            compressor._find_tail_cut_by_tokens = lambda messages, start: len(messages) - 2
+            compressor._generate_summary = lambda turns, focus_topic=None: "summary"
+
+            compressed = compressor.compress(original_messages, current_tokens=90_000)
+            assert compressed is not original_messages
+            assert all("_db_persisted" not in msg for msg in compressed)
+
+            agent.session_id = "compressed-child"
+            db.create_session(session_id="compressed-child", source="test")
+            agent._last_flushed_db_idx = 0
+            agent._flush_messages_to_session_db(compressed, None)
+
+            rows = db.get_messages("compressed-child")
+            assert len(rows) == len(compressed)
+            assert any("summary" in row["content"] for row in rows)
+
 
 # ---------------------------------------------------------------------------
 # Part 2: Gateway-side — history_offset after session split


### PR DESCRIPTION
## What does this PR do?

Fixes a rotated-compression persistence gap introduced by the intrinsic `_db_persisted` marker. When compression rotates into a child session, protected head/tail messages are shallow-copied into the compressed transcript. If those source dictionaries were already persisted in the parent session, the copied `_db_persisted` marker makes the child-session flush skip them, so the rotated transcript can lose live context.

This strips persistence-only markers from messages copied into a newly compressed transcript, while leaving in-place compaction semantics unchanged.

## Related Issue

Fixes #57491

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`
  - Add a compression-copy helper that removes session-store persistence markers from copied transcript messages.
  - Use the helper when copying protected head and tail messages into a rotated compressed transcript.
- `tests/run_agent/test_compression_persistence.py`
  - Add a regression test covering already-persisted parent messages copied into a rotated child transcript.
  - Verify the compressed child transcript is flushable and includes the summary row.

## How to Test

1. Run `python -m pytest tests/run_agent/test_compression_persistence.py tests/agent/test_codex_app_server_persist.py -q`
2. Run `python -m pytest tests/agent/test_context_compressor.py tests/agent/test_context_compressor_session_end_clears_state.py tests/agent/test_context_compressor_temporal_anchoring.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_context_compressor_cross_session_guard.py tests/run_agent/test_compression_persistence.py -q`
3. Confirm rotated compression copies no longer carry `_db_persisted` into the child session and the child session receives the compressed transcript rows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
$ python -m pytest tests/run_agent/test_compression_persistence.py tests/agent/test_codex_app_server_persist.py -q
.............                                                            [100%]
13 passed in 4.18s
```

```text
$ python -m pytest tests/agent/test_context_compressor.py tests/agent/test_context_compressor_session_end_clears_state.py tests/agent/test_context_compressor_temporal_anchoring.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_context_compressor_cross_session_guard.py tests/run_agent/test_compression_persistence.py -q
........................................................................ [ 43%]
........................................................................ [ 86%]
.......................                                                  [100%]
167 passed in 7.40s
```
