### PR TITLE
fix(desktop): preserve explicit text code fences

### DIFF
--- a/apps/desktop/src/lib/markdown-code.test.ts
+++ b/apps/desktop/src/lib/markdown-code.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest'
 
-import { isLikelyProseCodeBlock } from './markdown-code'
+import { isLikelyProseCodeBlock, isLikelyProseFence } from './markdown-code'
+
+describe('isLikelyProseFence', () => {
+  it('keeps explicit text fences out of prose downgrade so the language tag cannot leak', () => {
+    expect(
+      isLikelyProseFence(
+        'text',
+        [
+          'apps/desktop/src/components/assistant-ui/thread.tsx',
+          'apps/desktop/src/lib/markdown-code.ts',
+          'apps/desktop/src/styles.css'
+        ].join('\n')
+      )
+    ).toBe(false)
+  })
+
+  it('still detects prose fences with list-marker info strings', () => {
+    expect(isLikelyProseFence('- Notes', ['first point', 'second point'].join('\n'))).toBe(true)
+  })
+})
 
 describe('isLikelyProseCodeBlock', () => {
   it('detects prose that Streamdown mislabels as an unknown language', () => {

--- a/apps/desktop/src/lib/markdown-code.ts
+++ b/apps/desktop/src/lib/markdown-code.ts
@@ -1,4 +1,5 @@
 const VALID_LANGUAGE_RE = /^[a-z0-9][a-z0-9+#-]*$/i
+const EXPLICIT_TEXT_FENCE_LANGUAGES = new Set(['text', 'plain', 'plaintext'])
 const NON_CODE_FENCE_LANGUAGES = new Set(['', 'text', 'plain', 'plaintext', 'md', 'markdown'])
 
 const COMMON_CODE_LANGUAGES = new Set([
@@ -282,6 +283,10 @@ export function isLikelyProseFence(info: string, body: string): boolean {
     return true
   }
 
+  if (EXPLICIT_TEXT_FENCE_LANGUAGES.has(language)) {
+    return false
+  }
+
   const signals = codeSignals(body)
 
   if (!signals.trimmed) {
@@ -311,6 +316,10 @@ export function isLikelyProseCodeBlock(language: string | undefined, code: strin
   const signals = codeSignals(code || '')
 
   if (!signals.trimmed || signals.codeSignals >= 3) {
+    return false
+  }
+
+  if (EXPLICIT_TEXT_FENCE_LANGUAGES.has(cleanLanguage)) {
     return false
   }
 

--- a/apps/desktop/src/lib/markdown-preprocess.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { preprocessMarkdown } from './markdown-preprocess'
+
+describe('preprocessMarkdown text fences', () => {
+  it('preserves explicit text fences instead of leaking the language tag into prose', () => {
+    const input = [
+      '```text',
+      'apps/desktop/src/components/assistant-ui/thread.tsx',
+      'apps/desktop/src/lib/markdown-code.ts',
+      'apps/desktop/src/styles.css',
+      '```'
+    ].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
+  it('preserves explicit plain text fences', () => {
+    const input = ['```plaintext', 'hello world', '```'].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Prevents explicit `text`, `plain`, and `plaintext` fenced blocks from being
downgraded to prose by the desktop Markdown preprocessor.

Previously, prose-like content such as file paths could trigger the heuristic,
causing the language tag (`text`) to leak into the rendered response. Explicit
plain-text fences now remain code blocks. The fix also corrects previously
persisted messages when they are rendered again; it does not depend on the
agent producing a new response.

## Related Issue

Fixes #57540

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve explicit `text`, `plain`, and `plaintext` fences in
  `apps/desktop/src/lib/markdown-code.ts`.
- Add regression coverage for fence classification and end-to-end Markdown
  preprocessing.
- Verify list-marker info strings continue to be treated as prose.

## How to Test

1. Open Hermes Desktop.
2. Ask the assistant to return several file paths inside an explicitly tagged
   `text` fence.
3. Confirm the paths remain inside a `Code · text` block and `text` does not
   leak into prose.
4. Continue the conversation or reload the persisted session and confirm the
   existing block still renders correctly.
5. Run:

   ```bash
   npm run test:ui --workspace apps/desktop -- \
     src/lib/markdown-code.test.ts \
     src/lib/markdown-preprocess.test.ts

   npm run typecheck --workspace apps/desktop
   npm exec --workspace apps/desktop eslint -- \
     src/lib/markdown-code.ts \
     src/lib/markdown-code.test.ts \
     src/lib/markdown-preprocess.test.ts
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — browser-side TypeScript logic with no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The before/after screenshots are attached to #57540. They show the same
persisted assistant message: before the fix, the `text` tag and file paths are
rendered as prose; after the fix, the message renders as a `Code · text` block.

Targeted verification completed:

- 2 test files, 6 tests passed
- Desktop TypeScript typecheck passed
- ESLint passed for all changed files
- Manual single-turn, multi-turn, and persisted-message Desktop rendering passed
