### PR TITLE
fix(file-sync): re-deliver deferred Ctrl+C via raise_signal, not os.kill (Windows hard-kill)

### DIFF
--- a/tests/tools/test_file_sync_sigint.py
+++ b/tests/tools/test_file_sync_sigint.py
@@ -1,0 +1,56 @@
+"""Cross-platform regression for the deferred-SIGINT re-delivery in sync-back.
+
+``_sync_back_once`` defers a Ctrl+C that lands mid-sync, then re-delivers it once
+the sync completes. It must do so via ``signal.raise_signal`` — which invokes the
+handler through C ``raise()`` on every platform — and NOT via
+``os.kill(os.getpid(), signal.SIGINT)``: on Windows the latter routes SIGINT (2)
+to ``TerminateProcess`` and hard-kills the whole CLI instead of raising
+``KeyboardInterrupt``.
+
+Unlike ``test_file_sync_back.py`` this module does not depend on ``fcntl`` (the
+locked sync body is stubbed), so it runs on Windows too — the platform the bug
+actually manifests on.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+
+from tools.environments.file_sync import FileSyncManager
+
+
+def _make_manager() -> FileSyncManager:
+    return FileSyncManager(
+        get_files_fn=lambda: {},
+        upload_fn=lambda *a, **k: None,
+        delete_fn=lambda *a, **k: None,
+    )
+
+
+def test_deferred_sigint_redelivered_via_raise_signal(tmp_path, monkeypatch):
+    mgr = _make_manager()
+
+    # Simulate a Ctrl+C arriving during the sync body: invoke the deferring
+    # handler that _sync_back_once installed, so `deferred_sigint` is populated.
+    def fake_locked(lock_path):
+        signal.getsignal(signal.SIGINT)(signal.SIGINT, None)
+
+    monkeypatch.setattr(mgr, "_sync_back_locked", fake_locked)
+
+    raised: list[int] = []
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        "tools.environments.file_sync.signal.raise_signal", raised.append
+    )
+    monkeypatch.setattr(
+        "tools.environments.file_sync.os.kill",
+        lambda pid, sig: killed.append((pid, sig)),
+    )
+
+    mgr._sync_back_once(tmp_path / "sync.lock")
+
+    # The deferred Ctrl+C is re-delivered cross-platform via raise_signal,
+    assert raised == [signal.SIGINT]
+    # and never through os.kill(getpid, SIGINT) (which hard-kills on Windows).
+    assert (os.getpid(), signal.SIGINT) not in killed

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -302,7 +302,17 @@ class FileSyncManager:
             if on_main_thread and original_handler is not None:
                 signal.signal(signal.SIGINT, original_handler)
                 if deferred_sigint:
-                    os.kill(os.getpid(), signal.SIGINT)
+                    # Re-deliver the deferred Ctrl+C to the just-restored
+                    # handler. ``os.kill(os.getpid(), signal.SIGINT)`` is NOT a
+                    # graceful signal on Windows: os.kill only treats
+                    # CTRL_C_EVENT(0)/CTRL_BREAK_EVENT(1) as console events; any
+                    # other value (SIGINT == 2) routes to TerminateProcess(sig),
+                    # hard-killing the CLI (exit code 2) instead of raising
+                    # KeyboardInterrupt — so a Ctrl+C during a remote-backend
+                    # sync-back would kill the whole session on Windows.
+                    # ``signal.raise_signal`` (3.8+) invokes the handler via C
+                    # ``raise()`` on every platform.
+                    signal.raise_signal(signal.SIGINT)
 
     def _sync_back_locked(self, lock_path: Path) -> None:
         """Sync-back under file lock (serializes concurrent gateways)."""


### PR DESCRIPTION
## What does this PR do?

`FileSyncManager._sync_back_once` defers a `SIGINT` (Ctrl+C) that lands mid
sync-back and re-delivers it once the sync completes, so the user's interrupt
isn't lost. It did that with `os.kill(os.getpid(), signal.SIGINT)`.

That is **not** a graceful signal on Windows. `os.kill` there only treats
`CTRL_C_EVENT(0)` / `CTRL_BREAK_EVENT(1)` as console events; any other value
(`SIGINT == 2`) is routed to `TerminateProcess(sig)`. So on Windows, a Ctrl+C
during a remote-backend (`ssh` / `daytona` / `modal`) sync-back **hard-kills the
whole CLI process** (exit code 2) instead of raising `KeyboardInterrupt` — the
user loses the entire session on a single stray Ctrl+C.

Fix: use `signal.raise_signal(signal.SIGINT)` (Python 3.8+), which invokes the
just-restored handler through C `raise()` on every platform.

Verified on Windows 11:
- `os.kill(os.getpid(), signal.SIGINT)` → `TerminateProcess` (hard kill).
- `signal.raise_signal(signal.SIGINT)` → runs the SIGINT handler → graceful
  `KeyboardInterrupt`.

## Related Issue

N/A — found by auditing cross-platform signal handling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/file_sync.py` — in `_sync_back_once`, re-deliver the
  deferred `SIGINT` with `signal.raise_signal(signal.SIGINT)` instead of
  `os.kill(os.getpid(), signal.SIGINT)`.
- `tests/tools/test_file_sync_sigint.py` — new cross-platform regression test
  (stubs the locked sync body so it needs no `fcntl` and runs on Windows too,
  unlike `test_file_sync_back.py`).

## How to Test

```
pytest tests/tools/test_file_sync_sigint.py -q
```

→ passes. Mutation-verified: reverting the one-line change back to
`os.kill(os.getpid(), signal.SIGINT)` makes the test fail (the deferred SIGINT
is no longer routed through `raise_signal`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the new test (`pytest tests/tools/test_file_sync_sigint.py -q`) and it passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docstrings / N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — **this IS the cross-platform fix** (Windows)
- [x] Tool descriptions/schemas — N/A