### PR TITLE
fix(gateway): preserve busy-session steering across inputs

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -43,6 +43,14 @@ logger = logging.getLogger(__name__)
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 
 
+def _blocked_context_placeholder(filename: str, findings: list[str]) -> str:
+    """Return the safe placeholder used when a context file is blocked."""
+    return (
+        f"[BLOCKED: {filename} contained potential prompt injection "
+        f"({', '.join(findings)}). Content not loaded.]"
+    )
+
+
 def _scan_context_content(content: str, filename: str) -> str:
     """Scan context file content for injection. Returns sanitized content.
 
@@ -57,7 +65,7 @@ def _scan_context_content(content: str, filename: str) -> str:
     findings = _scan_for_threats(content, scope="context")
     if findings:
         logger.warning("Context file %s blocked: %s", filename, ", ".join(findings))
-        return f"[BLOCKED: {filename} contained potential prompt injection ({', '.join(findings)}). Content not loaded.]"
+        return _blocked_context_placeholder(filename, findings)
 
     return content
 
@@ -1219,7 +1227,8 @@ def _get_context_file_max_chars(context_length: Optional[int] = None) -> int:
         logger.debug("Could not read context_file_max_chars from config: %s", e)
     return _dynamic_context_file_max_chars(context_length)
 
-# Collect truncation warnings so the caller (run_agent) can surface them.
+# Collect context-file warnings (truncation, blocked SOUL fallback) so the
+# caller (run_agent) can surface them.
 # A ContextVar (not a module-global list) isolates accumulation per thread /
 # per async task, so concurrent gateway-session prompt builds can't drain or
 # clear each other's pending warnings (cross-session leak). Each build runs in
@@ -1230,7 +1239,11 @@ _truncation_warnings: "contextvars.ContextVar[Optional[list]]" = contextvars.Con
 
 
 def _record_truncation_warning(msg: str) -> None:
-    """Append a truncation warning to the current context's accumulator."""
+    """Append a context-file warning to the current context's accumulator.
+
+    Kept under the historical truncation name for compatibility with tests and
+    callers; the accumulator now also carries blocked-SOUL fallback warnings.
+    """
     warnings = _truncation_warnings.get()
     if warnings is None:
         warnings = []
@@ -1813,7 +1826,24 @@ def load_soul_md(context_length: Optional[int] = None) -> Optional[str]:
         content = soul_path.read_text(encoding="utf-8").strip()
         if not content:
             return None
-        content = _scan_context_content(content, "SOUL.md")
+        findings = _scan_for_threats(content, scope="context")
+        if findings:
+            findings_text = ", ".join(findings)
+            logger.warning("SOUL.md blocked: %s", findings_text)
+            warning = (
+                f"⚠️  SOUL.md blocked by context security scan ({findings_text}). "
+                "Default Hermes identity loaded instead; profile SOUL identity "
+                f"is not active. Fix {soul_path} and rebuild/start a new session "
+                "to restore the profile identity."
+            )
+            _record_truncation_warning(warning)
+            return (
+                DEFAULT_AGENT_IDENTITY
+                + "\n\n"
+                + f"[WARNING: {warning}]"
+                + "\n\n"
+                + _blocked_context_placeholder("SOUL.md", findings)
+            )
         content = _truncate_content(
             content, "SOUL.md", context_length=context_length,
             read_path=str(soul_path),

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -485,8 +485,9 @@ def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str
     parts = build_system_prompt_parts(agent, system_message=system_message)
     joined = "\n\n".join(p for p in (parts["stable"], parts["context"], parts["volatile"]) if p)
 
-    # Surface context-file truncation warnings through the normal agent status
-    # channel so gateway/CLI users see them in chat instead of only in logs.
+    # Surface context-file warnings through the normal agent status channel so
+    # gateway/CLI users see truncation or blocked-SOUL fallback in chat instead
+    # of only in logs.
     for warning in drain_truncation_warnings():
         agent._emit_status(warning)
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1133,10 +1133,12 @@ display:
   #   queue:     Queue your message for the next turn
   #   steer:     Inject your message mid-run via /steer, arriving at the agent
   #              after the next tool call — no interrupt, no role violation.
-  #              Falls back to 'queue' if the agent isn't running yet or if
-  #              images are attached (steer only carries text).
+  #              Falls back to 'frontdesk' (or queue if scheduling fails) if the
+  #              agent cannot accept steer input.
+  #   frontdesk: Capture busy follow-ups as isolated background tasks with an
+  #              immediate ACK, leaving the active run untouched.
   # Ctrl+C (or /stop in gateway) always interrupts regardless of this setting.
-  # Toggle at runtime with /busy <interrupt|queue|steer>.
+  # Toggle at runtime with /busy <interrupt|queue|steer|frontdesk>.
   busy_input_mode: interrupt
 
   # Background process notifications (gateway/messaging only).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4203,10 +4203,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return "restarting" if self._restart_requested else "shutting down"
 
     def _queue_during_drain_enabled(self) -> bool:
-        # Both "queue" and "steer" modes imply the user doesn't want messages
-        # to be lost during restart — queue them for the newly-spawned gateway
+        # Queue/steer/frontdesk modes imply the user doesn't want messages to
+        # be lost during restart — queue them for the newly-spawned gateway
         # process to pick up.  "interrupt" mode drops them (current behaviour).
-        return self._restart_requested and self._busy_input_mode in {"queue", "steer"}
+        return self._restart_requested and self._busy_input_mode in {"queue", "steer", "frontdesk"}
 
     # -------- /queue FIFO helpers --------------------------------------
     # /queue must produce one full agent turn per invocation, in FIFO
@@ -4751,6 +4751,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "queue"
         if mode == "steer":
             return "steer"
+        if mode == "frontdesk":
+            return "frontdesk"
         return "interrupt"
 
     @staticmethod
@@ -4761,8 +4763,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``interrupt``). The legacy ``busy_text_mode`` knob is honored only
         when a user explicitly set it, so existing queue setups keep
         working; new installs follow ``busy_input_mode``. Returns one of
