### PR TITLE
fix(cli): store custom endpoint API key in .env instead of config.yaml

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3726,7 +3726,8 @@ def _custom_provider_base_url_config_value(provider_info, resolved_base_url=""):
 
 
 def _save_custom_provider(
-    base_url, api_key="", model="", context_length=None, name=None, api_mode=None
+    base_url, api_key="", model="", context_length=None, name=None, api_mode=None,
+    key_env="",
 ):
     """Save a custom endpoint to custom_providers in config.yaml.
 
@@ -3764,6 +3765,12 @@ def _save_custom_provider(
             elif "api_mode" in entry:
                 entry.pop("api_mode", None)
                 changed = True
+            # Update key_env if provided (key stored in .env, not config)
+            if key_env and entry.get("key_env") != key_env:
+                entry["key_env"] = key_env
+                # Remove any stale raw api_key — the env var is authoritative
+                entry.pop("api_key", None)
+                changed = True
             if changed:
                 cfg["custom_providers"] = providers
                 save_config(cfg)
@@ -3774,7 +3781,9 @@ def _save_custom_provider(
         name = _auto_provider_name(base_url)
 
     entry = {"name": name, "base_url": base_url}
-    if api_key:
+    if key_env:
+        entry["key_env"] = key_env
+    elif api_key:
         entry["api_key"] = api_key
     if model:
         entry["model"] = model

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -27,6 +27,45 @@ import subprocess
 from hermes_cli.config import clear_model_endpoint_credentials
 
 
+def _derive_custom_endpoint_env_var(base_url: str) -> str:
+    """Derive an environment variable name from a custom endpoint URL.
+
+    Examples:
+        ``https://api.featherless.ai/v1`` => ``FEATHERLESS_API_KEY``
+        ``https://api.openai.com/v1``     => ``OPENAI_API_KEY``
+        ``http://localhost:11434/v1``      => ``LOCALHOST_11434_API_KEY``
+    """
+    import re
+    from urllib.parse import urlparse
+
+    parsed = urlparse(base_url)
+    hostname = (parsed.hostname or "").lower()
+
+    # Include port for non-standard ports (e.g. localhost:11434)
+    if parsed.port and parsed.port not in (80, 443):
+        hostname = f"{hostname}_{parsed.port}"
+
+    # Strip common prefixes
+    for prefix in ("api.", "api-", "openai."):
+        if hostname.startswith(prefix):
+            hostname = hostname[len(prefix):]
+            break
+
+    # Strip common TLDs
+    for tld in (".ai", ".com", ".io", ".dev", ".org", ".net", ".xyz"):
+        if hostname.endswith(tld):
+            hostname = hostname[: -len(tld)]
+            break
+
+    # Replace remaining dots/colons/hyphens with underscores
+    hostname = re.sub(r"[^a-z0-9]+", "_", hostname).strip("_")
+
+    if not hostname:
+        hostname = "custom"
+
+    return f"{hostname.upper()}_API_KEY"
+
+
 def _prompt_auth_credentials_choice(title: str) -> str:
     """Prompt for reuse / reauthenticate / cancel with the standard radio UI.
 
