### PR TITLE
fix(ssh): disable ControlMaster on Windows OpenSSH

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -45,10 +45,11 @@ class TestBuildSSHCommand:
                                                       stdin=MagicMock()))
         monkeypatch.setattr("tools.environments.base.time.sleep", lambda _: None)
 
-    def test_base_flags(self):
+    def test_base_flags(self, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_USE_CONTROL_MASTER", True)
         env = SSHEnvironment(host="h", user="u")
         cmd = " ".join(env._build_ssh_command())
-        for flag in ("ControlMaster=auto", "ControlPersist=300",
+        for flag in ("ControlPath=", "ControlMaster=auto", "ControlPersist=300",
                       "BatchMode=yes", "StrictHostKeyChecking=accept-new"):
             assert flag in cmd
 
@@ -65,6 +66,32 @@ class TestBuildSSHCommand:
     def test_user_host_suffix(self):
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
+
+    def test_windows_skips_controlmaster_flags(self, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_USE_CONTROL_MASTER", False)
+        env = SSHEnvironment(host="h", user="u")
+        cmd = " ".join(env._build_ssh_command())
+
+        for flag in ("ControlPath=", "ControlMaster=", "ControlPersist="):
+            assert flag not in cmd
+        assert "BatchMode=yes" in cmd
+        assert "StrictHostKeyChecking=accept-new" in cmd
+
+    def test_scp_omits_controlpath_on_windows(self, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_USE_CONTROL_MASTER", False)
+        env = SSHEnvironment(host="h", user="u")
+        calls = []
+
+        def _capture(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess([], 0)
+
+        monkeypatch.setattr(ssh_env.subprocess, "run", _capture)
+        env._scp_upload("/local/file", "/remote/file")
+
+        scp_calls = [cmd for cmd in calls if cmd and cmd[0] == "scp"]
+        assert scp_calls, "scp should have been invoked"
+        assert "ControlPath=" not in " ".join(scp_calls[0])
 
 
 class TestControlSocketPath:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -19,6 +20,12 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ControlMaster (SSH connection multiplexing) does not work on Windows
+# OpenSSH — Windows has no Unix domain socket support for this purpose.
+# Every connection attempt with ControlMaster=auto fails with
+# "Failed to connect to new control master". Disable it entirely on Windows.
+_USE_CONTROL_MASTER = not sys.platform.startswith("win")
 
 
 def _ensure_ssh_available() -> None:
@@ -39,7 +46,7 @@ class SSHEnvironment(BaseEnvironment):
     Spawn-per-call: every execute() spawns a fresh ``ssh ... bash -c`` process.
     Session snapshot preserves env vars across calls.
     CWD persists via in-band stdout markers.
-    Uses SSH ControlMaster for connection reuse.
+    Uses SSH ControlMaster for connection reuse (disabled on Windows).
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
@@ -82,9 +89,10 @@ class SSHEnvironment(BaseEnvironment):
 
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]
-        cmd.extend(["-o", f"ControlPath={self.control_socket}"])
-        cmd.extend(["-o", "ControlMaster=auto"])
-        cmd.extend(["-o", "ControlPersist=300"])
+        if _USE_CONTROL_MASTER:
+            cmd.extend(["-o", f"ControlPath={self.control_socket}"])
+            cmd.extend(["-o", "ControlMaster=auto"])
+            cmd.extend(["-o", "ControlPersist=300"])
         cmd.extend(["-o", "BatchMode=yes"])
         cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
         cmd.extend(["-o", "ConnectTimeout=10"])
@@ -169,7 +177,9 @@ class SSHEnvironment(BaseEnvironment):
             stdin=subprocess.DEVNULL,
         )
 
-        scp_cmd = ["scp", "-o", f"ControlPath={self.control_socket}"]
+        scp_cmd = ["scp"]
+        if _USE_CONTROL_MASTER:
+            scp_cmd.extend(["-o", f"ControlPath={self.control_socket}"])
         if self.port != 22:
             scp_cmd.extend(["-P", str(self.port)])
         if self.key_path:
@@ -357,7 +367,7 @@ class SSHEnvironment(BaseEnvironment):
             logger.info("SSH: syncing files from sandbox...")
             self._sync_manager.sync_back()
 
-        if self.control_socket.exists():
+        if _USE_CONTROL_MASTER and self.control_socket.exists():
             try:
                 cmd = ["ssh", "-o", f"ControlPath={self.control_socket}",
                        "-O", "exit", f"{self.user}@{self.host}"]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -303,7 +303,7 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 
 ### SSH Backend
 
-Runs commands on a remote server over SSH. Uses ControlMaster for connection reuse (5-minute idle keepalive). Persistent shell is enabled by default — state (cwd, env vars) survives across commands.
+Runs commands on a remote server over SSH. On Unix-like systems, it uses ControlMaster for connection reuse (5-minute idle keepalive). Native Windows opens a fresh SSH connection per command because Windows OpenSSH does not support ControlMaster. Persistent shell is enabled by default — state (cwd, env vars) survives across commands.
 
 ```yaml
 terminal:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -168,7 +168,7 @@ terminal:
 
 ### SSH 后端
 
-通过 SSH 在远程服务器上运行命令。使用 ControlMaster 进行连接复用（5 分钟空闲保活）。默认启用持久 shell —— 状态（cwd、环境变量）在命令之间保持。
+通过 SSH 在远程服务器上运行命令。在类 Unix 系统上，使用 ControlMaster 进行连接复用（5 分钟空闲保活）。由于 Windows OpenSSH 不支持 ControlMaster，原生 Windows 会为每条命令建立新的 SSH 连接。默认启用持久 shell —— 状态（cwd、环境变量）在命令之间保持。
 
 ```yaml
 terminal:


### PR DESCRIPTION
## Summary

Windows OpenSSH does not support Unix domain socket-based connection multiplexing (ControlMaster). Every SSH command issued with `ControlMaster=auto` fails with:

```
mux_client_request_session: read from master failed: Software caused connection abort
Failed to connect to new control master
```

This makes the `ssh` terminal backend **completely unusable on Windows** — the very first `_establish_connection()` call raises `RuntimeError` before the environment ever initializes.

## Root Cause

`SSHEnvironment._build_ssh_command()` unconditionally adds `ControlMaster=auto`, `ControlPath=...`, and `ControlPersist=300` to every SSH command. Windows OpenSSH (tested on OpenSSH_9.6p1, OpenSSL 3.2.1) cannot create or connect to Unix domain sockets for connection multiplexing — this is a known platform limitation, not a configuration issue.

## Fix

Gate all ControlMaster/ControlPath/ControlPersist options behind a platform check:

```python
_USE_CONTROL_MASTER = not sys.platform.startswith("win")
```

On Windows, each SSH command spawns a fresh connection (matching the behavior of every other command anyway, since Hermes already uses spawn-per-call). The `control_socket` field and `cleanup()` path are also guarded so they no-op on Windows instead of touching a socket that was never created.

No behavior change on macOS/Linux — ControlMaster stays enabled there.

## Test Plan

- [x] **Before fix**: `ssh -o ControlMaster=auto -p 2222 ctsvr@127.0.0.1 "echo test"` → fails with `Failed to connect to new control master` on Windows
- [x] **After fix**: SSH terminal backend connects and executes commands successfully on Windows (tested with 6x NVIDIA A10 GPU server via SSH tunnel)
- [x] No regression: `_build_ssh_command()` output unchanged on non-Windows platforms (verified by code inspection — all changes are behind `if _USE_CONTROL_MASTER`)

## Environment

- OS: Windows 10 (OpenSSH_9.6p1, OpenSSL 3.2.1)
- Hermes Agent: v0.18.0
- SSH backend configured via `terminal.backend: ssh` in config.yaml
