### PR TITLE
fix(dashboard): route typography through theme tokens

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15954,6 +15954,7 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
     {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
     {"name": "nous-blue",     "label": "Nous Blue",           "description": "Light mode — vivid Nous-blue accents on cream canvas"},
+    {"name": "clarity",       "label": "Clarity Dark",        "description": "Readable dark mode with neutral fonts and stronger contrast"},
     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
@@ -15987,8 +15988,8 @@ def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0)
 
 
 _THEME_DEFAULT_TYPOGRAPHY: Dict[str, str] = {
-    "fontSans": 'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-    "fontMono": 'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace',
+    "fontSans": 'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR", "Noto Sans CJK KR", sans-serif',
+    "fontMono": 'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, "D2Coding", "Noto Sans Mono CJK KR", monospace',
     "baseSize": "15px",
     "lineHeight": "1.55",
     "letterSpacing": "0",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17002,6 +17002,7 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
     {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
     {"name": "nous-blue",     "label": "Nous Blue",           "description": "Light mode — vivid Nous-blue accents on cream canvas"},
+    {"name": "clarity",       "label": "Clarity Dark",        "description": "Readable dark mode with neutral fonts and stronger contrast"},
     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
@@ -17035,8 +17036,8 @@ def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0)
 
 
 _THEME_DEFAULT_TYPOGRAPHY: Dict[str, str] = {
-    "fontSans": 'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
-    "fontMono": 'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace',
+    "fontSans": 'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR", "Noto Sans CJK KR", sans-serif',
+    "fontMono": 'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, "D2Coding", "Noto Sans Mono CJK KR", monospace',
     "baseSize": "15px",
     "lineHeight": "1.55",
     "letterSpacing": "0",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -141,7 +141,7 @@ class TestReloadEnv:
     def test_adds_new_vars(self, tmp_path):
         """reload_env() adds vars from .env that are not in os.environ."""
         env_file = tmp_path / ".env"
-        env_file.write_text("TEST_RELOAD_VAR=hello123\n")
+        env_file.write_text("TEST_RELOAD_VAR=hello123\n", encoding="utf-8")
         with patch.dict(reload_env.__globals__, {"get_env_path": lambda: env_file}):
             os.environ.pop("TEST_RELOAD_VAR", None)
             count = reload_env()
@@ -572,6 +572,13 @@ class TestWebServerEndpoints:
 
 
 
+
+    def test_get_dashboard_themes_includes_clarity_preset(self):
+        """The readable built-in theme is advertised by the dashboard API."""
+        resp = self.client.get("/api/dashboard/themes")
+        assert resp.status_code == 200
+        names = {theme["name"] for theme in resp.json()["themes"]}
+        assert "clarity" in names
 
     def _create_session_with_heavy_fields(self, session_id: str) -> None:
         from hermes_state import SessionDB
@@ -2455,6 +2462,20 @@ class TestNormaliseThemeDefinition:
         assert result["palette"]["foreground"]["hex"] == "#ffffff"
         assert result["palette"]["foreground"]["alpha"] == 0.0
 
+    def test_default_typography_applied_when_missing(self):
+        from hermes_cli.web_server import _normalise_theme_definition
+
+        result = _normalise_theme_definition({"name": "minimal"})
+        typo = result["typography"]
+        assert "fontSans" in typo
+        assert "fontMono" in typo
+        assert "Malgun Gothic" in typo["fontSans"]
+        assert "Noto Sans KR" in typo["fontSans"]
+        assert "D2Coding" in typo["fontMono"]
+        assert typo["baseSize"] == "15px"
+        assert typo["lineHeight"] == "1.55"
+        assert typo["letterSpacing"] == "0"
+
 
 
 
@@ -2496,7 +2517,7 @@ class TestDiscoverUserThemes:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         themes_dir = tmp_path / "dashboard-themes"
         themes_dir.mkdir()
-        (themes_dir / "mine.yaml").write_text("name: mine\n")
+        (themes_dir / "mine.yaml").write_text("name: mine\n", encoding="utf-8")
 
         other = tmp_path / "other-profile"
         other.mkdir()
@@ -3039,7 +3060,7 @@ class TestDashboardPluginManifestExtensions:
         import json
         plug_dir = tmp_path / "plugins" / name / "dashboard"
         plug_dir.mkdir(parents=True)
-        (plug_dir / "manifest.json").write_text(json.dumps(manifest))
+        (plug_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
         return plug_dir
 
     def test_override_and_hidden_carried_through(self, tmp_path, monkeypatch):
@@ -3639,5 +3660,3 @@ class TestDashboardComponentHealth:
         assert self.ws.DASHBOARD_HEALTH.selftest_status == "failing"
         assert self.ws.DASHBOARD_HEALTH.selftest_http_status == 500
         assert self.ws.DASHBOARD_HEALTH.snapshot()["status"] == "degraded"
-
-

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -154,7 +154,7 @@ class TestReloadEnv:
     def test_removes_deleted_known_vars(self, tmp_path):
         """reload_env() removes known Hermes vars not present in .env."""
         env_file = tmp_path / ".env"
-        env_file.write_text("")  # empty .env
+        env_file.write_text("", encoding="utf-8")  # empty .env
         # Pick a known key from OPTIONAL_ENV_VARS
         known_key = next(iter(OPTIONAL_ENV_VARS.keys()))
         with patch.dict(reload_env.__globals__, {"get_env_path": lambda: env_file}):
@@ -1021,6 +1021,13 @@ class TestWebServerEndpoints:
 
 
 
+    def test_get_dashboard_themes_includes_clarity_preset(self):
+        """The readable built-in theme is advertised by the dashboard API."""
+        resp = self.client.get("/api/dashboard/themes")
+        assert resp.status_code == 200
+        names = {theme["name"] for theme in resp.json()["themes"]}
+        assert "clarity" in names
+
     def _create_session_with_heavy_fields(self, session_id: str) -> None:
         from hermes_state import SessionDB
 
@@ -1677,13 +1684,13 @@ class TestWebServerEndpoints:
         # actually received the write.
         env_var = custom_endpoint_key_env("worker-proxy")
 
-        worker_cfg = (worker_home / "config.yaml").read_text()
+        worker_cfg = (worker_home / "config.yaml").read_text(encoding="utf-8")
         assert "worker-proxy" in worker_cfg
         assert env_var in worker_cfg
-        assert "sk-worker-secret" in (worker_home / ".env").read_text()
+        assert "sk-worker-secret" in (worker_home / ".env").read_text(encoding="utf-8")
 
         for leaked in (default_home / "config.yaml", default_home / ".env"):
-            text = leaked.read_text() if leaked.exists() else ""
+            text = leaked.read_text(encoding="utf-8") if leaked.exists() else ""
             assert "worker-proxy" not in text, f"endpoint leaked into default profile ({leaked.name})"
             assert "sk-worker-secret" not in text, f"credential leaked into default profile ({leaked.name})"
 
@@ -3329,6 +3336,20 @@ class TestNormaliseThemeDefinition:
         assert result["palette"]["foreground"]["hex"] == "#ffffff"
         assert result["palette"]["foreground"]["alpha"] == 0.0
 
+    def test_default_typography_applied_when_missing(self):
+        from hermes_cli.web_server import _normalise_theme_definition
+
+        result = _normalise_theme_definition({"name": "minimal"})
+        typo = result["typography"]
+        assert "fontSans" in typo
+        assert "fontMono" in typo
+        assert "Malgun Gothic" in typo["fontSans"]
+        assert "Noto Sans KR" in typo["fontSans"]
+        assert "D2Coding" in typo["fontMono"]
+        assert typo["baseSize"] == "15px"
+        assert typo["lineHeight"] == "1.55"
+        assert typo["letterSpacing"] == "0"
+
 
 
 
@@ -4697,8 +4718,6 @@ class TestDashboardComponentHealth:
         assert self.ws.DASHBOARD_HEALTH.selftest_status == "failing"
         assert self.ws.DASHBOARD_HEALTH.selftest_http_status == 500
         assert self.ws.DASHBOARD_HEALTH.snapshot()["status"] == "degraded"
-
-
 class TestSessionPatchUnread:
     """PATCH /api/sessions/{id} with {"unread": bool} marks the session
     read/unread, and GET /api/sessions surfaces the derived flag."""

--- a/web/README.md
+++ b/web/README.md
@@ -81,7 +81,7 @@ Read before adding or editing UI styles. These rules keep the dashboard legible 
 
 ### Fonts
 
-Typography is **opt-in per surface**, not global on layout shells — the app shell and page header keep their original theme/expanded fonts; Mondwest applies only where explicitly set.
+Typography is **opt-in per surface**, not global on layout shells. The class names below are stable dashboard tiers; CSS routes them through `--theme-font-display` / `--theme-font-sans` / `--theme-font-mono` so themes and the font picker can unify the UI without raw custom CSS.
 
 | Tier | Classes | Use for |
 |------|---------|---------|
@@ -93,12 +93,12 @@ Typography is **opt-in per surface**, not global on layout shells — the app sh
 
 - Do **not** put `themedBody` or `themedFont` on `<main>`, `App`, or other layout wrappers — it overrides component-scoped styles.
 - **`Card`** applies `themedBody`; **`CardTitle`** uses `text-display` (uppercase chrome); **`CardDescription`** uses `themedBody`.
+- **`font-mondwest` and `font-expanded` are token-backed tier names, not a mandate to use those literal font files.** They resolve to the active theme's display stack and include locale-aware system fallback.
 - **`NouiTypography`** defaults to `font-sans` unless a font prop is passed.
-- Do **not** use raw `font-sans` or `font-display` (theme sans variable) on new dashboard UI — prefer Mondwest tiers above where brand-appropriate.
+- Do **not** use raw `font-sans` or `font-display` on new dashboard UI — prefer the tier classes above where brand-appropriate.
 
 ### Color tokens
 
 - Prefer **semantic tokens** (`text-text-*`, `bg-card`, `border-border`, `text-foreground`, `text-destructive`, `text-success`, `text-warning`) over raw layer references (`text-midground`, `text-foreground`).
 - `text-muted-foreground` is now wired to `--color-text-secondary`, so existing call sites stay correct, but new code should prefer the semantic name.
 - When you genuinely need a non-token color (icon de-emphasis on a chart, terminal foreground via inline style), keep alpha at `≥ 0.7` for any text.
-

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -64,10 +64,15 @@
   /* Typography tokens — rewritten by ThemeProvider. Defaults match the
      system stack so themes that don't override look native. */
   --theme-font-sans: system-ui, -apple-system, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+    "Helvetica Neue", Arial, "Apple SD Gothic Neo", "Malgun Gothic",
+    "Noto Sans KR", "Noto Sans CJK KR", sans-serif;
   --theme-font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo,
-    Consolas, monospace;
+    Consolas, "D2Coding", "Noto Sans Mono CJK KR", monospace;
   --theme-font-display: var(--theme-font-sans);
+  --font-mondwest: var(--theme-font-display);
+  --font-expanded: var(--theme-font-display);
+  --font-compressed: var(--theme-font-display);
+  --font-courier: var(--theme-font-mono);
   --theme-base-size: 15px;
   --theme-line-height: 1.55;
   --theme-letter-spacing: 0;
@@ -120,6 +125,11 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
   --spacing: calc(0.25rem * var(--theme-spacing-mul, 1));
   --font-sans: var(--theme-font-sans);
   --font-mono: var(--theme-font-mono);
+  --font-display: var(--theme-font-display);
+  --font-mondwest: var(--theme-font-display);
+  --font-expanded: var(--theme-font-display);
+  --font-compressed: var(--theme-font-display);
+  --font-courier: var(--theme-font-mono);
 }
 
 #root {
@@ -145,6 +155,23 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
    dashboard sizes. Keep in sync. */
 small { font-size: 1.0625rem; }
 code { font-size: 0.875rem; }
+
+/* Route legacy/design-system font utilities through dashboard theme tokens.
+   Existing pages can keep their stable class names while theme typography
+   and the font picker actually control chrome, body, and CJK fallback. */
+.font-mondwest,
+.font-expanded,
+.font-compressed {
+  font-family: var(--theme-font-display);
+}
+
+.font-courier {
+  font-family: var(--theme-font-mono);
+}
+
+.text-display {
+  letter-spacing: var(--theme-letter-spacing);
+}
 
 /* Shadcn-compat tokens.
    The dashboard's page code predates the Nous DS and uses shadcn-style
@@ -252,4 +279,3 @@ code { font-size: 0.875rem; }
 html[dir="rtl"] {
   direction: rtl;
 }
-

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { themedBody, themedChrome, themedFont } from "./utils";
+
+describe("dashboard typography helper classes", () => {
+  it("keeps all reusable themed text helpers on the display-font token path", () => {
+    for (const className of [themedFont, themedBody, themedChrome]) {
+      expect(className).toContain("font-mondwest");
+    }
+    expect(themedBody).toContain("normal-case");
+    expect(themedChrome).toContain("text-display");
+  });
+});
+
+describe("dashboard display tracking", () => {
+  it("uses the theme letter-spacing token emitted by ThemeProvider", () => {
+    const stylesheet = readFileSync(new URL("../index.css", import.meta.url), "utf8");
+
+    expect(stylesheet).toContain(
+      ".text-display {\n  letter-spacing: var(--theme-letter-spacing);\n}",
+    );
+    expect(stylesheet).not.toContain("--theme-display-letter-spacing");
+  });
+});

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { themedBody, themedChrome, themedFont } from "./utils";
+
+describe("dashboard typography helper classes", () => {
+  it("keeps all reusable themed text helpers on the display-font token path", () => {
+    for (const className of [themedFont, themedBody, themedChrome]) {
+      expect(className).toContain("font-mondwest");
+    }
+    expect(themedBody).toContain("normal-case");
+    expect(themedChrome).toContain("text-display");
+  });
+});

--- a/web/src/themes/fonts.ts
+++ b/web/src/themes/fonts.ts
@@ -21,9 +21,9 @@
 
 /** System stacks reused from presets so "System" choices need no webfont. */
 const SYSTEM_SANS =
-  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR", "Noto Sans CJK KR", sans-serif';
 const SYSTEM_MONO =
-  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
+  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, "D2Coding", "Noto Sans Mono CJK KR", monospace';
 const SYSTEM_SERIF =
   'Georgia, Cambria, "Times New Roman", Times, serif';
 

--- a/web/src/themes/presets.test.ts
+++ b/web/src/themes/presets.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { BUILTIN_THEMES, clarityTheme, defaultTheme } from "./presets";
+
+describe("dashboard theme typography presets", () => {
+  it("includes a readable dark preset with unified display/body typography", () => {
+    expect(BUILTIN_THEMES.clarity).toBe(clarityTheme);
+    expect(clarityTheme.typography.fontDisplay).toBe(clarityTheme.typography.fontSans);
+    expect(clarityTheme.typography.baseSize).toBe("16px");
+    expect(clarityTheme.typography.letterSpacing).toBe("0");
+    expect(clarityTheme.palette.noiseOpacity).toBe(0);
+    expect(clarityTheme.colorOverrides?.mutedForeground).toBeTruthy();
+  });
+
+  it("uses CJK-capable system fallbacks for baseline dashboard typography", () => {
+    expect(defaultTheme.typography.fontSans).toContain("Malgun Gothic");
+    expect(defaultTheme.typography.fontSans).toContain("Noto Sans KR");
+    expect(defaultTheme.typography.fontMono).toContain("D2Coding");
+  });
+});

--- a/web/src/themes/presets.test.ts
+++ b/web/src/themes/presets.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_THEMES,
+  clarityTheme,
+  defaultLargeTheme,
+  defaultTheme,
+} from "./presets";
+
+describe("dashboard theme typography presets", () => {
+  it("includes a readable dark preset with unified display/body typography", () => {
+    expect(BUILTIN_THEMES.clarity).toBe(clarityTheme);
+    expect(clarityTheme.typography.fontDisplay).toBe(clarityTheme.typography.fontSans);
+    expect(clarityTheme.typography.baseSize).toBe("16px");
+    expect(clarityTheme.typography.letterSpacing).toBe("0");
+    expect(clarityTheme.palette.noiseOpacity).toBe(0);
+    expect(clarityTheme.colorOverrides?.mutedForeground).toBeTruthy();
+  });
+
+  it("uses CJK-capable system fallbacks for baseline dashboard typography", () => {
+    expect(defaultTheme.typography.fontSans).toContain("Malgun Gothic");
+    expect(defaultTheme.typography.fontSans).toContain("Noto Sans KR");
+    expect(defaultTheme.typography.fontMono).toContain("D2Coding");
+    expect(defaultLargeTheme.typography.fontSans).toBe(defaultTheme.typography.fontSans);
+    expect(defaultLargeTheme.typography.fontMono).toBe(defaultTheme.typography.fontMono);
+  });
+});

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -15,11 +15,11 @@ import type { DashboardTheme, ThemeTypography, ThemeLayout } from "./types";
 // Shared typography / layout presets
 // ---------------------------------------------------------------------------
 
-/** Default system stack — neutral, safe fallback for every platform. */
-const SYSTEM_SANS =
-  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
-const SYSTEM_MONO =
-  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
+/** Default system stacks — neutral, safe fallbacks for every platform. */
+export const SYSTEM_SANS =
+  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Apple SD Gothic Neo", "Malgun Gothic", "Noto Sans KR", "Noto Sans CJK KR", sans-serif';
+export const SYSTEM_MONO =
+  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, "D2Coding", "Noto Sans Mono CJK KR", monospace';
 
 const DEFAULT_TYPOGRAPHY: ThemeTypography = {
   fontSans: SYSTEM_SANS,
@@ -77,6 +77,52 @@ export const midnightTheme: DashboardTheme = {
     ...DEFAULT_LAYOUT,
     radius: "0.75rem",
   },
+};
+
+export const clarityTheme: DashboardTheme = {
+  name: "clarity",
+  label: "Clarity Dark",
+  description: "Readable dark mode with neutral fonts and stronger contrast",
+  palette: {
+    background: { hex: "#101114", alpha: 1 },
+    midground: { hex: "#f4f4f5", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(125, 211, 252, 0.16)",
+    noiseOpacity: 0,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Inter", ${SYSTEM_SANS}`,
+    fontDisplay: `"Inter", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap",
+    baseSize: "16px",
+    lineHeight: "1.6",
+    letterSpacing: "0",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0.375rem",
+  },
+  colorOverrides: {
+    card: "#17181d",
+    cardForeground: "#f4f4f5",
+    popover: "#17181d",
+    popoverForeground: "#f4f4f5",
+    muted: "#202127",
+    mutedForeground: "#d4d4d8",
+    border: "#3f3f46",
+    input: "#3f3f46",
+    ring: "#93c5fd",
+  },
+  terminalBackground: "#0b0c0f",
+  terminalForeground: "#f4f4f5",
+  seriesColors: {
+    inputTokenAccent: "#93c5fd",
+    outputTokenAccent: "#86efac",
+  },
+  swatchColors: ["#101114", "#f4f4f5", "#93c5fd"],
 };
 
 export const emberTheme: DashboardTheme = {
@@ -232,6 +278,7 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
   "default-large": defaultLargeTheme,
   "nous-blue": nousBlueTheme,
+  clarity: clarityTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,


### PR DESCRIPTION
## What does this PR do?

Routes the dashboard's legacy/display typography utilities through the active theme's typography tokens, adds Korean/CJK-capable fallback stacks, and adds a readable Clarity Dark built-in theme for users who want a more standard high-contrast dashboard.

## Related Issue

## Shared root cause

- The dashboard had `typography.fontDisplay` and `--theme-font-display`, but common dashboard classes such as `font-mondwest`, `font-expanded`, and direct `--font-mondwest` consumers stayed tied to fixed display faces. This meant themes and the font picker could not consistently unify sidebar, card, badge, and page-header typography.
- The default font stacks lacked Korean/CJK-aware fallbacks, so localized dashboard text could fall through inconsistently depending on the host OS.
- The built-in themes changed palette and some body/mono fonts, but there was no standard readable dark preset with larger base sizing, neutral sans typography, low tracking, and stronger contrast.

## How this fixes each issue

- #18080: Adds the Clarity Dark preset with neutral Inter/system typography, 16px base sizing, zero theme letter-spacing, stronger card/border/muted contrast, and no decorative noise.
- #56808: Adds Korean/CJK-capable sans and mono fallback fonts to the frontend presets, font picker system stacks, CSS defaults, and backend custom-theme defaults so localized dashboard UI has a stable fallback path.
- #57310: Wires `--theme-font-display` into Tailwind and legacy/design-system font variables/classes (`font-mondwest`, `font-expanded`, `font-compressed`, `font-courier`) and normalizes `text-display` tracking so themes can control display typography without raw custom CSS.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/src/index.css`: bridges dashboard font utilities and design-system font variables to theme typography tokens, adds CJK-capable CSS defaults, and normalizes `text-display` tracking.
- `web/src/themes/presets.ts`: adds the Clarity Dark built-in theme and CJK-capable default sans/mono stacks.
- `web/src/themes/fonts.ts`: keeps the dashboard font override catalog's system stacks aligned with the theme defaults.
- `hermes_cli/web_server.py`: advertises the new built-in theme and applies the same locale-aware defaults to user YAML themes.
- Tests cover the Clarity preset, token-backed typography helpers, backend theme metadata, and custom-theme typography defaults.
- `web/README.md`: documents that the historical font class names are theme-token-backed tiers.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` (aborted during collection in this runner because system Python lacks `fastapi`/`uvicorn` and lazy install is blocked by the externally managed Python environment)
2. `/opt/homebrew/bin/timeout -k 30 480 /Users/kon5i/.autocontrib/repos/NousResearch__hermes-agent/venv/bin/pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_dashboard_themes_includes_clarity_preset tests/hermes_cli/test_web_server.py::TestNormaliseThemeDefinition::test_default_typography_applied_when_missing -q --timeout=60`
3. `npm ci --workspace web`
4. `/opt/homebrew/bin/timeout -k 30 480 npm --workspace web test -- --run src/themes/presets.test.ts src/lib/utils.test.ts`
5. `BASE=$(git merge-base origin/main HEAD); { git diff --name-only --diff-filter=d "$BASE"; git ls-files --others --exclude-standard; } | grep -E '\.pyi?$' | sort -u | xargs /Users/kon5i/.autocontrib/repos/NousResearch__hermes-agent/venv/bin/ruff check`
6. `/opt/homebrew/bin/timeout -k 30 480 /Users/kon5i/.autocontrib/repos/NousResearch__hermes-agent/venv/bin/python scripts/check-windows-footguns.py hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (attempted; blocked by missing dashboard deps in system Python as noted above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not captured in this worker; verified via unit tests and token-level checks.

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #18080
Refs #56808
Refs #57310

<!-- autocontrib:worker-id=pr-spanning-54e6d298 kind=pr-open -->