### PR TITLE
fix: keep Codex gpt-5.5 compaction notice out of gateway replay

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1887,23 +1887,18 @@ def init_agent(
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
         # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
+        # exact opt-back-out command. Keep it CLI-only: gateway replay would send
+        # this lifecycle hint as a chat/status message every time an agent is
+        # constructed, which is noisy for Telegram/Discord bot profiles.
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
         if _autoraise and compression_enabled:
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
-    # Check immediately so CLI users see the warning at startup.
-    # Gateway status_callback is not yet wired, so any warning is stored
-    # in _compression_warning and replayed in the first run_conversation().
+    # Check immediately so CLI users see real compression warnings at startup.
+    # Gateway status_callback is not yet wired, so feasibility warnings store
+    # in _compression_warning and replay in the first run_conversation(). The
+    # Codex gpt-5.5 autoraise notice intentionally does not use this slot.
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/tests/agent/test_codex_gpt55_gateway_notice.py
+++ b/tests/agent/test_codex_gpt55_gateway_notice.py
@@ -1,0 +1,41 @@
+"""Codex gpt-5.5 autoraise notice behavior.
+
+The threshold override is useful, but gateway replay of the informational notice
+can spam Telegram when agents are repeatedly constructed. Gateway users should
+not receive that lifecycle hint as a per-agent status message.
+"""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def test_codex_gpt55_autoraise_does_not_create_gateway_warning():
+    cfg = {
+        "compression": {
+            "enabled": True,
+            "threshold": 0.50,
+            "codex_gpt55_autoraise": True,
+        },
+        "memory": {"memory_enabled": False, "user_profile_enabled": False},
+        "tools": {},
+    }
+
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        agent = AIAgent(
+            model="gpt-5.5",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="test-token",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=[],
+            platform="telegram",
+        )
+
+    assert getattr(agent, "_compression_threshold_autoraised") == {"from": 0.50, "to": 0.85}
+    compressor = getattr(agent, "context_compressor")
+    assert compressor.threshold_tokens == int(compressor.context_length * 0.85)
+    assert getattr(agent, "_compression_warning") is None


### PR DESCRIPTION
## Summary
- Keeps the Codex gpt-5.5 compression-threshold autoraise notice CLI-only.
- Prevents gateway status replay from sending that lifecycle hint to Telegram/Discord bot sessions on repeated agent construction.
- Adds a regression test for the gateway construction path.

## Test Plan
- Red check on origin/main plus the regression test file: `scripts/run_tests.sh tests/agent/test_codex_gpt55_gateway_notice.py -k test_codex_gpt55_autoraise_does_not_create_gateway_warning -v` fails because `_compression_warning` contains the lifecycle notice.
- Green check on this branch: `scripts/run_tests.sh tests/agent/test_codex_gpt55_gateway_notice.py -k test_codex_gpt55_autoraise_does_not_create_gateway_warning -v` passes.
- Broader targeted check: `scripts/run_tests.sh tests/agent/test_codex_gpt55_gateway_notice.py -q` passes.
- Diff hygiene: `git diff --check origin/main...HEAD` passes.

## Notes
The threshold override remains intact. The only behavior removed is gateway replay of an informational startup notice that is useful in CLI but noisy for bots.