### PR TITLE
fix(kanban): terminate worker process on block/archive/complete (#57596)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4015,6 +4015,15 @@ def complete_task(
     """
     now = int(time.time())
 
+    # Snapshot worker_pid/claim_lock before the UPDATE clears them so we
+    # can terminate the orphaned subprocess after the DB transition (#57596).
+    _snap = conn.execute(
+        "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    _prev_pid = _snap["worker_pid"] if _snap else None
+    _prev_lock = _snap["claim_lock"] if _snap else None
+
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
     # tiny dedicated txn, then raise. The caller is responsible for
@@ -4149,6 +4158,13 @@ def complete_task(
                     },
                     run_id=run_id,
                 )
+    # Terminate the worker process if the task was running.
+    # complete_task clears worker_pid in the DB but the subprocess
+    # keeps running unless we signal it (#57596). Normally the worker
+    # itself calls kanban_complete() and exits, but external completion
+    # (dashboard, CLI) leaves the process alive.
+    if _prev_pid:
+        _terminate_reclaimed_worker(_prev_pid, _prev_lock)
     # Successful completion — wipe the consecutive-failures counter.
     # Failure history stays on the event log for audit; the counter
     # just tracks "is there a current pathology the breaker should
@@ -4581,11 +4597,13 @@ def block_task(
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, block_kind, block_recurrences, worker_pid, claim_lock FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
             return False
+        prev_pid = cur_row["worker_pid"] if "worker_pid" in cur_row.keys() else None
+        prev_lock = cur_row["claim_lock"] if "claim_lock" in cur_row.keys() else None
         prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
         prev_recurrences = (
             int(cur_row["block_recurrences"])
@@ -4638,6 +4656,11 @@ def block_task(
                 run_id=run_id,
                 reason=reason,
             )
+            # Terminate the worker process if the task was running.
+            # block_task clears worker_pid in the DB but the subprocess
+            # keeps running unless we signal it (#57596).
+            if prev_pid:
+                _terminate_reclaimed_worker(prev_pid, prev_lock)
             return True
 
         # Truly-blocked kinds. Increment the unblock-loop counter when this is a
@@ -4742,6 +4765,11 @@ def block_task(
                 run_id=run_id,
             )
         _blocked_task = get_task(conn, task_id)
+    # Terminate the worker process if the task was running.
+    # block_task clears worker_pid in the DB but the subprocess
+    # keeps running unless we signal it (#57596).
+    if prev_pid:
+        _terminate_reclaimed_worker(prev_pid, prev_lock)
     _fire_kanban_lifecycle_hook(
         "kanban_task_blocked",
         task_id,
@@ -5205,6 +5233,14 @@ def decompose_triage_task(
 
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    # Snapshot worker_pid/claim_lock before the UPDATE clears them so we
+    # can terminate the orphaned subprocess after the DB transition (#57596).
+    _snap = conn.execute(
+        "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    _prev_pid = _snap["worker_pid"] if _snap else None
+    _prev_lock = _snap["claim_lock"] if _snap else None
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -5223,6 +5259,11 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             summary="task archived with run still active",
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
+    # Terminate the worker process if the task was running.
+    # archive_task clears worker_pid in the DB but the subprocess
+    # keeps running unless we signal it (#57596).
+    if _prev_pid:
+        _terminate_reclaimed_worker(_prev_pid, _prev_lock)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -993,7 +993,7 @@ def _set_status_direct(
     with kanban_db.write_txn(conn):
         # Snapshot current state so we know whether to close a run.
         prev = conn.execute(
-            "SELECT status, current_run_id FROM tasks WHERE id = ?",
+            "SELECT status, current_run_id, worker_pid, claim_lock FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if prev is None:
@@ -1015,6 +1015,8 @@ def _set_status_direct(
                 return False
 
         was_running = prev["status"] == "running"
+        prev_pid = prev["worker_pid"] if was_running else None
+        prev_lock = prev["claim_lock"] if was_running else None
         reopening_satisfied_parent = (
             prev["status"] in {"done", "archived"}
             and new_status not in {"done", "archived"}
@@ -1073,6 +1075,11 @@ def _set_status_direct(
                             int(time.time()),
                         ),
                     )
+    # Terminate the worker process if the task was running.
+    # _set_status_direct clears worker_pid in the DB but the subprocess
+    # keeps running unless we signal it (#57596).
+    if prev_pid:
+        kanban_db._terminate_reclaimed_worker(prev_pid, prev_lock)
     # If we re-opened something, children may have gone stale.
     if new_status in {"done", "ready"}:
         kanban_db.recompute_ready(conn)

--- a/tests/hermes_cli/test_kanban_worker_termination.py
+++ b/tests/hermes_cli/test_kanban_worker_termination.py
@@ -1,0 +1,151 @@
+"""Tests for worker process termination on task status transitions.
+
+When a task transitions away from ``running`` (blocked, archived, done),
+the associated worker subprocess must be terminated. Previously, only
+``reclaim_task`` and ``release_stale_claims`` terminated workers; status
+transitions via ``block_task``, ``archive_task``, ``complete_task``, and
+``_set_status_direct`` cleared ``worker_pid`` in the DB but left the
+subprocess alive (#57596).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _running_task_with_pid(conn, title="t", pid=12345):
+    """Create a task, drive to running, and set a fake worker_pid."""
+    tid = kb.create_task(conn, title=title, assignee="worker")
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    claimed = kb.claim_task(conn, tid, claimer="worker")
+    assert claimed is not None
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET worker_pid=?, claim_lock=? WHERE id=?",
+            (pid, f"host:{pid}", tid),
+        )
+    return tid
+
+
+class TestBlockTaskTerminatesWorker:
+    """block_task must terminate the worker process when transitioning from running."""
+
+    def test_block_task_terminates_running_worker(self, kanban_home):
+        conn = kb.connect()
+        try:
+            tid = _running_task_with_pid(conn, pid=99999)
+            with patch(
+                "hermes_cli.kanban_db._terminate_reclaimed_worker"
+            ) as mock_term:
+                result = kb.block_task(conn, tid, reason="test block")
+            assert result is True
+            mock_term.assert_called_once_with(99999, f"host:99999")
+        finally:
+            conn.close()
+
+    def test_block_task_no_termination_when_no_pid(self, kanban_home):
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="t", assignee="worker")
+            with kb.write_txn(conn):
+                conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+            # No worker_pid set
+            with patch(
+                "hermes_cli.kanban_db._terminate_reclaimed_worker"
+            ) as mock_term:
+                result = kb.block_task(conn, tid, reason="test block")
+            assert result is True
+            mock_term.assert_not_called()
+        finally:
+            conn.close()
+
+    def test_block_dependency_terminates_running_worker(self, kanban_home):
+        conn = kb.connect()
+        try:
+            tid = _running_task_with_pid(conn, pid=88888)
+            with patch(
+                "hermes_cli.kanban_db._terminate_reclaimed_worker"
+            ) as mock_term:
+                result = kb.block_task(conn, tid, reason="dep", kind="dependency")
+            assert result is True
+            mock_term.assert_called_once_with(88888, f"host:88888")
+        finally:
+            conn.close()
+
+
+class TestArchiveTaskTerminatesWorker:
+    """archive_task must terminate the worker process when transitioning from running."""
+
+    def test_archive_task_terminates_running_worker(self, kanban_home):
+        conn = kb.connect()
+        try:
+            tid = _running_task_with_pid(conn, pid=77777)
+            with patch(
+                "hermes_cli.kanban_db._terminate_reclaimed_worker"
+            ) as mock_term:
+                result = kb.archive_task(conn, tid)
+            assert result is True
+            mock_term.assert_called_once_with(77777, f"host:77777")
+        finally:
+            conn.close()
+
+    def test_archive_task_no_termination_when_no_pid(self, kanban_home):
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="t", assignee="worker")
+            with patch(
+                "hermes_cli.kanban_db._terminate_reclaimed_worker"
+            ) as mock_term:
+                result = kb.archive_task(conn, tid)
+            assert result is True
+            mock_term.assert_not_called()
+        finally:
+            conn.close()
+
+
+class TestCompleteTaskTerminatesWorker:
+    """complete_task must terminate the worker process when transitioning from running."""
+
+    def test_complete_task_terminates_running_worker(self, kanban_home):
+        conn = kb.connect()
+        try:
+            tid = _running_task_with_pid(conn, pid=66666)
+            with patch(
+                "hermes_cli.kanban_db._terminate_reclaimed_worker"
+            ) as mock_term:
+                result = kb.complete_task(conn, tid, result="done")
+            assert result is True
+            mock_term.assert_called_once_with(66666, f"host:66666")
+        finally:
+            conn.close()
+
+    def test_complete_task_no_termination_when_no_pid(self, kanban_home):
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="t", assignee="worker")
+            with kb.write_txn(conn):
+                conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+            with patch(
+                "hermes_cli.kanban_db._terminate_reclaimed_worker"
+            ) as mock_term:
+                result = kb.complete_task(conn, tid, result="done")
+            assert result is True
+            mock_term.assert_not_called()
+        finally:
+            conn.close()


