### PR TITLE
fix(state): cascade-delete compression chain on session delete

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -118,6 +118,90 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
         conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", ids)
     return ids
 
+
+def _collect_compression_chain_ids(
+    conn: sqlite3.Connection, seed_ids: List[str]
+) -> List[str]:
+    """Walk compression chains bidirectionally from *seed_ids* and return
+    every session id that belongs to the same logical conversation.
+
+    When the dashboard lists sessions with ``project_compression_tips=True``,
+    compression chain roots are projected to show the tip's id / title /
+    message count.  If a user bulk-deletes the displayed (tip) id, the
+    underlying root — which still satisfies ``_LISTABLE_CHILD_SQL`` —
+    survives and reappears on the next page load, making the delete look
+    partial.
+
+    This helper walks **upstream** (child → parent where
+    ``end_reason='compression'``) and **downstream** (parent → child via
+    the same ``get_compression_tip`` ordering) so that deleting *any*
+    member of a chain deletes the entire chain.
+
+    Returns additional ids to delete (excludes *seed_ids* themselves so
+    callers don't double-count).
+    """
+    extra: set[str] = set()
+    # --- Walk upstream: find compression roots ---
+    queue = list(seed_ids)
+    visited_up: set[str] = set(seed_ids)
+    while queue:
+        current = queue.pop()
+        cursor = conn.execute(
+            "SELECT p.id FROM sessions p "
+            "JOIN sessions c ON c.parent_session_id = p.id "
+            "WHERE c.id = ? AND p.end_reason = 'compression'",
+            (current,),
+        )
+        row = cursor.fetchone()
+        if row:
+            pid = row["id"]
+            if pid not in visited_up:
+                visited_up.add(pid)
+                extra.add(pid)
+                queue.append(pid)
+
+    # --- Walk downstream: find compression tips ---
+    queue = list(seed_ids) + list(extra)
+    visited_down: set[str] = set(seed_ids) | extra
+    while queue:
+        current = queue.pop()
+        cursor = conn.execute(
+            """
+            SELECT child.id
+            FROM sessions parent
+            JOIN sessions child ON child.parent_session_id = parent.id
+            WHERE parent.id = ?
+              AND parent.end_reason = 'compression'
+              AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL
+              AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL
+              AND COALESCE(child.source, '') != 'tool'
+            ORDER BY
+              CASE
+                WHEN child.end_reason = 'compression' THEN 0
+                WHEN child.ended_at IS NULL THEN 1
+                ELSE 2
+              END,
+              COALESCE(
+                (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = child.id),
+                child.started_at
+              ) DESC,
+              child.started_at DESC,
+              child.id DESC
+            LIMIT 1
+            """,
+            (current,),
+        )
+        row = cursor.fetchone()
+        if row:
+            cid = row["id"]
+            if cid not in visited_down:
+                visited_down.add(cid)
+                extra.add(cid)
+                queue.append(cid)
+
+    return list(extra)
+
+
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
@@ -4720,6 +4804,7 @@ class SessionDB:
         session. Returns True if the session was found and deleted.
         """
         removed_delegate_ids: List[str] = []
+        removed_chain_ids: List[str] = []
 
         def _do(conn):
             cursor = conn.execute(
@@ -4727,21 +4812,28 @@ class SessionDB:
             )
             if cursor.fetchone()[0] == 0:
                 return False
-            removed_delegate_ids.extend(_delete_delegate_children(conn, [session_id]))
+            # Expand to include entire compression chain (#57543).
+            chain_extras = _collect_compression_chain_ids(conn, [session_id])
+            all_ids = [session_id] + chain_extras
+            removed_delegate_ids.extend(_delete_delegate_children(conn, all_ids))
             # Orphan remaining child sessions (branches, etc.) so FK is satisfied.
+            ph = ",".join("?" * len(all_ids))
             conn.execute(
-                "UPDATE sessions SET parent_session_id = NULL "
-                "WHERE parent_session_id = ?",
-                (session_id,),
+                f"UPDATE sessions SET parent_session_id = NULL "
+                f"WHERE parent_session_id IN ({ph})",
+                all_ids,
             )
-            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
-            conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+            conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", all_ids)
+            conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", all_ids)
+            removed_chain_ids.extend(chain_extras)
             return True
 
         deleted = self._execute_write(_do)
         if deleted:
             for delegate_id in removed_delegate_ids:
                 self._remove_session_files(sessions_dir, delegate_id)
+            for chain_id in removed_chain_ids:
+                self._remove_session_files(sessions_dir, chain_id)
             self._remove_session_files(sessions_dir, session_id)
         return bool(deleted)
 
@@ -4839,6 +4931,15 @@ class SessionDB:
             existing = [row["id"] for row in cursor.fetchall()]
             if not existing:
                 return 0
+
+            # Expand the deletion set to include entire compression
+            # chains.  The dashboard projects chain roots to show the
+            # tip's id/title, so a bulk-delete sends tip ids; without
+            # expansion the orphaned root survives and reappears on the
+            # next page load (#57543).
+            chain_extras = _collect_compression_chain_ids(conn, existing)
+            if chain_extras:
+                existing = list(set(existing) | set(chain_extras))
 
             existing_placeholders = ",".join("?" * len(existing))
             removed_delegate_ids.extend(_delete_delegate_children(conn, existing))

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1775,6 +1775,104 @@ class TestDeleteAndExport:
     def test_delete_nonexistent(self, db):
         assert db.delete_session("nope") is False
 
+    def test_delete_session_cascades_compression_chain(self, db):
+        """Deleting a compression tip must also remove the chain root."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        # root → mid (compression continuation) → tip
+        db.create_session("root", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0, "root")
+        )
+        db.append_message("root", "user", "first")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason='compression' WHERE id=?",
+            (t0 + 100, "root"),
+        )
+
+        db.create_session("mid", "cli", parent_session_id="root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 101, "mid")
+        )
+        db.append_message("mid", "user", "second")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason='compression' WHERE id=?",
+            (t0 + 200, "mid"),
+        )
+
+        db.create_session("tip", "cli", parent_session_id="mid")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 201, "tip")
+        )
+        db.append_message("tip", "user", "third")
+        db._conn.commit()
+
+        # Delete the tip — root and mid should be cascade-deleted too.
+        assert db.delete_session("tip") is True
+        assert db.get_session("tip") is None
+        assert db.get_session("mid") is None
+        assert db.get_session("root") is None
+
+    def test_delete_session_chain_root_cascades_to_tip(self, db):
+        """Deleting a compression root must also remove the tip."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("root", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0, "root")
+        )
+        db.append_message("root", "user", "first")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason='compression' WHERE id=?",
+            (t0 + 100, "root"),
+        )
+
+        db.create_session("tip", "cli", parent_session_id="root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 101, "tip")
+        )
+        db.append_message("tip", "user", "second")
+        db._conn.commit()
+
+        assert db.delete_session("root") is True
+        assert db.get_session("root") is None
+        assert db.get_session("tip") is None
+
+    def test_delete_sessions_bulk_cascades_compression_chains(self, db):
+        """Bulk delete must expand compression chains for every id."""
+        import time as _time
+
+        t0 = _time.time() - 3600
+        # Chain 1: root1 → tip1
+        db.create_session("root1", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0, "root1")
+        )
+        db.append_message("root1", "user", "a")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason='compression' WHERE id=?",
+            (t0 + 100, "root1"),
+        )
+        db.create_session("tip1", "cli", parent_session_id="root1")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 101, "tip1")
+        )
+        db.append_message("tip1", "user", "b")
+
+        # Standalone session (no chain)
+        db.create_session("standalone", "cli")
+        db.append_message("standalone", "user", "c")
+        db._conn.commit()
+
+        # Bulk delete tip1 + standalone — root1 should be cascade-deleted.
+        deleted = db.delete_sessions(["tip1", "standalone"])
+        assert deleted == 3  # tip1 + root1 + standalone
+        assert db.get_session("tip1") is None
+        assert db.get_session("root1") is None
+        assert db.get_session("standalone") is None
+
     def test_resolve_session_id_exact(self, db):
         db.create_session(session_id="20260315_092437_c9a6ff", source="cli")
         assert db.resolve_session_id("20260315_092437_c9a6ff") == "20260315_092437_c9a6ff"


### PR DESCRIPTION
## What does this PR do?

Fixes bulk session deletion in the dashboard where deleting multiple sessions at once would leave compression chain roots behind, making it look like "some sessions weren't deleted."

When `list_sessions_rich(project_compression_tips=True)` lists sessions, compression chain roots are projected to show the tip's id/title/message_count. The dashboard sends these tip IDs for deletion. However, `delete_session()` and `delete_sessions()` only deleted the exact IDs received — leaving the underlying compression root sessions (which still satisfy `_LISTABLE_CHILD_SQL` as `parent_session_id IS NULL`) intact. After reload, these orphaned roots reappeared in the list.

## Related Issue

Fixes #57543

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: Added `_collect_compression_chain_ids()` helper that walks compression chains bidirectionally (upstream to find roots via `end_reason='compression'` parents, downstream to find tips via `get_compression_tip` ordering) and returns all related session IDs.
- `hermes_state.py`: Modified `delete_session()` to expand the deletion set to include the full compression chain before deleting.
- `hermes_state.py`: Modified `delete_sessions()` to expand the deletion set similarly, so bulk-delete from the dashboard correctly removes entire chains.
- `tests/test_hermes_state.py`: Added 3 regression tests covering tip→root cascade, root→tip cascade, and bulk delete with mixed chain/standalone sessions.

## How to Test

1. Create a compression chain: start a session, compress it (creating a continuation), then compress again.
2. In `hermes dashboard`, select the projected session (which shows the tip's data) and delete it.
3. Reload the page — the compression root should NOT reappear.
4. Run `python -m pytest tests/test_hermes_state.py::TestDeleteAndExport -x -q` — all 13 tests should pass (including the 3 new ones).
5. Run `python -m pytest tests/test_hermes_state.py -x -q` — all 306 tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_hermes_state.py -q` and all 306 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
