### PR TITLE
fix(qqbot): accept is_reconnect kwarg in connect() to match base contract

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,16 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """
+        Authenticate, obtain gateway URL, and open the WebSocket.
+
+        Args:
+            is_reconnect: False on a cold first boot; True when the
+                reconnect watcher is re-establishing this platform after
+                an outage. QQBot has no server-side update queue so this
+                flag is accepted for interface conformance only.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -190,6 +190,43 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
+    def test_connect_accepts_is_reconnect_kwarg(self):
+        """connect(is_reconnect=True) must not raise TypeError (regression
+        for #52914 / #57252 - the gateway reconnect watcher calls
+        connect(is_reconnect=True) and the missing kwarg caused an infinite
+        backoff loop).
+        """
+        from gateway.platforms.qqbot import QQAdapter
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        adapter._ensure_token = mock.AsyncMock(
+            side_effect=RuntimeError("stop after client init")
+        )
+
+        # Both forms must not raise TypeError.
+        assert asyncio.run(adapter.connect()) is False
+        assert asyncio.run(adapter.connect(is_reconnect=True)) is False
+
+    def test_connect_signature_matches_base_contract(self):
+        """connect() signature must conform to BasePlatformAdapter.connect -
+        same parameter name, KEYWORD_ONLY kind, and default False. Prevents
+        the regression from silently recurring if the kwarg is later moved
+        to a positional or given a different default.
+        """
+        import inspect
+        from gateway.platforms.base import BasePlatformAdapter
+        from gateway.platforms.qqbot import QQAdapter
+
+        base_sig = inspect.signature(BasePlatformAdapter.connect)
+        sig = inspect.signature(QQAdapter.connect)
+        assert sig.parameters.keys() == base_sig.parameters.keys(), (
+            f"QQAdapter.connect parameters {list(sig.parameters)} must match "
+            f"BasePlatformAdapter.connect parameters {list(base_sig.parameters)}"
+        )
+        is_reconnect_param = sig.parameters["is_reconnect"]
+        assert is_reconnect_param.kind == inspect.Parameter.KEYWORD_ONLY
+        assert is_reconnect_param.default is False
+
 
 # ---------------------------------------------------------------------------
 # WebSocket proxy handling


### PR DESCRIPTION
Fixes: #52914, #57252

QQAdapter.connect() was missing the is_reconnect keyword-only parameter that BasePlatformAdapter.connect declares (gateway/platforms/base.py:2637). The gateway's reconnect watcher calls adapter.connect(is_reconnect=True) after a fatal adapter error; without the kwarg, QQ raised TypeError and entered an infinite backoff loop.

9 of 9 platform adapters were updated when the base contract was tightened; only QQ was missed.

Adds two regression tests:
- test_connect_accepts_is_reconnect_kwarg: both connect() and connect(is_reconnect=True) must not raise TypeError.
- test_connect_signature_matches_base_contract: inspect.signature of QQAdapter.connect must match BasePlatformAdapter.connect (parameter names, KEYWORD_ONLY kind, default False) so the regression cannot silently recur.