### PR TITLE
fix(agent): honor custom_providers per-model max_tokens at startup

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1592,6 +1592,55 @@ def init_agent(
                                     )
                     break
 
+    # Check custom_providers per-model max_tokens (output cap)
+    if agent.max_tokens is None and _custom_providers:
+        try:
+            from hermes_cli.config import get_custom_provider_max_tokens
+            _cp_mt_resolved = get_custom_provider_max_tokens(
+                model=agent.model,
+                base_url=agent.base_url,
+                custom_providers=_custom_providers,
+            )
+            if _cp_mt_resolved:
+                agent.max_tokens = int(_cp_mt_resolved)
+                agent._session_init_model_config["max_tokens"] = agent.max_tokens
+        except Exception:
+            _cp_mt_resolved = None
+
+        if agent.max_tokens is None:
+            _target = agent.base_url.rstrip("/") if agent.base_url else ""
+            for _cp_entry in _custom_providers:
+                if not isinstance(_cp_entry, dict):
+                    continue
+                _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
+                if _target and _cp_url == _target:
+                    _cp_models = _cp_entry.get("models", {})
+                    if isinstance(_cp_models, dict):
+                        _cp_model_cfg = _cp_models.get(agent.model, {})
+                        if isinstance(_cp_model_cfg, dict):
+                            _cp_mt = _cp_model_cfg.get("max_tokens")
+                            if _cp_mt is not None:
+                                try:
+                                    if isinstance(_cp_mt, bool):
+                                        raise ValueError
+                                    _parsed_mt = int(_cp_mt)
+                                    if _parsed_mt <= 0:
+                                        raise ValueError
+                                except (TypeError, ValueError):
+                                    _ra().logger.warning(
+                                        "Invalid max_tokens for model %r in "
+                                        "custom_providers: %r — must be a positive "
+                                        "integer. Falling back to provider default.",
+                                        agent.model, _cp_mt,
+                                    )
+                                    print(
+                                        f"\n⚠ Invalid max_tokens for model {agent.model!r} in custom_providers: {_cp_mt!r}\n"
+                                        f"  Must be a positive integer (e.g. 32000).\n"
+                                        f"  Falling back to provider default.\n",
+                                        file=sys.stderr,
+                                    )
+                    break
+
     # Persist for reuse on switch_model / fallback activation. Must come
     # AFTER the custom_providers branch so per-model overrides aren't lost.
     agent._config_context_length = _config_context_length

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4934,6 +4934,64 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_max_tokens(
+    model: str,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Look up a per-model ``max_tokens`` override from ``custom_providers``.
+
+    Matches any entry whose ``base_url`` equals ``base_url`` (trailing-slash
+    insensitive) and returns ``custom_providers[i].models.<model>.max_tokens``
+    if present and valid.  Returns ``None`` when no override applies.
+
+    Mirrors :func:`get_custom_provider_context_length` for output-token caps
+    (see #28046).
+    """
+    if not model or not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        raw_mt = model_cfg.get("max_tokens")
+        if raw_mt is None:
+            continue
+        try:
+            if isinstance(raw_mt, bool):
+                continue
+            mt = int(raw_mt)
+        except (TypeError, ValueError):
+            continue
+        if mt > 0:
+            return mt
+    return None
+
+
 def _coerce_config_version(value: Any) -> int:
     """Return a safe integer config version, treating invalid values as legacy."""
     if isinstance(value, bool):

--- a/tests/hermes_cli/test_custom_provider_max_tokens.py
+++ b/tests/hermes_cli/test_custom_provider_max_tokens.py
@@ -1,0 +1,75 @@
+"""Regression tests for custom_providers per-model max_tokens resolution.
+
+Covers the fix for #28046 — startup must honor
+``custom_providers[].models.<id>.max_tokens`` the same way it already does for
+``context_length``.
+"""
+from __future__ import annotations
+
+from hermes_cli.config import get_custom_provider_max_tokens
+
+
+class TestGetCustomProviderMaxTokens:
+    def test_returns_override_for_matching_entry(self):
+        custom = [
+            {
+                "name": "xfyun",
+                "base_url": "https://example.invalid/v2",
+                "models": {"astron-code-latest": {"max_tokens": 32_000}},
+            }
+        ]
+        assert (
+            get_custom_provider_max_tokens(
+                "astron-code-latest", "https://example.invalid/v2", custom
+            )
+            == 32_000
+        )
+
+    def test_trailing_slash_insensitive(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v2/",
+                "models": {"m": {"max_tokens": 16_000}},
+            }
+        ]
+        assert (
+            get_custom_provider_max_tokens(
+                "m", "https://example.invalid/v2", custom
+            )
+            == 16_000
+        )
+
+    def test_returns_none_when_url_does_not_match(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v2",
+                "models": {"m": {"max_tokens": 8_000}},
+            }
+        ]
+        assert (
+            get_custom_provider_max_tokens(
+                "m", "https://other.invalid/v2", custom
+            )
+            is None
+        )
+
+    def test_returns_none_for_bool_or_non_positive(self):
+        for bad in (True, False, 0, -1, "32K"):
+            custom = [
+                {
+                    "base_url": "https://example.invalid/v2",
+                    "models": {"m": {"max_tokens": bad}},
+                }
+            ]
+            assert (
+                get_custom_provider_max_tokens(
+                    "m", "https://example.invalid/v2", custom
+                )
+                is None
+            ), f"value {bad!r} should be rejected"
+
+    def test_empty_inputs_return_none(self):
+        assert get_custom_provider_max_tokens("", "http://x", [{"base_url": "http://x", "models": {"": {"max_tokens": 1}}}]) is None
+        assert get_custom_provider_max_tokens("m", "", [{"base_url": "", "models": {"m": {"max_tokens": 1}}}]) is None
+        assert get_custom_provider_max_tokens("m", "http://x", None) is None
+        assert get_custom_provider_max_tokens("m", "http://x", []) is None


### PR DESCRIPTION
## Summary
- Fixes #28046
- `context_length` already resolves from `custom_providers[].models.<id>.context_length` via `get_custom_provider_context_length()`; `max_tokens` had no equivalent, so sessions on custom OpenAI-compatible endpoints fell back to the 4096 output cap.
- Add `get_custom_provider_max_tokens()` (mirrors the context-length helper) and call it from `init_agent` when `model.max_tokens` is unset.

## Test plan
- [x] `pytest tests/hermes_cli/test_custom_provider_max_tokens.py`