### PR TITLE
fix: forward reasoning_effort for custom providers (GLM-5.2 on ARK)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -377,6 +377,22 @@ class ChatCompletionsTransport(ProviderTransport):
             if _lm_effort is not None:
                 api_kwargs["reasoning_effort"] = _lm_effort
 
+        # Custom provider (e.g. GLM-5.2 on ARK): send top-level reasoning_effort
+        # string so the upstream API receives its native parameter format.
+        if params.get("is_custom_provider", False):
+            _custom_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _custom_thinking_off:
+                _custom_effort = "medium"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _custom_effort = (
+                        reasoning_config.get("effort", "medium") or "medium"
+                    )
+                api_kwargs["reasoning_effort"] = _custom_effort
+
         # extra_body assembly
         extra_body: dict[str, Any] = {}
 
@@ -423,7 +439,10 @@ class ChatCompletionsTransport(ProviderTransport):
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning
             else:
-                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+                _effort = "medium"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _effort = reasoning_config.get("effort", "medium") or "medium"
+                extra_body["reasoning"] = {"enabled": True, "effort": _effort}
 
         if provider_name == "gemini":
             raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -791,7 +791,7 @@ def apply_subprocess_home_env(env: dict[str, str]) -> None:
         env["HOME"] = home
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:


### PR DESCRIPTION
## Bug

When using a **custom provider** (e.g. GLM-5.2 on Volcengine ARK via OpenAI-compatible endpoint), the `reasoning_effort` config value is silently dropped — it never reaches the upstream API.

### Root cause

1. **`parse_reasoning_effort()` rejects `"max"`** — GLM-5.2's native API accepts only `"high"` and `"max"` (where `max` is the default deep-reasoning mode). But `"max"` is not in `VALID_REASONING_EFFORTS`, so `parse_reasoning_effort("max")` returns `None`.

2. **`_supports_reasoning_extra_body()` returns `False` for custom providers** — the method only returns `True` for Nous Portal, GitHub Models, LM Studio, and OpenRouter with known reasoning model prefixes. Custom providers never match, so `extra_body.reasoning` is never emitted.

3. **No top-level `reasoning_effort` for custom providers** — Kimi, TokenHub, and LM Studio all have dedicated branches that emit `api_kwargs["reasoning_effort"]` as a top-level string. Custom providers have no such branch.

4. **Legacy `extra_body.reasoning` hardcodes `"medium"`** — even when `supports_reasoning` is `True`, the fallback path at line 426 ignores the user's configured effort and always sends `{"enabled": True, "effort": "medium"}`.

### Result

All reasoning_effort settings are silently ignored for custom providers. The upstream API receives no reasoning parameter at all, relying on the model's default behavior.

For GLM-5.2 specifically: since `max` is the GLM default, users who explicitly set `reasoning_effort: high` (to get faster ~70 tok/s output) would still get `max` behavior — silently. And users on other custom-provider models that default to `high` or no reasoning get no reasoning at all.

## Fix

Three changes:

### 1. Add `"max"` to `VALID_REASONING_EFFORTS` (`hermes_constants.py`)

```python
VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
```

GLM-5.2 documents `reasoning_effort` as accepting `"high"` or `"max"`. Claude Code's own effort mapping also recognizes `max` (mapping `xhigh`/`max`/`ultracode` → GLM `max`).

### 2. Emit top-level `reasoning_effort` for custom providers (`chat_completions.py`)

New branch after the LM Studio block, mirroring the Kimi/TokenHub pattern:

```python
if params.get("is_custom_provider", False):
    _custom_thinking_off = bool(
        reasoning_config
        and isinstance(reasoning_config, dict)
        and reasoning_config.get("enabled") is False
    )
    if not _custom_thinking_off:
        _custom_effort = "medium"
        if reasoning_config and isinstance(reasoning_config, dict):
            _custom_effort = (
                reasoning_config.get("effort", "medium") or "medium"
            )
        api_kwargs["reasoning_effort"] = _custom_effort
```

This sends the user's actual configured effort as a top-level string — the format GLM-5.2 and other OpenAI-compatible APIs expect.

### 3. Stop hardcoding `"medium"` in legacy `extra_body.reasoning` (`chat_completions.py`)

```python
# Before:
extra_body["reasoning"] = {"enabled": True, "effort": "medium"}

# After:
_effort = "medium"
if reasoning_config and isinstance(reasoning_config, dict):
    _effort = reasoning_config.get("effort", "medium") or "medium"
extra_body["reasoning"] = {"enabled": True, "effort": _effort}
```

This path is reached by providers that go through `extra_body.reasoning` (OpenRouter-style). The hardcoded `"medium"` was ignoring the user's configured effort level.

## Testing

- Verified GLM-5.2 on ARK (`https://ark.cn-beijing.volces.com/api/plan/v3`) now receives `reasoning_effort: "max"` as a top-level parameter.
- Confirmed `parse_reasoning_effort("max")` now returns `{"enabled": True, "effort": "max"}` instead of `None`.
- Existing Kimi/TokenHub/LM Studio branches are untouched.

## References

- [GLM-5.2 Migration Guide](https://docs.z.ai/guides/overview/migrate-to-glm-new) — documents `reasoning_effort` accepting `"high"` and `"max"`
- [GLM-5 GitHub](https://github.com/zai-org/GLM-5) — confirms `max` is the default, `high` must be explicitly set