-        ``interrupt`` | ``queue`` (``steer`` is handled upstream by
-        ``busy_input_mode`` and maps to non-queue text handling here).
+        ``interrupt`` | ``queue`` (``steer`` and ``frontdesk`` are handled
+        upstream by ``busy_input_mode`` and map to non-queue text handling
+        here).
         """
         # Legacy explicit override wins for backward compat.
         legacy = os.getenv("HERMES_GATEWAY_BUSY_TEXT_MODE", "").strip().lower()
@@ -5034,6 +5037,223 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    def _frontdesk_background_prompt(self, text: str, *, reason: str) -> str:
+        """Build the isolated prompt for a front-desk background capture."""
+        captured = str(text or "").strip()
+        if not captured:
+            captured = "[User sent media while another gateway run was busy; inspect attached media if relevant.]"
+        return (
+            "Frontdesk capture: the user sent this while another gateway run "
+            "was already active. Treat it as a separate background request so "
+            "the active run can continue. Do not wait for, recurse into, or "
+            "mutate the previous run unless the captured text explicitly asks "
+            "for a control/status action.\n\n"
+            f"Capture reason: {reason}\n\n"
+            "Captured user message:\n"
+            f"{captured}"
+        )
+
+    def _persist_frontdesk_capture(
+        self,
+        *,
+        task_id: str,
+        source: SessionSource,
+        reason: str,
+        text: str,
+        event_message_id: Optional[str] = None,
+    ) -> None:
+        """Persist secret-safe metadata for front-desk captures.
+
+        The background session stores the full prompt/content. This metadata file
+        is intentionally content-free: SHA256 + length only, and never raw audio
+        paths or transcript previews, so operational state can prove capture
+        without turning voice/audio content into durable raw logs.
+        """
+        try:
+            import hashlib
+
+            state_dir = _hermes_home / "state"
+            state_dir.mkdir(parents=True, exist_ok=True)
+            path = state_dir / "frontdesk-captures.jsonl"
+            text_s = str(text or "")
+            record = {
+                "ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+                "task_id": task_id,
+                "reason": reason,
+                "platform": source.platform.value if source and source.platform else "",
+                "chat_id": str(getattr(source, "chat_id", "") or ""),
+                "thread_id": str(getattr(source, "thread_id", "") or ""),
+                "event_message_id": str(event_message_id or ""),
+                "text_len": len(text_s),
+                "text_sha256": hashlib.sha256(text_s.encode("utf-8")).hexdigest() if text_s else "",
+            }
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+            try:
+                with os.fdopen(fd, "a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+            finally:
+                try:
+                    os.chmod(path, 0o600)
+                except OSError:
+                    pass
+        except Exception:
+            logger.debug("Failed to persist frontdesk capture metadata", exc_info=True)
+
+    def _schedule_frontdesk_background_task(
+        self,
+        *,
+        source: SessionSource,
+        text: str,
+        reason: str,
+        event_message_id: Optional[str] = None,
+        media_urls: Optional[List[str]] = None,
+        media_types: Optional[List[str]] = None,
+    ) -> Optional[str]:
+        """Launch a separate background task for busy front-desk input."""
+        prompt = self._frontdesk_background_prompt(text, reason=reason)
+        task_id = f"fd_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        _media_urls = list(media_urls or [])
+        _media_types = list(media_types or [])
+        if str(text or "").strip() and _media_urls:
+            # If the audio/voice was already transcribed into text, do not carry
+            # the raw audio path into the background prompt/session. Keep images
+            # and other documents so non-audio attachments remain visible.
+            _kept_urls = []
+            _kept_types = []
+            for _i, _url in enumerate(_media_urls):
+                _mtype = _media_types[_i] if _i < len(_media_types) else ""
+                if _mtype.startswith("audio/"):
+                    continue
+                _kept_urls.append(_url)
+                _kept_types.append(_mtype)
+            _media_urls, _media_types = _kept_urls, _kept_types
+        self._persist_frontdesk_capture(
+            task_id=task_id,
+            source=source,
+            reason=reason,
+            text=text,
+            event_message_id=event_message_id,
+        )
+        try:
+            task = asyncio.create_task(
+                self._run_background_task(
+                    prompt,
+                    source,
+                    task_id,
+                    event_message_id=event_message_id,
+                    media_urls=_media_urls,
+                    media_types=_media_types,
+                )
+            )
+        except RuntimeError:
+            logger.warning("Frontdesk capture failed to schedule background task for %s", task_id)
+            return None
+        if not hasattr(self, "_background_tasks") or self._background_tasks is None:
+            self._background_tasks = set()
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        logger.info(
+            "Frontdesk captured busy input as background task %s (reason=%s)",
+            task_id,
+            reason,
+        )
+        return task_id
+
+    async def _capture_leftover_steer_as_frontdesk_background(
+        self,
+        *,
+        source: SessionSource,
+        steer_text: str,
+        session_key: str,
+        adapter: Any = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Route a final-call leftover steer to front-desk background work."""
+        text = str(steer_text or "").strip()
+        if not text:
+            return False
+        task_id = self._schedule_frontdesk_background_task(
+            source=source,
+            text=text,
+            reason="leftover_steer_after_last_tool_call",
+            event_message_id=None,
+        )
+        if not task_id:
+            return False
+        logger.info(
+            "Leftover steer for session %s captured as frontdesk background task %s",
+            session_key or "?",
+            task_id,
+        )
+        if adapter is not None:
+            try:
+                await adapter.send(
+                    source.chat_id,
+                    f"↪️ Your steer arrived after the last tool call; captured as background task {task_id}. The current run stays intact.",
+                    metadata=metadata,
+                )
+            except Exception:
+                logger.debug("Leftover-steer frontdesk ack failed", exc_info=True)
+        return True
+
+    async def _build_busy_steer_text_from_event(
+        self,
+        event: MessageEvent,
+        *,
+        session_key: str,
+        initial_text: Optional[str] = None,
+    ) -> str:
+        """Build text that can safely be injected via busy ``steer`` mode.
+
+        ``AIAgent.steer()`` accepts text only.  Busy media messages therefore
+        need the same pre-analysis used by normal inbound turns before the busy
+        handler decides between steer, frontdesk capture, or queue fallback.
+        """
+        steer_text = str(initial_text if initial_text is not None else (event.text or "")).strip()
+        media_urls = list(getattr(event, "media_urls", None) or [])
+        if not media_urls:
+            return steer_text
+
+        image_paths: List[str] = []
+        audio_paths: List[str] = []
+        for _i, _path in enumerate(media_urls):
+            if _event_media_is_image(event, _i):
+                image_paths.append(_path)
+            elif _event_media_is_audio(event, _i):
+                audio_paths.append(_path)
+
+        if image_paths:
+            try:
+                steer_text = await self._enrich_message_with_vision(
+                    steer_text,
+                    image_paths,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Gateway image steer enrichment failed for session %s: %s",
+                    session_key,
+                    exc,
+                )
+                if not steer_text:
+                    steer_text = _build_media_placeholder(event)
+
+        if audio_paths:
+            try:
+                _enriched_text, _transcripts = await self._enrich_message_with_transcription(
+                    steer_text,
+                    audio_paths,
+                )
+                if _transcripts or str(_enriched_text or "").strip():
+                    steer_text = str(_enriched_text or "").strip()
+            except Exception as exc:
+                logger.warning(
+                    "Gateway voice steer transcription failed for session %s: %s",
+                    session_key,
+                    exc,
+                )
+
+        return steer_text
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -5180,7 +5400,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if (
             event.message_type == MessageType.TEXT
             and busy_text_mode == "queue"
-            and effective_mode != "steer"
+            and effective_mode not in {"steer", "frontdesk"}
         ):
             return False
 
@@ -5219,8 +5439,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             effective_mode = "queue"
         steered = False
