### PR TITLE
fix(tui_gateway): don't run /compress in the throwaway slash worker

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3951,6 +3951,38 @@ def test_command_dispatch_compress_runs_live_compression(monkeypatch):
     assert "Compressed: 4 → 2 messages" in out
 
 
+def test_compress_session_history_forces_manual_compress(monkeypatch):
+    """A user-initiated /compress must call _compress_context with force=True,
+    matching the CLI's _manual_compress (cli.py). Without it, a manual compress
+    silently no-ops for the summary-failure cooldown window left by a prior
+    auto-compaction abort. Auto-compaction is a separate path and stays
+    force=False.
+    """
+    captured = {}
+
+    class _Agent:
+        def _compress_context(
+            self, history, system_message, approx_tokens=None, focus_topic=None, force=False
+        ):
+            captured["force"] = force
+            return history[-2:], None
+
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
+    session = _session(
+        agent=_Agent(),
+        history=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ],
+    )
+
+    server._compress_session_history(session, None, approx_tokens=1000)
+
+    assert captured["force"] is True
+
+
 def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
     """When AIAgent._compress_context rotates session_id (compression split),
     the gateway session_key must follow so subsequent approval routing,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3840,6 +3840,71 @@ def test_session_compress_uses_compress_helper(monkeypatch):
     emit.assert_any_call("status.update", "sid", {"kind": "status", "text": "ready"})
 
 
+def test_slash_exec_compress_does_not_run_the_throwaway_worker(monkeypatch):
+    """Regression: desktop/TUI /compress is routed through slash.exec, which used
+    to run it BOTH in the throwaway slash worker (empty conversation_history, so
+    cli._manual_compress emits a bogus "(._.) Not enough conversation to compress")
+    AND on the live agent via _mirror_slash_side_effects. The two were returned as
+    {output, warning} and the client stitched them into one self-contradictory
+    reply. /compress must run ONLY the live-agent path and return a single coherent
+    output — never touching the worker.
+    """
+
+    class _BogusWorker:
+        def __init__(self):
+            self.called = False
+
+        def run(self, cmd):
+            self.called = True
+            return (
+                "(._.) Not enough conversation to compress "
+                "(need at least 4 messages)."
+            )
+
+    def _fake_compress(session, focus_topic=None, **_kw):
+        # Simulate a real compression on the live history: drop the head. The
+        # return value is ignored by the mirror path; the "4 → 2" output derives
+        # from the before/after history length.
+        with session["history_lock"]:
+            session["history"] = session["history"][-2:]
+
+    monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+    monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+
+    worker = _BogusWorker()
+    agent = types.SimpleNamespace()
+    server._sessions["sid"] = _session(
+        agent=agent,
+        history=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ],
+        slash_worker=worker,
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "compress", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    out = resp["result"]["output"]
+    # The throwaway worker must never run /compress (empty-history guard is bogus).
+    assert worker.called is False
+    # No empty-history guard leak, and no split output/warning contradiction.
+    assert "Not enough conversation" not in out
+    assert "warning" not in resp["result"]
+    # The live-agent compression summary is the single, primary output.
+    assert "Compressed: 4 → 2 messages" in out
+
+
 def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
     """When AIAgent._compress_context rotates session_id (compression split),
     the gateway session_key must follow so subsequent approval routing,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3862,15 +3862,18 @@ def test_slash_exec_compress_does_not_run_the_throwaway_worker(monkeypatch):
             )
 
     def _fake_compress(session, focus_topic=None, **_kw):
-        # Simulate a real compression on the live history: drop the head. The
-        # return value is ignored by the mirror path; the "4 → 2" output derives
-        # from the before/after history length.
+        # Simulate a real compression on the live history: drop the head. Returns
+        # (removed, usage) like the real _compress_session_history; the "4 → 2"
+        # output derives from the before/after history length.
         with session["history_lock"]:
             session["history"] = session["history"][-2:]
+        return 2, {}
 
     monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
     monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_status_update", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
 
     worker = _BogusWorker()
     agent = types.SimpleNamespace()
@@ -3917,11 +3920,14 @@ def test_command_dispatch_compress_runs_live_compression(monkeypatch):
     def _fake_compress(session, focus_topic=None, **_kw):
         with session["history_lock"]:
             session["history"] = session["history"][-2:]
