### PR TITLE
fix(desktop): sync the composer queue across windows (#46732)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -1,8 +1,10 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import type { RefObject } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $queuedPromptsBySession, enqueueQueuedPrompt, getQueuedPrompts } from '@/store/composer-queue'
+import { enqueueQueuedPrompt, getQueuedPrompts } from '@/store/composer-queue'
+import { installFakeLocks, resetQueueStorage } from '@/store/composer-queue-test-utils'
+import { notify } from '@/store/notifications'
 
 import type { QueueEditState } from '../composer-utils'
 
@@ -10,9 +12,18 @@ import { useComposerQueue } from './use-composer-queue'
 
 vi.mock('@/lib/haptics', () => ({ triggerHaptic: () => {} }))
 vi.mock('@/i18n', () => ({
-  useI18n: () => ({ t: { composer: { queueStuckBody: 'stuck body', queueStuckTitle: 'stuck title' } } })
+  useI18n: () => ({
+    t: {
+      composer: {
+        queueBusyElsewhereBody: 'busy elsewhere body',
+        queueBusyElsewhereTitle: 'busy elsewhere title',
+        queueStuckBody: 'stuck body',
+        queueStuckTitle: 'stuck title'
+      }
+    }
+  })
 }))
-vi.mock('@/store/notifications', () => ({ notify: () => {} }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn() }))
 vi.mock('@/store/composer', () => ({ clearComposerAttachments: () => {} }))
 vi.mock('@/store/composer-input-history', () => ({ resetBrowseState: () => {} }))
 vi.mock('../composer-utils', () => ({
@@ -20,7 +31,6 @@ vi.mock('../composer-utils', () => ({
 }))
 
 const SESSION_KEY = 'session-drain'
-const QUEUE_STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
 
 type OnSubmit = (value: string, options?: { fromQueue?: boolean }) => Promise<boolean> | boolean
 
@@ -50,44 +60,10 @@ function renderWindow(onSubmit: OnSubmit, { busy = false }: { busy?: boolean } =
   )
 }
 
-// Minimal Web Locks stand-in (jsdom has none) with real exclusivity +
-// ifAvailable semantics, so two hook instances contend like two windows.
-function installFakeLocks() {
-  const held = new Set<string>()
-
-  const request = async (
-    name: string,
-    options: { ifAvailable?: boolean },
-    callback: (lock: null | { name: string }) => Promise<unknown>
-  ): Promise<unknown> => {
-    if (held.has(name)) {
-      if (!options.ifAvailable) {
-        throw new Error('fake lock manager only implements ifAvailable')
-      }
-
-      return callback(null)
-    }
-
-    held.add(name)
-
-    try {
-      return await callback({ name })
-    } finally {
-      held.delete(name)
-    }
-  }
-
-  Object.defineProperty(window.navigator, 'locks', { configurable: true, value: { request } })
-
-  return () => {
-    delete (window.navigator as { locks?: unknown }).locks
-  }
-}
-
 describe('useComposerQueue cross-window drain (#57516 review)', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
-    $queuedPromptsBySession.set({})
+    vi.mocked(notify).mockClear()
+    resetQueueStorage()
   })
 
   it('auto-drains an entry exactly once across two concurrently idle windows', async () => {
@@ -134,7 +110,7 @@ describe('useComposerQueue cross-window drain (#57516 review)', () => {
 
     // Another window drains the entry; its storage write is visible but the
     // `storage` event syncing our atom has not fired yet.
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    window.localStorage.removeItem('hermes.desktop.composerQueue.v1')
 
     await act(async () => {
       await expect(result.current.drainNextQueued()).resolves.toBe(false)
@@ -156,4 +132,161 @@ describe('useComposerQueue cross-window drain (#57516 review)', () => {
     expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
     unmount()
   })
+})
+
+describe('useComposerQueue drain liveness (#57516 follow-up)', () => {
+  beforeEach(() => {
+    vi.mocked(notify).mockClear()
+    resetQueueStorage()
+  })
+
+  it('a losing window retries after the winner’s claim releases without a send (winner rejected/crashed)', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'strand me not' })
+
+      // Window A wins the claim, then its submit is REJECTED: it writes no
+      // storage, so no storage event will ever reach window B.
+      let settleA!: (accepted: boolean) => void
+      const onSubmitA = vi.fn(() => new Promise<boolean>(resolve => (settleA = resolve)))
+      const windowA = renderWindow(onSubmitA)
+      await act(async () => {})
+
+      expect(onSubmitA).toHaveBeenCalledTimes(1)
+
+      const onSubmitB = vi.fn(() => Promise.resolve(true))
+      const windowB = renderWindow(onSubmitB)
+      await act(async () => {})
+
+      expect(onSubmitB).not.toHaveBeenCalled()
+
+      // A's submit is rejected → A releases the claim with no storage write.
+      // B's claim-release waiter must wake it up to drain the entry itself.
+      await act(async () => {
+        settleA(false)
+      })
+
+      await waitFor(() => expect(onSubmitB).toHaveBeenCalledTimes(1))
+      await act(async () => {})
+
+      expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
+
+      windowA.unmount()
+      windowB.unmount()
+    } finally {
+      restore()
+    }
+  })
+
+  it('a manual send-now waits for another window’s in-flight drain instead of silently dropping the tap', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      const first = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'auto head' })
+      const second = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'tapped entry' })
+
+      expect(first).not.toBeNull()
+      expect(second).not.toBeNull()
+
+      // Window A auto-drains the head and is mid-submit, holding the claim.
+      let settleA!: (accepted: boolean) => void
+      const onSubmitA = vi.fn(() => new Promise<boolean>(resolve => (settleA = resolve)))
+      const windowA = renderWindow(onSubmitA)
+      await act(async () => {})
+
+      expect(onSubmitA).toHaveBeenCalledTimes(1)
+
+      // The user taps "send now" on the second entry in window B: the tap must
+      // wait for A's claim, not vanish.
+      const onSubmitB = vi.fn(() => Promise.resolve(true))
+      const windowB = renderWindow(onSubmitB, { busy: true }) // busy: isolate the manual path
+
+      let sendResolved: null | boolean = null
+      let sendNow!: Promise<boolean>
+
+      // windowB renders busy, so sendQueuedNow's busy branch would promote
+      // instead of sending. Re-render idle w/o triggering auto-drain first:
+      // manual path only.
+      windowB.unmount()
+      const windowB2 = renderWindow(onSubmitB, { busy: false })
+      await act(async () => {})
+
+      // Auto-drain in B2 lost the claim (contended) — expected. Now the tap:
+      await act(async () => {
+        sendNow = windowB2.result.current.sendQueuedNow(second!.id)
+        void sendNow.then(sent => (sendResolved = sent))
+      })
+
+      expect(sendResolved).toBeNull()
+      expect(onSubmitB).not.toHaveBeenCalled()
+
+      // A's drain completes; B's waiting tap acquires the claim and sends the
+      // exact entry the user tapped.
+      await act(async () => {
+        settleA(true)
+      })
+
+      await waitFor(() => expect(onSubmitB).toHaveBeenCalledTimes(1))
+      expect(onSubmitB).toHaveBeenCalledWith('tapped entry', { attachments: [], fromQueue: true })
+      await expect(sendNow).resolves.toBe(true)
+
+      windowA.unmount()
+      windowB2.unmount()
+    } finally {
+      restore()
+    }
+  })
+
+  it('a tapped entry that no longer exists does not interrupt a live turn', async () => {
+    const onCancel = vi.fn()
+    const onSubmit = vi.fn(() => Promise.resolve(true))
+    const draftRef: RefObject<string> = { current: '' }
+    const queueEditRef: RefObject<QueueEditState | null> = { current: null }
+
+    const { result, unmount } = renderHook(() =>
+      useComposerQueue({
+        activeQueueSessionKey: SESSION_KEY,
+        attachments: [],
+        busy: true,
+        clearDraft: () => {},
+        draftRef,
+        focusInput: () => {},
+        loadIntoComposer: () => {},
+        onCancel,
+        onSubmit,
+        queueEditRef,
+        queueSessionKey: SESSION_KEY,
+        sessionId: SESSION_KEY
+      })
+    )
+
+    await act(async () => {
+      await expect(result.current.sendQueuedNow('queued-phantom-id')).resolves.toBe(false)
+    })
+
+    expect(onCancel).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('retries a rejected auto-drain with backoff until it sends (bounded)', async () => {
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'flaky send' })
+
+    // First two submits are rejected, the third succeeds — well inside
+    // MAX_AUTO_DRAIN_ATTEMPTS. Without the retry timer nothing would ever
+    // re-run auto-drain: the effect deps do not change on a rejected send.
+    let attempts = 0
+    const onSubmit = vi.fn(() => Promise.resolve(++attempts >= 3))
+
+    const { unmount } = renderWindow(onSubmit)
+    await act(async () => {})
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(3), { timeout: 8_000 })
+    await waitFor(() => expect(getQueuedPrompts(SESSION_KEY)).toEqual([]))
+
+    expect(vi.mocked(notify)).not.toHaveBeenCalled()
+    unmount()
+  }, 15_000)
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -1,0 +1,159 @@
+import { act, renderHook } from '@testing-library/react'
+import type { RefObject } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $queuedPromptsBySession, enqueueQueuedPrompt, getQueuedPrompts } from '@/store/composer-queue'
+
+import type { QueueEditState } from '../composer-utils'
+
+import { useComposerQueue } from './use-composer-queue'
+
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: () => {} }))
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({ t: { composer: { queueStuckBody: 'stuck body', queueStuckTitle: 'stuck title' } } })
+}))
+vi.mock('@/store/notifications', () => ({ notify: () => {} }))
+vi.mock('@/store/composer', () => ({ clearComposerAttachments: () => {} }))
+vi.mock('@/store/composer-input-history', () => ({ resetBrowseState: () => {} }))
+vi.mock('../composer-utils', () => ({
+  cloneAttachments: (attachments: unknown[]) => attachments.map(a => ({ ...(a as object) }))
+}))
+
+const SESSION_KEY = 'session-drain'
+const QUEUE_STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
+
+type OnSubmit = (value: string, options?: { fromQueue?: boolean }) => Promise<boolean> | boolean
+
+// One hook instance = one desktop window's composer. Instances share
+// localStorage and the (fake) lock manager exactly like real windows do; they
+// additionally share the module-level atom, which only makes the race harsher —
+// both "windows" see a new head entry instantly, with zero storage-event lag.
+function renderWindow(onSubmit: OnSubmit, { busy = false }: { busy?: boolean } = {}) {
+  const draftRef: RefObject<string> = { current: '' }
+  const queueEditRef: RefObject<QueueEditState | null> = { current: null }
+
+  return renderHook(() =>
+    useComposerQueue({
+      activeQueueSessionKey: SESSION_KEY,
+      attachments: [],
+      busy,
+      clearDraft: () => {},
+      draftRef,
+      focusInput: () => {},
+      loadIntoComposer: () => {},
+      onCancel: () => {},
+      onSubmit,
+      queueEditRef,
+      queueSessionKey: SESSION_KEY,
+      sessionId: SESSION_KEY
+    })
+  )
+}
+
+// Minimal Web Locks stand-in (jsdom has none) with real exclusivity +
+// ifAvailable semantics, so two hook instances contend like two windows.
+function installFakeLocks() {
+  const held = new Set<string>()
+
+  const request = async (
+    name: string,
+    options: { ifAvailable?: boolean },
+    callback: (lock: null | { name: string }) => Promise<unknown>
+  ): Promise<unknown> => {
+    if (held.has(name)) {
+      if (!options.ifAvailable) {
+        throw new Error('fake lock manager only implements ifAvailable')
+      }
+
+      return callback(null)
+    }
+
+    held.add(name)
+
+    try {
+      return await callback({ name })
+    } finally {
+      held.delete(name)
+    }
+  }
+
+  Object.defineProperty(window.navigator, 'locks', { configurable: true, value: { request } })
+
+  return () => {
+    delete (window.navigator as { locks?: unknown }).locks
+  }
+}
+
+describe('useComposerQueue cross-window drain (#57516 review)', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    $queuedPromptsBySession.set({})
+  })
+
+  it('auto-drains an entry exactly once across two concurrently idle windows', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'send me once' })
+
+      // Window A wins the claim and is stuck mid-submit (in-flight request).
+      let settleA!: (accepted: boolean) => void
+      const onSubmitA = vi.fn(() => new Promise<boolean>(resolve => (settleA = resolve)))
+      const windowA = renderWindow(onSubmitA)
+      await act(async () => {})
+
+      expect(onSubmitA).toHaveBeenCalledTimes(1)
+
+      // Window B goes idle while A's submit is still in flight: same head entry
+      // visible, but the claim is held, so B must not submit it.
+      const onSubmitB = vi.fn(() => Promise.resolve(true))
+      const windowB = renderWindow(onSubmitB)
+      await act(async () => {})
+
+      expect(onSubmitB).not.toHaveBeenCalled()
+
+      await act(async () => {
+        settleA(true)
+      })
+
+      expect(onSubmitA).toHaveBeenCalledTimes(1)
+      expect(onSubmitB).not.toHaveBeenCalled()
+      expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
+
+      windowA.unmount()
+      windowB.unmount()
+    } finally {
+      restore()
+    }
+  })
+
+  it('does not resubmit an entry another window already drained (stale local state)', async () => {
+    const onSubmit = vi.fn(() => Promise.resolve(true))
+    const { result, unmount } = renderWindow(onSubmit, { busy: true }) // busy: no auto-drain
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'drained elsewhere' })
+
+    // Another window drains the entry; its storage write is visible but the
+    // `storage` event syncing our atom has not fired yet.
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+
+    await act(async () => {
+      await expect(result.current.drainNextQueued()).resolves.toBe(false)
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('auto-drains normally in a single idle window (sanity)', async () => {
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'plain send' })
+
+    const onSubmit = vi.fn(() => Promise.resolve(true))
+    const { unmount } = renderWindow(onSubmit)
+    await act(async () => {})
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith('plain send', { attachments: [], fromQueue: true })
+    expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
+    unmount()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -6,7 +6,9 @@ import {
   enqueueQueuedPrompt,
   getQueuedPrompts,
   markQueuedPromptSent,
-  QUEUE_STORAGE_KEY
+  QUEUE_STORAGE_KEY,
+  QUEUE_TOMBSTONES_STORAGE_KEY,
+  withSessionDrainClaim
 } from '@/store/composer-queue'
 import { installFakeLocks, persistedQueueTexts, resetQueueStorage } from '@/store/composer-queue-test-utils'
 import { notify } from '@/store/notifications'
@@ -171,6 +173,44 @@ describe('useComposerQueue cross-window drain (#57516 review)', () => {
       expect(onSubmit).not.toHaveBeenCalled()
       await waitFor(() => expect(persistedQueueTexts(SESSION_KEY)).toEqual([]))
       unmount()
+    } finally {
+      restore()
+    }
+  })
+
+  it('a real successful drain marks its entry sent, protecting it even if tombstones are lost', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'sent for real' })
+
+      // Window A drains the entry through the real flow (this is what must
+      // call markQueuedPromptSent — the producer half of the protection).
+      const onSubmitA = vi.fn(() => Promise.resolve(true))
+      const windowA = renderWindow(onSubmitA)
+      await act(async () => {})
+
+      expect(onSubmitA).toHaveBeenCalledTimes(1)
+
+      // Simulate total loss of the storage-side protection: tombstones wiped
+      // and the entry resurrected by a stale save (event included, so the
+      // atom adopts the resurrected entry like a real cross-window write).
+      window.localStorage.removeItem(QUEUE_TOMBSTONES_STORAGE_KEY)
+      const resurrected = JSON.stringify({ [SESSION_KEY]: [entry] })
+      window.localStorage.setItem(QUEUE_STORAGE_KEY, resurrected)
+      window.dispatchEvent(new StorageEvent('storage', { key: QUEUE_STORAGE_KEY, newValue: resurrected }))
+
+      // A fresh idle window must purge the entry via A's held sent claim, not
+      // submit it a second time.
+      const onSubmitB = vi.fn(() => Promise.resolve(true))
+      const windowB = renderWindow(onSubmitB)
+      await act(async () => {})
+
+      expect(onSubmitB).not.toHaveBeenCalled()
+      await waitFor(() => expect(persistedQueueTexts(SESSION_KEY)).toEqual([]))
+
+      windowA.unmount()
+      windowB.unmount()
     } finally {
       restore()
     }
@@ -466,19 +506,38 @@ describe('useComposerQueue unmount safety', () => {
     }
   })
 
-  it('a pending backoff retry is cancelled by unmount', async () => {
+  it('a pending backoff retry is cancelled by unmount (timer actually cleared, not just guarded)', async () => {
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'no zombie retries' })
 
-    const onSubmit = vi.fn(() => Promise.resolve(false))
-    const { unmount } = renderWindow(onSubmit)
-    await act(async () => {})
+    const setSpy = vi.spyOn(globalThis, 'setTimeout')
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
 
-    expect(onSubmit).toHaveBeenCalledTimes(1) // rejected; retry timer armed
+    try {
+      const onSubmit = vi.fn(() => Promise.resolve(false))
+      const { unmount } = renderWindow(onSubmit)
+      await act(async () => {})
 
-    unmount()
-    await new Promise(resolve => setTimeout(resolve, 150))
+      expect(onSubmit).toHaveBeenCalledTimes(1) // rejected; retry timer armed
 
-    expect(onSubmit).toHaveBeenCalledTimes(1)
+      // Pin the clearTimeout itself — the mountedRef guard alone would also
+      // suppress the submit, so counting submits cannot distinguish them.
+      // The retry timer is the setTimeout armed with the mocked backoff
+      // (AUTO_DRAIN_RETRY_BASE_MS × 1 = 20ms).
+      const retryIndex = setSpy.mock.calls.findIndex(call => call[1] === 20)
+
+      expect(retryIndex).toBeGreaterThanOrEqual(0)
+
+      const retryHandle = setSpy.mock.results[retryIndex]!.value as ReturnType<typeof setTimeout>
+
+      unmount()
+      expect(clearSpy).toHaveBeenCalledWith(retryHandle)
+
+      await new Promise(resolve => setTimeout(resolve, 100))
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    } finally {
+      setSpy.mockRestore()
+      clearSpy.mockRestore()
+    }
   })
 })
 
@@ -488,11 +547,19 @@ describe('useComposerQueue runtime re-key migration', () => {
     resetQueueStorage()
   })
 
