### PR TITLE
fix(fallback): dedup fallback-chain adds by full (provider, model, base_url) identity

### DIFF
--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -184,10 +184,13 @@ def cmd_fallback_add(args) -> None:
         return
 
     # Picker picked the same thing that's already the primary → nothing changed,
-    # and there's nothing useful to add as a fallback to itself.
+    # and there's nothing useful to add as a fallback to itself.  Compare on the
+    # chain's full (provider, model, base_url) identity — the same tuple used for
+    # chain dedup below — so keeping the current model as primary on endpoint A
+    # while adding endpoint B as a fallback is not wrongly rejected as "same as
+    # primary".
     primary_entry = _extract_fallback_from_model_cfg(model_before)
-    if primary_entry and primary_entry["provider"] == new_entry["provider"] \
-            and primary_entry["model"] == new_entry["model"]:
+    if primary_entry and _entry_identity(primary_entry) == _entry_identity(new_entry):
         _restore_model_cfg(model_before)
         _restore_auth_active_provider(active_provider_before)
         print()

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import copy
 from typing import Any, Dict, List, Optional
 
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import _entry_identity, get_fallback_chain
 
 
 # ---------------------------------------------------------------------------
@@ -205,10 +205,13 @@ def cmd_fallback_add(args) -> None:
     final_cfg = load_config()
     chain = _read_chain(final_cfg)
 
-    # Reject exact-duplicate fallback entries.
+    # Reject exact-duplicate fallback entries. Use the chain's own identity
+    # (provider, model, base_url) — the same tuple ``get_fallback_chain`` dedups
+    # on — so two distinct routes that share a provider label and model name but
+    # target different base_urls are correctly treated as separate entries.
+    new_identity = _entry_identity(new_entry)
     for existing in chain:
-        if existing.get("provider") == new_entry["provider"] \
-                and existing.get("model") == new_entry["model"]:
+        if _entry_identity(existing) == new_identity:
             print()
             print(f"  {_format_entry(new_entry)} is already in the fallback chain — skipped.")
             return

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -255,6 +255,40 @@ class TestAddCommand:
         out = capsys.readouterr().out
         assert "already in the fallback chain" in out
 
