### PR TITLE
Add Telegram plugin callback handlers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1367,6 +1367,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
+    # >>> argus-acp fork: streaming Claude Code ACP client (render-oriented).
+    if agent.provider == "claude-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://claude"):
+        from agent.claude_acp_client import ClaudeACPClient
+
+        client = ClaudeACPClient(**client_kwargs)
+        _ra().logger.info(
+            "Claude ACP client created (%s, shared=%s) %s",
+            reason, shared, agent._client_log_context(),
+        )
+        return client
+    # <<< argus-acp fork
     if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
         from agent.copilot_acp_client import CopilotACPClient
 

--- a/agent/claude_acp_client.py
+++ b/agent/claude_acp_client.py
@@ -1,0 +1,377 @@
+"""Streaming ACP client for Claude Code (`claude-code-acp`).
+
+This is an OpenAI-client-compatible facade (like ``copilot_acp_client``) but it
+is STREAMING and render-oriented:
+
+* It drives ``claude-code-acp`` over the Agent Client Protocol (JSON-RPC/stdio).
+* Claude Code executes its OWN MCP tools (Gmail/Calendar/Trello, passed in
+  ``session/new``) — reliable, no tool-stripping fight. We auto-approve its
+  permission requests so it can act.
+* It streams ACP ``session/update`` events live as OpenAI chunks:
+    - ``agent_thought_chunk``                 -> ``delta.reasoning_content``
+    - ``tool_call`` / ``tool_call_update``    -> ``delta.reasoning_content`` (live tool trace)
+    - ``agent_message_chunk``                 -> ``delta.content`` (the answer)
+  We deliberately do NOT emit ``delta.tool_calls`` — Claude already ran the
+  tools, so the harness must render (not re-execute) them. Thinking + tool
+  traces land in the separate reasoning channel; only the answer is content.
+
+Wired in ``agent_runtime_helpers.create_openai_client`` for provider
+``claude-acp`` (base_url ``acp://claude``). New file → no upstream merge
+conflict; the only core edit is the 3-line dispatch branch.
+"""
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+ACP_MARKER_BASE_URL = "acp://claude"
+_DEFAULT_TIMEOUT_SECONDS = 1800.0
+
+_MCP_LABELS = {
+    "mcpc-gmail": "📨 Email",
+    "mcpc-drive": "📂 Drive",
+    "mcpc-sheets": "📊 Sheets",
+    "mcpc-gcal": "📅 Calendar",
+    "mcpc-trello": "📋 Trello",
+}
+
+
+def _resolve_command() -> str:
+    return os.getenv("HERMES_CLAUDE_ACP_COMMAND", "").strip() or "claude-code-acp"
+
+
+def _tool_label(title: str | None, kind: str | None) -> str:
+    t = title or "tool"
+    if t.startswith("mcp__"):
+        parts = t.split("__")
+        server = parts[1] if len(parts) > 1 else ""
+        tool = parts[2] if len(parts) > 2 else t
+        base = _MCP_LABELS.get(server)
+        return f"{base}: {tool}" if base else f"🔧 {tool}"
+    return f"🔧 {t}"
+
+
+def _load_mcp_servers() -> list[dict[str, Any]]:
+    """Read the proxy's MCP config (the mcpc servers) into ACP session/new shape."""
+    path = os.getenv("CLAUDE_MCP_CONFIG", "").strip()
+    if not path:
+        # Fall back to the known mcpc server config shipped with the proxy.
+        default = Path(os.path.expanduser("~/.hermes/claude-proxy-mcp.json"))
+        path = str(default) if default.exists() else ""
+    if not path or not Path(path).exists():
+        return []
+    try:
+        data = json.loads(Path(path).read_text())
+    except Exception:
+        return []
+    out: list[dict[str, Any]] = []
+    for name, spec in (data.get("mcpServers") or {}).items():
+        if not isinstance(spec, dict) or not spec.get("command"):
+            continue
+        out.append({
+            "name": name,
+            "command": spec["command"],
+            "args": list(spec.get("args") or []),
+            "env": [{"name": k, "value": str(v)} for k, v in (spec.get("env") or {}).items()],
+        })
+    return out
+
+
+def _flatten_messages(messages: list[dict[str, Any]]) -> str:
+    """Flatten an OpenAI message list into a single ACP prompt string.
+
+    Claude's tools come from the MCP servers (not the request `tools`), so the
+    prompt is just the conversation — no tool-definition bloat.
+    """
+    parts: list[str] = []
+    for m in messages or []:
+        role = m.get("role")
+        content = m.get("content")
+        if isinstance(content, list):
+            text = "\n".join(
+                b.get("text", "") for b in content
+                if isinstance(b, dict) and b.get("type") in ("text", "input_text")
+            )
+        else:
+            text = "" if content is None else str(content)
+        if role == "system":
+            parts.append(f"<system>\n{text}\n</system>")
+        elif role == "user":
+            parts.append(text)
+        elif role == "assistant":
+            tcs = m.get("tool_calls") or []
+            if tcs:
+                calls = "; ".join(
+                    f"{tc.get('function', {}).get('name')}({tc.get('function', {}).get('arguments')})"
+                    for tc in tcs
+                )
+                parts.append(f"<previous_action>{text} [called: {calls}]</previous_action>")
+            else:
+                parts.append(f"<previous_response>\n{text}\n</previous_response>")
+        elif role == "tool":
+            parts.append(f"<tool_result>\n{text}\n</tool_result>")
+    return "\n\n".join(p for p in parts if p).strip()
+
+
+def _chunk(model: str, *, content: str | None = None, reasoning: str | None = None,
+           finish: str | None = None, usage: Any = None) -> SimpleNamespace:
+    """Build an OpenAI-style streaming chunk the chat_completions transport reads."""
+    if usage is not None:
+        return SimpleNamespace(choices=[], model=model, usage=usage)
+    delta = SimpleNamespace(content=content, reasoning_content=reasoning,
+                            reasoning=reasoning, tool_calls=None, role="assistant")
+    return SimpleNamespace(
+        choices=[SimpleNamespace(index=0, delta=delta, finish_reason=finish)],
+        model=model,
+        usage=None,
+    )
+
+
+class _ACPChatCompletions:
+    def __init__(self, client: "ClaudeACPClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ACPChatNamespace:
+    def __init__(self, client: "ClaudeACPClient"):
+        self.completions = _ACPChatCompletions(client)
+
+
+class ClaudeACPClient:
+    """Minimal OpenAI-client-compatible STREAMING facade for Claude Code ACP."""
+
+    def __init__(self, *, api_key: str | None = None, base_url: str | None = None,
+                 acp_cwd: str | None = None, **_: Any):
+        self.api_key = api_key or "claude-acp"
+        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self._cmd = _resolve_command()
+        self._mcp = _load_mcp_servers()
+        self.chat = _ACPChatNamespace(self)
+        self.is_closed = False
+
+    def close(self) -> None:
+        self.is_closed = True
+
+    # ---- OpenAI-compatible entrypoint --------------------------------------
+    def _create_chat_completion(self, *, model: str | None = None,
+                                messages: list[dict[str, Any]] | None = None,
+                                stream: bool = False, timeout: Any = None,
+                                **_: Any) -> Any:
+        mdl = model or "claude-acp"
+        prompt = _flatten_messages(messages or [])
+        gen = self._run(prompt, mdl, self._timeout(timeout))
+        if stream:
+            return gen
+        # Non-streaming: drain the generator into a single response object.
+        content, reasoning = [], []
+        for ch in gen:
+            if not ch.choices:
+                continue
+            d = ch.choices[0].delta
+            if getattr(d, "content", None):
+                content.append(d.content)
+            if getattr(d, "reasoning_content", None):
+                reasoning.append(d.reasoning_content)
+        msg = SimpleNamespace(content="".join(content), tool_calls=None,
+                              reasoning="".join(reasoning) or None,
+                              reasoning_content="".join(reasoning) or None,
+                              reasoning_details=None, role="assistant")
+        usage = SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0,
+                                prompt_tokens_details=SimpleNamespace(cached_tokens=0))
+        return SimpleNamespace(
+            choices=[SimpleNamespace(index=0, message=msg, finish_reason="stop")],
+            model=mdl, usage=usage)
+
+    @staticmethod
+    def _timeout(timeout: Any) -> float:
+        if isinstance(timeout, (int, float)):
+            return float(timeout)
+        if timeout is not None:
+            cands = [getattr(timeout, a, None) for a in ("read", "timeout", "pool", "connect")]
+            nums = [float(v) for v in cands if isinstance(v, (int, float))]
+            if nums:
+                return max(nums)
+        return _DEFAULT_TIMEOUT_SECONDS
+
+    # ---- ACP session + live streaming --------------------------------------
+    def _run(self, prompt: str, model: str, timeout_s: float) -> Iterator[SimpleNamespace]:
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        # claude-code-acp (and the `claude` CLI it spawns) live in linuxbrew /
+        # ~/.local/bin — make sure they're findable regardless of caller PATH.
+        extra = ["/home/linuxbrew/.linuxbrew/bin", os.path.expanduser("~/.local/bin")]
+        env["PATH"] = os.pathsep.join(extra + [env.get("PATH", "")])
+        try:
+            proc = subprocess.Popen(
+                [self._cmd], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL, text=True, bufsize=1, env=env, cwd=self._cwd,
+            )
+        except FileNotFoundError:
+            yield _chunk(model, content=f"(claude-acp: command '{self._cmd}' not found)", finish="stop")
+            yield _chunk(model, usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0,
+                         total_tokens=0, prompt_tokens_details=SimpleNamespace(cached_tokens=0)))
+            return
+        handshake_timeout = min(timeout_s, 45.0)
+        events: "queue.Queue[tuple[str, Any]]" = queue.Queue()
+        resp: dict[int, queue.Queue] = {}
+        nid = [0]
+        lock = threading.Lock()
+
+        def send(obj: dict) -> None:
+            with lock:
+                if proc.stdin and not proc.stdin.closed:
+                    proc.stdin.write(json.dumps(obj) + "\n")
+                    proc.stdin.flush()
+
+        def request(method: str, params: dict, t: float | None = None) -> dict:
+            nid[0] += 1
+            rid = nid[0]
+            q: queue.Queue = queue.Queue()
+            resp[rid] = q
+            send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+            return q.get(timeout=t if t is not None else timeout_s)
+
+        def reader() -> None:
+            try:
+                for line in proc.stdout:  # type: ignore[union-attr]
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        msg = json.loads(line)
+                    except Exception:
+                        continue
+                    # response to one of our requests
+                    if "id" in msg and ("result" in msg or "error" in msg) and "method" not in msg:
+                        q = resp.pop(msg["id"], None)
+                        if q:
+                            q.put(msg)
+                        continue
+                    method = msg.get("method")
+                    # agent -> client request (needs a reply)
+                    if method and "id" in msg:
+                        if method == "session/request_permission":
+                            opts = (msg.get("params") or {}).get("options") or []
+                            pick = next((o.get("optionId") for o in opts
+                                         if "allow" in (o.get("optionId", "") + o.get("name", "")).lower()),
+                                        opts[0].get("optionId") if opts else None)
+                            send({"jsonrpc": "2.0", "id": msg["id"],
+                                  "result": {"outcome": {"outcome": "selected", "optionId": pick}}})
+                        elif method == "fs/read_text_file":
+                            p = (msg.get("params") or {}).get("path")
+                            try:
+                                send({"jsonrpc": "2.0", "id": msg["id"],
+                                      "result": {"content": Path(p).read_text()}})
+                            except Exception as e:
+                                send({"jsonrpc": "2.0", "id": msg["id"],
+                                      "error": {"code": -32000, "message": str(e)}})
+                        else:
+                            send({"jsonrpc": "2.0", "id": msg["id"], "result": {}})
+                        continue
+                    # agent -> client notification
+                    if method == "session/update":
+                        events.put(("update", (msg.get("params") or {}).get("update") or {}))
+            except Exception:
+                pass
+            finally:
+                events.put(("eof", None))
+
+        threading.Thread(target=reader, daemon=True).start()
+
+        try:
+            try:
+                request("initialize", {"protocolVersion": 1,
+                        "clientCapabilities": {"fs": {"readTextFile": True, "writeTextFile": False}}},
+                        t=handshake_timeout)
+                sn = request("session/new", {"cwd": self._cwd, "mcpServers": self._mcp},
+                             t=handshake_timeout)
+            except queue.Empty:
+                yield _chunk(model, content="(claude-acp: agent did not respond to handshake)", finish="stop")
+                yield _chunk(model, usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0,
+                             total_tokens=0, prompt_tokens_details=SimpleNamespace(cached_tokens=0)))
+                return
+            sid = (sn.get("result") or {}).get("sessionId")
+            if not sid:
+                yield _chunk(model, content="(claude-acp: failed to start session)", finish="stop")
+                yield _chunk(model, usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0,
+                             total_tokens=0, prompt_tokens_details=SimpleNamespace(cached_tokens=0)))
+                return
+
+            # Fire the prompt on a side thread; it signals completion by pushing
+            # a ("done", result) sentinel onto the SAME event queue — which the
+            # agent only sends after all session/update notifications, so the
+            # loop drains every update first, then cleanly finishes.
+            def run_prompt() -> None:
+                try:
+                    r = request("session/prompt", {"sessionId": sid,
+                                "prompt": [{"type": "text", "text": prompt}]})
+                    events.put(("done", r))
+                except Exception as e:
+                    events.put(("done", {"error": str(e)}))
+
+            threading.Thread(target=run_prompt, daemon=True).start()
+
+            # Buffer assistant message text. Text emitted BEFORE a tool call is
+            # narration → reasoning channel; the final text (after the last tool)
+            # is the answer → content. Real "thinking" (thought chunks) and tool
+            # traces always go to the reasoning channel.
+            seen_tool: set[str] = set()
+            msg_buf = ""
+            while True:
+                kind, payload = events.get(timeout=timeout_s)
+                if kind in ("eof", "done"):
+                    break
+                u = payload
+                su = str(u.get("sessionUpdate") or "")
+                if su == "agent_message_chunk":
+                    msg_buf += _text_of(u.get("content"))
+                elif su == "agent_thought_chunk":
+                    txt = _text_of(u.get("content"))
+                    if txt:
+                        yield _chunk(model, reasoning=txt)
+                elif su == "tool_call":
+                    tcid = str(u.get("toolCallId") or "")
+                    if tcid not in seen_tool:
+                        seen_tool.add(tcid)
+                        if msg_buf.strip():   # narration before this tool
+                            yield _chunk(model, reasoning=msg_buf.strip() + "\n")
+                            msg_buf = ""
+                        yield _chunk(model, reasoning=f"› {_tool_label(u.get('title'), u.get('kind'))}…\n")
+                elif su == "tool_call_update" and u.get("status") == "completed":
+                    yield _chunk(model, reasoning="  ✓\n")
+                # plan / other updates ignored for now
+
+            # Whatever message text remains after the last tool is the answer.
+            if msg_buf.strip():
+                yield _chunk(model, content=msg_buf.strip())
+
+            yield _chunk(model, finish="stop")
+            yield _chunk(model, usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0,
+                         total_tokens=0, prompt_tokens_details=SimpleNamespace(cached_tokens=0)))
+        finally:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+
+
+def _text_of(content: Any) -> str:
+    if isinstance(content, dict):
+        # ACP content block: {type:"text", text:"..."} or {type:"content", content:{...}}
+        if content.get("type") == "text":
+            return str(content.get("text") or "")
+        inner = content.get("content")
+        if isinstance(inner, dict):
+            return str(inner.get("text") or "")
+    if isinstance(content, str):
+        return content
+    return ""

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -770,6 +770,14 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
 
