### PR TITLE
fix(desktop): gift codicon on update-available toast

### DIFF
--- a/apps/desktop/src/components/notifications.tsx
+++ b/apps/desktop/src/components/notifications.tsx
@@ -116,7 +116,11 @@ function NotificationItem({ notification }: { notification: AppNotification }) {
       role={notification.kind === 'error' ? 'alert' : 'status'}
       variant="default"
     >
-      <Icon className={styles.iconClass} />
+      {notification.icon ? (
+        <Codicon className={styles.iconClass} name={notification.icon} size="1rem" />
+      ) : (
+        <Icon className={styles.iconClass} />
+      )}
       <div className="col-start-2 min-w-0">
         {notification.title && <AlertTitle className="col-start-auto">{notification.title}</AlertTitle>}
         <AlertDescription className="col-start-auto">

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -12,6 +12,8 @@ export interface NotificationAction {
 export interface AppNotification {
   id: string
   kind: NotificationKind
+  /** When set, renders this codicon instead of the default kind icon. */
+  icon?: string
   title?: string
   message: string
   detail?: string
@@ -23,6 +25,7 @@ export interface AppNotification {
 interface NotificationInput {
   id?: string
   kind?: NotificationKind
+  icon?: string
   title?: string
   message: string
   detail?: string
@@ -107,6 +110,7 @@ export function notify(input: NotificationInput): string {
   const notification: AppNotification = {
     id,
     kind,
+    icon: input.icon,
     title: input.title,
     message: input.message,
     detail: input.detail,

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -79,6 +79,7 @@ describe('maybeNotifyUpdateAvailable', () => {
   it('shows when an update is available and not snoozed', () => {
     maybeNotifyUpdateAvailable(status())
     expect(notifySpy).toHaveBeenCalledTimes(1)
+    expect(notifySpy.mock.calls[0]?.[0]).toMatchObject({ icon: 'gift' })
   })
 
   it('stays quiet for new commits once the toast was closed', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -185,6 +185,7 @@ export function maybeNotifyUpdateAvailable(status: DesktopUpdateStatus | null) {
       }
     },
     durationMs: 0,
+    icon: 'gift',
     id: UPDATE_TOAST_ID,
     kind: 'info',
     message: translateNow('notifications.updateReadyMessage', behind),


### PR DESCRIPTION
## Summary
- Add optional `icon` override to desktop notifications (renders a codicon instead of the default kind icon).
- Use `codicon-gift` on the "update available" toast so it reads as a present rather than generic info.

## Test plan
- [x] `npm --workspace apps/desktop run test:ui -- src/store/updates.test.ts`
- [ ] Launch Desktop, trigger an update-available state, confirm toast shows gift icon