### PR TITLE
fix(install): normalize 8.3 TEMP when COM expansion fails

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -110,7 +110,10 @@ try {
 # which never write a side log to %TEMP% through a provider cmdlet -- complete
 # fine. Expanding %TEMP%/%TMP% back to their long form once, up front, lets
 # every downstream cmdlet (and child process) see a path the provider can
-# resolve. (GH: Windows desktop installer fails at Node/Electron stages.)
+# resolve. When 8.3 generation is disabled (or the alias is stale), COM
+# expansion fails too -- e.g. Stone.ZEN8 -> STONE~1.ZEN. Rebuild the default
+# profile temp dir from LocalApplicationData, which stays in long form.
+# (GH: Windows desktop installer fails at Node/Electron stages.)
 
 function ConvertTo-LongPath {
     param([string]$Path)
@@ -128,10 +131,34 @@ function ConvertTo-LongPath {
     return $Path
 }
 
+function Resolve-TempEnvPath {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $Path }
+
+    $expanded = ConvertTo-LongPath $Path
+    if ($expanded -notmatch '~\d') { return $expanded }
+
+    # COM couldn't expand the profile's 8.3 alias. For the standard per-user
+    # temp location (%LOCALAPPDATA%\Temp), rebuild from the long
+    # LocalApplicationData folder -- Windows keeps this in long form even when
+    # TEMP/TMP still point at STONE~1.ZEN-style aliases.
+    if ($Path -match '(?i)[\\/]AppData[\\/]Local[\\/]Temp(?:[\\/]|$)') {
+        $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
+        if ($localAppData -and $localAppData -notmatch '~\d') {
+            $defaultTemp = Join-Path $localAppData 'Temp'
+            $tail = $Path -replace '(?i)^.*[\\/]AppData[\\/]Local[\\/]Temp[\\/]?', ''
+            if ($tail) { return Join-Path $defaultTemp $tail }
+            return $defaultTemp
+        }
+    }
+
+    return $expanded
+}
+
 foreach ($tmpVar in @('TEMP', 'TMP')) {
     $current = [Environment]::GetEnvironmentVariable($tmpVar)
     if ($current) {
-        $expanded = ConvertTo-LongPath $current
+        $expanded = Resolve-TempEnvPath $current
         if ($expanded -and $expanded -ne $current) {
             Set-Item -Path "Env:$tmpVar" -Value $expanded
         }
@@ -3233,7 +3260,7 @@ function Install-Desktop {
             throw "apps/desktop build failed (exit $code)"
         }
         Write-Success "Desktop app built"
-        Remove-Item -Force $buildLog -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $buildLog -Force -ErrorAction SilentlyContinue
     } catch {
         if ($prevEAP) { $ErrorActionPreference = $prevEAP }
         Pop-Location

--- a/scripts/tests/test-install-ps1-longpath.ps1
+++ b/scripts/tests/test-install-ps1-longpath.ps1
@@ -1,17 +1,18 @@
-# Unit tests for install.ps1's ConvertTo-LongPath helper.
+# Unit tests for install.ps1's ConvertTo-LongPath / Resolve-TempEnvPath helpers.
 #
 # Run from a PowerShell prompt:
 #
 #   powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
 #
 # Background: on a Windows profile whose folder name contains a space (e.g.
-# "First Last"), %TEMP%/%TMP% can be exposed as an 8.3 short path
-# (C:\Users\FIRST~1.LAS\...). PowerShell's FileSystem provider chokes on the
-# "~1.ext" component when it reaches a provider cmdlet (Tee-Object -FilePath),
-# aborting the Node/Electron install+build stages. install.ps1 expands such
-# paths to their long form up front; this verifies the helper's contract.
+# "First Last") or a dot (e.g. "Stone.ZEN8"), %TEMP%/%TMP% can be exposed as
+# an 8.3 short path (C:\Users\FIRST~1.LAS\... or STONE~1.ZEN\...). PowerShell's
+# FileSystem provider chokes on the "~1.ext" component when it reaches a provider
+# cmdlet (Tee-Object -FilePath), aborting the Node/Electron install+build stages.
+# install.ps1 expands such paths to their long form up front; this verifies the
+# helper contracts.
 #
-# We extract just the function from install.ps1 via the AST so the installer's
+# We extract just the functions from install.ps1 via the AST so the installer's
 # top-level body never runs (dot-sourcing would execute the whole script).
 # The COM-backed expansion only fires for inputs containing "~<digit>"; the
 # pass-through and graceful-fallback paths are assertable on any host (incl.
@@ -40,21 +41,25 @@ function Assert-Equal {
     }
 }
 
-# --- Load ConvertTo-LongPath from install.ps1 without executing the script ---
-$tokens = $null
-$errors = $null
-$ast = [System.Management.Automation.Language.Parser]::ParseFile($installScript, [ref]$tokens, [ref]$errors)
-$fnAst = $ast.FindAll(
-    {
-        param($node)
-        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
-        $node.Name -eq 'ConvertTo-LongPath'
-    }, $true) | Select-Object -First 1
-
-if (-not $fnAst) {
-    throw "ConvertTo-LongPath not found in install.ps1 -- did the helper get renamed/removed?"
+function Load-InstallFunction {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($installScript, [ref]$tokens, [ref]$errors)
+    $fnAst = $ast.FindAll(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $Name
+        }, $true) | Select-Object -First 1
+    if (-not $fnAst) {
+        throw "$Name not found in install.ps1 -- did the helper get renamed/removed?"
+    }
+    . ([scriptblock]::Create($fnAst.Extent.Text))
 }
-. ([scriptblock]::Create($fnAst.Extent.Text))
+
+Load-InstallFunction 'ConvertTo-LongPath'
+Load-InstallFunction 'Resolve-TempEnvPath'
 
 # --- Tests ---
 Write-Host ""
@@ -75,12 +80,42 @@ Assert-Equal -Expected $noTilde -Actual (ConvertTo-LongPath $noTilde) -Label "ti
 $fakeShort = "C:\Users\FIRST~1.LAS\does\not\exist"
 Assert-Equal -Expected $fakeShort -Actual (ConvertTo-LongPath $fakeShort) -Label "nonexistent 8.3 path falls back to input"
 
+Write-Host ""
+Write-Host "-- Resolve-TempEnvPath --"
+
+Assert-Equal -Expected "" -Actual (Resolve-TempEnvPath "") -Label "empty string returns empty"
+Assert-Equal -Expected $longish -Actual (Resolve-TempEnvPath $longish) -Label "long temp path is unchanged"
+
+# Standard profile temp with an unresolvable 8.3 alias -> rebuilt from
+# LocalApplicationData (long form on every host).
+$shortProfileTemp = "C:\Users\STONE~1.ZEN\AppData\Local\Temp"
+$localAppData = [Environment]::GetFolderPath('LocalApplicationData')
+$expectedTemp = if ($localAppData -and $localAppData -notmatch '~\d') {
+    Join-Path $localAppData 'Temp'
+} else {
+    $shortProfileTemp
+}
+Assert-Equal -Expected $expectedTemp -Actual (Resolve-TempEnvPath $shortProfileTemp) -Label "short profile temp rebuilds from LocalApplicationData"
+
+# Subpaths under the default temp dir are preserved.
+$shortNested = "C:\Users\STONE~1.ZEN\AppData\Local\Temp\hermes-desktop-build-123.log"
+$expectedNested = if ($localAppData -and $localAppData -notmatch '~\d') {
+    Join-Path (Join-Path $localAppData 'Temp') 'hermes-desktop-build-123.log'
+} else {
+    $shortNested
+}
+Assert-Equal -Expected $expectedNested -Actual (Resolve-TempEnvPath $shortNested) -Label "short temp subpath is preserved"
+
+# Custom temp outside AppData\Local\Temp stays on the COM fallback path.
+$customShort = "D:\SHORT~1\Temp"
+Assert-Equal -Expected $customShort -Actual (Resolve-TempEnvPath $customShort) -Label "non-profile short temp is unchanged"
+
 # --- Summary ---
 Write-Host ""
 if ($failures -gt 0) {
     Write-Host "FAILED: $failures assertion(s) failed" -ForegroundColor Red
     exit 1
 } else {
-    Write-Host "All ConvertTo-LongPath tests passed." -ForegroundColor Green
+    Write-Host "All long-path helper tests passed." -ForegroundColor Green
     exit 0
 }


### PR DESCRIPTION
## Summary
- When `%TEMP%`/`%TMP%` still contain an unresolvable 8.3 profile alias after COM expansion (e.g. `Stone.ZEN8` → `C:\Users\STONE~1.ZEN\AppData\Local\Temp` with 8dot3 disabled), **normalize** the path to long `LocalApplicationData\Temp` before any Node/Electron stage runs.
- This is **path normalization only** — same physical temp directory, long spelling PowerShell can resolve. Not a system dependency escape hatch (cf. review on #52913).
- Use `-LiteralPath` when deleting the desktop build side-log so `~` in paths cannot be misinterpreted.

Follow-up to #49838. Fixes installer reporting failure after a successful desktop build (`An object at the specified path C:\Users\STONE~1.ZEN does not exist`).

## Test plan
- [ ] `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1`
- [ ] Windows profile with dotted username (`Stone.ZEN8`) or disabled 8dot3: full Hermes-Setup install completes desktop stage
- [ ] Normal profiles unchanged (long TEMP passes through untouched)