### PR TITLE
fix(usage): stop double-counting reasoning_tokens in session token totals

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -584,12 +584,16 @@ class GatewaySlashCommandsMixin:
                 row = await self._session_db.get_session(session_entry.session_id)
                 if isinstance(row, dict):
                     session_row = row
+                    # reasoning_tokens is a subset of output_tokens (the
+                    # provider reports it as a breakdown of completion/output
+                    # tokens), so it must NOT be added again. Matches
+                    # CanonicalUsage.total_tokens (agent/usage_pricing.py) =
+                    # input + cache_read + cache_write + output.
                     db_total_tokens = (
                         _int_value(row.get("input_tokens"))
                         + _int_value(row.get("output_tokens"))
                         + _int_value(row.get("cache_read_tokens"))
                         + _int_value(row.get("cache_write_tokens"))
-                        + _int_value(row.get("reasoning_tokens"))
                     )
             except Exception:
                 db_total_tokens = 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1559,12 +1559,15 @@ def _print_tui_exit_summary(
         cache_read_tokens = int(session.get("cache_read_tokens") or 0)
         cache_write_tokens = int(session.get("cache_write_tokens") or 0)
         reasoning_tokens = int(session.get("reasoning_tokens") or 0)
+        # reasoning_tokens is a subset of output_tokens (the provider reports it
+        # as a breakdown of completion/output tokens), so it must NOT be added
+        # again here. This mirrors CanonicalUsage.total_tokens
+        # (agent/usage_pricing.py) = input + cache_read + cache_write + output.
         total_tokens = (
             input_tokens
             + output_tokens
             + cache_read_tokens
             + cache_write_tokens
-            + reasoning_tokens
         )
     except Exception:
         return

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -99,8 +99,10 @@ async def test_status_command_reads_token_totals_from_session_db():
 
     result = await runner._handle_message(_make_event("/status"))
 
-    # 1000 + 250 + 500 + 100 + 50 = 1,900
-    assert "**Lifetime tokens billed:** 1,900" in result
+    # input + output + cache_read + cache_write = 1000 + 250 + 500 + 100 = 1,850.
+    # reasoning_tokens (50) is a subset of output_tokens and must NOT be added
+    # again, matches CanonicalUsage.total_tokens.
+    assert "**Lifetime tokens billed:** 1,850" in result
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -284,5 +284,40 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
 
 
+def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            assert session_id == "20260409_000001_abc123"
+            return {
+                "message_count": 2,
+                "input_tokens": 10,
+                "output_tokens": 6,
+                "cache_read_tokens": 2,
+                "cache_write_tokens": 2,
+                "reasoning_tokens": 1,
+            }
+
+        def get_session_title(self, _session_id):
+            return "demo title"
+
+        def close(self):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
+
+    main_mod._print_tui_exit_summary("20260409_000001_abc123")
+    out = capsys.readouterr().out
+
+    assert "Resume this session with:" in out
+    assert "hermes --tui --resume 20260409_000001_abc123" in out
+    assert 'hermes --tui -c "demo title"' in out
+    # Total is input + output + cache (10 + 6 + 4) = 20. reasoning_tokens (1) is
+    # a subset of output_tokens and must NOT be added again — matches
+    # CanonicalUsage.total_tokens. It is still surfaced as the breakdown value.
+    assert "Tokens:         20 (in 10, out 6, cache 4, reasoning 1)" in out
 
 


### PR DESCRIPTION
## What does this PR do?

Two user-facing session token **totals** recompute the total from the persisted per-bucket columns and add `reasoning_tokens` on top of `output_tokens`:

- `hermes_cli/main.py` — the TUI-exit "Resume this session" summary
- `gateway/slash_commands.py` — the gateway `/status` "Cumulative API tokens" line

`reasoning_tokens` is a **subset** of `output_tokens`, not an additional bucket. The provider reports it as a breakdown of completion/output tokens (`completion_tokens_details.reasoning_tokens` for Chat Completions, `output_tokens_details.reasoning_tokens` for Responses), and `normalize_usage` (`agent/usage_pricing.py`) stores it as-is alongside the full `output_tokens`. Adding it again inflates the displayed total by exactly `reasoning_tokens`.

This contradicts the codebase's **own** canonical definition:

```python
# agent/usage_pricing.py — CanonicalUsage
@property
def total_tokens(self) -> int:
    return self.prompt_tokens + self.output_tokens   # prompt = input + cache_read + cache_write
```

and the product's other total surfaces already show the authoritative figure — `cli.py::_show_session_status` and the TUI-gateway status read `agent.session_total_tokens` (the provider's `prompt + completion` total, reasoning excluded). So today the **same session** reports different totals in `hermes` status vs. `/status`.

The inflation was latent until #57340 (`fix(usage): capture reasoning_tokens from completion_tokens_details`) populated `reasoning_tokens` for chat_completions reasoning models (OpenAI, OpenRouter, DeepSeek). A model like `deepseek-v4-flash` can burn 20K+ reasoning tokens per call (per #57340's own measurements), so the displayed session total drifts far above the real token count.

## Related Issue

Fixes #57565

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: drop `+ reasoning_tokens` from the TUI-exit summary total; total is now `input + output + cache_read + cache_write` (= `CanonicalUsage.total_tokens`). `reasoning` stays shown as the breakdown value.
- `gateway/slash_commands.py`: same fix for the `/status` cumulative-tokens total.
- `tests/hermes_cli/test_tui_resume_flow.py` and `tests/gateway/test_status_command.py`: the two existing tests asserted the inflated totals (`21` for 10+6+cache4+**1**, `1,900` for 1000+250+500+100+**50**). Corrected to `20` / `1,850` — they were written to match the buggy sum. Both now **fail on `main` and pass with this change**.

## How to Test

Reproduce the arithmetic on `main`:
```python
import types
from agent.usage_pricing import normalize_usage
u = normalize_usage(types.SimpleNamespace(
    prompt_tokens=1000, completion_tokens=74, total_tokens=1074,
    prompt_tokens_details=types.SimpleNamespace(cached_tokens=800),
    completion_tokens_details=types.SimpleNamespace(reasoning_tokens=61),
), provider="deepseek", api_mode="chat_completions")
display = u.input_tokens + u.output_tokens + u.cache_read_tokens + u.cache_write_tokens + u.reasoning_tokens
print(display, u.total_tokens)   # main: 1135 1074  -> display over-counts by 61 (== reasoning)
```

Test suite:
```
scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py tests/gateway/test_status_command.py   # 65 passed
# regression proof: revert only the two source files, keep the tests:
scripts/run_tests.sh ... -k "reads_token_totals or exit_summary_includes_resume"   # 2 failed
```

## What platforms did you test on?

macOS (Darwin 25.5.0), Python 3.12.12. Pure integer arithmetic in display code — no OS-specific paths; `scripts/check-windows-footguns.py` clean on both changed source files.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs/issues to make sure this isn't a duplicate (no open PR/issue touched these token-total computations)
- [x] My PR contains only changes related to this fix
- [x] I've run the tests and they pass (`scripts/run_tests.sh` on both affected files → 65 passed)
- [x] I've added/updated tests; both updated tests fail without the fix and pass with it
- [x] Cross-platform impact considered — none (integer arithmetic)
