### PR TITLE
feat(gateway): expose read-only journey command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9910,6 +9910,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "agents":
             return await self._handle_agents_command(event)
 
+        if canonical == "journey":
+            return await self._handle_journey_command(event)
+
         if canonical == "platform":
             return await self._handle_platform_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1051,6 +1051,51 @@ class GatewaySlashCommandsMixin:
 
         return "\n".join(lines)
 
+    async def _handle_journey_command(self, event: MessageEvent) -> str:
+        """Handle /journey in gateway chats as a read-only learning view."""
+        import argparse
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        from hermes_cli.journey import register_cli
+
+        parser = argparse.ArgumentParser(prog="/journey", add_help=False)
+        register_cli(parser)
+        raw_args = event.get_command_args().strip()
+        try:
+            argv = shlex.split(raw_args) if raw_args else []
+        except ValueError as exc:
+            return f"Usage: /journey [list]\nCould not parse arguments: {exc}"
+
+        if argv not in ([], ["list"]):
+            return (
+                "The gateway /journey command is read-only and supports only "
+                "`/journey` or `/journey list`. Use the CLI for other journey actions."
+            )
+
+        err = io.StringIO()
+        try:
+            with redirect_stderr(err):
+                args = parser.parse_args(argv)
+        except SystemExit:
+            msg = err.getvalue().strip()
+            return msg or "Usage: /journey [list]"
+
+        if hasattr(args, "no_color"):
+            args.no_color = True
+        if hasattr(args, "force_color"):
+            args.force_color = False
+
+        buf = io.StringIO()
+        try:
+            with redirect_stdout(buf):
+                args.func(args)
+        except Exception as exc:
+            logger.debug("gateway /journey failed", exc_info=True)
+            return f"/journey failed: {exc}"
+
+        return buf.getvalue().strip() or "No journey output."
+
     async def _handle_stop_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /stop command - interrupt a running agent.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -104,7 +104,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",)),
     CommandDef("journey", "Open the learning journey timeline",
-               "Session", aliases=("learning", "memory-graph"), cli_only=True,
+               "Session", aliases=("learning", "memory-graph"),
                args_hint="[list|delete <id>|edit <id>]",
                subcommands=("list", "delete", "edit")),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
@@ -1164,7 +1164,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - moa: high-cost slash mode, available through /hermes moa to avoid
 #     displacing existing native Slack slash commands at the 50-command cap.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug"})
+#   - journey: the learning timeline remains available as /hermes journey while
+#     preserving Slack's existing native commands at the 50-command cap.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug", "journey"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/tests/gateway/test_journey_command.py
+++ b/tests/gateway/test_journey_command.py
@@ -1,0 +1,105 @@
+"""Gateway coverage for the read-only /journey slash command."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    return runner
+
+
+def test_journey_is_available_on_gateway():
+    from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+
+    cmd = resolve_command("journey")
+    assert cmd is not None
+    assert not cmd.cli_only
+    assert "journey" in GATEWAY_KNOWN_COMMANDS
+
+
+def test_journey_uses_slack_hermes_subcommand_at_native_cap():
+    from hermes_cli.commands import slack_native_slashes, slack_subcommand_map
+
+    assert "journey" in slack_subcommand_map()
+    assert "journey" not in {name for name, _desc, _hint in slack_native_slashes()}
+
+
+def test_handle_journey_list_renders_plain_text(monkeypatch):
+    import hermes_cli.journey as journey
+
+    monkeypatch.setattr(
+        journey,
+        "_build_payload",
+        lambda: {
+            "nodes": [
+                {
+                    "id": "skill-alpha",
+                    "kind": "skill",
+                    "label": "Alpha Skill",
+                    "timestamp": 1_700_000_000,
+                }
+            ]
+        },
+    )
+
+    runner = _make_runner()
+    result = asyncio.run(runner._handle_journey_command(_make_event("/journey list")))
+
+    assert "skill-alpha" in result
+    assert "Alpha Skill" in result
+    assert "\x1b[" not in result
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        "delete skill-alpha",
+        "edit skill-alpha",
+        "--play",
+        "--json",
+    ],
+)
+def test_handle_journey_non_read_only_forms_are_cli_only(arguments):
+    runner = _make_runner()
+
+    result = asyncio.run(
+        runner._handle_journey_command(_make_event(f"/journey {arguments}"))
+    )
+
+    assert "read-only" in result
+    assert "CLI" in result


### PR DESCRIPTION
## Summary
- expose `/journey` to gateway slash-command discovery by removing the CLI-only gate
- add a gateway `/journey` handler that renders the existing read-only journey views (`/journey` and `/journey list`) as plain text
- keep interactive `/journey edit` and `/journey delete` on the CLI with an explicit gateway message

## Tests
- `python -m pytest tests/gateway/test_journey_command.py -q`
- `python -m pytest tests/agent/test_learn_prompt.py::TestLearnRegistryWiring tests/gateway/test_unknown_command.py -q`
- `scripts/run_tests.sh tests/gateway/test_journey_command.py tests/agent/test_learn_prompt.py::TestLearnRegistryWiring tests/gateway/test_unknown_command.py -q`
- `python -m py_compile hermes_cli/commands.py gateway/slash_commands.py gateway/run.py tests/gateway/test_journey_command.py`
- `git diff --check`

Refs #57472
