### PR TITLE
fix(tui_gateway): restore openrouter provider on session resume

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1233,10 +1233,11 @@ def test_session_cwd_set_profile_session_updates_profile_db(monkeypatch, tmp_pat
 
 
 def test_stored_session_runtime_overrides_skips_bare_billing_provider():
-    """A bare billing bucket ("custom"/"auto"/"openrouter") must not be restored as the
-    provider identity on resume. A custom endpoint that never used `/model` persists only
+    """A bare billing bucket ("custom"/"auto") must not be restored as the provider
+    identity on resume. A custom endpoint that never used `/model` persists only
     `billing_provider="custom"`; restoring that broke `session.resume` with "No LLM provider
-    configured" (agent_init treats it as non-routable). A real provider, or an explicit
+    configured" (agent_init treats it as non-routable). ``"openrouter"`` is NOT a bare bucket
+    — it is a fully routable provider; see #57588. A real provider, or an explicit
     `model_config.provider`, is still restored.
     """
     # Bare "custom" bucket, no explicit model_config.provider: no provider override restored.
@@ -1244,7 +1245,7 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     assert "provider_override" not in ov
     assert ov["model_override"]["provider"] is None
 
-    for bare in ("auto", "openrouter", "custom"):
+    for bare in ("auto", "custom"):
         ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": bare})
         assert "provider_override" not in ov
 
@@ -1259,6 +1260,33 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     )
     assert ov["provider_override"] == "custom:myendpoint"
     assert ov["model_override"]["provider"] == "custom:myendpoint"
+
+
+def test_openrouter_session_resume_restores_provider():
+    """OpenRouter is a fully routable provider — sessions that used OpenRouter must
+    restore the "openrouter" provider override on resume, not fall through to whatever
+    the current global model is.  (#57588)
+    """
+    # OpenRouter session with no explicit model_config.provider (the common case
+    # for sessions that never used /model): billing_provider="openrouter" should
+    # be restored as the provider override.
+    ov = server._stored_session_runtime_overrides(
+        {"model": "anthropic/claude-opus-4.8", "billing_provider": "openrouter"}
+    )
+    assert ov["provider_override"] == "openrouter"
+    assert ov["model_override"]["provider"] == "openrouter"
+    assert ov["model_override"]["model"] == "anthropic/claude-opus-4.8"
+
+    # When an explicit model_config.provider exists, it takes precedence over
+    # billing_provider (this path was already correct).
+    ov = server._stored_session_runtime_overrides(
+        {
+            "model": "anthropic/claude-opus-4.8",
+            "billing_provider": "openrouter",
+            "model_config": {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1"},
+        }
+    )
+    assert ov["provider_override"] == "openrouter"
 
 
 def test_persist_live_session_runtime_preserves_resume_metadata(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2008,7 +2008,12 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
 
 # Bare billing buckets are not routable provider identities (kept in parity with the
 # provider gate in agent_init). Restoring one as a session provider override breaks resume.
-_BARE_BILLING_PROVIDERS = {"auto", "openrouter", "custom"}
+# ``openrouter`` is deliberately excluded — it is a fully routable provider with its own
+# API key and base_url.  Sessions that used OpenRouter store
+# ``billing_provider="openrouter"``; dropping it forces resume to the current global
+# model (e.g. a custom endpoint), which is the wrong provider for the stored model.
+#  See #57588.
+_BARE_BILLING_PROVIDERS = {"auto", "custom"}
 
 
 def _stored_session_runtime_overrides(row: dict | None) -> dict:


### PR DESCRIPTION
## What does this PR do?

When a user switches from OpenRouter to a custom endpoint, resuming any previous OpenRouter session fails with a misleading context-window error. The root cause is `_BARE_BILLING_PROVIDERS` in `tui_gateway/server.py` treating `"openrouter"` as a non-routable billing bucket (alongside `"auto"` and `"custom"`), which causes `_stored_session_runtime_overrides` to drop the provider override on resume. The session then falls back to the current global model (the custom endpoint), which serves a completely different model catalog and returns a tiny context window for the stored model name.

OpenRouter is a fully routable provider with its own API key, base URL, and model catalog. Removing it from `_BARE_BILLING_PROVIDERS` lets OpenRouter sessions correctly restore their provider identity on resume.

## Related Issue

Fixes #57588

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — Remove `"openrouter"` from `_BARE_BILLING_PROVIDERS` set. `"auto"` and `"custom"` remain as non-routable billing classes. Added comment explaining why `"openrouter"` is excluded (#57588).
- `tests/test_tui_gateway_server.py` — Updated `test_stored_session_runtime_overrides_skips_bare_billing_provider` to remove `"openrouter"` from the bare-bucket loop. Added `test_openrouter_session_resume_restores_provider` regression test verifying that OpenRouter sessions restore the `"openrouter"` provider override on resume.

## How to Test

1. Configure Hermes with a custom endpoint (e.g. Featherless) as the default model.
2. Create a session using OpenRouter (e.g. `anthropic/claude-opus-4.8`).
3. Exit and restart Hermes.
4. Resume the OpenRouter session via `/sessions`.
   - **Before**: fails with "context window of 2,048 tokens, which is below the minimum 64,000" because the resume hits the custom endpoint with the OpenRouter model name.
   - **After**: session resumes correctly using OpenRouter as the provider.
5. Automated: `python -m pytest tests/test_tui_gateway_server.py::test_stored_session_runtime_overrides_skips_bare_billing_provider tests/test_tui_gateway_server.py::test_openrouter_session_resume_restores_provider tests/tui_gateway/test_custom_provider_session_persistence.py -v` → should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no doc/docstring impact)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
