### PR TITLE
fix(sms): add missing `import re` so standalone SMS send doesn't crash

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -24,6 +24,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import urllib.parse
 from typing import Any, Dict, Optional
 

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -108,6 +108,24 @@ class TestSmsFormatAndTruncate:
         assert result == "a\n\nb"
 
 
+class TestSmsStandaloneStripMarkdown:
+    """Regression for the standalone-send markdown stripper.
+
+    ``_strip_markdown_for_sms`` (used by ``_standalone_send`` — the path
+    ``send_message_tool``/cron take for agent-initiated SMS) calls ``re.sub``,
+    but the module was missing ``import re``. Sending any markdown over SMS
+    therefore raised ``NameError: name 're' is not defined`` and crashed the
+    send. This exercises the real path so the missing import can't regress.
+    """
+
+    def test_strip_markdown_for_sms_does_not_crash(self):
+        from plugins.platforms.sms.adapter import _strip_markdown_for_sms
+
+        out = _strip_markdown_for_sms("**bold** _it_ `code`\n\n\n\ndone")
+        assert "**" not in out and "`" not in out
+        assert "bold" in out and "code" in out and "done" in out
+
+
 # ── Echo prevention ────────────────────────────────────────────────
 
 class TestSmsEchoPrevention:


### PR DESCRIPTION
## What does this PR do?

`_strip_markdown_for_sms` in `plugins/platforms/sms/adapter.py` calls `re.sub`,
but the module has no `import re`. That helper runs in `_standalone_send` — the
path `send_message_tool` and cron delivery take for agent-initiated SMS — so
**sending any markdown-containing SMS raised `NameError: name 're' is not
defined` and crashed the send.** The import was dropped in the bundled-plugin
migration (`560010547`); `SmsAdapter.format_message` was unaffected (it uses the
shared `strip_markdown` helper), so the existing format tests missed it.

Fix: add `import re`.

## Changes

- `plugins/platforms/sms/adapter.py` — add `import re`.
- `tests/gateway/test_sms.py` — add `TestSmsStandaloneStripMarkdown` covering
  `_strip_markdown_for_sms` directly (the real crashing path).

## Tests

```
pytest tests/gateway/test_sms.py -q
→ 40 passed
```

Mutation-verified: removing `import re` fails the new test with
`NameError: name 're' is not defined` at `_strip_markdown_for_sms` (adapter.py:396).

## Type of Change

- [x] 🐛 Bug fix (non-breaking)