### PR TITLE
fix: handle JSON string `models` field in custom provider config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1408,6 +1408,20 @@ def _normalize_custom_provider_entry(
         normalized["model"] = model_name.strip()
 
     models = entry.get("models")
+    if isinstance(models, str) and models.strip():
+        # Hand-edited configs or ``hermes config set`` may store ``models`` as
+        # a JSON-encoded string (e.g. '["model-a","model-b"]').  Parse it so
+        # the normalizer doesn't silently drop the list and /model shows the
+        # provider with (0) models.
+        import json as _json
+        try:
+            decoded = _json.loads(models)
+            if isinstance(decoded, list):
+                models = decoded
+            elif isinstance(decoded, dict):
+                models = decoded
+        except (ValueError, TypeError):
+            pass  # not JSON — leave as-is (will be skipped below)
     if isinstance(models, dict) and models:
         # Shallow-copy: `entry` may alias a cached config sub-dict, and the
         # normalized entry escapes into long-lived runtime state

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -67,4 +67,43 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
 
+    def test_models_json_string_list_decoded(self):
+        """A JSON-encoded string for ``models`` (e.g. '["model-a","model-b"]')
+        must be decoded into a list so the normalizer doesn't drop it."""
+        import json
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "***",
+            "models": json.dumps(["model-a", "model-b"]),
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert "models" in result
+        assert set(result["models"].keys()) == {"model-a", "model-b"}
+
+    def test_models_json_string_dict_decoded(self):
+        """A JSON-encoded string for ``models`` as a dict is also decoded."""
+        import json
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "***",
+            "models": json.dumps({"model-a": {}, "model-b": {}}),
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert "models" in result
+        assert set(result["models"].keys()) == {"model-a", "model-b"}
+
+    def test_models_non_json_string_falls_through(self):
+        """A plain string that isn't valid JSON must not crash — it's left
+        as-is and silently dropped by the downstream dict/list checks."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "***",
+            "models": "not-json",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert "models" not in result
+
 


### PR DESCRIPTION
## Problem

When `models` is stored as a JSON string (e.g. from `hermes config set` which writes it as a YAML string), the normalizer in `_normalize_custom_provider_entry()` silently dropped it — it only handled `dict` and `list` types. This caused the provider to show **0 models** in the `/model` picker, and since the entry was also missing `base_url` (stored at the top-level `model:` section), the picker fell through to live discovery, returning the endpoint's full 20k-model catalog.

## Fix

Added `json.loads()` parsing for the `models` field when it's a string in three locations:

- `config.py` — `_normalize_custom_provider_entry()`: parse JSON string to list, then convert to the dict shape downstream expects
- `model_switch.py` — section 3 (`user_providers` dict) and section 4 (`custom_providers` list): same string-parsing fix
- `main.py` — `_model_flow_named_custom()`: same fix for the interactive `hermes model` flow

## Testing

All 70 existing tests pass:
```
tests/hermes_cli/test_model_switch_custom_providers.py
tests/hermes_cli/test_custom_provider_model_switch.py
tests/hermes_cli/test_user_providers_model_switch.py
```

Verified end-to-end: custom provider now shows 20 configured models, `discover_models: false` prevents the live fetch, and the provider is marked as current.