### PR TITLE
fix(tools): scale tool-search auto-gate to the active session model's context length

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1049,10 +1049,26 @@ def init_agent(
         agent._tool_snapshot_generation = _snapshot_registry._generation
     except Exception:
         agent._tool_snapshot_generation = 0
+    # Resolve the session model's explicit context_length (config-only lookup,
+    # no endpoint probing) so the tool-search auto-gate scales its deferral
+    # threshold to THIS session's model. Without the hint the gate falls back
+    # to the global default model's window (_resolve_active_context_length),
+    # which mis-sizes the threshold whenever the session runs a different
+    # model — e.g. a 98K local model gated against a 256K cloud default.
+    _ts_context_length = None
+    try:
+        from hermes_cli.config import get_custom_provider_context_length
+        _ts_context_length = get_custom_provider_context_length(
+            model=agent.model,
+            base_url=agent.base_url,
+        )
+    except Exception:
+        _ts_context_length = None
     agent.tools = _ra().get_tool_definitions(
         enabled_toolsets=enabled_toolsets,
         disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        context_length=_ts_context_length,
     )
     
     # Show tool configuration and store valid tool names for validation

--- a/model_tools.py
+++ b/model_tools.py
@@ -281,6 +281,7 @@ def get_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    context_length: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -296,6 +297,13 @@ def get_tool_definitions(
             tool_search / tool_describe bridge handlers so they can read the
             real catalog, not the already-collapsed one. Public callers should
             leave this False.
+        context_length: Context window of the model this tool list is being
+            assembled for. Scales the tool-search auto-deferral threshold to
+            the active session's model. When None or <= 0, falls back to
+            ``_resolve_active_context_length()``, which can only see the
+            configured default model — wrong whenever the session runs a
+            different one (e.g. a small-context local model; see the gate
+            mis-sizing this causes in the linked issue).
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -323,6 +331,7 @@ def get_tool_definitions(
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
             bool(skip_tool_search_assembly),
+            int(context_length) if context_length and context_length > 0 else None,
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -335,7 +344,8 @@ def get_tool_definitions(
             return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+                                       skip_tool_search_assembly=skip_tool_search_assembly,
+                                       context_length=context_length)
     if quiet_mode:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -359,6 +369,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    context_length: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -545,7 +556,11 @@ def _compute_tool_definitions(
         from tools.tool_search import assemble_tool_defs, load_config as _load_ts_config
         ts_cfg = _load_ts_config()
         if not skip_tool_search_assembly and ts_cfg.enabled != "off":
-            context_length = _resolve_active_context_length()
+            # Prefer the caller-supplied context length (the session's actual
+            # model); fall back to the config-default-model heuristic only
+            # when the caller didn't know it.
+            if not context_length or context_length <= 0:
+                context_length = _resolve_active_context_length()
             assembly = assemble_tool_defs(
                 filtered_tools,
                 context_length=context_length,

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -536,3 +536,74 @@ class TestDisabledToolsetsPlatformBundle:
         from toolsets import bundle_non_core_tools
         # A non-existent bundle resolves to an empty set (no tools), not a crash.
         assert bundle_non_core_tools("hermes-does-not-exist") == set()
+
+
+# =========================================================================
+# Tool-search gate: context_length threading (active-model scaling)
+# =========================================================================
+
+class TestToolSearchGateContextLength:
+    """The tool-search auto-gate must be scaled to the ACTIVE session model's
+    context window, not the configured default model's. get_tool_definitions
+    accepts an explicit context_length for this; when omitted it falls back
+    to the legacy default-model heuristic. Regression guard for the case
+    where a small-context local-model session inherited a large default
+    model's threshold and never deferred its MCP schemas."""
+
+    def _capture_assembly(self, monkeypatch):
+        """Route assemble_tool_defs through a spy that records the
+        context_length the gate receives, without changing behavior."""
+        import model_tools
+        from tools import tool_search as ts
+
+        captured = []
+
+        def fake_assemble(tool_defs, *, context_length=None, config=None):
+            captured.append(context_length)
+            return ts.AssemblyResult(tool_defs=list(tool_defs), activated=False)
+
+        monkeypatch.setattr(ts, "assemble_tool_defs", fake_assemble)
+        # Force the gate to run regardless of user config.
+        monkeypatch.setattr(
+            ts, "load_config",
+            lambda: ts.ToolSearchConfig.from_raw({"enabled": "auto"}),
+        )
+        # Deterministic legacy fallback value.
+        monkeypatch.setattr(model_tools, "_resolve_active_context_length", lambda: 256_000)
+        model_tools._clear_tool_defs_cache()
+        return captured
+
+    def test_explicit_context_length_reaches_gate(self, monkeypatch):
+        import model_tools
+        captured = self._capture_assembly(monkeypatch)
+        model_tools.get_tool_definitions(quiet_mode=True, context_length=98_304)
+        assert captured == [98_304]
+
+    def test_omitted_context_length_falls_back_to_legacy_resolver(self, monkeypatch):
+        import model_tools
+        captured = self._capture_assembly(monkeypatch)
+        model_tools.get_tool_definitions(quiet_mode=True)
+        assert captured == [256_000]
+
+    def test_non_positive_context_length_falls_back(self, monkeypatch):
+        import model_tools
+        captured = self._capture_assembly(monkeypatch)
+        model_tools.get_tool_definitions(quiet_mode=True, context_length=0)
+        assert captured == [256_000]
+
+    def test_memo_cache_distinguishes_context_lengths(self, monkeypatch):
+        """Two sessions with different context lengths in one process must not
+        share a memoized assembly — a small-context session could otherwise
+        be served the large-context session's un-deferred tool list."""
+        import model_tools
+        captured = self._capture_assembly(monkeypatch)
+        model_tools.get_tool_definitions(quiet_mode=True, context_length=98_304)
+        model_tools.get_tool_definitions(quiet_mode=True, context_length=200_000)
+        assert captured == [98_304, 200_000]
+
+    def test_memo_cache_hits_for_same_context_length(self, monkeypatch):
+        import model_tools
+        captured = self._capture_assembly(monkeypatch)
+        model_tools.get_tool_definitions(quiet_mode=True, context_length=98_304)
+        model_tools.get_tool_definitions(quiet_mode=True, context_length=98_304)
+        assert captured == [98_304], "second call should be served from the memo cache"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4687,6 +4687,14 @@ def refresh_agent_mcp_tools(
     # published. ``registry._generation`` bumps on every (de)register.
     snapshot_generation = registry._generation
 
+    # Scale the tool-search auto-gate to THIS agent's model. By refresh time
+    # the context compressor holds the fully-resolved context length; without
+    # the hint the gate falls back to the config-default model's window (see
+    # get_tool_definitions docstring). None keeps the legacy fallback.
+    _gate_context_length = getattr(
+        getattr(agent, "context_compressor", None), "context_length", None
+    )
+
     # Registry-derived tools (built-ins + MCP), filtered to the agent's toolsets.
     # Computed OUTSIDE the lock (get_tool_definitions can be slow); the diff and
     # publish below happen together in ONE critical section so two concurrent
@@ -4696,6 +4704,7 @@ def refresh_agent_mcp_tools(
             enabled_toolsets=enabled,
             disabled_toolsets=disabled,
             quiet_mode=quiet_mode,
+            context_length=_gate_context_length,
         )
         or []
     )


### PR DESCRIPTION
Fixes #57520

## What

`tools.tool_search.enabled: auto` sizes its deferral threshold as `threshold_pct` × the model's context window, but `_resolve_active_context_length()` reads `config.model.default` rather than the session's model (its own docstring says "the active model's context length"). Any session on a non-default model is gated against the wrong window. Measured worst case in the linked issue: a 98K local-model session inherited a 256K default's threshold (25,600 tokens instead of 9,830), so its ~97 MCP schemas were always inline — a 3-message chat produced a 66,371-token prompt, ~50K of it tool schemas, at 67.5% of the model's window before the first user word.

## How

- `get_tool_definitions()` gains an optional `context_length` parameter used by the tool-search gate; `None`/`<= 0` falls back to the existing `_resolve_active_context_length()` heuristic, so all current call sites behave exactly as before.
- The value is part of the memo cache key: two sessions with different windows in one gateway process can no longer share an assembly (a small-context session could otherwise be served a large-context session's un-deferred tool list).
- `AIAgent` init passes the session model's config-declared context length via `get_custom_provider_context_length()` — the documented single source of truth for these overrides, config-only, no endpoint probing, wrapped in try/except so tool loading can never break.

## Footprint

+104/−2 across `model_tools.py`, `agent/agent_init.py`, `tests/test_model_tools.py`. No new dependencies, no behavior change for callers that don't pass the parameter.

## Tests

5 new behavior tests in `tests/test_model_tools.py` (`TestToolSearchGateContextLength`): explicit value reaches the gate, omitted/non-positive values fall back to the legacy resolver, and the memo cache distinguishes context lengths while still hitting for repeats. `tests/test_model_tools.py` 36/36 and `tests/tools/test_tool_search.py` all pass; the 3 failures in `tests/test_model_tools_async_bridge.py` are pre-existing on a clean checkout of 88d1d6206 in this environment (macOS) and untouched by this change.

## Verified premise

Confirmed on a live install by request-dumping the same session shape before/after: with the gate mis-scaled, 97 MCP schemas inline (~50K tokens); with the correct window (via the `enabled: "on"` workaround, equivalent gating outcome), 113 tools deferred and the prompt dropped to ~22.5K tokens. Log line showing the mis-scaled threshold while a 98K model was active: `tool_search activated: 33 core/visible tools kept, 83 deferred (~27409 tokens, threshold ~25600)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)