-        if effective_mode == "steer":
-            steer_text = (event.text or "").strip()
+        frontdesk_task_id = None
+        if effective_mode == "frontdesk":
+            frontdesk_task_id = self._schedule_frontdesk_background_task(
+                source=event.source,
+                text=(event.text or "").strip(),
+                reason="busy_frontdesk_mode",
+                event_message_id=self._reply_anchor_for_event(event),
+                media_urls=getattr(event, "media_urls", None),
+                media_types=getattr(event, "media_types", None),
+            )
+            if not frontdesk_task_id:
+                effective_mode = "queue"
+        elif effective_mode == "steer":
+            steer_text = await self._build_busy_steer_text_from_event(
+                event,
+                session_key=session_key,
+            )
             can_steer = (
                 steer_text
                 and running_agent is not None
@@ -5234,13 +5469,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.warning("Gateway steer failed for session %s: %s", session_key, exc)
                     steered = False
             if not steered:
-                # Fall back to queue (merge into pending messages, no interrupt)
-                effective_mode = "queue"
+                # Front-desk fallback: if the message cannot be *actually*
+                # steered into a live agent, do not hide it in the same-session
+                # pending queue behind a long run. Capture it as a separate
+                # background session and ACK immediately; if scheduling fails,
+                # fall back to the old queue path so the content is not lost.
+                _frontdesk_text = steer_text or (event.text or "")
+                if _frontdesk_text and not (event.text or "").strip():
+                    try:
+                        event.text = _frontdesk_text
+                    except Exception:
+                        pass
+                frontdesk_task_id = self._schedule_frontdesk_background_task(
+                    source=event.source,
+                    text=_frontdesk_text,
+                    reason="busy_steer_fallback",
+                    event_message_id=self._reply_anchor_for_event(event),
+                    media_urls=getattr(event, "media_urls", None),
+                    media_types=getattr(event, "media_types", None),
+                )
+                if frontdesk_task_id:
+                    effective_mode = "frontdesk"
+                else:
+                    # Fall back to queue (merge into pending messages, no interrupt)
+                    effective_mode = "queue"
 
         # Store the message so it's processed as the next turn after the
         # current run finishes (or is interrupted).  Skip this for a
         # successful steer — the text already landed inside the run and
-        # must NOT also be replayed as a next-turn user message.
+        # must NOT also be replayed as a next-turn user message. Also skip
+        # front-desk background captures — they have their own isolated session.
         #
         # Route through _queue_or_replace_pending_event (the same FIFO
         # infrastructure used by busy queue-mode and /queue) rather than a
@@ -5252,11 +5510,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # turn (#43066 sub-bug 2). The FIFO path gives each text its own
         # turn in arrival order while still preserving photo-burst / album
         # merge semantics for media.
-        if not steered:
+        if not steered and not frontdesk_task_id:
             self._queue_or_replace_pending_event(session_key, event)
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
+        is_frontdesk_mode = frontdesk_task_id is not None
 
         # If not in queue/steer mode, interrupt the running agent immediately.
         # This aborts in-flight tool calls and causes the agent loop to exit
@@ -5318,10 +5577,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
 
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
-        if is_steer_mode:
+        if is_frontdesk_mode:
+            message = (
+                f"📥 Captured as background task {frontdesk_task_id}{status_detail}. "
+                f"The current run keeps going; I'll handle this separately."
+            )
+        elif is_steer_mode:
             message = (
                 f"⏩ Steered into current run{status_detail}. "
-                f"Your message arrives after the next tool call."
+                f"Your message arrives after the next tool call; if the run is already finalizing, it will continue separately."
             )
         elif is_queue_mode and demoted_for_subagents:
             # #30170 — explain the demotion so the user knows their
@@ -5360,7 +5624,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             _user_cfg = _load_gateway_config()
             if not is_seen(_user_cfg, BUSY_INPUT_FLAG):
-                if is_steer_mode:
+                if is_frontdesk_mode:
+                    _hint_mode = "steer"
+                elif is_steer_mode:
                     _hint_mode = "steer"
                 elif is_queue_mode:
                     _hint_mode = "queue"
@@ -8768,6 +9034,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _pending_clarify = None
         if _pending_clarify is not None and _clarify_mod is not None:
             _raw_clarify_reply = (event.text or "").strip()
+            # Telegram voice notes sent after tapping "Other" arrive here as
+            # MessageType.VOICE with no text.  The adapter already bypasses the
+            # active-session busy guard for pending clarifies, but the normal STT
+            # enrichment happens later in _prepare_inbound_message_text.  Without
+            # a local transcription step, captionless voice replies fall through
+            # as empty busy follow-ups and the clarify wait never resolves.
+            if (
+                not _raw_clarify_reply
+                and getattr(event, "media_urls", None)
+                and getattr(event, "message_type", None) == MessageType.VOICE
+            ):
+                try:
+                    _voice_text, _voice_transcripts = await self._enrich_message_with_transcription(
+                        "",
+                        list(event.media_urls or []),
+                    )
+                    if _voice_transcripts:
+                        _raw_clarify_reply = "\n".join(
+                            str(_tx).strip() for _tx in _voice_transcripts if str(_tx).strip()
+                        ).strip()
+                    elif _voice_text:
+                        _raw_clarify_reply = str(_voice_text).strip()
+                except Exception as _clarify_voice_exc:
+                    logger.warning(
+                        "Gateway clarify voice-response transcription failed (session=%s, id=%s): %s",
+                        _quick_key,
+                        getattr(_pending_clarify, "clarify_id", "unknown"),
+                        _clarify_voice_exc,
+                    )
             # Skip slash commands — the user clearly wanted to issue a
             # command, not answer the clarify.  Leave the clarify pending
             # so the user can retry; if it times out, the agent unblocks
@@ -8778,8 +9073,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 if _resolved:
                     logger.info(
-                        "Gateway intercepted clarify text response (session=%s, id=%s)",
-                        _quick_key, _pending_clarify.clarify_id,
+                        "Gateway intercepted clarify response (session=%s, id=%s, source=%s)",
+                        _quick_key,
+                        _pending_clarify.clarify_id,
+                        "voice" if getattr(event, "message_type", None) == MessageType.VOICE else "text",
                     )
                     # Acknowledge with empty string so adapters that emit
                     # the agent's response don't double-post.  The agent
@@ -9159,7 +9456,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
 
-            if event.message_type == MessageType.PHOTO:
+            if self._busy_input_mode == "frontdesk":
+                task_id = self._schedule_frontdesk_background_task(
+                    source=event.source,
+                    text=(event.text or "").strip(),
+                    reason="busy_frontdesk_mode_priority_path",
+                    event_message_id=self._reply_anchor_for_event(event),
+                    media_urls=getattr(event, "media_urls", None),
+                    media_types=getattr(event, "media_types", None),
+                )
+                if task_id:
+                    return (
+                        f"Captured as background task {task_id}. "
+                        "Current run continues; I handle this separately."
+                    )
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return "Queued for the next turn because frontdesk background capture failed."
+
+            if event.message_type == MessageType.PHOTO and self._busy_input_mode != "steer":
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
                 adapter = self.adapters.get(source.platform)
                 if adapter:
@@ -9230,7 +9544,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Steer mode: inject text into the running agent mid-run via
                 # agent.steer().  Falls back to queue semantics if the payload
                 # is empty, the agent lacks steer(), or steer() rejects.
-                steer_text = (event.text or "").strip()
+                steer_text = await self._build_busy_steer_text_from_event(
+                    event,
+                    session_key=_quick_key,
+                )
                 steered = False
                 if steer_text and hasattr(running_agent, "steer"):
                     try:
@@ -9242,6 +9559,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.debug("PRIORITY steer for session %s", _quick_key)
                     return None
                 logger.debug("PRIORITY steer-fallback-to-queue for session %s", _quick_key)
+                if steer_text and not (event.text or "").strip():
+                    try:
+                        event.text = steer_text
+                    except Exception:
+                        pass
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
             # #30170 — Subagent protection (PRIORITY path). Same rationale
@@ -9857,6 +10179,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "⏳ This agent is draining for a maintenance action and isn't "
                 "accepting new turns right now. It'll be back in a moment — "
                 "please resend shortly."
+            )
+
+        # ── Front-desk dispatcher mode ────────────────────────────────
+        # In this mode the gateway-facing session remains an orchestrator/desk,
+        # not a worker. Regular inbound user work is dispatched immediately to
+        # an isolated background task and the chat is freed for the next input.
+        # Slash/control/internal events keep their direct handlers above.
+        if self._busy_input_mode == "frontdesk" and not is_internal and not command:
+            task_id = self._schedule_frontdesk_background_task(
+                source=event.source,
+                text=(event.text or "").strip(),
+                reason="frontdesk_default_dispatch",
+                event_message_id=self._reply_anchor_for_event(event),
+                media_urls=getattr(event, "media_urls", None),
+                media_types=getattr(event, "media_types", None),
+            )
+            if task_id:
+                return (
+                    f"Captured as background task {task_id}. "
+                    "I stay available; the worker will report back when done."
+                )
+            logger.warning(
+                "Frontdesk default dispatch failed; falling back to normal turn for %s",
+                _quick_key,
             )
 
         # ── Claim this session before any await ───────────────────────
