### PR TITLE
fix: stabilize runtime delegation and gateway flow

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -57,7 +57,7 @@ def _ra():
 
 
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
-    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task"}
+    {"todo", "session_search", "memory", "clarify", "read_terminal", "delegate_task", "cost_router"}
 )
 
 
@@ -2171,6 +2171,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+    elif function_name == "cost_router":
+        def _execute(next_args: dict) -> Any:
+            return _finish_agent_tool(agent._dispatch_cost_router(next_args), next_args)
     else:
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1325,6 +1325,33 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     spinner.stop(cute_msg)
                 elif agent._should_emit_quiet_tool_messages():
                     agent._vprint(f"  {cute_msg}")
+        elif function_name == "cost_router":
+            spinner = None
+            profile = function_args.get("profile") or ""
+            if agent._should_emit_quiet_tool_messages() and agent._should_start_quiet_spinner():
+                face = random.choice(KawaiiSpinner.get_waiting_faces())
+                spinner = KawaiiSpinner(f"{face} 🧭 routing via {profile}", spinner_type='dots', print_fn=agent._print_fn)
+                spinner.start()
+            _cost_router_result = None
+            try:
+                def _execute(next_args: dict) -> Any:
+                    return agent._dispatch_cost_router(next_args)
+                function_result, function_args = _run_agent_tool_execution_middleware(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    execute=_execute,
+                )
+                _cost_router_result = function_result
+            finally:
+                tool_duration = time.time() - tool_start_time
+                cute_msg = _get_cute_tool_message_impl('cost_router', function_args, tool_duration, result=_cost_router_result)
+                if spinner:
+                    spinner.stop(cute_msg)
+                elif agent._should_emit_quiet_tool_messages():
+                    agent._vprint(f"  {cute_msg}")
         elif agent._context_engine_tool_names and function_name in agent._context_engine_tool_names:
             # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
             spinner = None

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -177,7 +177,12 @@ def _auto_sso_response(request: Request) -> Response | None:
 
     # list_session_providers() already filters on supports_session=True, so
     # token-only credentials (drain/service providers) are never candidates.
-    providers = list_session_providers()
+    # Password-only providers mint sessions, but they do not support the OAuth
+    # redirect entrypoint at /auth/login; let /login render the password form.
+    providers = [
+        p for p in list_session_providers()
+        if not getattr(p, "supports_password", False)
+    ]
     if len(providers) != 1:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None

--- a/model_tools.py
+++ b/model_tools.py
@@ -594,7 +594,7 @@ def _resolve_active_context_length() -> int:
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "cost_router"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3753,32 +3753,35 @@ class AIAgent:
 
     @staticmethod
     def _cap_delegate_task_calls(tool_calls: list) -> list:
-        """Truncate excess delegate_task calls to max_concurrent_children.
+        """Truncate excess delegation calls to max_concurrent_children.
 
         The delegate_tool caps the task list inside a single call, but the
-        model can emit multiple separate delegate_task tool_calls in one
-        turn.  This truncates the excess, preserving all non-delegate calls.
+        model can emit multiple separate delegate_task/cost_router tool_calls
+        in one turn. This truncates the excess across all delegation surfaces,
+        preserving all non-delegation calls.
 
         Returns the original list if no truncation was needed.
         """
         from tools.delegate_tool import _get_max_concurrent_children
+
         max_children = _get_max_concurrent_children()
-        delegate_count = sum(1 for tc in tool_calls if tc.function.name == "delegate_task")
-        if delegate_count <= max_children:
+        delegation_tools = {"delegate_task", "cost_router"}
+        delegation_count = sum(1 for tc in tool_calls if tc.function.name in delegation_tools)
+        if delegation_count <= max_children:
             return tool_calls
-        kept_delegates = 0
+        kept_delegation_calls = 0
         truncated = []
         for tc in tool_calls:
-            if tc.function.name == "delegate_task":
-                if kept_delegates < max_children:
+            if tc.function.name in delegation_tools:
+                if kept_delegation_calls < max_children:
                     truncated.append(tc)
-                    kept_delegates += 1
+                    kept_delegation_calls += 1
             else:
                 truncated.append(tc)
         logger.warning(
-            "Truncated %d excess delegate_task call(s) to enforce "
+            "Truncated %d excess delegation call(s) to enforce "
             "max_concurrent_children=%d limit",
-            delegate_count - max_children, max_children,
+            delegation_count - max_children, max_children,
         )
         return truncated
 
@@ -5647,6 +5650,12 @@ class AIAgent:
             background=(not _is_subagent),
             parent_agent=self,
         )
+
+    def _dispatch_cost_router(self, function_args: dict) -> str:
+        """Single call site for model-facing cost_router dispatch."""
+        from tools.delegate_tool import _handle_cost_router
+
+        return _handle_cost_router(function_args, parent_agent=self)
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
                      tool_call_id: Optional[str] = None, messages: list = None,

--- a/tests/acp/test_auth.py
+++ b/tests/acp/test_auth.py
@@ -1,5 +1,9 @@
 """Tests for acp_adapter.auth — provider detection."""
 
+import importlib.util
+
+import pytest
+
 from acp_adapter.auth import (
     TERMINAL_SETUP_AUTH_METHOD_ID,
     build_auth_methods,
@@ -68,6 +72,10 @@ class TestDetectProvider:
         assert detect_provider() == "openrouter"
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("acp") is None,
+    reason="agent-client-protocol optional dependency is not installed",
+)
 class TestBuildAuthMethods:
     def test_build_auth_methods_returns_provider_and_terminal_when_configured(self, monkeypatch):
         monkeypatch.setattr("acp_adapter.auth.detect_provider", lambda: "openrouter")

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import importlib.util
 import tempfile
 from pathlib import Path
+
+import pytest
 
 from acp_adapter.edit_approval import (
     EditProposal,
@@ -20,6 +23,10 @@ def teardown_function() -> None:
     clear_edit_approval_requester()
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("acp") is None,
+    reason="agent-client-protocol optional dependency is not installed",
+)
 def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
     proposal = EditProposal(
         tool_name="write_file",

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -2,8 +2,9 @@
 
 import sys
 
-import acp
 import pytest
+
+acp = pytest.importorskip("acp", reason="agent-client-protocol optional dependency is not installed")
 
 from acp_adapter import entry
 

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-import acp
+acp = pytest.importorskip("acp", reason="agent-client-protocol optional dependency is not installed")
 from acp.schema import AgentPlanUpdate
 
 from acp_adapter.events import (

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-import acp
+acp = pytest.importorskip("acp", reason="agent-client-protocol optional dependency is not installed")
 from acp.schema import (
     EnvVariable,
     HttpHeader,

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -5,6 +5,10 @@ import inspect
 from concurrent.futures import Future
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+pytest.importorskip("acp", reason="agent-client-protocol optional dependency is not installed")
+
 from acp.schema import (
     AllowedOutcome,
     DeniedOutcome,

--- a/tests/acp/test_ping_suppression.py
+++ b/tests/acp/test_ping_suppression.py
@@ -16,6 +16,8 @@ from io import StringIO
 
 import pytest
 
+pytest.importorskip("acp", reason="agent-client-protocol optional dependency is not installed")
+
 from acp.exceptions import RequestError
 
 from acp_adapter.entry import _BenignProbeMethodFilter

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
-import acp
+acp = pytest.importorskip("acp", reason="agent-client-protocol optional dependency is not installed")
 from acp.agent.router import build_agent_router
 from acp.schema import (
     AgentCapabilities,

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -1,5 +1,8 @@
 """Tests for acp_adapter.tools — tool kind mapping and ACP content building."""
 
+import pytest
+
+pytest.importorskip("acp", reason="agent-client-protocol optional dependency is not installed")
 
 from acp_adapter.edit_approval import EditProposal
 from acp_adapter.tools import (

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -406,6 +406,26 @@ class TestAutoSsoRedirect:
         assert r.headers["location"].startswith("/login")
         assert "/auth/login" not in r.headers["location"]
 
+    def test_password_only_provider_renders_login_not_oauth(self, gated_app):
+        """Password-only providers mint sessions but cannot start OAuth."""
+        from hermes_cli.dashboard_auth import clear_providers, register_provider
+        from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+        class _PasswordOnlyStub(StubAuthProvider):
+            name = "password-only"
+            display_name = "Password Only"
+            supports_password = True
+
+            def start_login(self, *, redirect_uri: str):
+                raise NotImplementedError("password-only provider")
+
+        clear_providers()
+        register_provider(_PasswordOnlyStub())
+        r = gated_app.get("/sessions", follow_redirects=False)
+        assert r.status_code == 302
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -5,7 +5,7 @@ Covers three static methods on AIAgent (inspired by PR #1321 — @alireza78a):
   - _cap_delegate_task_calls()  — Phase 2a: subagent concurrency limit
   - _deduplicate_tool_calls()   — Phase 2b: identical call deduplication
 """
-
+import json
 import types
 
 from run_agent import AIAgent
@@ -144,6 +144,51 @@ class TestCapDelegateTaskCalls:
         out = AIAgent._cap_delegate_task_calls(tcs)
         delegate_count = sum(1 for tc in out if tc.function.name == "delegate_task")
         assert delegate_count == MAX_CONCURRENT_CHILDREN
+
+    def test_excess_cost_router_calls_truncated(self):
+        tcs = [make_tc("cost_router") for _ in range(MAX_CONCURRENT_CHILDREN + 2)]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        router_count = sum(1 for tc in out if tc.function.name == "cost_router")
+        assert router_count == MAX_CONCURRENT_CHILDREN
+
+    def test_delegate_and_cost_router_share_concurrency_cap(self):
+        tcs = (
+            [make_tc("delegate_task") for _ in range(MAX_CONCURRENT_CHILDREN)]
+            + [make_tc("cost_router"), make_tc("terminal")]
+        )
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        names = [tc.function.name for tc in out]
+        assert names.count("delegate_task") + names.count("cost_router") == MAX_CONCURRENT_CHILDREN
+        assert "terminal" in names
+        assert names[-1] == "terminal"
+
+    def test_task_batches_do_not_consume_extra_tool_call_budget(self):
+        args = json.dumps({"tasks": [{"goal": f"task {i}"} for i in range(MAX_CONCURRENT_CHILDREN)]})
+        tcs = [make_tc("delegate_task", args), make_tc("cost_router"), make_tc("terminal")]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        assert out == tcs
+
+    def test_string_task_batches_do_not_consume_extra_tool_call_budget(self):
+        tasks = json.dumps([{"goal": f"task {i}"} for i in range(MAX_CONCURRENT_CHILDREN)])
+        args = json.dumps({"tasks": tasks})
+        tcs = [make_tc("delegate_task", args), make_tc("cost_router"), make_tc("terminal")]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        assert out == tcs
+
+    def test_oversized_single_task_batch_passes_to_delegate_validation(self):
+        args = json.dumps({"tasks": [{"goal": f"task {i}"} for i in range(MAX_CONCURRENT_CHILDREN + 1)]})
+        tcs = [make_tc("delegate_task", args), make_tc("terminal")]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        assert out == tcs
+
+    def test_oversized_task_batch_does_not_consume_followup_delegation_budget(self):
+        oversized_args = json.dumps(
+            {"tasks": [{"goal": f"task {i}"} for i in range(MAX_CONCURRENT_CHILDREN + 1)]}
+        )
+        tcs = [make_tc("delegate_task", oversized_args), make_tc("cost_router"), make_tc("terminal")]
+        out = AIAgent._cap_delegate_task_calls(tcs)
+        names = [tc.function.name for tc in out]
+        assert names == ["delegate_task", "cost_router", "terminal"]
 
     def test_non_delegate_calls_preserved(self):
         tcs = (

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import agent.model_metadata as model_metadata
 from agent.codex_responses_adapter import _normalize_codex_response
 
 import run_agent
@@ -45,6 +46,41 @@ def _make_tool_defs(*names: str) -> list:
         }
         for n in names
     ]
