### PR TITLE
fix(agent): nudge past progress-placeholder responses after tool call…

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -83,6 +83,15 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
     Returns:
         List[Dict]: Messages in trajectory format
     """
+    # Structural sweep: ephemeral recovery scaffolding (synthetic nudge
+    # pairs, empty-response sentinels, prefill placeholders) must never
+    # reach a saved trajectory.  The conversation loop pops trailing
+    # scaffolding before the final response, but rows buried under later
+    # tool turns are not trailing — filtering here guards the invariant
+    # regardless of where the scaffolding ended up in the list, mirroring
+    # the per-message filter in the session-store flush.
+    _is_scaffolding = _ra()._is_ephemeral_scaffolding
+    messages = [m for m in messages if not _is_scaffolding(m)]
     # Normalize multimodal tool results — trajectories are text-only, so
     # replace image-bearing tool messages with their text_summary to avoid
     # embedding ~1MB base64 blobs into every saved trajectory.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2785,6 +2785,59 @@ def looks_like_codex_intermediate_ack(
     return user_targets_workspace or assistant_targets_workspace
 
 
+# Progress-style placeholder phrases that signal "still working", not a
+# final answer.  Matched with word boundaries so short markers ("hold on")
+# don't fire inside unrelated words.  Kept deliberately narrow: a false
+# positive costs one extra nudge round-trip, but a false negative silently
+# ends the turn with the task unfinished (#42503).
+_PROGRESS_PLACEHOLDER_RE = re.compile(
+    r"\b("
+    r"working on (?:it|that|this)|still working|work in progress|"
+    r"one (?:moment|second|sec)|just a (?:moment|minute|second|sec)|"
+    r"hold on|hang tight|please wait|bear with me|"
+    r"give me a (?:moment|minute|second|sec)|"
+    r"let me continue|i(?:['’]ll| will) (?:continue|keep going|keep working)|"
+    r"continuing now"
+    r")\b"
+)
+
+# Future-commitment openers ("I'll now update the file…").  Only meaningful
+# combined with an open ending — a completed sentence that happens to start
+# with "I'll" can be a legitimate final answer.
+_FUTURE_ACK_RE = re.compile(r"\b(i['’]ll|i will|let me|going to|about to)\b")
+
+
+def looks_like_post_tool_progress_placeholder(agent, assistant_content: str) -> bool:
+    """Detect a progress placeholder that ended a tool-using turn (#42503).
+
+    After executing tool calls, some models close the turn with a short
+    progress note ("Working on it...", "I'll now analyze the results…")
+    instead of continuing to the next step or delivering the result.  The
+    conversation loop treats any non-empty no-tool-call response as the
+    final answer, so without detection the task silently ends unfinished.
+
+    Callers must additionally verify that tool calls actually ran this
+    turn — a progress-style sentence in a purely conversational reply
+    (e.g. answering "how's the report going?") is not a placeholder.
+
+    Two signals, both requiring a short (≤240 chars) non-question reply:
+      * an explicit progress phrase ("working on it", "please wait", ...)
+      * a future commitment ("I'll", "let me") with an open ending
+        ("...", "…", ":") and therefore no delivered result
+    """
+    text = agent._strip_think_blocks(assistant_content or "").strip()
+    if not text or len(text) > 240:
+        return False
+    lowered = text.lower()
+    # A question is a legitimate turn end — the model needs user input.
+    if lowered.rstrip("*_`\"'").endswith(("?", "？")):
+        return False
+    if _PROGRESS_PLACEHOLDER_RE.search(lowered):
+        return True
+    ends_open = lowered.rstrip("*_`\"'").endswith(("...", "…", ":", "："))
+    return bool(ends_open and _FUTURE_ACK_RE.search(lowered))
+
+
 def intent_ack_continuation_mode(agent) -> str:
     """Classify the resolved intent-ack continuation mode for this turn.
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4818,16 +4818,27 @@ def run_conversation(
                         if clean:
                             agent._vprint(f"  ┊ 💬 {clean}")
                 
-                # Pop thinking-only prefill message(s) before appending
-                # (tool-call path — same rationale as the final-response path).
+                # Pop thinking-only prefill and progress-placeholder nudge
+                # scaffolding before appending (tool-call path — same
+                # rationale as the final-response path).  Must be ONE loop
+                # over both flags: the rows can interleave (tool round →
+                # thinking-only prefill → placeholder nudge → tool calls
+                # leaves [prefill, placeholder, nudge] on the stack), and
+                # sequential single-flag loops strand whichever flag sits
+                # beneath the other — the buried row then replays as fake
+                # context on every later call.
                 _had_prefill = False
                 while (
                     messages
                     and isinstance(messages[-1], dict)
-                    and messages[-1].get("_thinking_prefill")
+                    and (
+                        messages[-1].get("_thinking_prefill")
+                        or messages[-1].get("_post_tool_placeholder_synthetic")
+                    )
                 ):
+                    if messages[-1].get("_thinking_prefill"):
+                        _had_prefill = True
                     messages.pop()
-                    _had_prefill = True
 
                 # Reset prefill counter when tool calls follow a prefill
                 # recovery.  Without this, the counter accumulates across
@@ -4839,19 +4850,6 @@ def run_conversation(
                 if _had_prefill:
                     agent._thinking_prefill_retries = 0
                     agent._empty_content_retries = 0
-                # Pop the progress-placeholder nudge pair once the nudge
-                # succeeds and the model answers with tool calls (#42503).
-                # The terminal scaffold pop before the final response only
-                # strips a trailing suffix, so if these rows survive here
-                # they become interior — buried under the new tool turns —
-                # and stay in the live context (replayed to the model on
-                # every later call) and in anything assembled from it.
-                while (
-                    messages
-                    and isinstance(messages[-1], dict)
-                    and messages[-1].get("_post_tool_placeholder_synthetic")
-                ):
-                    messages.pop()
                 # Successful tool execution — reset the post-tool nudge
                 # flag so it can fire again if the model goes empty on
                 # a LATER tool round.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4839,6 +4839,19 @@ def run_conversation(
                 if _had_prefill:
                     agent._thinking_prefill_retries = 0
                     agent._empty_content_retries = 0
+                # Pop the progress-placeholder nudge pair once the nudge
+                # succeeds and the model answers with tool calls (#42503).
+                # The terminal scaffold pop before the final response only
+                # strips a trailing suffix, so if these rows survive here
+                # they become interior — buried under the new tool turns —
+                # and stay in the live context (replayed to the model on
+                # every later call) and in anything assembled from it.
+                while (
+                    messages
+                    and isinstance(messages[-1], dict)
+                    and messages[-1].get("_post_tool_placeholder_synthetic")
+                ):
+                    messages.pop()
                 # Successful tool execution — reset the post-tool nudge
                 # flag so it can fire again if the model goes empty on
                 # a LATER tool round.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4843,6 +4843,9 @@ def run_conversation(
                 # flag so it can fire again if the model goes empty on
                 # a LATER tool round.
                 agent._post_tool_empty_retried = False
+                # Same fresh start for the progress-placeholder nudge
+                # (#42503): each tool round gets its own retry budget.
+                agent._post_tool_placeholder_retries = 0
 
                 messages.append(assistant_msg)
                 agent._emit_interim_assistant_message(assistant_msg)
@@ -5258,6 +5261,7 @@ def run_conversation(
 
                 from agent.agent_runtime_helpers import (
                     intent_ack_continuation_mode,
+                    looks_like_post_tool_progress_placeholder,
                 )
 
                 _ack_mode = intent_ack_continuation_mode(agent)
@@ -5300,7 +5304,65 @@ def run_conversation(
                     length_continue_retries = 0
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
-                
+
+                # ── Post-tool progress-placeholder continuation (#42503) ──
+                # After running tools, some models close the turn with a
+                # short progress note ("Working on it...", "I'll now update
+                # the file…") instead of continuing or answering.  The
+                # intermediate-ack check above deliberately skips turns that
+                # already ran tools, so without this branch the note is
+                # accepted as the final response and the task silently ends
+                # unfinished.  Nudge the model to keep going, mirroring the
+                # post-tool empty-response nudge.
+                _placeholder_final = False
+                _recent_tool_turn = any(
+                    isinstance(m, dict) and m.get("role") == "tool"
+                    for m in messages[-5:]
+                )
+                if (
+                    _recent_tool_turn
+                    and agent.valid_tool_names
+                    and looks_like_post_tool_progress_placeholder(
+                        agent, final_response
+                    )
+                ):
+                    if agent._post_tool_placeholder_retries < 2:
+                        agent._post_tool_placeholder_retries += 1
+                        logger.info(
+                            "Progress-placeholder response after tool calls "
+                            "(%r) — nudging model to continue (%d/2)",
+                            final_response[:80],
+                            agent._post_tool_placeholder_retries,
+                        )
+                        agent._buffer_status(
+                            f"↻ Model paused with a progress note — nudging "
+                            f"to continue "
+                            f"({agent._post_tool_placeholder_retries}/2)"
+                        )
+                        interim_msg = agent._build_assistant_message(
+                            assistant_message, "incomplete"
+                        )
+                        interim_msg["_post_tool_placeholder_synthetic"] = True
+                        messages.append(interim_msg)
+                        messages.append({
+                            "role": "user",
+                            "content": (
+                                "[System: Your previous message was a "
+                                "progress update, not a final answer. "
+                                "Continue the task now — run the remaining "
+                                "tool calls and reply with the final result "
+                                "once the task is actually complete.]"
+                            ),
+                            "_post_tool_placeholder_synthetic": True,
+                        })
+                        agent._session_messages = messages
+                        continue
+                    # Nudges exhausted — accept the note as the final
+                    # response, but mark the turn abnormal so the finalizer
+                    # appends a visible explanation instead of ending the
+                    # turn silently with the task unfinished.
+                    _placeholder_final = True
+
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 
                 # Pop thinking-only prefill and empty-response retry
@@ -5315,6 +5377,7 @@ def run_conversation(
                         messages[-1].get("_thinking_prefill")
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
+                        or messages[-1].get("_post_tool_placeholder_synthetic")
                     )
                 ):
                     messages.pop()
@@ -5473,8 +5536,11 @@ def run_conversation(
                     continue
 
                 messages.append(final_msg)
-                
-                _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
+
+                if _placeholder_final:
+                    _turn_exit_reason = "post_tool_placeholder_response"
+                else:
+                    _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -227,6 +227,7 @@ def build_turn_context(
     agent._codex_incomplete_retries = 0
     agent._thinking_prefill_retries = 0
     agent._post_tool_empty_retried = False
+    agent._post_tool_placeholder_retries = 0
     agent._last_content_with_tools = None
     agent._last_content_tools_all_housekeeping = False
     agent._mute_post_response = False

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -345,10 +345,16 @@ def finalize_turn(
                 _is_partial_stream_recovery = (
                     str(_turn_exit_reason) == "partial_stream_recovery"
                 )
+                # Progress placeholder accepted after nudges ran out
+                # (#42503): keep the note, append why the turn ended.
+                _is_progress_placeholder = (
+                    str(_turn_exit_reason) == "post_tool_placeholder_response"
+                )
                 if (
                     _is_empty_terminal
                     or _is_partial_fragment
                     or _is_partial_stream_recovery
+                    or _is_progress_placeholder
                 ):
                     _explanation = agent._format_turn_completion_explanation(
                         _turn_exit_reason

--- a/run_agent.py
+++ b/run_agent.py
@@ -225,6 +225,9 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     "_empty_recovery_synthetic",
     "_empty_terminal_sentinel",
     "_thinking_prefill",
+    # post-tool progress-placeholder nudge (#42503): synthetic assistant
+    # placeholder turn plus the user nudge that asks the model to continue.
+    "_post_tool_placeholder_synthetic",
     # verify-on-stop and pre_verify nudges append a synthetic assistant
     # "done" plus a synthetic user nudge to keep the agent going one more
     # turn before it can claim completion. Those messages exist only to
@@ -1758,6 +1761,7 @@ class AIAgent:
             and (
                 messages[-1].get("_empty_recovery_synthetic")
                 or messages[-1].get("_empty_terminal_sentinel")
+                or messages[-1].get("_post_tool_placeholder_synthetic")
             )
         ):
             messages.pop()
@@ -3074,6 +3078,15 @@ class AIAgent:
         # healthy terminal; anything that produced a real reply is fine.
         if reason.startswith("text_response"):
             return ""
+
+        if reason == "post_tool_placeholder_response":
+            # Unlike the "No reply" cases below, the user DID get text this
+            # turn — but it was a progress note, not a result (#42503).
+            return (
+                "⚠️ Incomplete turn: the reply above looks like a progress "
+                "update, not a final result — the model stopped without "
+                "finishing the task. Send `continue` to let it keep working."
+            )
 
         prefix = "⚠️ No reply: "
         if reason == "empty_response_exhausted":

--- a/tests/run_agent/test_42503_post_tool_placeholder.py
+++ b/tests/run_agent/test_42503_post_tool_placeholder.py
@@ -239,6 +239,47 @@ class TestPostToolPlaceholderNudge:
             if isinstance(m, dict)
         )
 
+    def test_interleaved_prefill_and_placeholder_scaffolds_all_popped(self, agent):
+        """tool round → thinking-only (prefill row) → placeholder (nudge pair)
+        → tool calls leaves [prefill, placeholder, nudge] stacked.  The
+        tool-call-path cleanup must pop across BOTH flags in one loop —
+        sequential single-flag loops strand the prefill row beneath the
+        popped nudge pair, leaving a fake assistant turn (and consecutive
+        assistant messages) in the live context forever."""
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_mock_tool_call(call_id="c1")],
+            ),
+            # In-content <think> routes to the prefill recovery, not the
+            # empty-response nudge (see _has_inline_thinking in the loop).
+            _mock_response(content="<think>planning the next step</think>"),
+            _mock_response(content="Working on it..."),
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_mock_tool_call(call_id="c2")],
+            ),
+            _mock_response(content="Done: everything checked."),
+        ]
+        result = _run(agent)
+        assert result["completed"] is True
+        assert result["final_response"] == "Done: everything checked."
+        leftovers = [
+            m
+            for m in result["messages"]
+            if isinstance(m, dict)
+            and (
+                m.get("_thinking_prefill")
+                or m.get("_post_tool_placeholder_synthetic")
+            )
+        ]
+        assert leftovers == []
+        # No consecutive assistant rows left by a stranded scaffold.
+        roles = [m.get("role") for m in result["messages"] if isinstance(m, dict)]
+        assert not any(a == b == "assistant" for a, b in zip(roles, roles[1:]))
+
     def test_trajectory_conversion_drops_buried_scaffolding(self, agent):
         """Trajectory saving converts the raw message list; a scaffold pair
         buried mid-list (nudge followed by more tool calls) must be filtered

--- a/tests/run_agent/test_42503_post_tool_placeholder.py
+++ b/tests/run_agent/test_42503_post_tool_placeholder.py
@@ -208,6 +208,95 @@ class TestPostToolPlaceholderNudge:
             a == b == "assistant" for a, b in zip(roles, roles[1:])
         )
 
+    def test_tool_call_after_nudge_leaves_no_buried_scaffolding(self, agent):
+        """When the nudge succeeds via ANOTHER tool call, the synthetic pair
+        would be buried under the new tool turns — the terminal pop only
+        strips a trailing suffix, so without the tool-call-path pop the fake
+        placeholder/nudge rows stay in the live context forever and leak
+        into everything assembled from the message list (PR #57610 review)."""
+        tc1 = _mock_tool_call(call_id="c1")
+        tc2 = _mock_tool_call(call_id="c2")
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc1]),
+            _mock_response(content="Working on it..."),
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc2]),
+            _mock_response(content="Task finished: both lookups done."),
+        ]
+        result = _run(agent)
+        assert result["completed"] is True
+        assert result["final_response"] == "Task finished: both lookups done."
+        # The scaffold pair must be gone even though it is no longer a
+        # trailing suffix — this is the buried-scaffold regression.
+        assert all(
+            not m.get("_post_tool_placeholder_synthetic")
+            for m in result["messages"]
+            if isinstance(m, dict)
+        )
+        # The placeholder note itself must not survive as transcript context.
+        assert all(
+            "Working on it..." != m.get("content")
+            for m in result["messages"]
+            if isinstance(m, dict)
+        )
+
+    def test_trajectory_conversion_drops_buried_scaffolding(self, agent):
+        """Trajectory saving converts the raw message list; a scaffold pair
+        buried mid-list (nudge followed by more tool calls) must be filtered
+        there too, or save_trajectories=True records the synthetic turns as
+        if the model had really said them (PR #57610 review)."""
+        nudge_text = (
+            "[System: Your previous message was a progress update, not a "
+            "final answer. Continue the task now.]"
+        )
+        messages = [
+            {"role": "user", "content": "do the task"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "name": "web_search", "content": "r1"},
+            # Buried scaffold pair: nudge fired, then the model continued
+            # with another tool call, so these rows are interior.
+            {
+                "role": "assistant",
+                "content": "Working on it...",
+                "_post_tool_placeholder_synthetic": True,
+            },
+            {
+                "role": "user",
+                "content": nudge_text,
+                "_post_tool_placeholder_synthetic": True,
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c2",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c2", "name": "web_search", "content": "r2"},
+            {"role": "assistant", "content": "All done."},
+        ]
+        trajectory = agent._convert_to_trajectory_format(
+            messages, "do the task", completed=True
+        )
+        values = [t["value"] for t in trajectory]
+        assert not any(nudge_text in v for v in values)
+        assert not any("Working on it..." in v for v in values)
+        # The real turns survive the sweep.
+        assert any("All done." in v for v in values)
+
     def test_exhausted_nudges_surface_incomplete_turn_explanation(self, agent):
         """If the model keeps emitting placeholders after 2 nudges, the turn
         must end VISIBLY incomplete — never silently (#42503's core complaint:

--- a/tests/run_agent/test_42503_post_tool_placeholder.py
+++ b/tests/run_agent/test_42503_post_tool_placeholder.py
@@ -1,0 +1,253 @@
+"""Tests for #42503 — progress placeholder after tool calls mistaken for a final answer.
+
+The failure mode: after executing tool calls, the model replies with a short
+progress note ("Working on it...", "I'll now update the file…") and no tool
+calls.  The conversation loop treats any non-empty no-tool-call response as
+the final answer, so the turn ends silently with the task unfinished.
+
+The fix nudges the model to continue (capped at 2 per tool round) and, if the
+nudges are exhausted, appends a visible "Incomplete turn" explanation instead
+of ending the turn silently.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers (mirrors tests/run_agent/test_run_agent.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    """Minimal AIAgent with mocked OpenAI client and tool loading."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _mock_tool_call(name="web_search", arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _run(agent, prompt="do the task"):
+    with (
+        patch("run_agent.handle_function_call", return_value="tool result"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(prompt)
+
+
+# ---------------------------------------------------------------------------
+# Detector unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceholderDetector:
+    """The detector decides whether a no-tool-call reply is a progress
+    placeholder.  A false negative silently ends the turn with the task
+    unfinished (the #42503 bug); a false positive costs one nudge round-trip.
+    """
+
+    def _detect(self, agent, text):
+        from agent.agent_runtime_helpers import (
+            looks_like_post_tool_progress_placeholder,
+        )
+        return looks_like_post_tool_progress_placeholder(agent, text)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Explicit progress phrases — the exact strings reported in
+            # #42503 as being mistaken for final answers.
+            "Working on it...",
+            "Still working on the report.",
+            "Please wait, processing the files.",
+            "Hang tight!",
+            "One moment.",
+            "I'll continue with the next step.",
+            # Future commitment with an open ending: announces work but
+            # delivers nothing.
+            "I'll now analyze the search results...",
+            "Let me update the config file:",
+            "Now I'm going to check the logs…",
+        ],
+    )
+    def test_progress_placeholders_detected(self, agent, text):
+        assert self._detect(agent, text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Real short answers must end the turn normally — nudging a
+            # legitimate "Done." would loop the model for no reason.
+            "Done.",
+            "The file has been updated and all tests pass.",
+            "The search returned 3 results: A, B and C.",
+            # Questions are legitimate stops: the model needs user input.
+            "Should I also update the README?",
+            # A future-tense sentence that terminates normally is a real
+            # answer ("I'll be available if you need more help.").
+            "I'll be here if you need anything else.",
+            # Empty content is handled by the empty-response path, not here.
+            "",
+            "<think>internal reasoning only</think>",
+        ],
+    )
+    def test_real_answers_not_detected(self, agent, text):
+        assert self._detect(agent, text) is False
+
+    def test_long_responses_never_detected(self, agent):
+        # Length guard: a substantive multi-sentence reply that happens to
+        # contain "working on it" is an answer, not a placeholder.
+        text = (
+            "I finished working on it. Here is the summary of everything "
+            "that was changed: the config loader now validates the schema "
+            "before use, the retry loop caps at three attempts with jittered "
+            "backoff, and the test suite covers both the success and failure "
+            "paths end to end. All 42 tests pass."
+        )
+        assert len(text) > 240  # the guard under test is the length cap
+        assert self._detect(agent, text) is False
+
+
+# ---------------------------------------------------------------------------
+# Conversation-loop integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestPostToolPlaceholderNudge:
+    def test_placeholder_after_tools_is_nudged_to_completion(self, agent):
+        """A placeholder after tool calls must NOT end the turn — the model
+        gets nudged and its real answer becomes the final response (#42503)."""
+        tc = _mock_tool_call(call_id="c1")
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc]),
+            _mock_response(content="Working on it..."),
+            _mock_response(content="Task finished: 3 files were updated."),
+        ]
+        result = _run(agent)
+        assert result["completed"] is True
+        assert result["final_response"] == "Task finished: 3 files were updated."
+        assert result["api_calls"] == 3  # tools + placeholder + nudged answer
+
+    def test_nudge_scaffolding_not_persisted(self, agent):
+        """The synthetic placeholder/nudge pair exists only to drive the next
+        API call — persisting it would replay fake turns on session resume."""
+        tc = _mock_tool_call(call_id="c1")
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc]),
+            _mock_response(content="Working on it..."),
+            _mock_response(content="All done."),
+        ]
+        result = _run(agent)
+        assert all(
+            not m.get("_post_tool_placeholder_synthetic")
+            for m in result["messages"]
+            if isinstance(m, dict)
+        )
+        # No consecutive assistant messages left behind by the popped nudge.
+        roles = [m.get("role") for m in result["messages"] if isinstance(m, dict)]
+        assert not any(
+            a == b == "assistant" for a, b in zip(roles, roles[1:])
+        )
+
+    def test_exhausted_nudges_surface_incomplete_turn_explanation(self, agent):
+        """If the model keeps emitting placeholders after 2 nudges, the turn
+        must end VISIBLY incomplete — never silently (#42503's core complaint:
+        no error, no hint, task just stops)."""
+        tc = _mock_tool_call(call_id="c1")
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc]),
+            _mock_response(content="Working on it..."),
+            _mock_response(content="Still working on it..."),
+            _mock_response(content="Working on it..."),
+        ]
+        result = _run(agent)
+        assert result["turn_exit_reason"] == "post_tool_placeholder_response"
+        # The placeholder text is kept AND the explanation is appended.
+        assert "Working on it..." in result["final_response"]
+        assert "Incomplete turn" in result["final_response"]
+        assert result["api_calls"] == 4  # tools + placeholder + 2 nudged retries
+
+    def test_placeholder_without_tool_round_ends_normally(self, agent):
+        """A progress-style sentence in a purely conversational turn (no tool
+        calls ran) is a legitimate answer — e.g. replying to "how's the
+        report going?" — and must not trigger the nudge."""
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="Still working on the report."),
+        ]
+        result = _run(agent, prompt="how's the report going?")
+        assert result["completed"] is True
+        assert result["final_response"] == "Still working on the report."
+        assert result["api_calls"] == 1
+        assert str(result["turn_exit_reason"]).startswith("text_response")
+
+    def test_real_answer_after_tools_ends_normally(self, agent):
+        """Regression guard: a genuine short answer after tool calls must not
+        be mistaken for a placeholder — no extra API calls, no footer."""
+        tc = _mock_tool_call(call_id="c1")
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc]),
+            _mock_response(content="The search returned no matches."),
+        ]
+        result = _run(agent)
+        assert result["final_response"] == "The search returned no matches."
+        assert result["api_calls"] == 2
+        assert str(result["turn_exit_reason"]).startswith("text_response")


### PR DESCRIPTION
…s (#42503)

After executing tool calls, some models (observed cross-provider, most often local/smaller models) close the turn with a short progress note ("Working on it...", "I'll now update the file…") instead of continuing to the next step or delivering the result. The conversation loop treats any non-empty no-tool-call response as the final answer, so the task silently ends unfinished — no error, no hint (#42503).

The existing intermediate-ack continuation deliberately skips turns that already ran tools, and the post-tool EMPTY-response nudge only covers blank content, so this failure mode fell between the two recoveries.

Fix, mirroring the empty-response nudge:
- detect progress placeholders after a tool round (short, non-question, explicit progress phrase OR future commitment with an open ending)
- nudge the model to continue, capped at 2 per tool round
- if the nudges are exhausted, keep the note but mark the turn post_tool_placeholder_response so the turn-completion explainer appends a visible "Incomplete turn" footer instead of ending silently
- flag the synthetic nudge pair as ephemeral scaffolding so it is popped before the real final response and never persisted

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

