### PR TITLE
fix(model_switch): filter /model picker for providers with no PROVIDER_REGISTRY entry

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1633,7 +1633,15 @@ def list_authenticated_providers(
         # section 2 (HERMES_OVERLAYS) with proper auth store checking.
         if pconfig and pconfig.auth_type != "api_key":
             continue
-        if pconfig and pconfig.api_key_env_vars:
+        # Skip providers that have no PROVIDER_REGISTRY entry. They appear
+        # in PROVIDER_TO_MODELS_DEV (so the picker sees their models.dev
+        # catalog and emits a row), but runtime resolution in
+        # resolve_provider() rejects them as "Unknown provider". Filter
+        # them here so the /model picker only ever lists providers that
+        # can actually be switched to. Fixes #57503 (mistral).
+        if not pconfig:
+            continue
+        if pconfig.api_key_env_vars:
             env_vars = list(pconfig.api_key_env_vars)
         else:
             env_vars = pdata.get("env", [])

--- a/tests/hermes_cli/test_model_switch_filter_unresolved.py
+++ b/tests/hermes_cli/test_model_switch_filter_unresolved.py
@@ -1,0 +1,120 @@
+"""Regression tests for picker filtering of unresolved providers.
+
+Bug — ``list_authenticated_providers()`` would emit ``/model`` picker rows for
+    providers that ``PROVIDER_TO_MODELS_DEV`` knows about but that the runtime
+    ``resolve_provider()`` rejects as ``Unknown provider``. The reporter set
+    ``MISTRAL_API_KEY`` and saw a ``Mistral (72)`` row in the Telegram picker;
+    selecting any model under it produced
+    ``Could not resolve credentials for provider 'Mistral': Unknown provider 'mistral'``
+    (#57503).
+
+The fix adds a resolve-gate in section 1 of ``list_authenticated_providers``:
+if a slug has no ``PROVIDER_REGISTRY`` entry, skip it. The picker now only
+shows providers that can actually be selected at runtime.
+
+These tests pin that behavior in two directions:
+
+1. With ``MISTRAL_API_KEY`` set, ``mistral`` MUST NOT appear in the picker
+   (it has no ``PROVIDER_REGISTRY`` entry at the time of this fix).
+2. A provider that IS in ``PROVIDER_REGISTRY`` (e.g. ``deepseek``) and has
+   its API key set MUST still appear, so the fix does not regress existing
+   picker coverage.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch
+
+
+def _reload():
+    """Force a fresh import of model_switch so module-level caches reset.
+
+    The picker caches ``PROVIDER_REGISTRY`` at import time. Each test must
+    see a fresh module to avoid bleeding env vars between cases.
+    """
+    for mod_name in [m for m in list(sys.modules) if m.startswith("hermes_cli.model_switch")]:
+        sys.modules.pop(mod_name, None)
+    return importlib.import_module("hermes_cli.model_switch")
+
+
+def _slug(rows):
+    """Return the set of provider slugs from picker rows."""
+    return {row.get("slug") for row in rows}
+
+
+def test_mistral_filtered_when_unregistered_but_api_key_set(monkeypatch):
+    """#57503 — MISTRAL_API_KEY set, mistral has no PROVIDER_REGISTRY entry.
+
+    Picker must NOT emit a 'mistral' row. Users with a working
+    custom_providers entry for Mistral no longer see the duplicate
+    broken-from-models.dev entry cluttering the list.
+    """
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-mistral-key-shouldnt-crash")
+
+    model_switch = _reload()
+    rows = model_switch.list_authenticated_providers(max_models=5)
+
+    slugs = _slug(rows)
+    assert "mistral" not in slugs, (
+        f"mistral leaked into /model picker despite being unregistered: {sorted(slugs)}"
+    )
+
+
+def test_resolveable_provider_still_appears(monkeypatch):
+    """Sanity — a registered provider with a key must still surface.
+
+    Guards against the new resolve-gate being too broad (e.g. nuking the
+    happy path of every other provider while filtering mistral).
+    """
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-deepseek-key-shouldnt-crash")
+
+    model_switch = _reload()
+    rows = model_switch.list_authenticated_providers(max_models=5)
+
+    slugs = _slug(rows)
+    assert "deepseek" in slugs, (
+        "deepseek disappeared from /model picker — resolve-gate is too broad. "
+        f"slugs seen: {sorted(slugs)}"
+    )
+
+
+def test_resolve_gate_skips_models_dev_only_provider_without_creds(monkeypatch):
+    """A models-dev provider with no key and no PROVIDER_REGISTRY entry has
+    no way to surface in the picker — verify we never emit such a row.
+
+    Keeps the fix idempotent: the previous ``if not has_creds: continue``
+    gate already handled the no-credential case; we add a second gate on
+    top that catches the WITH-credentials-but-no-registry case.
+    """
+    # No MISTRAL_API_KEY, no other mistral-shaped env vars set
+    for k in ("MISTRAL_API_KEY", "MISTRAL_BASE_URL"):
+        monkeypatch.delenv(k, raising=False)
+
+    model_switch = _reload()
+    rows = model_switch.list_authenticated_providers(max_models=5)
+
+    slugs = _slug(rows)
+    assert "mistral" not in slugs
+
+
+def test_picker_skips_pconfig_none_does_not_break_other_section1_providers(monkeypatch, tmp_path):
+    """Coverage guard — providers that share a models.dev id with their
+    canonical Hermes slug (e.g. ``gemini``, ``xai``, ``cohere``) must keep
+    appearing. These ARE in ``PROVIDER_REGISTRY`` so the new gate should
+    not touch them.
+    """
+    # Pick a registry-backed provider that exists in models.dev and is
+    # unlikely to be subject to the env-var duck-typing the picker uses
+    # for unnamespaced keys.
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key-shouldnt-crash")
+
+    model_switch = _reload()
+    rows = model_switch.list_authenticated_providers(max_models=5)
+
+    slugs = _slug(rows)
+    assert "xai" in slugs, (
+        "xai disappeared — the resolve-gate ended up filtering registry-backed "
+        "providers too. slugs seen: " + repr(sorted(slugs))
+    )


### PR DESCRIPTION
Summary
`list_authenticated_providers()` (powers `/model` in the CLI, gateway, and Telegram picker) emits a row for every slug in `PROVIDER_TO_MODELS_DEV` whose credential env-var is set. Several of those slugs (notably `mistral`) have no `PROVIDER_REGISTRY` entry, so `resolve_provider()` rejects them with `Unknown provider 'mistral'` once the user selects a model. The picker shows rows that cannot actually be selected. This is #57503.

Fix: a single resolve-gate in `list_authenticated_providers()` Section 1 — if `PROVIDER_REGISTRY.get(hermes_id)` is None, skip the slug. The picker now only lists providers that can actually be switched to. This also resolves the duplicate-Mistral dedup symptom: once the broken-from-models.dev row is filtered, the conflict between `PROVIDER_TO_MODELS_DEV['mistral']` and a `custom_providers` `Mistral` row becomes moot.

Composes with #50289 (the in-flight first-class-providers plugin merge for mistral): when/if that lands, `PROVIDER_REGISTRY` gains a `mistral` entry and the new gate becomes a no-op for it. The two PRs are independent — neither blocks nor breaks the other.

Changes
- `hermes_cli/model_switch.py`: 9-line addition in `list_authenticated_providers()` Section 1: a `if not pconfig: continue` gate after the existing `pconfig.auth_type != "api_key"` skip. Documented inline, references the issue.
- `tests/hermes_cli/test_model_switch_filter_unresolved.py` (new): 4 regression tests.
  - `test_mistral_filtered_when_unregistered_but_api_key_set` — pin: `MISTRAL_API_KEY` set ⇒ `mistral` MUST NOT appear in picker.
  - `test_resolveable_provider_still_appears` — regression guard: `deepseek` (PROVIDER_REGISTRY-backed) with key set MUST still appear.
  - `test_resolve_gate_skips_models_dev_only_provider_without_creds` — no-key case stays filtered.
  - `test_picker_skips_pconfig_none_does_not_break_other_section1_providers` — `xai` (REGISTRY-backed) with key set still appears.

How to Test
```bash
# new regression suite
pytest tests/hermes_cli/test_model_switch_filter_unresolved.py -xvs
# 4/4 passed

# Verify the test catches the bug: revert the fix and re-run
git stash push -m test hermes_cli/model_switch.py
pytest tests/hermes_cli/test_model_switch_filter_unresolved.py::test_mistral_filtered_when_unregistered_but_api_key_set -xvs
# FAILS with "mistral leaked into /model picker: ['mistral']" -- this is what the
# reporter in #57503 saw on the live picker
git stash pop

# Re-run broader suite to confirm no regressions
pytest tests/hermes_cli/test_model_switch_filter_unresolved.py \
       tests/hermes_cli/test_custom_provider_model_switch.py \
       tests/hermes_cli/test_model_switch_custom_providers.py \
       tests/hermes_cli/test_anthropic_picker_curated.py -q
# 55/55 passed
```

Checklist
- [x] Tests pass -- 4 new + 51 existing model-switch picker tests, 55/55 green
- [x] Follows Conventional Commits (`fix(scope):`)
- [x] Changes scoped to a single fix, single-file prod change (+1 test file)
- [x] Cross-platform impact: None (`os.environ` read with `monkeypatch`, no platform-specific code)
- [x] profile-safe paths: N/A, no paths touched
- [x] .env not used for non-credential settings: N/A, no settings added
- [x] No new dependencies
- [x] Composes cleanly with in-flight #50289 (different approach, no overlap)

Risk & Impact
Low. Single-file 9-line addition in the picker code path; behaviour change is strictly "drop a row from a list when that row would 100% fail on selection". Users who currently hit the bug get a fixed picker immediately; users with working environments see the picker unchanged (every other provider in `PROVIDER_TO_MODELS_DEV` is also in `PROVIDER_REGISTRY`, so they keep appearing).

Type: Bug fix
Closes #57503

Related findings (out of scope here, flagged for maintainers):
- The deeper fix is the provider-plugin promotion of mistral that #50289 is already driving -- when that lands, the resolve-gate becomes a no-op for `mistral` and just keeps defending against the next unregistered models.dev provider that anyone adds to `PROVIDER_TO_MODELS_DEV`. The gate is intentionally defensive: same code path would have caught a follow-up like "provider X has Y key set but isn't in registry" without a second PR.
- A future audit pass over `PROVIDER_TO_MODELS_DEV` against `PROVIDER_REGISTRY` (one-shot script, no runtime cost) would let us surface any other slugs that historically slipped through, instead of relying on users to file bugs one-by-one. Out of scope for this PR.
