### PR TITLE
fix(cli): add vertex provider to HERMES_OVERLAYS for /model command

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -211,6 +211,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
+    "vertex": HermesOverlay(
+        transport="openai_chat",
+        auth_type="vertex",
+        base_url_override="https://aiplatform.googleapis.com",
+        extra_env_vars=("GOOGLE_APPLICATION_CREDENTIALS", "VERTEX_PROJECT_ID", "VERTEX_REGION"),
+    ),
 }
 
 
@@ -334,6 +340,12 @@ ALIASES: Dict[str, str] = {
     "aws-bedrock": "bedrock",
     "amazon-bedrock": "bedrock",
     "amazon": "bedrock",
+
+    # vertex
+    "google-vertex": "vertex",
+    "vertex-ai": "vertex",
+    "gcp-vertex": "vertex",
+    "google-cloud-vertex": "vertex",
 
     # arcee
     "arcee-ai": "arcee",

--- a/tests/hermes_cli/test_vertex_overlay.py
+++ b/tests/hermes_cli/test_vertex_overlay.py
@@ -1,0 +1,36 @@
+"""Regression test for vertex provider overlay (#57539).
+
+Ensures the ``vertex`` provider is present in ``HERMES_OVERLAYS`` and
+its aliases resolve correctly, so ``/model --provider vertex`` works
+from the CLI.
+"""
+
+from hermes_cli.providers import ALIASES, HERMES_OVERLAYS
+
+
+def test_vertex_in_overlays():
+    """Vertex must be registered in HERMES_OVERLAYS."""
+    assert "vertex" in HERMES_OVERLAYS
+
+
+def test_vertex_overlay_transport():
+    overlay = HERMES_OVERLAYS["vertex"]
+    assert overlay.transport == "openai_chat"
+    assert overlay.auth_type == "vertex"
+
+
+def test_vertex_overlay_base_url():
+    overlay = HERMES_OVERLAYS["vertex"]
+    assert overlay.base_url_override == "https://aiplatform.googleapis.com"
+
+
+def test_vertex_overlay_env_vars():
+    overlay = HERMES_OVERLAYS["vertex"]
+    assert "GOOGLE_APPLICATION_CREDENTIALS" in overlay.extra_env_vars
+    assert "VERTEX_PROJECT_ID" in overlay.extra_env_vars
+    assert "VERTEX_REGION" in overlay.extra_env_vars
+
+
+def test_vertex_aliases_resolve():
+    for alias in ("google-vertex", "vertex-ai", "gcp-vertex", "google-cloud-vertex"):
+        assert ALIASES.get(alias) == "vertex", f"Alias {alias!r} should resolve to 'vertex'"


### PR DESCRIPTION
## What does this PR do?

Adds the `vertex` provider to `HERMES_OVERLAYS` in `hermes_cli/providers.py` so the `/model --provider vertex` CLI command can resolve the provider. The vertex plugin works at runtime but the CLI's provider resolution path (overlay table) was never wired up when the plugin was merged.

## Related Issue

Fixes #57539

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/providers.py`: Added `vertex` entry to `HERMES_OVERLAYS` dict with `openai_chat` transport, `vertex` auth type, base URL override, and required env vars (`GOOGLE_APPLICATION_CREDENTIALS`, `VERTEX_PROJECT_ID`, `VERTEX_REGION`).
- `hermes_cli/providers.py`: Added vertex aliases (`google-vertex`, `vertex-ai`, `gcp-vertex`, `google-cloud-vertex`) to `ALIASES` dict for discoverability.
- `tests/hermes_cli/test_vertex_overlay.py`: New regression test verifying overlay entry, transport, auth, base URL, env vars, and alias resolution.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_vertex_overlay.py -q` — should pass 5 tests.
2. Run `python -m pytest tests/hermes_cli/test_api_key_providers.py -q` — should pass (no regressions).
3. Manual: `hermes` → `/model gemini-3-flash-preview --provider vertex` should not return "Unknown provider 'vertex'".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_vertex_overlay.py -q
5 passed in 0.38s
```
