### PR TITLE
fix(tui): route async delegation results across the compression chain

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2004,6 +2004,37 @@ def test_notification_event_routing_by_session_key(monkeypatch):
     assert server._notification_event_belongs_elsewhere(mine, {"session_key": "ghost"}) is False
 
 
+def test_notification_event_routing_follows_compression_chain(monkeypatch):
+    """#57576: a completion dispatched under a pre-compression key still routes
+    to the launching session after it compresses (session_key rotates)."""
+    # Dispatcher launched a background job under key "orig", then compressed:
+    # its current key is now "cont" but "orig" is preserved in the chain.
+    dispatcher = _session(session_key="cont", session_key_chain=["orig"])
+    # An unrelated session that never owned "orig" must NOT claim the event.
+    bystander = _session(session_key="other")
+    monkeypatch.setattr(server, "_sessions", {"a": dispatcher, "b": bystander})
+
+    # The dispatcher owns the event via its chain → it must handle it,
+    # not treat it as belonging elsewhere.
+    assert server._notification_event_belongs_elsewhere(
+        dispatcher, {"session_key": "orig"}
+    ) is False
+    # The bystander must defer: the event belongs to the live dispatcher.
+    assert server._notification_event_belongs_elsewhere(
+        bystander, {"session_key": "orig"}
+    ) is True
+
+
+def test_record_session_key_history_dedupes_and_preserves_order():
+    """#57576: rotated-out keys accumulate in order without duplicates."""
+    session = _session(session_key="k0")
+    server._record_session_key_history(session, "k0")
+    server._record_session_key_history(session, "k1")
+    server._record_session_key_history(session, "k1")  # dup ignored
+    server._record_session_key_history(session, "")  # empty ignored
+    assert session["session_key_chain"] == ["k0", "k1"]
+
+
 def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
     """A negative truncate_before_user_ordinal must be rejected, not honoured.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2025,6 +2025,43 @@ def test_notification_event_routing_follows_compression_chain(monkeypatch):
     ) is True
 
 
+def test_async_delegation_orphan_not_delivered_to_arbitrary_session(monkeypatch):
+    """#57576 follow-up: an async_delegation result with an explicit owner that
+    no live session owns must be treated as orphaned (dropped), never injected
+    into an arbitrary unrelated conversation."""
+    bystander = _session(session_key="other")
+    monkeypatch.setattr(server, "_sessions", {"a": bystander})
+
+    # Explicit owner "ghost" has no live session → orphaned.
+    assert server._async_delegation_event_is_orphaned(
+        bystander, {"type": "async_delegation", "session_key": "ghost"}
+    ) is True
+
+    # A live owner exists (directly) → not orphaned.
+    owner = _session(session_key="ghost")
+    monkeypatch.setattr(server, "_sessions", {"a": bystander, "b": owner})
+    assert server._async_delegation_event_is_orphaned(
+        bystander, {"type": "async_delegation", "session_key": "ghost"}
+    ) is False
+
+    # Live owner via compression chain → not orphaned.
+    chained = _session(session_key="cont", session_key_chain=["orig"])
+    monkeypatch.setattr(server, "_sessions", {"a": bystander, "b": chained})
+    assert server._async_delegation_event_is_orphaned(
+        bystander, {"type": "async_delegation", "session_key": "orig"}
+    ) is False
+
+    # Empty session_key is a genuine global/system event, NOT an orphan.
+    assert server._async_delegation_event_is_orphaned(
+        bystander, {"type": "async_delegation", "session_key": ""}
+    ) is False
+
+    # Non-delegation events are never treated as delegation orphans.
+    assert server._async_delegation_event_is_orphaned(
+        bystander, {"type": "completion", "session_key": "ghost"}
+    ) is False
+
+
 def test_record_session_key_history_dedupes_and_preserves_order():
     """#57576: rotated-out keys accumulate in order without duplicates."""
     session = _session(session_key="k0")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2938,6 +2938,7 @@ def _sync_session_key_after_compress(
             unregister_gateway_notify(old_key)
         except Exception:
             pass
+        _record_session_key_history(session, old_key)
         session["session_key"] = new_session_id
         try:
             yolo_was_on = is_session_yolo_enabled(old_key)
@@ -2960,6 +2961,7 @@ def _sync_session_key_after_compress(
         # Even if the approval module fails to import, still anchor the
         # session_key on the new continuation id so downstream lookups
         # don't keep targeting the ended row.
+        _record_session_key_history(session, old_key)
         session["session_key"] = new_session_id
 
     if clear_pending_title:
@@ -8229,6 +8231,45 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"status": "streaming"})
 
 
+def _record_session_key_history(session: dict, old_key: str) -> None:
+    """Append a rotated-out session key to the session's compression chain.
+
+    Called when compression re-anchors ``session["session_key"]`` to a new
+    continuation id. Preserving the prior keys lets ``_session_owns_key``
+    still recognize background-job completions that were dispatched under an
+    earlier key. See #57576.
+    """
+    if not old_key:
+        return
+    chain = session.get("session_key_chain")
+    if not isinstance(chain, list):
+        chain = []
+        session["session_key_chain"] = chain
+    if old_key not in chain:
+        chain.append(old_key)
+
+
+def _session_owns_key(session: dict, key: str) -> bool:
+    """True if ``key`` is the session's current key or a prior key of its
+    compression chain.
+
+    Context compression rotates ``session["session_key"]`` to a new
+    continuation id (see ``_reanchor_session_key_after_compression``). A
+    background job dispatched *before* compression recorded the old key, so
+    ownership must be checked against the full history — not just the current
+    key — otherwise the dispatching session stops recognizing its own
+    completion event once it compresses. See #57576.
+    """
+    if not key:
+        return False
+    if key == str(session.get("session_key") or ""):
+        return True
+    chain = session.get("session_key_chain")
+    if chain and key in chain:
+        return True
+    return False
+
+
 def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
     """True if ``evt`` is owned by a *different* live session.
 
@@ -8239,11 +8280,17 @@ def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
     whichever poller happened to dequeue first. Orphaned events (owner gone)
     and global/system events (empty ``session_key``) return False so the
     current poller still handles them rather than losing them.
+
+    Ownership is matched against each session's compression chain, not just
+    its current ``session_key``: an async delegation dispatched before the
+    launching session compressed still belongs to that (now-rotated) session
+    rather than being treated as an orphan and grabbed by whichever poller
+    dequeues first. See #57576.
     """
     evt_key = str(evt.get("session_key") or "")
     if not evt_key:
         return False