+        return 2, {}
 
     monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": {}})
     monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
     monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_status_update", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
 
     server._sessions["sid"] = _session(
         agent=types.SimpleNamespace(),

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3905,6 +3905,52 @@ def test_slash_exec_compress_does_not_run_the_throwaway_worker(monkeypatch):
     assert "Compressed: 4 → 2 messages" in out
 
 
+def test_command_dispatch_compress_runs_live_compression(monkeypatch):
+    """Regression: the desktop/web clients call slash.exec for /compress and fall
+    back to command.dispatch when slash.exec throws (e.g. a slow compression trips
+    the client RPC timeout). command.dispatch had no compress branch, so the
+    fallback dead-ended in a bogus "not a quick/plugin/skill command: compress".
+    command.dispatch must run the same live-agent compression and return it as an
+    exec directive — never a 4018.
+    """
+
+    def _fake_compress(session, focus_topic=None, **_kw):
+        with session["history_lock"]:
+            session["history"] = session["history"][-2:]
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": {}})
+    monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+    monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+
+    server._sessions["sid"] = _session(
+        agent=types.SimpleNamespace(),
+        history=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ],
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {"name": "compress", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    # No 4018 dead-end; a coherent exec directive carrying the compression summary.
+    assert "error" not in resp
+    assert resp["result"]["type"] == "exec"
+    out = resp["result"]["output"]
+    assert "not a quick/plugin/skill command" not in out
+    assert "Compressed: 4 → 2 messages" in out
+
+
 def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
     """When AIAgent._compress_context rotates session_id (compression split),
     the gateway session_key must follow so subsequent approval routing,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11783,18 +11783,17 @@ def _(rid, params: dict) -> dict:
             )
 
     if name == "compress":
-        # slash.exec is the desktop/web client's primary path for /compress, but
-        # those clients fall back to command.dispatch whenever slash.exec throws
-        # (e.g. a slow compression trips the client's RPC timeout). Without a
-        # compress branch here that fallback dead-ended in a bogus
-        # "not a quick/plugin/skill command: compress". Run the same live-agent
-        # compression slash.exec does and hand it back as exec output.
-        if not session:
-            return _ok(rid, {"type": "exec", "output": "compress: no active session"})
-        result = _mirror_slash_side_effects(
-            params.get("session_id", ""), session, f"compress {arg}".strip()
+        # Desktop/web fall back to command.dispatch when slash.exec throws (e.g. a
+        # slow compression trips the client RPC timeout). Without a compress branch
+        # this dead-ended in "not a quick/plugin/skill command: compress". Route it
+        # through the TUI's session.compress handler for identical behavior.
+        return _ok(
+            rid,
+            {
+                "type": "exec",
+                "output": _compress_via_session_rpc(params.get("session_id", ""), arg),
+            },
         )
-        return _ok(rid, {"type": "exec", "output": result or "(no output)"})
 
     return _err(rid, 4018, f"not a quick/plugin/skill command: {name}")
 
@@ -12575,6 +12574,24 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     return ""
 
 
+def _compress_via_session_rpc(sid: str, focus_topic: str = "") -> str:
+    """Run /compress through the TUI's session.compress handler so desktop/web
+    (slash.exec, command.dispatch) behave exactly like the TUI: same compression
+    core + force, busy-guard, and "compressing…" progress status. Renders the
+    handler's structured result as the single output line the slash client shows.
+    """
+    resp = _methods["session.compress"](
+        None, {"session_id": sid, "focus_topic": focus_topic or ""}
+    )
+    if "error" in resp:
+        return resp["error"].get("message", "compress failed")
+    summary = (resp.get("result") or {}).get("summary") or {}
+    lines = [summary.get("headline", ""), summary.get("token_line", "")]
+    if summary.get("note"):
+        lines.append(summary["note"])
+    return "\n".join(x for x in lines if x) or "(no output)"
+
+
 @method("slash.exec")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
@@ -12648,15 +12665,17 @@ def _(rid, params: dict) -> dict:
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})
 
-    # /compress must skip the throwaway slash worker: that subprocess never enters
-    # run()/_preload_resumed_session(), so its conversation_history is empty and
-    # cli._manual_compress emits a bogus "not enough conversation to compress". The
-    # real compression already runs on the live agent in _mirror_slash_side_effects,
-    # so running both returned a contradictory output+warning pair. Run only the
-    # live-agent path.
+    # /compress runs through the TUI's session.compress handler, NOT the throwaway
+    # slash worker: that subprocess never enters run()/_preload_resumed_session(),
+    # so its history is empty and cli._manual_compress emits a bogus "not enough
+    # conversation to compress". Delegating to session.compress gives desktop/web
+    # the exact TUI behavior — same compression core + force, progress status, and
+    # busy-guard — instead of a bespoke slash.exec-only path.
     if _cmd_base == "compress":
-        result = _mirror_slash_side_effects(params.get("session_id", ""), session, cmd)
-        return _ok(rid, {"output": result or "(no output)"})
+        return _ok(
+            rid,
+            {"output": _compress_via_session_rpc(params.get("session_id", ""), _cmd_arg)},
+        )
 
     worker = session.get("slash_worker")
     if not worker:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2864,11 +2864,16 @@ def _compress_session_history(
     # cached prompt (which already contains the agent identity block)
     # makes the rebuild append the identity a second time. Mirrors the
     # CLI's _manual_compress fix for issue #15281.
+    # force=True mirrors the CLI's _manual_compress (cli.py): a user-initiated
+    # /compress clears any summary-failure cooldown left by a prior auto-compact
+    # abort and retries immediately, instead of silently no-opping for the
+    # cooldown window. Auto-compaction is a separate path and stays force=False.
     compressed, _ = agent._compress_context(
         history,
         None,
         approx_tokens=approx_tokens,
         focus_topic=focus_topic or None,
+        force=True,
     )
     with session["history_lock"]:
         if int(session.get("history_version", 0)) != history_version:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12629,6 +12629,16 @@ def _(rid, params: dict) -> dict:
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})
 
+    # /compress must skip the throwaway slash worker: that subprocess never enters
+    # run()/_preload_resumed_session(), so its conversation_history is empty and
+    # cli._manual_compress emits a bogus "not enough conversation to compress". The
+    # real compression already runs on the live agent in _mirror_slash_side_effects,
+    # so running both returned a contradictory output+warning pair. Run only the
+    # live-agent path.
+    if _cmd_base == "compress":
+        result = _mirror_slash_side_effects(params.get("session_id", ""), session, cmd)
+        return _ok(rid, {"output": result or "(no output)"})
+
     worker = session.get("slash_worker")
     if not worker:
         try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11777,6 +11777,20 @@ def _(rid, params: dict) -> dict:
                 },
             )
 
+    if name == "compress":
+        # slash.exec is the desktop/web client's primary path for /compress, but
+        # those clients fall back to command.dispatch whenever slash.exec throws
+        # (e.g. a slow compression trips the client's RPC timeout). Without a
+        # compress branch here that fallback dead-ended in a bogus
+        # "not a quick/plugin/skill command: compress". Run the same live-agent
+        # compression slash.exec does and hand it back as exec output.
+        if not session:
+            return _ok(rid, {"type": "exec", "output": "compress: no active session"})
+        result = _mirror_slash_side_effects(
+            params.get("session_id", ""), session, f"compress {arg}".strip()
+        )
+        return _ok(rid, {"type": "exec", "output": result or "(no output)"})
+
     return _err(rid, 4018, f"not a quick/plugin/skill command: {name}")
 
 


### PR DESCRIPTION
## What does this PR do?

Makes desktop/web `/compress` produce **one coherent result** instead of a self-contradictory reply or a bogus error. Two related defects on the desktop `/compress` path, one per commit.

## Fix 1 — `slash.exec` ran `/compress` twice (contradictory `{output, warning}`)

The self-contradictory reply, e.g.:

```
warning: No changes from compression: 87 messages
Approx request size: ~200,614 tokens (unchanged)
(._.) Not enough conversation to compress (need at least 4 messages).
```

87 messages vs. "need at least 4" can't both be true.

**Root cause:** the `slash.exec` handler (`tui_gateway/server.py`, `@method("slash.exec")`) ran `/compress` **twice**:

1. `output = worker.run(cmd)` — the throwaway `_SlashWorker` subprocess builds `HermesCLI(resume=…)` and calls `process_command()` directly, never entering the interactive `run()` loop that hydrates `conversation_history` via `_preload_resumed_session()`. Its history is therefore empty, so `cli._manual_compress` hits the `< 4` guard and prints `(._.) Not enough conversation to compress (need at least 4 messages).`
2. `warning = _mirror_slash_side_effects(...)` — because `name == "compress"`, this compresses the **live** agent's real history and returns the `summarize_manual_compression` summary.

Both were returned and the client stitched them into one contradictory message.

**Fix:** special-case `compress` in `slash.exec` to skip the throwaway worker entirely and return only the live-agent compression feedback as the primary `output` (no `warning`). The worker fundamentally can't do `compress` — even with hydrated history it would compress a throwaway copy that never reaches the live gateway session; the live-agent path (`_mirror_slash_side_effects`, added in #46686) is the one that does the real work.

## Fix 2 — `command.dispatch` fallback dead-ended for `/compress`

After Fix 1, `/compress` could still surface a confusing error:

```
/compress · error: not a quick/plugin/skill command: compress
```

**Root cause:** the desktop and web clients call `slash.exec` as the primary path for `/compress`, and **fall back to `command.dispatch` whenever `slash.exec` throws** — e.g. a slow live compression trips the client's RPC timeout (`apps/desktop/…/use-prompt-actions/slash.ts` `runExec`; `web/src/lib/slashExec.ts`; `ui-tui/src/app/createSlashHandler.ts` all share this pattern). `command.dispatch` (`tui_gateway/server.py`, `@method("command.dispatch")`) only handles quick/plugin/skill commands, so `compress` fell through to `return _err(rid, 4018, "not a quick/plugin/skill command: compress")` — a dead-end the client rendered as `error: …`.

**Fix:** add a `compress` branch to `command.dispatch` that runs the **same** live-agent compression as `slash.exec` (`_mirror_slash_side_effects`) and returns it as an `exec` directive. Both RPC entry points for `/compress` now converge on the one real compression path, so either the primary call or the fallback yields the same coherent summary — never the 4018.

## Scope

The **desktop (and web) clients are the ones that route `/compress` through `slash.exec` → `command.dispatch`**, so that is where both symptoms appear. The TUI sends `/compress` to the `session.compress` RPC (`ui-tui/src/app/slash/commands/session.ts`) and the ACP adapter has its own `_compress_context` handler (`acp_adapter/server.py`) — both already avoid these paths. Both fixes are backend-only in `tui_gateway/server.py` and touch no client code.

## Relationship to existing PRs (#44462, #53755)

Those two open PRs fix the desktop symptom of #44456 by rerouting the **desktop client** to call the `session.compress` RPC instead of `slash.exec`. This PR is complementary, not a duplicate: it fixes the defects at their **source** in `tui_gateway/server.py` so `slash.exec`/`command.dispatch` handle `/compress` coherently for *any* caller, rather than steering one client around them. The approaches are orthogonal and can land independently or together. Backend-only, touching none of the desktop files those PRs change.

## Related Issue

Fixes #57525

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`, `@method("slash.exec")` — before acquiring the slash worker, special-case `compress`: run only `_mirror_slash_side_effects(...)` and return `{"output": result or "(no output)"}`. No worker run, no split `warning`.
- `tui_gateway/server.py`, `@method("command.dispatch")` — before the final 4018, add a `compress` branch that runs `_mirror_slash_side_effects(...)` and returns `{"type": "exec", "output": …}` (with a no-session guard).
- `tests/test_tui_gateway_server.py` — two regression tests:
  - `test_slash_exec_compress_does_not_run_the_throwaway_worker` — `/compress` via `slash.exec` never calls the worker, returns a single coherent `Compressed: 4 → 2 messages`, no `Not enough conversation`, no `warning` key.
  - `test_command_dispatch_compress_runs_live_compression` — `/compress` via `command.dispatch` returns an `exec` directive with the compression summary, never the 4018 `not a quick/plugin/skill command`.

## How to Test

1. **Reproduce (before):** In the desktop app on a >4-message conversation, run `/compress` — you get the contradictory `warning:` + `(._.) Not enough…` reply, and (when the compression is slow enough to time out the primary call) a trailing `error: not a quick/plugin/skill command: compress`.
2. **Unit:** `uv run pytest tests/test_tui_gateway_server.py -k "compress and (throwaway_worker or command_dispatch)" -q` → passes.
3. **After:** `/compress` returns one coherent line — `Compressed: N → M messages / Approx request size: …`, or a clear no-op — from either the primary `slash.exec` call or the `command.dispatch` fallback, and never the `(._.) Not enough…` or `not a quick/plugin/skill command` lines.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tui_gateway): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (two commits, both on the desktop `/compress` path)
- [x] I've run the affected suite locally: `tests/test_tui_gateway_server.py` (all pass; the single unrelated `test_browser_manage_connect_default_local_reports_launch_hint` env-failure reproduces identically on clean `main`), plus `ruff check .` and `check-windows-footguns.py --all` (both clean). CI runs the full matrix.
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS (Darwin 25.5), and deployed both fixes to a live Linux gateway/dashboard.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior-only fix; rationale captured in inline comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (no platform-specific code; windows-footguns clean)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes / follow-ups (out of scope)

- The deeper root of Fix 2's fallback is that the live compression runs **synchronously** inside the `slash.exec` handler and can exceed the client RPC timeout. Making compression async / returning immediately with progress would remove the fallback entirely; left as future work. Fix 2 makes the fallback coherent in the meantime.
- `/compress here N` and `/compress --preview` are not wired through this desktop path (pre-existing gap — the mirror treats the whole arg as a focus topic). Not regressed here.
- `/save` may share the empty-worker-history issue (it isn't in `_PENDING_INPUT_COMMANDS`); worth a separate look.
