### PR TITLE
fix(kanban): skip torn-extend file-length check under WAL (false positives wedge the dispatcher)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2246,6 +2246,18 @@ def _check_file_length_invariant(conn: sqlite3.Connection) -> None:
         if not path_str:
             return  # in-memory or unnamed DB; skip
         path = path_str
+        # WAL-mode DBs allocate new pages in the -wal file until a checkpoint,
+        # and a checkpoint updates the main file's header page-count and its
+        # physical length non-atomically. So reading the main file directly can
+        # observe header_page_count > on-disk pages as a normal transient — not
+        # a torn extend. WAL frames also carry per-frame checksums, so SQLite
+        # itself detects a genuinely torn extend on a WAL DB. This raw-file
+        # invariant is only meaningful for rollback-journal mode, which extends
+        # the main file in place mid-transaction. Skip it under WAL to avoid
+        # false "torn-extend detected" errors that wedge the kanban dispatcher.
+        journal_mode = conn.execute("PRAGMA journal_mode").fetchone()
+        if journal_mode and str(journal_mode[0]).lower() == "wal":
+            return
         page_size = conn.execute("PRAGMA page_size").fetchone()[0]
         file_size = os.path.getsize(path)
         with open(path, "rb") as f:


### PR DESCRIPTION
## Summary

`_check_file_length_invariant` (in `hermes_cli/kanban_db.py`, called from `write_txn` after every kanban write commit) raises `sqlite3.DatabaseError("torn-extend detected")` when the DB header's page count exceeds the **main file's** size in pages. **That comparison is invalid in WAL mode** and produces false positives that wedge the kanban dispatcher.

## Root cause

In WAL mode:
- Newly allocated pages live in the `-wal` file until a checkpoint.
- A checkpoint updates the main file's page-1 header page-count and its physical length **non-atomically**.

So reading the main file directly (bypassing SQLite) can observe `header_page_count > on-disk pages` as a **normal transient during a checkpoint** — not a torn extend.

## Impact

On a busy board the check fires as a false positive and poisons every kanban write. `recompute_ready()` (called from the gateway dispatcher tick via `write_txn`) then raises on every tick → the dispatcher never promotes/spawns, spins in a fail-retry loop, and saturates CPU. Observed in the wild: the gateway's asyncio loop starved (`ws write slow (loop stalled >10.0s)`), the desktop app's 15s backend probe timed out, and the app appeared to **crash on every view**. Meanwhile `PRAGMA integrity_check` on the affected DB returns `ok` — the database was never actually corrupt.

## Fix

Skip the invariant when `PRAGMA journal_mode` is `wal`. WAL frames carry per-frame checksums, so SQLite itself detects a genuinely torn extend on a WAL DB. The raw-file check is only meaningful for rollback-journal mode, which extends the main file in place mid-transaction.

## Verification

- Healthy WAL DB (real kanban board with a 4 MB uncheckpointed `-wal`): no longer raises. ✅
- Genuinely short non-WAL DB (`journal_mode=DELETE`, header page count inflated past the file): still raises `torn-extend detected`. ✅
- `python -m py_compile hermes_cli/kanban_db.py`: clean. ✅