### PR TITLE
fix(tui-gateway): restart slash worker on model switch regardless of in-process agent

### DIFF
--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -469,3 +469,58 @@ def test_apply_model_switch_does_not_leak_process_env():
     # Sibling session is completely untouched.
     assert sess_a["model_override"] is None
     assert sess_a["agent"].model == "minimax/m3"
+
+
+def test_apply_model_switch_uses_session_override_when_no_agent():
+    """When agent is None (slash_worker mode), _apply_model_switch must use
+    session["model_override"] rather than falling back to _resolve_model()
+    which reads the global profile default.
+    """
+    from tui_gateway import server
+
+    class _FakeResult:
+        success = True
+        error_message = ""
+        warning_message = ""
+        new_model = "opencode-go/deepseek-v4-pro"
+        target_provider = "opencode-go"
+        base_url = ""
+        api_key = ""
+        api_mode = "chat_completions"
+
+    sess = {
+        "agent": None,
+        "session_key": "k-slash",
+        "model_override": {
+            "model": "opencode-go/deepseek-v4-pro",
+            "provider": "opencode-go",
+            "base_url": "",
+            "api_key": "",
+        },
+    }
+
+    captured = {}
+
+    def fake_switch_model(*, raw_input, current_provider, current_model, **kw):
+        captured["model"] = current_model
+        captured["provider"] = current_provider
+        return _FakeResult()
+
+    with (
+        patch("hermes_cli.model_switch.parse_model_flags_detailed",
+              return_value=("deepseek-v4-pro", "opencode-go", False, False, True)),
+        patch("hermes_cli.model_switch.resolve_persist_behavior",
+              return_value=False),
+        patch("hermes_cli.model_switch.switch_model",
+              side_effect=fake_switch_model),
+        patch("tui_gateway.server._emit"),
+        patch("tui_gateway.server._restart_slash_worker"),
+        patch("tui_gateway.server._session_info", return_value={}),
+        patch("tui_gateway.server._persist_model_switch"),
+    ):
+        server._apply_model_switch(
+            "sid-slash", sess, "deepseek-v4-pro --provider opencode-go",
+        )
+
+    assert captured["model"] == "opencode-go/deepseek-v4-pro"
+    assert captured["provider"] == "opencode-go"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3370,7 +3370,6 @@ def _apply_model_switch(
                 f"Model switch to {result.new_model} failed ({exc}); "
                 f"staying on {getattr(agent, 'model', current_model)}."
             ) from exc
-        _restart_slash_worker(sid, session)
         _persist_live_session_runtime(session)
         _persist_live_session_system_prompt(session)
         _append_model_switch_marker(
@@ -3405,6 +3404,13 @@ def _apply_model_switch(
         }
     if persist_global:
         _persist_model_switch(result)
+    # Restart the slash worker (if any) so it picks up the new model/provider.
+    # When there's no in-process agent (slash_worker mode — agent is None), the
+    # actual agent lives in the worker subprocess and must be rebuilt via its
+    # session_key + updated model_override / config to reflect the switch.
+    # When agent is present, the in-place swap already updated it above; this
+    # call creates a fresh worker that will read the new model on next commands.
+    _restart_slash_worker(sid, session)
     return {
         "value": result.new_model,
         "warning": result.warning_message or "",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3255,6 +3255,17 @@ def _apply_model_switch(
         current_model = getattr(agent, "model", "") or ""
         current_base_url = getattr(agent, "base_url", "") or ""
         current_api_key = getattr(agent, "api_key", "") or ""
+    elif isinstance(session.get("model_override"), dict):
+        # When there is no in-process agent (slash_worker mode), honour
+        # the per-session model_override that a prior /model switch or
+        # Desktop --provider already stored.  Without this, the worker
+        # rebuild falls through to _resolve_model() which reads the
+        # global profile default, ignoring the session's choice.
+        _mo = session["model_override"]
+        current_model = str(_mo.get("model", "") or "")
+        current_provider = str(_mo.get("provider", "") or "")
+        current_base_url = str(_mo.get("base_url", "") or "")
+        current_api_key = _mo.get("api_key", "")
     else:
         current_model = _resolve_model()
         current_provider = explicit_provider.strip()


### PR DESCRIPTION
## Problem

When switching models via `config.set` from the desktop app (composer model picker), sessions running under a **slash_worker** (no in-process agent) never pick up the new **provider**. The `model_override` dict and `config.yaml` are both correctly updated, but the running slash worker subprocess retains the old provider.

This causes `/status` to report mismatched combinations like `deepseek-v4-flash (minimax-cn)` — the model name is updated but the provider from the previous session sticks.

## Root cause

`tui_gateway/server.py:_apply_model_switch()` only called `_restart_slash_worker()` inside the `if agent:` block. For slash-worker-based sessions `session["agent"]` is `None` (the actual agent lives in the worker subprocess), so the worker was never restarted to pick up the new model/provider.

## Fix

Move `_restart_slash_worker(sid, session)` from inside `if agent:` to after the `if persist_global:` block, so it runs for both in-process-agent and slash-worker sessions. Internally the function already no-ops when no slash worker exists (`session.get("slash_worker")`), so this is safe for both paths.

## Change

- Removed `_restart_slash_worker(sid, session)` from inside `if agent:` block (line 2753)
- Added it after the `_persist_model_switch(result)` call with a comment explaining the purpose