@@ -12788,22 +13134,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
-            # Enrich the prompt with image descriptions so the background
-            # agent can see user-attached images (same as the main flow).
+            # Enrich the prompt with image/audio descriptions so the background
+            # agent can see user-attached media (same as the main flow where safe).
             enriched_prompt = prompt
             if media_urls:
                 image_paths = []
+                audio_paths = []
                 for i, path in enumerate(media_urls):
                     mtype = media_types[i] if i < len(media_types) else ""
                     if mtype.startswith("image/"):
                         image_paths.append(path)
+                    elif mtype.startswith("audio/"):
+                        audio_paths.append(path)
                 if image_paths:
                     try:
                         enriched_prompt = await self._enrich_message_with_vision(
-                            prompt, image_paths,
+                            enriched_prompt, image_paths,
                         )
                     except Exception as e:
                         logger.warning("Background task vision enrichment failed: %s", e)
+                if audio_paths:
+                    try:
+                        enriched_prompt, _background_transcripts = await self._enrich_message_with_transcription(
+                            enriched_prompt, audio_paths,
+                        )
+                        # Frontdesk captures run outside the normal inbound path,
+                        # so the usual immediate Telegram voice-transcript echo
+                        # would be skipped. Echo it here before the background
+                        # worker result so Pierre can verify exactly what STT saw.
+                        if _background_transcripts:
+                            for _tx in _background_transcripts:
+                                try:
+                                    await adapter.send(
+                                        chat_id=source.chat_id,
+                                        content=f'🎙️ "{_tx}"',
+                                        metadata=_thread_metadata,
+                                    )
+                                except Exception as _echo_exc:
+                                    logger.debug(
+                                        "Background task transcript echo failed (non-fatal): %s",
+                                        _echo_exc,
+                                    )
+                    except Exception as e:
+                        logger.warning("Background task audio transcription failed: %s", e)
 
             def run_sync():
                 agent = AIAgent(
@@ -18810,14 +19183,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
 
             # Leftover /steer: if a steer arrived after the last tool batch
-            # (e.g. during the final API call), the agent couldn't inject it
-            # and returned it in result["pending_steer"]. Deliver it as the
-            # next user turn so it isn't silently dropped.
+            # (e.g. during the final API call), the agent couldn't inject it.
+            # Do NOT recurse it as another same-session turn: that makes the
+            # chat feel queued behind the just-finished run and can hit the
+            # interrupt recursion cap. Capture it as isolated front-desk
+            # background work instead; only fall back to recursion if scheduling
+            # fails, so content is never dropped.
             if result and not pending and not pending_event:
                 _leftover_steer = result.get("pending_steer")
                 if _leftover_steer:
-                    pending = _leftover_steer
-                    logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
+                    _captured_leftover = await self._capture_leftover_steer_as_frontdesk_background(
+                        source=source,
+                        steer_text=_leftover_steer,
+                        session_key=session_key,
+                        adapter=adapter,
+                        metadata=_status_thread_metadata,
+                    )
+                    if not _captured_leftover:
+                        pending = _leftover_steer
+                        logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -18,6 +18,7 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
+    load_soul_md,
     CONTEXT_FILE_MAX_CHARS,
     _dynamic_context_file_max_chars,
     _get_context_file_max_chars,
@@ -740,6 +741,31 @@ class TestBuildContextFilesPrompt:
         (hermes_home / "SOUL.md").write_text("\n\n", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert result == ""
+
+    def test_blocked_soul_md_uses_default_identity_and_visible_warning(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text(
+            "<!-- system override -->",
+            encoding="utf-8",
+        )
+        drain_truncation_warnings()
+
+        result = load_soul_md()
+
+        assert result is not None
+        assert DEFAULT_AGENT_IDENTITY in result
+        assert "profile SOUL identity is not active" in result
+        assert "BLOCKED: SOUL.md" in result
+        assert "html_comment_injection" in result
+
+        warnings = drain_truncation_warnings()
+        assert len(warnings) == 1
+        assert "SOUL.md blocked by context security scan" in warnings[0]
+        assert "Default Hermes identity loaded instead" in warnings[0]
 
     def test_blocks_injection_in_agents_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text(

--- a/tests/gateway/test_busy_image_steer.py
+++ b/tests/gateway/test_busy_image_steer.py
@@ -1,0 +1,192 @@
+"""Regression tests for image/photo messages arriving while a gateway session is busy."""
+
+from types import SimpleNamespace
+import time
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.steered = []
+
+    def steer(self, text):
+        self.steered.append(text)
+        return True
+
+    def get_activity_summary(self):
+        return {
+            "api_call_count": 2,
+            "max_iterations": 10,
+            "current_tool": "terminal",
+            "seconds_since_activity": 0,
+            "last_activity_desc": "test-active",
+        }
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self.sent = []
+        self._pending_messages = {}
+
+    async def _send_with_retry(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SimpleNamespace(success=True)
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return await self._send_with_retry(
+            chat_id,
+            content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="5767139348",
+        chat_type="dm",
+        user_id="5767139348",
+    )
+
+
+def _photo_event(source=None):
+    return MessageEvent(
+        text="",
+        message_type=MessageType.PHOTO,
+        source=source or _source(),
+        media_urls=["/tmp/busy-photo.png"],
+        media_types=["image/png"],
+        message_id="photo-1",
+    )
+
+
+def _make_busy_runner(adapter, agent, session_key):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.session_store = None
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._update_prompt_pending = {}
+    runner._running_agents = {session_key: agent}
+    runner._running_agents_ts = {session_key: time.time()}
+    runner._busy_input_mode = "steer"
+    runner._busy_text_mode = "interrupt"
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner._startup_restore_in_progress = False
+    runner._agent_has_active_subagents = lambda _agent: False
+    runner._session_has_compression_in_flight = lambda _session_key: False
+    runner._is_user_authorized = lambda _source: True
+    runner._reply_anchor_for_event = lambda event: event.message_id
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_busy_steer_photo_is_vision_enriched_and_steered(monkeypatch):
+    """A captionless photo during a busy steer run should not fall back opaque.
+
+    The busy path used to look only at event.text.  Telegram photos often have
+    empty text, so the image was queued/captured without a vision pre-analysis
+    even though the live agent could accept steer text.
+    """
+    source = _source()
+    event = _photo_event(source)
+    session_key = "agent:main:telegram:dm:5767139348"
+    adapter = _FakeAdapter()
+    agent = _FakeAgent()
+    runner = _make_busy_runner(adapter, agent, session_key)
+
+    queued = []
+    background_calls = []
+    vision_calls = []
+
+    runner._queue_or_replace_pending_event = lambda _session_key, _event: queued.append(_event)
+    runner._schedule_frontdesk_background_task = lambda **kwargs: background_calls.append(kwargs) or "fd_photo"
+
+    async def fake_vision(user_text, image_paths):
+        vision_calls.append((user_text, list(image_paths)))
+        return "[vision] the image shows a handwritten deployment checklist"
+
+    runner._enrich_message_with_vision = fake_vision
+
+    import agent.onboarding as onboarding
+    monkeypatch.setattr(onboarding, "is_seen", lambda *_args, **_kwargs: True)
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    assert vision_calls == [("", ["/tmp/busy-photo.png"])]
+    assert agent.steered == ["[vision] the image shows a handwritten deployment checklist"]
+    assert queued == []
+    assert background_calls == []
+    assert adapter.sent
+    assert "Steered into current run" in adapter.sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_busy_steer_photo_is_not_masked_by_pending_clarify(monkeypatch):
+    """A pending clarify must not swallow a media-only photo follow-up.
+
+    Telegram can route the next message to the runner to give an active clarify
+    a chance to resolve.  If that next message is a captionless photo, it has no
+    clarify text; it must keep flowing to busy steer with vision context instead
+    of being left as an opaque pending photo behind the run.
+    """
+    from tools import clarify_gateway as cm
+
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+        cm._notify_cbs.clear()
+
+    source = _source()
+    event = _photo_event(source)
+    adapter = _FakeAdapter()
+    agent = _FakeAgent()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.session_store = None
+    session_key = runner._session_key_for_source(source)
+    runner = _make_busy_runner(adapter, agent, session_key)
+
+    queued = []
+    background_calls = []
+    vision_calls = []
+
+    runner._queue_or_replace_pending_event = lambda _session_key, _event: queued.append(_event)
+    runner._schedule_frontdesk_background_task = lambda **kwargs: background_calls.append(kwargs) or "fd_photo"
+
+    async def fake_vision(user_text, image_paths):
+        vision_calls.append((user_text, list(image_paths)))
+        return "[vision] the image shows a Telegram screenshot with an error banner"
+
+    runner._enrich_message_with_vision = fake_vision
+
+    cm.register("clarify-image", session_key, "Choose", ["A", "B"])
+    cm.mark_awaiting_text("clarify-image")
+
+    response = await runner._handle_message(event)
+
+    assert response is None
+    assert vision_calls == [("", ["/tmp/busy-photo.png"])]
+    assert agent.steered == ["[vision] the image shows a Telegram screenshot with an error banner"]
+    assert queued == []
+    assert adapter._pending_messages == {}
+    assert background_calls == []
+    with cm._lock:
+        entry = cm._entries["clarify-image"]
+    assert entry.response is None
+    assert not entry.event.is_set()

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -123,6 +123,56 @@ class TestBusySessionAck:
         running_agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_handle_message_frontdesk_mode_captures_without_queue_or_interrupt(self):
+        """Runner frontdesk mode starts separate background work for busy input."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="idée neuve pendant run long")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._busy_input_mode = "frontdesk"
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+        runner._schedule_frontdesk_background_task = MagicMock(return_value="fd_test")
+        queued = []
+        runner._queue_or_replace_pending_event = lambda _session_key, _event: queued.append(_event)
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert "Captured as background task fd_test" in result
+        runner._schedule_frontdesk_background_task.assert_called_once()
+        assert queued == []
+        assert sk not in adapter._pending_messages
+        running_agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_message_frontdesk_mode_dispatches_new_turn_without_claiming_session(self):
+        """In frontdesk mode, even a fresh normal message becomes background work."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="traite cette demande et reviens quand c'est fait")
+        sk = build_session_key(event.source)
+
+        runner._busy_input_mode = "frontdesk"
+        runner.adapters[event.source.platform] = adapter
+        runner._schedule_frontdesk_background_task = MagicMock(return_value="fd_new")
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert "Captured as background task fd_new" in result
+        assert "I stay available" in result
+        runner._schedule_frontdesk_background_task.assert_called_once()
+        assert sk not in runner._running_agents
+        assert sk not in adapter._pending_messages
+
+    @pytest.mark.asyncio
     async def test_telegram_grace_followups_respect_queue_fifo(self, monkeypatch):
         """Rapid Telegram text follow-ups in queue mode must not merge."""
         from gateway.run import GatewayRunner
@@ -298,8 +348,8 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
-    async def test_steer_mode_falls_back_to_queue_when_agent_rejects(self):
-        """If agent.steer() returns False, fall back to queue behavior."""
+    async def test_steer_mode_falls_back_to_frontdesk_when_agent_rejects(self):
+        """If agent.steer() returns False, capture as frontdesk background."""
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "steer"
         adapter = _make_adapter()
@@ -311,25 +361,25 @@ class TestBusySessionAck:
         agent = MagicMock()
         agent.steer = MagicMock(return_value=False)  # rejected
         runner._running_agents[sk] = agent
+        runner._schedule_frontdesk_background_task = MagicMock(return_value="fd_reject")
 
         await runner._handle_active_session_busy_message(event, sk)
 
         agent.steer.assert_called_once()
         agent.interrupt.assert_not_called()
-        # Fell back to queue semantics: event was stored for the next turn
-        # via the FIFO path (each follow-up its own turn — no newline-merge
-        # that would mash separate messages together, #43066).
-        assert adapter._pending_messages.get(sk) is event
+        runner._schedule_frontdesk_background_task.assert_called_once()
+        assert sk not in adapter._pending_messages
 
-        # Ack uses queue-mode wording (not steer, not interrupt)
+        # Ack uses frontdesk wording (not steer, not queue, not interrupt)
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
-        assert "Queued for the next turn" in content
+        assert "background task" in content
+        assert "Queued for the next turn" not in content
         assert "Steered" not in content
 
     @pytest.mark.asyncio
-    async def test_steer_mode_falls_back_to_queue_when_agent_pending(self):
-        """If agent is still starting (sentinel), steer mode falls back to queue."""
+    async def test_steer_mode_falls_back_to_frontdesk_when_agent_pending(self):
+        """If agent is still starting, capture as frontdesk background."""
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "steer"
         adapter = _make_adapter()
@@ -340,15 +390,17 @@ class TestBusySessionAck:
 
         # Agent is still being set up — sentinel in place
         runner._running_agents[sk] = sentinel
+        runner._schedule_frontdesk_background_task = MagicMock(return_value="fd_pending")
 
         await runner._handle_active_session_busy_message(event, sk)
 
-        # Event was queued instead of steered (FIFO path, #43066)
-        assert adapter._pending_messages.get(sk) is event
+        runner._schedule_frontdesk_background_task.assert_called_once()
+        assert sk not in adapter._pending_messages
 
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
-        assert "Queued for the next turn" in content
+        assert "background task" in content
+        assert "Queued for the next turn" not in content
 
     @pytest.mark.asyncio
     async def test_interrupt_mode_text_followups_fifo_not_merged(self):
@@ -512,8 +564,15 @@ class TestBusySessionAck:
         assert "10 min" in content  # elapsed
 
     @pytest.mark.asyncio
-    async def test_telegram_omits_status_detail_by_default(self):
+    async def test_telegram_omits_status_detail_when_opted_out(self, monkeypatch):
         """Telegram busy acks stay concise unless busy_ack_detail is enabled."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"platforms": {"telegram": {"busy_ack_detail": False}}}},
+        )
         runner, sentinel = _make_runner()
         runner._busy_input_mode = "interrupt"
         adapter = _make_adapter()

--- a/tests/gateway/test_busy_voice_steer.py
+++ b/tests/gateway/test_busy_voice_steer.py
@@ -1,0 +1,430 @@
+"""Regression tests for voice messages arriving while a gateway session is busy."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.steered = []
+
+    def steer(self, text):
+        self.steered.append(text)
+        return True
+
+    def get_activity_summary(self):
+        return {
+            "api_call_count": 1,
+            "max_iterations": 10,
+            "current_tool": "terminal",
+        }
+
+
+class _FakeAdapter:
+    def __init__(self):
+        self.sent = []
+
+    async def _send_with_retry(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SimpleNamespace(success=True)
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return await self._send_with_retry(
+            chat_id,
+            content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    def extract_media(self, response):
+        return [], response
+
+    def extract_images(self, response):
+        return [], response
+
+
+@pytest.mark.asyncio
+async def test_busy_steer_transcribes_voice_before_queue_fallback(monkeypatch):
+    """In steer mode, a captionless voice note should steer its transcript.
+
+    Before this regression guard, _handle_active_session_busy_message looked only
+    at event.text. Telegram voice notes have no text until STT runs, so steer mode
+    silently degraded to queue mode even though STT was enabled and an agent was
+    available to accept steer input.
+    """
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="5767139348",
+        chat_type="dm",
+        user_id="5767139348",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/busy-steer.ogg"],
+        media_types=["audio/ogg"],
+        message_id="voice-1",
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(stt_enabled=True)
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner._draining = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_input_mode = "steer"
+    runner._busy_text_mode = "interrupt"
+    runner._busy_ack_ts = {}
+    runner._agent_has_active_subagents = lambda _agent: False
+    runner._is_user_authorized = lambda _source: True
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    queued = []
+    runner._queue_or_replace_pending_event = lambda _session_key, _event: queued.append(_event)
+
+    agent = _FakeAgent()
+    session_key = "agent:main:telegram:dm:5767139348"
+    runner._running_agents[session_key] = agent
+    runner._running_agents_ts[session_key] = 123.0
+
+    import agent.onboarding as onboarding
+    monkeypatch.setattr(onboarding, "is_seen", lambda *_args, **_kwargs: True)
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "nouvelle idée à traiter directement",
+            "provider": "whisper",
+        },
+    ) as transcribe:
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    transcribe.assert_called_once_with("/tmp/busy-steer.ogg")
+    assert agent.steered == ['"nouvelle idée à traiter directement"']
+    assert queued == []
+    assert runner.adapters[Platform.TELEGRAM].sent
+    assert "Steered into current run" in runner.adapters[Platform.TELEGRAM].sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_busy_steer_fallback_captures_background_instead_of_queue(monkeypatch):
+    """If a busy message cannot be truly steered, front-desk captures it.
+
+    The previous steer fallback stored the message in the session pending queue,
+    so Pierre saw the idea as blocked behind the current long run.  Front-desk
+    mode should ACK immediately and launch a separate background session instead.
+    """
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="5767139348",
+        chat_type="dm",
+        user_id="5767139348",
+    )
+    event = MessageEvent(
+        text="note indépendante pendant le long run",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="text-1",
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(stt_enabled=True)
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner._background_tasks = set()
+    runner._draining = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_input_mode = "steer"
+    runner._busy_text_mode = "interrupt"
+    runner._busy_ack_ts = {}
+    runner._agent_has_active_subagents = lambda _agent: False
+    runner._is_user_authorized = lambda _source: True
+    runner._reply_anchor_for_event = lambda _event: "text-1"
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    runner._persist_frontdesk_capture = lambda **_kwargs: None
+    queued = []
+    runner._queue_or_replace_pending_event = lambda _session_key, _event: queued.append(_event)
+
+    background_calls = []
+
+    async def fake_background_task(prompt, source, task_id, **kwargs):
+        background_calls.append({
+            "prompt": prompt,
+            "source": source,
+            "task_id": task_id,
+            "kwargs": kwargs,
+        })
+
+    runner._run_background_task = fake_background_task
+    # Agent exists but cannot accept steer(), which used to force queue fallback.
+    runner._running_agents["agent:main:telegram:dm:5767139348"] = SimpleNamespace()
+    runner._running_agents_ts["agent:main:telegram:dm:5767139348"] = 123.0
+
+    import agent.onboarding as onboarding
+    monkeypatch.setattr(onboarding, "is_seen", lambda *_args, **_kwargs: True)
+
+    handled = await runner._handle_active_session_busy_message(
+        event,
+        "agent:main:telegram:dm:5767139348",
+    )
+    await asyncio.sleep(0)
+
+    assert handled is True
+    assert queued == []
+    assert len(background_calls) == 1
+    assert "note indépendante pendant le long run" in background_calls[0]["prompt"]
+    assert background_calls[0]["kwargs"]["event_message_id"] == "text-1"
+    assert runner.adapters[Platform.TELEGRAM].sent
+    assert "background task" in runner.adapters[Platform.TELEGRAM].sent[0]["content"]
+    assert "Queued for the next turn" not in runner.adapters[Platform.TELEGRAM].sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_busy_frontdesk_mode_captures_text_without_steering_or_queueing(monkeypatch):
+    """frontdesk mode turns busy follow-ups into isolated background work."""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="5767139348",
+        chat_type="dm",
+        user_id="5767139348",
+    )
+    event = MessageEvent(
+        text="nouvelle idée pendant un chantier long",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="frontdesk-text-1",
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(stt_enabled=True)
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner._background_tasks = set()
+    runner._draining = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_input_mode = "frontdesk"
+    runner._busy_text_mode = "interrupt"
+    runner._busy_ack_ts = {}
+    runner._agent_has_active_subagents = lambda _agent: False
+    runner._is_user_authorized = lambda _source: True
+    runner._reply_anchor_for_event = lambda _event: "frontdesk-text-1"
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    runner._persist_frontdesk_capture = lambda **_kwargs: None
+    queued = []
+    runner._queue_or_replace_pending_event = lambda _session_key, _event: queued.append(_event)
+
+    background_calls = []
+
+    async def fake_background_task(prompt, source, task_id, **kwargs):
+        background_calls.append({"prompt": prompt, "source": source, "task_id": task_id, "kwargs": kwargs})
+
+    runner._run_background_task = fake_background_task
+    agent = _FakeAgent()
+    session_key = "agent:main:telegram:dm:5767139348"
+    runner._running_agents[session_key] = agent
+    runner._running_agents_ts[session_key] = 123.0
+
+    import agent.onboarding as onboarding
+    monkeypatch.setattr(onboarding, "is_seen", lambda *_args, **_kwargs: True)
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+    await asyncio.sleep(0)
+
+    assert handled is True
+    assert agent.steered == []
+    assert queued == []
+    assert len(background_calls) == 1
+    assert "nouvelle idée pendant un chantier long" in background_calls[0]["prompt"]
+    assert background_calls[0]["kwargs"]["event_message_id"] == "frontdesk-text-1"
+    assert "background task" in runner.adapters[Platform.TELEGRAM].sent[0]["content"]
+    assert "Queued for the next turn" not in runner.adapters[Platform.TELEGRAM].sent[0]["content"]
+    assert "Steered into current run" not in runner.adapters[Platform.TELEGRAM].sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_busy_frontdesk_mode_passes_voice_and_image_media_to_background_task(monkeypatch):
+    """frontdesk mode must not strand media in the same-session pending queue."""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="5767139348",
+        chat_type="dm",
+        user_id="5767139348",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/frontdesk-voice.ogg", "/tmp/frontdesk-image.png"],
+        media_types=["audio/ogg", "image/png"],
+        message_id="frontdesk-media-1",
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(stt_enabled=True)
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner._background_tasks = set()
+    runner._draining = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_input_mode = "frontdesk"
+    runner._busy_text_mode = "interrupt"
+    runner._busy_ack_ts = {}
+    runner._agent_has_active_subagents = lambda _agent: False
+    runner._is_user_authorized = lambda _source: True
+    runner._reply_anchor_for_event = lambda _event: "frontdesk-media-1"
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    runner._persist_frontdesk_capture = lambda **_kwargs: None
+    queued = []
+    runner._queue_or_replace_pending_event = lambda _session_key, _event: queued.append(_event)
+
+    background_calls = []
+
+    async def fake_background_task(prompt, source, task_id, **kwargs):
+        background_calls.append({"prompt": prompt, "source": source, "task_id": task_id, "kwargs": kwargs})
+
+    runner._run_background_task = fake_background_task
+    session_key = "agent:main:telegram:dm:5767139348"
+    runner._running_agents[session_key] = _FakeAgent()
+    runner._running_agents_ts[session_key] = 123.0
+
+    import agent.onboarding as onboarding
+    monkeypatch.setattr(onboarding, "is_seen", lambda *_args, **_kwargs: True)
+
+    handled = await runner._handle_active_session_busy_message(event, session_key)
+    await asyncio.sleep(0)
+
+    assert handled is True
+    assert queued == []
+    assert len(background_calls) == 1
+    assert background_calls[0]["kwargs"]["media_urls"] == [
+        "/tmp/frontdesk-voice.ogg",
+        "/tmp/frontdesk-image.png",
+    ]
+    assert background_calls[0]["kwargs"]["media_types"] == ["audio/ogg", "image/png"]
+    assert "background task" in runner.adapters[Platform.TELEGRAM].sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_leftover_steer_is_captured_as_frontdesk_background(monkeypatch):
+    """A steer that arrives after the final tool batch must not recurse/queue.
+
+    This covers the final-stream tail: the current run is allowed to finish, and
+    the leftover steer becomes an independent background task instead of another
+    recursive same-session turn.
+    """
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="5767139348",
+        chat_type="dm",
+        user_id="5767139348",
+    )
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    runner._background_tasks = set()
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {}
+    runner._persist_frontdesk_capture = lambda **_kwargs: None
+
+    background_calls = []
+
+    async def fake_background_task(prompt, source, task_id, **kwargs):
+        background_calls.append({"prompt": prompt, "source": source, "task_id": task_id, "kwargs": kwargs})
+
+    runner._run_background_task = fake_background_task
+
+    captured = await runner._capture_leftover_steer_as_frontdesk_background(
+        source=source,
+        steer_text="idée arrivée pendant la finalisation",
+        session_key="agent:main:telegram:dm:5767139348",
+        adapter=runner.adapters[Platform.TELEGRAM],
+        metadata={},
+    )
+    await asyncio.sleep(0)
+
+    assert captured is True
+    assert len(background_calls) == 1
+    assert "idée arrivée pendant la finalisation" in background_calls[0]["prompt"]
+    assert runner.adapters[Platform.TELEGRAM].sent
+    assert "after the last tool call" in runner.adapters[Platform.TELEGRAM].sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_frontdesk_background_audio_echoes_transcript_before_result(monkeypatch):
+    """Voice sent to a frontdesk background worker must still be visible to Pierre.
+
+    Frontdesk mode schedules the worker before the normal inbound STT echo path.
+    The background enrichment step therefore owns the transcript echo.
+    """
+    import gateway.run as gateway_run
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="5767139348",
+        chat_type="dm",
+        user_id="5767139348",
+    )
+    adapter = _FakeAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(stt_enabled=True)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._service_tier = None
+    runner._session_db = SimpleNamespace(_db=None)
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: {"thread_id": "test"}
+    runner._resolve_session_agent_runtime = lambda **_kwargs: ("test-model", {"api_key": "ok"})
+    runner._resolve_session_reasoning_config = lambda **_kwargs: None
+    runner._load_service_tier = lambda: None
+    runner._resolve_turn_agent_config = lambda prompt, model, runtime: {
+        "model": model,
+        "runtime": runtime,
+        "request_overrides": None,
+    }
+
+    async def fake_executor(_fn):
+        return {"final_response": "fait"}
+
+    runner._run_in_executor_with_context = fake_executor
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"agent": {}, "tools": {}, "display": {}},
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "texte brut du vocal frontdesk",
+            "provider": "whisper",
+        },
+    ) as transcribe:
+        await runner._run_background_task(
+            prompt="Frontdesk capture:\nCaptured user message:\n[media]",
+            source=source,
+            task_id="fd_voice_echo",
+            event_message_id="voice-42",
+            media_urls=["/tmp/frontdesk-voice.ogg"],
+            media_types=["audio/ogg"],
+        )
+
+    transcribe.assert_called_once_with("/tmp/frontdesk-voice.ogg")
+    contents = [item["content"] for item in adapter.sent]
+    assert '🎙️ "texte brut du vocal frontdesk"' in contents
+    assert any("Background task complete" in item for item in contents)

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -1,7 +1,7 @@
 """Regression tests for clarify replies while a gateway session is busy."""
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -85,3 +85,61 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     adapter._message_handler.assert_awaited_once_with(event)
     adapter._busy_session_handler.assert_not_awaited()
     assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_pending_clarify_voice_reply_is_transcribed_and_resolves_before_busy_path():