@@ -732,7 +771,7 @@ def _model_flow_custom(config):
     """
     from hermes_cli.main import _auto_provider_name, _prompt_custom_api_mode_selection, _save_custom_provider
     from hermes_cli.auth import _save_model_choice, deactivate_provider
-    from hermes_cli.config import get_env_value, load_config, save_config
+    from hermes_cli.config import get_env_value, load_config, save_config, save_env_value
     from hermes_cli.secret_prompt import masked_secret_prompt
 
     current_url = get_env_value("OPENAI_BASE_URL") or ""
@@ -767,6 +806,14 @@ def _model_flow_custom(config):
         return
 
     effective_key = api_key or current_key
+
+    # Save API key to .env instead of config.yaml to prevent credential
+    # leakage when Hermes edits its own config (#57547).
+    _custom_key_env = ""
+    if effective_key:
+        _custom_key_env = _derive_custom_endpoint_env_var(effective_url)
+        save_env_value(_custom_key_env, effective_key)
+        print(f"  🔑 API key saved to .env as {_custom_key_env}")
 
     # Hint: most local model servers (Ollama, vLLM, llama.cpp) require /v1
     # in the base URL for OpenAI-compatible chat completions.  Prompt the
@@ -898,7 +945,9 @@ def _model_flow_custom(config):
             cfg["model"] = model
         model["provider"] = "custom"
         model["base_url"] = effective_url
-        if effective_key:
+        if _custom_key_env:
+            model["api_key"] = f"${{{_custom_key_env}}}"
+        elif effective_key:
             model["api_key"] = effective_key
         if api_mode:
             model["api_mode"] = api_mode
@@ -924,7 +973,9 @@ def _model_flow_custom(config):
             _caller_model = {"default": _caller_model} if _caller_model else {}
         _caller_model["provider"] = "custom"
         _caller_model["base_url"] = effective_url
-        if effective_key:
+        if _custom_key_env:
+            _caller_model["api_key"] = f"${{{_custom_key_env}}}"
+        elif effective_key:
             _caller_model["api_key"] = effective_key
         if api_mode:
             _caller_model["api_mode"] = api_mode
@@ -941,6 +992,7 @@ def _model_flow_custom(config):
         context_length=context_length,
         name=display_name,
         api_mode=api_mode,
+        key_env=_custom_key_env,
     )
 
 def _model_flow_azure_foundry(config, current_model=""):

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -754,9 +754,10 @@ def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
     )
     monkeypatch.setattr("hermes_cli.config.load_config", lambda: saved_cfg)
     monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_cfg.update(cfg))
+    monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
     monkeypatch.setattr(
         "hermes_cli.main._save_custom_provider",
-        lambda base_url, api_key="", model="", context_length=None, name=None, api_mode=None: captured_provider.update(
+        lambda base_url, api_key="", model="", context_length=None, name=None, api_mode=None, key_env="": captured_provider.update(
             {
                 "base_url": base_url,
                 "api_key": api_key,
@@ -764,6 +765,7 @@ def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
                 "context_length": context_length,
                 "name": name,
                 "api_mode": api_mode,
+                "key_env": key_env,
             }
         ),
     )
@@ -784,9 +786,11 @@ def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
 
     assert saved_cfg["model"]["provider"] == "custom"
     assert saved_cfg["model"]["base_url"] == "https://codex.example.com/v1"
-    assert saved_cfg["model"]["api_key"] == "test-key"
+    # API key is now stored as env var reference, not raw value (#57547)
+    assert saved_cfg["model"]["api_key"] == "${CODEX_EXAMPLE_API_KEY}"
     assert saved_cfg["model"]["api_mode"] == "codex_responses"
     assert captured_provider["api_mode"] == "codex_responses"
+    assert captured_provider["key_env"] == "CODEX_EXAMPLE_API_KEY"
 
 
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):
@@ -882,3 +886,17 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
     entries = saved.get("custom_providers", [])
     assert len(entries) == 1
     assert entries[0]["name"] == "Ollama"
+
+def test_derive_custom_endpoint_env_var():
+    """_derive_custom_endpoint_env_var strips prefix/TLD and uppercases."""
+    from hermes_cli.model_setup_flows import _derive_custom_endpoint_env_var
+
+    assert _derive_custom_endpoint_env_var("https://api.featherless.ai/v1") == "FEATHERLESS_API_KEY"
+    assert _derive_custom_endpoint_env_var("https://api.openai.com/v1") == "OPENAI_API_KEY"
+    assert _derive_custom_endpoint_env_var("https://openrouter.ai/api/v1") == "OPENROUTER_API_KEY"
+    assert _derive_custom_endpoint_env_var("http://localhost:11434/v1") == "LOCALHOST_11434_API_KEY"
+    assert _derive_custom_endpoint_env_var("https://together.xyz/v1") == "TOGETHER_API_KEY"
+    assert _derive_custom_endpoint_env_var("https://api.groq.com/openai/v1") == "GROQ_API_KEY"
+    assert _derive_custom_endpoint_env_var("http://127.0.0.1:8080/v1") == "127_0_0_1_8080_API_KEY"
+    assert _derive_custom_endpoint_env_var("https://custom.endpoint.dev/v1") == "CUSTOM_ENDPOINT_API_KEY"
+


### PR DESCRIPTION
## What does this PR do?

When configuring a "Custom endpoint" via `hermes model`, the API key was stored
directly in `config.yaml` under `model.api_key` and `custom_providers[].api_key`.
This is a security concern: when Hermes edits its own config file, the raw API key
can leak into the model's context window.

This fix derives an environment variable name from the endpoint hostname (e.g.
`api.featherless.ai` → `FEATHERLESS_API_KEY`), saves the key to `~/.hermes/.env`,
and stores a `${VAR}` reference in `config.yaml` instead. The existing
`_expand_env_vars()` mechanism in `load_config()` resolves these references at
runtime.

## Related Issue

Fixes #57547

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/model_setup_flows.py`: Added `_derive_custom_endpoint_env_var()` helper that extracts the hostname from a custom endpoint URL, strips common prefixes/TLDs, and produces an `UPPER_SNAKE_CASE_API_KEY` env var name.
- `hermes_cli/model_setup_flows.py`: Modified `_model_flow_custom()` to save the API key to `~/.hermes/.env` via `save_env_value()` and store `${ENV_VAR}` reference in `config.yaml` instead of the raw key.
- `hermes_cli/main.py`: Extended `_save_custom_provider()` with a `key_env` parameter. When provided, stores `key_env` (not raw `api_key`) in the `custom_providers` entry. The runtime already resolves `key_env` via `os.getenv()` in `auxiliary_client.py`.
- `tests/cli/test_cli_provider_resolution.py`: Updated `test_model_flow_custom_persists_selected_api_mode` to expect `${CODEX_EXAMPLE_API_KEY}` instead of the raw key, and to verify `key_env` propagation. Added `test_derive_custom_endpoint_env_var` covering 8 URL patterns.

## How to Test

1. Run `python -m pytest tests/cli/test_cli_provider_resolution.py -x -q` — all 24 tests should pass.
2. Run `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -x -q -k "custom"` — all 48 tests should pass.
3. Manual: run `hermes model`, select "Custom endpoint", enter a URL and API key. Verify the key appears in `~/.hermes/.env` (not in `config.yaml`) and that `${ENV_VAR}` is stored in `config.yaml` under `model.api_key`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cli/test_cli_provider_resolution.py -q` and all 24 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python, `urllib.parse` and `save_env_value` are cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