+        # Linear: Linear-Signature = <hex HMAC-SHA256 of raw body>
+        linear_sig = _header("Linear-Signature")
+        if linear_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(linear_sig, expected)
+
         # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
         generic_sig = request.headers.get("X-Webhook-Signature", "")
         if generic_sig:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -926,6 +926,55 @@ class PluginContext:
             action_id,
         )
 
+    # -- telegram callback handler registration -----------------------------
+
+    def register_telegram_callback_handler(
+        self,
+        matcher: Any,
+        callback: Callable,
+    ) -> None:
+        """Register a Telegram inline-keyboard callback handler from a plugin.
+
+        Hermes' Telegram adapter dispatches plugin handlers from its
+        ``CallbackQueryHandler`` path when a button's ``callback_data`` matches
+        the registered matcher.
+
+        Callback signature::
+
+            async def handler(query, data) -> None:
+                await query.answer()  # acknowledge the button click
+                ...
+
+        Args:
+            matcher: A literal string prefix (``data.startswith(matcher)``) or
+                a compiled regular expression with a ``match(data)`` method.
+                Prefix strings should be namespaced (e.g. ``"idea:"``) to
+                avoid collisions with built-in Telegram callback prefixes.
+            callback: Async callable receiving ``(query, data)``.
+
+        Raises:
+            ValueError: if ``callback`` is not callable, or ``matcher`` is
+                empty/None.
+        """
+        if not callable(callback):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Telegram "
+                f"callback handler with a non-callable callback."
+            )
+        if matcher is None or (isinstance(matcher, str) and not matcher.strip()):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' tried to register a Telegram "
+                f"callback handler with an empty matcher."
+            )
+        self._manager._telegram_callback_handlers.append(
+            (matcher, callback, self.manifest.name)
+        )
+        logger.debug(
+            "Plugin %s registered Telegram callback handler: %s",
+            self.manifest.name,
+            matcher,
+        )
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------
@@ -1157,6 +1206,12 @@ class PluginManager:
         # ``re.Pattern``, or a constraint dict); ``callback`` is an async
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
+        # Telegram inline-keyboard callback handlers registered by plugins.
+        # Each entry is (matcher, callback, plugin_name); ``matcher`` is a
+        # literal callback-data prefix string or compiled regex with match().
+        # The Telegram adapter invokes ``callback(query, data)`` from its
+        # CallbackQueryHandler path.
+        self._telegram_callback_handlers: List[tuple] = []
 
     # -----------------------------------------------------------------------
     # Public
