### PR TITLE
fix(cli): add vertex provider to HERMES_OVERLAYS for /model resolution

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -211,6 +211,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
+    "vertex": HermesOverlay(
+        transport="openai_chat",
+        auth_type="vertex",
+        base_url_override="https://aiplatform.googleapis.com",
+        extra_env_vars=("VERTEX_CREDENTIALS_PATH", "GOOGLE_APPLICATION_CREDENTIALS", "VERTEX_PROJECT_ID", "VERTEX_REGION"),
+    ),
 }
 
 
@@ -335,6 +341,12 @@ ALIASES: Dict[str, str] = {
     "amazon-bedrock": "bedrock",
     "amazon": "bedrock",
 
+    # vertex
+    "google-vertex": "vertex",
+    "vertex-ai": "vertex",
+    "gcp-vertex": "vertex",
+    "vertexai": "vertex",
+
     # arcee
     "arcee-ai": "arcee",
     "arceeai": "arcee",
@@ -371,6 +383,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "lmstudio": "LM Studio",
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
+    "vertex": "Google Vertex AI",
     "ollama-cloud": "Ollama Cloud",
     "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
 }

--- a/tests/hermes_cli/test_vertex_provider.py
+++ b/tests/hermes_cli/test_vertex_provider.py
@@ -98,3 +98,58 @@ def test_vertex_extra_body_empty_without_reasoning():
 
     p = get_provider_profile("vertex")
     assert p.build_extra_body(model="google/gemini-3-flash-preview") == {}
+
+
+# ---------------------------------------------------------------------------
+# CLI overlay resolution (issue #57539)
+# ---------------------------------------------------------------------------
+
+
+class TestVertexCliOverlay:
+    """Vertex must be in HERMES_OVERLAYS for /model CLI resolution."""
+
+    def test_overlay_exists(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        assert "vertex" in HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS["vertex"]
+        assert overlay.transport == "openai_chat"
+        assert overlay.auth_type == "vertex"
+        assert overlay.base_url_override == "https://aiplatform.googleapis.com"
+        assert not overlay.is_aggregator
+
+    def test_extra_env_vars(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        env = HERMES_OVERLAYS["vertex"].extra_env_vars
+        assert "VERTEX_CREDENTIALS_PATH" in env
+        assert "GOOGLE_APPLICATION_CREDENTIALS" in env
+        assert "VERTEX_PROJECT_ID" in env
+        assert "VERTEX_REGION" in env
+
+    def test_get_provider_resolves(self):
+        from hermes_cli.providers import get_provider
+
+        p = get_provider("vertex")
+        assert p is not None
+        assert p.id == "vertex"
+        assert p.transport == "openai_chat"
+        assert p.auth_type == "vertex"
+        assert p.base_url == "https://aiplatform.googleapis.com"
+        assert p.source == "hermes"
+
+    def test_label(self):
+        from hermes_cli.providers import get_label
+
+        assert get_label("vertex") == "Google Vertex AI"
+
+    @pytest.mark.parametrize(
+        "alias", ["google-vertex", "vertex-ai", "gcp-vertex", "vertexai"]
+    )
+    def test_cli_alias_resolves(self, alias):
+        from hermes_cli.providers import ALIASES, get_provider
+
+        assert ALIASES.get(alias) == "vertex"
+        p = get_provider(alias)
+        assert p is not None
+        assert p.id == "vertex"


### PR DESCRIPTION
## What does this PR do?

Adds the `vertex` provider to `HERMES_OVERLAYS` in `hermes_cli/providers.py` so that `/model --provider vertex` (and its aliases `google-vertex`, `vertex-ai`, `gcp-vertex`, `vertexai`) resolves correctly in the CLI.

The vertex plugin (`plugins/model-providers/vertex/`) works at runtime via `resolve_runtime_provider()`, but the CLI's `/model` command uses a separate resolution path (`get_provider()` → `HERMES_OVERLAYS`). The overlay table was never wired up when the vertex plugin landed.

## Related Issue

Fixes #57539

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/providers.py`: Added `"vertex"` entry to `HERMES_OVERLAYS` dict with `transport="openai_chat"`, `auth_type="vertex"`, `base_url_override="https://aiplatform.googleapis.com"`, and the four relevant env vars (`VERTEX_CREDENTIALS_PATH`, `GOOGLE_APPLICATION_CREDENTIALS`, `VERTEX_PROJECT_ID`, `VERTEX_REGION`). Added vertex aliases to `ALIASES` dict. Added `"vertex": "Google Vertex AI"` to `_LABEL_OVERRIDES`.
- `tests/hermes_cli/test_vertex_provider.py`: Added `TestVertexCliOverlay` class with 5 test methods covering overlay existence, env vars, `get_provider()` resolution, label, and CLI alias resolution.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_vertex_provider.py -v` — all 22 tests should pass
2. Verify CLI resolution: `python -c "from hermes_cli.providers import get_provider; p = get_provider('vertex'); print(p.id, p.transport, p.auth_type)"` should output `vertex openai_chat vertex`
3. Verify aliases: `python -c "from hermes_cli.providers import get_provider; [print(a, get_provider(a).id) for a in ['google-vertex','vertex-ai','gcp-vertex','vertexai']]"` should all resolve to `vertex`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_vertex_provider.py -v` and all 22 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
