### PR TITLE
fix(mcp): reset reconnect retry counter after successful session establishment

### DIFF
--- a/tests/tools/test_mcp_reconnect_retry_reset.py
+++ b/tests/tools/test_mcp_reconnect_retry_reset.py
@@ -1,0 +1,196 @@
+"""Tests for MCP reconnect retry counter reset (#57604).
+
+Verifies that the reconnect retry counter resets after each successful
+reconnection, so transient blips do not accumulate toward permanent parking.
+"""
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.no_isolate
+def test_reconnect_counter_resets_after_successful_session(monkeypatch, tmp_path):
+    """Transient disconnections must not accumulate toward permanent parking.
+
+    Before the fix, ``retries`` was a local variable in ``run()`` that only
+    reset on clean transport return (line 2367) or park-wake (line 2468).
+    Each exception from ``_run_stdio`` incremented it without reset, so 5
+    transient blips over a long-uptime gateway would permanently park the
+    server.
+
+    After the fix, ``_reconnect_retries`` is an instance variable that resets
+    to 0 whenever a session is successfully established (``_reset_server_error``
+    call sites in ``_run_stdio`` / ``_run_http``).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    # Shrink budget so the test can exhaust it quickly if the counter
+    # does NOT reset (the bug scenario).
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 3)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {
+        "transport_calls": 0,
+        "parked": False,
+        "max_retries_seen": 0,
+    }
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] = True
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                call = state["transport_calls"]
+
+                if call == 1:
+                    # First connect: succeed (sets _ready), then fail.
+                    self.session = object()
+                    self._ready.set()
+                    self.session = None
+                    raise RuntimeError("blip 1")
+
+                # Subsequent calls: succeed (session established, which
+                # triggers _reset_server_error and should reset retries),
+                # then immediately fail again — simulating a new transient
+                # blip.  If retries accumulate, call 4 would exceed the
+                # budget of 3 and park.  If retries reset correctly,
+                # this loop can continue indefinitely.
+                if call <= 8:
+                    self.session = object()
+                    # _run_stdio calls _reset_server_error and sets
+                    # _reconnect_retries = 0 after session establishment.
+                    # We simulate that by calling the real method.
+                    mcp_tool._reset_server_error(self.name)
+                    self._reconnect_retries = 0
+                    self.session = None
+                    raise RuntimeError(f"blip {call}")
+
+                # If we reach here without parking, the fix works.
+                self.session = object()
+                mcp_tool._reset_server_error(self.name)
+                self._reconnect_retries = 0
+                await self._wait_for_lifecycle_event()
+                return
+
+        task = _Task("srv")
+        task._registered_tool_names = ["srv__tool"]
+
+        run_task = asyncio.ensure_future(task.run({"command": "x"}))
+
+        # Let the scenario run.
+        for _ in range(2000):
+            await _real_sleep(0)
+            if state["transport_calls"] >= 8 or state["parked"]:
+                break
+
+        # The fix: the server should NOT have parked despite 8 transient
+        # disconnections, because each successful reconnection reset the
+        # retry counter.
+        assert not state["parked"], (
+            f"server parked after {state['transport_calls']} transport calls "
+            f"— retry counter accumulated instead of resetting"
+        )
+        assert state["transport_calls"] >= 8, (
+            f"only {state['transport_calls']} transport calls reached "
+            f"(expected >= 8)"
+        )
+
+        # Verify the counter is an instance variable, not a local.
+        assert hasattr(task, "_reconnect_retries"), (
+            "_reconnect_retries should be an instance variable"
+        )
+
+        # Clean shutdown.
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=2)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+
+@pytest.mark.no_isolate
+def test_reconnect_counter_still_parks_on_consecutive_failures(monkeypatch, tmp_path):
+    """The server must still park when failures are genuinely consecutive
+    (no successful reconnection in between).
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_MAX_RECONNECT_RETRIES", 2)
+
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(mcp_tool.asyncio, "sleep", _fast_sleep)
+
+    state = {"transport_calls": 0, "parked": False}
+
+    async def _scenario():
+        class _Task(MCPServerTask):
+            def _is_http(self):
+                return False
+
+            def _deregister_tools(self):
+                state["parked"] = True
+                self._registered_tool_names = []
+
+            async def _run_stdio(self, config):
+                state["transport_calls"] += 1
+                call = state["transport_calls"]
+
+                if call == 1:
+                    self.session = object()
+                    self._ready.set()
+                    self.session = None
+                    raise RuntimeError("first failure")
+
+                # All subsequent calls fail WITHOUT establishing a session
+                # (no _reset_server_error, no retry reset). This simulates
+                # genuinely consecutive failures.
+                raise RuntimeError(f"failure {call}")
+
+        task = _Task("srv")
+        task._registered_tool_names = ["srv__tool"]
+
+        run_task = asyncio.ensure_future(task.run({"command": "x"}))
+
+        for _ in range(500):
+            await _real_sleep(0)
+            if state["parked"] or run_task.done():
+                break
+
+        assert state["parked"], (
+            "server should park on consecutive failures without successful reconnect"
+        )
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=2)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1430,6 +1430,7 @@ class MCPServerTask:
         "_rpc_lock", "_pending_refresh_tasks",
         "_pending_call_context",
         "initialize_result", "_ping_unsupported",