-  it('chains two quick re-keys so entries land under the final key', async () => {
+  it('chains two quick re-keys so entries land under the final key even when the first move must wait', async () => {
     const restore = installFakeLocks()
 
     try {
       enqueueQueuedPrompt('rt-1', { attachments: [], text: 'follow me' })
+
+      // A drain claim is held on rt-1 (an in-flight submit under the old key),
+      // so the rt-1 → rt-2 migration must WAIT. Without chaining, the
+      // rt-2 → rt-3 migration would run first (moving nothing) and the entry
+      // would strand under the dead intermediate key rt-2 forever.
+      let releaseDrain!: () => void
+      const heldDrain = withSessionDrainClaim('rt-1', () => new Promise<void>(resolve => (releaseDrain = resolve)))
+      await Promise.resolve()
 
       const onSubmit = vi.fn(() => Promise.resolve(true))
       const draftRef: RefObject<string> = { current: '' }
@@ -520,10 +587,15 @@ describe('useComposerQueue runtime re-key migration', () => {
       // Two re-keys in quick succession, no flush in between.
       rerender({ sessionKey: 'rt-2' })
       rerender({ sessionKey: 'rt-3' })
-
       await act(async () => {})
-      await waitFor(() => expect(persistedQueueTexts('rt-3')).toEqual(['follow me']))
 
+      // Both migrations are queued behind the held rt-1 claim; nothing moved.
+      expect(persistedQueueTexts('rt-1')).toEqual(['follow me'])
+
+      releaseDrain()
+      await heldDrain
+
+      await waitFor(() => expect(persistedQueueTexts('rt-3')).toEqual(['follow me']))
       expect(persistedQueueTexts('rt-1')).toEqual([])
       expect(persistedQueueTexts('rt-2')).toEqual([])
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -2,8 +2,13 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import type { RefObject } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { enqueueQueuedPrompt, getQueuedPrompts } from '@/store/composer-queue'
-import { installFakeLocks, resetQueueStorage } from '@/store/composer-queue-test-utils'
+import {
+  enqueueQueuedPrompt,
+  getQueuedPrompts,
+  markQueuedPromptSent,
+  QUEUE_STORAGE_KEY
+} from '@/store/composer-queue'
+import { installFakeLocks, persistedQueueTexts, resetQueueStorage } from '@/store/composer-queue-test-utils'
 import { notify } from '@/store/notifications'
 
 import type { QueueEditState } from '../composer-utils'
@@ -29,35 +34,50 @@ vi.mock('@/store/composer-input-history', () => ({ resetBrowseState: () => {} })
 vi.mock('../composer-utils', () => ({
   cloneAttachments: (attachments: unknown[]) => attachments.map(a => ({ ...(a as object) }))
 }))
+// Real store, tiny retry backoff: the liveness tests drive real retries and
+// must not spend seconds of wall clock per attempt.
+vi.mock('@/store/composer-queue', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  AUTO_DRAIN_RETRY_BASE_MS: 20
+}))
 
 const SESSION_KEY = 'session-drain'
 
 type OnSubmit = (value: string, options?: { fromQueue?: boolean }) => Promise<boolean> | boolean
 
+interface WindowProps {
+  busy: boolean
+  sessionKey: string
+}
+
 // One hook instance = one desktop window's composer. Instances share
 // localStorage and the (fake) lock manager exactly like real windows do; they
 // additionally share the module-level atom, which only makes the race harsher —
 // both "windows" see a new head entry instantly, with zero storage-event lag.
-function renderWindow(onSubmit: OnSubmit, { busy = false }: { busy?: boolean } = {}) {
+function renderWindow(onSubmit: OnSubmit, { busy = false, onCancel = () => {} } = {}) {
   const draftRef: RefObject<string> = { current: '' }
   const queueEditRef: RefObject<QueueEditState | null> = { current: null }
 
-  return renderHook(() =>
-    useComposerQueue({
-      activeQueueSessionKey: SESSION_KEY,
-      attachments: [],
-      busy,
-      clearDraft: () => {},
-      draftRef,
-      focusInput: () => {},
-      loadIntoComposer: () => {},
-      onCancel: () => {},
-      onSubmit,
-      queueEditRef,
-      queueSessionKey: SESSION_KEY,
-      sessionId: SESSION_KEY
-    })
+  const rendered = renderHook(
+    (props: WindowProps) =>
+      useComposerQueue({
+        activeQueueSessionKey: props.sessionKey,
+        attachments: [],
+        busy: props.busy,
+        clearDraft: () => {},
+        draftRef,
+        focusInput: () => {},
+        loadIntoComposer: () => {},
+        onCancel,
+        onSubmit,
+        queueEditRef,
+        queueSessionKey: undefined,
+        sessionId: props.sessionKey
+      }),
+    { initialProps: { busy, sessionKey: SESSION_KEY } }
   )
+
+  return { ...rendered, queueEditRef }
 }
 
 describe('useComposerQueue cross-window drain (#57516 review)', () => {
@@ -110,7 +130,7 @@ describe('useComposerQueue cross-window drain (#57516 review)', () => {
 
     // Another window drains the entry; its storage write is visible but the
     // `storage` event syncing our atom has not fired yet.
-    window.localStorage.removeItem('hermes.desktop.composerQueue.v1')
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
 
     await act(async () => {
       await expect(result.current.drainNextQueued()).resolves.toBe(false)
@@ -131,6 +151,29 @@ describe('useComposerQueue cross-window drain (#57516 review)', () => {
     expect(onSubmit).toHaveBeenCalledWith('plain send', { attachments: [], fromQueue: true })
     expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
     unmount()
+  })
+
+  it('purges (never resubmits) an entry whose sent claim is held by a broken-storage window', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'sent by broken window' })
+
+      // A window whose removals cannot reach storage marked its send with a
+      // held Web Lock instead.
+      markQueuedPromptSent(entry!.id)
+      await Promise.resolve()
+
+      const onSubmit = vi.fn(() => Promise.resolve(true))
+      const { unmount } = renderWindow(onSubmit)
+      await act(async () => {})
+
+      expect(onSubmit).not.toHaveBeenCalled()
+      await waitFor(() => expect(persistedQueueTexts(SESSION_KEY)).toEqual([]))
+      unmount()
+    } finally {
+      restore()
+    }
   })
 })
 
@@ -179,7 +222,7 @@ describe('useComposerQueue drain liveness (#57516 follow-up)', () => {
     }
   })
 
-  it('a manual send-now waits for another window’s in-flight drain instead of silently dropping the tap', async () => {
+  it('a manual send-now waits for ANOTHER window’s in-flight drain instead of silently dropping the tap', async () => {
     const restore = installFakeLocks()
 
     try {
@@ -198,23 +241,25 @@ describe('useComposerQueue drain liveness (#57516 follow-up)', () => {
       expect(onSubmitA).toHaveBeenCalledTimes(1)
 
       // The user taps "send now" on the second entry in window B: the tap must
-      // wait for A's claim, not vanish.
+      // wait for A's claim, not vanish. Marking the entry as "being edited" in
+      // B's ref keeps B's own auto-drain off it, isolating the manual path.
       const onSubmitB = vi.fn(() => Promise.resolve(true))
-      const windowB = renderWindow(onSubmitB, { busy: true }) // busy: isolate the manual path
+      const windowB = renderWindow(onSubmitB)
+      windowB.queueEditRef.current = {
+        attachments: [],
+        draft: '',
+        entryId: second!.id,
+        sessionKey: SESSION_KEY
+      } as QueueEditState
+      await act(async () => {})
+
+      windowB.queueEditRef.current = null
 
       let sendResolved: null | boolean = null
       let sendNow!: Promise<boolean>
 
-      // windowB renders busy, so sendQueuedNow's busy branch would promote
-      // instead of sending. Re-render idle w/o triggering auto-drain first:
-      // manual path only.
-      windowB.unmount()
-      const windowB2 = renderWindow(onSubmitB, { busy: false })
-      await act(async () => {})
-
-      // Auto-drain in B2 lost the claim (contended) — expected. Now the tap:
       await act(async () => {
-        sendNow = windowB2.result.current.sendQueuedNow(second!.id)
+        sendNow = windowB.result.current.sendQueuedNow(second!.id)
         void sendNow.then(sent => (sendResolved = sent))
       })
 
@@ -227,52 +272,108 @@ describe('useComposerQueue drain liveness (#57516 follow-up)', () => {
         settleA(true)
       })
 
-      await waitFor(() => expect(onSubmitB).toHaveBeenCalledTimes(1))
-      expect(onSubmitB).toHaveBeenCalledWith('tapped entry', { attachments: [], fromQueue: true })
+      await waitFor(() => expect(onSubmitB).toHaveBeenCalledWith('tapped entry', { attachments: [], fromQueue: true }))
       await expect(sendNow).resolves.toBe(true)
+      expect(vi.mocked(notify)).not.toHaveBeenCalled()
 
       windowA.unmount()
-      windowB2.unmount()
+      windowB.unmount()
     } finally {
       restore()
     }
   })
 
-  it('a tapped entry that no longer exists does not interrupt a live turn', async () => {
-    const onCancel = vi.fn()
-    const onSubmit = vi.fn(() => Promise.resolve(true))
-    const draftRef: RefObject<string> = { current: '' }
-    const queueEditRef: RefObject<QueueEditState | null> = { current: null }
+  it('a manual send-now during THIS window’s own in-flight drain waits too (no false “busy elsewhere”)', async () => {
+    const restore = installFakeLocks()
 
-    const { result, unmount } = renderHook(() =>
-      useComposerQueue({
-        activeQueueSessionKey: SESSION_KEY,
+    try {
+      enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'auto head' })
+      const tapped = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'tapped entry' })
+
+      let settleAuto!: (accepted: boolean) => void
+
+      const onSubmit = vi
+        .fn<OnSubmit>()
+        .mockImplementationOnce(() => new Promise<boolean>(resolve => (settleAuto = resolve)))
+        .mockImplementation(() => Promise.resolve(true))
+
+      const win = renderWindow(onSubmit)
+      // Keep this window's auto-drain off the tapped entry so the manual path
+      // owns it deterministically.
+      win.queueEditRef.current = {
         attachments: [],
-        busy: true,
-        clearDraft: () => {},
-        draftRef,
-        focusInput: () => {},
-        loadIntoComposer: () => {},
-        onCancel,
-        onSubmit,
-        queueEditRef,
-        queueSessionKey: SESSION_KEY,
-        sessionId: SESSION_KEY
+        draft: '',
+        entryId: tapped!.id,
+        sessionKey: SESSION_KEY
+      } as QueueEditState
+      await act(async () => {})
+
+      expect(onSubmit).toHaveBeenCalledTimes(1) // auto-drain of the head, in flight
+
+      win.queueEditRef.current = null
+
+      let sendNow!: Promise<boolean>
+      await act(async () => {
+        sendNow = win.result.current.sendQueuedNow(tapped!.id)
       })
-    )
 
-    await act(async () => {
-      await expect(result.current.sendQueuedNow('queued-phantom-id')).resolves.toBe(false)
-    })
+      // Still waiting on the LOCAL in-flight drain — not bounced, not toasted.
+      expect(onSubmit).toHaveBeenCalledTimes(1)
 
-    expect(onCancel).not.toHaveBeenCalled()
-    unmount()
+      await act(async () => {
+        settleAuto(true)
+      })
+
+      await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('tapped entry', { attachments: [], fromQueue: true }))
+      await expect(sendNow).resolves.toBe(true)
+      expect(vi.mocked(notify)).not.toHaveBeenCalled()
+
+      win.unmount()
+    } finally {
+      restore()
+    }
+  })
+
+  it('a manual send-now that outwaits its budget resolves false and says the queue is busy', async () => {
+    // failWaits: waiting requests reject as a timed-out AbortSignal would,
+    // without spending the real 15s budget.
+    const restore = installFakeLocks({ failWaits: true })
+
+    try {
+      const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'blocked tap' })
+
+      // Window A holds the claim forever.
+      const onSubmitA = vi.fn(() => new Promise<boolean>(() => {}))
+      const windowA = renderWindow(onSubmitA)
+      await act(async () => {})
+
+      expect(onSubmitA).toHaveBeenCalledTimes(1)
+
+      const onSubmitB = vi.fn(() => Promise.resolve(true))
+      const windowB = renderWindow(onSubmitB, { busy: true }) // busy: no auto-drain noise
+      windowB.rerender({ busy: false, sessionKey: SESSION_KEY })
+      await act(async () => {})
+
+      await act(async () => {
+        await expect(windowB.result.current.sendQueuedNow(entry!.id)).resolves.toBe(false)
+      })
+
+      expect(onSubmitB).not.toHaveBeenCalled()
+      expect(vi.mocked(notify)).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'composer-queue-busy-elsewhere' })
+      )
+
+      windowA.unmount()
+      windowB.unmount()
+    } finally {
+      restore()
+    }
   })
 
   it('retries a rejected auto-drain with backoff until it sends (bounded)', async () => {
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'flaky send' })
 
-    // First two submits are rejected, the third succeeds — well inside
+    // First two submits are rejected, the third succeeds — inside
     // MAX_AUTO_DRAIN_ATTEMPTS. Without the retry timer nothing would ever
     // re-run auto-drain: the effect deps do not change on a rejected send.
     let attempts = 0
@@ -283,10 +384,152 @@ describe('useComposerQueue drain liveness (#57516 follow-up)', () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1)
 
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(3), { timeout: 8_000 })
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(3), { timeout: 4_000 })
     await waitFor(() => expect(getQueuedPrompts(SESSION_KEY)).toEqual([]))
 
     expect(vi.mocked(notify)).not.toHaveBeenCalled()
     unmount()
-  }, 15_000)
+  })
+
+  it('stops at the retry cap and raises the stuck-queue toast exactly once', async () => {
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'never sends' })
+
+    const onSubmit = vi.fn(() => Promise.resolve(false))
+    const { unmount } = renderWindow(onSubmit)
+    await act(async () => {})
+
+    // MAX_AUTO_DRAIN_ATTEMPTS = 4: the initial attempt plus three backoff
+    // retries, then the toast — and NO further attempts.
+    await waitFor(() => expect(vi.mocked(notify)).toHaveBeenCalledWith(expect.objectContaining({ id: 'composer-queue-stuck' })), {
+      timeout: 4_000
+    })
+    expect(onSubmit).toHaveBeenCalledTimes(4)
+
+    await new Promise(resolve => setTimeout(resolve, 250))
+    expect(onSubmit).toHaveBeenCalledTimes(4)
+    expect(vi.mocked(notify)).toHaveBeenCalledTimes(1)
+
+    // The entry stays queued for a manual send.
+    expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['never sends'])
+    unmount()
+  })
+
+  it('a tapped entry that no longer exists does not interrupt a live turn', async () => {
+    const onCancel = vi.fn()
+    const onSubmit = vi.fn(() => Promise.resolve(true))
+    const { result, unmount } = renderWindow(onSubmit, { busy: true, onCancel })
+
+    await act(async () => {
+      await expect(result.current.sendQueuedNow('queued-phantom-id')).resolves.toBe(false)
+    })
+
+    expect(onCancel).not.toHaveBeenCalled()
+    unmount()
+  })
+})
+
+describe('useComposerQueue unmount safety', () => {
+  beforeEach(() => {
+    vi.mocked(notify).mockClear()
+    resetQueueStorage()
+  })
+
+  it('an armed claim-release waiter does not drain after its window unmounts', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'not for the dead window' })
+
+      let settleA!: (accepted: boolean) => void
+      const onSubmitA = vi.fn(() => new Promise<boolean>(resolve => (settleA = resolve)))
+      const windowA = renderWindow(onSubmitA)
+      await act(async () => {})
+
+      const onSubmitB = vi.fn(() => Promise.resolve(true))
+      const windowB = renderWindow(onSubmitB)
+      await act(async () => {}) // B contends and arms its claim-release waiter
+
+      windowB.unmount()
+
+      await act(async () => {
+        settleA(false) // release with no send: the waiter fires…
+      })
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      // …but B is unmounted, so it must not drain.
+      expect(onSubmitB).not.toHaveBeenCalled()
+      expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['not for the dead window'])
+
+      windowA.unmount()
+    } finally {
+      restore()
+    }
+  })
+
+  it('a pending backoff retry is cancelled by unmount', async () => {
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'no zombie retries' })
+
+    const onSubmit = vi.fn(() => Promise.resolve(false))
+    const { unmount } = renderWindow(onSubmit)
+    await act(async () => {})
+
+    expect(onSubmit).toHaveBeenCalledTimes(1) // rejected; retry timer armed
+
+    unmount()
+    await new Promise(resolve => setTimeout(resolve, 150))
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useComposerQueue runtime re-key migration', () => {
+  beforeEach(() => {
+    vi.mocked(notify).mockClear()
+    resetQueueStorage()
+  })
+
+  it('chains two quick re-keys so entries land under the final key', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      enqueueQueuedPrompt('rt-1', { attachments: [], text: 'follow me' })
+
+      const onSubmit = vi.fn(() => Promise.resolve(true))
+      const draftRef: RefObject<string> = { current: '' }
+      const queueEditRef: RefObject<QueueEditState | null> = { current: null }
+
+      const { rerender, unmount } = renderHook(
+        (props: { sessionKey: string }) =>
+          useComposerQueue({
+            activeQueueSessionKey: props.sessionKey,
+            attachments: [],
+            busy: true, // keep auto-drain out of the way; migration is the subject
+            clearDraft: () => {},
+            draftRef,
+            focusInput: () => {},
+            loadIntoComposer: () => {},
+            onCancel: () => {},
+            onSubmit,
+            queueEditRef,
+            queueSessionKey: undefined,
+            sessionId: props.sessionKey
+          }),
+        { initialProps: { sessionKey: 'rt-1' } }
+      )
+
+      // Two re-keys in quick succession, no flush in between.
+      rerender({ sessionKey: 'rt-2' })
+      rerender({ sessionKey: 'rt-3' })
+
+      await act(async () => {})
+      await waitFor(() => expect(persistedQueueTexts('rt-3')).toEqual(['follow me']))
+
+      expect(persistedQueueTexts('rt-1')).toEqual([])
+      expect(persistedQueueTexts('rt-2')).toEqual([])
+
+      unmount()
+    } finally {
+      restore()
+    }
+  })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -8,6 +8,7 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
+  getQueuedPrompts,
   MAX_AUTO_DRAIN_ATTEMPTS,
   migrateQueuedPrompts,
   promoteQueuedPrompt,