+    """A Telegram voice note sent after tapping clarify Other must resolve the prompt.
+
+    The active-session adapter bypass already routes the media event to the
+    runner; this guards the runner-side intercept.  Without transcription here,
+    a captionless voice note has empty event.text, falls through as a normal
+    busy follow-up, and the clarify wait remains unresolved.
+    """
+    _clear_clarify_state()
+    from gateway.config import GatewayConfig
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="private",
+        user_id="user1",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/clarify-other-voice.ogg"],
+        media_types=["audio/ogg"],
+        message_id="voice-msg-1",
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._update_prompt_pending = {}
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._is_user_authorized = lambda _source: True
+
+    session_key = runner._session_key_for_source(source)
+    cm.register("clarify-voice", session_key, "Pick", ["A", "B"])
+    cm.mark_awaiting_text("clarify-voice")
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "ma réponse vocale autre",
+            "provider": "whisper",
+        },
+    ) as transcribe:
+        response = await runner._handle_message(event)
+
+    assert response == ""
+    transcribe.assert_called_once_with("/tmp/clarify-other-voice.ogg")
+    with cm._lock:
+        entry = cm._entries["clarify-voice"]
+    assert entry.response == "ma réponse vocale autre"
+    assert entry.event.is_set()

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -105,11 +105,19 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     )
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
 
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  busy_input_mode: frontdesk\n", encoding="utf-8"
+    )
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "frontdesk"
+
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "interrupt")
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
 
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "steer")
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
+
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "frontdesk")
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "frontdesk"
 
     # Unknown values fall through to the safe default
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "bogus")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -24,7 +24,7 @@ import run_agent
 from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
 from agent.memory_manager import MemoryManager