+        "_reconnect_retries",
     )
 
     def __init__(self, name: str):
@@ -1451,6 +1452,7 @@ class MCPServerTask:
         self._sampling: Optional[SamplingHandler] = None
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
+        self._reconnect_retries: int = 0
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -1904,6 +1906,10 @@ class MCPServerTask:
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
+                    # This session is live: reset the reconnect retry counter
+                    # so transient prior failures do not accumulate toward
+                    # permanent parking (#57604).
+                    self._reconnect_retries = 0
                     # stdio transport does not use OAuth, but we still honor
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
@@ -2139,6 +2145,7 @@ class MCPServerTask:
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
+                    self._reconnect_retries = 0
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
                         logger.info(
@@ -2192,6 +2199,7 @@ class MCPServerTask:
                         # a prior outage so the first call after recovery
                         # isn't gated on a stale failure count (#16788).
                         _reset_server_error(self.name)
+                        self._reconnect_retries = 0
                         reason = await self._wait_for_lifecycle_event()
                         if reason == "reconnect":
                             logger.info(
@@ -2219,6 +2227,7 @@ class MCPServerTask:
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
+                    self._reconnect_retries = 0
                     reason = await self._wait_for_lifecycle_event()
                     if reason == "reconnect":
                         logger.info(
@@ -2335,7 +2344,7 @@ class MCPServerTask:
                     self._ready.set()
                     return
 
-        retries = 0
+        self._reconnect_retries = 0
         initial_retries = 0
         backoff = 1.0
 
@@ -2364,7 +2373,7 @@ class MCPServerTask:
                 # failure budget — otherwise transient drops accumulated over
                 # a long-lived session would eventually exhaust it and
                 # permanently kill an otherwise-healthy server.
-                retries = 0
+                self._reconnect_retries = 0
                 backoff = 1.0
                 # Reset the session reference; _run_http/_run_stdio will
                 # repopulate it on successful re-entry.
@@ -2438,8 +2447,8 @@ class MCPServerTask:
                     )
                     return
 
-                retries += 1
-                if retries > _MAX_RECONNECT_RETRIES:
+                self._reconnect_retries += 1
+                if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "
                         "parking until a reconnect is requested: %s",
@@ -2465,14 +2474,14 @@ class MCPServerTask:
                         "rebuilding transport.",
                         self.name,
                     )
-                    retries = 0
+                    self._reconnect_retries = 0
                     backoff = 1.0
                     continue
 
                 logger.warning(
                     "MCP server '%s' connection lost (attempt %d/%d), "
                     "reconnecting in %.0fs: %s",
-                    self.name, retries, _MAX_RECONNECT_RETRIES,
+                    self.name, self._reconnect_retries, _MAX_RECONNECT_RETRIES,
                     backoff, exc,
                 )
                 await asyncio.sleep(backoff)


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP reconnect retry counter accumulating across successful reconnections. Previously, `retries` was a local variable in `MCPServerTask.run()` that incremented on every transport exception but only reset on clean transport return (auth recovery / manual refresh) or park-wake. This meant 5 transient network blips over a long-uptime gateway — each followed by a successful reconnect — would permanently park the MCP server, requiring a gateway restart to recover.

The fix promotes `retries` to an instance variable (`_reconnect_retries`) and resets it whenever a session is successfully established (at the same `_reset_server_error()` call sites in `_run_stdio` / `_run_http`). Now only **consecutive** failures without any successful reconnection count toward the parking budget.

## Related Issue

Fixes #57604

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Promoted local `retries` variable to instance attribute `_reconnect_retries` in `MCPServerTask`. Added reset (`self._reconnect_retries = 0`) at all 4 session-establishment sites in `_run_stdio` and `_run_http` (SSE, new HTTP, deprecated HTTP, stdio).
- `tests/tools/test_mcp_reconnect_retry_reset.py`: Two new tests:
  - `test_reconnect_counter_resets_after_successful_session`: 8 transient disconnections with successful reconnects between them → server does NOT park.
  - `test_reconnect_counter_still_parks_on_consecutive_failures`: Genuine consecutive failures (no successful reconnect) → server still parks as expected.

## How to Test

1. Run `python -m pytest tests/tools/test_mcp_reconnect_retry_reset.py tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_reconnect_signal.py -v` — all 12 tests should pass.
2. Verify the structural invariant: `MCPServerTask` should have `_reconnect_retries` as an instance attribute (not a local in `run()`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