@@ -187,7 +188,11 @@ export function useComposerQueue({
         return false
       }
 
-      const entry = pickEntry(queuedPrompts)
+      // Pick from the live store, not the rendered slice: with several windows
+      // open, another window may have drained (removed) this entry after our
+      // last render, and sending from the stale slice would double-submit the
+      // prompt into the session (#46732).
+      const entry = pickEntry(getQueuedPrompts(activeQueueSessionKey))
 
       if (!entry) {
         return false
@@ -213,7 +218,7 @@ export function useComposerQueue({
         drainingQueueRef.current = false
       }
     },
-    [activeQueueSessionKey, onSubmit, queuedPrompts, sessionId]
+    [activeQueueSessionKey, onSubmit, sessionId]
   )
 
   const pickDrainHead = useCallback(

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -8,14 +8,15 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
-  getQueuedPrompts,
   MAX_AUTO_DRAIN_ATTEMPTS,
   migrateQueuedPrompts,
   promoteQueuedPrompt,
   type QueuedPromptEntry,
+  readPersistedQueuedPrompts,
   removeQueuedPrompt,
   shouldAutoDrain,
-  updateQueuedPrompt
+  updateQueuedPrompt,
+  withSessionDrainClaim
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
 
@@ -40,7 +41,8 @@ interface UseComposerQueueArgs {
 /**
  * The composer's queue engine — everything about queued turns: the per-session
  * queue store binding, in-place queued-prompt editing (begin/step/exit), the
- * shared drain lock + send-then-remove sequence, manual send-now, and the
+ * drain locks (renderer-local + cross-window claim) + send-then-remove
+ * sequence, manual send-now, and the
  * edge-independent auto-drain with bounded retries. It consumes the draft API
  * (draftRef/clearDraft/loadIntoComposer/focusInput) and writes the
  * coordinator-owned `queueEditRef` so the draft engine can read the edit state
@@ -180,40 +182,57 @@ export function useComposerQueue({
     return true
   }, [activeQueueSessionKey, attachments, clearDraft, draftRef])
 
-  // All queue drain paths share one lock + send-then-remove sequence.
-  // `pickEntry` lets each caller choose head, by-id, or skip-edited.
+  // All queue drain paths share one send-then-remove sequence behind two
+  // exclusion layers: the renderer-local ref serializes attempts within THIS
+  // window, and the session's cross-window drain claim serializes across
+  // windows — every idle window schedules auto-drain, so without the claim two
+  // of them could pick the same head and each submit it before either reaches
+  // the removal below (#46732). `pickEntry` lets each caller choose head,
+  // by-id, or skip-edited; the outcome (not a bare boolean) lets auto-drain
+  // count only genuine send failures toward its retry cap.
   const runDrain = useCallback(
-    async (pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined): Promise<boolean> => {
+    async (
+      pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined
+    ): Promise<'contended' | 'empty' | 'rejected' | 'sent'> => {
       if (drainingQueueRef.current || !activeQueueSessionKey) {
-        return false
-      }
-
-      // Pick from the live store, not the rendered slice: with several windows
-      // open, another window may have drained (removed) this entry after our
-      // last render, and sending from the stale slice would double-submit the
-      // prompt into the session (#46732).
-      const entry = pickEntry(getQueuedPrompts(activeQueueSessionKey))
-
-      if (!entry) {
-        return false
+        return 'contended'
       }
 
       drainingQueueRef.current = true
 
       try {
-        const accepted = await Promise.resolve(
-          onSubmit(entry.text, { attachments: entry.attachments, fromQueue: true })
+        const outcome = await withSessionDrainClaim(
+          activeQueueSessionKey,
+          async (): Promise<'empty' | 'rejected' | 'sent'> => {
+            // Pick INSIDE the claim, and from persisted storage rather than the
+            // rendered slice or the atom: the storage event that syncs them is
+            // asynchronous, so only storage itself is guaranteed to reflect a
+            // removal another window just made. Picking any earlier (or from
+            // anything staler) is what allowed the double submit.
+            const entry = pickEntry(readPersistedQueuedPrompts(activeQueueSessionKey))
+
+            if (!entry) {
+              return 'empty'
+            }
+
+            const accepted = await Promise.resolve(
+              onSubmit(entry.text, { attachments: entry.attachments, fromQueue: true })
+            )
+
+            if (accepted === false) {
+              return 'rejected'
+            }
+
+            drainFailuresRef.current.delete(entry.id)
+            removeQueuedPrompt(activeQueueSessionKey, entry.id)
+            resetBrowseState(sessionId)
+
+            return 'sent'
+          }
         )
 
-        if (accepted === false) {
-          return false
-        }
-
-        drainFailuresRef.current.delete(entry.id)
-        removeQueuedPrompt(activeQueueSessionKey, entry.id)
-        resetBrowseState(sessionId)
-
-        return true
+        // null grant = another window holds the claim; the entry is theirs now.
+        return outcome ?? 'contended'
       } finally {
         drainingQueueRef.current = false
       }
@@ -230,7 +249,10 @@ export function useComposerQueue({
     [queueEditRef] // reads the edit id off a ref so the lock-holder always sees the latest
   )
 
-  const drainNextQueued = useCallback(() => runDrain(pickDrainHead), [pickDrainHead, runDrain])
+  const drainNextQueued = useCallback(
+    () => runDrain(pickDrainHead).then(outcome => outcome === 'sent'),
+    [pickDrainHead, runDrain]
+  )
 
   const sendQueuedNow = useCallback(
     (id: string) => {
@@ -253,7 +275,7 @@ export function useComposerQueue({
       // taps gets a fresh attempt (and re-enables auto-retry on success).
       drainFailuresRef.current.delete(id)
 
-      return runDrain(entries => entries.find(e => e.id === id))
+      return runDrain(entries => entries.find(e => e.id === id)).then(outcome => outcome === 'sent')
     },
     [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain]
   )
@@ -287,9 +309,15 @@ export function useComposerQueue({
       }
     }
 
-    void runDrain(() => entry)
-      .then(sent => {
-        if (!sent) {
+    // Re-locate the entry by id rather than submitting the captured object:
+    // runDrain picks from live persisted state inside the drain claim, so an
+    // entry another window drained meanwhile simply isn't found ('empty').
+    // Only a rejected send counts toward the retry cap — burning attempts on
+    // 'empty'/'contended' (races this window lost) would strand a healthy
+    // entry and raise the stuck-queue toast spuriously.
+    void runDrain(entries => entries.find(candidate => candidate.id === entry.id))
+      .then(outcome => {
+        if (outcome === 'rejected') {
           onFail()
         }
       })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -96,18 +96,19 @@ export function useComposerQueue({
 
   // Liveness plumbing for auto-drain: a bounded-backoff retry timer (rejected
   // sends), one pending claim-release waiter per session key (lost
-  // cross-window races), a swallowed-wakeup flag (wake-ups that landed while
-  // this window's own drain was in flight and must be replayed), a settle
-  // promise waiting manual sends can queue on, and a ref to the latest
-  // autoDrainNext so every wake-up re-triggers fresh logic. The mounted flag
+  // cross-window races), a settle promise waiting manual sends can queue on,
+  // and refs to the latest autoDrainNext / busy so every wake-up and every
+  // in-claim decision sees fresh state, not a stale closure. The mounted flag
   // stops a late-firing timer/waiter from draining for an unmounted composer.
   const retryTimerRef = useRef<null | ReturnType<typeof setTimeout>>(null)
   const claimWaiterKeyRef = useRef<null | string>(null)
-  const swallowedWakeupRef = useRef(false)
   const drainSettledRef = useRef<null | Promise<void>>(null)
   const migrationChainRef = useRef<Promise<unknown>>(Promise.resolve())
   const autoDrainRef = useRef<() => void>(() => {})
+  const busyRef = useRef(busy)
   const mountedRef = useRef(true)
+
+  busyRef.current = busy
 
   const beginQueuedEdit = (entry: QueuedPromptEntry) => {
     if (!activeQueueSessionKey || queueEdit) {
@@ -218,7 +219,7 @@ export function useComposerQueue({
     async (
       pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined,
       claim: { wait?: boolean; timeoutMs?: number } = {}
-    ): Promise<{ entryId: null | string; outcome: 'contended' | 'empty' | 'rejected' | 'sent' }> => {
+    ): Promise<{ entryId: null | string; outcome: 'busy' | 'contended' | 'empty' | 'rejected' | 'sent' }> => {
       if (!activeQueueSessionKey) {
         return { entryId: null, outcome: 'contended' }
       }
@@ -230,15 +231,23 @@ export function useComposerQueue({
 
         // A waiting caller (manual send) must not be bounced by THIS window's
         // own in-flight drain — that is local contention, not "another
-        // window". Wait for the local lane to clear, inside the same budget.
+        // window". Wait for the local lane to clear, inside the same budget:
+        // the settle promise is raced against the remaining time so a hung
+        // in-flight drain cannot suspend the deadline check itself.
         const deadline = claim.timeoutMs === undefined ? Infinity : Date.now() + claim.timeoutMs
 
         while (drainingQueueRef.current) {
-          if (Date.now() >= deadline) {
+          const remaining = deadline - Date.now()
+
+          if (remaining <= 0) {
             return { entryId: null, outcome: 'contended' }
           }
 
-          await (drainSettledRef.current ?? Promise.resolve())
+          const settled = drainSettledRef.current ?? Promise.resolve()
+
+          await (remaining === Infinity
+            ? settled
+            : Promise.race([settled, new Promise(resolve => setTimeout(resolve, remaining))]))
         }
 
         if (claim.timeoutMs !== undefined) {
@@ -254,7 +263,15 @@ export function useComposerQueue({
       try {
         const outcome = await withSessionDrainClaim(
           activeQueueSessionKey,
-          async (): Promise<'empty' | 'rejected' | 'sent'> => {
+          async (): Promise<'busy' | 'empty' | 'rejected' | 'sent'> => {
+            // The session may have started a turn while we waited for the
+            // lane or the claim (typically: the very drain we waited on got
+            // accepted). Submitting now would just bounce off the gateway;
+            // the caller decides what busy means for its flow.
+            if (busyRef.current) {
+              return 'busy'
+            }
+
             // Pick INSIDE the claim, and from the fresh store read rather than
             // the rendered slice or the atom: the storage event that syncs them
             // is asynchronous, so only the fresh read reflects a removal
@@ -277,9 +294,18 @@ export function useComposerQueue({
               return 'empty'
             }
 
-            const accepted = await Promise.resolve(
-              onSubmit(entry.text, { attachments: entry.attachments, fromQueue: true })
-            )
+            let accepted: boolean | void
+
+            try {
+              accepted = await Promise.resolve(
+                onSubmit(entry.text, { attachments: entry.attachments, fromQueue: true })
+              )
+            } catch {
+              // A thrown submit is a rejection of THIS entry — reporting it
+              // through the outcome keeps the failure count attributed to the
+              // entry actually attempted, not a pre-claim guess.
+              return 'rejected'
+            }
 
             if (accepted === false) {
               return 'rejected'
@@ -298,19 +324,13 @@ export function useComposerQueue({
         // null = the claim was unavailable (or the wait timed out); whoever
         // holds it owns the entry for now.
         return { entryId: attemptedId, outcome: outcome ?? 'contended' }
+      } catch {
+        // Lock-manager failure. Post-pick it is a rejection of the attempted
+        // entry; pre-pick it is indistinguishable from contention.
+        return { entryId: attemptedId, outcome: attemptedId ? 'rejected' : 'contended' }
       } finally {
         drainingQueueRef.current = false
         settleDrain()
-
-        // A wake-up (claim-release waiter, storage-event effect, retry timer)
-        // that landed while this drain was in flight was swallowed by the
-        // local guard above. Re-check once the lane is clear — each re-entry
-        // either finds nothing to do or arms its own bounded wake-up, so this
-        // cannot loop.
-        if (swallowedWakeupRef.current) {
-          swallowedWakeupRef.current = false
-          setTimeout(() => autoDrainRef.current(), 0)
-        }
       }
     },
     [activeQueueSessionKey, onSubmit, sessionId]
@@ -330,6 +350,21 @@ export function useComposerQueue({
     [pickDrainHead, runDrain]
   )
 
+  // Send-now while a turn runs: promote to the head, then interrupt. The
+  // gateway always emits a settle (message.complete + session.info
+  // running:false) when the turn unwinds, and the busy→false auto-drain
+  // sends the promoted entry.
+  const promoteAndInterrupt = useCallback(
+    (id: string) => {
+      promoteQueuedPrompt(activeQueueSessionKey, id)
+      triggerHaptic('selection')
+      void Promise.resolve(onCancel())
+
+      return true
+    },
+    [activeQueueSessionKey, onCancel]
+  )
+
   const sendQueuedNow = useCallback(
     async (id: string) => {
       if (!activeQueueSessionKey || id === queueEdit?.entryId) {
@@ -344,14 +379,7 @@ export function useComposerQueue({
       }
 
       if (busy) {
-        // Promote to the head, then interrupt. The gateway always emits a
-        // settle (message.complete + session.info running:false) when the
-        // turn unwinds, and the busy→false auto-drain below sends this entry.
-        promoteQueuedPrompt(activeQueueSessionKey, id)
-        triggerHaptic('selection')
-        void Promise.resolve(onCancel())
-
-        return true
+        return promoteAndInterrupt(id)
       }
 
       // A manual send clears the auto-drain backoff so a stuck entry the user
@@ -365,6 +393,12 @@ export function useComposerQueue({
         timeoutMs: MANUAL_SEND_WAIT_MS,
         wait: true
       })
+
+      // A turn started while we waited (usually the very drain we waited on
+      // being accepted): the tap now means what a tap-during-busy means.
+      if (outcome === 'busy' && readFreshQueuedPrompts(activeQueueSessionKey).some(e => e.id === id)) {
+        return promoteAndInterrupt(id)
+      }
 
       if (outcome === 'contended') {
         notify({
@@ -384,7 +418,7 @@ export function useComposerQueue({
 
       return outcome === 'sent'
     },
-    [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain, t]
+    [activeQueueSessionKey, busy, promoteAndInterrupt, queueEdit, runDrain, t]
   )
 
   // Edge-independent auto-drain: send the head whenever the session is idle and
@@ -397,11 +431,11 @@ export function useComposerQueue({
     }
 
     if (drainingQueueRef.current) {
-      // A drain is already in flight in this window: don't drop this wake-up
-      // (it may be the claim waiter's one shot) — flag it for replay when the
-      // in-flight drain settles.
-      swallowedWakeupRef.current = true
-
+      // A drain is already in flight in this window; drop this wake-up. Every
+      // outcome of the in-flight drain produces its own follow-up signal —
+      // 'sent' writes storage (event → effect), 'rejected' schedules a
+      // backoff retry, 'contended' arms the claim waiter, manual sends kick a
+      // re-check when they finish — so nothing is lost by not replaying.
       return
     }
 
@@ -474,12 +508,13 @@ export function useComposerQueue({
 
     // Re-pick the head INSIDE the claim from fresh state (not the captured
     // entry object): another window's removal, edit, or PROMOTE must all be
-    // honored at send time. The cap guard rides along in the picker so an
-    // entry that exhausted its attempts blocks auto-drain without burning a
-    // claim cycle; failure counts land on whatever entry was actually
-    // attempted. Only a rejected send counts toward the retry cap — burning
-    // attempts on 'empty'/'contended' (races this window lost) would strand a
-    // healthy entry and raise the stuck-queue toast spuriously.
+    // honored at send time. The cap guard rides along in the picker as a
+    // defensive backstop for rendered-vs-fresh skew (tombstones make that
+    // skew nearly unreachable, so the pre-check above is the pinned path).
+    // Failure counts land on whatever entry was actually attempted — runDrain
+    // converts thrown submits into 'rejected' with the attempted id, so only
+    // genuine send failures burn attempts; 'busy' waits for the busy→false
+    // effect edge, 'empty'/'contended' are races this window lost.
     void runDrain(entries => {
       const candidate = pickDrainHead(entries)
 
@@ -488,15 +523,13 @@ export function useComposerQueue({
       }
 
       return candidate
+    }).then(({ entryId, outcome }) => {
+      if (outcome === 'rejected' && entryId) {
+        onFail(entryId)
+      } else if (outcome === 'contended') {
+        onContended()
+      }
     })
-      .then(({ entryId, outcome }) => {
-        if (outcome === 'rejected' && entryId) {
-          onFail(entryId)
-        } else if (outcome === 'contended') {
-          onContended()
-        }
-      })
-      .catch(() => onFail(entry.id))
   }, [activeQueueSessionKey, busy, pickDrainHead, queuedPrompts, runDrain, t])
 
   // Keep the liveness wake-ups (retry timer, claim waiter) pointing at the

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -9,6 +9,8 @@ import {
   $queuedPromptsBySession,
   AUTO_DRAIN_RETRY_BASE_MS,
   enqueueQueuedPrompt,
+  isQueuedPromptSentElsewhere,
+  markQueuedPromptSent,
   MAX_AUTO_DRAIN_ATTEMPTS,
   migrateQueuedPrompts,
   promoteQueuedPrompt,
@@ -93,12 +95,17 @@ export function useComposerQueue({
   const drainFailuresRef = useRef(new Map<string, number>())
 
   // Liveness plumbing for auto-drain: a bounded-backoff retry timer (rejected
-  // sends), a single pending claim-release waiter (lost cross-window races),
-  // and a ref to the latest autoDrainNext so both re-trigger fresh logic. The
-  // mounted flag stops a late-firing timer/waiter from draining on behalf of
-  // an unmounted composer.
+  // sends), one pending claim-release waiter per session key (lost
+  // cross-window races), a swallowed-wakeup flag (wake-ups that landed while
+  // this window's own drain was in flight and must be replayed), a settle
+  // promise waiting manual sends can queue on, and a ref to the latest
+  // autoDrainNext so every wake-up re-triggers fresh logic. The mounted flag
+  // stops a late-firing timer/waiter from draining for an unmounted composer.
   const retryTimerRef = useRef<null | ReturnType<typeof setTimeout>>(null)
-  const claimWaiterArmedRef = useRef(false)
+  const claimWaiterKeyRef = useRef<null | string>(null)
+  const swallowedWakeupRef = useRef(false)
+  const drainSettledRef = useRef<null | Promise<void>>(null)
+  const migrationChainRef = useRef<Promise<unknown>>(Promise.resolve())
   const autoDrainRef = useRef<() => void>(() => {})
   const mountedRef = useRef(true)
 
@@ -204,18 +211,45 @@ export function useComposerQueue({
   // windows — every idle window schedules auto-drain, so without the claim two
   // of them could pick the same head and each submit it before either reaches
   // the removal below (#46732). `pickEntry` lets each caller choose head,
-  // by-id, or skip-edited; the outcome (not a bare boolean) lets auto-drain
-  // count only genuine send failures toward its retry cap.
+  // by-id, or skip-edited; the result reports an outcome (not a bare boolean)
+  // so auto-drain counts only genuine send failures toward its retry cap, plus
+  // the id actually attempted so the count lands on the right entry.
   const runDrain = useCallback(
     async (
       pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined,
       claim: { wait?: boolean; timeoutMs?: number } = {}
-    ): Promise<'contended' | 'empty' | 'rejected' | 'sent'> => {
-      if (drainingQueueRef.current || !activeQueueSessionKey) {
-        return 'contended'
+    ): Promise<{ entryId: null | string; outcome: 'contended' | 'empty' | 'rejected' | 'sent' }> => {
+      if (!activeQueueSessionKey) {
+        return { entryId: null, outcome: 'contended' }
+      }
+
+      if (drainingQueueRef.current) {
+        if (!claim.wait) {
+          return { entryId: null, outcome: 'contended' }
+        }
+
+        // A waiting caller (manual send) must not be bounced by THIS window's
+        // own in-flight drain — that is local contention, not "another
+        // window". Wait for the local lane to clear, inside the same budget.
+        const deadline = claim.timeoutMs === undefined ? Infinity : Date.now() + claim.timeoutMs
+
+        while (drainingQueueRef.current) {
+          if (Date.now() >= deadline) {
+            return { entryId: null, outcome: 'contended' }
+          }
+
+          await (drainSettledRef.current ?? Promise.resolve())
+        }
+
+        if (claim.timeoutMs !== undefined) {
+          claim = { ...claim, timeoutMs: Math.max(1, deadline - Date.now()) }
+        }
       }
 
       drainingQueueRef.current = true
+      let settleDrain!: () => void
+      drainSettledRef.current = new Promise<void>(resolve => (settleDrain = resolve))
+      let attemptedId: null | string = null
 
       try {
         const outcome = await withSessionDrainClaim(
@@ -232,6 +266,17 @@ export function useComposerQueue({
               return 'empty'
             }
 
+            attemptedId = entry.id
+
+            // Second, storage-independent sent check: a window whose removals
+            // cannot reach storage (quota) marks its sends with a held Web
+            // Lock instead. Purge rather than resubmit.
+            if (await isQueuedPromptSentElsewhere(entry.id)) {
+              removeQueuedPrompt(activeQueueSessionKey, entry.id)
+
+              return 'empty'
+            }
+
             const accepted = await Promise.resolve(
               onSubmit(entry.text, { attachments: entry.attachments, fromQueue: true })
             )
@@ -241,6 +286,7 @@ export function useComposerQueue({
             }
 
             drainFailuresRef.current.delete(entry.id)
+            markQueuedPromptSent(entry.id)
             removeQueuedPrompt(activeQueueSessionKey, entry.id)
             resetBrowseState(sessionId)
 
@@ -251,9 +297,20 @@ export function useComposerQueue({
 
         // null = the claim was unavailable (or the wait timed out); whoever
         // holds it owns the entry for now.
-        return outcome ?? 'contended'
+        return { entryId: attemptedId, outcome: outcome ?? 'contended' }
       } finally {
         drainingQueueRef.current = false
+        settleDrain()
+
+        // A wake-up (claim-release waiter, storage-event effect, retry timer)
+        // that landed while this drain was in flight was swallowed by the
+        // local guard above. Re-check once the lane is clear — each re-entry
+        // either finds nothing to do or arms its own bounded wake-up, so this
+        // cannot loop.
+        if (swallowedWakeupRef.current) {
+          swallowedWakeupRef.current = false
+          setTimeout(() => autoDrainRef.current(), 0)
+        }
       }
     },
     [activeQueueSessionKey, onSubmit, sessionId]
@@ -269,7 +326,7 @@ export function useComposerQueue({
   )
 
   const drainNextQueued = useCallback(
-    () => runDrain(pickDrainHead).then(outcome => outcome === 'sent'),
+    () => runDrain(pickDrainHead).then(({ outcome }) => outcome === 'sent'),
     [pickDrainHead, runDrain]
   )
 
@@ -302,9 +359,9 @@ export function useComposerQueue({
       drainFailuresRef.current.delete(id)
 
       // An explicit tap must not be silently swallowed by a race: WAIT for an
-      // in-flight drain elsewhere (bounded), and say so if it outlasts us —
-      // the entry stays queued either way.
-      const outcome = await runDrain(entries => entries.find(e => e.id === id), {
+      // in-flight drain (this window's or another's, bounded), and say so if
+      // it outlasts us — the entry stays queued either way.
+      const { outcome } = await runDrain(entries => entries.find(e => e.id === id), {
         timeoutMs: MANUAL_SEND_WAIT_MS,
         wait: true
       })
@@ -318,6 +375,13 @@ export function useComposerQueue({
         })
       }
 
+      if (outcome !== 'sent') {
+        // The tap consumed no auto-drain wake-up, but the queue may still have
+        // drainable entries whose wake-ups landed during our in-flight window;
+        // one bounded re-check keeps the lane live.
+        setTimeout(() => autoDrainRef.current(), 0)
+      }
+
       return outcome === 'sent'
     },
     [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain, t]
@@ -328,7 +392,16 @@ export function useComposerQueue({
   // a stale-session 404) can't strand the entry permanently nor spin-loop. The
   // drain locks serialize sends; a remount/reconnect resets the failure counts.
   const autoDrainNext = useCallback(() => {
-    if (!mountedRef.current || busy || drainingQueueRef.current || !activeQueueSessionKey) {
+    if (!mountedRef.current || busy || !activeQueueSessionKey) {
+      return
+    }
+
+    if (drainingQueueRef.current) {
+      // A drain is already in flight in this window: don't drop this wake-up
+      // (it may be the claim waiter's one shot) — flag it for replay when the
+      // in-flight drain settles.
+      swallowedWakeupRef.current = true
+
       return
     }
 
@@ -353,9 +426,9 @@ export function useComposerQueue({
       }, AUTO_DRAIN_RETRY_BASE_MS * attempt)
     }
 
-    const onFail = () => {
-      const fails = (drainFailuresRef.current.get(entry.id) ?? 0) + 1
-      drainFailuresRef.current.set(entry.id, fails)
+    const onFail = (id: string) => {
+      const fails = (drainFailuresRef.current.get(id) ?? 0) + 1
+      drainFailuresRef.current.set(id, fails)
 
       if (fails >= MAX_AUTO_DRAIN_ATTEMPTS) {
         notify({
@@ -373,36 +446,57 @@ export function useComposerQueue({
     // the winner only writes storage (and thus emits the event that re-runs
     // us) when it SENDS. A winner that gets rejected — or whose window dies
     // mid-submit — leaves no trace, so wait for its claim to release (the
-    // browser frees a dead window's locks) and re-check then. One waiter at a
-    // time is enough: it re-enters this function, which re-arms if still needed.
+    // browser frees a dead window's locks) and re-check then. One waiter per
+    // session key is enough (keyed, so a stale waiter on a previous session
+    // can never suppress the current one): it re-enters this function, which
+    // re-arms if still needed.
     const onContended = () => {
-      if (claimWaiterArmedRef.current) {
+      const key = activeQueueSessionKey
+
+      if (claimWaiterKeyRef.current === key) {
         return
       }
 
-      claimWaiterArmedRef.current = true
+      claimWaiterKeyRef.current = key
 
-      void whenSessionDrainClaimReleased(activeQueueSessionKey).then(() => {
-        claimWaiterArmedRef.current = false
-        autoDrainRef.current()
+      void whenSessionDrainClaimReleased(key).then(waited => {
+        if (claimWaiterKeyRef.current === key) {
+          claimWaiterKeyRef.current = null
+        }
+
+        // Only a genuine wait-and-release is a wake-up; re-running on a
+        // failed wait would spin arm→fail→re-arm with no progress.
+        if (waited) {
+          autoDrainRef.current()
+        }
       })
     }
 
-    // Re-locate the entry by id rather than submitting the captured object:
-    // runDrain picks from the fresh store read inside the drain claim, so an
-    // entry another window drained meanwhile simply isn't found ('empty').
-    // Only a rejected send counts toward the retry cap — burning attempts on
-    // 'empty'/'contended' (races this window lost) would strand a healthy
-    // entry and raise the stuck-queue toast spuriously.
-    void runDrain(entries => entries.find(candidate => candidate.id === entry.id))
-      .then(outcome => {
-        if (outcome === 'rejected') {
-          onFail()
+    // Re-pick the head INSIDE the claim from fresh state (not the captured
+    // entry object): another window's removal, edit, or PROMOTE must all be
+    // honored at send time. The cap guard rides along in the picker so an
+    // entry that exhausted its attempts blocks auto-drain without burning a
+    // claim cycle; failure counts land on whatever entry was actually
+    // attempted. Only a rejected send counts toward the retry cap — burning
+    // attempts on 'empty'/'contended' (races this window lost) would strand a
+    // healthy entry and raise the stuck-queue toast spuriously.
+    void runDrain(entries => {
+      const candidate = pickDrainHead(entries)
+
+      if (!candidate || (drainFailuresRef.current.get(candidate.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
+        return undefined
+      }
+
+      return candidate
+    })
+      .then(({ entryId, outcome }) => {
+        if (outcome === 'rejected' && entryId) {
+          onFail(entryId)
         } else if (outcome === 'contended') {
           onContended()
         }
       })
-      .catch(onFail)
+      .catch(() => onFail(entry.id))
   }, [activeQueueSessionKey, busy, pickDrainHead, queuedPrompts, runDrain, t])
 
   // Keep the liveness wake-ups (retry timer, claim waiter) pointing at the
@@ -426,6 +520,10 @@ export function useComposerQueue({
   // never churns, so a change there is a real session switch and must NOT
   // migrate; only the runtime-derived key (queueSessionKey falsy → key is
   // sessionId) churns on a backend bounce/resume of the same conversation.
+  // Migrations CHAIN: migrate waits (unbounded) on the source key's drain
+  // claim, so two re-keys in quick succession must run K1→K2 before K2→K3 or
+  // the second move reads K2 before the first lands and strands entries under
+  // a dead intermediate key.
   useEffect(() => {
     const prev = prevQueueKeyRef.current
     prevQueueKeyRef.current = activeQueueSessionKey
@@ -434,7 +532,11 @@ export function useComposerQueue({
       return
     }
 
-    void migrateQueuedPrompts(prev, activeQueueSessionKey)
+    const next = activeQueueSessionKey
+    migrationChainRef.current = migrationChainRef.current
+      .then(() => migrateQueuedPrompts(prev, next))
+      .then(() => undefined)
+      .catch(() => undefined)
   }, [activeQueueSessionKey, queueSessionKey])
 
   // Queued turns flow whenever the session is idle — on the busy→false settle

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -106,9 +106,11 @@ export function useComposerQueue({
   const migrationChainRef = useRef<Promise<unknown>>(Promise.resolve())
   const autoDrainRef = useRef<() => void>(() => {})
   const busyRef = useRef(busy)
+  const sessionKeyRef = useRef(activeQueueSessionKey)
   const mountedRef = useRef(true)
 
   busyRef.current = busy
+  sessionKeyRef.current = activeQueueSessionKey
 
   const beginQueuedEdit = (entry: QueuedPromptEntry) => {
     if (!activeQueueSessionKey || queueEdit) {
@@ -267,8 +269,11 @@ export function useComposerQueue({
             // The session may have started a turn while we waited for the
             // lane or the claim (typically: the very drain we waited on got
             // accepted). Submitting now would just bounce off the gateway;
-            // the caller decides what busy means for its flow.
-            if (busyRef.current) {
+            // the caller decides what busy means for its flow. Only honored
+            // while the hook still shows the session this drain belongs to:
+            // after a mid-drain session switch, the window-global busy
+            // describes the NEW session and must not veto the old one's send.
+            if (busyRef.current && sessionKeyRef.current === activeQueueSessionKey) {
               return 'busy'
             }
 
@@ -346,7 +351,18 @@ export function useComposerQueue({
   )
 
   const drainNextQueued = useCallback(
-    () => runDrain(pickDrainHead).then(({ outcome }) => outcome === 'sent'),
+    () =>
+      runDrain(pickDrainHead).then(({ outcome }) => {
+        // Like sendQueuedNow: a manual drain that didn't send consumed no
+        // auto-drain wake-up, but may have dropped one that landed while it
+        // was in flight — one bounded re-check keeps the lane live. ('sent'
+        // needs none: its storage write re-runs the auto-drain effect.)
+        if (outcome !== 'sent') {
+          setTimeout(() => autoDrainRef.current(), 0)
+        }
+
+        return outcome === 'sent'
+      }),
     [pickDrainHead, runDrain]
   )
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -7,21 +7,27 @@ import { clearComposerAttachments, type ComposerAttachment } from '@/store/compo
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $queuedPromptsBySession,
+  AUTO_DRAIN_RETRY_BASE_MS,
   enqueueQueuedPrompt,
   MAX_AUTO_DRAIN_ATTEMPTS,
   migrateQueuedPrompts,
   promoteQueuedPrompt,
   type QueuedPromptEntry,
-  readPersistedQueuedPrompts,
+  readFreshQueuedPrompts,
   removeQueuedPrompt,
   shouldAutoDrain,
   updateQueuedPrompt,
+  whenSessionDrainClaimReleased,
   withSessionDrainClaim
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import type { ChatBarProps } from '../types'
+
+/** How long a manual "send now" waits for another window's in-flight drain
+ * before giving up and telling the user (the entry stays queued). */
+const MANUAL_SEND_WAIT_MS = 15_000
 
 interface UseComposerQueueArgs {
   activeQueueSessionKey: string | null
@@ -85,6 +91,16 @@ export function useComposerQueue({
   const prevQueueKeyRef = useRef(activeQueueSessionKey)
   const drainingQueueRef = useRef(false)
   const drainFailuresRef = useRef(new Map<string, number>())
+
+  // Liveness plumbing for auto-drain: a bounded-backoff retry timer (rejected
+  // sends), a single pending claim-release waiter (lost cross-window races),
+  // and a ref to the latest autoDrainNext so both re-trigger fresh logic. The
+  // mounted flag stops a late-firing timer/waiter from draining on behalf of
+  // an unmounted composer.
+  const retryTimerRef = useRef<null | ReturnType<typeof setTimeout>>(null)
+  const claimWaiterArmedRef = useRef(false)
+  const autoDrainRef = useRef<() => void>(() => {})
+  const mountedRef = useRef(true)
 
   const beginQueuedEdit = (entry: QueuedPromptEntry) => {
     if (!activeQueueSessionKey || queueEdit) {
@@ -192,7 +208,8 @@ export function useComposerQueue({
   // count only genuine send failures toward its retry cap.
   const runDrain = useCallback(
     async (
-      pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined
+      pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined,
+      claim: { wait?: boolean; timeoutMs?: number } = {}
     ): Promise<'contended' | 'empty' | 'rejected' | 'sent'> => {
       if (drainingQueueRef.current || !activeQueueSessionKey) {
         return 'contended'
@@ -204,12 +221,12 @@ export function useComposerQueue({
         const outcome = await withSessionDrainClaim(
           activeQueueSessionKey,
           async (): Promise<'empty' | 'rejected' | 'sent'> => {
-            // Pick INSIDE the claim, and from persisted storage rather than the
-            // rendered slice or the atom: the storage event that syncs them is
-            // asynchronous, so only storage itself is guaranteed to reflect a
-            // removal another window just made. Picking any earlier (or from
-            // anything staler) is what allowed the double submit.
-            const entry = pickEntry(readPersistedQueuedPrompts(activeQueueSessionKey))
+            // Pick INSIDE the claim, and from the fresh store read rather than
+            // the rendered slice or the atom: the storage event that syncs them
+            // is asynchronous, so only the fresh read reflects a removal
+            // another window just made. Picking any earlier (or from anything
+            // staler) is what allowed the double submit.
+            const entry = pickEntry(readFreshQueuedPrompts(activeQueueSessionKey))
 
             if (!entry) {
               return 'empty'
@@ -228,10 +245,12 @@ export function useComposerQueue({
             resetBrowseState(sessionId)
 
             return 'sent'
-          }
+          },
+          claim
         )
 
-        // null grant = another window holds the claim; the entry is theirs now.
+        // null = the claim was unavailable (or the wait timed out); whoever
+        // holds it owns the entry for now.
         return outcome ?? 'contended'
       } finally {
         drainingQueueRef.current = false
@@ -255,8 +274,15 @@ export function useComposerQueue({
   )
 
   const sendQueuedNow = useCallback(
-    (id: string) => {
+    async (id: string) => {
       if (!activeQueueSessionKey || id === queueEdit?.entryId) {
+        return false
+      }
+
+      // The tapped entry may be a phantom: another window drained or deleted
+      // it and our storage-event sync hasn't landed, so the panel still shows
+      // it. Bail before interrupting a live turn for something that is gone.
+      if (!readFreshQueuedPrompts(activeQueueSessionKey).some(e => e.id === id)) {
         return false
       }
 
@@ -275,17 +301,34 @@ export function useComposerQueue({
       // taps gets a fresh attempt (and re-enables auto-retry on success).
       drainFailuresRef.current.delete(id)
 
-      return runDrain(entries => entries.find(e => e.id === id)).then(outcome => outcome === 'sent')
+      // An explicit tap must not be silently swallowed by a race: WAIT for an
+      // in-flight drain elsewhere (bounded), and say so if it outlasts us —
+      // the entry stays queued either way.
+      const outcome = await runDrain(entries => entries.find(e => e.id === id), {
+        timeoutMs: MANUAL_SEND_WAIT_MS,
+        wait: true
+      })
+
+      if (outcome === 'contended') {
+        notify({
+          id: 'composer-queue-busy-elsewhere',
+          kind: 'info',
+          title: t.composer.queueBusyElsewhereTitle,
+          message: t.composer.queueBusyElsewhereBody
+        })
+      }
+
+      return outcome === 'sent'
     },
-    [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain]
+    [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain, t]
   )
 
   // Edge-independent auto-drain: send the head whenever the session is idle and
   // the queue is non-empty, bounding retries so a thrown/rejected onSubmit (e.g.
   // a stale-session 404) can't strand the entry permanently nor spin-loop. The
-  // drain lock serializes sends; a remount/reconnect resets the failure counts.
+  // drain locks serialize sends; a remount/reconnect resets the failure counts.
   const autoDrainNext = useCallback(() => {
-    if (busy || drainingQueueRef.current || !activeQueueSessionKey) {
+    if (!mountedRef.current || busy || drainingQueueRef.current || !activeQueueSessionKey) {
       return
     }
 
@@ -293,6 +336,21 @@ export function useComposerQueue({
 
     if (!entry || (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
       return
+    }
+
+    // The effect below only re-fires when its deps change, and neither a
+    // rejected send nor a lost claim changes them — each non-sent outcome must
+    // therefore schedule its own wake-up or the entry strands in an idle
+    // window (and MAX_AUTO_DRAIN_ATTEMPTS could never actually be reached).
+    const scheduleRetry = (attempt: number) => {
+      if (retryTimerRef.current !== null) {
+        return
+      }
+
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null
+        autoDrainRef.current()
+      }, AUTO_DRAIN_RETRY_BASE_MS * attempt)
     }
 
     const onFail = () => {
@@ -306,11 +364,32 @@ export function useComposerQueue({
           title: t.composer.queueStuckTitle,
           message: t.composer.queueStuckBody
         })
+      } else {
+        scheduleRetry(fails)
       }
     }
 
+    // A lost cross-window race needs a different wake-up than a failed send:
+    // the winner only writes storage (and thus emits the event that re-runs
+    // us) when it SENDS. A winner that gets rejected — or whose window dies
+    // mid-submit — leaves no trace, so wait for its claim to release (the
+    // browser frees a dead window's locks) and re-check then. One waiter at a
+    // time is enough: it re-enters this function, which re-arms if still needed.
+    const onContended = () => {
+      if (claimWaiterArmedRef.current) {
+        return
+      }
+
+      claimWaiterArmedRef.current = true
+
+      void whenSessionDrainClaimReleased(activeQueueSessionKey).then(() => {
+        claimWaiterArmedRef.current = false
+        autoDrainRef.current()
+      })
+    }
+
     // Re-locate the entry by id rather than submitting the captured object:
-    // runDrain picks from live persisted state inside the drain claim, so an
+    // runDrain picks from the fresh store read inside the drain claim, so an
     // entry another window drained meanwhile simply isn't found ('empty').
     // Only a rejected send counts toward the retry cap — burning attempts on
     // 'empty'/'contended' (races this window lost) would strand a healthy
@@ -319,10 +398,29 @@ export function useComposerQueue({
       .then(outcome => {
         if (outcome === 'rejected') {
           onFail()
+        } else if (outcome === 'contended') {
+          onContended()
         }
       })
       .catch(onFail)
   }, [activeQueueSessionKey, busy, pickDrainHead, queuedPrompts, runDrain, t])
+
+  // Keep the liveness wake-ups (retry timer, claim waiter) pointing at the
+  // latest closure, and never let a timer outlive the composer.
+  autoDrainRef.current = autoDrainNext
+
+  useEffect(() => {
+    mountedRef.current = true
+
+    return () => {
+      mountedRef.current = false
+
+      if (retryTimerRef.current !== null) {
+        clearTimeout(retryTimerRef.current)
+        retryTimerRef.current = null
+      }
+    }
+  }, [])
 
   // Re-key on a runtime session-id change. A stable stored id (queueSessionKey)
   // never churns, so a change there is a real session switch and must NOT
@@ -336,7 +434,7 @@ export function useComposerQueue({
       return
     }
 
-    migrateQueuedPrompts(prev, activeQueueSessionKey)
+    void migrateQueuedPrompts(prev, activeQueueSessionKey)
   }, [activeQueueSessionKey, queueSessionKey])
 
   // Queued turns flow whenever the session is idle — on the busy→false settle

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1510,7 +1510,7 @@ export const en: Translations = {
     queueStuckBody: 'A queued turn kept failing to send. It is still in the queue — try sending it again.',
     queueBusyElsewhereTitle: 'Queued message not sent yet',
     queueBusyElsewhereBody:
-      'Another window is currently sending from this session’s queue. Your message is still queued — try again in a moment.',
+      'The queue is busy sending another message. Yours is still queued — try again in a moment.',
     previewUnavailable: 'Preview unavailable',
     previewLabel: label => `Preview ${label}`,
     couldNotPreview: label => `Could not preview ${label}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1508,6 +1508,9 @@ export const en: Translations = {
     queueDelete: 'Delete',
     queueStuckTitle: 'Queued message not sent',
     queueStuckBody: 'A queued turn kept failing to send. It is still in the queue — try sending it again.',
+    queueBusyElsewhereTitle: 'Queued message not sent yet',
+    queueBusyElsewhereBody:
+      'Another window is currently sending from this session’s queue. Your message is still queued — try again in a moment.',
     previewUnavailable: 'Preview unavailable',
     previewLabel: label => `Preview ${label}`,
     couldNotPreview: label => `Could not preview ${label}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1614,6 +1614,9 @@ export const ja = defineLocale({
     queueStuckTitle: 'キュー内のメッセージを送信できません',
     queueStuckBody:
       'キューに入れたターンの送信が繰り返し失敗しました。まだキューに残っています。もう一度送信してください。',
+    queueBusyElsewhereTitle: 'キュー内のメッセージはまだ送信されていません',
+    queueBusyElsewhereBody:
+      '別のウィンドウがこのセッションのキューから送信中です。メッセージはまだキューに残っています。しばらくしてからもう一度お試しください。',
     previewUnavailable: 'プレビューは利用できません',
     previewLabel: label => `${label} のプレビュー`,
     couldNotPreview: label => `${label} をプレビューできませんでした`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1616,7 +1616,7 @@ export const ja = defineLocale({
       'キューに入れたターンの送信が繰り返し失敗しました。まだキューに残っています。もう一度送信してください。',
     queueBusyElsewhereTitle: 'キュー内のメッセージはまだ送信されていません',
     queueBusyElsewhereBody:
-      '別のウィンドウがこのセッションのキューから送信中です。メッセージはまだキューに残っています。しばらくしてからもう一度お試しください。',
+      'キューは別のメッセージを送信中です。メッセージはまだキューに残っています。しばらくしてからもう一度お試しください。',
     previewUnavailable: 'プレビューは利用できません',
     previewLabel: label => `${label} のプレビュー`,
     couldNotPreview: label => `${label} をプレビューできませんでした`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1219,6 +1219,8 @@ export interface Translations {
     queueDelete: string
     queueStuckTitle: string
     queueStuckBody: string
+    queueBusyElsewhereTitle: string
+    queueBusyElsewhereBody: string
     previewUnavailable: string
     previewLabel: (label: string) => string
     couldNotPreview: (label: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1565,7 +1565,7 @@ export const zhHant = defineLocale({
     queueStuckTitle: '佇列訊息未送出',
     queueStuckBody: '佇列中的對話多次傳送失敗。它仍在佇列中，請重試傳送。',
     queueBusyElsewhereTitle: '佇列訊息尚未送出',
-    queueBusyElsewhereBody: '另一個視窗正在從此工作階段的佇列傳送訊息。您的訊息仍在佇列中，請稍後再試。',
+    queueBusyElsewhereBody: '佇列正在傳送另一則訊息。您的訊息仍在佇列中，請稍後再試。',
     previewUnavailable: '預覽不可用',
     previewLabel: label => `預覽 ${label}`,
     couldNotPreview: label => `無法預覽 ${label}`,

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1564,6 +1564,8 @@ export const zhHant = defineLocale({
     queueDelete: '刪除',
     queueStuckTitle: '佇列訊息未送出',
     queueStuckBody: '佇列中的對話多次傳送失敗。它仍在佇列中，請重試傳送。',
+    queueBusyElsewhereTitle: '佇列訊息尚未送出',
+    queueBusyElsewhereBody: '另一個視窗正在從此工作階段的佇列傳送訊息。您的訊息仍在佇列中，請稍後再試。',
     previewUnavailable: '預覽不可用',
     previewLabel: label => `預覽 ${label}`,
     couldNotPreview: label => `無法預覽 ${label}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1688,7 +1688,7 @@ export const zh: Translations = {
     queueStuckTitle: '排队消息未发送',
     queueStuckBody: '排队的对话多次发送失败。它仍在队列中，请重试发送。',
     queueBusyElsewhereTitle: '排队消息尚未发送',
-    queueBusyElsewhereBody: '另一个窗口正在从此会话的队列中发送消息。您的消息仍在队列中，请稍后重试。',
+    queueBusyElsewhereBody: '队列正在发送另一条消息。您的消息仍在队列中，请稍后重试。',
     previewUnavailable: '预览不可用',
     previewLabel: label => `预览 ${label}`,
     couldNotPreview: label => `无法预览 ${label}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1687,6 +1687,8 @@ export const zh: Translations = {
     queueDelete: '删除',
     queueStuckTitle: '排队消息未发送',
     queueStuckBody: '排队的对话多次发送失败。它仍在队列中，请重试发送。',
+    queueBusyElsewhereTitle: '排队消息尚未发送',
+    queueBusyElsewhereBody: '另一个窗口正在从此会话的队列中发送消息。您的消息仍在队列中，请稍后重试。',
     previewUnavailable: '预览不可用',
     previewLabel: label => `预览 ${label}`,
     couldNotPreview: label => `无法预览 ${label}`,

--- a/apps/desktop/src/store/composer-queue-test-utils.ts
+++ b/apps/desktop/src/store/composer-queue-test-utils.ts
@@ -1,0 +1,120 @@
+import { $queuedPromptsBySession, QUEUE_STORAGE_KEY, QUEUE_TOMBSTONES_STORAGE_KEY } from './composer-queue'
+import type { QueuedPromptEntry } from './composer-queue'
+
+/**
+ * Shared helpers for the composer-queue suites (store + hook). The fake lock
+ * manager encodes real Web Locks semantics — exclusivity, FIFO waiting,
+ * `ifAvailable` null grants, abort-signal rejection, release-on-settle — so
+ * both suites model cross-window contention against the SAME behavior.
+ */
+
+interface FakeLockOptions {
+  ifAvailable?: boolean
+  signal?: AbortSignal
+}
+
+type FakeLockCallback = (lock: null | { name: string }) => Promise<unknown> | unknown
+
+export function installFakeLocks() {
+  // name → FIFO of waiters. A key existing (even with an empty array) means
+  // the lock is currently held.
+  const queues = new Map<string, Array<() => void>>()
+
+  const release = (name: string) => {
+    const waiters = queues.get(name)
+    const next = waiters?.shift()
+
+    if (next) {
+      next() // hand over; the map entry stays = still held
+    } else {
+      queues.delete(name)
+    }
+  }
+
+  const request = async (name: string, options: FakeLockOptions = {}, callback: FakeLockCallback) => {
+    if (queues.has(name)) {
+      if (options.ifAvailable) {
+        return callback(null)
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const waiter = () => resolve()
+        const signal = options.signal
+
+        if (signal) {
+          if (signal.aborted) {
+            reject(signal.reason instanceof DOMException ? signal.reason : new DOMException('Aborted', 'AbortError'))
+
+            return
+          }
+
+          signal.addEventListener(
+            'abort',
+            () => {
+              const waiters = queues.get(name)
+              const index = waiters ? waiters.indexOf(waiter) : -1
+
+              if (waiters && index >= 0) {
+                waiters.splice(index, 1)
+              }
+
+              reject(signal.reason instanceof DOMException ? signal.reason : new DOMException('Aborted', 'AbortError'))
+            },
+            { once: true }
+          )
+        }
+
+        queues.get(name)!.push(waiter)
+      })
+    } else {
+      queues.set(name, [])
+    }
+
+    try {
+      return await callback({ name })
+    } finally {
+      release(name)
+    }
+  }
+
+  Object.defineProperty(window.navigator, 'locks', { configurable: true, value: { request } })
+
+  return () => {
+    delete (window.navigator as { locks?: unknown }).locks
+  }
+}
+
+/** Reset every storage surface the queue store uses, plus the atom. */
+export function resetQueueStorage() {
+  window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+  window.localStorage.removeItem(QUEUE_TOMBSTONES_STORAGE_KEY)
+  $queuedPromptsBySession.set({})
+}
+
+export function remoteEntry(id: string, text: string): QueuedPromptEntry {
+  return { id, text, attachments: [], queuedAt: 1 }
+}
+
+/**
+ * Simulate another window writing the shared queue key. With `fireEvent` the
+ * `storage` event is dispatched too (it never fires in the writing window
+ * itself, so dispatching manually is exactly the other-window signal); without
+ * it, the write models the worst case — persisted but not yet synced.
+ */
+export function otherWindowWrites(state: Record<string, unknown>, { fireEvent = false } = {}) {
+  const value = JSON.stringify(state)
+  window.localStorage.setItem(QUEUE_STORAGE_KEY, value)
+
+  if (fireEvent) {
+    window.dispatchEvent(new StorageEvent('storage', { key: QUEUE_STORAGE_KEY, newValue: value }))
+  }
+}
+
+export function persistedQueueTexts(sid: string): string[] {
+  const parsed = JSON.parse(window.localStorage.getItem(QUEUE_STORAGE_KEY) ?? '{}') as Record<
+    string,
+    { text: string }[]
+  >
+
+  return (parsed[sid] ?? []).map(e => e.text)
+}

--- a/apps/desktop/src/store/composer-queue-test-utils.ts
+++ b/apps/desktop/src/store/composer-queue-test-utils.ts
@@ -1,11 +1,18 @@
-import { $queuedPromptsBySession, QUEUE_STORAGE_KEY, QUEUE_TOMBSTONES_STORAGE_KEY } from './composer-queue'
+import {
+  $queuedPromptsBySession,
+  clearQueuedPrompts,
+  enqueueQueuedPrompt,
+  QUEUE_STORAGE_KEY,
+  QUEUE_TOMBSTONES_STORAGE_KEY
+} from './composer-queue'
 import type { QueuedPromptEntry } from './composer-queue'
 
 /**
  * Shared helpers for the composer-queue suites (store + hook). The fake lock
  * manager encodes real Web Locks semantics — exclusivity, FIFO waiting,
- * `ifAvailable` null grants, abort-signal rejection, release-on-settle — so
- * both suites model cross-window contention against the SAME behavior.
+ * `ifAvailable` null grants, abort-signal rejection, release-on-settle, and a
+ * `query()` snapshot of held locks — so both suites model cross-window
+ * contention against the SAME behavior.
  */
 
 interface FakeLockOptions {
@@ -15,7 +22,7 @@ interface FakeLockOptions {
 
 type FakeLockCallback = (lock: null | { name: string }) => Promise<unknown> | unknown
 
-export function installFakeLocks() {
+export function installFakeLocks({ failWaits = false }: { failWaits?: boolean } = {}) {
   // name → FIFO of waiters. A key existing (even with an empty array) means
   // the lock is currently held.
   const queues = new Map<string, Array<() => void>>()
@@ -35,6 +42,14 @@ export function installFakeLocks() {
     if (queues.has(name)) {
       if (options.ifAvailable) {
         return callback(null)
+      }
+
+      // failWaits simulates a wait that outlives its AbortSignal budget
+      // without spending real wall-clock time on it. Only signal-carrying
+      // requests can time out — unbounded waits (no signal) keep waiting,
+      // exactly like the real API.
+      if (failWaits && options.signal) {
+        throw new DOMException('Fake lock wait timed out', 'TimeoutError')
       }
 
       await new Promise<void>((resolve, reject) => {
@@ -77,15 +92,28 @@ export function installFakeLocks() {
     }
   }
 
-  Object.defineProperty(window.navigator, 'locks', { configurable: true, value: { request } })
+  const query = async () => ({
+    held: [...queues.keys()].map(name => ({ name })),
+    pending: [] as { name: string }[]
+  })
+
+  Object.defineProperty(window.navigator, 'locks', { configurable: true, value: { query, request } })
 
   return () => {
     delete (window.navigator as { locks?: unknown }).locks
   }
 }
 
-/** Reset every storage surface the queue store uses, plus the atom. */
+/**
+ * Reset every storage surface the queue store uses, plus the atom — and heal
+ * the store's module state through its public API: one successful save clears
+ * the persist-failure flag and one successful tombstone write flushes the
+ * in-memory tombstone overlay, both of which would otherwise leak across
+ * tests (they are module-level, not storage-level).
+ */
 export function resetQueueStorage() {
+  enqueueQueuedPrompt('__queue-test-reset__', { attachments: [], text: 'reset' })
+  clearQueuedPrompts('__queue-test-reset__')
   window.localStorage.removeItem(QUEUE_STORAGE_KEY)
   window.localStorage.removeItem(QUEUE_TOMBSTONES_STORAGE_KEY)
   $queuedPromptsBySession.set({})

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -149,6 +149,79 @@ describe('migrateQueuedPrompts', () => {
   })
 })
 
+describe('cross-window sync (#46732)', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    $queuedPromptsBySession.set({})
+  })
+
+  // Simulate another window writing the shared key: localStorage mutates and a
+  // `storage` event fires — that event never fires in the writing window itself,
+  // so dispatching it manually is exactly the other-window signal.
+  function otherWindowWrites(state: Record<string, unknown>) {
+    const value = JSON.stringify(state)
+    window.localStorage.setItem(QUEUE_STORAGE_KEY, value)
+    window.dispatchEvent(new StorageEvent('storage', { key: QUEUE_STORAGE_KEY, newValue: value }))
+  }
+
+  it('adopts another window\u2019s write into the local atom', () => {
+    otherWindowWrites({ 'session-remote': [{ id: 'q-1', text: 'from window B', attachments: [], queuedAt: 1 }] })
+
+    expect(getQueuedPrompts('session-remote').map(e => e.text)).toEqual(['from window B'])
+  })
+
+  it('does not clobber another window\u2019s entries when saving its own', () => {
+    // Window B enqueues for its session; this window then enqueues for a
+    // different session. Both must survive in storage.
+    otherWindowWrites({ 'session-b': [{ id: 'q-b', text: 'B entry', attachments: [], queuedAt: 1 }] })
+    enqueueQueuedPrompt('session-a', { attachments: [], text: 'A entry' })
+
+    const persisted = JSON.parse(window.localStorage.getItem(QUEUE_STORAGE_KEY) ?? '{}')
+    expect(Object.keys(persisted).sort()).toEqual(['session-a', 'session-b'])
+  })
+
+  it('merges over live storage even without a storage event (same-frame race)', () => {
+    // The `storage` event is asynchronous in real browsers; a write racing it
+    // must still be preserved because writeSession re-reads storage at save time.
+    window.localStorage.setItem(
+      QUEUE_STORAGE_KEY,
+      JSON.stringify({ 'session-b': [{ id: 'q-b', text: 'unsynced B entry', attachments: [], queuedAt: 1 }] })
+    )
+
+    enqueueQueuedPrompt('session-a', { attachments: [], text: 'A entry' })
+
+    const persisted = JSON.parse(window.localStorage.getItem(QUEUE_STORAGE_KEY) ?? '{}')
+    expect(Object.keys(persisted).sort()).toEqual(['session-a', 'session-b'])
+  })
+
+  it('drops entries locally once another window drains them', () => {
+    enqueueQueuedPrompt('session-a', { attachments: [], text: 'about to be drained elsewhere' })
+
+    // Window B drains session-a and persists the now-empty map.
+    otherWindowWrites({})
+
+    expect(getQueuedPrompts('session-a')).toEqual([])
+    expect(dequeueQueuedPrompt('session-a')).toBeNull()
+  })
+
+  it('resyncs on full storage clear (event.key === null)', () => {
+    enqueueQueuedPrompt('session-a', { attachments: [], text: 'entry' })
+
+    window.localStorage.clear()
+    window.dispatchEvent(new StorageEvent('storage', { key: null }))
+
+    expect(getQueuedPrompts('session-a')).toEqual([])
+  })
+
+  it('ignores storage events for unrelated keys', () => {
+    enqueueQueuedPrompt('session-a', { attachments: [], text: 'kept' })
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'some.other.key', newValue: '"x"' }))
+
+    expect(getQueuedPrompts('session-a').map(e => e.text)).toEqual(['kept'])
+  })
+})
+
 describe('shouldAutoDrain', () => {
   it('drains whenever idle with a non-empty queue', () => {
     expect(shouldAutoDrain({ isBusy: false, queueLength: 1 })).toBe(true)

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -387,10 +387,22 @@ describe('storage-failure in-memory fallback', () => {
     resetQueueStorage()
   })
 
-  it('keeps queueing, reading, and removing in-memory while saves fail, and recovers', () => {
-    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+  const breakStorage = () => {
+    const quota = () => {
       throw new DOMException('quota exceeded', 'QuotaExceededError')
-    })
+    }
+
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(quota)
+    const removeItem = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(quota)
+
+    return () => {
+      setItem.mockRestore()
+      removeItem.mockRestore()
+    }
+  }
+
+  it('keeps queueing, reading, and removing in-memory while saves fail', () => {
+    const restore = breakStorage()
 
     try {
       const a = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'first (unsaved)' })
@@ -404,7 +416,8 @@ describe('storage-failure in-memory fallback', () => {
       expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['first (unsaved)', 'second (unsaved)'])
       expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['first (unsaved)', 'second (unsaved)'])
 
-      // In-memory entries stay mutable: remove works without storage.
+      // In-memory entries stay mutable: remove works without storage — even
+      // its tombstone lives in the in-memory overlay.
       expect(removeQueuedPrompt(SESSION_KEY, a!.id)).toBe(true)
       expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['second (unsaved)'])
 
@@ -412,14 +425,155 @@ describe('storage-failure in-memory fallback', () => {
       clearQueuedPrompts(SESSION_KEY)
       expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
     } finally {
-      setItem.mockRestore()
+      restore()
+    }
+  })
+
+  it('recovers exactly on the first successful save — not before, not never', () => {
+    const restore = breakStorage()
+    const survivorText = 'survivor (unsaved)'
+
+    try {
+      enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: survivorText })
+    } finally {
+      restore()
     }
 
-    // Recovery: the first successful save re-persists and re-enables storage
-    // as the fresh source.
+    // Storage works again, but no successful save has happened yet: fresh
+    // reads must STILL serve the atom, or the in-memory survivor would vanish.
+    // (Pins that persistFailed stays set until an actual save succeeds.)
+    otherWindowWrites({ [SESSION_KEY]: [remoteEntry('q-b', 'from healthy window')] })
+    expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual([survivorText])
+
+    // The first mutation persists the atom-derived state (this window's truth
+    // reconciles over storage) and clears the flag…
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'persisted again' })
-    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['persisted again'])
-    expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['persisted again'])
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual([survivorText, 'persisted again'])
+
+    // …after which fresh reads follow STORAGE again. (Pins that the
+    // persistFailed reset in save()'s success path actually runs.)
+    otherWindowWrites({ [SESSION_KEY]: [remoteEntry('q-c', 'storage truth')] })
+    expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['storage truth'])
+  })
+
+  it('ignores cross-window storage events while persistence is broken', () => {
+    const restore = breakStorage()
+
+    try {
+      enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'memory only' })
+
+      // Another window's write lands as a storage event; adopting it would
+      // delete the in-memory-only entry.
+      window.dispatchEvent(new StorageEvent('storage', { key: QUEUE_STORAGE_KEY, newValue: '{}' }))
+
+      expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['memory only'])
+      expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['memory only'])
+    } finally {
+      restore()
+    }
+  })
+})
+
+describe('corrupt storage sanitization', () => {
+  beforeEach(() => {
+    resetQueueStorage()
+  })
+
+  it('drops malformed session values and entries instead of throwing', () => {
+    window.localStorage.setItem(
+      QUEUE_STORAGE_KEY,
+      JSON.stringify({
+        'session-bad': 'not an array',
+        'session-mixed': [remoteEntry('q-ok', 'ok'), 'garbage', { id: 42 }, null, 7],
+        'session-num': 12
+      })
+    )
+    window.dispatchEvent(new StorageEvent('storage', { key: QUEUE_STORAGE_KEY, newValue: 'x' }))
+
+    expect(getQueuedPrompts('session-mixed').map(e => e.text)).toEqual(['ok'])
+    expect(getQueuedPrompts('session-bad')).toEqual([])
+    expect(readFreshQueuedPrompts('session-num')).toEqual([])
+
+    // Mutations over the corrupt map still work and persist a clean shape.
+    enqueueQueuedPrompt('session-bad', { attachments: [], text: 'recovered' })
+    expect(persistedQueueTexts('session-bad')).toEqual(['recovered'])
+  })
+
+  it('treats unparseable storage as unreadable, not as a crash', () => {
+    window.localStorage.setItem(QUEUE_STORAGE_KEY, '{"truncated": ')
+    window.dispatchEvent(new StorageEvent('storage', { key: QUEUE_STORAGE_KEY, newValue: 'x' }))
+
+    expect(readFreshQueuedPrompts(SESSION_KEY)).toEqual([])
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'fresh start' })
+    expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['fresh start'])
+  })
+})
+
+describe('tombstone lifetime', () => {
+  beforeEach(() => {
+    resetQueueStorage()
+  })
+
+  it('purges a resurrected ghost from storage on the next storage event', () => {
+    const sent = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'sent already' })
+    removeQueuedPrompt(SESSION_KEY, sent!.id)
+
+    // The stale save resurrects it — with the event, as another window's
+    // write would. The ghost must leave STORAGE, not just be filtered.
+    otherWindowWrites({ [SESSION_KEY]: [sent!, remoteEntry('q-b', 'B entry')] }, { fireEvent: true })
+
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['B entry'])
+    expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['B entry'])
+  })
+
+  it('keeps a tombstone effective throughout the TTL and sheds it after', () => {
+    vi.useFakeTimers({ now: new Date('2026-07-16T00:00:00Z'), toFake: ['Date'] })
+
+    try {
+      const sent = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'sent once' })
+      removeQueuedPrompt(SESSION_KEY, sent!.id)
+
+      otherWindowWrites({ [SESSION_KEY]: [sent!] }) // resurrected, no event
+
+      expect(readFreshQueuedPrompts(SESSION_KEY)).toEqual([])
+
+      vi.setSystemTime(new Date('2026-07-16T12:00:00Z')) // 12h — inside the 24h TTL
+      expect(readFreshQueuedPrompts(SESSION_KEY)).toEqual([])
+
+      vi.setSystemTime(new Date('2026-07-17T00:00:01Z')) // past the TTL
+      // Documented shedding behavior: after the (deliberately long) TTL an
+      // un-purged raw copy becomes visible again. Ghosts are normally purged
+      // within one storage event (test above), far inside the TTL.
+      expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['sent once'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('evicts the oldest tombstones beyond the cap, keeping the newest effective', () => {
+    vi.useFakeTimers({ now: new Date('2026-07-16T00:00:00Z'), toFake: ['Date'] })
+
+    try {
+      const first = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'oldest removal' })
+      removeQueuedPrompt(SESSION_KEY, first!.id)
+
+      let last = first
+
+      for (let i = 0; i < 70; i++) {
+        vi.setSystemTime(new Date(Date.parse('2026-07-16T00:00:00Z') + (i + 1) * 1_000))
+        const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: `filler ${i}` })
+        removeQueuedPrompt(SESSION_KEY, entry!.id)
+        last = entry
+      }
+
+      // The oldest tombstone fell off the cap: its entry resurrects. The
+      // newest is still effective.
+      otherWindowWrites({ [SESSION_KEY]: [first!, last!] })
+
+      expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['oldest removal'])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 
@@ -526,13 +680,13 @@ describe('whenSessionDrainClaimReleased', () => {
     resetQueueStorage()
   })
 
-  it('resolves immediately when the claim is free or Web Locks are unavailable', async () => {
-    await expect(whenSessionDrainClaimReleased('session-x')).resolves.toBeUndefined()
+  it('reports false without Web Locks (no wait happened) and true for a free claim', async () => {
+    await expect(whenSessionDrainClaimReleased('session-x')).resolves.toBe(false)
 
     const restore = installFakeLocks()
 
     try {
-      await expect(whenSessionDrainClaimReleased('session-x')).resolves.toBeUndefined()
+      await expect(whenSessionDrainClaimReleased('session-x')).resolves.toBe(true)
     } finally {
       restore()
     }

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -9,17 +9,24 @@ import {
   getQueuedPrompts,
   migrateQueuedPrompts,
   promoteQueuedPrompt,
-  type QueuedPromptEntry,
-  readPersistedQueuedPrompts,
+  QUEUE_STORAGE_KEY,
+  readFreshQueuedPrompts,
   removeQueuedPrompt,
   shouldAutoDrain,
   updateQueuedPrompt,
   updateQueuedPromptText,
+  whenSessionDrainClaimReleased,
   withSessionDrainClaim
 } from './composer-queue'
+import {
+  installFakeLocks,
+  otherWindowWrites,
+  persistedQueueTexts,
+  remoteEntry,
+  resetQueueStorage
+} from './composer-queue-test-utils'
 
 const SESSION_KEY = 'session-abc'
-const QUEUE_STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
 
 function attachment(id: string, kind: ComposerAttachment['kind'] = 'file'): ComposerAttachment {
   return {
@@ -32,8 +39,7 @@ function attachment(id: string, kind: ComposerAttachment['kind'] = 'file'): Comp
 
 describe('composer queue store', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
-    $queuedPromptsBySession.set({})
+    resetQueueStorage()
   })
 
   it('queues prompts in FIFO order', () => {
@@ -113,95 +119,119 @@ describe('composer queue store', () => {
   it('persists queue entries into local storage', () => {
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'persist me' })
 
-    const raw = window.localStorage.getItem(QUEUE_STORAGE_KEY)
-    expect(raw).toBeTruthy()
-
-    const parsed = JSON.parse(String(raw)) as Record<string, { text: string }[]>
-    expect(parsed[SESSION_KEY]?.[0]?.text).toBe('persist me')
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['persist me'])
   })
 })
 
 describe('migrateQueuedPrompts', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
-    $queuedPromptsBySession.set({})
+    resetQueueStorage()
   })
 
-  it('moves entries from a dead runtime key onto the live one', () => {
+  it('moves entries from a dead runtime key onto the live one', async () => {
     enqueueQueuedPrompt('rt-old', { attachments: [], text: 'stranded' })
 
-    expect(migrateQueuedPrompts('rt-old', 'rt-new')).toBe(true)
+    await expect(migrateQueuedPrompts('rt-old', 'rt-new')).resolves.toBe(true)
     expect(getQueuedPrompts('rt-old')).toEqual([])
     expect(getQueuedPrompts('rt-new').map(e => e.text)).toEqual(['stranded'])
     // The dead key is dropped from the store entirely.
     expect($queuedPromptsBySession.get()['rt-old']).toBeUndefined()
   })
 
-  it('appends after existing target entries (FIFO preserved)', () => {
+  it('appends after existing target entries (FIFO preserved)', async () => {
     enqueueQueuedPrompt('rt-new', { attachments: [], text: 'already here' })
     enqueueQueuedPrompt('rt-old', { attachments: [], text: 'migrated' })
 
-    migrateQueuedPrompts('rt-old', 'rt-new')
+    await migrateQueuedPrompts('rt-old', 'rt-new')
 
     expect(getQueuedPrompts('rt-new').map(e => e.text)).toEqual(['already here', 'migrated'])
   })
 
-  it('is a no-op when source is empty or keys match', () => {
-    expect(migrateQueuedPrompts('rt-old', 'rt-new')).toBe(false)
-    expect(migrateQueuedPrompts('rt-x', 'rt-x')).toBe(false)
+  it('is a no-op when source is empty or keys match', async () => {
+    await expect(migrateQueuedPrompts('rt-old', 'rt-new')).resolves.toBe(false)
+    await expect(migrateQueuedPrompts('rt-x', 'rt-x')).resolves.toBe(false)
+  })
+
+  it('waits for an in-flight drain on the source key before moving (#57516 follow-up)', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      const entry = enqueueQueuedPrompt('rt-old', { attachments: [], text: 'in flight' })
+
+      // A drain holds rt-old's claim, mid-submit.
+      let settleDrain!: () => void
+      const drain = withSessionDrainClaim('rt-old', () => new Promise<void>(res => (settleDrain = res)))
+      await Promise.resolve()
+
+      // Migration must NOT move the in-flight entry while the claim is held.
+      let migrated = false
+
+      const migration = migrateQueuedPrompts('rt-old', 'rt-new').then(moved => {
+        migrated = true
+
+        return moved
+      })
+
+      await Promise.resolve()
+
+      expect(migrated).toBe(false)
+      expect(persistedQueueTexts('rt-old')).toEqual(['in flight'])
+
+      // The drain finishes and removes its entry under the OLD key, exactly as
+      // it would in the hook; only then does migration proceed (with nothing
+      // left to move here).
+      removeQueuedPrompt('rt-old', entry!.id)
+      settleDrain()
+      await drain
+
+      await expect(migration).resolves.toBe(false)
+      expect(persistedQueueTexts('rt-new')).toEqual([])
+    } finally {
+      restore()
+    }
   })
 })
 
 describe('cross-window sync (#46732)', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
-    $queuedPromptsBySession.set({})
+    resetQueueStorage()
   })
 
-  // Simulate another window writing the shared key: localStorage mutates and a
-  // `storage` event fires — that event never fires in the writing window itself,
-  // so dispatching it manually is exactly the other-window signal.
-  function otherWindowWrites(state: Record<string, unknown>) {
-    const value = JSON.stringify(state)
-    window.localStorage.setItem(QUEUE_STORAGE_KEY, value)
-    window.dispatchEvent(new StorageEvent('storage', { key: QUEUE_STORAGE_KEY, newValue: value }))
-  }
-
-  it('adopts another window\u2019s write into the local atom', () => {
-    otherWindowWrites({ 'session-remote': [{ id: 'q-1', text: 'from window B', attachments: [], queuedAt: 1 }] })
+  it('adopts another window’s write into the local atom', () => {
+    otherWindowWrites(
+      { 'session-remote': [remoteEntry('q-1', 'from window B')] },
+      { fireEvent: true }
+    )
 
     expect(getQueuedPrompts('session-remote').map(e => e.text)).toEqual(['from window B'])
   })
 
-  it('does not clobber another window\u2019s entries when saving its own', () => {
+  it('does not clobber another window’s entries when saving its own', () => {
     // Window B enqueues for its session; this window then enqueues for a
     // different session. Both must survive in storage.
-    otherWindowWrites({ 'session-b': [{ id: 'q-b', text: 'B entry', attachments: [], queuedAt: 1 }] })
+    otherWindowWrites({ 'session-b': [remoteEntry('q-b', 'B entry')] }, { fireEvent: true })
     enqueueQueuedPrompt('session-a', { attachments: [], text: 'A entry' })
 
-    const persisted = JSON.parse(window.localStorage.getItem(QUEUE_STORAGE_KEY) ?? '{}')
-    expect(Object.keys(persisted).sort()).toEqual(['session-a', 'session-b'])
+    expect(persistedQueueTexts('session-a')).toEqual(['A entry'])
+    expect(persistedQueueTexts('session-b')).toEqual(['B entry'])
   })
 
   it('merges over live storage even without a storage event (same-frame race)', () => {
     // The `storage` event is asynchronous in real browsers; a write racing it
-    // must still be preserved because writeSession re-reads storage at save time.
-    window.localStorage.setItem(
-      QUEUE_STORAGE_KEY,
-      JSON.stringify({ 'session-b': [{ id: 'q-b', text: 'unsynced B entry', attachments: [], queuedAt: 1 }] })
-    )
+    // must still be preserved because mutations re-read storage at save time.
+    otherWindowWrites({ 'session-b': [remoteEntry('q-b', 'unsynced B entry')] })
 
     enqueueQueuedPrompt('session-a', { attachments: [], text: 'A entry' })
 
-    const persisted = JSON.parse(window.localStorage.getItem(QUEUE_STORAGE_KEY) ?? '{}')
-    expect(Object.keys(persisted).sort()).toEqual(['session-a', 'session-b'])
+    expect(persistedQueueTexts('session-a')).toEqual(['A entry'])
+    expect(persistedQueueTexts('session-b')).toEqual(['unsynced B entry'])
   })
 
   it('drops entries locally once another window drains them', () => {
     enqueueQueuedPrompt('session-a', { attachments: [], text: 'about to be drained elsewhere' })
 
     // Window B drains session-a and persists the now-empty map.
-    otherWindowWrites({})
+    otherWindowWrites({}, { fireEvent: true })
 
     expect(getQueuedPrompts('session-a')).toEqual([])
     expect(dequeueQueuedPrompt('session-a')).toBeNull()
@@ -227,137 +257,176 @@ describe('cross-window sync (#46732)', () => {
 
 describe('same-session cross-window races (#57516 review)', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
-    $queuedPromptsBySession.set({})
+    resetQueueStorage()
   })
 
-  const remoteEntry = (id: string, text: string): QueuedPromptEntry => ({ id, text, attachments: [], queuedAt: 1 })
-
-  // The worst case: another window wrote OUR session's key and the async
-  // `storage` event has not landed yet, so the local atom is stale. Writing
-  // directly (no event dispatch) simulates exactly that gap.
-  function otherWindowPersists(state: Record<string, QueuedPromptEntry[]>) {
-    window.localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(state))
-  }
-
-  const persistedTexts = (sid: string): string[] => {
-    const parsed = JSON.parse(window.localStorage.getItem(QUEUE_STORAGE_KEY) ?? '{}') as Record<
-      string,
-      { text: string }[]
-    >
-
-    return (parsed[sid] ?? []).map(e => e.text)
-  }
-
   it('enqueue appends to the other window’s unsynced same-session write instead of clobbering it', () => {
-    otherWindowPersists({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
+    otherWindowWrites({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
 
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'local entry' })
 
-    expect(persistedTexts(SESSION_KEY)).toEqual(['B entry', 'local entry'])
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['B entry', 'local entry'])
     // The merge also lands in the local atom, not just storage.
     expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['B entry', 'local entry'])
   })
 
   it('update edits the fresh queue, preserving entries the local atom has not seen', () => {
     const mine = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'mine' })
-    otherWindowPersists({ [SESSION_KEY]: [mine!, remoteEntry('q-b', 'B entry')] })
+    otherWindowWrites({ [SESSION_KEY]: [mine!, remoteEntry('q-b', 'B entry')] })
 
     expect(updateQueuedPromptText(SESSION_KEY, mine!.id, 'mine edited')).toBe(true)
 
-    expect(persistedTexts(SESSION_KEY)).toEqual(['mine edited', 'B entry'])
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['mine edited', 'B entry'])
   })
 
   it('remove filters the fresh queue, preserving entries the local atom has not seen', () => {
     const mine = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'mine' })
-    otherWindowPersists({ [SESSION_KEY]: [mine!, remoteEntry('q-b', 'B entry')] })
+    otherWindowWrites({ [SESSION_KEY]: [mine!, remoteEntry('q-b', 'B entry')] })
 
     expect(removeQueuedPrompt(SESSION_KEY, mine!.id)).toBe(true)
 
-    expect(persistedTexts(SESSION_KEY)).toEqual(['B entry'])
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['B entry'])
   })
 
   it('remove reports false for an entry another window already drained', () => {
     const mine = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'mine' })
-    otherWindowPersists({})
+    otherWindowWrites({})
 
     expect(removeQueuedPrompt(SESSION_KEY, mine!.id)).toBe(false)
   })
 
   it('dequeue takes the head of the fresh queue, not the stale atom’s head', () => {
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'already drained elsewhere' })
-    otherWindowPersists({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
+    otherWindowWrites({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
 
     expect(dequeueQueuedPrompt(SESSION_KEY)?.text).toBe('B entry')
-    expect(persistedTexts(SESSION_KEY)).toEqual([])
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual([])
   })
 
   it('promote reorders the fresh queue, preserving entries the local atom has not seen', () => {
     const first = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'first' })
     const second = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'second' })
-    otherWindowPersists({ [SESSION_KEY]: [first!, second!, remoteEntry('q-b', 'B entry')] })
+    otherWindowWrites({ [SESSION_KEY]: [first!, second!, remoteEntry('q-b', 'B entry')] })
 
     expect(promoteQueuedPrompt(SESSION_KEY, second!.id)).toBe(true)
 
-    expect(persistedTexts(SESSION_KEY)).toEqual(['second', 'first', 'B entry'])
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['second', 'first', 'B entry'])
   })
 
-  it('migrate moves the fresh source queue and appends to the fresh target queue', () => {
+  it('migrate moves the fresh source queue and appends to the fresh target queue', async () => {
     enqueueQueuedPrompt('rt-old', { attachments: [], text: 'seen locally' })
-    otherWindowPersists({
+    otherWindowWrites({
       'rt-old': [remoteEntry('q-o', 'unsynced source entry')],
       'rt-new': [remoteEntry('q-n', 'unsynced target entry')]
     })
 
-    expect(migrateQueuedPrompts('rt-old', 'rt-new')).toBe(true)
+    await expect(migrateQueuedPrompts('rt-old', 'rt-new')).resolves.toBe(true)
 
-    expect(persistedTexts('rt-old')).toEqual([])
-    expect(persistedTexts('rt-new')).toEqual(['unsynced target entry', 'unsynced source entry'])
+    expect(persistedQueueTexts('rt-old')).toEqual([])
+    expect(persistedQueueTexts('rt-new')).toEqual(['unsynced target entry', 'unsynced source entry'])
   })
 
-  it('readPersistedQueuedPrompts bypasses the stale atom', () => {
+  it('readFreshQueuedPrompts bypasses the stale atom', () => {
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'stale' })
-    otherWindowPersists({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
+    otherWindowWrites({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
 
     expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['stale'])
-    expect(readPersistedQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['B entry'])
+    expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['B entry'])
+  })
+})
+
+describe('removal tombstones (#57516 follow-up)', () => {
+  beforeEach(() => {
+    resetQueueStorage()
+  })
+
+  it('a stale concurrent save cannot resurrect a removed entry into reads', () => {
+    const sent = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'sent already' })
+    removeQueuedPrompt(SESSION_KEY, sent!.id)
+
+    // Window B loaded the map before the removal and saves after it: the raw
+    // map now contains the removed entry again, plus B's own new entry.
+    otherWindowWrites({ [SESSION_KEY]: [sent!, remoteEntry('q-b', 'B entry')] })
+
+    // Neither drains nor displays may ever see the resurrected entry.
+    expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['B entry'])
+
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: QUEUE_STORAGE_KEY, newValue: window.localStorage.getItem(QUEUE_STORAGE_KEY) })
+    )
+    expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['B entry'])
+
+    // The next write purges it from storage too.
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'local entry' })
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['B entry', 'local entry'])
+  })
+
+  it('cleared entries cannot be resurrected either', () => {
+    const a = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'cleared A' })
+    const b = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'cleared B' })
+
+    clearQueuedPrompts(SESSION_KEY)
+    otherWindowWrites({ [SESSION_KEY]: [a!, b!] })
+
+    expect(readFreshQueuedPrompts(SESSION_KEY)).toEqual([])
+  })
+
+  it('does not affect entries that were never removed', () => {
+    const kept = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'kept' })
+    const removed = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'removed' })
+
+    removeQueuedPrompt(SESSION_KEY, removed!.id)
+
+    expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['kept'])
+    expect(kept).not.toBeNull()
+  })
+})
+
+describe('storage-failure in-memory fallback', () => {
+  beforeEach(() => {
+    resetQueueStorage()
+  })
+
+  it('keeps queueing, reading, and removing in-memory while saves fail, and recovers', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError')
+    })
+
+    try {
+      const a = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'first (unsaved)' })
+      const b = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'second (unsaved)' })
+
+      expect(a).not.toBeNull()
+      expect(b).not.toBeNull()
+
+      // Both entries survive in the atom AND in the fresh read drains use —
+      // the second enqueue must not rebuild from empty storage and drop the first.
+      expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['first (unsaved)', 'second (unsaved)'])
+      expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['first (unsaved)', 'second (unsaved)'])
+
+      // In-memory entries stay mutable: remove works without storage.
+      expect(removeQueuedPrompt(SESSION_KEY, a!.id)).toBe(true)
+      expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['second (unsaved)'])
+
+      // Clearing a session with in-memory-only entries works too.
+      clearQueuedPrompts(SESSION_KEY)
+      expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
+    } finally {
+      setItem.mockRestore()
+    }
+
+    // Recovery: the first successful save re-persists and re-enables storage
+    // as the fresh source.
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'persisted again' })
+    expect(persistedQueueTexts(SESSION_KEY)).toEqual(['persisted again'])
+    expect(readFreshQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['persisted again'])
   })
 })
 
 describe('withSessionDrainClaim', () => {
-  // Minimal Web Locks stand-in with real exclusivity + ifAvailable semantics;
-  // jsdom has no navigator.locks, which is also what the fallback test relies on.
-  function installFakeLocks() {
-    const held = new Set<string>()
-
-    const request = async (
-      name: string,
-      options: { ifAvailable?: boolean },
-      callback: (lock: null | { name: string }) => Promise<unknown>
-    ): Promise<unknown> => {
-      if (held.has(name)) {
-        if (!options.ifAvailable) {
-          throw new Error('fake lock manager only implements ifAvailable')
-        }
-
-        return callback(null)
-      }
-
-      held.add(name)
-
-      try {
-        return await callback({ name })
-      } finally {
-        held.delete(name)
-      }
-    }
-
-    Object.defineProperty(window.navigator, 'locks', { configurable: true, value: { request } })
-
-    return () => {
-      delete (window.navigator as { locks?: unknown }).locks
-    }
-  }
+  beforeEach(() => {
+    resetQueueStorage()
+  })
 
   it('runs the task directly when Web Locks are unavailable (single-window env)', async () => {
     expect('locks' in window.navigator).toBe(false)
@@ -393,6 +462,112 @@ describe('withSessionDrainClaim', () => {
 
       // Released claim is available again.
       await expect(withSessionDrainClaim('session-x', () => Promise.resolve('second ran'))).resolves.toBe('second ran')
+    } finally {
+      restore()
+    }
+  })
+
+  it('wait: true queues behind the holder and runs after release', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      let releaseWinner!: () => void
+      const winner = withSessionDrainClaim('session-x', () => new Promise<void>(res => (releaseWinner = res)))
+      await Promise.resolve()
+
+      const order: string[] = []
+
+      const waiter = withSessionDrainClaim(
+        'session-x',
+        async () => {
+          order.push('waiter ran')
+
+          return 'waited'
+        },
+        { wait: true }
+      )
+
+      await Promise.resolve()
+
+      expect(order).toEqual([])
+
+      releaseWinner()
+      await winner
+
+      await expect(waiter).resolves.toBe('waited')
+      expect(order).toEqual(['waiter ran'])
+    } finally {
+      restore()
+    }
+  })
+
+  it('wait with timeoutMs resolves null (not a rejection) when the holder outlasts it', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      let releaseWinner!: () => void
+      const winner = withSessionDrainClaim('session-x', () => new Promise<void>(res => (releaseWinner = res)))
+      await Promise.resolve()
+
+      const task = vi.fn(() => Promise.resolve('late'))
+      await expect(withSessionDrainClaim('session-x', task, { timeoutMs: 20, wait: true })).resolves.toBeNull()
+      expect(task).not.toHaveBeenCalled()
+
+      releaseWinner()
+      await winner
+    } finally {
+      restore()
+    }
+  })
+})
+
+describe('whenSessionDrainClaimReleased', () => {
+  beforeEach(() => {
+    resetQueueStorage()
+  })
+
+  it('resolves immediately when the claim is free or Web Locks are unavailable', async () => {
+    await expect(whenSessionDrainClaimReleased('session-x')).resolves.toBeUndefined()
+
+    const restore = installFakeLocks()
+
+    try {
+      await expect(whenSessionDrainClaimReleased('session-x')).resolves.toBeUndefined()
+    } finally {
+      restore()
+    }
+  })
+
+  it('resolves only after the current holder releases — including a failed winner', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      let failWinner!: (error: Error) => void
+
+      const winner = withSessionDrainClaim(
+        'session-x',
+        () => new Promise<never>((_resolve, reject) => (failWinner = reject))
+      ).catch(() => 'winner failed')
+
+      await Promise.resolve()
+
+      let released = false
+
+      const waiter = whenSessionDrainClaimReleased('session-x').then(() => {
+        released = true
+      })
+
+      await Promise.resolve()
+
+      expect(released).toBe(false)
+
+      // The winner FAILS (rejected submit / crash analogue): it writes nothing,
+      // but the claim release alone must wake the waiter.
+      failWinner(new Error('submit rejected'))
+      await winner
+      await waiter
+
+      expect(released).toBe(true)
     } finally {
       restore()
     }

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerAttachment } from './composer'
 import {
@@ -9,10 +9,13 @@ import {
   getQueuedPrompts,
   migrateQueuedPrompts,
   promoteQueuedPrompt,
+  type QueuedPromptEntry,
+  readPersistedQueuedPrompts,
   removeQueuedPrompt,
   shouldAutoDrain,
   updateQueuedPrompt,
-  updateQueuedPromptText
+  updateQueuedPromptText,
+  withSessionDrainClaim
 } from './composer-queue'
 
 const SESSION_KEY = 'session-abc'
@@ -219,6 +222,180 @@ describe('cross-window sync (#46732)', () => {
     window.dispatchEvent(new StorageEvent('storage', { key: 'some.other.key', newValue: '"x"' }))
 
     expect(getQueuedPrompts('session-a').map(e => e.text)).toEqual(['kept'])
+  })
+})
+
+describe('same-session cross-window races (#57516 review)', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    $queuedPromptsBySession.set({})
+  })
+
+  const remoteEntry = (id: string, text: string): QueuedPromptEntry => ({ id, text, attachments: [], queuedAt: 1 })
+
+  // The worst case: another window wrote OUR session's key and the async
+  // `storage` event has not landed yet, so the local atom is stale. Writing
+  // directly (no event dispatch) simulates exactly that gap.
+  function otherWindowPersists(state: Record<string, QueuedPromptEntry[]>) {
+    window.localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(state))
+  }
+
+  const persistedTexts = (sid: string): string[] => {
+    const parsed = JSON.parse(window.localStorage.getItem(QUEUE_STORAGE_KEY) ?? '{}') as Record<
+      string,
+      { text: string }[]
+    >
+
+    return (parsed[sid] ?? []).map(e => e.text)
+  }
+
+  it('enqueue appends to the other window’s unsynced same-session write instead of clobbering it', () => {
+    otherWindowPersists({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
+
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'local entry' })
+
+    expect(persistedTexts(SESSION_KEY)).toEqual(['B entry', 'local entry'])
+    // The merge also lands in the local atom, not just storage.
+    expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['B entry', 'local entry'])
+  })
+
+  it('update edits the fresh queue, preserving entries the local atom has not seen', () => {
+    const mine = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'mine' })
+    otherWindowPersists({ [SESSION_KEY]: [mine!, remoteEntry('q-b', 'B entry')] })
+
+    expect(updateQueuedPromptText(SESSION_KEY, mine!.id, 'mine edited')).toBe(true)
+
+    expect(persistedTexts(SESSION_KEY)).toEqual(['mine edited', 'B entry'])
+  })
+
+  it('remove filters the fresh queue, preserving entries the local atom has not seen', () => {
+    const mine = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'mine' })
+    otherWindowPersists({ [SESSION_KEY]: [mine!, remoteEntry('q-b', 'B entry')] })
+
+    expect(removeQueuedPrompt(SESSION_KEY, mine!.id)).toBe(true)
+
+    expect(persistedTexts(SESSION_KEY)).toEqual(['B entry'])
+  })
+
+  it('remove reports false for an entry another window already drained', () => {
+    const mine = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'mine' })
+    otherWindowPersists({})
+
+    expect(removeQueuedPrompt(SESSION_KEY, mine!.id)).toBe(false)
+  })
+
+  it('dequeue takes the head of the fresh queue, not the stale atom’s head', () => {
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'already drained elsewhere' })
+    otherWindowPersists({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
+
+    expect(dequeueQueuedPrompt(SESSION_KEY)?.text).toBe('B entry')
+    expect(persistedTexts(SESSION_KEY)).toEqual([])
+  })
+
+  it('promote reorders the fresh queue, preserving entries the local atom has not seen', () => {
+    const first = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'first' })
+    const second = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'second' })
+    otherWindowPersists({ [SESSION_KEY]: [first!, second!, remoteEntry('q-b', 'B entry')] })
+
+    expect(promoteQueuedPrompt(SESSION_KEY, second!.id)).toBe(true)
+
+    expect(persistedTexts(SESSION_KEY)).toEqual(['second', 'first', 'B entry'])
+  })
+
+  it('migrate moves the fresh source queue and appends to the fresh target queue', () => {
+    enqueueQueuedPrompt('rt-old', { attachments: [], text: 'seen locally' })
+    otherWindowPersists({
+      'rt-old': [remoteEntry('q-o', 'unsynced source entry')],
+      'rt-new': [remoteEntry('q-n', 'unsynced target entry')]
+    })
+
+    expect(migrateQueuedPrompts('rt-old', 'rt-new')).toBe(true)
+
+    expect(persistedTexts('rt-old')).toEqual([])
+    expect(persistedTexts('rt-new')).toEqual(['unsynced target entry', 'unsynced source entry'])
+  })
+
+  it('readPersistedQueuedPrompts bypasses the stale atom', () => {
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'stale' })
+    otherWindowPersists({ [SESSION_KEY]: [remoteEntry('q-b', 'B entry')] })
+
+    expect(getQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['stale'])
+    expect(readPersistedQueuedPrompts(SESSION_KEY).map(e => e.text)).toEqual(['B entry'])
+  })
+})
+
+describe('withSessionDrainClaim', () => {
+  // Minimal Web Locks stand-in with real exclusivity + ifAvailable semantics;
+  // jsdom has no navigator.locks, which is also what the fallback test relies on.
+  function installFakeLocks() {
+    const held = new Set<string>()
+
+    const request = async (
+      name: string,
+      options: { ifAvailable?: boolean },
+      callback: (lock: null | { name: string }) => Promise<unknown>
+    ): Promise<unknown> => {
+      if (held.has(name)) {
+        if (!options.ifAvailable) {
+          throw new Error('fake lock manager only implements ifAvailable')
+        }
+
+        return callback(null)
+      }
+
+      held.add(name)
+
+      try {
+        return await callback({ name })
+      } finally {
+        held.delete(name)
+      }
+    }
+
+    Object.defineProperty(window.navigator, 'locks', { configurable: true, value: { request } })
+
+    return () => {
+      delete (window.navigator as { locks?: unknown }).locks
+    }
+  }
+
+  it('runs the task directly when Web Locks are unavailable (single-window env)', async () => {
+    expect('locks' in window.navigator).toBe(false)
+
+    await expect(withSessionDrainClaim('session-x', () => Promise.resolve('ran'))).resolves.toBe('ran')
+  })
+
+  it('resolves null without running the task for an unusable session key', async () => {
+    const task = vi.fn(() => Promise.resolve('ran'))
+
+    await expect(withSessionDrainClaim('   ', task)).resolves.toBeNull()
+    expect(task).not.toHaveBeenCalled()
+  })
+
+  it('skips (null) while another window holds the claim, and reacquires after release', async () => {
+    const restore = installFakeLocks()
+
+    try {
+      let releaseWinner!: (value: string) => void
+      const winner = withSessionDrainClaim('session-x', () => new Promise<string>(res => (releaseWinner = res)))
+
+      const loserTask = vi.fn(() => Promise.resolve('loser ran'))
+      await expect(withSessionDrainClaim('session-x', loserTask)).resolves.toBeNull()
+      expect(loserTask).not.toHaveBeenCalled()
+
+      // Claims are per session: a different session drains concurrently.
+      await expect(withSessionDrainClaim('session-y', () => Promise.resolve('other session'))).resolves.toBe(
+        'other session'
+      )
+
+      releaseWinner('winner ran')
+      await expect(winner).resolves.toBe('winner ran')
+
+      // Released claim is available again.
+      await expect(withSessionDrainClaim('session-x', () => Promise.resolve('second ran'))).resolves.toBe('second ran')
+    } finally {
+      restore()
+    }
   })
 })
 

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -10,6 +10,7 @@ import {
   migrateQueuedPrompts,
   promoteQueuedPrompt,
   QUEUE_STORAGE_KEY,
+  QUEUE_TOMBSTONES_STORAGE_KEY,
   readFreshQueuedPrompts,
   removeQueuedPrompt,
   shouldAutoDrain,
@@ -548,6 +549,28 @@ describe('tombstone lifetime', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('clamps future-dated tombstone garbage so it cannot evict genuine tombstones', () => {
+    // Corruption scenario: the sidecar is stuffed with future-dated stamps.
+    // Unclamped, they would never expire, always sort newest, permanently
+    // occupy the cap, and evict every genuine tombstone at the next prune.
+    const garbage: Record<string, number> = {}
+
+    for (let i = 0; i < 70; i++) {
+      garbage[`junk-${i}`] = Date.parse('2199-01-01T00:00:00Z') + i * 1_000
+    }
+
+    window.localStorage.setItem(QUEUE_TOMBSTONES_STORAGE_KEY, JSON.stringify(garbage))
+
+    const a = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'genuinely removed A' })
+    const b = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'genuinely removed B' })
+    removeQueuedPrompt(SESSION_KEY, a!.id)
+    removeQueuedPrompt(SESSION_KEY, b!.id) // this prune must NOT evict A's tombstone
+
+    otherWindowWrites({ [SESSION_KEY]: [a!, b!] }) // stale save resurrects both
+
+    expect(readFreshQueuedPrompts(SESSION_KEY)).toEqual([])
   })
 
   it('evicts the oldest tombstones beyond the cap, keeping the newest effective', () => {

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -46,9 +46,25 @@ const save = (state: QueueState) => {
 
 export const $queuedPromptsBySession = atom<QueueState>(load())
 
+// Cross-window sync: every desktop window boots this store from the same
+// localStorage key, but without this listener each window keeps a private,
+// diverging snapshot forever. A window that enqueues/drains would then clobber
+// the others' entries on its next save (#46732: prompts resurrecting, vanishing,
+// or draining from a window the user never typed in). `storage` fires only in
+// the windows that did NOT write, so there is no self-echo to guard against.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', event => {
+    if (event.key === STORAGE_KEY || event.key === null) {
+      $queuedPromptsBySession.set(load())
+    }
+  })
+}
+
 const writeSession = (sid: string, queue: QueuedPromptEntry[]) => {
-  const current = $queuedPromptsBySession.get()
-  const next = { ...current }
+  // Merge over the freshly-persisted map, not the in-memory atom: another
+  // window may have written between our last sync event and now, and basing
+  // the save on a stale snapshot would silently revert its change.
+  const next = { ...load() }
 
   if (queue.length === 0) {
     delete next[sid]
@@ -230,7 +246,7 @@ export const migrateQueuedPrompts = (fromKey: string | null | undefined, toKey: 
     return false
   }
 
-  const next = { ...$queuedPromptsBySession.get() }
+  const next = { ...load() }
   delete next[from]
   next[to] = [...queueFor(to), ...pending]
 

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -93,7 +93,11 @@ const readStorage = (): null | QueueState => {
   }
 }
 
-const save = (state: QueueState) => {
+// `quiet` writes never touch persistFailed: the storage-event listener's
+// opportunistic ghost purge must not flip a purely PASSIVE window into
+// degraded in-memory mode — such a window performs no mutations, so nothing
+// would ever clear the flag again and it would ignore every future event.
+const save = (state: QueueState, { quiet = false } = {}) => {
   if (typeof window === 'undefined') {
     return
   }
@@ -110,11 +114,15 @@ const save = (state: QueueState) => {
       cachedQueueState = state
     }
 
-    persistFailed = false
+    if (!quiet) {
+      persistFailed = false
+    }
   } catch {
     // Best-effort: the queue keeps working in-memory — freshState() serves the
     // atom while this flag is set, so nothing is lost from the UI or drains.
-    persistFailed = true
+    if (!quiet) {
+      persistFailed = true
+    }
   }
 }
 
@@ -158,10 +166,14 @@ const sanitizeTombstones = (parsed: unknown): RemovalTombstones => {
   }
 
   const tombstones: RemovalTombstones = {}
+  const now = Date.now()
 
   for (const [id, at] of Object.entries(parsed as Record<string, unknown>)) {
     if (typeof at === 'number' && Number.isFinite(at)) {
-      tombstones[id] = at
+      // Clamp to now: a future-dated stamp (corruption — all windows share
+      // one clock) would never expire, sort newest, and 64 of them would
+      // permanently occupy the cap, evicting every genuine tombstone.
+      tombstones[id] = Math.min(at, now)
     }
   }
 
@@ -292,8 +304,9 @@ if (typeof window !== 'undefined') {
     // purged map back so the ghost leaves storage now, not "on the next
     // write" — an idle queue might not see one before the tombstone expires.
     // Idempotent across windows: whoever writes last writes the same content.
+    // Quiet: an opportunistic purge failing must not enter degraded mode.
     if (filtered !== stored) {
-      save(filtered)
+      save(filtered, { quiet: true })
     }
   })
 }

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -33,6 +33,39 @@ let cachedQueueRaw: null | string = null
 let cachedQueueState: null | QueueState = null
 
 // null = storage unreadable (disabled/corrupt access), distinct from empty.
