### PR TITLE
feat(cli): forward --skills flag in ACP mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12327,6 +12327,9 @@ def cmd_acp(args):
             acp_argv.append("--setup-browser")
         if getattr(args, "assume_yes", False):
             acp_argv.append("--yes")
+        if getattr(args, "skills", None):
+            for skill_name in args.skills:
+                acp_argv.extend(["--skills", skill_name])
         acp_main(acp_argv)
     except ImportError:
         print("ACP dependencies not installed.", file=sys.stderr)


### PR DESCRIPTION
## Description

Forward the `--skills` flag from the `hermes acp` CLI command to the ACP adapter's argument parser, enabling users to preload skills when launching the ACP server.

```bash
hermes acp --skills "my-skill" --skills "another-skill"
# or comma-separated:
hermes acp --skills "my-skill,another-skill"
```

## Changes

- `hermes_cli/main.py` — forward `args.skills` to `acp_main()`

**1 file, +3 lines.**

## Related

- **#30560** — Open competing PR that forwards `--skills` through the full ACP stack (CLI → entry → HermesACPAgent → SessionManager → build_preloaded_skills_prompt) with tests. This PR is intentionally scoped to the CLI layer only — the adapter-side skills plumbing is handled by companion PR **#57510** (`feat(acp): adapter compliance v1`). Together #57510 + #57511 cover the same ground as #30560, split across two focused PRs by concern.
- **#57510** — Companion adapter compliance PR that implements the full ACP skills stack (session-level skill preloading, entry-point integration, tests).