### PR DESCRIPTION
## What does this PR do?

Terminates the worker subprocess when a Kanban task transitions away from `running` via `block_task`, `archive_task`, or `complete_task`. Previously these functions cleared `worker_pid` in the database but never sent a signal to the actual process, leaving orphaned workers consuming CPU until manually killed.

The existing `_terminate_reclaimed_worker()` function (used by `reclaim_task` and `release_stale_claims`) is now also called from the status-transition paths.

## Related Issue

Fixes #57596

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — `block_task()`: added `worker_pid, claim_lock` to initial SELECT; calls `_terminate_reclaimed_worker()` at both return paths (dependency block and normal block)
- `hermes_cli/kanban_db.py` — `archive_task()`: reads `worker_pid, claim_lock` before the UPDATE; calls `_terminate_reclaimed_worker()` after the DB transition
- `hermes_cli/kanban_db.py` — `complete_task()`: reads `worker_pid, claim_lock` before the UPDATE; calls `_terminate_reclaimed_worker()` after the DB transition
- `plugins/kanban/dashboard/plugin_api.py` — `_set_status_direct()`: added `worker_pid, claim_lock` to the SELECT; calls `kanban_db._terminate_reclaimed_worker()` when transitioning from running
- `tests/hermes_cli/test_kanban_worker_termination.py` — 7 new tests verifying termination is called for running→blocked/archived/done transitions and skipped when no PID is set

## How to Test

1. Run `pytest tests/hermes_cli/test_kanban_worker_termination.py -v` — all 7 tests should pass
2. Run `pytest tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py -q` — all existing tests should pass (no regressions)
3. Manual: create a kanban task, let it reach `running` status with a worker, then archive it from the dashboard — the worker process should be terminated (no orphan)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (uses existing `_terminate_reclaimed_worker` which is already cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
