### PR TITLE
fix(desktop): skip macOS TCC-protected media dirs in git repo scan

### DIFF
--- a/apps/desktop/electron/git-repo-scan.test.ts
+++ b/apps/desktop/electron/git-repo-scan.test.ts
@@ -22,6 +22,17 @@ function foundRoots(results: { root: string }[]) {
   return results.map(entry => entry.root).sort()
 }
 
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T>) {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { ...descriptor, value: platform })
+
+  try {
+    return await run()
+  } finally {
+    Object.defineProperty(process, 'platform', descriptor!)
+  }
+}
+
 test('finds a normal repo but skips root-level macOS media folders', async () => {
   const root = mkTmpDir()
 
@@ -32,7 +43,7 @@ test('finds a normal repo but skips root-level macOS media folders', async () =>
     mkRepo(root, 'Movies', 'clips')
     mkRepo(root, 'Public', 'shared')
 
-    assert.deepEqual(foundRoots(await scanGitRepos([root])), [dev])
+    assert.deepEqual(await withPlatform('darwin', async () => foundRoots(await scanGitRepos([root]))), [dev])
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
   }
@@ -60,7 +71,7 @@ test('skips Apple media-library packages at any depth', async () => {
     mkRepo(root, 'backups', 'TV Library.tvlibrary', 'inner')
     mkRepo(root, 'backups', 'Old.aplibrary', 'inner')
 
-    assert.deepEqual(foundRoots(await scanGitRepos([root])), [keeper])
+    assert.deepEqual(await withPlatform('darwin', async () => foundRoots(await scanGitRepos([root]))), [keeper])
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
   }
@@ -74,6 +85,22 @@ test('walks an explicitly passed media root', async () => {
     const repo = mkRepo(musicRoot, 'samples')
 
     assert.deepEqual(foundRoots(await scanGitRepos([musicRoot])), [repo])
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('preserves media directories and Apple library packages outside macOS', async () => {
+  const root = mkTmpDir()
+
+  try {
+    const musicRepo = mkRepo(root, 'Music', 'samples')
+    const libraryRepo = mkRepo(root, 'backups', 'Photos Library.photoslibrary', 'inner')
+
+    assert.deepEqual(
+      await withPlatform('linux', async () => foundRoots(await scanGitRepos([root]))),
+      [libraryRepo, musicRepo].sort()
+    )
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
   }

--- a/apps/desktop/electron/git-repo-scan.test.ts
+++ b/apps/desktop/electron/git-repo-scan.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { scanGitRepos } from './git-repo-scan'
+
+function mkTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-git-repo-scan-'))
+}
+
+function mkRepo(root: string, ...segments: string[]) {
+  const repo = path.join(root, ...segments)
+  fs.mkdirSync(path.join(repo, '.git'), { recursive: true })
+
+  return repo
+}
+
+function foundRoots(results: { root: string }[]) {
+  return results.map(entry => entry.root).sort()
+}
+
+test('finds a normal repo but skips root-level macOS media folders', async () => {
+  const root = mkTmpDir()
+
+  try {
+    const dev = mkRepo(root, 'dev', 'proj')
+    mkRepo(root, 'Pictures', 'wallpapers')
+    mkRepo(root, 'Music', 'samples')
+    mkRepo(root, 'Movies', 'clips')
+    mkRepo(root, 'Public', 'shared')
+
+    assert.deepEqual(foundRoots(await scanGitRepos([root])), [dev])
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('still scans a media-named directory below the search root', async () => {
+  const root = mkTmpDir()
+
+  try {
+    const nested = mkRepo(root, 'dev', 'Music', 'app')
+
+    assert.deepEqual(foundRoots(await scanGitRepos([root])), [nested])
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('skips Apple media-library packages at any depth', async () => {
+  const root = mkTmpDir()
+
+  try {
+    const keeper = mkRepo(root, 'code', 'site')
+    mkRepo(root, 'code', 'Photos Library.photoslibrary', 'inner')
+    mkRepo(root, 'backups', 'Music Library.MUSICLIBRARY', 'inner')
+    mkRepo(root, 'backups', 'TV Library.tvlibrary', 'inner')
+    mkRepo(root, 'backups', 'Old.aplibrary', 'inner')
+
+    assert.deepEqual(foundRoots(await scanGitRepos([root])), [keeper])
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('walks an explicitly passed media root', async () => {
+  const root = mkTmpDir()
+
+  try {
+    const musicRoot = path.join(root, 'Music')
+    const repo = mkRepo(musicRoot, 'samples')
+
+    assert.deepEqual(foundRoots(await scanGitRepos([musicRoot])), [repo])
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/electron/git-repo-scan.ts
+++ b/apps/desktop/electron/git-repo-scan.ts
@@ -57,6 +57,7 @@ async function mapLimit(items, limit, fn) {
 async function scanGitRepos(roots, options: any = {}) {
   const maxDepth = Number(options.maxDepth) || DEFAULT_MAX_DEPTH
   const searchRoots = Array.isArray(roots) && roots.length > 0 ? roots : [os.homedir()]
+  const skipTccProtectedPaths = process.platform === 'darwin'
   const found = new Map()
 
   async function walk(dir, depth) {
@@ -93,11 +94,11 @@ async function scanGitRepos(roots, options: any = {}) {
         continue
       }
 
-      if (depth === 0 && MEDIA_ROOT_DIRS.has(entry.name)) {
+      if (skipTccProtectedPaths && depth === 0 && MEDIA_ROOT_DIRS.has(entry.name)) {
         continue
       }
 
-      if (isLibraryPackage(entry.name)) {
+      if (skipTccProtectedPaths && isLibraryPackage(entry.name)) {
         continue
       }
 

--- a/apps/desktop/electron/git-repo-scan.ts
+++ b/apps/desktop/electron/git-repo-scan.ts
@@ -23,6 +23,19 @@ const MAX_CONCURRENCY = 32
 // only needs the non-hidden heavyweights.
 const JUNK_DIRS = new Set(['Applications', 'Library', 'node_modules', 'site-packages', 'vendor', 'venv'])
 
+// Avoid macOS TCC prompts when the default home scan reaches protected media
+// folders. Nested names and explicitly supplied media roots remain scannable.
+const MEDIA_ROOT_DIRS = new Set(['Movies', 'Music', 'Pictures', 'Public'])
+
+// These packages look like directories but are TCC-protected and cannot contain
+// user repositories, including when stored outside the default media folders.
+const LIBRARY_PACKAGE_SUFFIXES = ['.photoslibrary', '.musiclibrary', '.tvlibrary', '.aplibrary']
+
+function isLibraryPackage(name) {
+  const lower = String(name).toLowerCase()
+  return LIBRARY_PACKAGE_SUFFIXES.some(suffix => lower.endsWith(suffix))
+}
+
 async function mapLimit(items, limit, fn) {
   let cursor = 0
 
@@ -77,6 +90,14 @@ async function scanGitRepos(roots, options: any = {}) {
       // Real directories only (skip symlinks to avoid loops), no hidden dirs, no
       // known heavy trees.
       if (!entry.isDirectory() || entry.name.startsWith('.') || JUNK_DIRS.has(entry.name)) {
+        continue
+      }
+
+      if (depth === 0 && MEDIA_ROOT_DIRS.has(entry.name)) {
+        continue
+      }
+
+      if (isLibraryPackage(entry.name)) {
         continue
       }
 


### PR DESCRIPTION
## Summary

Desktop project discovery scans the home directory for git repositories. On macOS, descending into protected media folders and Apple media-library packages triggers TCC permission prompts attributed to Hermes.app; ad-hoc-signed self-updates can cause those grants to be requested again.

On macOS only:

- Skip `Movies`, `Music`, `Pictures`, and `Public` when they are direct children of a search root
- Continue scanning nested directories with those names and explicitly supplied media roots
- Skip `*.photoslibrary`, `*.musiclibrary`, `*.tvlibrary`, and `*.aplibrary` packages at any depth, case-insensitively

Linux and Windows retain the original discovery behavior for all of those paths. The regression coverage runs against the current TypeScript/Vitest Electron test suite and explicitly exercises Darwin and non-Darwin behavior.

Partial mitigation for #49110 / #52010 / #43365 / #43788. Stable release signing remains the underlying identity fix.

## Test Plan

- [x] RED: forced-Linux regression returned no repositories before the platform guard
- [x] `cd apps/desktop && npx vitest run electron/git-repo-scan.test.ts` — 5 passed
- [x] `cd apps/desktop && npx prettier --check electron/git-repo-scan.ts electron/git-repo-scan.test.ts`
- [x] `cd apps/desktop && npm run typecheck`
- [x] `git diff --check`
