### PR TITLE
fix(desktop): use cube codicon for Model settings nav

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -490,7 +490,7 @@ export const SECTIONS: DesktopConfigSection[] = [
   {
     id: 'model',
     label: 'Model',
-    icon: codiconIcon('hubot'),
+    icon: codiconIcon('symbol-namespace'),
     keys: ['model_context_length', 'fallback_providers']
   },
   {


### PR DESCRIPTION
The Model section in Settings used `codicon-hubot` (the agent/robot glyph). Swap it for `codicon-symbol-namespace`, the cube icon, which better represents a model configuration section vs. an agent entity.

One line changed in `SECTIONS` in `constants.ts`.