### PR TITLE
fix(feishu): send markdown tables as post instead of forcing plain text

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4468,13 +4468,13 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        # Send markdown content (including tables) as 'post' message type.
+        # Feishu's post md tag renders standard markdown; tables are also
+        # rendered correctly when sent via post. The previous workaround that
+        # forced table content to plain text (msg_type="text") produced raw
+        # pipe-delimited output which was strictly worse.
+        # Refs: #21866, #27469
+        if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)


### PR DESCRIPTION
## Problem

When Hermes sends a Feishu message containing a markdown table, `_build_outbound_payload` detects the table via `_MARKDOWN_TABLE_RE` and forces `msg_type="text"`. This renders the table as raw pipe-delimited text (`| col | col |`), which is strictly worse than any alternative.

Related issues: #21866, #27469

## Fix

Remove the table→text fallback and let tables take the same `post` path as other markdown content. The `_MARKDOWN_TABLE_RE` regex now triggers the `post` branch (alongside `_MARKDOWN_HINT_RE`) instead of the `text` fallback.

```python
# Before
if _MARKDOWN_TABLE_RE.search(content):
    text_payload = {"text": content}
    return "text", json.dumps(text_payload, ensure_ascii=False)
if _MARKDOWN_HINT_RE.search(content):
    return "post", _build_markdown_post_payload(content)

# After
if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
    return "post", _build_markdown_post_payload(content)
```

## Safety

The existing `send_message()` method already catches post payload rejections from the Feishu API (`_POST_CONTENT_INVALID_RE`) and falls back to plain text with `_strip_markdown_to_plain_text()`. This safety net remains intact — if the post payload is rejected, the user still gets the message, just without formatting.

## Testing

Verified with the following markdown elements in Feishu client — all render correctly:

| Element | Status |
|---------|--------|
| Headers (H1-H3) | ✅ |
| Bold / Italic / Strikethrough | ✅ |
| Ordered / Unordered lists | ✅ |
| Code blocks (fenced) | ✅ |
| Inline code | ✅ |
| Blockquotes | ✅ |
| Tables | ✅ |
| Links | ✅ |
| Horizontal rules | ✅ |

## Notes

- For users with `hermes-lark-streaming` plugin installed, this code path is typically bypassed (streaming cards set `already_sent=True`), but the fix ensures correct behavior for all users regardless of plugin setup.
- The more comprehensive solution proposed in #27469 (using `msg_type="interactive"` Card 2.0 for tables) would be a separate enhancement. This PR is the minimal fix that removes the actively harmful fallback.