-from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.prompt_builder import DEFAULT_AGENT_IDENTITY, drain_truncation_warnings
 
 
 # ---------------------------------------------------------------------------
@@ -1250,6 +1250,38 @@ class TestBuildSystemPrompt:
 
         assert "SOUL IDENTITY" in prompt
         assert DEFAULT_AGENT_IDENTITY not in prompt
+
+    def test_blocked_soul_identity_falls_back_and_emits_status(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text(
+            "<!-- system override -->",
+            encoding="utf-8",
+        )
+        drain_truncation_warnings()
+        statuses = []
+        placeholder_credential = "test-k...7890"
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key=placeholder_credential,
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                load_soul_identity=True,
+                skip_memory=True,
+            )
+            agent._emit_status = statuses.append
+            prompt = agent._build_system_prompt()
+
+        assert DEFAULT_AGENT_IDENTITY in prompt
+        assert "profile SOUL identity is not active" in prompt
+        assert any("SOUL.md blocked by context security scan" in s for s in statuses)
 
     def test_includes_system_message(self, agent):
         prompt = agent._build_system_prompt(system_message="Custom instruction")

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -96,6 +96,30 @@ def test_busy_steer_mode_falls_back_to_queue_when_rejected(monkeypatch):
     assert session["queued_prompt"]["text"] == "nudge"
 
 
