### PR TITLE
fix(qqbot): accept is_reconnect kwarg in connect() to match base adapter interface

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
Closes #52914

   Supersedes #52922, which was closed due to encoding artifacts in the diff
   (BOM + mojibake introduced by a local editor/PowerShell re-encoding pass —
   see OutThisLife's comment on #52922). This PR is a clean rebase onto
   current upstream/main; the diff is exactly the one-line signature change
   below, no unrelated formatting or encoding changes.

   `is_reconnect` was added to `BasePlatformAdapter.connect()` in commit
   43b8ba4 (fix(telegram): preserve Bot API update queue on watcher
   reconnect). QQAdapter was never updated to accept it, so the gateway's
   reconnect watcher raises `TypeError: QQAdapter.connect() got an
   unexpected keyword argument 'is_reconnect'` on every reconnect attempt,
   causing an infinite retry loop (see #52914 for full repro + logs).

   The flag is accepted and intentionally ignored — QQ has no server-side
   update queue to preserve, unlike Telegram.