### PR TITLE
fix(file-sync): serialize sync_back on Windows (#57572)

### DIFF
--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -10,7 +10,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-fcntl = pytest.importorskip("fcntl")
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -307,12 +310,15 @@ class TestPushedHashesPopulated:
 class TestSyncBackFileLock:
     """Verify that fcntl.flock is used during sync-back."""
 
-    @patch("tools.environments.file_sync.fcntl.flock")
-    def test_sync_back_file_lock(self, mock_flock, tmp_path):
+    def test_sync_back_file_lock(self, tmp_path):
+        if fcntl is None:
+            pytest.skip("fcntl is unavailable on this platform")
+
         download_fn = _make_download_fn({})
         mgr = _make_manager(tmp_path, bulk_download_fn=download_fn)
 
-        mgr.sync_back(hermes_home=tmp_path / ".hermes")
+        with patch.object(fcntl, "flock") as mock_flock:
+            mgr.sync_back(hermes_home=tmp_path / ".hermes")
 
         # flock should have been called at least twice: LOCK_EX to acquire, LOCK_UN to release
         assert mock_flock.call_count >= 2
@@ -327,7 +333,7 @@ class TestSyncBackFileLock:
         download_fn = _make_download_fn({})
         mgr = _make_manager(tmp_path, bulk_download_fn=download_fn)
         fake_msvcrt = MagicMock()
-        fake_msvcrt.LK_LOCK = 1
+        fake_msvcrt.LK_NBLCK = 1
         fake_msvcrt.LK_UNLCK = 2
 
         with patch("tools.environments.file_sync.fcntl", None), \
@@ -335,7 +341,7 @@ class TestSyncBackFileLock:
             mgr.sync_back(hermes_home=tmp_path / ".hermes")
 
         lock_ops = [call.args[1] for call in fake_msvcrt.locking.call_args_list]
-        assert lock_ops == [fake_msvcrt.LK_LOCK, fake_msvcrt.LK_UNLCK]
+        assert lock_ops == [fake_msvcrt.LK_NBLCK, fake_msvcrt.LK_UNLCK]
 
     def test_sync_back_waits_for_busy_msvcrt_lock(self, tmp_path):
         """Windows locking should retry until the byte-range lock is free."""
@@ -344,7 +350,7 @@ class TestSyncBackFileLock:
         download_fn = _make_download_fn({})
         mgr = _make_manager(tmp_path, bulk_download_fn=download_fn)
         fake_msvcrt = MagicMock()
-        fake_msvcrt.LK_LOCK = 1
+        fake_msvcrt.LK_NBLCK = 1
         fake_msvcrt.LK_UNLCK = 2
         fake_msvcrt.locking.side_effect = [
             OSError(errno.EACCES, "locked"),
@@ -360,8 +366,8 @@ class TestSyncBackFileLock:
         sleep.assert_called_once_with(0.1)
         lock_ops = [call.args[1] for call in fake_msvcrt.locking.call_args_list]
         assert lock_ops == [
-            fake_msvcrt.LK_LOCK,
-            fake_msvcrt.LK_LOCK,
+            fake_msvcrt.LK_NBLCK,
+            fake_msvcrt.LK_NBLCK,
             fake_msvcrt.LK_UNLCK,
         ]
 

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -322,14 +322,60 @@ class TestSyncBackFileLock:
         assert fcntl.LOCK_EX in lock_ops
         assert fcntl.LOCK_UN in lock_ops
 
-    def test_sync_back_skips_flock_when_fcntl_none(self, tmp_path):
-        """On Windows (fcntl=None), sync_back should skip file locking."""
+    def test_sync_back_uses_msvcrt_when_fcntl_none(self, tmp_path):
+        """On Windows (fcntl=None), sync_back should use msvcrt locking."""
+        download_fn = _make_download_fn({})
+        mgr = _make_manager(tmp_path, bulk_download_fn=download_fn)
+        fake_msvcrt = MagicMock()
+        fake_msvcrt.LK_LOCK = 1
+        fake_msvcrt.LK_UNLCK = 2
+
+        with patch("tools.environments.file_sync.fcntl", None), \
+             patch("tools.environments.file_sync.msvcrt", fake_msvcrt):
+            mgr.sync_back(hermes_home=tmp_path / ".hermes")
+
+        lock_ops = [call.args[1] for call in fake_msvcrt.locking.call_args_list]
+        assert lock_ops == [fake_msvcrt.LK_LOCK, fake_msvcrt.LK_UNLCK]
+
+    def test_sync_back_waits_for_busy_msvcrt_lock(self, tmp_path):
+        """Windows locking should retry until the byte-range lock is free."""
+        import errno
+
+        download_fn = _make_download_fn({})
+        mgr = _make_manager(tmp_path, bulk_download_fn=download_fn)
+        fake_msvcrt = MagicMock()
+        fake_msvcrt.LK_LOCK = 1
+        fake_msvcrt.LK_UNLCK = 2
+        fake_msvcrt.locking.side_effect = [
+            OSError(errno.EACCES, "locked"),
+            None,
+            None,
+        ]
+
+        with patch("tools.environments.file_sync.fcntl", None), \
+             patch("tools.environments.file_sync.msvcrt", fake_msvcrt), \
+             patch("tools.environments.file_sync._sleep") as sleep:
+            mgr.sync_back(hermes_home=tmp_path / ".hermes")
+
+        sleep.assert_called_once_with(0.1)
+        lock_ops = [call.args[1] for call in fake_msvcrt.locking.call_args_list]
+        assert lock_ops == [
+            fake_msvcrt.LK_LOCK,
+            fake_msvcrt.LK_LOCK,
+            fake_msvcrt.LK_UNLCK,
+        ]
+
+    def test_sync_back_warns_when_no_locking_module_available(self, tmp_path, caplog):
+        """If neither fcntl nor msvcrt exists, sync_back logs the unlocked path."""
         download_fn = _make_download_fn({})
         mgr = _make_manager(tmp_path, bulk_download_fn=download_fn)
 
-        with patch("tools.environments.file_sync.fcntl", None):
-            # Should not raise — locking is skipped
+        with patch("tools.environments.file_sync.fcntl", None), \
+             patch("tools.environments.file_sync.msvcrt", None), \
+             caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
             mgr.sync_back(hermes_home=tmp_path / ".hermes")
+
+        assert any("without serialization" in r.message for r in caplog.records)
 
 
 class TestInferHostPath:

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -6,6 +6,7 @@ and Daytona.  Docker and Singularity use bind mounts (live host FS
 view) and don't need this.
 """
 
+import errno
 import hashlib
 import logging
 import os
@@ -18,10 +19,15 @@ import tempfile
 import threading
 import time
 
+msvcrt = None
 try:
     import fcntl
 except ImportError:
-    fcntl = None  # Windows — file locking skipped
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        pass
 from pathlib import Path
 from typing import Callable
 
@@ -129,6 +135,25 @@ def _sha256_file(path: str) -> str:
 _SYNC_BACK_MAX_RETRIES = 3
 _SYNC_BACK_BACKOFF = (2, 4, 8)  # seconds between retries
 _SYNC_BACK_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB — refuse to extract larger tars
+_MSVCRT_LOCK_RETRY_SECONDS = 0.1
+_MSVCRT_LOCK_RETRY_ERRNOS = {
+    errno.EACCES,
+    errno.EDEADLK,
+    getattr(errno, "EDEADLOCK", errno.EDEADLK),
+}
+
+
+def _lock_with_msvcrt(lock_fd) -> None:
+    """Acquire an msvcrt byte-range lock, waiting until it is available."""
+    while True:
+        lock_fd.seek(0)
+        try:
+            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_LOCK, 1)
+            return
+        except OSError as exc:
+            if exc.errno not in _MSVCRT_LOCK_RETRY_ERRNOS:
+                raise
+            _sleep(_MSVCRT_LOCK_RETRY_SECONDS)
 
 
 class FileSyncManager:
@@ -324,19 +349,35 @@ class FileSyncManager:
 
     def _sync_back_locked(self, lock_path: Path) -> None:
         """Sync-back under file lock (serializes concurrent gateways)."""
-        if fcntl is None:
-            # Windows: no flock — run without serialization
+        if fcntl is None and msvcrt is None:
+            logger.warning(
+                "sync_back: no file-locking module available — "
+                "proceeding without serialization"
+            )
             self._sync_back_impl()
             return
-        lock_fd = open(lock_path, "w", encoding="utf-8")
+        if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+            lock_path.write_text(" ", encoding="utf-8")
+
+        lock_fd = open(lock_path, "r+" if msvcrt else "a+", encoding="utf-8")
         try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            if fcntl:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            else:
+                _lock_with_msvcrt(lock_fd)
             self._sync_back_impl()
         finally:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
+            if fcntl:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    lock_fd.seek(0)
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
             lock_fd.close()
 
     def _sync_back_impl(self) -> None:

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -148,7 +148,7 @@ def _lock_with_msvcrt(lock_fd) -> None:
     while True:
         lock_fd.seek(0)
         try:
-            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_LOCK, 1)
+            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
             return
         except OSError as exc:
             if exc.errno not in _MSVCRT_LOCK_RETRY_ERRNOS:

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -6,6 +6,7 @@ and Daytona.  Docker and Singularity use bind mounts (live host FS
 view) and don't need this.
 """
 
+import errno
 import hashlib
 import logging
 import os
@@ -18,10 +19,15 @@ import tempfile
 import threading
 import time
 
+msvcrt = None
 try:
     import fcntl
 except ImportError:
-    fcntl = None  # Windows — file locking skipped
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        pass
 from pathlib import Path
 from typing import Callable
 
@@ -129,6 +135,25 @@ def _sha256_file(path: str) -> str:
 _SYNC_BACK_MAX_RETRIES = 3
 _SYNC_BACK_BACKOFF = (2, 4, 8)  # seconds between retries
 _SYNC_BACK_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB — refuse to extract larger tars
+_MSVCRT_LOCK_RETRY_SECONDS = 0.1
+_MSVCRT_LOCK_RETRY_ERRNOS = {
+    errno.EACCES,
+    errno.EDEADLK,
+    getattr(errno, "EDEADLOCK", errno.EDEADLK),
+}
+
+
+def _lock_with_msvcrt(lock_fd) -> None:
+    """Acquire an msvcrt byte-range lock, waiting until it is available."""
+    while True:
+        lock_fd.seek(0)
+        try:
+            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_LOCK, 1)
+            return
+        except OSError as exc:
+            if exc.errno not in _MSVCRT_LOCK_RETRY_ERRNOS:
+                raise
+            _sleep(_MSVCRT_LOCK_RETRY_SECONDS)
 
 
 class FileSyncManager:
@@ -335,19 +360,35 @@ class FileSyncManager:
 
     def _sync_back_locked(self, lock_path: Path) -> None:
         """Sync-back under file lock (serializes concurrent gateways)."""
-        if fcntl is None:
-            # Windows: no flock — run without serialization
+        if fcntl is None and msvcrt is None:
+            logger.warning(
+                "sync_back: no file-locking module available — "
+                "proceeding without serialization"
+            )
             self._sync_back_impl()
             return
-        lock_fd = open(lock_path, "w", encoding="utf-8")
+        if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+            lock_path.write_text(" ", encoding="utf-8")
+
+        lock_fd = open(lock_path, "r+" if msvcrt else "a+", encoding="utf-8")
         try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            if fcntl:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            else:
+                _lock_with_msvcrt(lock_fd)
             self._sync_back_impl()
         finally:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
+            if fcntl:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    lock_fd.seek(0)
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
             lock_fd.close()
 
     def _sync_back_impl(self) -> None:


### PR DESCRIPTION
Consolidated into the original author's active [#47880](https://github.com/NousResearch/hermes-agent/pull/47880) plus the verified [nonblocking retry and regression follow-up](https://github.com/yubingz/hermes-agent/pull/3). The follow-up targets the original contributor's branch and preserves this PR's useful Windows retry and test work. Its published head is `89be628b6ba4b2ca98c0865d3b1b8f39786231fd`.

Validation: 40 focused tests pass on the source branch plus follow-up; the combined implementation integrated onto main `193f05dec5a736bef89d7bc680236a99feb870ca` passes 39 tests with one Windows-only skip. The locking functions and test module match across both validation trees. Native Windows/macOS and the full suite were not run; CodeRabbit was skipped for this self-authored P3 work.

Original implementation credit: yubingz. Nonblocking retry and Windows test-collection review: Teknium. Both credits are retained in the follow-up commit.

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.