@@ -1190,6 +1245,7 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._slack_action_handlers.clear()
+            self._telegram_callback_handlers.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
         # can transitively trigger discovery again), but reset it if the sweep
@@ -1785,6 +1841,21 @@ class PluginManager:
         :meth:`PluginContext.register_slack_action_handler`.
         """
         return list(self._slack_action_handlers)
+
+    # -----------------------------------------------------------------------
+    # Telegram callback handler accessor
+    # -----------------------------------------------------------------------
+
+    def get_telegram_callback_handlers(self) -> List[tuple]:
+        """Return the list of plugin-registered Telegram callback handlers.
+
+        Each entry is a ``(matcher, callback, plugin_name)`` tuple. Consumed by
+        the Telegram adapter from its ``CallbackQueryHandler`` path.
+
+        Plugins register handlers via
+        :meth:`PluginContext.register_telegram_callback_handler`.
+        """
+        return list(self._telegram_callback_handlers)
 
     # -----------------------------------------------------------------------
     # Introspection

--- a/plugins/model-providers/claude-acp/__init__.py
+++ b/plugins/model-providers/claude-acp/__init__.py
@@ -1,0 +1,27 @@
+"""Claude Code ACP provider (argus-acp fork).
+
+Routes to the streaming ``ClaudeACPClient`` via the ``create_openai_client``
+dispatch (matched on provider name / ``acp://claude`` base_url). Claude Code
+runs as a real ACP agent — executes its own MCP tools, streams thinking + tool
+traces to the reasoning channel and the answer to content. Uses the local
+``claude`` Max auth (no API key, Anthropic-permitted).
+"""
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClaudeACPProfile(ProviderProfile):
+    """External ACP subprocess — no REST models endpoint."""
+
+    def fetch_models(self, *, api_key=None, base_url=None, timeout: float = 8.0):
+        return None
+
+
+register_provider(ClaudeACPProfile(
+    name="claude-acp",
+    aliases=("claude-code-acp", "claude-acp-agent"),
+    api_mode="chat_completions",   # dispatched to ClaudeACPClient in create_openai_client
+    env_vars=(),                   # auth handled by the local claude CLI (Max)
+    base_url="acp://claude",
+    auth_type="external_process",
+))

--- a/plugins/model-providers/claude-acp/plugin.yaml
+++ b/plugins/model-providers/claude-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Claude Code via streaming ACP — native tool/thinking traces, Max auth
+author: tjtorres (argus-acp fork)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4170,6 +4170,58 @@ class TelegramAdapter(BasePlatformAdapter):
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
 
+    @staticmethod
+    def _plugin_callback_matches(matcher: Any, data: str) -> bool:
+        """Return True when a plugin Telegram callback matcher accepts data."""
+        if isinstance(matcher, str):
+            return data.startswith(matcher)
+        match = getattr(matcher, "match", None)
+        if callable(match):
+            try:
+                return bool(match(data))
+            except Exception:
+                logger.debug(
+                    "[Telegram] Plugin callback matcher raised for %r",
+                    data,
+                    exc_info=True,
+                )
+                return False
+        return False
+
+    async def _dispatch_plugin_callback_query(self, query: Any, data: str) -> bool:
+        """Dispatch a Telegram callback query to a plugin handler if matched.
+
+        Returns True when a plugin matcher handled the callback (including the
+        defensive-error path), so built-in fallback routing should stop.
+        """
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            handlers = get_plugin_manager().get_telegram_callback_handlers()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "[Telegram] Could not load plugin callback handlers: %s", exc,
+            )
+            return False
+
+        for matcher, callback, plugin_name in handlers:
+            if not self._plugin_callback_matches(matcher, data):
+                continue
+            try:
+                await callback(query, data)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error(
+                    "[Telegram] Plugin '%s' callback handler raised: %s",
+                    plugin_name,
+                    exc,
+                    exc_info=True,
+                )
+                try:
+                    await query.answer(text="Plugin callback failed.")
+                except Exception:
+                    pass
+            return True
+        return False
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -4480,9 +4532,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return
 
-        # --- Update prompt callbacks ---
+        # --- Plugin callbacks (custom plugin prefixes / regexes) ---
+        # Built-in callback prefixes above keep priority; update_prompt remains
+        # reserved below. Plugin authors should namespace callback_data such as
+        # "idea:" or "gift:" to avoid collisions.
         if not data.startswith("update_prompt:"):
+            if await self._dispatch_plugin_callback_query(query, data):
+                return
             return
+
+        # --- Update prompt callbacks ---
         answer = data.split(":", 1)[1]  # "y" or "n"
         caller_id = str(getattr(query.from_user, "id", ""))
         if not self._is_callback_user_authorized(

--- a/tests/gateway/test_telegram_plugin_callback_handlers.py
+++ b/tests/gateway/test_telegram_plugin_callback_handlers.py
@@ -1,0 +1,225 @@
+"""Tests for plugin-registered Telegram inline keyboard callback handlers.
+
+Covers:
+* ``PluginContext.register_telegram_callback_handler`` validation + queuing
+* ``PluginManager.get_telegram_callback_handlers`` accessor
+* ``TelegramAdapter._handle_callback_query`` dispatching matching callbacks
+  while isolating plugin exceptions from the gateway.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable when this test runs directly
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Telegram mock so TelegramAdapter can be imported without PTB
+# ---------------------------------------------------------------------------
+def _ensure_telegram_mock() -> None:
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig  # noqa: E402
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _make_ctx(name: str = "test_plugin") -> tuple[PluginManager, PluginContext]:
+    mgr = PluginManager()
+    manifest = PluginManifest(name=name, version="0.1.0", description="test")
+    ctx = PluginContext(manifest=manifest, manager=mgr)
+    return mgr, ctx
+
+
+def _make_adapter() -> TelegramAdapter:
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _make_callback_update(data: str):
+    query = AsyncMock()
+    query.data = data
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.message_thread_id = None
+    query.message.chat = MagicMock()
+    query.message.chat.type = "private"
+    query.from_user = MagicMock()
+    query.from_user.id = "777"
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+    context = MagicMock()
+    return update, context, query
+
+
+class TestRegisterTelegramCallbackHandlerAPI:
+    """Behaviour of ctx.register_telegram_callback_handler()."""
+
+    def test_string_prefix_is_queued(self):
+        mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover - never called here
+            await query.answer()
+
+        ctx.register_telegram_callback_handler("idea:", cb)
+
+        handlers = mgr.get_telegram_callback_handlers()
+        assert len(handlers) == 1
+        matcher, callback, plugin_name = handlers[0]
+        assert matcher == "idea:"
+        assert callback is cb
+        assert plugin_name == "test_plugin"
+
+    def test_regex_matcher_is_accepted(self):
+        import re as _re
+
+        mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover
+            await query.answer()
+
+        pat = _re.compile(r"^idea:(love|no):")
+        ctx.register_telegram_callback_handler(pat, cb)
+
+        handlers = mgr.get_telegram_callback_handlers()
+        assert handlers[0][0] is pat
+
+    def test_non_callable_callback_raises(self):
+        _mgr, ctx = _make_ctx()
+        with pytest.raises(ValueError, match="non-callable"):
+            ctx.register_telegram_callback_handler("idea:", "not a function")  # type: ignore[arg-type]
+
+    def test_empty_string_matcher_raises(self):
+        _mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover
+            await query.answer()
+
+        with pytest.raises(ValueError, match="empty matcher"):
+            ctx.register_telegram_callback_handler("   ", cb)
+
+    def test_none_matcher_raises(self):
+        _mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover
+            await query.answer()
+
+        with pytest.raises(ValueError, match="empty matcher"):
+            ctx.register_telegram_callback_handler(None, cb)
+
+    def test_get_telegram_callback_handlers_returns_copy(self):
+        mgr, ctx = _make_ctx()
+
+        async def cb(query, data):  # pragma: no cover
+            await query.answer()
+
+        ctx.register_telegram_callback_handler("idea:", cb)
+        handlers = mgr.get_telegram_callback_handlers()
+        handlers.clear()
+        assert len(mgr.get_telegram_callback_handlers()) == 1
+
+
+class TestTelegramAdapterPluginCallbackDispatch:
+    """_handle_callback_query must dispatch plugin-supplied handlers."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_callback_prefix_dispatches_and_stops_builtin_fallback(self):
+        adapter = _make_adapter()
+        calls: list[tuple[object, str]] = []
+
+        async def my_handler(query, data):
+            calls.append((query, data))
+            await query.answer(text="handled")
+
+        fake_mgr = MagicMock()
+        fake_mgr.get_telegram_callback_handlers.return_value = [
+            ("idea:", my_handler, "argus-ideas"),
+        ]
+        update, context, query = _make_callback_update("idea:love:abc123")
+
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=fake_mgr):
+            await adapter._handle_callback_query(update, context)
+
+        assert calls == [(query, "idea:love:abc123")]
+        query.answer.assert_awaited_once_with(text="handled")
+
+    @pytest.mark.asyncio
+    async def test_plugin_callback_regex_dispatches(self):
+        import re as _re
+
+        adapter = _make_adapter()
+        seen: list[str] = []
+
+        async def my_handler(query, data):
+            seen.append(data)
+            await query.answer()
+
+        fake_mgr = MagicMock()
+        fake_mgr.get_telegram_callback_handlers.return_value = [
+            (_re.compile(r"^gift:(save|reject):"), my_handler, "argus-gifts"),
+        ]
+        update, context, query = _make_callback_update("gift:save:42")
+
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=fake_mgr):
+            await adapter._handle_callback_query(update, context)
+
+        assert seen == ["gift:save:42"]
+        query.answer.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_plugin_exception_is_answered_and_swallowed(self):
+        adapter = _make_adapter()
+
+        async def boom(query, data):
+            raise RuntimeError("plugin bug")
+
+        fake_mgr = MagicMock()
+        fake_mgr.get_telegram_callback_handlers.return_value = [
+            ("idea:", boom, "buggy-plugin"),
+        ]
+        update, context, query = _make_callback_update("idea:explode")
+
+        with patch("hermes_cli.plugins.get_plugin_manager", return_value=fake_mgr):
+            await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_awaited_once()
+        assert "failed" in query.answer.call_args.kwargs["text"].lower()

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -887,6 +887,33 @@ def register(ctx):
 
 This is the public way for plugins to participate in Slack interactivity. Older plugins may patch `SlackAdapter.connect`; prefer this API instead.
 
+### Handle Telegram inline keyboard button clicks
+
+Plugins that send Telegram messages with inline keyboards can register callback-query handlers directly with the Telegram adapter. This is the right surface for card-like flows where a button should do deterministic work without routing the click back through the LLM as text.
+
+```python
+def register(ctx):
+    async def _on_idea_action(query, data: str):
+        # data is the button callback_data, e.g. "idea:love:abc123"
+        await query.answer(text="Saved")
+        action, idea_id = data.split(":", 2)[1:]
+        # query.message.chat_id, query.from_user.id, query.message.message_id
+        # ...do deterministic work, then edit/reply as needed.
+
+    ctx.register_telegram_callback_handler("idea:", _on_idea_action)
+```
+
+**Signature:** `ctx.register_telegram_callback_handler(matcher, callback) -> None`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `matcher` | `str \| re.Pattern` | A literal `callback_data` prefix string (`data.startswith(matcher)`) or compiled regex whose `match(data)` succeeds |
+| `callback` | async callable | Receives `(query, data)` where `query` is the python-telegram-bot `CallbackQuery` object |
+
+**Collision rules:** Built-in Hermes Telegram callbacks keep priority. Custom plugins should namespace their `callback_data` prefixes (for example `"idea:"`, `"gift:"`, `"team_digest:"`) and avoid built-in prefixes like `ea:`, `cl:`, `sc:`, `gt:`, `mp:` and `update_prompt:`.
+
+**Runtime behavior:** The handler is queued at plugin-load time and consulted from the Telegram adapter's `CallbackQueryHandler` path. If a matching plugin handler raises, Hermes logs the exception and best-effort-answers the callback query so Telegram stops showing the loading spinner.
+
 :::tip
 This guide covers **general plugins** (tools, hooks, slash commands, CLI commands). The sections below sketch the authoring pattern for each specialized plugin type; each links to its full guide for field reference and examples.
 :::

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -108,6 +108,8 @@ Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.
 | Gate on env vars | `requires_env: [API_KEY]` in plugin.yaml — prompted during `hermes plugins install` |
 | Distribute via pip | `[project.entry-points."hermes_agent.plugins"]` |
 | Register a gateway platform (Discord, Telegram, IRC, …) | `ctx.register_platform(name, label, adapter_factory, check_fn, ...)` — see [Adding Platform Adapters](/developer-guide/adding-platform-adapters) |
+| Handle Slack interactive components | `ctx.register_slack_action_handler(action_id, callback)` — dispatches Block Kit button/menu/etc. actions to plugin code |
+| Handle Telegram inline buttons | `ctx.register_telegram_callback_handler(matcher, callback)` — dispatches matching inline-keyboard `callback_data` to plugin code |
 | Register an image-generation backend | `ctx.register_image_gen_provider(provider)` — see [Image Generation Provider Plugins](/developer-guide/image-gen-provider-plugin) |
 | Register a video-generation backend | `ctx.register_video_gen_provider(provider)` — see [Video Generation Provider Plugins](/developer-guide/video-gen-provider-plugin) |
 | Register a context-compression engine | `ctx.register_context_engine(engine)` — see [Context Engine Plugins](/developer-guide/context-engine-plugin) |
@@ -224,6 +226,7 @@ The table above shows the four plugin categories, but within "General plugins" t
 | A **tool** the LLM can call | Python plugin — `ctx.register_tool()` | [Build a Hermes Plugin](/guides/build-a-hermes-plugin) · [Adding Tools](/developer-guide/adding-tools) |
 | A **lifecycle hook** (pre/post LLM, session start/end, tool filter) | Python plugin — `ctx.register_hook()` | [Hooks reference](/user-guide/features/hooks) · [Build a Hermes Plugin](/guides/build-a-hermes-plugin) |
 | A **slash command** for the CLI / gateway | Python plugin — `ctx.register_command()` | [Build a Hermes Plugin](/guides/build-a-hermes-plugin) · [Extending the CLI](/developer-guide/extending-the-cli) |
+| Gateway **interactive button/menu handlers** | Python plugin — `ctx.register_slack_action_handler()` for Slack Block Kit, `ctx.register_telegram_callback_handler()` for Telegram inline keyboards | [Build a Hermes Plugin](/guides/build-a-hermes-plugin#handle-slack-block-kit-button-clicks) |
 | A **subcommand** for `hermes <thing>` | Python plugin — `ctx.register_cli_command()` | [Extending the CLI](/developer-guide/extending-the-cli) |
 | A bundled **skill** that your plugin ships | Python plugin — `ctx.register_skill()` | [Creating Skills](/developer-guide/creating-skills) |
 | An **inference backend** (LLM provider: OpenAI-compat, Codex, Anthropic-Messages, Bedrock) | Provider plugin — `register_provider(ProviderProfile(...))` in `plugins/model-providers/<name>/` | **[Model Provider Plugins](/developer-guide/model-provider-plugin)** · [Adding Providers](/developer-guide/adding-providers) |


### PR DESCRIPTION
## Summary
- Add `ctx.register_telegram_callback_handler(matcher, callback)` for plugin-owned Telegram inline-keyboard callbacks
- Dispatch matching plugin callbacks from the Telegram adapter after built-in callback prefixes and before fallback
- Document Slack/Telegram interactive handler plugin APIs

## Test plan
- `python -m pytest tests/gateway/test_telegram_plugin_callback_handlers.py -q -o 'addopts='` → 9 passed
- `python -m pytest tests/gateway/test_slack_plugin_action_handlers.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_plugin_callback_handlers.py -q -o 'addopts='` → 55 passed, 3 pre-existing Slack watchdog coroutine warnings