+
+
+@pytest.fixture(autouse=True)
+def _disable_model_metadata_network_probes(monkeypatch):
+    """Keep run_agent unit tests hermetic when AIAgent initializes compressors."""
+    monkeypatch.setattr(
+        model_metadata,
+        "_query_anthropic_context_length",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "fetch_model_metadata",
+        lambda *_a, **_k: {},
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "_resolve_endpoint_context_length",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "_query_ollama_api_show",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "_query_local_context_length",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        model_metadata,
+        "_fetch_codex_oauth_context_lengths",
+        lambda *_a, **_k: {},
+    )
 
 
 def test_is_destructive_command_treats_cp_as_mutating():
@@ -2349,6 +2385,38 @@ class TestExecuteToolCalls:
         assert messages[0]["role"] == "tool"
         assert messages[0]["tool_call_id"] == "c1"
 
+    def test_dispatch_cost_router_injects_parent_agent(self, agent):
+        with patch("tools.delegate_tool._handle_cost_router", return_value='{"results": []}') as mock_router:
+            result = agent._dispatch_cost_router({"profile": "worker-dsflash", "goal": "cluster"})
+
+        assert result == '{"results": []}'
+        mock_router.assert_called_once_with(
+            {"profile": "worker-dsflash", "goal": "cluster"},
+            parent_agent=agent,
+        )
+
+    def test_cost_router_tool_call_uses_agent_dispatch_path(self, agent):
+        tc = _mock_tool_call(
+            name="cost_router",
+            arguments='{"profile":"worker-dsflash","goal":"cluster"}',
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with (
+            patch("run_agent.handle_function_call") as mock_hfc,
+            patch.object(agent, "_dispatch_cost_router", return_value='{"results": []}') as mock_dispatch,
+        ):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        mock_hfc.assert_not_called()
+        mock_dispatch.assert_called_once_with({"profile": "worker-dsflash", "goal": "cluster"})
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+        assert messages[0]["tool_call_id"] == "c1"
+        assert json.loads(messages[0]["content"]) == {"results": []}
+
     def test_result_truncation_over_100k(self, agent, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         (tmp_path / ".hermes").mkdir()
@@ -2653,6 +2721,37 @@ class TestConcurrentToolExecution:
         assert "alpha" in messages[0]["content"]
         assert "beta" in messages[1]["content"]
         assert "gamma" in messages[2]["content"]
+
+    def test_concurrent_cost_router_injects_parent_agent(self, agent):
+        """Parallel tool execution should route cost_router through the agent dispatch path."""
+        tc1 = _mock_tool_call(
+            name="cost_router",
+            arguments='{"profile":"worker-dsflash","goal":"cluster"}',
+            call_id="c1",
+        )
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"alpha"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+
+        def fake_handle(name, args, task_id, **kwargs):
+            assert name == "web_search"
+            return json.dumps({"result": args.get("q")})
+
+        with (
+            patch("tools.delegate_tool._handle_cost_router", return_value=json.dumps({"routed": True})) as mock_router,
+            patch("run_agent.handle_function_call", side_effect=fake_handle),
+        ):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        mock_router.assert_called_once_with(
+            {"profile": "worker-dsflash", "goal": "cluster"},
+            parent_agent=agent,
+        )
+        assert len(messages) == 2
+        assert messages[0]["tool_call_id"] == "c1"
+        assert json.loads(messages[0]["content"]) == {"routed": True}
+        assert messages[1]["tool_call_id"] == "c2"
+        assert json.loads(messages[1]["content"]) == {"result": "alpha"}
 
     def test_concurrent_preserves_order_despite_timing(self, agent):
         """Even if tools finish in different order, messages should be in original order."""
@@ -3182,7 +3281,7 @@ class TestConcurrentToolExecution:
         """Sequential and concurrent agent-level paths share post-hook ownership."""
         from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook
 
-        for tool_name in ("todo", "session_search", "memory", "clarify", "delegate_task"):
+        for tool_name in ("todo", "session_search", "memory", "clarify", "delegate_task", "cost_router"):
             assert agent_runtime_owns_post_tool_hook(agent, tool_name) is True
 
         agent._context_engine_tool_names = {"context_query"}

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -9,16 +9,28 @@ sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
 sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
 sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
+import agent.model_metadata as model_metadata
 import run_agent
 
 
 @pytest.fixture(autouse=True)
 def _no_codex_backoff(monkeypatch):
     """Short-circuit retry backoff so Codex retry tests don't block on real
-    wall-clock waits (5s jittered_backoff base delay + tight time.sleep loop)."""
+    wall-clock waits (5s jittered_backoff base delay + tight time.sleep loop).
+
+    These tests build Codex OAuth agents with fake bearer tokens. Keep model
+    metadata hermetic too: otherwise AIAgent initialization may probe the live
+    ChatGPT Codex /models endpoint to discover context windows before the fake
+    response stream is installed.
+    """
     import time as _time
     monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
     monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        model_metadata,
+        "_fetch_codex_oauth_context_lengths",
+        lambda *_a, **_k: {},
+    )
 
 
 def _patch_agent_bootstrap(monkeypatch):

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -212,6 +212,7 @@ class TestAgentLoopTools:
         assert "memory" in _AGENT_LOOP_TOOLS
         assert "session_search" in _AGENT_LOOP_TOOLS
         assert "delegate_task" in _AGENT_LOOP_TOOLS
+        assert "cost_router" in _AGENT_LOOP_TOOLS
 
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -275,7 +275,7 @@ class TestResolveToolsetIncludeRegistry:
     def test_get_toolset_include_registry_false_is_static(self):
         ts = get_toolset("delegation", include_registry=False)
         assert ts is not None
-        assert ts["tools"] == ["delegate_task"]
+        assert ts["tools"] == ["delegate_task", "cost_router"]
 
     def test_static_view_threads_through_includes(self):
         # 'debugging' has direct tools [terminal, process] and includes [web, file]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16,6 +16,13 @@ from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
 
 
+@pytest.fixture(autouse=True)
+def _clear_rpc_result_cache():
+    server._rpc_result_cache.clear()
+    yield
+    server._rpc_result_cache.clear()
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -2000,8 +2007,55 @@ def test_notification_event_routing_by_session_key(monkeypatch):
     assert server._notification_event_belongs_elsewhere(mine, {}) is False
     # Owned by another *live* session → defer to that session's poller.
     assert server._notification_event_belongs_elsewhere(mine, {"session_key": "other"}) is True
-    # Owner is gone (not in _sessions) → handle as fallback so it isn't lost.
-    assert server._notification_event_belongs_elsewhere(mine, {"session_key": "ghost"}) is False
+    # Async delegation completions are user-visible conversation turns. If the
+    # owner is temporarily not live, an unrelated session must NOT consume the
+    # event as a fallback; keep it queued until the owner is resumed.
+    assert server._notification_event_belongs_elsewhere(
+        mine, {"type": "async_delegation", "session_key": "ghost"}
+    ) is True
+    # Legacy process completions keep the historical fallback: without a live
+    # owner, surface them somewhere rather than losing the terminal notification.
+    assert server._notification_event_belongs_elsewhere(
+        mine, {"type": "completion", "session_key": "ghost"}
+    ) is False
+
+
+def test_notification_poller_does_not_inject_foreign_async_completion(monkeypatch):
+    """A poller for session B must not reinject session A's async delegation.
+
+    This reproduces the cross-chat leak: a detached async completion with an
+    explicit owner key was popped by whichever session poller woke first when
+    the owner was not currently live, then reinjected into that unrelated chat.
+    """
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    stop = threading.Event()
+    mine = _session(session_key="mine")
+    foreign_evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_foreign",
+        "session_key": "owner-not-live",
+        "goal": "foreign task",
+        "status": "completed",
+        "summary": "foreign result",
+    }
+    process_registry.completion_queue.put(foreign_evt)
+    monkeypatch.setattr(server, "_sessions", {"mine-sid": mine})
+    monkeypatch.setattr(server.time, "sleep", lambda _seconds: stop.set())
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda *args, **kwargs: pytest.fail("foreign async completion was injected"),
+    )
+
+    server._notification_poller_loop(stop, "mine-sid", mine)
+
+    assert mine["running"] is False
+    assert process_registry.completion_queue.get_nowait() == foreign_evt
 
 
 def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
@@ -2998,6 +3052,24 @@ def test_setup_status_reports_provider_config(monkeypatch):
     resp = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
 
     assert resp["result"]["provider_configured"] is False
+
+
+def test_setup_status_uses_short_ttl_cache(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_has_any_provider_configured():
+        calls["count"] += 1
+        return True
+
+    server._rpc_result_cache.clear()
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", fake_has_any_provider_configured)
+
+    first = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
+    second = server.handle_request({"id": "2", "method": "setup.status", "params": {}})
+
+    assert first["result"]["provider_configured"] is True
+    assert second["result"]["provider_configured"] is True
+    assert calls["count"] == 1
 
 
 def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
@@ -5865,6 +5937,109 @@ def test_model_options_propagates_list_exception(monkeypatch):
     assert "catalog blew up" in resp["error"]["message"]
 
 
+def test_model_options_uses_cached_payload_until_refresh(monkeypatch):
+    calls = {"count": 0}
+
+    class _Ctx:
+        def with_overrides(self, **kwargs):
+            return self
+
+    def fake_build_models_payload(*args, **kwargs):
+        calls["count"] += 1
+        return {
+            "providers": [{"slug": f"p{calls['count']}", "models": [], "total_models": 0}],
+            "provider": "demo",
+            "model": "m",
+        }
+
+    server._rpc_result_cache.clear()
+    monkeypatch.setattr("hermes_cli.inventory.load_picker_context", lambda: _Ctx())
+    monkeypatch.setattr("hermes_cli.inventory.build_models_payload", fake_build_models_payload)
+
+    first = server._methods["model.options"]("1", {"session_id": ""})
+    second = server._methods["model.options"]("2", {"session_id": ""})
+    refreshed = server._methods["model.options"]("3", {"session_id": "", "refresh": True})
+
+    assert first["result"]["providers"][0]["slug"] == "p1"
+    assert second["result"]["providers"][0]["slug"] == "p1"
+    assert refreshed["result"]["providers"][0]["slug"] == "p2"
+    assert calls["count"] == 2
+
+
+def test_pet_info_uses_meta_fast_path_for_unchanged_revision(monkeypatch):
+    called = {"meta": 0, "full": 0}
+
+    def fake_meta(rid, params):
+        called["meta"] += 1
+        return {
+            "jsonrpc": "2.0",
+            "id": rid,
+            "result": {
+                "enabled": True,
+                "slug": "pet-1",
+                "displayName": "Pet One",
+                "scale": 1.0,
+                "spritesheetRevision": "rev-1",
+            },
+        }
+
+    def boom_selection():
+        called["full"] += 1
+        raise AssertionError("full pet selection should not run for unchanged revision")
+
+    monkeypatch.setitem(server._methods, "pet.info.meta", fake_meta)
+    monkeypatch.setattr(server, "_pet_active_selection", boom_selection)
+
+    resp = server._methods["pet.info"]("1", {"revision": "rev-1"})
+
+    assert resp["result"] == {
+        "enabled": True,
+        "slug": "pet-1",
+        "displayName": "Pet One",
+        "scale": 1.0,
+        "spritesheetRevision": "rev-1",
+        "unchanged": True,
+    }
+    assert called == {"meta": 1, "full": 0}
+
+
+def test_pet_info_force_full_bypasses_meta_fast_path(monkeypatch):
+    called = {"meta": 0, "full": 0}
+
+    def fake_meta(rid, params):
+        called["meta"] += 1
+        return {
+            "jsonrpc": "2.0",
+            "id": rid,
+            "result": {
+                "enabled": True,
+                "slug": "pet-1",
+                "displayName": "Pet One",
+                "scale": 1.0,
+                "spritesheetRevision": "rev-1",
+            },
+        }
+
+    class _Pet:
+        slug = "pet-1"
+        display_name = "Pet One"
+        exists = True
+        spritesheet = object()
+
+    def fake_selection():
+        called["full"] += 1
+        return True, _Pet(), 1.0
+
+    monkeypatch.setitem(server._methods, "pet.info.meta", fake_meta)
+    monkeypatch.setattr(server, "_pet_active_selection", fake_selection)
+    monkeypatch.setattr(server, "_pet_sprite_payload", lambda pet, *, scale: {"slug": pet.slug, "full": True})
+
+    resp = server._methods["pet.info"]("1", {"revision": "rev-1", "force_full": True})
+
+    assert resp["result"] == {"enabled": True, "slug": "pet-1", "full": True}
+    assert called == {"meta": 0, "full": 1}
+
+
 # ---------------------------------------------------------------------------
 # prompt.submit — auto-title
 # ---------------------------------------------------------------------------
@@ -6625,7 +6800,8 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
         == "Chromium-family browser isn't running with remote debugging — attempting to launch..."
     )
     assert any(
-        "No supported Chromium-family browser executable was found" in line
+        "Start a Chromium-family browser with remote debugging" in line
+        or "No supported Chromium-family browser executable was found" in line
         for line in resp["result"]["messages"]
     )
     assert any(
@@ -7935,6 +8111,125 @@ def test_slash_worker_close_reaps_zombie_and_closes_fds():
     assert calls["kill"] == 1
     assert calls["wait"] >= 2  # reaped after both terminate and kill
     assert calls["stdin"] == calls["stdout"] == calls["stderr"] == 1
+
+
+def test_slash_worker_stdio_tail_is_byte_bounded_and_summarized():
+    worker = object.__new__(server._SlashWorker)
+    worker.stdout_tail = server.deque(maxlen=server._SLASH_WORKER_STDIO_TAIL_LINES)
+    worker.stderr_tail = server.deque(maxlen=server._SLASH_WORKER_STDIO_TAIL_LINES)
+    worker.stdout_bytes = 0
+    worker.stderr_bytes = 0
+    worker.stdout_lines_dropped = 0
+    worker.stderr_lines_dropped = 0
+
+    big = "x" * (server._SLASH_WORKER_OUTPUT_MAX_BYTES // 2)
+    worker._record_stdio_line("stderr", big)
+    worker._record_stdio_line("stderr", big)
+    worker._record_stdio_line("stderr", big)
+
+    assert worker.stderr_bytes <= server._SLASH_WORKER_OUTPUT_MAX_BYTES
+    assert worker.stderr_lines_dropped >= 1
+    summary = worker._format_stdio_summary("stderr", limit=2)
+    assert "dropped" in summary
+
+
+def test_slash_worker_run_appends_bounded_stderr_summary_on_failure():
+    worker = object.__new__(server._SlashWorker)
+    worker.proc = type("_Proc", (), {"poll": lambda self: None})()
+    worker._lock = server.threading.Lock()
+    worker._seq = 0
+    worker.stdout_queue = server.queue.Queue()
+    worker.stdout_tail = server.deque(maxlen=server._SLASH_WORKER_STDIO_TAIL_LINES)
+    worker.stderr_tail = server.deque(maxlen=server._SLASH_WORKER_STDIO_TAIL_LINES)
+    worker.stdout_bytes = 0
+    worker.stderr_bytes = 0
+    worker.stdout_lines_dropped = 0
+    worker.stderr_lines_dropped = 0
+    worker.stdout_queue_dropped = 0
+    worker._closed = False
+    worker.stderr_tail.append("trace 1")
+    worker.stderr_tail.append("trace 2")
+    worker.stderr_bytes = len("trace 1".encode()) + len("trace 2".encode())
+    worker.stdout_queue.put({"id": 1, "ok": False, "error": "boom"})
+
+    class _In:
+        def write(self, data):
+            return None
+
+        def flush(self):
+            return None
+
+    worker.proc.stdin = _In()
+
+    try:
+        worker.run("/boom")
+        raise AssertionError("expected RuntimeError")
+    except RuntimeError as exc:
+        message = str(exc)
+        assert "boom" in message
+        assert "trace 1" in message
+        assert "trace 2" in message
+
+
+def test_slash_worker_stdout_queue_is_bounded_and_drops_oldest_json_results():
+    worker = object.__new__(server._SlashWorker)
+    worker.stdout_tail = server.deque(maxlen=server._SLASH_WORKER_STDIO_TAIL_LINES)
+    worker.stderr_tail = server.deque(maxlen=server._SLASH_WORKER_STDIO_TAIL_LINES)
+    worker.stdout_bytes = 0
+    worker.stderr_bytes = 0
+    worker.stdout_lines_dropped = 0
+    worker.stderr_lines_dropped = 0
+    worker.stdout_queue_dropped = 0
+    worker.stdout_queue = server.queue.Queue(maxsize=2)
+
+    class _Proc:
+        stdout = iter([
+            '{"id": 1, "ok": true, "output": "one"}\n',
+            '{"id": 2, "ok": true, "output": "two"}\n',
+            '{"id": 3, "ok": true, "output": "three"}\n',
+        ])
+
+    worker.proc = _Proc()
+
+    worker._drain_stdout()
+
+    items = [worker.stdout_queue.get_nowait(), worker.stdout_queue.get_nowait()]
+    assert any(item is None for item in items)
+    payloads = [item for item in items if isinstance(item, dict)]
+    assert [item["id"] for item in payloads] == [3]
+    assert worker.stdout_queue_dropped >= 2
+    assert "dropped" in worker._format_queue_drop_summary()
+
+
+def test_slash_worker_closed_pipe_reports_queue_drop_summary():
+    worker = object.__new__(server._SlashWorker)
+    worker.proc = type("_Proc", (), {"poll": lambda self: None})()
+    worker._lock = server.threading.Lock()
+    worker._seq = 0
+    worker.stdout_queue = server.queue.Queue()
+    worker.stdout_tail = server.deque(maxlen=server._SLASH_WORKER_STDIO_TAIL_LINES)
+    worker.stderr_tail = server.deque(maxlen=server._SLASH_WORKER_STDIO_TAIL_LINES)
+    worker.stdout_bytes = 0
+    worker.stderr_bytes = 0
+    worker.stdout_lines_dropped = 0
+    worker.stderr_lines_dropped = 0
+    worker.stdout_queue_dropped = 3
+    worker._closed = False
+    worker.stdout_queue.put(None)
+
+    class _In:
+        def write(self, data):
+            return None
+
+        def flush(self):
+            return None
+
+    worker.proc.stdin = _In()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker.run("/closed")
+
+    assert "dropped 3 earlier JSON result message" in str(excinfo.value)
 
 
 def test_close_session_by_id_is_idempotent_and_full(monkeypatch):

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import threading
 import time
 
@@ -128,10 +129,8 @@ def test_ws_disconnect_preserves_and_repoints_reconnectable_session(monkeypatch)
 
 
 def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
-    """A write that times out because the event loop is stalled (GIL-heavy
-    agent turn) must NOT latch the transport closed — the frame is already
-    scheduled and flushes when the loop recovers. Latching here permanently
-    silenced live watch windows after one slow write."""
+    """A worker-thread write while the loop is stalled enqueues without latching
+    the transport closed. The single writer flushes after the loop breathes."""
     monkeypatch.setattr(ws_mod, "_WS_WRITE_TIMEOUT_S", 0.05)
     sent = []
 
@@ -142,16 +141,13 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
     loop = asyncio.new_event_loop()
     thread = threading.Thread(target=loop.run_forever, daemon=True)
     thread.start()
+    transport = None
     try:
         transport = ws_mod.WSTransport(FakeWS(), loop, peer="stall-test")
-        # Stall the loop well past the write timeout, then write from this
-        # (non-loop) thread: the wait times out but the send stays in flight.
         loop.call_soon_threadsafe(time.sleep, 0.3)
         assert transport.write({"a": 1}) is True
         assert transport._closed is False
 
-        # Once the loop breathes again, both the stalled frame and new writes
-        # must reach the socket.
         assert transport.write({"b": 2}) is True
         deadline = time.time() + 2
         while len(sent) < 2 and time.time() < deadline:
@@ -159,6 +155,142 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         assert len(sent) == 2
         assert transport._closed is False
     finally:
+        if transport is not None:
+            transport.close()
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=2)
         loop.close()
+
+
+def _event(event_type, sid="sid", payload=None):
+    params = {"type": event_type, "session_id": sid}
+    if payload is not None:
+        params["payload"] = payload
+    return {"jsonrpc": "2.0", "method": "event", "params": params}
+
+
+async def _wait_until(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.01)
+    return predicate()
+
+
+def _frame_types(lines):
+    return [json.loads(line).get("params", {}).get("type") for line in lines]
+
+
+def test_ws_transport_overload_bounds_noncritical_queue(monkeypatch):
+    monkeypatch.setattr(ws_mod, "_WS_NONCRITICAL_MAX_FRAMES", 8)
+    monkeypatch.setattr(ws_mod, "_TOKEN_COALESCE_S", 60.0)
+
+    class FakeWS:
+        async def send_text(self, line):
+            raise AssertionError("streaming frames should remain queued during this test")
+
+    async def scenario():
+        transport = ws_mod.WSTransport(FakeWS(), asyncio.get_running_loop(), peer="bounded")
+        try:
+            for i in range(40):
+                assert transport.write(_event("message.delta", payload={"text": str(i)})) is True
+            with transport._lock:
+                queued = len(transport._streaming) + len(transport._normal) + len(transport._snapshots)
+                dropped = transport._dropped_noncritical
+            assert queued <= ws_mod._WS_NONCRITICAL_MAX_FRAMES
+            assert dropped > 0
+        finally:
+            transport.close()
+
+    asyncio.run(scenario())
+
+
+def test_ws_transport_coalesces_latest_only_snapshots(monkeypatch):
+    monkeypatch.setattr(ws_mod, "_WS_SEND_BURST", 1000)
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            sent.append(line)
+
+    async def scenario():
+        transport = ws_mod.WSTransport(FakeWS(), asyncio.get_running_loop(), peer="snapshots")
+        try:
+            for i in range(25):
+                assert transport.write(_event("status.update", payload={"kind": "run", "text": f"step {i}"})) is True
+            assert await _wait_until(lambda: len(sent) == 1)
+        finally:
+            transport.close()
+
+    asyncio.run(scenario())
+
+    assert _frame_types(sent) == ["status.update"]
+    assert json.loads(sent[0])["params"]["payload"]["text"] == "step 24"
+
+
+def test_ws_transport_preserves_critical_during_noncritical_overload(monkeypatch):
+    monkeypatch.setattr(ws_mod, "_WS_NONCRITICAL_MAX_FRAMES", 4)
+    monkeypatch.setattr(ws_mod, "_TOKEN_COALESCE_S", 60.0)
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            sent.append(line)
+
+    async def scenario():
+        transport = ws_mod.WSTransport(FakeWS(), asyncio.get_running_loop(), peer="critical")
+        try:
+            for i in range(30):
+                assert transport.write(_event("message.delta", payload={"text": str(i)})) is True
+            assert transport.write(_event("approval.request", payload={"id": "approve-1"})) is True
+            assert await _wait_until(lambda: "approval.request" in _frame_types(sent))
+        finally:
+            transport.close()
+
+    asyncio.run(scenario())
+
+    assert "approval.request" in _frame_types(sent)
+
+
+def test_ws_transport_critical_overflow_closes_explicitly(monkeypatch):
+    monkeypatch.setattr(ws_mod, "_WS_CRITICAL_MAX_FRAMES", 2)
+
+    class FakeWS:
+        async def send_text(self, line):
+            raise AssertionError("critical overflow is checked before drain")
+
+    async def scenario():
+        transport = ws_mod.WSTransport(FakeWS(), asyncio.get_running_loop(), peer="critical-overflow")
+        try:
+            assert transport.write(_event("approval.request", payload={"id": 1})) is True
+            assert transport.write(_event("approval.request", payload={"id": 2})) is True
+            assert transport.write(_event("approval.request", payload={"id": 3})) is False
+            assert transport._closed is True
+        finally:
+            transport.close()
+
+    asyncio.run(scenario())
+
+
+def test_ws_transport_close_cancels_writer_timer_and_clears_noncritical(monkeypatch):
+    monkeypatch.setattr(ws_mod, "_TOKEN_COALESCE_S", 60.0)
+
+    class FakeWS:
+        async def send_text(self, line):
+            raise AssertionError("close should cancel queued streaming send")
+
+    async def scenario():
+        transport = ws_mod.WSTransport(FakeWS(), asyncio.get_running_loop(), peer="close")
+        assert transport.write(_event("message.delta", payload={"text": "queued"})) is True
+        await asyncio.sleep(0)
+        transport.close()
+        await asyncio.sleep(0)
+        with transport._lock:
+            assert not transport._streaming
+            assert not transport._normal
+            assert not transport._snapshots
+        assert transport._stream_flush_handle is None
+        assert transport._writer_task is None or transport._writer_task.done() or transport._writer_task.cancelled()
+
+    asyncio.run(scenario())

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,14 +11,17 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import tempfile
 import threading
 import time
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
+    COST_ROUTER_SCHEMA,
     DelegateEvent,
     _get_max_concurrent_children,
     _LEGACY_EVENT_MAP,
@@ -32,6 +35,10 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _resolve_worker_profile_credentials,
+    _worker_profile_delegation_config,
+    _profile_config_path,
+    _handle_cost_router,
     _inherit_parent_base_url,
 )
 
@@ -128,6 +135,252 @@ class TestDelegateRequirements(unittest.TestCase):
         )
         self.assertIn(f"up to {_get_max_concurrent_children()}", fn["description"])
         self.assertIn(f"max_spawn_depth={_get_max_spawn_depth()}", fn["description"])
+
+
+class TestCostRouter(unittest.TestCase):
+    def test_schema_valid(self):
+        self.assertEqual(COST_ROUTER_SCHEMA["name"], "cost_router")
+        props = COST_ROUTER_SCHEMA["parameters"]["properties"]
+        self.assertIn("profile", props)
+        self.assertIn("goal", props)
+        self.assertIn("tasks", props)
+        self.assertNotIn("provider", props)
+        self.assertNotIn("base_url", props)
+        self.assertNotIn("api_key", props)
+        self.assertNotIn("api_mode", props)
+
+    def test_cost_router_exposed_in_agent_toolsets(self):
+        import tools.delegate_tool  # noqa: F401 - import registers tools
+        from tools.registry import registry
+        from toolsets import get_toolset
+
+        for toolset_name in ("delegation", "coding", "hermes-acp", "hermes-api-server"):
+            toolset = get_toolset(toolset_name)
+            self.assertIsNotNone(toolset)
+            tools = toolset["tools"] if toolset is not None else []
+            self.assertIn("cost_router", tools)
+
+        defs = registry.get_definitions({"cost_router"})
+        self.assertEqual(len(defs), 1)
+        self.assertEqual(defs[0]["function"]["name"], "cost_router")
+
+    def test_profile_config_path_rejects_paths(self):
+        for profile in ("", ".", "..", "../worker", "worker/name", "worker\\name"):
+            with self.subTest(profile=profile):
+                with self.assertRaises(ValueError):
+                    _profile_config_path(profile)
+
+    def test_worker_profile_config_reads_model_and_provider_settings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_dir = root / "profiles" / "worker-dsflash"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "config.yaml").write_text(
+                "\n".join(
+                    [
+                        "model:",
+                        "  provider: custom:deepseek",
+                        "  default: deepseek-v4-flash",
+                        "providers:",
+                        "  custom:deepseek:",
+                        "    base_url: https://deepseek.example/v1",
+                        "    api_key: test-key",
+                        "    api_mode: chat_completions",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with patch("tools.delegate_tool.get_default_hermes_root", return_value=root):
+                cfg = _worker_profile_delegation_config("worker-dsflash")
+
+        self.assertEqual(cfg["model"], "deepseek-v4-flash")
+        self.assertEqual(cfg["provider"], "custom:deepseek")
+        self.assertEqual(cfg["base_url"], "https://deepseek.example/v1")
+        self.assertEqual(cfg["api_key"], "test-key")
+        self.assertEqual(cfg["api_mode"], "chat_completions")
+
+    def test_worker_profile_model_settings_override_provider_settings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_dir = root / "profiles" / "worker-cli"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "config.yaml").write_text(
+                "\n".join(
+                    [
+                        "model:",
+                        "  provider: custom:worker",
+                        "  default: worker-model",
+                        "  base_url: https://model.example/v1",
+                        "  api_key: model-key",
+                        "  api_mode: responses",
+                        "  command: model-command",
+                        "  args:",
+                        "    - --model-arg",
+                        "providers:",
+                        "  custom:worker:",
+                        "    base_url: https://provider.example/v1",
+                        "    api_key: provider-key",
+                        "    api_mode: chat_completions",
+                        "    command: provider-command",
+                        "    args:",
+                        "      - --provider-arg",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with patch("tools.delegate_tool.get_default_hermes_root", return_value=root):
+                cfg = _worker_profile_delegation_config("worker-cli")
+
+        self.assertEqual(cfg["model"], "worker-model")
+        self.assertEqual(cfg["provider"], "custom:worker")
+        self.assertEqual(cfg["base_url"], "https://model.example/v1")
+        self.assertEqual(cfg["api_key"], "model-key")
+        self.assertEqual(cfg["api_mode"], "responses")
+        self.assertEqual(cfg["command"], "model-command")
+        self.assertEqual(cfg["args"], ["--model-arg"])
+
+    def test_worker_profile_config_reads_codex_cli_settings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_dir = root / "profiles" / "worker-codex"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "config.yaml").write_text(
+                "\n".join(
+                    [
+                        "model:",
+                        "  acp_command: codex",
+                        "  acp_args:",
+                        "    - --ask-for-approval",
+                        "    - never",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with patch("tools.delegate_tool.get_default_hermes_root", return_value=root):
+                cfg = _worker_profile_delegation_config("worker-codex")
+
+        self.assertEqual(cfg["command"], "codex")
+        self.assertEqual(cfg["args"], ["--ask-for-approval", "never"])
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_worker_profile_credentials_reuse_delegation_resolver(self, mock_resolve):
+        mock_resolve.return_value = {
+            "model": "deepseek-v4-flash",
+            "provider": "custom:deepseek",
+            "base_url": "https://deepseek.example/v1",
+            "api_key": "test-key",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+        }
+        parent = _make_mock_parent()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_dir = root / "profiles" / "worker-dsflash"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "config.yaml").write_text(
+                "\n".join(
+                    [
+                        "model:",
+                        "  provider: custom:deepseek",
+                        "  default: deepseek-v4-flash",
+                        "providers:",
+                        "  custom:deepseek:",
+                        "    base_url: https://deepseek.example/v1",
+                        "    api_key: test-key",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with patch("tools.delegate_tool.get_default_hermes_root", return_value=root):
+                creds = _resolve_worker_profile_credentials("worker-dsflash", parent)
+
+        mock_resolve.assert_called_once()
+        resolved_cfg, resolved_parent = mock_resolve.call_args.args
+        self.assertEqual(resolved_parent, parent)
+        self.assertEqual(resolved_cfg["model"], "deepseek-v4-flash")
+        self.assertEqual(resolved_cfg["provider"], "custom:deepseek")
+        self.assertEqual(creds["base_url"], "https://deepseek.example/v1")
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_worker_profile_credentials_allow_codex_cli_only_profile(self, mock_resolve):
+        mock_resolve.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "command": "codex",
+            "args": ["--model", "gpt-5.1-codex-max"],
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_dir = root / "profiles" / "worker-codex"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "config.yaml").write_text(
+                "\n".join(
+                    [
+                        "model:",
+                        "  command: codex",
+                        "  args: --model gpt-5.1-codex-max",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with patch("tools.delegate_tool.get_default_hermes_root", return_value=root):
+                creds = _resolve_worker_profile_credentials("worker-codex", _make_mock_parent())
+
+        resolved_cfg, _ = mock_resolve.call_args.args
+        self.assertEqual(resolved_cfg["command"], "codex")
+        self.assertEqual(resolved_cfg["args"], ["--model", "gpt-5.1-codex-max"])
+        self.assertEqual(creds["args"], ["--model", "gpt-5.1-codex-max"])
+
+    @patch("tools.delegate_tool.delegate_task")
+    @patch("tools.delegate_tool._resolve_worker_profile_credentials")
+    def test_handle_cost_router_passes_concrete_overrides(self, mock_resolve, mock_delegate):
+        parent = _make_mock_parent()
+        creds = {
+            "model": "deepseek-v4-flash",
+            "provider": "custom:deepseek",
+            "base_url": "https://deepseek.example/v1",
+            "api_key": "test-key",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+        }
+        mock_resolve.return_value = creds
+        mock_delegate.return_value = '{"results": []}'
+
+        result = _handle_cost_router(
+            {"profile": "worker-dsflash", "goal": "cluster warnings", "context": "logs"},
+            parent_agent=parent,
+        )
+
+        self.assertEqual(result, '{"results": []}')
+        mock_resolve.assert_called_once_with("worker-dsflash", parent)
+        mock_delegate.assert_called_once()
+        kwargs = mock_delegate.call_args.kwargs
+        self.assertEqual(kwargs["goal"], "cluster warnings")
+        self.assertEqual(kwargs["context"], "logs")
+        self.assertEqual(kwargs["parent_agent"], parent)
+        self.assertEqual(kwargs["credential_overrides"], creds)
+
+    @patch("tools.delegate_tool._resolve_worker_profile_credentials")
+    def test_handle_cost_router_reports_profile_errors(self, mock_resolve):
+        mock_resolve.side_effect = ValueError("worker profile missing")
+
+        result = _handle_cost_router({"profile": "missing", "goal": "test"}, parent_agent=_make_mock_parent())
+        payload = json.loads(result)
+
+        self.assertIn("error", payload)
+        self.assertIn("worker profile missing", payload["error"])
 
 
 class TestChildSystemPrompt(unittest.TestCase):
@@ -388,7 +641,7 @@ class TestDelegateTask(unittest.TestCase):
         parent.provider = "openai-codex"
         parent.api_mode = "codex_responses"
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with patch("tools.delegate_tool._load_config", return_value={}), patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
             mock_child.run_conversation.return_value = {
                 "final_response": "ok",

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,8 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +79,7 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(str(Path("/tmp/out.txt").resolve()), "hello world!\n")
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -182,7 +184,7 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "foo", "bar", False)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -195,7 +197,7 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(os.path.realpath("/tmp/f.py"), "x", "y", True)
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -401,6 +401,10 @@ class TestDispatchersTriggerPluginDiscovery:
                     web_search_registry.register_provider(FakeFirecrawl())
 
             mock_hook = MagicMock(wraps=_register_fake)
+
+            async def _safe_url(_url: str) -> bool:
+                return True
+
             # Patch the helper on ``tools.web_tools`` directly rather than the
             # underlying ``hermes_cli.plugins._ensure_plugins_discovered`` so
             # the test stays valid even if the import inside the helper is
@@ -412,6 +416,7 @@ class TestDispatchersTriggerPluginDiscovery:
                 web_tools, "_load_web_config",
                 lambda: {"extract_backend": "firecrawl"},
             )
+            monkeypatch.setattr(web_tools, "async_is_safe_url", _safe_url)
             # Sanity: registry IS empty before the tool call.
             assert web_search_registry.get_provider("firecrawl") is None
 

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -215,6 +215,7 @@ class TestWebExtractTavily:
 
         with patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
+             patch("tools.web_tools.async_is_safe_url", return_value=True), \
              patch("tools.web_tools.httpx.post", return_value=mock_response):
             from tools.web_tools import web_extract_tool
             result = json.loads(asyncio.get_event_loop().run_until_complete(

--- a/tests/tui_gateway/test_pet_generate_rpc.py
+++ b/tests/tui_gateway/test_pet_generate_rpc.py
@@ -236,6 +236,7 @@ def test_pet_info_meta_avoids_full_payload(monkeypatch):
         lambda: {"display": {"pet": {"enabled": True, "slug": pet.slug, "scale": 0.7}}},
     )
 
+    server._rpc_result_cache.clear()
     resp = server._methods["pet.info.meta"]("r_meta", {})
     result = resp["result"]
     assert result["enabled"] is True
@@ -243,3 +244,25 @@ def test_pet_info_meta_avoids_full_payload(monkeypatch):
     assert result["displayName"] == "Meta Pet"
     assert result["scale"] == 0.7
     assert ":" in result["spritesheetRevision"]
+
+
+def test_pet_info_revision_short_circuits_full_payload(monkeypatch):
+    import hermes_cli.config as cli_config
+    from agent.pet import constants, store
+
+    sheet = Image.new("RGBA", (constants.FRAME_W * 8, constants.FRAME_H * 9), (80, 120, 220, 255))
+    pet = store.register_local_pet(sheet, slug="meta-pet-rev", display_name="Meta Pet Rev")
+    monkeypatch.setattr(
+        cli_config,
+        "load_config",
+        lambda: {"display": {"pet": {"enabled": True, "slug": pet.slug, "scale": 0.7}}},
+    )
+
+    revision = server._pet_sheet_revision(pet.spritesheet)
+    resp = server._methods["pet.info"]("r_info", {"revision": revision})
+    result = resp["result"]
+
+    assert result["enabled"] is True
+    assert result["unchanged"] is True
+    assert result["spritesheetRevision"] == revision
+    assert "spritesheetBase64" not in result

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -19,6 +19,7 @@ never the child's intermediate tool calls or reasoning.
 import enum
 import json
 import logging
+import shlex
 
 logger = logging.getLogger(__name__)
 import os
@@ -28,8 +29,10 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from hermes_constants import get_default_hermes_root
 from toolsets import TOOLSETS
 
 # Sentinel value used by the runtime provider system for providers that are
@@ -2351,6 +2354,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
+    credential_overrides: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -2426,10 +2430,21 @@ def delegate_task(
     # bundle (base_url, api_key, api_mode) via the same runtime provider system
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
+    if credential_overrides is not None:
+        creds = {
+            "model": credential_overrides.get("model"),
+            "provider": credential_overrides.get("provider"),
+            "base_url": credential_overrides.get("base_url"),
+            "api_key": credential_overrides.get("api_key"),
+            "api_mode": credential_overrides.get("api_mode"),
+            "command": credential_overrides.get("command"),
+            "args": credential_overrides.get("args"),
+        }
+    else:
+        try:
+            creds = _resolve_delegation_credentials(cfg, parent_agent)
+        except ValueError as exc:
+            return tool_error(str(exc))
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2984,6 +2999,16 @@ def _resolve_child_credential_pool(
     return None
 
 
+def _normalize_acp_args(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return shlex.split(value)
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -3010,6 +3035,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
     configured_api_mode = str(cfg.get("api_mode") or "").strip().lower() or None
+    configured_command = str(
+        cfg.get("command") or cfg.get("acp_command") or ""
+    ).strip() or None
+    configured_args = _normalize_acp_args(cfg.get("args", cfg.get("acp_args")))
 
     # Native-SDK providers (Bedrock, Vertex, Google GenAI) speak their own
     # wire protocol — they cannot be reached via OpenAI chat_completions against
@@ -3065,6 +3094,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            "command": configured_command,
+            "args": configured_args,
         }
 
     if not configured_provider:
@@ -3075,6 +3106,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": None,
             "api_key": None,
             "api_mode": None,
+            "command": configured_command,
+            "args": configured_args,
         }
 
     # Provider is configured — resolve full credentials
@@ -3103,9 +3136,87 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
         "api_mode": runtime.get("api_mode"),
-        "command": runtime.get("command"),
-        "args": list(runtime.get("args") or []),
+        "command": configured_command or runtime.get("command"),
+        "args": configured_args or list(runtime.get("args") or []),
     }
+
+
+def _profile_config_path(profile: str) -> Path:
+    profile_name = str(profile or "").strip()
+    if not profile_name:
+        raise ValueError("cost_router requires a non-empty worker profile name.")
+    if profile_name in {".", ".."} or "/" in profile_name or "\\" in profile_name:
+        raise ValueError("worker profile must be a simple profile name, not a path.")
+
+    root = get_default_hermes_root()
+    path = root / "profiles" / profile_name / "config.yaml"
+    profiles_dir = (root / "profiles").resolve()
+    try:
+        path.resolve().relative_to(profiles_dir)
+    except ValueError as exc:
+        raise ValueError("worker profile path escapes the Hermes profiles directory.") from exc
+    return path
+
+
+def _load_worker_profile_config(profile: str) -> dict:
+    path = _profile_config_path(profile)
+    if not path.exists():
+        raise ValueError(f"worker profile '{profile}' has no config.yaml at {path}.")
+    try:
+        import yaml
+
+        with path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as exc:
+        raise ValueError(f"cannot read worker profile '{profile}' config.yaml: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"worker profile '{profile}' config.yaml must contain a mapping.")
+    return data
+
+
+def _worker_profile_delegation_config(profile: str) -> dict:
+    profile_cfg = _load_worker_profile_config(profile)
+    model_cfg = profile_cfg.get("model") or {}
+    if not isinstance(model_cfg, dict):
+        raise ValueError(f"worker profile '{profile}' model config must be a mapping.")
+
+    provider = str(model_cfg.get("provider") or "").strip() or None
+    provider_cfg = {}
+    providers_cfg = profile_cfg.get("providers") or {}
+    if provider and isinstance(providers_cfg, dict):
+        raw_provider_cfg = providers_cfg.get(provider) or {}
+        if isinstance(raw_provider_cfg, dict):
+            provider_cfg = raw_provider_cfg
+
+    cfg = {
+        "model": model_cfg.get("default") or model_cfg.get("model"),
+        "provider": provider,
+        "base_url": model_cfg.get("base_url") or provider_cfg.get("base_url"),
+        "api_key": model_cfg.get("api_key") or provider_cfg.get("api_key"),
+        "api_mode": model_cfg.get("api_mode") or provider_cfg.get("api_mode"),
+        "command": (
+            model_cfg.get("command")
+            or model_cfg.get("acp_command")
+            or provider_cfg.get("command")
+            or provider_cfg.get("acp_command")
+        ),
+        "args": _normalize_acp_args(
+            model_cfg.get("args")
+            or model_cfg.get("acp_args")
+            or provider_cfg.get("args")
+            or provider_cfg.get("acp_args")
+        ),
+    }
+    return {k: v for k, v in cfg.items() if v is not None}
+
+
+def _resolve_worker_profile_credentials(profile: str, parent_agent) -> dict:
+    cfg = _worker_profile_delegation_config(profile)
+    if not (cfg.get("model") or cfg.get("provider") or cfg.get("base_url") or cfg.get("command")):
+        raise ValueError(
+            f"worker profile '{profile}' must define model.default, model.provider, base_url, or command."
+        )
+    return _resolve_delegation_credentials(cfg, parent_agent)
 
 
 def _load_config() -> dict:
@@ -3472,6 +3583,57 @@ DELEGATE_TASK_SCHEMA = {
 }
 
 
+COST_ROUTER_SCHEMA = {
+    "name": "cost_router",
+    "description": (
+        "Route a delegated subtask through a named Hermes worker profile. "
+        "Reads <Hermes root>/profiles/<worker>/config.yaml, resolves its "
+        "model/provider/base_url/api_mode/api_key settings into concrete "
+        "delegation overrides, then dispatches through the normal delegate_task "
+        "runtime. Use this instead of inventing delegate_task(profile=...)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "string",
+                "description": "Worker profile name, e.g. worker-dsflash, worker-dspro, worker-gpt54, worker-gpt55.",
+            },
+            "goal": {
+                "type": "string",
+                "description": "The subtask for the worker profile to complete.",
+            },
+            "context": {
+                "type": "string",
+                "description": "Background information the worker needs. Include source paths, constraints, and requested output shape.",
+            },
+            "tasks": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "goal": {"type": "string"},
+                        "context": {"type": "string"},
+                        "role": {
+                            "type": "string",
+                            "enum": ["leaf", "orchestrator"],
+                        },
+                    },
+                    "required": ["goal"],
+                },
+                "description": "Optional batch of subtasks for the same worker profile. Omit when using goal/context.",
+            },
+            "role": {
+                "type": "string",
+                "enum": ["leaf", "orchestrator"],
+                "description": "Optional child role. Defaults to leaf unless config permits orchestrator nesting.",
+            },
+        },
+        "required": ["profile"],
+    },
+}
+
+
 # --- Registry ---
 from tools.registry import registry, tool_error
 
@@ -3492,6 +3654,25 @@ def _model_background_value(args: dict, parent_agent=None) -> bool:
     return not is_subagent
 
 
+def _handle_cost_router(args: dict, **kw) -> str:
+    profile = str(args.get("profile") or "")
+    parent_agent = kw.get("parent_agent")
+    try:
+        creds = _resolve_worker_profile_credentials(profile, parent_agent)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+    return delegate_task(
+        goal=args.get("goal"),
+        context=args.get("context"),
+        tasks=args.get("tasks"),
+        role=args.get("role"),
+        background=_model_background_value(args, parent_agent),
+        parent_agent=parent_agent,
+        credential_overrides=creds,
+    )
+
+
 registry.register(
     name="delegate_task",
     toolset="delegation",
@@ -3510,4 +3691,13 @@ registry.register(
     check_fn=check_delegate_requirements,
     emoji="🔀",
     dynamic_schema_overrides=_build_dynamic_schema_overrides,
+)
+
+registry.register(
+    name="cost_router",
+    toolset="delegation",
+    schema=COST_ROUTER_SCHEMA,
+    handler=_handle_cost_router,
+    check_fn=check_delegate_requirements,
+    emoji="🧭",
 )

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -483,6 +483,9 @@ _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
     "/private/etc/", "/private/var/",
 )
+_NON_SENSITIVE_SYSTEM_TEMP_PREFIXES = (
+    "/private/var/folders/",
+)
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 _hermes_config_resolved: str | None = None
@@ -509,23 +512,27 @@ def _get_hermes_config_resolved() -> str | None:
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved_path = _resolve_path_for_task(filepath, task_id)
+        resolved = str(resolved_path)
     except (OSError, ValueError):
+        resolved_path = None
         resolved = filepath
-    normalized = os.path.normpath(_expand_tilde(filepath))
+    if resolved_path is not None and Path(filepath).expanduser().is_absolute():
+        normalized = os.path.normpath(str(Path(_expand_tilde(filepath)).resolve()))
+    else:
+        # Relative paths must be classified only after task-cwd resolution;
+        # normalizing them against the agent process cwd can incorrectly treat
+        # ordinary workspace files as /private/var on macOS test runners.
+        normalized = resolved
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
-    for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
-            return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
-        return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or
     # prompt-injected agent could silently disable exec approval by writing to
-    # this file.
+    # this file. Check this before generic system-prefix blocks so macOS
+    # realpaths under /private/var/folders still get the specific diagnostic.
     hermes_config = _get_hermes_config_resolved()
     if hermes_config and (resolved == hermes_config or normalized == hermes_config):
         return (
@@ -533,6 +540,13 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    for prefix in _SENSITIVE_PATH_PREFIXES:
+        resolved_sensitive = resolved.startswith(prefix) and not resolved.startswith(_NON_SENSITIVE_SYSTEM_TEMP_PREFIXES)
+        normalized_sensitive = normalized.startswith(prefix) and not normalized.startswith(_NON_SENSITIVE_SYSTEM_TEMP_PREFIXES)
+        if resolved_sensitive or normalized_sensitive:
+            return _err
+    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+        return _err
     return None
 
 
@@ -920,6 +934,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 # invalidating the stale cache entry (fixes #26211: silent
                 # file-creation failures in long-running conversations).
                 old_cwd = getattr(cached, "cwd", None)
+                if not old_cwd:
+                    old_cwd = getattr(getattr(cached, "env", None), "cwd", None)
                 if old_cwd:
                     with _file_ops_lock:
                         _last_known_cwd[task_id] = old_cwd

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -706,8 +706,6 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
-
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
             # tavily, firecrawl) now live as plugins. The dispatcher is a
             # registry lookup + delegation. Some providers' extract() is
@@ -721,6 +719,7 @@ async def web_extract_tool(
                 get_provider as _wsp_get_provider,
             )
 
+            backend = _get_extract_backend()
             provider = _wsp_get_provider(backend) if backend else None
             if provider is None or not provider.supports_extract():
                 # When the configured name IS registered but doesn't support

--- a/toolsets.py
+++ b/toolsets.py
@@ -62,7 +62,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "cost_router",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
@@ -244,7 +244,7 @@ TOOLSETS = {
     
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "tools": ["delegate_task", "cost_router"],
         "includes": []
     },
 
@@ -357,7 +357,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search", "clarify",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "cost_router",
         ],
         "includes": [],
         # Posture toolset: selected per-session by agent/coding_context.py,
@@ -389,7 +389,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "cost_router",
         ],
         "includes": []
     },
@@ -417,7 +417,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "cost_router",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import copy
+from collections import deque
 import inspect
 import json
 import logging
@@ -145,6 +146,16 @@ try:
 except (ValueError, TypeError):
     _slash_timeout = 45.0
 _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
+_SLASH_WORKER_STDIO_TAIL_LINES = 80
+_SLASH_WORKER_OUTPUT_MAX_BYTES = 16384
+_SLASH_WORKER_SUMMARY_MAX_LINES = 12
+_SLASH_WORKER_STDOUT_QUEUE_MAX = 256
+_RPC_RESULT_CACHE_DEFAULT_TTL_S = 2.0
+_RPC_RESULT_CACHE_TTL_OVERRIDES = {
+    "model.options": 15.0,
+    "pet.info.meta": 5.0,
+    "setup.status": 5.0,
+}
 
 # When a WebSocket client (the dashboard's embedded-chat tab / desktop app)
 # disconnects, ``tui_gateway.ws`` detaches the transport but intentionally
@@ -270,6 +281,51 @@ _stdio_transport = StdioTransport(lambda: _real_stdout, _stdout_lock)
 # the gateway in-process and captures stdout into logs, so stale JSON-RPC frames
 # must not fall through there while the session waits for resume or reap.
 _detached_ws_transport = _DropTransport()
+_local = threading.local()
+_rpc_result_cache_lock = threading.Lock()
+_rpc_result_cache: dict[tuple[str, str], tuple[float, dict]] = {}
+
+
+def _drop_oldest_queue_item(q: queue.Queue) -> bool:
+    """Best-effort drop of one oldest queued item to preserve bounded memory."""
+    try:
+        q.get_nowait()
+        return True
+    except queue.Empty:
+        return False
+
+
+def _cacheable_rpc_params(params: dict | None) -> str:
+    try:
+        return json.dumps(params or {}, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    except Exception:
+        return "{}"
+
+
+def _get_cached_rpc_result(method_name: str, params: dict | None) -> dict | None:
+    ttl = _RPC_RESULT_CACHE_TTL_OVERRIDES.get(method_name, _RPC_RESULT_CACHE_DEFAULT_TTL_S)
+    if ttl <= 0:
+        return None
+    key = (method_name, _cacheable_rpc_params(params))
+    now = time.monotonic()
+    with _rpc_result_cache_lock:
+        cached = _rpc_result_cache.get(key)
+        if cached is None:
+            return None
+        expires_at, payload = cached
+        if expires_at <= now:
+            _rpc_result_cache.pop(key, None)
+            return None
+        return copy.deepcopy(payload)
+
+
+def _set_cached_rpc_result(method_name: str, params: dict | None, payload: dict) -> None:
+    ttl = _RPC_RESULT_CACHE_TTL_OVERRIDES.get(method_name, _RPC_RESULT_CACHE_DEFAULT_TTL_S)
+    if ttl <= 0:
+        return
+    key = (method_name, _cacheable_rpc_params(params))
+    with _rpc_result_cache_lock:
+        _rpc_result_cache[key] = (time.monotonic() + ttl, copy.deepcopy(payload))
 
 
 class _SlashWorker:
@@ -278,8 +334,14 @@ class _SlashWorker:
     def __init__(self, session_key: str, model: str):
         self._lock = threading.Lock()
         self._seq = 0
-        self.stderr_tail: list[str] = []
-        self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
+        self.stderr_tail: deque[str] = deque(maxlen=_SLASH_WORKER_STDIO_TAIL_LINES)
+        self.stdout_tail: deque[str] = deque(maxlen=_SLASH_WORKER_STDIO_TAIL_LINES)
+        self.stdout_bytes = 0
+        self.stderr_bytes = 0
+        self.stdout_lines_dropped = 0
+        self.stderr_lines_dropped = 0
+        self.stdout_queue_dropped = 0
+        self.stdout_queue: queue.Queue[dict | None] = queue.Queue(maxsize=_SLASH_WORKER_STDOUT_QUEUE_MAX)
 
         argv = [
             sys.executable,
@@ -321,16 +383,73 @@ class _SlashWorker:
 
     def _drain_stdout(self):
         for line in self.proc.stdout or []:
+            text = line.rstrip("\n")
+            if text:
+                self._record_stdio_line("stdout", text)
             try:
-                self.stdout_queue.put(json.loads(line))
+                msg = json.loads(line)
             except json.JSONDecodeError:
                 continue
-        self.stdout_queue.put(None)
+            while True:
+                try:
+                    self.stdout_queue.put_nowait(msg)
+                    break
+                except queue.Full:
+                    if not _drop_oldest_queue_item(self.stdout_queue):
+                        break
+                    self.stdout_queue_dropped += 1
+        while True:
+            try:
+                self.stdout_queue.put_nowait(None)
+                break
+            except queue.Full:
+                if not _drop_oldest_queue_item(self.stdout_queue):
+                    break
+                self.stdout_queue_dropped += 1
 
     def _drain_stderr(self):
         for line in self.proc.stderr or []:
             if text := line.rstrip("\n"):
-                self.stderr_tail = (self.stderr_tail + [text])[-80:]
+                self._record_stdio_line("stderr", text)
+
+    def _record_stdio_line(self, stream: str, text: str) -> None:
+        tail = self.stdout_tail if stream == "stdout" else self.stderr_tail
+        attr_bytes = "stdout_bytes" if stream == "stdout" else "stderr_bytes"
+        attr_dropped = "stdout_lines_dropped" if stream == "stdout" else "stderr_lines_dropped"
+        encoded_len = len(text.encode("utf-8", errors="replace"))
+        current_bytes = getattr(self, attr_bytes)
+
+        while tail and current_bytes + encoded_len > _SLASH_WORKER_OUTPUT_MAX_BYTES:
+            removed = tail.popleft()
+            current_bytes -= len(removed.encode("utf-8", errors="replace"))
+            setattr(self, attr_dropped, getattr(self, attr_dropped) + 1)
+
+        if encoded_len > _SLASH_WORKER_OUTPUT_MAX_BYTES:
+            budget = max(0, _SLASH_WORKER_OUTPUT_MAX_BYTES - 3)
+            trimmed = text.encode("utf-8", errors="replace")[:budget].decode("utf-8", errors="ignore")
+            text = trimmed + ("..." if trimmed else "")
+            encoded_len = len(text.encode("utf-8", errors="replace"))
+            setattr(self, attr_dropped, getattr(self, attr_dropped) + 1)
+
+        tail.append(text)
+        setattr(self, attr_bytes, current_bytes + encoded_len)
+
+    def _format_stdio_summary(self, stream: str, *, limit: int = 8) -> str:
+        tail = list(self.stdout_tail if stream == "stdout" else self.stderr_tail)
+        dropped = self.stdout_lines_dropped if stream == "stdout" else self.stderr_lines_dropped
+        label = stream.upper()
+        lines = [f"[{label}] dropped {dropped} earlier line(s); showing last {min(limit, len(tail))}." ] if dropped else []
+        lines.extend(tail[-limit:])
+        return "\n".join(lines).strip()
+
+    def _format_queue_drop_summary(self) -> str:
+        dropped = getattr(self, "stdout_queue_dropped", 0)
+        if dropped <= 0:
+            return ""
+        return (
+            "[STDOUT] dropped "
+            f"{dropped} earlier JSON result message(s) due to slash-worker backlog."
+        )
 
     def run(self, command: str) -> str:
         if self.proc.poll() is not None:
@@ -352,11 +471,22 @@ class _SlashWorker:
                 if msg.get("id") != rid:
                     continue
                 if not msg.get("ok"):
-                    raise RuntimeError(msg.get("error", "slash worker failed"))
+                    summary = self._format_stdio_summary("stderr", limit=_SLASH_WORKER_SUMMARY_MAX_LINES)
+                    queue_summary = self._format_queue_drop_summary()
+                    detail = msg.get("error", "slash worker failed")
+                    extras = [part for part in (summary, queue_summary) if part]
+                    if extras:
+                        detail = f"{detail}\n{chr(10).join(extras)}"
+                    raise RuntimeError(detail)
                 return str(msg.get("output", "")).rstrip()
 
+            stderr_summary = self._format_stdio_summary("stderr", limit=_SLASH_WORKER_SUMMARY_MAX_LINES)
+            stdout_summary = self._format_stdio_summary("stdout", limit=4)
+            queue_summary = self._format_queue_drop_summary()
+            extras = [part for part in (stderr_summary, stdout_summary, queue_summary) if part]
             raise RuntimeError(
-                f"slash worker closed pipe{': ' + chr(10).join(self.stderr_tail[-8:]) if self.stderr_tail else ''}"
+                "slash worker closed pipe"
+                + (f": {chr(10).join(extras)}" if extras else "")
             )
 
     def close(self):
@@ -6459,10 +6589,36 @@ def _(rid, params: dict) -> dict:
     on any error rather than erroring the surface.
     """
     try:
+        if not bool(params.get("force_full")):
+            meta = _methods["pet.info.meta"](rid, params)
+            meta_result = meta.get("result") if isinstance(meta, dict) else None
+            if isinstance(meta_result, dict):
+                requested_revision = str(params.get("revision") or "").strip()
+                current_revision = str(meta_result.get("spritesheetRevision") or "")
+                if not meta_result.get("enabled"):
+                    return _ok(rid, {"enabled": False})
+                if requested_revision and requested_revision == current_revision:
+                    return _ok(rid, {**meta_result, "unchanged": True})
+
         enabled, pet, scale = _pet_active_selection()
 
         if not enabled or pet is None or not pet.exists:
             return _ok(rid, {"enabled": False})
+
+        requested_revision = str(params.get("revision") or "").strip()
+        current_revision = _pet_sheet_revision(pet.spritesheet)
+        if requested_revision and requested_revision == current_revision:
+            return _ok(
+                rid,
+                {
+                    "enabled": True,
+                    "unchanged": True,
+                    "slug": pet.slug,
+                    "displayName": pet.display_name,
+                    "scale": scale,
+                    "spritesheetRevision": current_revision,
+                },
+            )
 
         return _ok(rid, {"enabled": True, **_pet_sprite_payload(pet, scale=scale)})
     except Exception as exc:  # noqa: BLE001 - cosmetic, never break the surface
@@ -6474,11 +6630,16 @@ def _(rid, params: dict) -> dict:
 @_profile_scoped
 def _(rid, params: dict) -> dict:
     """Cheap active-pet metadata used to avoid full payload refreshes."""
+    cached = _get_cached_rpc_result("pet.info.meta", params)
+    if cached is not None:
+        return cached
     try:
         enabled, pet, scale = _pet_active_selection()
         if not enabled or pet is None or not pet.exists:
-            return _ok(rid, {"enabled": False})
-        return _ok(
+            result = _ok(rid, {"enabled": False})
+            _set_cached_rpc_result("pet.info.meta", params, result)
+            return result
+        result = _ok(
             rid,
             {
                 "enabled": True,
@@ -6488,6 +6649,8 @@ def _(rid, params: dict) -> dict:
                 "spritesheetRevision": _pet_sheet_revision(pet.spritesheet),
             },
         )
+        _set_cached_rpc_result("pet.info.meta", params, result)
+        return result
     except Exception as exc:  # noqa: BLE001 - cosmetic, never break the surface
         logger.debug("pet.info.meta failed: %s", exc)
         return _ok(rid, {"enabled": False})
@@ -8236,15 +8399,22 @@ def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
     started the process. Since all desktop sessions share one process-wide
     completion queue, each poller must skip events it doesn't own so a
     background job's completion surfaces in the session that launched it — not
-    whichever poller happened to dequeue first. Orphaned events (owner gone)
-    and global/system events (empty ``session_key``) return False so the
+    whichever poller happened to dequeue first. Orphaned process events (owner
+    gone) and global/system events (empty ``session_key``) return False so the
     current poller still handles them rather than losing them.
+
+    Async-delegation completions are user-visible agent turns, not disposable
+    terminal notifications. If they carry an explicit owner key, an unrelated
+    live session must never consume them as an orphan fallback; keep them queued
+    until the owner session is available.
     """
     evt_key = str(evt.get("session_key") or "")
     if not evt_key:
         return False
     if evt_key == str(session.get("session_key") or ""):
         return False
+    if evt.get("type") == "async_delegation":
+        return True
     try:
         with _sessions_lock:
             snapshot = list(_sessions.values())
@@ -10905,10 +11075,15 @@ def _(rid, params: dict) -> dict:
 
 @method("setup.status")
 def _(rid, params: dict) -> dict:
+    cached = _get_cached_rpc_result("setup.status", params)
+    if cached is not None:
+        return cached
     try:
         from hermes_cli.main import _has_any_provider_configured
 
-        return _ok(rid, {"provider_configured": bool(_has_any_provider_configured())})
+        result = _ok(rid, {"provider_configured": bool(_has_any_provider_configured())})
+        _set_cached_rpc_result("setup.status", params, result)
+        return result
     except Exception as e:
         return _err(rid, 5016, str(e))
 
@@ -12293,6 +12468,10 @@ def _(rid, params: dict) -> dict:
 
 @method("model.options")
 def _(rid, params: dict) -> dict:
+    if not bool(params.get("refresh")):
+        cached = _get_cached_rpc_result("model.options", params)
+        if cached is not None:
+            return cached
     try:
         from hermes_cli.inventory import build_models_payload, load_picker_context
 
@@ -12326,7 +12505,10 @@ def _(rid, params: dict) -> dict:
             capabilities=True,
             refresh=bool(params.get("refresh")),
         )
-        return _ok(rid, payload)
+        result = _ok(rid, payload)
+        if not bool(params.get("refresh")):
+            _set_cached_rpc_result("model.options", params, result)
+        return result
     except Exception as e:
         return _err(rid, 5033, str(e))
 

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -24,32 +24,28 @@ Mounting
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import json
 import logging
 import socket
 import threading
+import time
+from collections import OrderedDict, deque
+from dataclasses import dataclass
 from typing import Any
 
 from tui_gateway import server
 
 _log = logging.getLogger(__name__)
 
-# Max seconds a pool-dispatched handler will block waiting for the event loop
-# to flush a WS frame before we mark the transport dead. Protects handler
-# threads from a wedged socket.
+# Max seconds an inline WS response waits for its queued frame to reach the
+# socket before the caller resumes. Worker-thread writes enqueue only; the
+# single writer task owns all socket sends.
 _WS_WRITE_TIMEOUT_S = 10.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
-# Per-token streaming frames are coalesced: buffered and flushed as a batch on
-# a short timer instead of waking the event loop once per token. A model reply
-# emits hundreds of these in a burst, and each one is a loop wakeup competing
-# with the agent turn for the GIL — coalescing cuts that churn (CF-2). The task
-# that introduced this called them "agent.token"/"agent.thinking"; in this
-# codebase the per-token frames are the ``*.delta`` stream events below. Keep
-# this set to genuinely high-frequency, display-only events — anything a client
-# must see promptly (tool/approval/status/completion frames) is non-streaming
-# and flushes the buffer ahead of itself, so ordering is preserved.
+# Per-token streaming frames are coalesced: buffered and flushed on a fixed
+# cadence instead of waking/sending once per token. A model reply emits hundreds
+# of these in a burst, and each one used to create its own event-loop task.
 _STREAMING_EVENT_TYPES = frozenset({
     "message.delta",
     "reasoning.delta",
@@ -59,6 +55,43 @@ _STREAMING_EVENT_TYPES = frozenset({
 # enough to stay imperceptible to the live token cadence.
 _TOKEN_COALESCE_S = 0.033
 
+# Observation-plane backpressure bounds. The websocket sidecar is a UI/event
+# stream; it must never let arbitrary worker stdout/tool/progress storms create
+# unbounded send tasks or in-memory frame lists. Critical control/RPC frames are
+# kept on their own bounded priority lane; overload there means the connection is
+# no longer safe to use and is closed explicitly.
+_WS_NONCRITICAL_MAX_FRAMES = 256
+_WS_CRITICAL_MAX_FRAMES = 64
+_WS_SEND_BURST = 60
+_WS_SEND_INTERVAL_S = 1.0 / 30.0
+
+_CRITICAL_EVENT_TYPES = frozenset({
+    "approval.request",
+    "clarify.request",
+    "sudo.request",
+    "secret.request",
+    "terminal.read.request",
+    "terminal.write.request",
+    "gateway.ready",
+    "message.complete",
+    "error",
+})
+
+_LATEST_ONLY_EVENT_TYPES = frozenset({
+    "session.info",
+    "status.update",
+    "notification.show",
+    "notification.clear",
+    "pet.info",
+    "pet.info.meta",
+})
+
+_PROGRESS_EVENT_TYPES = frozenset({
+    "preview.restart.progress",
+    "pet.generate.progress",
+    "tool.generating",
+})
+
 # Keep starlette optional at import time; handle_ws uses the real class when
 # it's available and falls back to a generic Exception sentinel otherwise.
 try:
@@ -67,20 +100,21 @@ except ImportError:  # pragma: no cover - starlette is a required install path
     _WebSocketDisconnect = Exception  # type: ignore[assignment]
 
 
+@dataclass(slots=True)
+class _QueuedFrame:
+    line: str
+    waiter: asyncio.Future | None = None
+
+
 class WSTransport:
-    """Per-connection WS transport.
+    """Per-connection WS transport with a bounded single-writer queue.
 
-    ``write`` is safe to call from any thread *other than* the event loop
-    thread that owns the socket. Pool workers (the only real caller) run in
-    their own threads, so marshalling onto the loop via
-    :func:`asyncio.run_coroutine_threadsafe` + ``future.result()`` is correct
-    and deadlock-free there.
-
-    When called from the loop thread itself (e.g. by ``handle_ws`` for an
-    inline response) the same call would deadlock: we'd schedule work onto
-    the loop we're currently blocking. We detect that case and fire-and-
-    forget instead. Callers that need to know when the bytes are on the wire
-    should use :meth:`write_async` from the loop thread.
+    ``write`` is safe to call from any thread. It never sends directly and never
+    creates a per-frame send task; all frames flow through one writer task owned
+    by this transport. Non-critical UI frames are bounded/coalesced. Critical
+    JSON-RPC/control frames are preserved on a priority lane; if that lane
+    overflows, the transport closes explicitly instead of silently dropping
+    control events.
     """
 
     def __init__(
@@ -94,162 +128,330 @@ class WSTransport:
         self._loop = loop
         self._peer = peer
         self._closed = False
-        # Token-coalescing buffer (CF-2). Streamed token frames land here and a
-        # short timer flushes the batch. The lock guards the buffer + the
-        # "armed" flag against the worker threads that call write(); the timer
-        # handle is only ever touched on the loop thread.
-        self._token_lock = threading.Lock()
-        self._pending_tokens: list[str] = []
-        self._token_flush_handle: asyncio.TimerHandle | None = None
-        self._token_flush_armed = False
+        self._lock = threading.Lock()
+        self._critical: deque[_QueuedFrame] = deque()
+        self._streaming: deque[_QueuedFrame] = deque()
+        self._normal: deque[_QueuedFrame] = deque()
+        self._snapshots: OrderedDict[tuple[Any, ...], _QueuedFrame] = OrderedDict()
+        self._dropped_noncritical = 0
+        self._last_backpressure_event = 0.0
+        self._writer_task: asyncio.Task | None = None
+        self._wake_event: asyncio.Event | None = None
+        self._stream_flush_handle: asyncio.TimerHandle | None = None
+        self._next_stream_flush = 0.0
+        self._last_send_at = 0.0
+        self._sent_in_burst = 0
+        self._loop.call_soon_threadsafe(self._ensure_writer)
+
+    @staticmethod
+    def _event_type(obj: dict) -> str | None:
+        if not isinstance(obj, dict) or obj.get("method") != "event":
+            return None
+        params = obj.get("params")
+        if not isinstance(params, dict):
+            return None
+        event_type = params.get("type")
+        return event_type if isinstance(event_type, str) else None
 
     @staticmethod
     def _is_streaming_frame(obj: dict) -> bool:
         """True for high-frequency per-token frames eligible for coalescing."""
+        return WSTransport._event_type(obj) in _STREAMING_EVENT_TYPES
+
+    @staticmethod
+    def _snapshot_key(obj: dict, event_type: str) -> tuple[Any, ...]:
         params = obj.get("params") if isinstance(obj, dict) else None
-        if not isinstance(params, dict):
+        payload = params.get("payload") if isinstance(params, dict) else None
+        sid = params.get("session_id") if isinstance(params, dict) else None
+        if isinstance(payload, dict):
+            if event_type == "status.update":
+                return (event_type, sid, payload.get("kind"))
+            if event_type.startswith("notification."):
+                return (event_type, sid, payload.get("key"))
+            if event_type in _PROGRESS_EVENT_TYPES or event_type.endswith(".progress"):
+                return (
+                    "progress",
+                    event_type,
+                    sid,
+                    payload.get("task_id"),
+                    payload.get("token"),
+                    payload.get("name"),
+                )
+        return (event_type, sid)
+
+    @staticmethod
+    def _noncritical_size(
+        streaming: deque[_QueuedFrame],
+        normal: deque[_QueuedFrame],
+        snapshots: OrderedDict[tuple[Any, ...], _QueuedFrame],
+    ) -> int:
+        return len(streaming) + len(normal) + len(snapshots)
+
+    @staticmethod
+    def _finish_waiter(frame: _QueuedFrame, ok: bool) -> None:
+        waiter = frame.waiter
+        if waiter is not None and not waiter.done():
+            waiter.set_result(ok)
+
+    def _ensure_writer(self) -> None:
+        if self._closed:
+            return
+        if self._wake_event is None:
+            self._wake_event = asyncio.Event()
+        if self._writer_task is None or self._writer_task.done():
+            self._writer_task = self._loop.create_task(self._writer_loop())
+
+    def _wake_writer(self) -> None:
+        if self._closed:
+            return
+        self._ensure_writer()
+        if self._wake_event is not None:
+            self._wake_event.set()
+
+    def _schedule_wake(self) -> None:
+        try:
+            self._loop.call_soon_threadsafe(self._wake_writer)
+        except RuntimeError:
+            self._closed = True
+
+    def _arm_stream_flush_locked(self) -> None:
+        if self._closed or not self._streaming:
+            return
+        now = time.monotonic()
+        if self._next_stream_flush <= now:
+            self._next_stream_flush = now + _TOKEN_COALESCE_S
+        if self._stream_flush_handle is None:
+            delay = max(0.0, self._next_stream_flush - now)
+            self._loop.call_soon_threadsafe(self._schedule_stream_flush, delay)
+
+    def _schedule_stream_flush(self, delay: float) -> None:
+        if self._closed or self._stream_flush_handle is not None:
+            return
+        self._stream_flush_handle = self._loop.call_later(delay, self._stream_flush_due)
+
+    def _stream_flush_due(self) -> None:
+        self._stream_flush_handle = None
+        self._wake_writer()
+
+    def _record_drop_locked(self, reason: str) -> None:
+        self._dropped_noncritical += 1
+        now = time.monotonic()
+        if now - self._last_backpressure_event < 1.0:
+            return
+        self._last_backpressure_event = now
+        line = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {
+                    "type": "stream.backpressure",
+                    "payload": {
+                        "dropped": self._dropped_noncritical,
+                        "reason": reason,
+                        "max_frames": _WS_NONCRITICAL_MAX_FRAMES,
+                    },
+                },
+            },
+            ensure_ascii=False,
+        )
+        self._snapshots[("stream.backpressure", None)] = _QueuedFrame(line)
+
+    def _drop_one_noncritical_locked(self) -> bool:
+        frame: _QueuedFrame | None = None
+        if self._streaming:
+            frame = self._streaming.popleft()
+        elif self._normal:
+            frame = self._normal.popleft()
+        elif self._snapshots:
+            _key, frame = self._snapshots.popitem(last=False)
+        if frame is None:
             return False
-        return params.get("type") in _STREAMING_EVENT_TYPES
+        self._finish_waiter(frame, False)
+        self._record_drop_locked("noncritical_queue_full")
+        return True
+
+    def _enqueue_locked(self, obj: dict, line: str, waiter: asyncio.Future | None = None) -> bool:
+        event_type = self._event_type(obj)
+        frame = _QueuedFrame(line, waiter)
+
+        # JSON-RPC replies/errors and blocking user-control prompts must never be
+        # silently dropped. If even this protected lane is full, explicitly
+        # degrade by closing the transport rather than pretending delivery is OK.
+        if event_type in _CRITICAL_EVENT_TYPES or (event_type is None and obj.get("id") is not None):
+            if len(self._critical) >= _WS_CRITICAL_MAX_FRAMES:
+                self._closed = True
+                self._finish_waiter(frame, False)
+                _log.error(
+                    "ws critical queue overflow peer=%s max=%d — closing transport",
+                    self._peer,
+                    _WS_CRITICAL_MAX_FRAMES,
+                )
+                return False
+            self._critical.append(frame)
+            return True
+
+        if self._is_streaming_frame(obj):
+            while self._noncritical_size(self._streaming, self._normal, self._snapshots) >= _WS_NONCRITICAL_MAX_FRAMES:
+                if not self._drop_one_noncritical_locked():
+                    break
+            self._streaming.append(frame)
+            self._arm_stream_flush_locked()
+            return True
+
+        if event_type in _LATEST_ONLY_EVENT_TYPES or event_type in _PROGRESS_EVENT_TYPES or (
+            isinstance(event_type, str) and event_type.endswith(".progress")
+        ):
+            key = self._snapshot_key(obj, event_type)
+            old = self._snapshots.pop(key, None)
+            if old is not None:
+                self._finish_waiter(old, False)
+            while self._noncritical_size(self._streaming, self._normal, self._snapshots) >= _WS_NONCRITICAL_MAX_FRAMES:
+                if not self._drop_one_noncritical_locked():
+                    break
+            self._snapshots[key] = frame
+            return True
+
+        while self._noncritical_size(self._streaming, self._normal, self._snapshots) >= _WS_NONCRITICAL_MAX_FRAMES:
+            if not self._drop_one_noncritical_locked():
+                break
+        self._normal.append(frame)
+        return True
 
     def write(self, obj: dict) -> bool:
         if self._closed:
             return False
-
         line = json.dumps(obj, ensure_ascii=False)
-
-        try:
-            on_loop = asyncio.get_running_loop() is self._loop
-        except RuntimeError:
-            on_loop = False
-
-        # Coalesce streamed token frames: buffer this frame and arm a short
-        # flush timer instead of waking the loop right now. Cheap and
-        # non-blocking — the worker returns immediately. Ordering is preserved
-        # because every non-streaming frame (below) drains the buffer ahead of
-        # itself.
-        if self._is_streaming_frame(obj):
-            with self._token_lock:
-                self._pending_tokens.append(line)
-                if not self._token_flush_armed:
-                    self._token_flush_armed = True
-                    # call_soon_threadsafe arms the call_later timer on the loop
-                    # thread and is safe to call from a worker or the loop.
-                    self._loop.call_soon_threadsafe(self._arm_token_flush)
-            return not self._closed
-
-        # Non-streaming frame (RPC response, control frame, non-token event):
-        # append it behind any buffered tokens and flush the whole batch NOW so
-        # it can never overtake the tokens that preceded it. The send is
-        # scheduled INSIDE the lock so the on-the-wire order matches the buffer
-        # order even if the coalesce timer fires on the loop at the same moment.
-        from agent.async_utils import safe_schedule_threadsafe
-        with self._token_lock:
-            self._pending_tokens.append(line)
-            batch = self._pending_tokens
-            self._pending_tokens = []
-            if on_loop:
-                # Fire-and-forget — don't block the loop waiting on itself.
-                self._loop.create_task(self._safe_send_many(batch))
-                return True
-            fut = safe_schedule_threadsafe(
-                self._safe_send_many(batch), self._loop
-            )
-            if fut is None:
-                self._closed = True
+        with self._lock:
+            if self._closed:
                 return False
-
-        try:
-            fut.result(timeout=_WS_WRITE_TIMEOUT_S)
-            return not self._closed
-        except concurrent.futures.TimeoutError:  # builtin TimeoutError on 3.11+
-            # The event loop is stalled (GIL-heavy agent turn, delegation
-            # running N children), NOT the socket dead. The send coroutine is
-            # already scheduled and will flush once the loop breathes — latching
-            # _closed here permanently silenced live windows after one slow
-            # write (the "subagent window shows zero streaming" bug). Unblock
-            # the worker thread and keep the transport alive; _safe_send_many
-            # latches on a real socket error when the frame actually fails.
-            _log.warning(
-                "ws write slow (loop stalled >%ss) peer=%s — frame left in flight",
-                _WS_WRITE_TIMEOUT_S, self._peer,
-            )
-            return not self._closed
-        except Exception as exc:
-            self._closed = True
-            _log.warning(
-                "ws write failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
-            )
-            return False
-
-    def _arm_token_flush(self) -> None:
-        """Arm the coalesce timer. Runs on the loop thread (call_soon_threadsafe)."""
-        if self._closed:
-            return
-        self._token_flush_handle = self._loop.call_later(
-            _TOKEN_COALESCE_S, self._flush_tokens
-        )
-
-    def _flush_tokens(self) -> None:
-        """Send buffered tokens as one batch. Runs on the loop thread (timer).
-
-        The send is scheduled under the lock so its wire order is fixed relative
-        to a concurrent non-streaming flush in :meth:`write`.
-        """
-        with self._token_lock:
-            self._token_flush_handle = None
-            self._token_flush_armed = False
-            if not self._pending_tokens or self._closed:
-                self._pending_tokens = []
-                return
-            batch = self._pending_tokens
-            self._pending_tokens = []
-            self._loop.create_task(self._safe_send_many(batch))
+            ok = self._enqueue_locked(obj, line)
+        if ok:
+            self._schedule_wake()
+        return ok and not self._closed
 
     async def write_async(self, obj: dict) -> bool:
-        """Send from the owning event loop. Awaits until the frame is on the wire."""
+        """Queue from the owning event loop and wait until the frame is sent."""
         if self._closed:
             return False
-        # Flush any buffered streamed tokens ahead of this frame (RPC response /
-        # control frame) so it can't overtake the tokens that preceded it.
-        with self._token_lock:
-            pending = self._pending_tokens
-            self._pending_tokens = []
-        if pending:
-            await self._safe_send_many(pending)
-        await self._safe_send(json.dumps(obj, ensure_ascii=False))
-        return not self._closed
+        waiter = self._loop.create_future()
+        line = json.dumps(obj, ensure_ascii=False)
+        with self._lock:
+            if self._closed:
+                return False
+            ok = self._enqueue_locked(obj, line, waiter)
+        if not ok:
+            return False
+        self._wake_writer()
+        try:
+            return bool(await asyncio.wait_for(waiter, timeout=_WS_WRITE_TIMEOUT_S)) and not self._closed
+        except asyncio.TimeoutError:
+            _log.warning(
+                "ws async write slow (loop stalled >%ss) peer=%s — frame left queued",
+                _WS_WRITE_TIMEOUT_S,
+                self._peer,
+            )
+            return not self._closed
 
-    async def _safe_send(self, line: str) -> None:
+    def _pop_next_frame_locked(self) -> tuple[_QueuedFrame | None, float | None]:
+        if self._critical:
+            return self._critical.popleft(), None
+        if self._snapshots:
+            _key, frame = self._snapshots.popitem(last=False)
+            return frame, None
+        now = time.monotonic()
+        if self._streaming:
+            if now < self._next_stream_flush:
+                return None, self._next_stream_flush - now
+            return self._streaming.popleft(), None
+        if self._normal:
+            return self._normal.popleft(), None
+        return None, None
+
+    async def _writer_loop(self) -> None:
+        assert self._wake_event is not None
+        try:
+            while not self._closed:
+                frame: _QueuedFrame | None
+                sleep_for: float | None
+                with self._lock:
+                    frame, sleep_for = self._pop_next_frame_locked()
+
+                if frame is None:
+                    if sleep_for is None:
+                        await self._wake_event.wait()
+                        self._wake_event.clear()
+                    else:
+                        try:
+                            await asyncio.wait_for(self._wake_event.wait(), timeout=sleep_for)
+                            self._wake_event.clear()
+                        except asyncio.TimeoutError:
+                            pass
+                    continue
+
+                if self._sent_in_burst >= _WS_SEND_BURST:
+                    elapsed = time.monotonic() - self._last_send_at
+                    if elapsed < _WS_SEND_INTERVAL_S:
+                        await asyncio.sleep(_WS_SEND_INTERVAL_S - elapsed)
+                    self._sent_in_burst = 0
+
+                ok = await self._safe_send(frame.line)
+                self._finish_waiter(frame, ok)
+                self._last_send_at = time.monotonic()
+                self._sent_in_burst += 1
+        except asyncio.CancelledError:
+            pass
+        finally:
+            with self._lock:
+                queued = [*self._critical, *self._streaming, *self._normal, *self._snapshots.values()]
+                self._critical.clear()
+                self._streaming.clear()
+                self._normal.clear()
+                self._snapshots.clear()
+            for frame in queued:
+                self._finish_waiter(frame, False)
+
+    async def _safe_send(self, line: str) -> bool:
         try:
             await self._ws.send_text(line)
+            return True
         except Exception as exc:
             self._closed = True
             _log.warning(
                 "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
+                self._peer,
+                type(exc).__name__,
+                exc,
             )
-
-    async def _safe_send_many(self, lines: list[str]) -> None:
-        """Send a batch of pre-serialized frames in order on the loop thread."""
-        try:
-            for line in lines:
-                await self._ws.send_text(line)
-        except Exception as exc:
-            self._closed = True
-            _log.warning(
-                "ws send failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
-            )
+            return False
 
     def close(self) -> None:
-        self._closed = True
-        # Cancel any pending coalesce flush. close() runs on the loop thread
-        # (the handle_ws finally), so touching the TimerHandle here is safe.
-        handle = self._token_flush_handle
-        if handle is not None:
-            handle.cancel()
-            self._token_flush_handle = None
+        with self._lock:
+            self._closed = True
+            queued = [*self._streaming, *self._normal, *self._snapshots.values()]
+            self._streaming.clear()
+            self._normal.clear()
+            self._snapshots.clear()
+        for frame in queued:
+            self._finish_waiter(frame, False)
+
+        def _cancel() -> None:
+            handle = self._stream_flush_handle
+            if handle is not None:
+                handle.cancel()
+                self._stream_flush_handle = None
+            task = self._writer_task
+            if task is not None and not task.done():
+                task.cancel()
+            if self._wake_event is not None:
+                self._wake_event.set()
+
+        try:
+            if asyncio.get_running_loop() is self._loop:
+                _cancel()
+            else:
+                self._loop.call_soon_threadsafe(_cancel)
+        except RuntimeError:
+            self._loop.call_soon_threadsafe(_cancel)
 
 
 def _ws_peer_label(ws: Any) -> str:


### PR DESCRIPTION
## Summary
- route `cost_router` through the same parent-agent dispatch path and concurrency caps as `delegate_task`
- preserve worker profile credential/ACP overrides for routed delegation
- harden TUI gateway slash worker/websocket backpressure, RPC caching, auth redirects, and related tool stability
- make ACP and run_agent tests more deterministic/offline-friendly

## Validation
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_agent_guardrails.py tests/tools/test_delegate.py tests/test_toolsets.py tests/test_tui_gateway_server.py tests/test_tui_gateway_ws.py tests/hermes_cli/test_dashboard_auth_401_reauth.py tests/tools/test_file_tools.py tests/tools/test_web_providers.py tests/tools/test_web_tools_tavily.py tests/tui_gateway/test_pet_generate_rpc.py tests/acp --tb=short -q`
- Result: 26 files, 1284 tests passed, 0 failed in 57.9s

## Notes
- This is targeted validation, not a full-suite run.