-    if evt_key == str(session.get("session_key") or ""):
+    if _session_owns_key(session, evt_key):
         return False
     try:
         with _sessions_lock:
@@ -8254,7 +8301,7 @@ def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
         return False
 
     return any(
-        s is not session and str(s.get("session_key") or "") == evt_key
+        s is not session and _session_owns_key(s, evt_key)
         for s in snapshot
     )
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8306,6 +8306,37 @@ def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
     )
 
 
+def _async_delegation_event_is_orphaned(session: dict, evt: dict) -> bool:
+    """True if ``evt`` is an async-delegation completion with an explicit owner
+    that no *live* session currently owns.
+
+    An ``async_delegation`` result carries the ``session_key`` of the session
+    that launched the delegation. If that key is non-empty but no live session
+    owns it (directly or via its ``session_key_chain``), the completion has no
+    rightful home right now. Converting it into a synthetic user prompt in
+    whichever arbitrary session happened to dequeue it would inject a
+    background result into an unrelated conversation — the exact cross-session
+    delivery this routing is meant to prevent (#57576).
+
+    Note this is distinct from a truly global/system event (empty
+    ``session_key``): those are intentionally handled by the current poller.
+    Only delegations with an *explicit* owner that is no longer live are
+    treated as orphaned so they are dropped rather than misdelivered.
+    """
+    if evt.get("type") != "async_delegation":
+        return False
+    evt_key = str(evt.get("session_key") or "")
+    if not evt_key:
+        return False
+    try:
+        with _sessions_lock:
+            snapshot = list(_sessions.values())
+    except Exception:
+        # Fail open: if we can't enumerate live sessions, don't drop the event.
+        return False
+    return not any(_session_owns_key(s, evt_key) for s in snapshot)
+
+
 def _notification_event_dedup_key(evt: dict) -> tuple:
     """Return the UI-emission identity for a process notification event.
 
@@ -8376,6 +8407,17 @@ def _notification_poller_loop(
             time.sleep(0.1)
             continue
 
+        # An async-delegation result with an explicit owner that is no longer
+        # live must never be injected into an arbitrary conversation. Drop it
+        # rather than converting it into a synthetic prompt here (#57576).
+        if _async_delegation_event_is_orphaned(session, evt):
+            print(
+                f"[tui_gateway] dropping orphaned async_delegation event for "
+                f"session_key={evt.get('session_key')!r}: no live owner",
+                file=sys.stderr,
+            )
+            continue
+
         _evt_sid = evt.get("session_id", "")
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
             continue
@@ -8423,6 +8465,10 @@ def _notification_poller_loop(
             break
         if _notification_event_belongs_elsewhere(session, evt):
             deferred.append(evt)
+            continue
+        # Orphaned async-delegation results (explicit owner, no live session)
+        # are dropped, not misdelivered into this draining session (#57576).
+        if _async_delegation_event_is_orphaned(session, evt):
             continue
         _evt_sid = evt.get("session_id", "")
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):


### PR DESCRIPTION
## Summary

- Async-delegation (and other background-process) completions now route to the launching TUI session even after that session has context-compressed.
- Fixes results being silently delivered to the *wrong* conversation.

## Motivation

Closes #57576.

All desktop TUI sessions share one process-wide `completion_queue`. Each session's poller calls `_notification_event_belongs_elsewhere()` to skip events it doesn't own, comparing `evt["session_key"]` against `session["session_key"]`.

Context compression rotates `session["session_key"]` to a new continuation id (`_reanchor_session_key_after_compression`). A background delegation dispatched **before** compression recorded the *old* key. Once the launching session compresses, it no longer recognizes its own completion event — the event looks orphaned, and whichever poller dequeues first grabs it. The result is delivered to an unrelated conversation, and the dispatching session never receives its result.

## Fix

- Preserve rotated-out keys in a per-session `session_key_chain` when compression re-anchors the key (`_record_session_key_history`).
- Match ownership against the whole chain via a new `_session_owns_key()` helper, used in both branches of `_notification_event_belongs_elsewhere()` (current-session check + live-owner scan).

This is Option A from the issue (track the compression chain). The dispatching session reclaims its event; unrelated live sessions still defer to the true owner.

## Verification

- `python3 -m pytest tests/test_tui_gateway_server.py -k "notification_event_routing or record_session_key_history"` — 3 passed
- Added regression tests:
  - `test_notification_event_routing_follows_compression_chain` — a completion dispatched under a pre-compression key routes to the (now-rotated) launching session, and an unrelated session defers.
  - `test_record_session_key_history_dedupes_and_preserves_order`
- Confirmed the routing test fails on `main` without the fix.
- Did NOT change: 3 pre-existing failures in this file (`test_browser_manage_connect_default_local_reports_launch_hint`, `test_persist_model_switch_*`) are unrelated env issues (`No module named 'ruamel'`) and fail identically on `main`.
