### PR TITLE
[codex] fix packaged TUI bundle launch

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ graft skills
 graft optional-skills
 graft optional-mcps
 graft locales
+recursive-include hermes_cli/tui_dist *
 # Bundled plugin manifests (plugin.yaml / plugin.yml). Without these the
 # PluginManager scan (hermes_cli/plugins.py) finds zero plugins on installs
 # built from the sdist (e.g. Homebrew, downstream packagers). package-data

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1749,10 +1749,9 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         )
         sys.exit(1)
 
-    if not ext_dir:
-        _ensure_tui_workspace(tui_dir)
-
-    # 1. Prebuilt bundle (nix / packaged release): just run it.
+    # 1. Prebuilt bundle (nix / packaged release): just run it.  Check this
+    # before requiring the source workspace so wheels/Homebrew formulae that
+    # ship hermes_cli/tui_dist but not ui-tui/ can launch normally.
     if not tui_dev:
         if ext_dir:
             p = Path(ext_dir)
@@ -1765,6 +1764,9 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if bundled is not None:
             node = _node_bin("node")
             return [node, "--expose-gc", str(bundled)], bundled.parent
+
+    if not ext_dir:
+        _ensure_tui_workspace(tui_dir)
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.

--- a/tests/hermes_cli/test_tui_bundled.py
+++ b/tests/hermes_cli/test_tui_bundled.py
@@ -18,3 +18,29 @@ def test_tui_returns_none_when_no_bundle(tmp_path):
     from hermes_cli.main import _find_bundled_tui
     result = _find_bundled_tui(hermes_cli_dir=tmp_path / "hermes_cli")
     assert result is None
+
+
+def test_tui_uses_bundled_dist_without_source_workspace(tmp_path, monkeypatch):
+    """Packaged installs may ship hermes_cli/tui_dist but not ui-tui/."""
+    from hermes_cli import main
+
+    bundled = tmp_path / "hermes_cli" / "tui_dist" / "entry.js"
+    bundled.parent.mkdir(parents=True)
+    bundled.write_text("// bundled TUI", encoding="utf-8")
+    project_root = tmp_path / "site-packages"
+    project_root.mkdir()
+
+    def fail_if_workspace_required(_tui_dir):
+        raise AssertionError("source ui-tui workspace should not be required")
+
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setattr(main, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(main, "_find_bundled_tui", lambda: bundled)
+    monkeypatch.setattr(main, "_ensure_tui_workspace", fail_if_workspace_required)
+    monkeypatch.setattr(main, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main.shutil, "which", lambda name: "/usr/bin/node" if name == "node" else None)
+
+    argv, cwd = main._make_tui_argv(project_root / "ui-tui", tui_dev=False)
+
+    assert argv == ["/usr/bin/node", "--expose-gc", str(bundled)]
+    assert cwd == bundled.parent

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -156,6 +156,27 @@ def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
     )
 
 
+def test_bundled_tui_dist_ships_in_both_wheel_and_sdist():
+    """Packaged installs run hermes_cli/tui_dist, not a source ui-tui tree.
+
+    PyPI release builds generate ``hermes_cli/tui_dist/entry.js`` before
+    packaging. Wheels need package-data coverage; Homebrew and other source
+    packagers also need MANIFEST.in coverage so building from the sdist does
+    not drop the generated bundle and fall back to a missing ``ui-tui/``.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    hermes_cli_pkg_data = data["tool"]["setuptools"]["package-data"].get("hermes_cli", [])
+    assert any("tui_dist" in glob for glob in hermes_cli_pkg_data), (
+        "pyproject package-data 'hermes_cli' must ship tui_dist (wheel)"
+    )
+
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "recursive-include hermes_cli/tui_dist" in manifest, (
+        "MANIFEST.in must recursive-include hermes_cli/tui_dist so the sdist "
+        "ships the bundled TUI"
+    )
+
+
 # Minimum non-vulnerable Starlette: CVE-2026-48710 ("BadHost") was fixed in
 # 1.0.1. Anything below that lets a malformed Host header desync
 # ``request.url.path`` from the dispatched ASGI path, bypassing path-based


### PR DESCRIPTION
## Summary

Fixes the Homebrew/Linuxbrew TUI launch failure from #57031 by using the bundled `hermes_cli/tui_dist/entry.js` before requiring a source `ui-tui/` workspace.

This branch preserves the original launcher fix commit from #57087, then adds sdist packaging coverage so source-based packagers such as Homebrew do not drop the generated TUI bundle.

## Root Cause

Packaged installs place Hermes under `site-packages` and do not ship a source `ui-tui/` tree next to `hermes_cli/main.py`. The launcher checked for that missing source workspace before checking the bundled TUI entry point, so Homebrew users exited with a checkout-only `git restore -- ui-tui` recovery hint.

The wheel package data already declared `hermes_cli/tui_dist`, but the sdist manifest did not, which is a separate risk for Homebrew-style source builds.

## Validation

- `uv run --extra dev python -m pytest -q tests/hermes_cli/test_tui_bundled.py tests/hermes_cli/test_tui_npm_install.py tests/test_packaging_metadata.py -o addopts=`
- `uv run --extra dev ruff check hermes_cli/main.py tests/hermes_cli/test_tui_bundled.py tests/test_packaging_metadata.py`
- `git diff --check`