+// Storage content is attacker-adjacent input (another app version, manual
+// edits, corruption): sanitize per session and per entry, or a non-array
+// session value would make the very first filterState throw during module
+// evaluation and brick every window.
+const sanitizeState = (parsed: unknown): QueueState => {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {}
+  }
+
+  const state: QueueState = {}
+
+  for (const [sid, queue] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!Array.isArray(queue)) {
+      continue
+    }
+
+    const entries = queue.filter(
+      (e): e is QueuedPromptEntry =>
+        !!e &&
+        typeof e === 'object' &&
+        typeof (e as { id?: unknown }).id === 'string' &&
+        typeof (e as { text?: unknown }).text === 'string' &&
+        Array.isArray((e as { attachments?: unknown }).attachments)
+    )
+
+    if (entries.length > 0) {
+      state[sid] = entries
+    }
+  }
+
+  return state
+}
+
 const readStorage = (): null | QueueState => {
   if (typeof window === 'undefined') {
     return null
@@ -49,10 +82,7 @@ const readStorage = (): null | QueueState => {
       return cachedQueueState
     }
 
-    const parsed = JSON.parse(raw) as unknown
-
-    const state =
-      parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as QueueState) : {}
+    const state = sanitizeState(JSON.parse(raw) as unknown)
 
     cachedQueueRaw = raw
     cachedQueueState = state
@@ -99,49 +129,76 @@ const save = (state: QueueState) => {
 // mutators cannot take async Web Locks, so instead every removal records the
 // entry id here FIRST, and every queue read/write filters tombstoned ids — a
 // resurrected entry can reappear in the raw map, but never in a drainable or
-// visible state, and the next write purges it. The sidecar lives under its own
+// visible state; the storage listener writes the purged map back so the ghost
+// leaves storage within one event round trip. The sidecar lives under its own
 // key so queue-map writes can never clobber it wholesale; concurrent sidecar
 // writers can at worst lose one id to each other (falling back to today's
-// behavior, never worse). TTL + cap bound its size: a tombstone only needs to
-// outlive the seconds-wide stale-save window it defends against.
+// behavior, never worse). The cap bounds its size; the TTL exists only to shed
+// abandoned ids and is deliberately long — a resurrected ghost must never
+// outlive the tombstone that hides it, and ghosts are purged within one
+// storage event or the next write, both far inside the TTL.
 // ---------------------------------------------------------------------------
 
 type RemovalTombstones = Record<string, number>
 
-const TOMBSTONE_TTL_MS = 5 * 60_000
+const TOMBSTONE_TTL_MS = 24 * 60 * 60_000
 const TOMBSTONE_CAP = 64
 
 let cachedTombstonesRaw: null | string = null
 let cachedTombstones: null | RemovalTombstones = null
+
+// Removals recorded while the sidecar was unwritable (quota). Merged into
+// every read so THIS window keeps filtering its own removals even when it
+// cannot tell the other windows about them; bounded by the same prune+cap.
+let unpersistedTombstones: RemovalTombstones = {}
+
+const sanitizeTombstones = (parsed: unknown): RemovalTombstones => {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {}
+  }
+
+  const tombstones: RemovalTombstones = {}
+
+  for (const [id, at] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof at === 'number' && Number.isFinite(at)) {
+      tombstones[id] = at
+    }
+  }
+
+  return tombstones
+}
 
 const readTombstones = (): RemovalTombstones => {
   if (typeof window === 'undefined') {
     return {}
   }
 
+  const overlay = unpersistedTombstones
+
   try {
     const raw = window.localStorage.getItem(QUEUE_TOMBSTONES_STORAGE_KEY)
 
     if (raw === null) {
-      return {}
+      return overlay
     }
 
-    if (cachedTombstonesRaw === raw && cachedTombstones) {
-      return cachedTombstones
+    if (cachedTombstonesRaw !== raw || !cachedTombstones) {
+      cachedTombstonesRaw = raw
+      cachedTombstones = sanitizeTombstones(JSON.parse(raw) as unknown)
     }
 
-    const parsed = JSON.parse(raw) as unknown
-
-    const tombstones =
-      parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as RemovalTombstones) : {}
-
-    cachedTombstonesRaw = raw
-    cachedTombstones = tombstones
-
-    return tombstones
+    return Object.keys(overlay).length === 0 ? cachedTombstones : { ...cachedTombstones, ...overlay }
   } catch {
-    return {}
+    return overlay
   }
+}
+
+const pruneTombstones = (tombstones: RemovalTombstones): RemovalTombstones => {
+  const cutoff = Date.now() - TOMBSTONE_TTL_MS
+  const alive = Object.entries(tombstones).filter(([, at]) => at > cutoff)
+  alive.sort((a, b) => a[1] - b[1])
+
+  return Object.fromEntries(alive.slice(-TOMBSTONE_CAP))
 }
 
 const recordTombstones = (ids: string[]) => {
@@ -149,24 +206,23 @@ const recordTombstones = (ids: string[]) => {
     return
   }
 
+  const next = pruneTombstones(readTombstones())
+  const now = Date.now()
+
+  for (const id of ids) {
+    next[id] = now
+  }
+
   try {
-    const cutoff = Date.now() - TOMBSTONE_TTL_MS
-    const alive = Object.entries(readTombstones()).filter(([, at]) => at > cutoff)
-    alive.sort((a, b) => a[1] - b[1])
-
-    const next: RemovalTombstones = Object.fromEntries(alive.slice(-TOMBSTONE_CAP))
-    const now = Date.now()
-
-    for (const id of ids) {
-      next[id] = now
-    }
-
     const raw = JSON.stringify(next)
     window.localStorage.setItem(QUEUE_TOMBSTONES_STORAGE_KEY, raw)
     cachedTombstonesRaw = raw
     cachedTombstones = next
+    unpersistedTombstones = {}
   } catch {
-    // Best-effort: without the tombstone we degrade to pre-tombstone behavior.
+    // Sidecar unwritable: keep the merged set in memory so this window still
+    // filters its own removals; other windows degrade to pre-tombstone behavior.
+    unpersistedTombstones = next
   }
 }
 
