### PR TITLE
Hardening fixes for compression, Hindsight, and env snapshots

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -600,9 +600,10 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
         [search_files] content search for 'compress' in agent/ -> 12 matches
     """
     try:
-        args = json.loads(tool_args) if tool_args else {}
+        parsed_args = json.loads(tool_args) if tool_args else {}
     except (json.JSONDecodeError, TypeError):
-        args = {}
+        parsed_args = {}
+    args = parsed_args if isinstance(parsed_args, dict) else {}
 
     content = tool_content or ""
     content_len = len(content)

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import concurrent.futures
 import importlib
 import json
 import logging
@@ -271,14 +272,18 @@ def _get_loop() -> asyncio.AbstractEventLoop:
         return _loop
 
 
-def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT):
+def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT, operation_name: str = "hindsight operation"):
     """Schedule *coro* on the shared loop and block until done."""
     from agent.async_utils import safe_schedule_threadsafe
     loop = _get_loop()
     future = safe_schedule_threadsafe(coro, loop)
     if future is None:
         raise RuntimeError("Hindsight loop unavailable")
-    return future.result(timeout=timeout)
+    try:
+        return future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError as exc:
+        future.cancel()
+        raise TimeoutError(f"{operation_name} timed out after {timeout}s") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -1062,9 +1067,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = Hindsight(**kwargs)
         return self._client
 
-    def _run_sync(self, coro):
+    def _run_sync(self, coro, operation_name: str = "hindsight operation"):
         """Schedule *coro* on the shared loop using the configured timeout."""
-        return _run_sync(coro, timeout=self._timeout)
+        return _run_sync(coro, timeout=self._timeout, operation_name=operation_name)
 
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
@@ -1152,7 +1157,7 @@ class HindsightMemoryProvider(MemoryProvider):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), operation_name="hindsight client operation")
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
@@ -1163,7 +1168,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), operation_name="hindsight client operation retry")
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1713,10 +1718,12 @@ class HindsightMemoryProvider(MemoryProvider):
                     tags=args.get("tags"),
                 )
                 # aretain_batch takes bank_id/retain_async as call args, not item keys.
+                retain_async = item.pop("retain_async", None)
                 item.pop("bank_id", None)
-                item.pop("retain_async", None)
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
+                logger.debug(
+                    "Tool hindsight_retain: bank=%s, url=%s, timeout=%s, async=%s, content_len=%d, context=%s",
+                    self._bank_id, self._api_url, self._timeout, retain_async, len(content), context,
+                )
                 self._run_hindsight_operation(
                     lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
                 )
@@ -1724,7 +1731,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)
-                return tool_error(f"Failed to store memory: {e}")
+                detail = str(e) or type(e).__name__
+                return tool_error(f"Failed to store memory: {detail}")
 
         elif tool_name == "hindsight_recall":
             query = args.get("query", "")

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -9,6 +9,7 @@ from agent.context_compressor import (
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
     COMPRESSED_SUMMARY_METADATA_KEY,
+    _summarize_tool_result,
 )
 from hermes_state import SessionDB
 
@@ -111,6 +112,26 @@ class TestPreflightDeferral:
         # short-circuit applies => no deferral.
         assert compressor.should_defer_preflight_to_real_usage(95_000) is False
 
+
+
+class TestSummarizeToolResult:
+    @pytest.mark.parametrize("tool_args", [
+        '[{"code": "print(1)"}]',
+        '"not an object"',
+        "123",
+        "true",
+        "null",
+    ])
+    def test_non_object_tool_args_do_not_crash(self, tool_args):
+        """Regression: pre-compression pruning may see legacy non-dict args."""
+        summary = _summarize_tool_result(
+            "execute_code",
+            tool_args,
+            '{"output": "1", "exit_code": 0}',
+        )
+
+        assert summary.startswith("[execute_code]")
+        assert "lines output" in summary
 
 
 class TestCompress:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -5,6 +5,7 @@ prefetch (auto_recall, preamble, query truncation), sync_turn (auto_retain,
 turn counting, tags), and schema completeness.
 """
 
+import concurrent.futures
 import json
 import os
 import re
@@ -1777,6 +1778,30 @@ class TestSharedEventLoopLifecycle:
         assert hindsight_mod._run_sync(_still_working()) == 42
 
         provider_b.shutdown()
