### PR TITLE
fix(browser): retry next debug candidate on early exit + surface launch diagnostics

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import platform
 import shlex
 import shutil
 import subprocess
 import time
+from dataclasses import dataclass, field
 
 from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
 
 
 DEFAULT_BROWSER_CDP_PORT = 9222
@@ -222,24 +226,124 @@ def _wait_for_browser_debug_ready_or_exit(
     return "starting"
 
 
-def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> bool:
+_LAUNCH_STDERR_LOG = "launch-stderr.log"
+_STDERR_TAIL_LIMIT = 2000
+
+
+@dataclass
+class LaunchAttempt:
+    """Outcome of one candidate-binary launch attempt."""
+
+    binary: str
+    state: str  # "ready" | "starting" | "exited" | "spawn-failed"
+    returncode: int | None = None
+    stderr_tail: str = ""
+
+
+@dataclass
+class ChromeDebugLaunch:
+    """Structured result of ``launch_chrome_debug``.
+
+    ``launched`` mirrors the legacy boolean contract: a launch command was
+    executed and the browser is ready or still starting (it does NOT
+    guarantee the CDP port ever opens). ``attempts`` carries per-candidate
+    diagnostics so callers can explain *why* nothing came up.
+    """
+
+    launched: bool = False
+    attempts: list[LaunchAttempt] = field(default_factory=list)
+
+    @property
+    def hint(self) -> str | None:
+        """Best user-facing explanation for a failed/soft launch, if any."""
+        for attempt in self.attempts:
+            if attempt.state == "exited" and attempt.returncode == 0:
+                name = os.path.basename(attempt.binary)
+                return (
+                    f"{name} exited immediately without opening the debug port — an already-running "
+                    f"{name} instance likely absorbed the launch (Chromium's single-instance "
+                    "behavior). Close ALL of its processes (including background/tray instances) "
+                    "and retry /browser connect."
+                )
+        for attempt in self.attempts:
+            if attempt.state == "exited" and attempt.stderr_tail:
+                return (
+                    f"{os.path.basename(attempt.binary)} exited before the debug port opened: "
+                    f"{attempt.stderr_tail.splitlines()[-1].strip()}"
+                )
+        return None
+
+
+def _read_stderr_tail(path: str) -> str:
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()
+        return data[-_STDERR_TAIL_LIMIT:].decode("utf-8", errors="replace").strip()
+    except OSError:
+        return ""
+
+
+def launch_chrome_debug(
+    port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None
+) -> ChromeDebugLaunch:
+    """Launch a Chromium-family browser with remote debugging, with diagnostics.
+
+    Tries each detected candidate binary in turn. A candidate that exits
+    before the CDP port opens (crash, singleton forward to an existing
+    instance, bad profile dir) is logged — with exit code and a stderr tail —
+    and the next candidate is tried.
+    """
     system = system or platform.system()
+    result = ChromeDebugLaunch()
     candidates = get_chrome_debug_candidates(system)
     if not candidates:
-        return False
+        logger.info("browser debug launch: no Chromium-family binary found (system=%s)", system)
+        return result
 
-    os.makedirs(chrome_debug_data_dir(), exist_ok=True)
+    data_dir = chrome_debug_data_dir()
+    os.makedirs(data_dir, exist_ok=True)
+    stderr_path = os.path.join(data_dir, _LAUNCH_STDERR_LOG)
+
     for candidate in candidates:
         try:
-            proc = subprocess.Popen(
-                [candidate, *_chrome_debug_args(port)],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                **_detach_kwargs(system),
-            )
-            state = _wait_for_browser_debug_ready_or_exit(proc, port)
-            if state != "exited":
-                return True
-        except Exception:
+            with open(stderr_path, "wb") as stderr_file:
+                proc = subprocess.Popen(
+                    [candidate, *_chrome_debug_args(port)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=stderr_file,
+                    **_detach_kwargs(system),
+                )
+        except Exception as exc:
+            result.attempts.append(LaunchAttempt(binary=candidate, state="spawn-failed"))
+            logger.info("browser debug launch: failed to spawn %s: %s", candidate, exc)
             continue
-    return False
+
+        logger.info(
+            "browser debug launch: spawned %s (pid=%s) with --remote-debugging-port=%d",
+            candidate,
+            getattr(proc, "pid", None),
+            port,
+        )
+        state = _wait_for_browser_debug_ready_or_exit(proc, port)
+        attempt = LaunchAttempt(binary=candidate, state=state)
+        result.attempts.append(attempt)
+
+        if state != "exited":
+            result.launched = True
+            return result
+
+        attempt.returncode = getattr(proc, "returncode", None)
+        attempt.stderr_tail = _read_stderr_tail(stderr_path)
+        logger.warning(
+            "browser debug launch: %s exited (code=%s) before port %d opened%s",
+            candidate,
+            attempt.returncode,
+            port,
+            f"; stderr tail: {attempt.stderr_tail}" if attempt.stderr_tail else "",
+        )
+
+    return result
+
+
+def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> bool:
+    return launch_chrome_debug(port, system).launched

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -7,6 +7,7 @@ import platform
 import shlex
 import shutil
 import subprocess
+import time
 
 from hermes_constants import get_hermes_home
 
@@ -196,6 +197,31 @@ def _detach_kwargs(system: str) -> dict:
     return {"creationflags": flags} if flags else {}
 
 
+def _wait_for_browser_debug_ready_or_exit(
+    proc: subprocess.Popen,
+    port: int,
+    timeout: float = 2.0,
+    interval: float = 0.1,
+) -> str:
+    """Classify a launched browser as ready, exited, or still starting.
+
+    We only need to wait long enough to catch the common failure mode where a
+    candidate binary exists but exits immediately before exposing the CDP port.
+    Slower browsers can still finish starting after this grace window.
+    """
+    cdp_url = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        if is_browser_debug_ready(cdp_url, timeout=min(interval, 0.2)):
+            return "ready"
+        if proc.poll() is not None:
+            return "exited"
+        time.sleep(interval)
+
+    return "starting"
+
+
 def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> bool:
     system = system or platform.system()
     candidates = get_chrome_debug_candidates(system)
@@ -205,13 +231,15 @@ def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | 
     os.makedirs(chrome_debug_data_dir(), exist_ok=True)
     for candidate in candidates:
         try:
-            subprocess.Popen(
+            proc = subprocess.Popen(
                 [candidate, *_chrome_debug_args(port)],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 **_detach_kwargs(system),
             )
-            return True
+            state = _wait_for_browser_debug_ready_or_exit(proc, port)
+            if state != "exited":
+                return True
         except Exception:
             continue
     return False

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -31,6 +31,7 @@ from hermes_constants import display_hermes_home, is_termux as _is_termux_enviro
 from hermes_cli.browser_connect import (
     DEFAULT_BROWSER_CDP_URL,
     is_browser_debug_ready,
+    launch_chrome_debug,
     manual_chrome_debug_command,
 )
 
@@ -1850,8 +1851,8 @@ class CLICommandsMixin:
             elif cdp_url == _DEFAULT_CDP:
                 # Try to auto-launch a Chromium-family browser with remote debugging
                 print("   Chromium-family browser isn't running with remote debugging — attempting to launch...")
-                _launched = self._try_launch_chrome_debug(_port, _plat.system())
-                if _launched:
+                _launch = launch_chrome_debug(_port, _plat.system())
+                if _launch.launched:
                     # Wait for the DevTools discovery endpoint to come up
                     for _wait in range(10):
                         if is_browser_debug_ready(cdp_url, timeout=1.0):
@@ -1865,6 +1866,9 @@ class CLICommandsMixin:
                         print("     Try again in a few seconds — the debug instance may still be starting")
                 else:
                     print("   ⚠ Could not auto-launch a Chromium-family browser")
+                    _hint = _launch.hint
+                    if _hint:
+                        print(f"     {_hint}")
                     sys_name = _plat.system()
                     chrome_cmd = manual_chrome_debug_command(_port, sys_name)
                     if chrome_cmd:

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -12,6 +12,7 @@ from hermes_cli.browser_connect import (
     _wait_for_browser_debug_ready_or_exit,
     get_chrome_debug_candidates,
     is_browser_debug_ready,
+    launch_chrome_debug,
     manual_chrome_debug_command,
 )
 
@@ -197,6 +198,7 @@ class TestChromeDebugLaunch:
             return object()
 
         with patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[brave, chrome]), \
+             patch("hermes_cli.browser_connect._wait_for_browser_debug_ready_or_exit", return_value="ready"), \
              patch("subprocess.Popen", side_effect=fake_popen):
             assert HermesCLI._try_launch_chrome_debug(9222, "Linux") is True
 
@@ -235,6 +237,71 @@ class TestChromeDebugLaunch:
             assert HermesCLI._try_launch_chrome_debug(9222, "Linux") is True
 
         assert attempts == [brave, chrome]
+
+    def test_launch_result_hints_singleton_forward_on_clean_exit(self, tmp_path, monkeypatch):
+        """A candidate that exits code 0 without opening the port = an existing
+        instance absorbed the launch (Chromium single-instance behavior)."""
+        chrome = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+
+        class _Proc:
+            pid = 1234
+            returncode = 0
+
+            def poll(self):
+                return 0
+
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.chrome_debug_data_dir", lambda: str(tmp_path)
+        )
+        with patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[chrome]), \
+             patch("hermes_cli.browser_connect.is_browser_debug_ready", return_value=False), \
+             patch("subprocess.Popen", return_value=_Proc()):
+            result = launch_chrome_debug(9222, "Windows")
+
+        assert result.launched is False
+        assert result.attempts[0].state == "exited"
+        assert result.attempts[0].returncode == 0
+        assert result.hint is not None
+        assert "already-running" in result.hint
+        assert "chrome.exe" in result.hint
+
+    def test_launch_result_surfaces_stderr_tail_on_crash(self, tmp_path, monkeypatch):
+        chrome = "/usr/bin/google-chrome"
+
+        class _Proc:
+            pid = 4321
+            returncode = 127
+
+            def __init__(self, stderr_path):
+                # Simulate the browser writing to the redirected stderr file.
+                with open(stderr_path, "w", encoding="utf-8") as fh:
+                    fh.write("error while loading shared libraries: libnspr4.so\n")
+
+            def poll(self):
+                return 127
+
+        monkeypatch.setattr(
+            "hermes_cli.browser_connect.chrome_debug_data_dir", lambda: str(tmp_path)
+        )
+        stderr_path = tmp_path / "launch-stderr.log"
+        with patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[chrome]), \
+             patch("hermes_cli.browser_connect.is_browser_debug_ready", return_value=False), \
+             patch("subprocess.Popen", side_effect=lambda *a, **k: _Proc(stderr_path)):
+            result = launch_chrome_debug(9222, "Linux")
+
+        assert result.launched is False
+        assert result.attempts[0].returncode == 127
+        assert "libnspr4.so" in result.attempts[0].stderr_tail
+        assert result.hint is not None
+        assert "libnspr4.so" in result.hint
+
+    def test_launch_result_no_hint_when_no_candidates(self):
+        with patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[]):
+            result = launch_chrome_debug(9222, "Linux")
+
+        assert result.launched is False
+        assert result.attempts == []
+        assert result.hint is None
 
     def test_manual_command_uses_wsl_windows_chrome_when_available(self):
         chrome = "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from cli import HermesCLI
 from hermes_cli.browser_connect import (
+    _wait_for_browser_debug_ready_or_exit,
     get_chrome_debug_candidates,
     is_browser_debug_ready,
     manual_chrome_debug_command,
@@ -65,6 +66,7 @@ class TestChromeDebugLaunch:
 
         with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: r"C:\Chrome\chrome.exe" if name == "chrome.exe" else None), \
              patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == r"C:\Chrome\chrome.exe"), \
