### PR TITLE
fix(security): verify shell-hook script content hash in allowlist gate

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -663,12 +663,24 @@ def save_allowlist(data: Dict[str, Any]) -> None:
 
 def _is_allowlisted(event: str, command: str) -> bool:
     data = load_allowlist()
-    return any(
-        isinstance(e, dict)
-        and e.get("event") == event
-        and e.get("command") == command
-        for e in data.get("approvals", [])
-    )
+    for e in data.get("approvals", []):
+        if (
+            isinstance(e, dict)
+            and e.get("event") == event
+            and e.get("command") == command
+        ):
+            stored_hash = e.get("script_hash_at_approval")
+            if stored_hash is not None:
+                current_hash = script_content_hash(command)
+                if current_hash != stored_hash:
+                    logger.warning(
+                        "Shell hook %s -> %s: script content changed since "
+                        "approval (hash mismatch). Re-approval required.",
+                        event, command,
+                    )
+                    return False
+            return True
+    return False
 
 
 @contextmanager
@@ -749,6 +761,7 @@ def _record_approval(event: str, command: str) -> None:
         "command": command,
         "approved_at": _utc_now_iso(),
         "script_mtime_at_approval": script_mtime_iso(command),
+        "script_hash_at_approval": script_content_hash(command),
     }
     with _locked_update_approvals() as data:
         data["approvals"] = [
@@ -867,6 +880,21 @@ def script_mtime_iso(command: str) -> Optional[str]:
         return datetime.fromtimestamp(
             os.path.getmtime(expanded), tz=timezone.utc,
         ).isoformat().replace("+00:00", "Z")
+    except OSError:
+        return None
+
+
+def script_content_hash(command: str) -> Optional[str]:
+    """SHA-256 hex digest of the resolved script file, or ``None`` if
+    the script is missing or unreadable."""
+    import hashlib
+    path = _command_script_path(command)
+    if not path:
+        return None
+    try:
+        expanded = os.path.expanduser(path)
+        with open(expanded, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
     except OSError:
         return None
 

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -484,6 +484,30 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
             if not spec.matches_tool(kwargs.get("tool_name")):
                 return None
 
+        # Runtime hash gate — re-verify the script content matches the
+        # stored approval hash before executing.  Catches edits made after
+        # registration (TOCTOU between approval and firing).  (Fixes #56688)
+        # Only enforce when an allowlist entry exists with a stored hash.
+        # If the entry was removed or never existed, fall through (the
+        # registration-time check already handled that path).
+        _al_data = load_allowlist()
+        for _al_entry in _al_data.get("approvals", []):
+            if (
+                isinstance(_al_entry, dict)
+                and _al_entry.get("event") == spec.event
+                and _al_entry.get("command") == spec.command
+                and _al_entry.get("script_hash_at_approval") is not None
+            ):
+                _current_hash = script_content_hash(spec.command)
+                if _current_hash != _al_entry["script_hash_at_approval"]:
+                    logger.warning(
+                        "Shell hook %s -> %s: script content changed since "
+                        "approval (hash mismatch) — skipping execution.",
+                        spec.event, spec.command,
+                    )
+                    return None
+                break
+
         r = _spawn(spec, _serialize_payload(spec.event, kwargs))
 
         if r["error"]:

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -89,14 +89,24 @@ def _cmd_list(_args) -> None:
                 entry = shell_hooks.allowlist_entry_for(spec.event, spec.command)
                 if entry and entry.get("approved_at"):
                     print(f"      approved_at: {entry['approved_at']}")
-                    mtime_now = shell_hooks.script_mtime_iso(spec.command)
-                    mtime_at = entry.get("script_mtime_at_approval")
-                    if mtime_now and mtime_at and mtime_now > mtime_at:
-                        print(
-                            f"      ⚠ script modified since approval "
-                            f"(was {mtime_at}, now {mtime_now}) — "
-                            f"run `hermes hooks doctor` to re-validate"
-                        )
+                    if entry.get("script_hash_at_approval"):
+                        current_hash = shell_hooks.script_content_hash(spec.command)
+                        stored_hash = entry["script_hash_at_approval"]
+                        if current_hash and current_hash != stored_hash:
+                            print(
+                                f"      ⚠ script content changed since approval "
+                                f"(hash mismatch) — will be re-prompted at "
+                                f"next run"
+                            )
+                    elif entry.get("script_mtime_at_approval"):
+                        mtime_now = shell_hooks.script_mtime_iso(spec.command)
+                        mtime_at = entry.get("script_mtime_at_approval")
+                        if mtime_now and mtime_at and mtime_now > mtime_at:
+                            print(
+                                f"      ⚠ script modified since approval "
+                                f"(was {mtime_at}, now {mtime_now}) — "
+                                f"run `hermes hooks doctor` to re-validate"
+                            )
         print()
 
 
@@ -343,8 +353,21 @@ def _doctor_one(spec, shell_hooks) -> int:
         print("      ✗ not allowlisted — hook will NOT fire at runtime "
               "(run with --accept-hooks once, or confirm at the TTY prompt)")
 
-    # 3. Mtime drift
-    if entry and entry.get("script_mtime_at_approval"):
+    # 3. Content hash and mtime drift
+    if entry and entry.get("script_hash_at_approval"):
+        current_hash = shell_hooks.script_content_hash(spec.command)
+        stored_hash = entry["script_hash_at_approval"]
+        if current_hash is None:
+            problems += 1
+            print("      ✗ script unreadable — hash cannot be verified")
+        elif current_hash != stored_hash:
+            problems += 1
+            print(f"      ✗ script content changed since approval "
+                  f"(hash mismatch) — hook will be blocked at runtime. "
+                  f"Re-approve with `hermes hooks revoke` + re-run")
+        else:
+            print("      ✓ script content unchanged since approval")
+    elif entry and entry.get("script_mtime_at_approval"):
         mtime_now = shell_hooks.script_mtime_iso(spec.command)
         mtime_at = entry["script_mtime_at_approval"]
         if mtime_now and mtime_at and mtime_now > mtime_at:

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -833,3 +833,37 @@ class TestAllowlistContentHash:
         assert entry is not None
         assert "script_hash_at_approval" in entry
         assert len(entry["script_hash_at_approval"]) == 64
+
+
+class TestRuntimeHashEnforcement:
+    """Regression: live callback must block execution when script content
+    changes after approval (TOCTOU between registration and firing).
+
+    Uses a script that emits a ``{"decision": "block", "reason": "..."}``
+    payload so we can distinguish "callback ran" (returns a dict) from
+    "callback was skipped" (returns None).
+    """
+
+    def test_live_callback_blocks_after_script_edit(self, tmp_path, monkeypatch):
+        """Register a hook, edit the script, invoke — callback must skip."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        script = _write_script(
+            tmp_path, "hook.sh",
+            '#!/bin/bash\necho \'{"decision": "block", "reason": "original"}\'\n',
+        )
+        command = str(script)
+        _allowlist_pair(monkeypatch, tmp_path, "pre_tool_call", command)
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_tool_call", command=command, matcher=None, timeout=5,
+        )
+        cb = shell_hooks._make_callback(spec)
+        # First invocation should succeed (returns block dict)
+        r1 = cb(tool_name="read_file", args={}, session_id="s1")
+        assert r1 is not None, "First invocation should succeed"
+        assert r1["action"] == "block"
+
+        # Edit the script (simulate TOCTOU attack)
+        script.write_text("#!/bin/bash\necho PWNED\n")
+        # Second invocation must be blocked (hash mismatch → returns None)
+        r2 = cb(tool_name="read_file", args={}, session_id="s1")
+        assert r2 is None, "Callback should skip after script content changed"

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -753,3 +753,83 @@ class TestAllowlistConcurrency:
 
         assert len(tmp_paths_seen) == 2
         assert tmp_paths_seen[0] != tmp_paths_seen[1]
+
+
+# ── script_content_hash ───────────────────────────────────────────────────
+
+
+class TestScriptContentHash:
+    def test_returns_sha256_of_script(self, tmp_path):
+        script = tmp_path / "hook.sh"
+        script.write_text("#!/bin/bash\necho hello\n")
+        script.chmod(0o755)
+        h = shell_hooks.script_content_hash(str(script))
+        assert h is not None
+        assert len(h) == 64  # SHA-256 hex digest
+
+    def test_returns_none_for_missing_script(self, tmp_path):
+        assert shell_hooks.script_content_hash(str(tmp_path / "nope")) is None
+
+    def test_changes_when_content_changes(self, tmp_path):
+        script = tmp_path / "hook.sh"
+        script.write_text("echo original")
+        script.chmod(0o755)
+        h1 = shell_hooks.script_content_hash(str(script))
+        script.write_text("echo modified")
+        h2 = shell_hooks.script_content_hash(str(script))
+        assert h1 != h2
+
+
+# ── _is_allowlisted content-hash enforcement ──────────────────────────────
+
+
+class TestAllowlistContentHash:
+    def test_allowlisted_when_hash_matches(self, tmp_path, monkeypatch):
+        script = tmp_path / "hook.sh"
+        script.write_text("#!/bin/bash\necho safe\n")
+        script.chmod(0o755)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        shell_hooks._record_approval("pre_tool_call", str(script))
+        assert shell_hooks._is_allowlisted("pre_tool_call", str(script))
+
+    def test_blocked_when_hash_mismatches(self, tmp_path, monkeypatch, caplog):
+        """Editing a script after approval must trigger re-prompt."""
+        import logging
+        script = tmp_path / "hook.sh"
+        script.write_text("#!/bin/bash\necho safe\n")
+        script.chmod(0o755)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        shell_hooks._record_approval("pre_tool_call", str(script))
+        assert shell_hooks._is_allowlisted("pre_tool_call", str(script))
+        # Edit the script
+        script.write_text("#!/bin/bash\necho MALICIOUS\n")
+        with caplog.at_level(logging.WARNING, logger=shell_hooks.logger.name):
+            assert not shell_hooks._is_allowlisted("pre_tool_call", str(script))
+        assert any("hash mismatch" in r.getMessage() for r in caplog.records)
+
+    def test_backward_compat_old_entry_without_hash(self, tmp_path, monkeypatch):
+        """Old allowlist entries without script_hash_at_approval must
+        still pass (backward compatibility)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        # Manually write an old-format entry (no hash)
+        data = {
+            "approvals": [{
+                "event": "pre_tool_call",
+                "command": "/some/script.sh",
+                "approved_at": "2025-01-01T00:00:00Z",
+                "script_mtime_at_approval": None,
+            }]
+        }
+        shell_hooks.save_allowlist(data)
+        assert shell_hooks._is_allowlisted("pre_tool_call", "/some/script.sh")
+
+    def test_record_approval_stores_hash(self, tmp_path, monkeypatch):
+        script = tmp_path / "hook.sh"
+        script.write_text("#!/bin/bash\necho test\n")
+        script.chmod(0o755)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        shell_hooks._record_approval("pre_tool_call", str(script))
+        entry = shell_hooks.allowlist_entry_for("pre_tool_call", str(script))
+        assert entry is not None
+        assert "script_hash_at_approval" in entry
+        assert len(entry["script_hash_at_approval"]) == 64


### PR DESCRIPTION
## What does this PR do?

Adds a content-hash check to the shell-hook allowlist gate. Previously, `_is_allowlisted()` only matched on `(event, command)` strings — once a hook was approved, editing the script at the same path retained approval with no re-prompt. Now `_record_approval()` stores a SHA-256 of the script, and `_is_allowlisted()` verifies it. A mismatch returns `False`, triggering the normal re-prompt flow.

## Related Issue

Fixes #57558

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `agent/shell_hooks.py`: Add `script_content_hash()` helper (SHA-256 of resolved script file). Store `script_hash_at_approval` in `_record_approval()`. Verify hash in `_is_allowlisted()` — mismatch returns `False` with a warning log. Backward-compatible: old entries without a hash still pass.
- `hermes_cli/hooks.py`: Update `hooks list` and `hooks doctor` advisory output to check content hash first, falling back to mtime drift for old-format entries.
- `tests/agent/test_shell_hooks.py`: 7 new tests covering `script_content_hash()` (SHA-256, missing file, content change detection) and `_is_allowlisted()` enforcement (hash match, hash mismatch, backward compat, stored hash format).

## How to Test

1. Run `python -m pytest tests/agent/test_shell_hooks.py -q` — all 63 tests should pass (7 new).
2. Manual verification: approve a shell hook, then edit the script — the next run should re-prompt instead of silently running the modified script.
3. `hermes hooks doctor` should show `✗ script content changed since approval (hash mismatch)` for edited scripts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_shell_hooks.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ hermes hooks list
  pre_tool_call -> /tmp/test-hook.sh
      approved_at: 2026-07-03T06:30:00Z
      ⚠ script content changed since approval (hash mismatch) — will be re-prompted at next run
```
