### PR TITLE
fix(toolsets): preserve core tools when a posture toolset is in disabled_toolsets (#57315)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -399,16 +399,19 @@ def _compute_tool_definitions(
     if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):
-                if toolset_name.startswith("hermes-"):
-                    # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS, so
-                    # subtracting the whole bundle would strip core tools shared
-                    # by other enabled toolsets and empty the tool list (#33924).
-                    # Subtract only the bundle's non-core delta; keep core.
-                    from toolsets import bundle_non_core_tools
+                from toolsets import bundle_non_core_tools, get_toolset
+                if toolset_name.startswith("hermes-") or (get_toolset(toolset_name) or {}).get("posture"):
+                    # Platform bundles (hermes-*) include _HERMES_CORE_TOOLS, and
+                    # posture toolsets (`posture: True`, e.g. `coding`) re-list
+                    # those same core tools without owning them, so subtracting
+                    # the whole toolset would strip core tools shared by other
+                    # enabled toolsets and empty the tool list (#33924, #57315).
+                    # Subtract only the non-core delta; keep core.
                     to_remove = bundle_non_core_tools(toolset_name)
                     tools_to_include.difference_update(to_remove)
                     resolved = sorted(to_remove)
-                    if not quiet_mode and toolset_name not in _WARNED_DISABLED_BUNDLES:
+                    if (not quiet_mode and toolset_name.startswith("hermes-")
+                            and toolset_name not in _WARNED_DISABLED_BUNDLES):
                         _WARNED_DISABLED_BUNDLES.add(toolset_name)
                         logger.info(
                             "agent.disabled_toolsets contains platform-bundle "

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -536,3 +536,54 @@ class TestDisabledToolsetsPlatformBundle:
         from toolsets import bundle_non_core_tools
         # A non-existent bundle resolves to an empty set (no tools), not a crash.
         assert bundle_non_core_tools("hermes-does-not-exist") == set()
+
+
+class TestDisabledToolsetsPostureToolset:
+    """Regression test for #57315: disabling a posture toolset (`coding`,
+    posture: True) must preserve the shared core tools it re-lists but does
+    not own -- same non-core-delta subtraction as hermes-* bundles (#33924) --
+    while atomic toolsets stay fully removable."""
+
+    def test_disabling_coding_preserves_core_but_atomic_disables_still_remove(self):
+        from model_tools import get_tool_definitions
+
+        # web_search is check_fn-gated (needs an API key); probe only the core
+        # tools actually present in baseline so gating cannot mask the fix.
+        core_probe = {"terminal", "read_file", "write_file", "web_search", "execute_code"}
+
+        baseline = {
+            t["function"]["name"]
+            for t in get_tool_definitions(quiet_mode=True)
+        }
+        present_core = core_probe & baseline
+        # Sanity: at least some probed core tools are available in this env.
+        assert present_core, "no probed core tools present in baseline"
+
+        no_coding = {
+            t["function"]["name"]
+            for t in get_tool_definitions(
+                disabled_toolsets=["coding"], quiet_mode=True
+            )
+        }
+        # Previously the full resolve_toolset("coding") subtraction stripped
+        # these shared core tools, collapsing the schema to a handful (#57315).
+        assert present_core <= no_coding, (
+            f"Core tools stripped by disabling 'coding': {present_core - no_coding}"
+        )
+
+        # Atomic (non-posture) toolsets must still be fully removable.
+        no_terminal = {
+            t["function"]["name"]
+            for t in get_tool_definitions(
+                disabled_toolsets=["terminal"], quiet_mode=True
+            )
+        }
+        assert "terminal" not in no_terminal
+
+        no_file = {
+            t["function"]["name"]
+            for t in get_tool_definitions(
+                disabled_toolsets=["file"], quiet_mode=True
+            )
+        }
+        assert "write_file" not in no_file


### PR DESCRIPTION
## Summary

`agent.disabled_toolsets` entries naming a *posture* toolset (`coding`) no longer strip the model's core tools. Previously `disabled_toolsets: ["coding"]` collapsed the full 34-tool schema down to a handful (`computer_use`/`text_to_speech`/`project_*`), taking `terminal`, `read_file`, `write_file`, `web_search`, `execute_code`, and the browser tools with it.

Root cause: in `model_tools._compute_tool_definitions`, the `disabled_toolsets` subtraction loop preserves shared core tools only for `hermes-*` platform bundles (#33924) — it subtracts just `bundle_non_core_tools()`. Every other name falls into the `else` branch and gets a full `resolve_toolset()` subtraction. `coding` is a posture toolset (`posture: True`) whose definition re-lists `_HERMES_CORE_TOOLS` it does not own, so the full subtraction removes those core tools out from under every other enabled toolset that legitimately provides them.

Only `coding` carries `posture: True`, so this is surgical: atomic toolsets stay fully removable (`terminal` disable still removes `terminal`, `file` disable still removes `write_file`). A blanket core-preservation would be wrong — many toolsets contain core tools, and preserving core for all of them would make `disabled_toolsets` a no-op for them.

## Changes

- **`model_tools.py`** `_compute_tool_definitions()`: extend the #33924 core-preserving branch to also match posture toolsets — treat a name as core-aggregating when `toolset_name.startswith("hermes-")` **or** `get_toolset(name)` has truthy `posture`, and subtract only `bundle_non_core_tools()` for it (for `coding` the non-core delta is empty, so disabling it removes nothing). The bundle-misconfiguration `logger.info` is gated to `hermes-*` names, since its wording is bundle-specific and `disabled_toolsets: [coding]` is a legitimate entry written by older `hermes setup` runs. The `else` full-subtraction path and legacy/unknown branches are unchanged; `toolsets.py` is untouched.
- **`tests/test_model_tools.py`**: add `TestDisabledToolsetsPostureToolset`, next to the existing `TestDisabledToolsetsPlatformBundle` (#33924) coverage.

## Validation

| Case | Before | After |
|---|---|---|
| `disabled_toolsets=["coding"]` | 34 → a handful; `terminal`/`read_file`/`write_file`/`web_search`/`execute_code` gone | 34, set-equal to baseline; all core present |
| `disabled_toolsets=["terminal"]` | `terminal` removed | `terminal` removed (unchanged) |
| `disabled_toolsets=["file"]` | `write_file` removed | `write_file` removed (unchanged) |

- Regression test is real (fail → pass): revert the `model_tools.py` hunk (keep the test) and `TestDisabledToolsetsPostureToolset` **fails** with the core tools in the stripped set; restore the fix and it **passes**.
- `pytest tests/test_model_tools.py` → **32 passed** (existing #33924 `TestDisabledToolsetsPlatformBundle` still green).
- `ruff check model_tools.py tests/test_model_tools.py` → All checks passed.
- Full CI is green on the fork for this exact head SHA, including the "All required checks pass" gate: https://github.com/bbopen/hermes-agent/actions/runs/28641297332 (upstream Actions haven't run yet pending first-contribution workflow approval).

## Relationship to #51586 / #57332

Both touch the same bug family (#57315); this PR is deliberately the minimal, general **runtime** fix, and the other pieces are complementary rather than competing:

- **#57332** (setup-time): stops `hermes setup` writing `coding` into Blank Slate `disabled_toolsets` on *new* installs. It doesn't help configs that already contain the entry and doesn't change the subtraction, so the runtime collapse stays reachable without this PR. The two can land independently.
- **#51586** (@dodo-reach) bundles three fixes. Its `model_tools.py` hunk addresses the same collapse by a narrower route — skipping subtraction when the posture toolset isn't in the explicitly-enabled surface — which doesn't cover default installs where `enabled_toolsets` isn't set. This PR fixes the mechanism generally (any `posture: True` toolset, any config shape), consistent with how #33924 already handles `hermes-*` bundles. #51586's `prompt-size` parity and setup changes are orthogonal and valuable; they can land independently of whichever runtime fix is picked, and I'm happy to coordinate or rebase either way.

Fixes the reproducible runtime collapse in #57315 (see my root-cause comment there). References: #33924 (the `hermes-*` core-preservation this extends).
