### PR TITLE
feat(voice): add TUI draft/refine transcript flow

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1551,6 +1551,14 @@ DEFAULT_CONFIG = {
             "timeout": 30,
             "extra_body": {},
         },
+        "voice_refine": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 30,
+            "extra_body": {},
+        },
         # Triage specifier — flesh out a rough one-liner in the Kanban
         # Triage column into a concrete spec, then promote it to ``todo``.
         # Invoked by ``hermes kanban specify`` (single id or --all). Set a
@@ -2034,11 +2042,17 @@ DEFAULT_CONFIG = {
 
     "voice": {
         "record_key": "ctrl+b",
+        "submit_mode": "direct",       # direct = submit transcript immediately; draft = place transcript in composer
         "max_recording_seconds": 120,
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "refine": {
+            "enabled": False,        # Opt-in TUI transcript cleanup via auxiliary.voice_refine
+            "mode": "medium",       # light | medium | strict — conservative, language-agnostic cleanup intensity
+            "min_chars": 40,         # Skip very short transcripts; avoids latency/spend for one-word commands
+        },
     },
     
     "human_delay": {

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -664,6 +664,117 @@ def test_voice_toggle_tts_branch_also_carries_record_key(monkeypatch):
     assert tts_resp["result"]["tts"] is True
 
 
+def _voice_refine_llm_response(text: str):
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=text))]
+    )
+
+
+def test_voice_refine_disabled_returns_original_without_llm(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"refine": {"enabled": False}}})
+
+    def fail_call_llm(**_kwargs):
+        raise AssertionError("voice.refine should not call an LLM when disabled")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.auxiliary_client",
+        types.SimpleNamespace(call_llm=fail_call_llm),
+    )
+
+    resp = server.dispatch(
+        {
+            "id": "voice-refine-disabled",
+            "method": "voice.refine",
+            "params": {"text": "  ähm bitte morgen testen  "},
+        }
+    )
+
+    assert resp is not None
+    assert "result" in resp
+    assert resp["result"] == {
+        "changed": False,
+        "reason": "disabled",
+        "text": "ähm bitte morgen testen",
+    }
+
+
+def test_voice_refine_uses_auxiliary_llm_with_language_agnostic_prompt(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"voice": {"refine": {"enabled": True, "mode": "medium", "min_chars": 1}}},
+    )
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _voice_refine_llm_response("Kannst du morgen die App testen?")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.auxiliary_client",
+        types.SimpleNamespace(call_llm=fake_call_llm),
+    )
+
+    resp = server.dispatch(
+        {
+            "id": "voice-refine",
+            "method": "voice.refine",
+            "params": {"text": "Ähm kannst du morgen morgen die App testen?"},
+        }
+    )
+
+    assert resp is not None
+    assert "result" in resp
+    assert resp["result"] == {
+        "changed": True,
+        "mode": "medium",
+        "reason": "refined",
+        "text": "Kannst du morgen die App testen?",
+    }
+    assert captured["task"] == "voice_refine"
+    assert captured["temperature"] == 0
+    assert captured["max_tokens"] >= 128
+    system_prompt = captured["messages"][0]["content"]
+    assert "same language" in system_prompt
+    assert "Do not translate" in system_prompt
+    assert "When uncertain, keep the original wording" in system_prompt
+    assert "ähm" not in system_prompt.lower()
+
+
+def test_voice_refine_rejects_output_that_drops_protected_tokens(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"voice": {"refine": {"enabled": True, "mode": "strict", "min_chars": 1}}},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.auxiliary_client",
+        types.SimpleNamespace(
+            call_llm=lambda **_kwargs: _voice_refine_llm_response("Bitte deployen."),
+        ),
+    )
+
+    original = "Bitte deploye /tmp/app auf Port 443 und ping ops@example.com."
+    resp = server.dispatch(
+        {
+            "id": "voice-refine-protected",
+            "method": "voice.refine",
+            "params": {"text": original},
+        }
+    )
+
+    assert resp is not None
+    assert "result" in resp
+    assert resp["result"] == {
+        "changed": False,
+        "reason": "validation_failed",
+        "text": original,
+    }
+
+
 def test_load_enabled_toolsets_prefers_tui_env(monkeypatch):
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "web, terminal, ,memory")
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -682,7 +682,7 @@ def test_voice_refine_disabled_returns_original_without_llm(monkeypatch):
         types.SimpleNamespace(call_llm=fail_call_llm),
     )
 