+
+    def test_run_sync_cancels_future_and_names_timeout(self, monkeypatch):
+        from plugins.memory import hindsight as hindsight_mod
+
+        class TimedOutFuture:
+            cancelled = False
+
+            def result(self, timeout=None):
+                raise concurrent.futures.TimeoutError()
+
+            def cancel(self):
+                self.cancelled = True
+
+        future = TimedOutFuture()
+        monkeypatch.setattr(hindsight_mod, "_get_loop", lambda: object())
+        monkeypatch.setattr(
+            "agent.async_utils.safe_schedule_threadsafe",
+            lambda coro, loop: future,
+        )
+
+        with pytest.raises(TimeoutError, match="hindsight retain timed out after 0.01s"):
+            hindsight_mod._run_sync(object(), timeout=0.01, operation_name="hindsight retain")
+
+        assert future.cancelled
 
     def test_client_aclose_called_on_cloud_mode_shutdown(self, provider):
         """Per-provider session cleanup still runs even though the shared

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -32,7 +32,7 @@ class TestWrapCommand:
         assert "cd -- /tmp" in wrapped or "cd -- '/tmp'" in wrapped
         assert "eval 'echo hello'" in wrapped
         assert "__hermes_ec=$?" in wrapped
-        assert "export -p >" in wrapped
+        assert "export -p | grep -Eiv" in wrapped
         assert "pwd -P >" in wrapped
         assert env._cwd_marker in wrapped
         assert "exit $__hermes_ec" in wrapped

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -181,7 +181,7 @@ class TestAtomicSnapshotWrite:
 
         assert "umask 077" in wrapped
         assert wrapped.index("eval 'echo hi'") < wrapped.index("umask 077")
-        assert wrapped.index("umask 077") < wrapped.index("export -p >")
+        assert wrapped.index("umask 077") < wrapped.index("export -p |")
 
     def test_init_session_bootstrap_uses_private_umask(self):
         env = _TestableEnv()
@@ -198,7 +198,7 @@ class TestAtomicSnapshotWrite:
             pass
         boot = captured.get("cmd", "")
         assert "umask 077" in boot
-        assert boot.index("umask 077") < boot.index("export -p >")
+        assert boot.index("umask 077") < boot.index("export -p |")
 
 
 class TestAtomicSnapshotConcurrencyBehavioral:

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -105,14 +105,14 @@ class TestAtomicSnapshotWrite:
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
         # Env dump goes to a temp file, not directly over the live snapshot.
-        assert "export -p > " in wrapped
+        assert "export -p | " in wrapped
         assert ".tmp." in wrapped
         # Then an atomic rename onto the real snapshot path.
         assert "mv -f " in wrapped
         # The env-dump must NOT write the live snapshot in place (the bug).
         snap = env._snapshot_path
-        assert f"export -p > {snap} " not in wrapped
-        assert f"export -p > '{snap}'" not in wrapped
+        assert f"> {snap} " not in wrapped
+        assert f"> '{snap}'" not in wrapped
 
     def test_temp_path_uses_bashpid_not_dollardollar(self):
         """The temp name MUST use ``$BASHPID`` (the real subshell PID), not
@@ -150,7 +150,7 @@ class TestAtomicSnapshotWrite:
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "export -p > " in wrapped and "&& mv -f " in wrapped
+        assert "export -p | " in wrapped and "&& mv -f " in wrapped
         assert "rm -f " in wrapped  # temp cleanup on failure
 
     def test_init_session_bootstrap_also_atomic_and_bashpid(self):

--- a/tests/tools/test_init_session_cwd_respect.py
+++ b/tests/tools/test_init_session_cwd_respect.py
@@ -16,7 +16,11 @@ running ``pwd -P``, so the configured cwd is always what gets recorded.
 from tempfile import TemporaryFile
 from unittest.mock import MagicMock
 
-from tools.environments.base import BaseEnvironment
+from tools.environments.base import (
+    BaseEnvironment,
+    _SNAPSHOT_SECRET_ENV_RE,
+    _snapshot_export_command,
+)
 
 
 class _TestableEnv(BaseEnvironment):
@@ -146,3 +150,82 @@ class TestInitSessionCwdRespect:
         assert "'/my project/with spaces'" in bootstrap, (
             "bootstrap cd must properly quote paths with spaces"
         )
