### PR TITLE
fix(gateway): use getattr for __cause__ in _is_transient_network_error

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -267,7 +267,7 @@ def _is_transient_network_error(exc: BaseException) -> bool:
         name = type(cur).__name__
         if name in transient_class_names:
             return True
-        cur = cur.__cause__ or cur.__context__
+        cur = getattr(cur, "__cause__", None) or getattr(cur, "__context__", None)
     return False
 
 

--- a/tests/gateway/test_loop_exception_handler.py
+++ b/tests/gateway/test_loop_exception_handler.py
@@ -113,6 +113,26 @@ def test_transient_classifier_does_not_infinite_loop_on_cyclic_cause():
     assert _is_transient_network_error(exc) is False
 
 
+def test_transient_classifier_tolerates_traceback_exception():
+    """A ``TracebackException`` (no ``__cause__`` attr) is walked safely.
+
+    Regression for #57294: ``_is_transient_network_error`` crashed with
+    ``AttributeError`` when the exception chain contained a
+    ``traceback.TracebackException`` object instead of a live exception.
+    """
+    import traceback as tb_mod
+
+    try:
+        raise ConnectError("boom")
+    except ConnectError as e:
+        tb_exc = tb_mod.TracebackException.from_exception(e)
+    # A TracebackException object does not expose ``__cause__`` as an
+    # instance attribute; the pre-fix walker accessed it directly and
+    # crashed. The fixed walker uses getattr() so this returns False
+    # (TracebackException is not a transient class name) without raising.
+    assert _is_transient_network_error(tb_exc) is False
+
+
 # ---------------------------------------------------------------------
 # Loop handler
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Fixes #57294

## Description

`_is_transient_network_error()` in `gateway/run.py` crashed with `AttributeError: 'TracebackException' object has no attribute '__cause__'` when the exception chain contained a `traceback.TracebackException` object instead of a live exception instance. This can occur in asyncio exception handler chains or when python-telegram-bot formats exception context.

The fix changes the direct attribute access `cur.__cause__ or cur.__context__` to use `getattr()` — the same safe pattern already used in the Telegram adapter (lines 878 and 913):

```python
cur = getattr(cur, "__cause__", None) or getattr(cur, "__context__", None)
```

This ensures the chain walker terminates gracefully on objects that don't expose `__cause__`/`__context__` as instance attributes, instead of crashing and masking the real network error during Telegram reconnect.

## Verification

- `python -m pytest tests/gateway/test_loop_exception_handler.py -q` — 15 passed (14 existing + 1 new regression test)
- New regression test `test_transient_classifier_tolerates_traceback_exception` confirms a `TracebackException` object is walked safely without raising
- All existing classifier and loop-handler tests continue to pass
- Quality gates: S1 (secrets) clean, S2 (personal refs) clean, C1 (conventional commits) clean, F1 (focused diff: 2 files only)