-    resp = server.dispatch(
+    resp = server.handle_request(
         {
             "id": "voice-refine-disabled",
             "method": "voice.refine",
@@ -697,6 +697,47 @@ def test_voice_refine_disabled_returns_original_without_llm(monkeypatch):
         "reason": "disabled",
         "text": "ähm bitte morgen testen",
     }
+
+
+def test_voice_refine_dispatch_runs_on_long_handler_pool(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"voice": {"refine": {"enabled": True, "mode": "medium", "min_chars": 1}}},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.auxiliary_client",
+        types.SimpleNamespace(
+            call_llm=lambda **_kwargs: _voice_refine_llm_response("clean transcript"),
+        ),
+    )
+
+    written: list[dict] = []
+    done = threading.Event()
+
+    class CaptureTransport:
+        def write(self, obj: dict) -> bool:
+            written.append(obj)
+            done.set()
+            return True
+
+        def close(self) -> None:
+            return None
+
+    resp = server.dispatch(
+        {
+            "id": "voice-refine-pooled",
+            "method": "voice.refine",
+            "params": {"text": "um clean transcript"},
+        },
+        transport=CaptureTransport(),
+    )
+
+    assert resp is None
+    assert done.wait(2)
+    assert written[0]["id"] == "voice-refine-pooled"
+    assert written[0]["result"]["text"] == "clean transcript"
 
 
 def test_voice_refine_uses_auxiliary_llm_with_language_agnostic_prompt(monkeypatch):
@@ -717,7 +758,7 @@ def test_voice_refine_uses_auxiliary_llm_with_language_agnostic_prompt(monkeypat
         types.SimpleNamespace(call_llm=fake_call_llm),
     )
 
-    resp = server.dispatch(
+    resp = server.handle_request(
         {
             "id": "voice-refine",
             "method": "voice.refine",
@@ -758,7 +799,7 @@ def test_voice_refine_rejects_output_that_drops_protected_tokens(monkeypatch):
     )
 
     original = "Bitte deploye /tmp/app auf Port 443 und ping ops@example.com."
-    resp = server.dispatch(
+    resp = server.handle_request(
         {
             "id": "voice-refine-protected",
             "method": "voice.refine",
@@ -768,6 +809,46 @@ def test_voice_refine_rejects_output_that_drops_protected_tokens(monkeypatch):
 
     assert resp is not None
     assert "result" in resp
+    assert resp["result"] == {
+        "changed": False,
+        "reason": "validation_failed",
+        "text": original,
+    }
+
+
+@pytest.mark.parametrize(
+    ("original", "cleaned"),
+    [
+        ("Bitte nutze 5 statt 15.", "Bitte nutze 15."),
+        ("Bitte zahle €5 statt €15.", "Bitte zahle €15."),
+        ("Bitte öffne /tmp/app statt /tmp/application.", "Bitte öffne /tmp/application."),
+    ],
+)
+def test_voice_refine_rejects_structured_token_substring_changes(
+    monkeypatch, original, cleaned
+):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"voice": {"refine": {"enabled": True, "mode": "strict", "min_chars": 1}}},
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.auxiliary_client",
+        types.SimpleNamespace(
+            call_llm=lambda **_kwargs: _voice_refine_llm_response(cleaned),
+        ),
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "voice-refine-substring-token",
+            "method": "voice.refine",
+            "params": {"text": original},
+        }
+    )
+
+    assert resp is not None
     assert resp["result"] == {
         "changed": False,
         "reason": "validation_failed",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import time
 import uuid
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
@@ -230,6 +231,7 @@ _LONG_HANDLERS = frozenset(
         "shell.exec",
         "skills.manage",
         "slash.exec",
+        "voice.refine",
     }
 )
 
@@ -12844,7 +12846,7 @@ def _voice_refine_protected_tokens(text: str) -> list[str]:
     tokens: list[str] = []
     for match in _VOICE_REFINE_PROTECTED_RE.finditer(text):
         token = match.group(0).strip().strip(".,;:!?)]}\"'")
-        if token and token not in tokens:
+        if token:
             tokens.append(token)
     return tokens
 
@@ -12871,9 +12873,9 @@ def _voice_refine_valid(original: str, cleaned: str) -> bool:
     if len(cleaned) > len(original) * 2 + 120:
         return False
 
-    cleaned_norm = cleaned
-    for token in _voice_refine_protected_tokens(original):
-        if token not in cleaned_norm:
+    cleaned_tokens = Counter(_voice_refine_protected_tokens(cleaned))
+    for token, count in Counter(_voice_refine_protected_tokens(original)).items():
+        if cleaned_tokens[token] < count:
             return False
     return True
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import re
 import subprocess
 import sys
 import threading
@@ -12713,6 +12714,212 @@ def _voice_record_key() -> str:
     record_key = _voice_cfg_dict().get("record_key")
 
     return str(record_key) if isinstance(record_key, str) and record_key else "ctrl+b"
+
+
+_VOICE_REFINE_TASK = "voice_refine"
+_VOICE_REFINE_MODES = {"light", "medium", "strict"}
+_VOICE_REFINE_DEFAULT_MODE = "medium"
+_VOICE_REFINE_DEFAULT_MIN_CHARS = 40
+_VOICE_REFINE_SYSTEM_PROMPT = """You are a conservative dictation transcript cleaner.
+
+Return only the cleaned transcript. No explanations. No Markdown.
+
+You are cleaning speech-to-text dictation, not rewriting prose.
+
+Cleanup intensity: {mode}
+- light: minimal cleanup only; fix punctuation, capitalization, spacing, and obvious transcript artifacts.
+- medium: remove clear disfluencies, hesitation sounds, filler phrases, accidental repeats, false starts, and immediate self-corrections while preserving the speaker's style.
+- strict: remove more disfluencies than medium, but still never rewrite, summarize, translate, or polish the content.
+
+Core goals:
+- Preserve the speaker's meaning, intent, tone, style, language, and order of ideas.
+- Keep the output in the same language or mix of languages as the input.
+- Improve readability only where the change is clearly a transcript cleanup.
+
+Allowed:
+- Remove clear speech disfluencies, hesitation sounds, filler words, filler phrases, accidental repeated words, false starts, and immediate self-corrections.
+- Add or fix punctuation, capitalization, paragraph breaks, and spacing when obvious.
+- Correct obvious speech-to-text errors only when the intended wording is highly certain from context.
+- Keep casual wording casual and formal wording formal.
+
+Forbidden:
+- Do not translate.
+- Do not summarize.
+- Do not paraphrase.
+- Do not make the text more professional, polite, concise, persuasive, or polished.
+- Do not reorder ideas.
+- Do not add context, explanations, assumptions, or inferred intent.
+- Do not remove content unless it is clearly filler, repetition, or a false start.
+- Do not change names, numbers, URLs, code, file paths, commands, quoted text, handles, or domain-specific terms unless the correction is obvious.
+
+When uncertain, keep the original wording.
+
+Priority:
+Meaning preservation > readability > filler removal.
+A slightly messy faithful transcript is better than a fluent rewrite."""
+
+# Tokens whose accidental loss is more harmful than a slightly messy transcript.
+# This is intentionally language-agnostic: protect structured facts, not filler
+# vocabularies.  The model owns language-specific cleanup decisions.
+_VOICE_REFINE_PROTECTED_RE = re.compile(
+    r"(?ix)"
+    r"(?:https?://\S+|www\.\S+)"
+    r"|(?:[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})"
+    r"|(?:`[^`]+`)"
+    r"|(?:[$€£¥]\s?\d[\d.,]*(?:[kKmMbB])?)"
+    r"|(?:\b\d+(?:[.,:]\d+)*(?:[%kKmMbB])?\b)"
+    r"|(?:@[A-Z0-9_][A-Z0-9_.-]*)"
+    r"|(?:\B\#[A-Z0-9_][A-Z0-9_.-]*)"
+    r"|(?:(?<!\w)(?:~?/|\.\.?/)[^\s]+)"
+    r"|(?:\b[A-Z]:\\[^\s]+)"
+)
+
+
+def _voice_refine_cfg_dict() -> dict:
+    refine = _voice_cfg_dict().get("refine")
+    return refine if isinstance(refine, dict) else {}
+
+
+def _voice_refine_enabled() -> bool:
+    return is_truthy_value(_voice_refine_cfg_dict().get("enabled", False))
+
+
+def _voice_refine_mode(raw: Any = None) -> str:
+    mode = str(raw or _voice_refine_cfg_dict().get("mode") or "").strip().lower()
+    return mode if mode in _VOICE_REFINE_MODES else _VOICE_REFINE_DEFAULT_MODE
+
+
+def _voice_refine_min_chars() -> int:
+    raw = _voice_refine_cfg_dict().get("min_chars", _VOICE_REFINE_DEFAULT_MIN_CHARS)
+    if isinstance(raw, bool):
+        return _VOICE_REFINE_DEFAULT_MIN_CHARS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _VOICE_REFINE_DEFAULT_MIN_CHARS
+    return max(0, min(value, 10_000))
+
+
+def _voice_refine_prompt(mode: str) -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": _VOICE_REFINE_SYSTEM_PROMPT.format(mode=mode)},
+        {
+            "role": "user",
+            "content": (
+                "Clean this speech-to-text transcript. Return only the cleaned transcript.\n\n"
+                "Transcript:\n{transcript}"
+            ),
+        },
+    ]
+
+
+def _voice_refine_messages(text: str, mode: str) -> list[dict[str, str]]:
+    messages = _voice_refine_prompt(mode)
+    messages[1] = {
+        **messages[1],
+        "content": messages[1]["content"].format(transcript=text),
+    }
+    return messages
+
+
+def _voice_refine_extract_response_text(response: Any) -> str:
+    try:
+        content = response.choices[0].message.content
+    except Exception:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text") or block.get("content")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts).strip()
+    return ""
+
+
+def _voice_refine_protected_tokens(text: str) -> list[str]:
+    tokens: list[str] = []
+    for match in _VOICE_REFINE_PROTECTED_RE.finditer(text):
+        token = match.group(0).strip().strip(".,;:!?)]}\"'")
+        if token and token not in tokens:
+            tokens.append(token)
+    return tokens
+
+
+def _voice_refine_meta_leak(text: str) -> bool:
+    lowered = text.strip().lower()
+    return lowered.startswith(
+        (
+            "here is",
+            "here's",
+            "cleaned transcript",
+            "the cleaned transcript",
+            "sure,",
+            "```",
+        )
+    )
+
+
+def _voice_refine_valid(original: str, cleaned: str) -> bool:
+    if not cleaned or _voice_refine_meta_leak(cleaned):
+        return False
+    if len(original) >= 80 and len(cleaned) < max(20, int(len(original) * 0.35)):
+        return False
+    if len(cleaned) > len(original) * 2 + 120:
+        return False
+
+    cleaned_norm = cleaned
+    for token in _voice_refine_protected_tokens(original):
+        if token not in cleaned_norm:
+            return False
+    return True
+
+
+@method("voice.refine")
+def _(rid, params: dict) -> dict:
+    """Conservatively clean a voice transcript using the auxiliary LLM router.
+
+    The TUI calls this only when ``voice.refine.enabled`` is true.  The method
+    still checks the gate itself so direct RPC calls cannot accidentally spend
+    tokens.  All language-specific cleanup is delegated to the configured model;
+    local validation only protects structured tokens and obvious meta-output.
+    """
+    original = str(params.get("text") or "").strip()
+    if not original:
+        return _err(rid, 4021, "text required")
+    if not _voice_refine_enabled():
+        return _ok(rid, {"text": original, "changed": False, "reason": "disabled"})
+
+    min_chars = _voice_refine_min_chars()
+    if min_chars and len(original) < min_chars:
+        return _ok(rid, {"text": original, "changed": False, "reason": "too_short"})
+
+    mode = _voice_refine_mode(params.get("mode"))
+    try:
+        from agent.auxiliary_client import call_llm
+
+        response = call_llm(
+            task=_VOICE_REFINE_TASK,
+            messages=_voice_refine_messages(original, mode),
+            temperature=0,
+            max_tokens=min(2048, max(128, len(original) // 2 + 64)),
+        )
+        cleaned = _voice_refine_extract_response_text(response)
+    except Exception as e:
+        logger.warning("voice.refine failed; using original transcript: %s", e)
+        return _ok(rid, {"text": original, "changed": False, "reason": "llm_error"})
+
+    if not _voice_refine_valid(original, cleaned):
+        logger.warning("voice.refine rejected unsafe cleanup; using original transcript")
+        return _ok(rid, {"text": original, "changed": False, "reason": "validation_failed"})
+
+    if cleaned == original:
+        return _ok(rid, {"text": original, "changed": False, "reason": "unchanged", "mode": mode})
+
+    return _ok(rid, {"text": cleaned, "changed": True, "reason": "refined", "mode": mode})
 
 
 @method("voice.toggle")

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -17,6 +17,18 @@ vi.mock('../lib/openExternalUrl.js', () => ({
 
 const ref = <T>(current: T) => ({ current })
 
+const deferred = <T>() => {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, reject, resolve }
+}
+
 const buildCtx = (appended: Msg[]) =>
   ({
     composer: {
@@ -109,6 +121,43 @@ describe('createGatewayEventHandler', () => {
     await vi.waitFor(() => expect(ctx.gateway.rpc).toHaveBeenCalledWith('voice.refine', { text: 'um please please test this' }))
     await vi.waitFor(() => expect(ctx.submission.submitRef.current).toHaveBeenCalledWith('please test this'))
     expect(ctx.composer.setInput).toHaveBeenCalledWith('')
+  })
+
+  it('serializes refined voice transcripts so submissions keep speech order', async () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const refineCalls: Array<ReturnType<typeof deferred<{ text: string }>> & { rawText: string }> = []
+    ctx.gateway.rpc = vi.fn((method: string, params: any) => {
+      if (method === 'config.get') {
+        return Promise.resolve({ config: { voice: { refine: { enabled: true }, submit_mode: 'direct' } } })
+      }
+
+      if (method === 'voice.refine') {
+        const call = { ...deferred<{ text: string }>(), rawText: params.text }
+        refineCalls.push(call)
+
+        return call.promise
+      }
+
+      return Promise.resolve(null)
+    })
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { text: 'first raw' }, type: 'voice.transcript' } as any)
+    onEvent({ payload: { text: 'second raw' }, type: 'voice.transcript' } as any)
+
+    await vi.waitFor(() => expect(refineCalls).toHaveLength(1))
+    expect(refineCalls[0].rawText).toBe('first raw')
+    refineCalls[0].resolve({ text: 'first refined' })
+
+    await vi.waitFor(() => expect(ctx.submission.submitRef.current).toHaveBeenCalledWith('first refined'))
+    await vi.waitFor(() => expect(refineCalls).toHaveLength(2))
+    expect(refineCalls[1].rawText).toBe('second raw')
+    refineCalls[1].resolve({ text: 'second refined' })
+
+    await vi.waitFor(() => expect(ctx.submission.submitRef.current).toHaveBeenCalledWith('second refined'))
+    expect(ctx.submission.submitRef.current).toHaveBeenNthCalledWith(1, 'first refined')
+    expect(ctx.submission.submitRef.current).toHaveBeenNthCalledWith(2, 'second refined')
   })
 
   it('falls back to the original voice transcript when refine fails', async () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -66,6 +66,73 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
+  it('keeps voice transcripts as editable drafts when voice.submit_mode is draft', async () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { voice: { refine: { enabled: false }, submit_mode: 'draft' } } }
+      }
+
+      return null
+    })
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { text: '  please check this  ' }, type: 'voice.transcript' } as any)
+
+    await vi.waitFor(() => expect(ctx.composer.setInput).toHaveBeenCalledWith('please check this'))
+    expect(ctx.submission.submitRef.current).not.toHaveBeenCalled()
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.get', { key: 'full' })
+    expect(ctx.gateway.rpc).not.toHaveBeenCalledWith('voice.refine', expect.anything())
+  })
+
+  it('refines voice transcripts before direct submit when enabled', async () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.gateway.rpc = vi.fn(async (method: string, params: any) => {
+      if (method === 'config.get') {
+        return { config: { voice: { refine: { enabled: true }, submit_mode: 'direct' } } }
+      }
+
+      if (method === 'voice.refine') {
+        expect(params.text).toBe('um please please test this')
+
+        return { changed: true, text: 'please test this' }
+      }
+
+      return null
+    })
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { text: 'um please please test this' }, type: 'voice.transcript' } as any)
+
+    await vi.waitFor(() => expect(ctx.gateway.rpc).toHaveBeenCalledWith('voice.refine', { text: 'um please please test this' }))
+    await vi.waitFor(() => expect(ctx.submission.submitRef.current).toHaveBeenCalledWith('please test this'))
+    expect(ctx.composer.setInput).toHaveBeenCalledWith('')
+  })
+
+  it('falls back to the original voice transcript when refine fails', async () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { voice: { refine: { enabled: true }, submit_mode: 'direct' } } }
+      }
+
+      if (method === 'voice.refine') {
+        throw new Error('provider offline')
+      }
+
+      return null
+    })
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { text: 'keep original' }, type: 'voice.transcript' } as any)
+
+    await vi.waitFor(() => expect(ctx.submission.submitRef.current).toHaveBeenCalledWith('keep original'))
+    expect(ctx.system.sys).toHaveBeenCalledWith(expect.stringContaining('voice refine failed'))
+  })
+
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -126,6 +126,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   let pendingThinkingStatus = ''
   let thinkingStatusTimer: null | ReturnType<typeof setTimeout> = null
   let startupPromptSubmitted = false
