### PR TITLE
fix(cron): normalize string repeat values

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -792,6 +792,24 @@ def _normalize_job_optional_text(value: Any, *, strip_trailing_slash: bool = Fal
     return text or None
 
 
+def _normalize_repeat_times(repeat: Any) -> Optional[int]:
+    """Normalize user/model supplied repeat counts.
+
+    The model tool schema asks for an integer, but LLMs occasionally pass
+    strings such as ``"once"`` for one-shot jobs. Treat non-numeric values as
+    unset so callers get the existing defaults (once for one-shot schedules,
+    forever for recurring schedules) instead of crashing on numeric
+    comparisons.
+    """
+    if repeat is None:
+        return None
+    try:
+        repeat_int = int(repeat)
+    except (TypeError, ValueError):
+        return None
+    return repeat_int if repeat_int > 0 else None
+
+
 def _compute_provider_model_snapshots(
     *,
     provider: Any,
@@ -851,7 +869,7 @@ def create_job(
     prompt: Optional[str],
     schedule: str,
     name: Optional[str] = None,
-    repeat: Optional[int] = None,
+    repeat: Optional[Union[int, str]] = None,
     deliver: Optional[str] = None,
     origin: Optional[Dict[str, Any]] = None,
     skill: Optional[str] = None,
@@ -915,9 +933,10 @@ def create_job(
     """
     parsed_schedule = parse_schedule(schedule)
 
-    # Normalize repeat: treat 0 or negative values as None (infinite)
-    if repeat is not None and repeat <= 0:
-        repeat = None
+    # Normalize repeat: treat non-numeric strings, 0, or negative values as
+    # None (infinite/default). Models sometimes pass repeat="once" even
+    # though the schema asks for an integer.
+    repeat = _normalize_repeat_times(repeat)
 
     # Auto-set repeat=1 for one-shot schedules if not specified
     if parsed_schedule["kind"] == "once" and repeat is None:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -305,6 +305,20 @@ class TestJobCRUD:
         job = create_job(prompt="One-shot", schedule="1h")
         assert job["repeat"]["times"] == 1
 
+    def test_repeat_once_string_on_one_shot_uses_auto_repeat(self, tmp_cron_dir):
+        """LLMs may pass repeat='once'; one-shot schedules should still run once."""
+        job = create_job(prompt="One-shot", schedule="1h", repeat="once")
+        assert job["repeat"]["times"] == 1
+
+    def test_repeat_once_string_on_recurring_is_infinite(self, tmp_cron_dir):
+        """Non-numeric repeat strings are treated as unset/infinite."""
+        job = create_job(prompt="Recurring", schedule="every 1h", repeat="once")
+        assert job["repeat"]["times"] is None
+
+    def test_repeat_numeric_string_is_coerced_to_int(self, tmp_cron_dir):
+        job = create_job(prompt="Twice", schedule="every 1h", repeat="2")
+        assert job["repeat"]["times"] == 2
+
     def test_interval_no_auto_repeat(self, tmp_cron_dir):
         job = create_job(prompt="Recurring", schedule="every 1h")
         assert job["repeat"]["times"] is None

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -309,6 +309,24 @@ class TestUnifiedCronjobTool:
         assert updated["job"]["name"] == "New Name"
         assert updated["job"]["schedule"] == "every 120m"
 
+    def test_update_repeat_once_string_is_normalized_to_infinite(self):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        job_id = created["job_id"]
+
+        updated = json.loads(cronjob(action="update", job_id=job_id, repeat="once"))
+
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "forever"
+
+    def test_update_repeat_numeric_string_is_coerced_to_int(self):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        job_id = created["job_id"]
+
+        updated = json.loads(cronjob(action="update", job_id=job_id, repeat="2"))
+
+        assert updated["success"] is True
+        assert updated["job"]["repeat"] == "2 times"
+
     def test_update_runtime_overrides_can_set_and_clear(self):
         created = json.loads(
             cronjob(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
+    _normalize_repeat_times,
     claim_job_for_fire,
     create_job,
     get_job,
@@ -652,7 +653,7 @@ def cronjob(
     prompt: Optional[str] = None,
     schedule: Optional[str] = None,
     name: Optional[str] = None,
-    repeat: Optional[int] = None,
+    repeat: Optional[Union[int, str]] = None,
     deliver: Optional[str] = None,
     include_disabled: bool = False,
     skill: Optional[str] = None,
@@ -932,8 +933,10 @@ def cronjob(
                         )
                 updates["no_agent"] = target_no_agent
             if repeat is not None:
-                # Normalize: treat 0 or negative as None (infinite)
-                normalized_repeat = None if repeat <= 0 else repeat
+                # Normalize: treat non-numeric strings, 0, or negative values
+                # as None (infinite/default). Models sometimes pass
+                # repeat="once" even though the schema asks for an integer.
+                normalized_repeat = _normalize_repeat_times(repeat)
                 repeat_state = dict(job.get("repeat") or {})
                 repeat_state["times"] = normalized_repeat
                 updates["repeat"] = repeat_state


### PR DESCRIPTION
## Summary
- Normalize cron `repeat` values before numeric comparison so strings like `"once"` do not crash create/update flows
- Preserve existing defaults: one-shot schedules auto-repeat once, recurring schedules stay forever when repeat is unset/non-numeric
- Coerce numeric repeat strings such as `"2"` to integer counts

Fixes #7142

## Test Plan
- [x] `scripts/run_tests.sh tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py -q`
- [x] `scripts/run_tests.sh tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py tests/tools/test_cronjob_run_immediate.py tests/cron/test_cronjob_schema.py -q`
- [x] `python3 -m compileall -q cron/jobs.py tools/cronjob_tools.py`
