### PR TITLE
fix(api-server): add exclude_source query param to session listing

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1678,9 +1678,16 @@ class APIServerAdapter(BasePlatformAdapter):
         limit = self._parse_nonnegative_int(request.query.get("limit"), default=50, maximum=200)
         offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
         source = request.query.get("source") or None
+        exclude_source_raw = request.query.get("exclude_source") or None
+        exclude_sources = (
+            [s.strip() for s in exclude_source_raw.split(",") if s.strip()]
+            if exclude_source_raw
+            else None
+        )
         include_children = _coerce_request_bool(request.query.get("include_children"), default=False)
         sessions = db.list_sessions_rich(
             source=source,
+            exclude_sources=exclude_sources,
             limit=limit,
             offset=offset,
             include_children=include_children,

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -438,3 +438,45 @@ async def test_session_header_rejected_without_api_key(adapter, session_db):
         assert resp.status == 403
         data = await resp.json()
         assert "X-Hermes-Session-Key requires API key" in data["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_exclude_source(adapter, session_db):
+    """GET /api/sessions?exclude_source=cron filters out cron sessions.
+
+    The ``exclude_source`` query param is parsed as a comma-separated list
+    and forwarded to ``list_sessions_rich(exclude_sources=...)``.
+    """
+    session_db.create_session("chat-1", "cli")
+    session_db.create_session("cron-job-1", "cron")
+    session_db.create_session("chat-2", "telegram")
+    session_db.create_session("cron-job-2", "cron")
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        # Without filter — all sessions returned
+        resp = await cli.get("/api/sessions?limit=50")
+        assert resp.status == 200
+        data = await resp.json()
+        ids = {s["id"] for s in data["data"]}
+        assert "chat-1" in ids
+        assert "cron-job-1" in ids
+
+        # Exclude cron — cron sessions hidden
+        resp = await cli.get("/api/sessions?limit=50&exclude_source=cron")
+        assert resp.status == 200
+        data = await resp.json()
+        ids = {s["id"] for s in data["data"]}
+        assert "chat-1" in ids
+        assert "chat-2" in ids
+        assert "cron-job-1" not in ids
+        assert "cron-job-2" not in ids
+
+        # Exclude multiple sources
+        resp = await cli.get("/api/sessions?limit=50&exclude_source=cron,cli")
+        assert resp.status == 200
+        data = await resp.json()
+        ids = {s["id"] for s in data["data"]}
+        assert "chat-2" in ids
+        assert "chat-1" not in ids
+        assert "cron-job-1" not in ids


### PR DESCRIPTION
## What does this PR do?

Adds an `exclude_source` query parameter to `GET /api/sessions` in the API server. Clients can now filter out sessions by source (e.g., `?exclude_source=cron`) to keep the session listing clean.

The backend `list_sessions_rich()` already supports `exclude_sources` — this PR wires the missing query parameter through to the existing backend filter. The dashboard web server (`hermes_cli/web_server.py`) already had this parameter; this PR brings parity to the API server endpoint.

## Related Issue

Fixes #57527

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: Parse `exclude_source` query param (comma-separated) and forward as `exclude_sources` list to `list_sessions_rich()`
- `tests/gateway/test_session_api.py`: Add `test_list_sessions_exclude_source` — verifies single-source exclusion, multi-source exclusion, and backward compatibility (no param = no exclusion)

## How to Test

1. Run `python -m pytest tests/gateway/test_session_api.py -xvs` — all 14 tests should pass
2. Start the API server and create sessions with different sources
3. `GET /api/sessions?exclude_source=cron` should return only non-cron sessions
4. `GET /api/sessions?exclude_source=cron,cli` should exclude both sources
5. `GET /api/sessions` (no param) should return all sessions as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