+
+    def test_snapshot_capture_filters_secret_env_names(self):
+        env = _TestableEnv(cwd="/tmp")
+        captured = {}
+
+        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+            captured["cmd"] = cmd_string
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 0
+            stdout = TemporaryFile(mode="w+b")
+            stdout.seek(0)
+            mock.stdout = stdout
+            return mock
+
+        env._run_bash = mock_run_bash
+        env.init_session()
+
+        bootstrap = captured["cmd"]
+        assert "export -p | grep -Eiv" in bootstrap
+        assert "TOKEN" in bootstrap
+        assert "PASSWORD" in bootstrap
+        assert "KEY" in bootstrap
+        assert "CREDENTIALS?" in bootstrap
+        assert "AUTHORIZATION" in bootstrap
+        assert "BEARER" in bootstrap
+
+    def test_snapshot_refresh_filters_secret_env_names(self):
+        env = _TestableEnv(cwd="/tmp")
+        env._snapshot_ready = True
+
+        wrapped = env._wrap_command("true", "/tmp")
+
+        assert "export -p | grep -Eiv" in wrapped
+        assert "TOKEN" in wrapped
+        assert "PASSWORD" in wrapped
+        assert "KEY" in wrapped
+        assert "CREDENTIALS?" in wrapped
+        assert "AUTHORIZATION" in wrapped
+
+    def test_snapshot_filter_does_not_drop_auth_socket_names(self):
+        cmd = _snapshot_export_command("/tmp/snap.sh")
+        assert "AUTHORIZATION" in cmd
+        assert "BEARER" in cmd
+        assert "AUTH($|_)" not in cmd
+
+    def test_snapshot_filter_scrubs_common_secret_names_but_keeps_socket_names(self):
+        lines = "\n".join(
+            [
+                'declare -x OPENAI_API_KEY="secret"',
+                'declare -x api_key="secret"',
+                'declare -x OPENAI_KEY="secret"',
+                'declare -x GOOGLE_APPLICATION_CREDENTIALS="secret"',
+                'declare -x AWS_ACCESS_KEY_ID="secret"',
+                'declare -x NPM_CONFIG__AUTH_TOKEN="secret"',
+                'declare -x SSH_AUTH_SOCK="/tmp/ssh.sock"',
+                'declare -x XAUTHORITY="/tmp/auth"',
+                'declare -x TOKENIZER_PARALLELISM="false"',
+            ]
+        )
+        import subprocess
+
+        proc = subprocess.run(
+            ["grep", "-Eiv", _SNAPSHOT_SECRET_ENV_RE],
+            input=lines,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        snapshot = proc.stdout
+        assert "OPENAI_API_KEY" not in snapshot
+        assert "api_key" not in snapshot
+        assert "OPENAI_KEY" not in snapshot
+        assert "GOOGLE_APPLICATION_CREDENTIALS" not in snapshot
+        assert "AWS_ACCESS_KEY_ID" not in snapshot
+        assert "NPM_CONFIG__AUTH_TOKEN" not in snapshot
+        assert "SSH_AUTH_SOCK" in snapshot
+        assert "XAUTHORITY" in snapshot
+        assert "TOKENIZER_PARALLELISM" in snapshot

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -26,6 +26,24 @@ from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
 
+_SNAPSHOT_SECRET_ENV_RE = (
+    r"(^|[^[:alnum:]])(TOKEN|SECRET|PASSWORD|PASSWD|KEY|API_?KEY|ACCESS_?KEY|PRIVATE_?KEY|"
+    r"CREDENTIALS?|AUTHORIZATION|BEARER)([^[:alnum:]]|$)"
+)
+
+
+def _snapshot_export_command(target: str) -> str:
+    """Write non-secret exported variables to *target* for session replay."""
+    # ``export -p`` emits shell-safe declarations.  Keep the session snapshot
+    # useful for PATH/HOME/etc. but do not persist credentials into /tmp-backed
+    # hermes-snap-*.sh files.  Avoid a broad ``AUTH`` match so SSH_AUTH_SOCK and
+    # XAUTHORITY survive; explicit AUTHORIZATION/BEARER cover HTTP credentials.
+    return (
+        "export -p | "
+        f"grep -Eiv {shlex.quote(_SNAPSHOT_SECRET_ENV_RE)} "
+        f"> {target}"
+    )
+
 # Opt-in debug tracing for the interrupt/activity/poll machinery.  Set
 # HERMES_DEBUG_INTERRUPT=1 to log loop entry/exit, periodic heartbeats, and
 # every is_interrupted() state change from _wait_for_process.  Off by default
@@ -396,7 +414,7 @@ class BaseEnvironment(ABC):
         _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
         bootstrap = (
             f"umask 077\n"
-            f"export -p > {_snap_tmp}\n"
+            f"{_snapshot_export_command(_snap_tmp)}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
             # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
@@ -507,13 +525,13 @@ class BaseEnvironment(ABC):
         # umask. Snapshot files may contain env-carried secrets.
         parts.append("umask 077")
 
-        # Re-dump env vars to snapshot (atomic replacement to avoid races).
+        # Re-dump non-secret env vars to snapshot (atomic replacement to avoid races).
         # Chain mv on the export succeeding so a failed/partial dump never
         # replaces a good snapshot; drop the temp on failure so it isn't
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
         if self._snapshot_ready:
             parts.append(
-                f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_quoted_snap}; }} "
+                f"{{ {_snapshot_export_command(_snap_tmp)} && mv -f {_snap_tmp} {_quoted_snap}; }} "
                 f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
             )
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -414,7 +414,8 @@ class BaseEnvironment(ABC):
         _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$BASHPID"
         bootstrap = (
             f"umask 077\n"
-            f"{_snapshot_export_command(_snap_tmp)}\n"
+            f"__hermes_snap_tmp={_snap_tmp}\n"
+            + _snapshot_export_command('"$__hermes_snap_tmp"') + "\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
             # helpers — mainly bash-completion internals (``_git``, ``_make``…)
             # — by NAME, not by line.  A naive ``declare -f | grep -vE '^_[^_]'``
@@ -429,14 +430,14 @@ class BaseEnvironment(ABC):
             # very functions we meant to drop.
             f"__hermes_fns=$(declare -F | awk '{{print $3}}' | grep -vE '^_[^_]') || true\n"
             f"[ -n \"$__hermes_fns\" ] && declare -f $__hermes_fns "
-            f">> {_snap_tmp} 2>/dev/null || true\n"
-            f"alias -p >> {_snap_tmp}\n"
-            f"echo 'shopt -s expand_aliases' >> {_snap_tmp}\n"
-            f"echo 'set +e' >> {_snap_tmp}\n"
-            f"echo 'set +u' >> {_snap_tmp}\n"
+            f">> \"$__hermes_snap_tmp\" 2>/dev/null || true\n"
+            f"alias -p >> \"$__hermes_snap_tmp\"\n"
+            f"echo 'shopt -s expand_aliases' >> \"$__hermes_snap_tmp\"\n"
+            f"echo 'set +e' >> \"$__hermes_snap_tmp\"\n"
+            f"echo 'set +u' >> \"$__hermes_snap_tmp\"\n"
             # Publish atomically only if assembly succeeded; otherwise drop the
             # partial temp rather than leave it to be sourced or orphaned.
-            f"mv -f {_snap_tmp} {_quoted_snap} || rm -f {_snap_tmp}\n"
+            f"mv -f \"$__hermes_snap_tmp\" {_quoted_snap} || rm -f \"$__hermes_snap_tmp\"\n"
             f"builtin cd -- {_quoted_cwd} 2>/dev/null || true\n"
             f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
@@ -501,6 +502,8 @@ class BaseEnvironment(ABC):
 
         parts = []
 
+        parts.append(f"__hermes_snap_tmp={_snap_tmp}")
+
         # Source snapshot (env vars from previous commands).
         # Redirect stdout to /dev/null: on macOS (bash 3.2 and certain
         # Homebrew bash builds) sourcing a file containing ``declare -x``
@@ -531,8 +534,10 @@ class BaseEnvironment(ABC):
         # orphaned (cleaned up wholesale in LocalEnvironment.cleanup too).
         if self._snapshot_ready:
             parts.append(
-                f"{{ {_snapshot_export_command(_snap_tmp)} && mv -f {_snap_tmp} {_quoted_snap}; }} "
-                f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
+                "{ "
+                + _snapshot_export_command('"$__hermes_snap_tmp"')
+                + f" && mv -f \"$__hermes_snap_tmp\" {_quoted_snap}; }} "
+                f"2>/dev/null || rm -f \"$__hermes_snap_tmp\" 2>/dev/null || true"
             )
 
         # Write CWD to file (local reads this) and stdout marker (remote parses this)


### PR DESCRIPTION
## Summary

This PR collects small, generic hardening fixes that were carried locally and replay cleanly on current `origin/main`:

- tolerate non-object tool-call args while compressing context
- surface Hindsight retain timeouts clearly instead of returning ambiguous failures
- scrub secret-looking variables from terminal environment snapshots
- keep shell snapshot temp filenames stable across `export -p | grep ... && mv ...` pipelines so exported env/session PATH changes persist correctly

## Verification

Run locally on the PR branch after the latest push:

```bash
PYTHONPATH="$PWD" /home/manfred/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/agent/test_context_compressor.py \
  tests/plugins/memory/test_hindsight_provider.py \
  tests/tools/test_init_session_cwd_respect.py \
  tests/tools/test_base_environment.py \
  -q
# 301 passed in 10.64s

PYTHONPATH="$PWD" /home/manfred/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/tools/test_local_shell_init.py \
  -q
# 16 passed in 1.01s

git diff --check origin/main...HEAD
# rc=0
```

Earlier CI caught the shell-snapshot temp-name regression in `tests/tools/test_local_shell_init.py`; this branch now includes the fix and the local reproducer suite is green.