+             patch("hermes_cli.browser_connect._wait_for_browser_debug_ready_or_exit", return_value="ready"), \
              patch("subprocess.Popen", side_effect=fake_popen):
             assert HermesCLI._try_launch_chrome_debug(9333, "Windows") is True
 
@@ -94,6 +96,7 @@ class TestChromeDebugLaunch:
 
         with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \
              patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == installed), \
+             patch("hermes_cli.browser_connect._wait_for_browser_debug_ready_or_exit", return_value="ready"), \
              patch("subprocess.Popen", side_effect=fake_popen):
             assert HermesCLI._try_launch_chrome_debug(9222, "Windows") is True
 
@@ -194,6 +197,40 @@ class TestChromeDebugLaunch:
             return object()
 
         with patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[brave, chrome]), \
+             patch("subprocess.Popen", side_effect=fake_popen):
+            assert HermesCLI._try_launch_chrome_debug(9222, "Linux") is True
+
+        assert attempts == [brave, chrome]
+
+    def test_wait_for_browser_debug_ready_or_exit_detects_early_exit(self, monkeypatch):
+        class _Proc:
+            def __init__(self):
+                self.calls = 0
+
+            def poll(self):
+                self.calls += 1
+                return 1 if self.calls >= 2 else None
+
+        monkeypatch.setattr("hermes_cli.browser_connect.time.sleep", lambda _seconds: None)
+        with patch("hermes_cli.browser_connect.is_browser_debug_ready", return_value=False):
+            state = _wait_for_browser_debug_ready_or_exit(_Proc(), 9222, timeout=0.3, interval=0.01)
+
+        assert state == "exited"
+
+    def test_launch_tries_next_browser_when_first_candidate_exits_before_debug_ready(self):
+        brave = "/usr/bin/brave-browser"
+        chrome = "/usr/bin/google-chrome"
+        attempts = []
+
+        class _Proc:
+            pass
+
+        def fake_popen(cmd, **kwargs):
+            attempts.append(cmd[0])
+            return _Proc()
+
+        with patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[brave, chrome]), \
+             patch("hermes_cli.browser_connect._wait_for_browser_debug_ready_or_exit", side_effect=["exited", "ready"]), \
              patch("subprocess.Popen", side_effect=fake_popen):
             assert HermesCLI._try_launch_chrome_debug(9222, "Linux") is True
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13217,13 +13217,14 @@ def _browser_connect(rid, params: dict) -> dict:
             ok = any(_http_ok(p, timeout=2.0) for p in probes)
 
             if not ok and _is_default_local_cdp(parsed):
