### PR TITLE
fix(acp): instruct model to treat ACP attached-file blocks as inline context

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -381,6 +381,13 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             f"after explicit direction."
         )
 
+    # ACP attached-file context — the adapter inlines file content as text
+    # blocks. Tell the model to use it directly rather than trying to fetch.
+    stable_parts.append(
+        "`[Attached file: ...]` blocks contain the actual file — read the "
+        "content inline, do not call tools to fetch it."
+    )
+
     platform_key = (agent.platform or "").lower().strip()
     # Resolve the built-in/plugin default hint for this platform, then apply
     # any per-platform override from config (platform_hints.<platform>).


### PR DESCRIPTION
## Description

When the ACP adapter (Zed editor) sends `@`-tagged files to the model, the file content is inlined as `[Attached file: <name>]` text blocks. Without explicit instruction, LLMs treat these blocks as ordinary text and may attempt to fetch the file via tools instead of reading the content already present in the conversation.

This PR adds a one-line instruction to the agent's system prompt telling the model to read `[Attached file: ...]` blocks directly as file context.

## Changes

- `agent/system_prompt.py` — add instruction for ACP attached-file blocks

**1 file, +7 lines.**

## Related issues

- **Related to #25611** — The adapter now properly advertises `embedded_context` and extracts resource blocks, but the model also needs an explicit system-prompt instruction to treat `[Attached file: ...]` blocks as inline content rather than attempting tool-based fetches.