+def test_busy_frontdesk_mode_spawns_background_without_interrupt_or_queue(monkeypatch):
+    monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "frontdesk")
+    calls = {"interrupt": 0, "background": []}
+    agent = types.SimpleNamespace(
+        interrupt=lambda *a, **k: calls.__setitem__("interrupt", calls["interrupt"] + 1)
+    )
+    session = _session(agent=agent)
+    monkeypatch.setattr(
+        server,
+        "_start_frontdesk_background_task",
+        lambda sid, sess, text, *, reason: calls["background"].append(
+            (sid, sess, text, reason)
+        )
+        or "fd_test",
+    )
+
+    resp = server._handle_busy_submit("r1", "sid", session, "nouvelle idée", "ws-1")
+
+    assert resp["result"] == {"status": "background", "task_id": "fd_test"}
+    assert calls["interrupt"] == 0
+    assert calls["background"] == [("sid", session, "nouvelle idée", "busy_frontdesk_mode")]
+    assert session.get("queued_prompt") is None
+
+
 # ── _drain_queued_prompt ───────────────────────────────────────────────────
 
 def test_drain_fires_queued_prompt_and_claims_running(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2729,7 +2729,7 @@ def test_config_busy_get_and_set(monkeypatch):
     monkeypatch.setattr(
         server,
         "_load_cfg",
-        lambda: {"display": {"busy_input_mode": "steer"}},
+        lambda: {"display": {"busy_input_mode": "frontdesk"}},
     )
     monkeypatch.setattr(
         server, "_write_config_key", lambda path, value: writes.append((path, value))
@@ -2738,17 +2738,17 @@ def test_config_busy_get_and_set(monkeypatch):
     get_resp = server.handle_request(
         {"id": "1", "method": "config.get", "params": {"key": "busy"}}
     )
-    assert get_resp["result"]["value"] == "steer"
+    assert get_resp["result"]["value"] == "frontdesk"
 
     set_resp = server.handle_request(
         {
             "id": "2",
             "method": "config.set",
-            "params": {"key": "busy", "value": "interrupt"},
+            "params": {"key": "busy", "value": "frontdesk"},
         }
     )
-    assert set_resp["result"]["value"] == "interrupt"
-    assert ("display.busy_input_mode", "interrupt") in writes
+    assert set_resp["result"]["value"] == "frontdesk"
+    assert ("display.busy_input_mode", "frontdesk") in writes
 
 
 def test_config_set_yolo_process_scope_treats_false_like_env_as_disabled(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -394,7 +394,7 @@ def _load_busy_input_mode() -> str:
     if not isinstance(display, dict):
         display = {}
     raw = str(display.get("busy_input_mode", "") or "").strip().lower()
-    return raw if raw in {"queue", "steer", "interrupt"} else "interrupt"
+    return raw if raw in {"queue", "steer", "frontdesk", "interrupt"} else "interrupt"
 
 
 def _notify_session_boundary(event_type: str, session_id: str | None) -> None:
@@ -4824,6 +4824,72 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any) -> None:
     session["queued_prompt"] = {"text": text, "transport": transport}
 
 
+def _frontdesk_background_prompt(text: Any, *, reason: str) -> str:
+    captured = str(text or "").strip()
+    if not captured:
+        captured = "[User sent an empty prompt while another TUI run was busy.]"
+    return (
+        "Frontdesk capture: the user sent this while another Hermes run was "
+        "already active in the parent TUI session. Treat it as a separate "
+        "background request so the active run can continue. Do not wait for, "
+        "recurse into, or mutate the parent run unless the captured text "
+        "explicitly asks for a control/status action.\n\n"
+        f"Capture reason: {reason}\n\n"
+        "Captured user message:\n"
+        f"{captured}"
+    )
+
+
+def _start_frontdesk_background_task(
+    sid: str,
+    session: dict,
+    text: Any,
+    *,
+    reason: str,
+) -> str | None:
+    """Run a busy TUI prompt in an isolated background agent session."""
+    agent = session.get("agent")
+    if agent is None:
+        return None
+
+    task_id = f"fd_{uuid.uuid4().hex[:6]}"
+    prompt = _frontdesk_background_prompt(text, reason=reason)
+    parent = sid
+
+    def run() -> None:
+        session_tokens = _set_session_context(task_id, cwd=_session_cwd(session))
+        try:
+            from run_agent import AIAgent
+
+            result = AIAgent(**_background_agent_kwargs(agent, task_id)).run_conversation(
+                user_message=prompt,
+                task_id=task_id,
+            )
+            _emit(
+                "background.complete",
+                parent,
+                {
+                    "task_id": task_id,
+                    "text": (
+                        result.get("final_response", str(result))
+                        if isinstance(result, dict)
+                        else str(result)
+                    ),
+                },
+            )
+        except Exception as e:
+            _emit(
+                "background.complete",
+                parent,
+                {"task_id": task_id, "text": f"error: {e}"},
+            )
+        finally:
+            _clear_session_context(session_tokens)
+
+    threading.Thread(target=run, daemon=True).start()
+    return task_id
+
+
 def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any) -> dict:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
@@ -4837,10 +4903,22 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any)
 
     Modes: ``interrupt`` (default) → interrupt + queue; ``queue`` → queue
     without interrupting; ``steer`` → inject into the live turn if accepted,