+    def test_add_allows_same_model_different_base_url(self, isolated_home, capsys):
+        # Same provider label + model name but a DIFFERENT base_url is a distinct
+        # route (e.g. the same model served by two OpenAI-compatible endpoints),
+        # so it must be added, not rejected as a duplicate.
+        _write_config(isolated_home, {
+            "model": {"provider": "anthropic", "default": "claude-sonnet-4-6"},
+            "fallback_providers": [
+                {"provider": "openai", "model": "gpt-oss", "base_url": "http://hostA:8000/v1"},
+            ],
+        })
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "openai",
+                "default": "gpt-oss",
+                "base_url": "http://hostB:8000/v1",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), \
+                patch("hermes_cli.main._require_tty"):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        # Both distinct routes should be present.
+        assert len(cfg["fallback_providers"]) == 2
+        base_urls = {e.get("base_url") for e in cfg["fallback_providers"]}
+        assert base_urls == {"http://hostA:8000/v1", "http://hostB:8000/v1"}
+        out = capsys.readouterr().out
+        assert "already in the fallback chain" not in out
+
     def test_add_rejects_same_as_primary(self, isolated_home, capsys):
         _write_config(isolated_home, {
             "model": {"provider": "openrouter", "default": "gpt-5.4"},

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -311,6 +311,78 @@ class TestAddCommand:
         out = capsys.readouterr().out
         assert "matches the current primary" in out
 
+    def test_add_allows_same_model_as_primary_different_base_url(self, isolated_home, capsys):
+        # The PRIMARY is openai/gpt-oss on endpoint A. Adding openai/gpt-oss on a
+        # DIFFERENT base_url (endpoint B) is a distinct route, so the "same as
+        # primary" guard must NOT reject it — it should be appended as a fallback.
+        # Pre-fix, the guard compared only (provider, model) and blocked this.
+        _write_config(isolated_home, {
+            "model": {
+                "provider": "openai",
+                "default": "gpt-oss",
+                "base_url": "http://hostA:8000/v1",
+            },
+        })
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "openai",
+                "default": "gpt-oss",
+                "base_url": "http://hostB:8000/v1",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), \
+                patch("hermes_cli.main._require_tty"):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        # Primary is preserved on endpoint A
+        assert cfg["model"]["provider"] == "openai"
+        assert cfg["model"]["default"] == "gpt-oss"
+        assert cfg["model"]["base_url"] == "http://hostA:8000/v1"
+        # The endpoint-B route was added as a fallback (not rejected as same-as-primary)
+        assert cfg["fallback_providers"] == [
+            {"provider": "openai", "model": "gpt-oss", "base_url": "http://hostB:8000/v1"},
+        ]
+        out = capsys.readouterr().out
+        assert "Added fallback" in out
+        assert "matches the current primary" not in out
+
+    def test_add_rejects_same_as_primary_identical_base_url(self, isolated_home, capsys):
+        # Negative case for the guard above: identical (provider, model, base_url)
+        # as the primary is still a self-fallback and must be rejected.
+        _write_config(isolated_home, {
+            "model": {
+                "provider": "openai",
+                "default": "gpt-oss",
+                "base_url": "http://hostA:8000/v1",
+            },
+        })
+
+        def fake_picker(args=None):
+            from hermes_cli.config import load_config, save_config
+            cfg = load_config()
+            cfg["model"] = {
+                "provider": "openai",
+                "default": "gpt-oss",
+                "base_url": "http://hostA:8000/v1",
+            }
+            save_config(cfg)
+
+        with patch("hermes_cli.main.select_provider_and_model", side_effect=fake_picker), \
+                patch("hermes_cli.main._require_tty"):
+            from hermes_cli.fallback_cmd import cmd_fallback_add
+            cmd_fallback_add(types.SimpleNamespace())
+
+        cfg = _read_config(isolated_home)
+        assert "fallback_providers" not in cfg or cfg["fallback_providers"] == []
+        out = capsys.readouterr().out
+        assert "matches the current primary" in out
+
     def test_add_preserves_primary_when_picker_changes_it(self, isolated_home):
         """The picker mutates config["model"]; fallback_add must restore the primary."""
         _write_config(isolated_home, {


### PR DESCRIPTION
## What does this PR do?

`hermes fallback add` rejects a distinct fallback route as a duplicate when it shares a provider label and model name with an existing entry but targets a different `base_url`. The add-side dedup in `cmd_fallback_add` compares only `provider` + `model`, but the fallback chain's own identity model (`_entry_identity`, used by `get_fallback_chain`) is the three-tuple `(provider, model, base_url)`. The two identity notions disagree, so a user running the same model on two OpenAI-compatible endpoints (e.g. two self-hosted vLLM/Ollama/LiteLLM proxies, or two regional gateways) cannot add the second endpoint as a fallback — it is silently skipped with "… is already in the fallback chain."

This aligns the add path with the merge/read path by deduping on the chain's own `_entry_identity` tuple, so "exact duplicate" means provider **and** model **and** base_url all match. A genuine full-identity duplicate is still rejected.

## Related Issue

N/A — author-found correctness bug in the CLI fallback add path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/fallback_cmd.py`: in `cmd_fallback_add`, replace the provider+model-only duplicate check with a comparison on `_entry_identity(existing) == _entry_identity(new_entry)` (imported from `hermes_cli.fallback_config`) — the same `(provider, model, base_url)` tuple `get_fallback_chain` dedups on.
- `tests/hermes_cli/test_fallback_cmd.py`: add `test_add_allows_same_model_different_base_url` regression test.

## How to Test

1. Configure a fallback with a model on one endpoint: `fallback_providers: [{provider: openai, model: gpt-oss, base_url: http://hostA:8000/v1}]`.
2. Run `hermes fallback add` and pick the same provider/model but a different `base_url` (e.g. `http://hostB:8000/v1`).
3. Before this fix: the second route is skipped with "already in the fallback chain." After this fix: both routes are present in the chain.

Regression test: `test_add_allows_same_model_different_base_url` fails before the production change (chain stays length 1, "skipped" printed) and passes after. The existing `test_add_rejects_duplicate` (a true full-identity duplicate) still passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_fallback_cmd.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure config-identity logic, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A