@@ -210,11 +266,34 @@ export const $queuedPromptsBySession = atom<QueueState>(filterState(readStorage(
 if (typeof window !== 'undefined') {
   window.addEventListener('storage', event => {
     if (
-      event.key === QUEUE_STORAGE_KEY ||
-      event.key === QUEUE_TOMBSTONES_STORAGE_KEY ||
-      event.key === null
+      event.key !== QUEUE_STORAGE_KEY &&
+      event.key !== QUEUE_TOMBSTONES_STORAGE_KEY &&
+      event.key !== null
     ) {
-      $queuedPromptsBySession.set(filterState(readStorage() ?? $queuedPromptsBySession.get()))
+      return
+    }
+
+    // While persistence is broken, this window's atom is its only truth:
+    // adopting another window's map would delete every in-memory-only entry.
+    if (persistFailed) {
+      return
+    }
+
+    const stored = readStorage()
+
+    if (stored === null) {
+      return
+    }
+
+    const filtered = filterState(stored)
+    $queuedPromptsBySession.set(filtered)
+
+    // A stale save resurrected a tombstoned entry into the raw map: write the
+    // purged map back so the ghost leaves storage now, not "on the next
+    // write" — an idle queue might not see one before the tombstone expires.
+    // Idempotent across windows: whoever writes last writes the same content.
+    if (filtered !== stored) {
+      save(filtered)
     }
   })
 }
@@ -424,7 +503,14 @@ export const updateQueuedPrompt = (
 
       const attachments = update.attachments ? cloneAttachments(update.attachments) : entry.attachments
 
-      if (entry.text === update.text && !update.attachments) {
+      // Structural comparison, not presence: edit flows always pass an
+      // attachments array (usually an identical one), and treating "passed"
+      // as "changed" made every arrow-step through the edit stack a full
+      // stringify + storage write + cross-window event for nothing.
+      const sameAttachments =
+        !update.attachments || JSON.stringify(update.attachments) === JSON.stringify(entry.attachments)
+
+      if (entry.text === update.text && sameAttachments) {
         return entry
       }
 
@@ -466,6 +552,11 @@ export const clearQueuedPrompts = (key: string | null | undefined) => {
  * before the remainder moves, or the moved copy would be picked up under the
  * new key's (different) claim while the original submit is still in flight and
  * be submitted twice.
+ *
+ * Accepted limit: the write to the TARGET key races concurrent unlocked
+ * mutations on it like any same-instant same-session write (milliseconds,
+ * lost-update only) — holding the target's drain claim would not help, since
+ * mutations never take claims.
  */
 export const migrateQueuedPrompts = async (
   fromKey: string | null | undefined,
@@ -567,26 +658,75 @@ export const withSessionDrainClaim = async <T>(
  * releasing it). Losers of an `ifAvailable` attempt use this as their wake-up:
  * a winner whose submit is rejected — or whose window dies mid-submit — never
  * writes storage, so no storage event will re-trigger them, but the browser
- * always releases a dead window's locks. Resolves immediately when Web Locks
- * are unavailable (single-window environments have no winner to wait on).
+ * always releases a dead window's locks.
+ *
+ * Resolves `true` only after a genuine wait-and-release. `false` means no
+ * wait happened (no usable key, no Web Locks, or the request failed) — the
+ * caller must NOT treat that as a wake-up, or an environment whose lock
+ * requests reject would spin arm→fail→re-arm forever.
  */
-export const whenSessionDrainClaimReleased = async (key: string | null | undefined): Promise<void> => {
+export const whenSessionDrainClaimReleased = async (key: string | null | undefined): Promise<boolean> => {
   const sid = sidOf(key)
 
   if (!sid) {
-    return
+    return false
   }
 
+  const locks = typeof navigator === 'undefined' ? undefined : navigator.locks
+
+  if (!locks) {
+    return false
+  }
+
+  try {
+    await locks.request(`${QUEUE_STORAGE_KEY}.drain.${sid}`, {}, async () => undefined)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+const sentLockName = (id: string) => `${QUEUE_STORAGE_KEY}.sent.${id}`
+
+/**
+ * Hold a browser-arbitrated "already sent" claim on this entry id for the rest
+ * of this window's lifetime. This is the storage-independent second layer
+ * under the tombstones: when THIS window's removals cannot reach storage
+ * (quota exhausted — the persistFailed mode), a healthy sibling window would
+ * otherwise re-drain and re-submit every entry this window sends, because
+ * storage still lists them. The held lock is visible to every window via
+ * {@link isQueuedPromptSentElsewhere} and needs no storage at all. It releases
+ * when this window closes, degrading to the accepted crash race — never worse
+ * than the storage layer alone.
+ */
+export const markQueuedPromptSent = (id: string) => {
   const locks = typeof navigator === 'undefined' ? undefined : navigator.locks
 
   if (!locks) {
     return
   }
 
+  void locks
+    .request(sentLockName(id), { ifAvailable: true }, grant => (grant ? new Promise<never>(() => {}) : undefined))
+    .catch(() => undefined)
+}
+
+/** Whether any window (this one included) holds the sent claim for this id. */
+export const isQueuedPromptSentElsewhere = async (id: string): Promise<boolean> => {
+  const locks = typeof navigator === 'undefined' ? undefined : navigator.locks
+
+  if (!locks?.query) {
+    return false
+  }
+
   try {
-    await locks.request(`${QUEUE_STORAGE_KEY}.drain.${sid}`, {}, async () => undefined)
+    const { held } = await locks.query()
+    const name = sentLockName(id)
+
+    return (held ?? []).some(lock => lock?.name === name)
   } catch {
-    // A failed wait must never break the caller's drain loop.
+    return false
   }
 }
 

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -11,20 +11,55 @@ export interface QueuedPromptEntry {
 
 type QueueState = Record<string, QueuedPromptEntry[]>
 
-const STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
+export const QUEUE_STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
 
-const load = (): QueueState => {
+/** See the tombstone block below for why this lives under its own key. */
+export const QUEUE_TOMBSTONES_STORAGE_KEY = 'hermes.desktop.composerQueue.sent.v1'
+
+// True after a persistence attempt failed; cleared by the next success. While
+// set, mutations and drain picks base themselves on the in-memory atom instead
+// of storage — entries that never reached storage would otherwise vanish from
+// every subsequent operation. Storage that cannot be written cannot sync
+// windows anyway, so degrading to single-window in-memory semantics is the
+// correct fallback, and recovery is automatic on the first save that succeeds.
+let persistFailed = false
+
+// Cache of the last parsed queue map, keyed by the exact raw string. Repeated
+// reads (every mutation + drain pick + storage event re-reads the whole map)
+// then parse once per distinct content, and — critically — return the SAME
+// per-session array references, preserving the referential stability that
+// useSessionSlice's re-render bail-out depends on.
+let cachedQueueRaw: null | string = null
+let cachedQueueState: null | QueueState = null
+
+// null = storage unreadable (disabled/corrupt access), distinct from empty.
+const readStorage = (): null | QueueState => {
   if (typeof window === 'undefined') {
-    return {}
+    return null
   }
 
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
-    const parsed = raw ? JSON.parse(raw) : null
+    const raw = window.localStorage.getItem(QUEUE_STORAGE_KEY)
 
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as QueueState) : {}
+    if (raw === null) {
+      return {}
+    }
+
+    if (cachedQueueRaw === raw && cachedQueueState) {
+      return cachedQueueState
+    }
+
+    const parsed = JSON.parse(raw) as unknown
+
+    const state =
+      parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as QueueState) : {}
+
+    cachedQueueRaw = raw
+    cachedQueueState = state
+
+    return state
   } catch {
-    return {}
+    return null
   }
 }
 
@@ -35,16 +70,136 @@ const save = (state: QueueState) => {
 
   try {
     if (Object.keys(state).length === 0) {
-      window.localStorage.removeItem(STORAGE_KEY)
+      window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+      cachedQueueRaw = null
+      cachedQueueState = null
     } else {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+      const raw = JSON.stringify(state)
+      window.localStorage.setItem(QUEUE_STORAGE_KEY, raw)
+      cachedQueueRaw = raw
+      cachedQueueState = state
     }
+
+    persistFailed = false
   } catch {
-    // best-effort: storage may be unavailable, queue still works in-memory
+    // Best-effort: the queue keeps working in-memory — freshState() serves the
+    // atom while this flag is set, so nothing is lost from the UI or drains.
+    persistFailed = true
   }
 }
 
-export const $queuedPromptsBySession = atom<QueueState>(load())
+// ---------------------------------------------------------------------------
+// Removal tombstones.
+//
+// The queue map alone cannot survive one interleaving: a mutation in window B
+// that loaded the map BEFORE window A removed entry X and saved AFTER puts X
+// back into storage. If X was just drained, the next auto-drain would submit
+// it a second time; if the user deleted X, it would send something they
+// explicitly discarded. localStorage has no compare-and-swap and synchronous
+// mutators cannot take async Web Locks, so instead every removal records the
+// entry id here FIRST, and every queue read/write filters tombstoned ids — a
+// resurrected entry can reappear in the raw map, but never in a drainable or
+// visible state, and the next write purges it. The sidecar lives under its own
+// key so queue-map writes can never clobber it wholesale; concurrent sidecar
+// writers can at worst lose one id to each other (falling back to today's
+// behavior, never worse). TTL + cap bound its size: a tombstone only needs to
+// outlive the seconds-wide stale-save window it defends against.
+// ---------------------------------------------------------------------------
+
+type RemovalTombstones = Record<string, number>
+
+const TOMBSTONE_TTL_MS = 5 * 60_000
+const TOMBSTONE_CAP = 64
+
+let cachedTombstonesRaw: null | string = null
+let cachedTombstones: null | RemovalTombstones = null
+
+const readTombstones = (): RemovalTombstones => {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  try {
+    const raw = window.localStorage.getItem(QUEUE_TOMBSTONES_STORAGE_KEY)
+
+    if (raw === null) {
+      return {}
+    }
+
+    if (cachedTombstonesRaw === raw && cachedTombstones) {
+      return cachedTombstones
+    }
+
+    const parsed = JSON.parse(raw) as unknown
+
+    const tombstones =
+      parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as RemovalTombstones) : {}
+
+    cachedTombstonesRaw = raw
+    cachedTombstones = tombstones
+
+    return tombstones
+  } catch {
+    return {}
+  }
+}
+
+const recordTombstones = (ids: string[]) => {
+  if (typeof window === 'undefined' || ids.length === 0) {
+    return
+  }
+
+  try {
+    const cutoff = Date.now() - TOMBSTONE_TTL_MS
+    const alive = Object.entries(readTombstones()).filter(([, at]) => at > cutoff)
+    alive.sort((a, b) => a[1] - b[1])
+
+    const next: RemovalTombstones = Object.fromEntries(alive.slice(-TOMBSTONE_CAP))
+    const now = Date.now()
+
+    for (const id of ids) {
+      next[id] = now
+    }
+
+    const raw = JSON.stringify(next)
+    window.localStorage.setItem(QUEUE_TOMBSTONES_STORAGE_KEY, raw)
+    cachedTombstonesRaw = raw
+    cachedTombstones = next
+  } catch {
+    // Best-effort: without the tombstone we degrade to pre-tombstone behavior.
+  }
+}
+
+/** Preserves the input reference when nothing is filtered. */
+const filterTombstoned = (queue: QueuedPromptEntry[], tombstones = readTombstones()): QueuedPromptEntry[] => {
+  const cutoff = Date.now() - TOMBSTONE_TTL_MS
+  const next = queue.filter(e => !(tombstones[e.id] !== undefined && tombstones[e.id]! > cutoff))
+
+  return next.length === queue.length ? queue : next
+}
+
+/** Filter every session's queue; preserves references (and the map) when clean. */
+const filterState = (state: QueueState): QueueState => {
+  const tombstones = readTombstones()
+  let changed = false
+  const next: QueueState = {}
+
+  for (const [sid, queue] of Object.entries(state)) {
+    const filtered = filterTombstoned(queue, tombstones)
+
+    if (filtered.length > 0) {
+      next[sid] = filtered
+    }
+
+    if (filtered !== queue || filtered.length === 0) {
+      changed = true
+    }
+  }
+
+  return changed ? next : state
+}
+
+export const $queuedPromptsBySession = atom<QueueState>(filterState(readStorage() ?? {}))
 
 // Cross-window sync: every desktop window boots this store from the same
 // localStorage key, but without this listener each window keeps a private,
@@ -54,46 +209,78 @@ export const $queuedPromptsBySession = atom<QueueState>(load())
 // the windows that did NOT write, so there is no self-echo to guard against.
 if (typeof window !== 'undefined') {
   window.addEventListener('storage', event => {
-    if (event.key === STORAGE_KEY || event.key === null) {
-      $queuedPromptsBySession.set(load())
+    if (
+      event.key === QUEUE_STORAGE_KEY ||
+      event.key === QUEUE_TOMBSTONES_STORAGE_KEY ||
+      event.key === null
+    ) {
+      $queuedPromptsBySession.set(filterState(readStorage() ?? $queuedPromptsBySession.get()))
     }
   })
 }
 
-// Operation-based cross-window mutation: reload the persisted map and apply
-// `op` to the freshest version of THIS session's queue — never to an array the
-// caller derived from the in-memory atom. Reloading the map alone only
-// protected other sessions' keys: two windows mutating the same session would
-// still replace its array with competing stale versions (window B's append
-// built on a queue that predates window A's), silently dropping entries.
-// `op` receives the fresh queue and returns the next one, or null for "nothing
-// to do" (no write, no atom churn). Returns whether a write happened.
-//
-// The load→op→save sequence is synchronous, so the only remaining race is two
-// renderer processes interleaving inside it at the exact same instant —
-// microseconds, versus the seconds-wide stale-snapshot window this closes.
-// Fully eliminating it would need cross-window mutual exclusion (Web Locks)
-// around every mutation, which forces all these APIs async; the drain path,
-// where a race double-submits a prompt into the model, does exactly that via
-// withSessionDrainClaim below.
-const mutateSession = (sid: string, op: (fresh: QueuedPromptEntry[]) => null | QueuedPromptEntry[]): boolean => {
-  const next = { ...load() }
-  const queue = op(next[sid] ?? [])
+// The freshest queue map a mutation or drain pick may act on: persisted
+// storage — the only synchronously cross-window source — unless persistence is
+// broken or storage is unreadable, in which case the in-memory atom is the
+// best (and only) truth this window has.
+const freshState = (): QueueState =>
+  persistFailed ? $queuedPromptsBySession.get() : (readStorage() ?? $queuedPromptsBySession.get())
 
-  if (queue === null) {
+// Map-level operation-based mutation: `op` receives a copy of the freshest
+// visible state and returns the next state, or null for "nothing to do".
+// Basing every write on freshState() — never on an array a caller computed
+// from the atom — is what stops two windows from replacing the same session's
+// queue with competing stale versions (#57516 review). The remaining race is
+// two renderer processes interleaving inside one another's load→op→save; its
+// worst case is a briefly resurrected or lost entry in the raw map, and the
+// tombstone filter above guarantees a resurrected entry is never drained or
+// shown again. Cross-window double-SUBMIT protection does not rest on this
+// path at all — that is withSessionDrainClaim's job.
+const mutateState = (op: (fresh: QueueState) => null | QueueState): boolean => {
+  const next = op({ ...freshState() })
+
+  if (next === null) {
     return false
   }
 
-  if (queue.length === 0) {
-    delete next[sid]
-  } else {
-    next[sid] = queue
-  }
-
-  $queuedPromptsBySession.set(next)
-  save(next)
+  const filtered = filterState(next)
+  $queuedPromptsBySession.set(filtered)
+  save(filtered)
 
   return true
+}
+
+// Returns whether `op` applied (its null = "didn't apply", which is what the
+// mutators' booleans report). The write itself can additionally happen for a
+// non-applying op when tombstoned entries got purged from the stored queue:
+// the remove/clear path tombstones FIRST, so its op sees the entry already
+// filtered out — but the atom and storage still hold it and must be rewritten
+// without it.
+const mutateSession = (sid: string, op: (fresh: QueuedPromptEntry[]) => null | QueuedPromptEntry[]): boolean => {
+  let applied = false
+
+  mutateState(state => {
+    const stored = state[sid] ?? []
+    const filtered = filterTombstoned(stored)
+    const queue = op(filtered)
+    applied = queue !== null
+
+    if (queue === null && filtered === stored) {
+      return null
+    }
+
+    const next = queue ?? filtered
+
+    if (next.length === 0) {
+      delete state[sid]
+    } else {
+      state[sid] = next
+    }
+
+    return state
+  })
+
+  return applied
 }
 
 const sidOf = (key: string | null | undefined): null | string => {
@@ -108,6 +295,12 @@ const nextId = () => `queued-${Date.now()}-${Math.random().toString(36).slice(2,
 
 const cloneAttachments = (attachments: ComposerAttachment[]) => attachments.map(a => ({ ...a }))
 
+/**
+ * Rendered-state reader (the atom): right for display and render-time checks.
+ * Drains and mutations must NOT pick from this — the storage event that syncs
+ * the atom is asynchronous, so it can trail what another window just did; they
+ * use {@link readFreshQueuedPrompts} / the internal fresh-state path instead.
+ */
 export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEntry[] => {
   const sid = sidOf(key)
 
@@ -115,53 +308,14 @@ export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEn
 }
 
 /**
- * Read a session's queue straight from persisted storage, bypassing the atom.
- * The `storage` event that syncs the atom is asynchronous, so around a drain
- * the atom can still list an entry another window already removed. Drain paths
- * must pick from this — inside {@link withSessionDrainClaim} — so they never
- * act on that stale echo.
+ * Read a session's queue from the freshest source (persisted storage, or the
+ * atom when persistence is broken), with removal tombstones filtered. This is
+ * the ONLY read drain paths may pick from, inside {@link withSessionDrainClaim}.
  */
-export const readPersistedQueuedPrompts = (key: string | null | undefined): QueuedPromptEntry[] => {
+export const readFreshQueuedPrompts = (key: string | null | undefined): QueuedPromptEntry[] => {
   const sid = sidOf(key)
 
-  return sid ? (load()[sid] ?? []) : []
-}
-
-/**
- * Run `task` while holding the exclusive cross-window drain claim for this
- * session, resolving null WITHOUT running it when another window already holds
- * the claim. A renderer-local lock cannot stop two windows from picking the
- * same queued entry and double-submitting it — every idle window schedules
- * auto-drain — so the mutex must live outside the renderer. Web Locks are
- * arbitrated by the browser process across all windows of the origin, and the
- * claim is released automatically if the holding window closes or crashes,
- * unlike a localStorage claim flag which would leak and jam the queue forever.
- * `ifAvailable` keeps losers non-blocking: they skip this attempt and try
- * again when the winner's removal lands as a storage event.
- *
- * Environments without Web Locks (non-Chromium test DOMs) run `task` directly:
- * there is no second window to exclude there, and the caller's renderer-local
- * lock still serializes attempts within this one.
- */
-export const withSessionDrainClaim = async <T>(
-  key: string | null | undefined,
-  task: () => Promise<T>
-): Promise<null | T> => {
-  const sid = sidOf(key)
-
-  if (!sid) {
-    return null
-  }
-
-  const locks = typeof navigator === 'undefined' ? undefined : navigator.locks
-
-  if (!locks) {
-    return task()
-  }
-
-  return (await locks.request(`${STORAGE_KEY}.drain.${sid}`, { ifAvailable: true }, grant =>
-    grant ? task() : Promise.resolve(null)
-  )) as null | T
+  return sid ? filterTombstoned(freshState()[sid] ?? []) : []
 }
 
 export const enqueueQueuedPrompt = (
@@ -193,17 +347,13 @@ export const dequeueQueuedPrompt = (key: string | null | undefined): null | Queu
     return null
   }
 
-  let head: null | QueuedPromptEntry = null
+  const head = readFreshQueuedPrompts(sid)[0] ?? null
 
-  mutateSession(sid, fresh => {
-    if (fresh.length === 0) {
-      return null
-    }
+  if (!head) {
+    return null
+  }
 
-    head = fresh[0]!
-
-    return fresh.slice(1)
-  })
+  removeQueuedPrompt(sid, head.id)
 
   return head
 }
@@ -215,11 +365,22 @@ export const removeQueuedPrompt = (key: string | null | undefined, id: string): 
     return false
   }
 
-  return mutateSession(sid, fresh => {
+  if (!readFreshQueuedPrompts(sid).some(e => e.id === id)) {
+    return false
+  }
+
+  // Tombstone FIRST: from this instant no stale concurrent save can resurrect
+  // the entry into a drainable or visible state, even though the map write
+  // below has not happened yet.
+  recordTombstones([id])
+
+  mutateSession(sid, fresh => {
     const next = fresh.filter(e => e.id !== id)
 
     return next.length === fresh.length ? null : next
   })
+
+  return true
 }
 
 export const promoteQueuedPrompt = (key: string | null | undefined, id: string): boolean => {
@@ -286,6 +447,10 @@ export const clearQueuedPrompts = (key: string | null | undefined) => {
     return
   }
 
+  // Cleared entries are removals too: without tombstones a concurrent stale
+  // save could resurrect a deleted session's prompts and later send them.
+  recordTombstones(readFreshQueuedPrompts(sid).map(e => e.id))
+
   mutateSession(sid, fresh => (fresh.length === 0 ? null : []))
 }
 
@@ -295,8 +460,17 @@ export const clearQueuedPrompts = (key: string | null | undefined) => {
  * resume can mint a fresh runtime session id for the *same* conversation; the
  * entries enqueued under the old id would otherwise be stranded under a key
  * nothing reads anymore. No-op unless both keys resolve and differ.
+ *
+ * Async on purpose: it WAITS on the source key's drain claim. A drain in
+ * flight under the old key must finish — and remove its entry under that key —
+ * before the remainder moves, or the moved copy would be picked up under the
+ * new key's (different) claim while the original submit is still in flight and
+ * be submitted twice.
  */
-export const migrateQueuedPrompts = (fromKey: string | null | undefined, toKey: string | null | undefined): boolean => {
+export const migrateQueuedPrompts = async (
+  fromKey: string | null | undefined,
+  toKey: string | null | undefined
+): Promise<boolean> => {
   const from = sidOf(fromKey)
   const to = sidOf(toKey)
 
@@ -304,23 +478,116 @@ export const migrateQueuedPrompts = (fromKey: string | null | undefined, toKey: 
     return false
   }
 
-  // Same operation-based rule as mutateSession, spanning two keys: both the
-  // migrated entries and the target queue come from the fresh persisted map,
-  // not the atom, so entries another window just enqueued are not dropped.
-  const next = { ...load() }
-  const pending = next[from] ?? []
+  const moved = await withSessionDrainClaim(
+    from,
+    async () =>
+      mutateState(state => {
+        const tombstones = readTombstones()
+        const pending = filterTombstoned(state[from] ?? [], tombstones)
 
-  if (pending.length === 0) {
-    return false
+        if (pending.length === 0) {
+          return null
+        }
+
+        delete state[from]
+        state[to] = [...filterTombstoned(state[to] ?? [], tombstones), ...pending]
+
+        return state
+      }),
+    { wait: true }
+  )
+
+  return moved ?? false
+}
+
+export interface DrainClaimOptions {
+  /** Wait for the current holder to release instead of skipping. */
+  wait?: boolean
+  /** Bound the wait (ms); a timed-out wait resolves null. Unbounded when omitted. */
+  timeoutMs?: number
+}
+
+/**
+ * Run `task` while holding the exclusive cross-window drain claim for this
+ * session, resolving null WITHOUT running it when the claim is unavailable
+ * (held by another window and not waited for, or the wait timed out). A
+ * renderer-local lock cannot stop two windows from picking the same queued
+ * entry and double-submitting it — every idle window schedules auto-drain —
+ * so the mutex must live outside the renderer. Web Locks are arbitrated by
+ * the browser process across all windows of the origin, and the claim is
+ * released automatically if the holding window closes or crashes, unlike a
+ * localStorage claim flag which would leak and jam the queue forever.
+ *
+ * Environments without Web Locks (non-Chromium test DOMs) run `task` directly:
+ * there is no second window to exclude there, and the caller's renderer-local
+ * lock still serializes attempts within this one.
+ */
+export const withSessionDrainClaim = async <T>(
+  key: string | null | undefined,
+  task: () => Promise<T>,
+  options: DrainClaimOptions = {}
+): Promise<null | T> => {
+  const sid = sidOf(key)
+
+  if (!sid) {
+    return null
   }
 
-  delete next[from]
-  next[to] = [...(next[to] ?? []), ...pending]
+  const locks = typeof navigator === 'undefined' ? undefined : navigator.locks
 
-  $queuedPromptsBySession.set(next)
-  save(next)
+  if (!locks) {
+    return task()
+  }
 
-  return true
+  const name = `${QUEUE_STORAGE_KEY}.drain.${sid}`
+
+  try {
+    if (!options.wait) {
+      return (await locks.request(name, { ifAvailable: true }, grant =>
+        grant ? task() : Promise.resolve(null)
+      )) as null | T
+    }
+
+    const signal = options.timeoutMs === undefined ? undefined : AbortSignal.timeout(options.timeoutMs)
+
+    return (await locks.request(name, signal ? { signal } : {}, () => task())) as T
+  } catch (error) {
+    // An aborted wait (timeout) means the holder outlasted our patience —
+    // report contention rather than surfacing a DOMException to drain logic.
+    if (error instanceof DOMException && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
+      return null
+    }
+
+    throw error
+  }
+}
+
+/**
+ * Resolve once this session's drain claim is free (acquiring and instantly
+ * releasing it). Losers of an `ifAvailable` attempt use this as their wake-up:
+ * a winner whose submit is rejected — or whose window dies mid-submit — never
+ * writes storage, so no storage event will re-trigger them, but the browser
+ * always releases a dead window's locks. Resolves immediately when Web Locks
+ * are unavailable (single-window environments have no winner to wait on).
+ */
+export const whenSessionDrainClaimReleased = async (key: string | null | undefined): Promise<void> => {
+  const sid = sidOf(key)
+
+  if (!sid) {
+    return
+  }
+
+  const locks = typeof navigator === 'undefined' ? undefined : navigator.locks
+
+  if (!locks) {
+    return
+  }
+
+  try {
+    await locks.request(`${QUEUE_STORAGE_KEY}.drain.${sid}`, {}, async () => undefined)
+  } catch {
+    // A failed wait must never break the caller's drain loop.
+  }
 }
 
 /** Inputs to {@link shouldAutoDrain}. */
@@ -345,3 +612,6 @@ export const shouldAutoDrain = ({ isBusy, queueLength }: AutoDrainInput): boolea
 /** Auto-drain attempts for one entry before we stop retrying and toast. The
  * entry stays queued for a manual send; a remount/reconnect resets the count. */
 export const MAX_AUTO_DRAIN_ATTEMPTS = 4
+
+/** Base delay between bounded auto-drain retries (attempt N waits N × this). */
+export const AUTO_DRAIN_RETRY_BASE_MS = 1_000

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -60,11 +60,29 @@ if (typeof window !== 'undefined') {
   })
 }
 
-const writeSession = (sid: string, queue: QueuedPromptEntry[]) => {
-  // Merge over the freshly-persisted map, not the in-memory atom: another
-  // window may have written between our last sync event and now, and basing
-  // the save on a stale snapshot would silently revert its change.
+// Operation-based cross-window mutation: reload the persisted map and apply
+// `op` to the freshest version of THIS session's queue — never to an array the
+// caller derived from the in-memory atom. Reloading the map alone only
+// protected other sessions' keys: two windows mutating the same session would
+// still replace its array with competing stale versions (window B's append
+// built on a queue that predates window A's), silently dropping entries.
+// `op` receives the fresh queue and returns the next one, or null for "nothing
+// to do" (no write, no atom churn). Returns whether a write happened.
+//
+// The load→op→save sequence is synchronous, so the only remaining race is two
+// renderer processes interleaving inside it at the exact same instant —
+// microseconds, versus the seconds-wide stale-snapshot window this closes.
+// Fully eliminating it would need cross-window mutual exclusion (Web Locks)
+// around every mutation, which forces all these APIs async; the drain path,
+// where a race double-submits a prompt into the model, does exactly that via
+// withSessionDrainClaim below.
+const mutateSession = (sid: string, op: (fresh: QueuedPromptEntry[]) => null | QueuedPromptEntry[]): boolean => {
   const next = { ...load() }
+  const queue = op(next[sid] ?? [])
+
+  if (queue === null) {
+    return false
+  }
 
   if (queue.length === 0) {
     delete next[sid]
@@ -74,6 +92,8 @@ const writeSession = (sid: string, queue: QueuedPromptEntry[]) => {
 
   $queuedPromptsBySession.set(next)
   save(next)
+
+  return true
 }
 
 const sidOf = (key: string | null | undefined): null | string => {
@@ -94,6 +114,56 @@ export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEn
   return sid ? queueFor(sid) : []
 }
 
+/**
+ * Read a session's queue straight from persisted storage, bypassing the atom.
+ * The `storage` event that syncs the atom is asynchronous, so around a drain
+ * the atom can still list an entry another window already removed. Drain paths
+ * must pick from this — inside {@link withSessionDrainClaim} — so they never
+ * act on that stale echo.
+ */
+export const readPersistedQueuedPrompts = (key: string | null | undefined): QueuedPromptEntry[] => {
+  const sid = sidOf(key)
+
+  return sid ? (load()[sid] ?? []) : []
+}
+
+/**
+ * Run `task` while holding the exclusive cross-window drain claim for this
+ * session, resolving null WITHOUT running it when another window already holds
+ * the claim. A renderer-local lock cannot stop two windows from picking the
+ * same queued entry and double-submitting it — every idle window schedules
+ * auto-drain — so the mutex must live outside the renderer. Web Locks are
+ * arbitrated by the browser process across all windows of the origin, and the
+ * claim is released automatically if the holding window closes or crashes,
+ * unlike a localStorage claim flag which would leak and jam the queue forever.
+ * `ifAvailable` keeps losers non-blocking: they skip this attempt and try
+ * again when the winner's removal lands as a storage event.
+ *
+ * Environments without Web Locks (non-Chromium test DOMs) run `task` directly:
+ * there is no second window to exclude there, and the caller's renderer-local
+ * lock still serializes attempts within this one.
+ */
+export const withSessionDrainClaim = async <T>(
+  key: string | null | undefined,
+  task: () => Promise<T>
+): Promise<null | T> => {
+  const sid = sidOf(key)
+
+  if (!sid) {
+    return null
+  }
+
+  const locks = typeof navigator === 'undefined' ? undefined : navigator.locks
+
+  if (!locks) {
+    return task()
+  }
+
+  return (await locks.request(`${STORAGE_KEY}.drain.${sid}`, { ifAvailable: true }, grant =>
+    grant ? task() : Promise.resolve(null)
+  )) as null | T
+}
+
 export const enqueueQueuedPrompt = (
   key: string | null | undefined,
   payload: { text: string; attachments: ComposerAttachment[] }
@@ -111,7 +181,7 @@ export const enqueueQueuedPrompt = (
     queuedAt: Date.now()
   }
 
-  writeSession(sid, [...queueFor(sid), entry])
+  mutateSession(sid, fresh => [...fresh, entry])
 
   return entry
 }
@@ -123,13 +193,17 @@ export const dequeueQueuedPrompt = (key: string | null | undefined): null | Queu
     return null
   }
 
-  const [head, ...rest] = queueFor(sid)
+  let head: null | QueuedPromptEntry = null
 
-  if (!head) {
-    return null
-  }
+  mutateSession(sid, fresh => {
+    if (fresh.length === 0) {
+      return null
+    }
 
-  writeSession(sid, rest)
+    head = fresh[0]!
+
+    return fresh.slice(1)
+  })
 
   return head
 }
@@ -141,16 +215,11 @@ export const removeQueuedPrompt = (key: string | null | undefined, id: string): 
     return false
   }
 
-  const queue = queueFor(sid)
-  const next = queue.filter(e => e.id !== id)
+  return mutateSession(sid, fresh => {
+    const next = fresh.filter(e => e.id !== id)
 
-  if (next.length === queue.length) {
-    return false
-  }
-
-  writeSession(sid, next)
-
-  return true
+    return next.length === fresh.length ? null : next
+  })
 }
 
 export const promoteQueuedPrompt = (key: string | null | undefined, id: string): boolean => {
@@ -160,17 +229,17 @@ export const promoteQueuedPrompt = (key: string | null | undefined, id: string):
     return false
   }
 
-  const queue = queueFor(sid)
-  const index = queue.findIndex(e => e.id === id)
+  return mutateSession(sid, fresh => {
+    const index = fresh.findIndex(e => e.id === id)
 
-  if (index <= 0) {
-    return false
-  }
+    if (index <= 0) {
+      return null
+    }
 
-  const entry = queue[index]!
-  writeSession(sid, [entry, ...queue.slice(0, index), ...queue.slice(index + 1)])
+    const entry = fresh[index]!
 
-  return true
+    return [entry, ...fresh.slice(0, index), ...fresh.slice(index + 1)]
+  })
 }
 
 export const updateQueuedPrompt = (
@@ -184,32 +253,27 @@ export const updateQueuedPrompt = (
     return false
   }
 
-  const queue = queueFor(sid)
-  let changed = false
+  return mutateSession(sid, fresh => {
+    let changed = false
 
-  const next = queue.map(entry => {
-    if (entry.id !== id) {
-      return entry
-    }
+    const next = fresh.map(entry => {
+      if (entry.id !== id) {
+        return entry
+      }
 
-    const attachments = update.attachments ? cloneAttachments(update.attachments) : entry.attachments
+      const attachments = update.attachments ? cloneAttachments(update.attachments) : entry.attachments
 
-    if (entry.text === update.text && !update.attachments) {
-      return entry
-    }
+      if (entry.text === update.text && !update.attachments) {
+        return entry
+      }
 
-    changed = true
+      changed = true
 
-    return { ...entry, text: update.text, attachments }
+      return { ...entry, text: update.text, attachments }
+    })
+
+    return changed ? next : null
   })
-
-  if (!changed) {
-    return false
-  }
-
-  writeSession(sid, next)
-
-  return true
 }
 
 export const updateQueuedPromptText = (key: string | null | undefined, id: string, text: string): boolean =>
@@ -218,11 +282,11 @@ export const updateQueuedPromptText = (key: string | null | undefined, id: strin
 export const clearQueuedPrompts = (key: string | null | undefined) => {
   const sid = sidOf(key)
 
-  if (!sid || !(sid in $queuedPromptsBySession.get())) {
+  if (!sid) {
     return
   }
 
-  writeSession(sid, [])
+  mutateSession(sid, fresh => (fresh.length === 0 ? null : []))
 }
 
 /**
@@ -240,15 +304,18 @@ export const migrateQueuedPrompts = (fromKey: string | null | undefined, toKey: 
     return false
   }
 
-  const pending = queueFor(from)
+  // Same operation-based rule as mutateSession, spanning two keys: both the
+  // migrated entries and the target queue come from the fresh persisted map,
+  // not the atom, so entries another window just enqueued are not dropped.
+  const next = { ...load() }
+  const pending = next[from] ?? []
 
   if (pending.length === 0) {
     return false
   }
 
-  const next = { ...load() }
   delete next[from]
-  next[to] = [...queueFor(to), ...pending]
+  next[to] = [...(next[to] ?? []), ...pending]
 
   $queuedPromptsBySession.set(next)
   save(next)
@@ -269,8 +336,9 @@ export interface AutoDrainInput {
  * idle and has pending entries, NOT only on an observed busy true → false edge.
  * A backend bounce / websocket reconnect remounts the composer and resets the
  * busy ref to the current value, swallowing the settle edge — an edge-gated
- * drain would then strand the entry forever. The caller's drain lock
- * (`drainingQueueRef`) serializes sends so being edge-free can't double-submit.
+ * drain would then strand the entry forever. Being edge-free can't
+ * double-submit: the caller serializes sends within a window (its drain ref)
+ * and across windows ({@link withSessionDrainClaim}).
  */
 export const shouldAutoDrain = ({ isBusy, queueLength }: AutoDrainInput): boolean => !isBusy && queueLength > 0
 


### PR DESCRIPTION
## What does this PR do?

Fixes cross-window contamination of the composer prompt queue: with several desktop windows open, a prompt queued in one window could silently vanish, resurrect after being drained, or **auto-drain and submit from a window the user never typed in**.

### Root cause

Every desktop window boots `$queuedPromptsBySession` from the same localStorage key (`hermes.desktop.composerQueue.v1`) and then never syncs again:

- no `storage` event listener anywhere — each window keeps a private, diverging snapshot of the *entire cross-session queue map*;
- every `save()` writes the window's whole snapshot back, so window B's next write clobbers entries window A enqueued after B booted;
- `runDrain()` picks the entry from the rendered React slice, so an entry another window already drained can double-submit;
- the auto-drain loop runs in **every** window, so whichever window's drain fires first sends the prompt — regardless of where the user typed it.

### Fix (3 small pieces, no architecture change)

1. **`composer-queue.ts`** — listen for `storage` events on the queue key and reload the atom. The event only fires in non-writing windows, so there's no self-echo to guard against.
2. **`writeSession()` / `migrateQueuedPrompts()`** — merge over `load()` (the live persisted map) instead of the in-memory atom, so a save can never revert a write that landed between sync events. The `storage` event is async in real browsers; this closes the same-frame race.
3. **`runDrain()`** — pick the entry from `getQueuedPrompts()` (live store) instead of the rendered slice, so a cross-window removal observed at send time stops a double-submit. Also drops a now-unneeded `queuedPrompts` dependency from the callback.

Single-window behavior is unchanged: `load()`/`save()` round-trip identical data and the listener never fires without a second window.

## Related Issue

Fixes #46732
Related: #46194 (queued follow-up state leaking across session switches — the storage-sync half of that report is covered here; the composer *UI-state* half is separate), #39086, #40394

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- 6 new vitest cases in `composer-queue.test.ts` (`cross-window sync (#46732)` describe block):
  - adopts another window's write into the local atom
  - does not clobber another window's entries when saving its own
  - merges over live storage even without a `storage` event (same-frame race)
  - drops entries locally once another window drains them
  - resyncs on full storage clear (`event.key === null`)
  - ignores storage events for unrelated keys
- `npx vitest run src/store/composer-queue.test.ts` → **20/20** (14 existing + 6 new)
- `npx vitest run src/app/chat/composer` → 42 pass / 1 fail — the failing `AttachmentList renders empty list without error` fails identically on a clean `main` checkout (verified via stash), pre-existing and unrelated
- `tsc -p . --noEmit` → clean
- `npx eslint` on all three touched files → no issues
- Manual repro on Windows 11: two windows on the same profile, queue a prompt in window A while its session is busy → before: window B's drain loop could submit it / A's entries disappeared after B queued anything; after: the queue stays consistent in both windows and drains exactly once.

## Screenshots (if applicable)

N/A — behavioral fix; the symptom is prompts appearing/vanishing across windows.

## Checklist

- [x] My code follows the repository's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
