### PR TITLE
fix(cli): sort model picker list alphabetically

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6747,11 +6747,15 @@ def _prompt_model_selection(
             return None
         return mid
 
-    # Reorder: current model first, then the rest (deduplicated)
+    # Reorder: current model first, then the rest sorted alphabetically
+    # (case-insensitive, deduplicated). Provider/catalog order is often
+    # non-deterministic (Ollama Cloud merges live + registry lists;
+    # OpenRouter's models.dev order isn't stable), so a stable alphabetical
+    # sort makes a 30+ model picker scannable. See #57578.
     ordered = []
     if current_model and current_model in model_ids:
         ordered.append(current_model)
-    for mid in model_ids:
+    for mid in sorted(model_ids, key=str.casefold):
         if mid not in ordered:
             ordered.append(mid)
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -8331,11 +8331,15 @@ def _prompt_model_selection(
             return None
         return mid
 
-    # Reorder: current model first, then the rest (deduplicated)
+    # Reorder: current model first, then the rest sorted alphabetically
+    # (case-insensitive, deduplicated). Provider/catalog order is often
+    # non-deterministic (Ollama Cloud merges live + registry lists;
+    # OpenRouter's models.dev order isn't stable), so a stable alphabetical
+    # sort makes a 30+ model picker scannable. See #57578.
     ordered = []
     if current_model and current_model in model_ids:
         ordered.append(current_model)
-    for mid in model_ids:
+    for mid in sorted(model_ids, key=str.casefold):
         if mid not in ordered:
             ordered.append(mid)
 

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -25,6 +25,44 @@ def test_prompt_model_selection_falls_back_on_menu_runtime_error(monkeypatch):
     assert selected == "model-b"
 
 
+def test_prompt_model_selection_sorts_models_alphabetically(monkeypatch):
+    """#57578: unsorted provider/catalog order is presented alphabetically.
+
+    The numbered fallback lists models in display order, so selecting "1"
+    must return the alphabetically-first model even though it was passed
+    last in the input list.
+    """
+    from hermes_cli.auth import _prompt_model_selection
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+    responses = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+
+    # Deliberately reverse-alphabetical / mixed-case input order.
+    selected = _prompt_model_selection(["zeta", "Beta", "alpha"])
+
+    # Case-insensitive sort → alpha, Beta, zeta; choice "1" is the first.
+    assert selected == "alpha"
+
+
+def test_prompt_model_selection_keeps_current_first_then_sorted(monkeypatch):
+    """#57578: the current model stays pinned to the top; the rest sort."""
+    from hermes_cli.auth import _prompt_model_selection
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+    responses = iter(["2"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+
+    # current_model "zeta" is pinned first; the remainder sort to
+    # alpha, Beta, so choice "2" is "alpha".
+    selected = _prompt_model_selection(
+        ["zeta", "Beta", "alpha"],
+        current_model="zeta",
+    )
+
+    assert selected == "alpha"
+
+
 def test_prompt_model_selection_requires_expensive_confirmation(monkeypatch, capsys):
     from hermes_cli.auth import _prompt_model_selection
 

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -57,6 +57,44 @@ def test_scoped_numbered_input_handles_navigation_keys(sequence, expected):
 
 
 
+def test_prompt_model_selection_sorts_models_alphabetically(monkeypatch):
+    """#57578: unsorted provider/catalog order is presented alphabetically.
+
+    The numbered fallback lists models in display order, so selecting "1"
+    must return the alphabetically-first model even though it was passed
+    last in the input list.
+    """
+    from hermes_cli.auth import _prompt_model_selection
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+    responses = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+
+    # Deliberately reverse-alphabetical / mixed-case input order.
+    selected = _prompt_model_selection(["zeta", "Beta", "alpha"])
+
+    # Case-insensitive sort → alpha, Beta, zeta; choice "1" is the first.
+    assert selected == "alpha"
+
+
+def test_prompt_model_selection_keeps_current_first_then_sorted(monkeypatch):
+    """#57578: the current model stays pinned to the top; the rest sort."""
+    from hermes_cli.auth import _prompt_model_selection
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+    responses = iter(["2"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+
+    # current_model "zeta" is pinned first; the remainder sort to
+    # alpha, Beta, so choice "2" is "alpha".
+    selected = _prompt_model_selection(
+        ["zeta", "Beta", "alpha"],
+        current_model="zeta",
+    )
+
+    assert selected == "alpha"
+
+
 def test_prompt_model_selection_requires_expensive_confirmation(monkeypatch, capsys):
     from hermes_cli.auth import _prompt_model_selection
 


### PR DESCRIPTION
## Summary

- Sort the interactive model picker list alphabetically (case-insensitive).
- The current model still gets pinned to the top with its `← currently in use` marker.

## Motivation

Closes #57578.

`_prompt_model_selection()` in `hermes_cli/auth.py` presented `model_ids` in whatever order they arrived from the provider probe / catalog. For Ollama Cloud (a live `/v1/models` list merged with the models.dev registry) and OpenRouter (models.dev catalog order) that order is non-deterministic and changes between invocations, so finding a specific model in a 30+ entry list is an unnecessary visual search.

## Fix

Sort `model_ids` with `sorted(model_ids, key=str.casefold)` before building the `ordered` list. The "current model first" behaviour and dedup are unchanged.

## Verification

- `python3 -m pytest tests/hermes_cli/test_terminal_menu_fallbacks.py` — 8 passed
- Added 2 regression tests (via the numbered-input fallback):
  - `test_prompt_model_selection_sorts_models_alphabetically` — unsorted/mixed-case input is presented alphabetically
  - `test_prompt_model_selection_keeps_current_first_then_sorted` — current model stays pinned first, remainder sorted
- Confirmed both tests fail on `main` without the one-line sort change.