-    else queue.
+    else queue; ``frontdesk`` → run in an isolated background session without
+    touching the active turn.
     """
     mode = _load_busy_input_mode()
     agent = session.get("agent")
+    if mode == "frontdesk":
+        task_id = _start_frontdesk_background_task(
+            sid,
+            session,
+            text,
+            reason="busy_frontdesk_mode",
+        )
+        if task_id:
+            session["last_active"] = time.time()
+            return _ok(rid, {"status": "background", "task_id": task_id})
+        mode = "queue"
     if mode == "steer" and agent is not None and hasattr(agent, "steer"):
         try:
             if agent.steer(text):
@@ -9924,7 +10002,7 @@ def _(rid, params: dict) -> dict:
         raw = str(value or "").strip().lower()
         if raw in {"", "status"}:
             return _ok(rid, {"key": key, "value": _load_busy_input_mode()})
-        if raw not in {"queue", "steer", "interrupt"}:
+        if raw not in {"queue", "steer", "frontdesk", "interrupt"}:
             return _err(rid, 4002, f"unknown busy mode: {value}")
         _write_config_key("display.busy_input_mode", raw)
         return _ok(rid, {"key": key, "value": raw})

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -78,7 +78,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/voice [on\|off\|tts\|status]` | Toggle CLI voice mode and spoken playback. Recording uses `voice.record_key` (default: `Ctrl+B`). |
 | `/yolo` | Toggle YOLO mode — skip all dangerous command approval prompts. |
 | `/footer [on\|off\|status]` | Toggle the gateway runtime-metadata footer on final replies (shows model, context %, and cwd). |
-| `/busy [queue\|steer\|interrupt\|status]` | CLI-only: control what pressing Enter does while Hermes is working — queue the new message, steer mid-turn, or interrupt immediately. |
+| `/busy [queue\|steer\|frontdesk\|interrupt\|status]` | CLI-only: control what pressing Enter does while Hermes is working — queue the new message, steer mid-turn, capture it as an isolated background task, or interrupt immediately. |
 | `/indicator [kaomoji\|emoji\|unicode\|ascii]` | CLI-only: pick the TUI busy-indicator style. |
 | `/timestamps [on\|off\|status]` | CLI-only: toggle `[HH:MM]` timestamps on messages and in `/history`. |
 


### PR DESCRIPTION
## Summary

- fix(gateway): preserve busy-session steering across inputs
- Prepared from a local maintenance overlay in an isolated worktree.
- Includes regression coverage and a sanitized public test plan.

## Test plan

- [x] git diff --check
- [x] added-line security scan passed
- [x] py_compile changed Python files
- [x] ........................................................................ [ 98%] .......                                                                  [100%] 511 passed in 13.81s

## Notes

Draft contribution candidate; publication requires an explicit human gate.