+  let voiceTranscriptChain: Promise<void> = Promise.resolve()
 
   // Request IDs of clarify prompts we've already flushed to the transcript as
   // an abandoned-prompt record, so the tool.complete and message.complete
@@ -222,33 +223,38 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     setTimeout(() => submitRef.current(text), 0)
   }
 
-  const handleVoiceTranscript = (rawText: string) => {
-    void (async () => {
-      const cfg = await getFullConfigOnce()
-      const voiceCfg = cfg?.config?.voice
-      const voiceRecord = isRecord(voiceCfg) ? voiceCfg : {}
-      const submitMode = normalizeVoiceSubmitMode(voiceRecord.submit_mode)
-      let text = rawText
+  const processVoiceTranscript = async (rawText: string) => {
+    const cfg = await getFullConfigOnce()
+    const voiceCfg = cfg?.config?.voice
+    const voiceRecord = isRecord(voiceCfg) ? voiceCfg : {}
+    const submitMode = normalizeVoiceSubmitMode(voiceRecord.submit_mode)
+    let text = rawText
 
-      if (isVoiceRefineEnabled(voiceRecord.refine)) {
-        setVoiceProcessing(true)
+    if (isVoiceRefineEnabled(voiceRecord.refine)) {
+      setVoiceProcessing(true)
 
-        try {
-          const refined = await rpc<VoiceRefineResponse>('voice.refine', { text: rawText })
-          const refinedText = typeof refined?.text === 'string' ? refined.text.trim() : ''
+      try {
+        const refined = await rpc<VoiceRefineResponse>('voice.refine', { text: rawText })
+        const refinedText = typeof refined?.text === 'string' ? refined.text.trim() : ''
 
-          if (refinedText) {
-            text = refinedText
-          }
-        } catch (err) {
-          sys(`voice refine failed; using original transcript (${rpcErrorMessage(err)})`)
-        } finally {
-          setVoiceProcessing(false)
+        if (refinedText) {
+          text = refinedText
         }
+      } catch (err) {
+        sys(`voice refine failed; using original transcript (${rpcErrorMessage(err)})`)
+      } finally {
+        setVoiceProcessing(false)
       }
+    }
 
-      finishVoiceTranscript(text, submitMode)
-    })()
+    finishVoiceTranscript(text, submitMode)
+  }
+
+  const handleVoiceTranscript = (rawText: string) => {
+    voiceTranscriptChain = voiceTranscriptChain
+      .catch(() => undefined)
+      .then(() => processVoiceTranscript(rawText))
+      .catch(err => sys(`voice transcript handling failed (${rpcErrorMessage(err)})`))
   }
 
   // ── Nudge toward /agents on delegation ───────────────────────────────

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -27,6 +27,42 @@ import { getUiState, patchUiState } from './uiStore.js'
 
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
 
+type VoiceSubmitMode = 'direct' | 'draft'
+
+interface VoiceRefineResponse {
+  changed?: boolean
+  reason?: string
+  text?: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const normalizeVoiceSubmitMode = (value: unknown): VoiceSubmitMode =>
+  typeof value === 'string' && value.trim().toLowerCase() === 'draft' ? 'draft' : 'direct'
+
+const isVoiceRefineEnabled = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  const enabled = value.enabled
+
+  if (typeof enabled === 'boolean') {
+    return enabled
+  }
+
+  if (typeof enabled === 'number') {
+    return enabled !== 0
+  }
+
+  if (typeof enabled === 'string') {
+    return ['1', 'true', 'yes', 'on'].includes(enabled.trim().toLowerCase())
+  }
+
+  return false
+}
+
 const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
 
 const applySkin = (s: GatewaySkin) =>
@@ -169,6 +205,50 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     fullConfigPromise ??= rpc<ConfigFullResponse>('config.get', { key: 'full' }).catch(() => null)
 
     return fullConfigPromise
+  }
+
+  const finishVoiceTranscript = (text: string, submitMode: VoiceSubmitMode) => {
+    if (submitMode === 'draft') {
+      setInput(text)
+
+      return
+    }
+
+    // We can't branch on composer input from inside a setInput updater
+    // (React strict mode double-invokes it, duplicating the submit).
+    // Just clear + defer submit so the cleared input is committed before
+    // submit reads it.
+    setInput('')
+    setTimeout(() => submitRef.current(text), 0)
+  }
+
+  const handleVoiceTranscript = (rawText: string) => {
+    void (async () => {
+      const cfg = await getFullConfigOnce()
+      const voiceCfg = cfg?.config?.voice
+      const voiceRecord = isRecord(voiceCfg) ? voiceCfg : {}
+      const submitMode = normalizeVoiceSubmitMode(voiceRecord.submit_mode)
+      let text = rawText
+
+      if (isVoiceRefineEnabled(voiceRecord.refine)) {
+        setVoiceProcessing(true)
+
+        try {
+          const refined = await rpc<VoiceRefineResponse>('voice.refine', { text: rawText })
+          const refinedText = typeof refined?.text === 'string' ? refined.text.trim() : ''
+
+          if (refinedText) {
+            text = refinedText
+          }
+        } catch (err) {
+          sys(`voice refine failed; using original transcript (${rpcErrorMessage(err)})`)
+        } finally {
+          setVoiceProcessing(false)
+        }
+      }
+
+      finishVoiceTranscript(text, submitMode)
+    })()
   }
 
   // ── Nudge toward /agents on delegation ───────────────────────────────
@@ -618,16 +698,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
-        // CLI parity: _pending_input.put(transcript) unconditionally feeds
-        // the transcript to the agent as its next turn — draft handling
-        // doesn't apply because voice-mode users are speaking, not typing.
-        //
-        // We can't branch on composer input from inside a setInput updater
-        // (React strict mode double-invokes it, duplicating the submit).
-        // Just clear + defer submit so the cleared input is committed before
-        // submit reads it.
-        setInput('')
-        setTimeout(() => submitRef.current(text), 0)
+        // Default remains CLI parity: direct submit.  When users opt into
+        // voice.submit_mode=draft, leave the transcript editable in the
+        // composer.  Optional voice.refine cleanup happens asynchronously via
+        // the backend auxiliary LLM router and falls back to the original text.
+        handleVoiceTranscript(text)
 
         return
       }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -182,9 +182,11 @@ export interface ConfigDisplayConfig {
 }
 
 export interface ConfigVoiceConfig {
-  // Raw `yaml.safe_load()` value from config; may be non-string if hand-edited.
-  // Callers must normalize/validate at runtime (parseVoiceRecordKey()).
+  // Raw `yaml.safe_load()` values from config; may be non-string if hand-edited.
+  // Callers must normalize/validate at runtime.
   record_key?: unknown
+  refine?: unknown
+  submit_mode?: unknown
 }
 
 export interface ConfigFullResponse {

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -166,11 +166,16 @@ If you skip that install or it fails, the wizard falls back to Edge TTS.
 ```yaml
 voice:
   record_key: "ctrl+b"
+  submit_mode: "direct"   # TUI: direct | draft
   max_recording_seconds: 120
   auto_tts: false
   beep_enabled: true
   silence_threshold: 200
   silence_duration: 3.0
+  refine:
+    enabled: false       # TUI: opt-in model cleanup of STT transcripts
+    mode: "medium"      # light | medium | strict
+    min_chars: 40
 
 stt:
   provider: "local"
@@ -291,6 +296,42 @@ If `Ctrl+B` conflicts with your terminal or tmux habits:
 ```yaml
 voice:
   record_key: "ctrl+space"
+```
+
+### TUI draft/refine flow
+
+The TUI submits transcripts immediately by default, matching the CLI. If you
+want to review voice input before sending it, use draft mode:
+
+```yaml
+voice:
+  submit_mode: "draft"
+```
+
+For optional model-backed cleanup of dictated transcripts, enable `voice.refine`:
+
+```yaml
+voice:
+  refine:
+    enabled: true
+    mode: "medium"   # light | medium | strict
+    min_chars: 40
+```
+
+The cleanup prompt is language-agnostic and conservative: it removes obvious
+speech disfluencies, repeats, and false starts while preserving language, tone,
+order, names, numbers, URLs, file paths, and commands. If the cleanup model
+fails or fails validation, Hermes uses the original transcript.
+
+Route that auxiliary LLM call with `auxiliary.voice_refine` when you want a
+specific provider/model:
+
+```yaml
+auxiliary:
+  voice_refine:
+    provider: "auto"
+    model: ""
+    timeout: 30
 ```
 
 ## Use case 2: voice replies in Telegram or Discord


### PR DESCRIPTION
## Summary
Adds an opt-in TUI voice draft/refine flow while preserving the existing direct-submit behavior by default.

Motivation: voice dictation often contains speech disfluencies, repeats, and false starts. This lets users either review transcripts before sending them (`voice.submit_mode: draft`) or ask their configured Hermes auxiliary model to conservatively clean transcripts before submit, without hardcoding any locale, filler-word dictionary, or provider/model assumption.

## Changes
- `tui_gateway/server.py`: adds `voice.refine`, a gated JSON-RPC method that uses the auxiliary LLM router (`auxiliary.voice_refine`) with a conservative, language-agnostic cleanup prompt.
- Routes `voice.refine` through the TUI long-handler pool so slow model calls do not block the gateway reader thread.
- Adds validation/fallback guardrails: disabled/min-length paths do not call the model; model errors, empty/meta output, excessive expansion/shrinkage, or loss/change of protected structured tokens fall back to the original transcript.
- `ui-tui`: reads `voice.submit_mode` (`direct` | `draft`) and optional `voice.refine.enabled`; refined/direct transcripts submit as before, draft mode leaves text editable in the composer.
- Serializes multiple refined voice transcripts so submissions preserve speech order even if model cleanup would resolve out of order.
- `hermes_cli/config.py`: adds backward-compatible defaults for `voice.submit_mode`, `voice.refine`, and `auxiliary.voice_refine`.
- Docs: documents TUI draft/refine config and auxiliary routing.

## Validation
- `/Users/zion/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/test_tui_gateway_server.py -k 'voice'` → `14 passed`
- `npx eslint src/app/createGatewayEventHandler.ts src/gatewayTypes.ts src/__tests__/createGatewayEventHandler.test.ts` → pass
- `npm run typecheck` → pass
- `npm test -- --run src/__tests__/createGatewayEventHandler.test.ts` → `81 passed`
- `npm run build` → pass
- `/Users/zion/.hermes/hermes-agent/venv/bin/python -m ruff check tui_gateway/server.py hermes_cli/config.py tests/test_tui_gateway_server.py` → pass
- `/Users/zion/.hermes/hermes-agent/venv/bin/python -m compileall -q tui_gateway/server.py hermes_cli/config.py tests/test_tui_gateway_server.py` → pass
- `git diff --check` → pass
