### PR TITLE
fix(desktop): enable WSLg window controls overlay

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -48,7 +48,7 @@ const { readWindowsUserEnvVar } = require('./windows-user-env.cjs')
 const { readWslWindowsClipboardImage } = require('./wsl-clipboard-image.cjs')
 const {
   nativeOverlayWidth: computeNativeOverlayWidth,
-  macTitleBarOverlayHeight
+  titleBarOverlayOptions
 } = require('./titlebar-overlay-width.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { readLiveUpdateMarker } = require('./update-marker.cjs')
@@ -533,41 +533,22 @@ function getWindowBackgroundColor() {
   return nativeTheme.shouldUseDarkColors ? '#111111' : '#f7f7f7'
 }
 
-// Transparent WCO — renderer chrome shows through. rgba(0,0,0,0) can fall back
-// to GetFrameColor() on some Electron builds; rgba(1,0,0,0) is the escape hatch.
-const TITLEBAR_OVERLAY_COLOR = 'rgba(1, 0, 0, 0)'
-
 function getTitleBarOverlayOptions() {
-  if (IS_MAC) {
-    // Tahoe (Darwin 25+) misplaces the traffic lights when the overlay has a
-    // nonzero height (electron#49183); 0 there keeps them at the configured
-    // inset. See macTitleBarOverlayHeight.
-    return { height: macTitleBarOverlayHeight({ darwinMajor: DARWIN_MAJOR, titlebarHeight: TITLEBAR_HEIGHT }) }
-  }
-
-  // WSLg paints WCO via the RDP host's own min/max/close, so requesting
-  // an Electron overlay there just leaves a dead gap. Plain Linux (KDE,
-  // GNOME) can use the native overlay — let it through.
-  if (!IS_WINDOWS && IS_WSL) {
-    return false
-  }
-
-  return {
-    color: TITLEBAR_OVERLAY_COLOR,
-    height: TITLEBAR_HEIGHT,
+  return titleBarOverlayOptions({
+    isMac: IS_MAC,
+    darwinMajor: DARWIN_MAJOR,
+    titlebarHeight: TITLEBAR_HEIGHT,
     symbolColor:
       rendererTitleBarTheme && isHexColor(rendererTitleBarTheme.foreground)
         ? rendererTitleBarTheme.foreground
         : nativeTheme.shouldUseDarkColors
           ? '#f7f7f7'
           : '#242424'
-  }
+  })
 }
 
 // Push refreshed overlay options to a live window after a theme/appearance
-// change. No-op only on plain (non-WSL) Linux, where getTitleBarOverlayOptions()
-// returns false; the try/catch additionally guards builds where
-// setTitleBarOverlay isn't supported.
+// change. The try/catch guards builds where setTitleBarOverlay isn't supported.
 function applyTitleBarOverlay(win) {
   const options = getTitleBarOverlayOptions()
   if (!options || typeof options !== 'object') {

--- a/apps/desktop/electron/titlebar-overlay-width.cjs
+++ b/apps/desktop/electron/titlebar-overlay-width.cjs
@@ -1,6 +1,9 @@
 'use strict'
 
 const OVERLAY_FALLBACK_WIDTH = 144
+// Transparent WCO — renderer chrome shows through. rgba(0,0,0,0) can fall back
+// to GetFrameColor() on some Electron builds; rgba(1,0,0,0) is the escape hatch.
+const TITLEBAR_OVERLAY_COLOR = 'rgba(1, 0, 0, 0)'
 
 /**
  * Static pre-layout reservation (px) for the right-side native window-controls
@@ -16,7 +19,7 @@ const OVERLAY_FALLBACK_WIDTH = 144
  *
  * @param {{ isWindows?: boolean, isWsl?: boolean, isMac?: boolean }} opts
  */
-function nativeOverlayWidth({ isWindows = false, isWsl = false, isMac = false } = {}) {
+function nativeOverlayWidth({ isMac = false } = {}) {
   if (isMac) return 0
   return OVERLAY_FALLBACK_WIDTH
 }
@@ -40,4 +43,42 @@ function macTitleBarOverlayHeight({ darwinMajor = 0, titlebarHeight = 0 } = {}) 
   return darwinMajor >= MACOS_TAHOE_DARWIN_MAJOR ? 0 : titlebarHeight
 }
 
-module.exports = { MACOS_TAHOE_DARWIN_MAJOR, OVERLAY_FALLBACK_WIDTH, macTitleBarOverlayHeight, nativeOverlayWidth }
+/**
+ * Options to pass to BrowserWindow `titleBarOverlay`.
+ *
+ * WSLg needs the Electron overlay just like native Windows and plain Linux.
+ * Disabling it while using `titleBarStyle: "hidden"` leaves a frameless window
+ * with no visible min/max/close buttons on common WSLg builds.
+ *
+ * @param {{ isMac?: boolean, isWindows?: boolean, isWsl?: boolean, darwinMajor?: number, titlebarHeight?: number, symbolColor?: string }} opts
+ */
+function titleBarOverlayOptions({
+  isMac = false,
+  isWindows = false,
+  isWsl = false,
+  darwinMajor = 0,
+  titlebarHeight = 0,
+  symbolColor = '#242424'
+} = {}) {
+  void isWindows
+  void isWsl
+
+  if (isMac) {
+    return { height: macTitleBarOverlayHeight({ darwinMajor, titlebarHeight }) }
+  }
+
+  return {
+    color: TITLEBAR_OVERLAY_COLOR,
+    height: titlebarHeight,
+    symbolColor
+  }
+}
+
+module.exports = {
+  MACOS_TAHOE_DARWIN_MAJOR,
+  OVERLAY_FALLBACK_WIDTH,
+  TITLEBAR_OVERLAY_COLOR,
+  macTitleBarOverlayHeight,
+  nativeOverlayWidth,
+  titleBarOverlayOptions
+}

--- a/apps/desktop/electron/titlebar-overlay-width.test.cjs
+++ b/apps/desktop/electron/titlebar-overlay-width.test.cjs
@@ -4,8 +4,10 @@ const test = require('node:test')
 const {
   MACOS_TAHOE_DARWIN_MAJOR,
   OVERLAY_FALLBACK_WIDTH,
+  TITLEBAR_OVERLAY_COLOR,
   macTitleBarOverlayHeight,
-  nativeOverlayWidth
+  nativeOverlayWidth,
+  titleBarOverlayOptions
 } = require('./titlebar-overlay-width.cjs')
 
 // This static reservation is only the pre-layout FALLBACK. Once laid out the
@@ -51,4 +53,62 @@ test('Tahoe (Darwin 25+) drops the overlay height to 0 to avoid electron#49183',
 
 test('macTitleBarOverlayHeight tolerates missing args (unknown platform → 0)', () => {
   assert.equal(macTitleBarOverlayHeight(), 0)
+})
+
+test('WSLg gets Electron titlebar overlay options', () => {
+  assert.deepEqual(
+    titleBarOverlayOptions({
+      isWsl: true,
+      titlebarHeight: 34,
+      symbolColor: '#f7f7f7'
+    }),
+    {
+      color: TITLEBAR_OVERLAY_COLOR,
+      height: 34,
+      symbolColor: '#f7f7f7'
+    }
+  )
+})
+
+test('plain Linux keeps Electron titlebar overlay options', () => {
+  assert.deepEqual(
+    titleBarOverlayOptions({
+      isWindows: false,
+      isWsl: false,
+      titlebarHeight: 34,
+      symbolColor: '#242424'
+    }),
+    {
+      color: TITLEBAR_OVERLAY_COLOR,
+      height: 34,
+      symbolColor: '#242424'
+    }
+  )
+})
+
+test('Windows gets Electron titlebar overlay options', () => {
+  assert.deepEqual(
+    titleBarOverlayOptions({
+      isWindows: true,
+      titlebarHeight: 34,
+      symbolColor: '#f7f7f7'
+    }),
+    {
+      color: TITLEBAR_OVERLAY_COLOR,
+      height: 34,
+      symbolColor: '#f7f7f7'
+    }
+  )
+})
+
+test('macOS titlebar overlay options only carry the traffic-light height', () => {
+  assert.deepEqual(
+    titleBarOverlayOptions({
+      isMac: true,
+      darwinMajor: MACOS_TAHOE_DARWIN_MAJOR - 1,
+      titlebarHeight: 34,
+      symbolColor: '#f7f7f7'
+    }),
+    { height: 34 }
+  )
 })


### PR DESCRIPTION
Summary
- Enable Electron titlebar overlay options for WSLg instead of returning false.
- Move the overlay option decision into the tested titlebar helper.
- Add platform coverage for WSLg, plain Linux, Windows, and macOS overlay options.

Problem
WSLg windows used titleBarStyle hidden while titleBarOverlay was disabled, so common WSLg builds showed no visible minimize, maximize, or close buttons.

Validation
- node --test apps/desktop/electron/titlebar-overlay-width.test.cjs
- node --check apps/desktop/electron/main.cjs
- node --check apps/desktop/electron/titlebar-overlay-width.cjs
- node --check apps/desktop/electron/titlebar-overlay-width.test.cjs
- npm --workspace apps/desktop exec eslint -- electron/main.cjs electron/titlebar-overlay-width.cjs electron/titlebar-overlay-width.test.cjs

Refs #57614