-                from hermes_cli.browser_connect import try_launch_chrome_debug
+                from hermes_cli.browser_connect import launch_chrome_debug
 
                 announce(
                     "Chromium-family browser isn't running with remote debugging — attempting to launch..."
                 )
 
-                if try_launch_chrome_debug(port, system):
+                launch = launch_chrome_debug(port, system)
+                if launch.launched:
                     for _ in range(20):
                         time.sleep(0.5)
                         if any(_http_ok(p, timeout=1.0) for p in probes):
@@ -13233,6 +13234,9 @@ def _browser_connect(rid, params: dict) -> dict:
                 if ok:
                     announce(f"Chromium-family browser launched and listening on port {port}")
                 else:
+                    hint = launch.hint
+                    if hint:
+                        announce(hint, level="error")
                     for line in _failure_messages(url, port, system)[1:]:
                         announce(line, level="error")
                     return _ok(


### PR DESCRIPTION
## Summary
`/browser connect` failures on Windows (and everywhere else) now explain themselves: the debug-browser auto-launch retries the next candidate when a binary exits early, detects Chromium's single-instance forward (the common Windows failure where an existing chrome.exe absorbs the launch and the port never opens), and logs the chosen binary, exit code, and stderr tail to agent.log so debug reports actually contain the failure.

Root cause of the reported symptom class: `try_launch_chrome_debug()` was fire-and-forget — stderr to DEVNULL, no exit detection, no logging — so singleton forwards, bad profile dirs, missing shared libraries, and policy blocks all collapsed into the same unactionable "port 9222 isn't responding yet" message.

Salvages #35617 by @LeonSGP43 (early-exit detection + candidate fallthrough, with tests) onto current main with authorship preserved, and extends it with the diagnostics layer.

## Changes
- `hermes_cli/browser_connect.py`: cherry-picked `_wait_for_browser_debug_ready_or_exit()` + retry-next-candidate (@LeonSGP43); new `launch_chrome_debug()` returning structured `ChromeDebugLaunch` (per-candidate state / exit code / stderr tail, `hint` property); stderr captured to `<hermes_home>/chrome-debug/launch-stderr.log`; spawn/exit logged to agent.log; `try_launch_chrome_debug()` kept as a thin bool wrapper for compat
- `hermes_cli/cli_commands_mixin.py`: `/browser connect` prints the targeted hint (e.g. "chrome.exe exited immediately… close ALL of its processes") on launch failure
- `tui_gateway/server.py`: `browser.manage` connect path announces the same hint to TUI/desktop/dashboard
- `tests/cli/test_cli_browser_connect.py`: contributor's tests + singleton-hint, stderr-tail, and no-candidates coverage

## Validation
| | Result |
|---|---|
| `scripts/run_tests.sh tests/cli/test_cli_browser_connect.py` | 21/21 passed |
| `scripts/run_tests.sh tests/test_tui_gateway_server.py -k browser` | 20/20 passed |
| E2E (real fake binaries, temp HERMES_HOME) | clean-exit → singleton hint; crash → stderr tail (`libnspr4.so`) surfaced; working binary → `ready`; dead→working fallthrough works |
| ruff | clean |

Context: user report of `/browser connect` on Windows CLI + desktop launching a browser but 9222 never responding, with debug-share logs containing zero browser-launch evidence. Related: #53822 (Trap 3), #27018, #12912.

## Infographic

![browser-launch-fix](https://v3b.fal.media/files/b/0aa0bd83/raaeVqY6KbCCBijOc9DqI_hpvqOMRy.png)
