### PR TITLE
fix(gateway): add authenticated active-work diagnostics

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1543,13 +1543,23 @@ class APIServerAdapter(BasePlatformAdapter):
         from gateway.status import (
             derive_gateway_busy,
             derive_gateway_drainable,
+            parse_active_agent_details,
             parse_active_agents,
+            parse_active_work_counts,
             read_runtime_status,
         )
 
         runtime = read_runtime_status() or {}
         gw_state = runtime.get("gateway_state")
         gw_active = parse_active_agents(runtime.get("active_agents", 0))
+        raw_work_counts = runtime.get("active_work_counts")
+        gw_work_counts = parse_active_work_counts(raw_work_counts)
+        if not isinstance(raw_work_counts, dict):
+            gw_work_counts["messaging"] = gw_active
+        gw_active = sum(gw_work_counts.values())
+        gw_active_details = parse_active_agent_details(
+            runtime.get("active_agent_details", [])
+        )
         # This endpoint is served BY the gateway process, so it is by definition
         # alive — gateway_running is True. Derive busy/drainable from the same
         # shared contract /api/status uses so the two surfaces never disagree.
@@ -1571,6 +1581,8 @@ class APIServerAdapter(BasePlatformAdapter):
             "gateway_state": gw_state,
             "platforms": runtime.get("platforms", {}),
             "active_agents": gw_active,
+            "active_work_counts": gw_work_counts,
+            "active_agent_details": gw_active_details,
             "gateway_busy": derive_gateway_busy(
                 gateway_running=True,
                 gateway_state=gw_state,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4149,14 +4149,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _running_agent_count(self) -> int:
         return len(self._running_agents)
 
-    def _active_work_count(self) -> int:
-        """All agent work the gateway must expose and drain as one total."""
-        return (
-            self._running_agent_count()
-            + self._active_cron_job_count()
-            + self._active_api_run_count()
-        )
-
     def _active_cron_job_count(self) -> int:
         """Count of cron jobs currently executing, from the cron scheduler's
         own in-flight tracking (``cron.scheduler._running_job_ids``).
@@ -4190,6 +4182,91 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return max(0, int(helper())) if callable(helper) else 0
         except Exception:
             return 0
+
+    def _active_work_counts(self) -> dict[str, int]:
+        """Return one bounded count for every gateway-owned agent source."""
+        return {
+            "messaging": max(0, self._running_agent_count()),
+            "cron": max(0, self._active_cron_job_count()),
+            "api_server": max(0, self._active_api_run_count()),
+        }
+
+    def _active_work_count(self) -> int:
+        """All agent work the gateway must expose and drain as one total."""
+        return sum(self._active_work_counts().values())
+
+    def _active_agent_details(self) -> list[dict[str, Any]]:
+        """Return bounded, content-free diagnostics for active gateway turns."""
+        now = time.time()
+        running_agents = getattr(self, "_running_agents", {}) or {}
+        running_started = getattr(self, "_running_agents_ts", {}) or {}
+        session_entries = {}
+        try:
+            store = getattr(self, "session_store", None)
+            session_entries = getattr(store, "_entries", {}) or {}
+        except Exception:
+            session_entries = {}
+
+        details: list[dict[str, Any]] = []
+        for session_key, agent in running_agents.items():
+            started = running_started.get(session_key, now)
+            try:
+                elapsed = max(0, int(now - float(started)))
+            except (TypeError, ValueError):
+                elapsed = 0
+
+            row: dict[str, Any] = {
+                "session_key": session_key,
+                "elapsed_seconds": elapsed,
+                "state": (
+                    "starting"
+                    if agent is _AGENT_PENDING_SENTINEL
+                    else "running"
+                ),
+            }
+
+            entry = (
+                session_entries.get(session_key)
+                if isinstance(session_entries, dict)
+                else None
+            )
+            source = getattr(entry, "origin", None) if entry is not None else None
+            platform = getattr(source, "platform", None)
+            if platform is not None:
+                row["platform"] = getattr(platform, "value", str(platform))
+            elif isinstance(session_key, str):
+                parts = session_key.split(":")
+                if len(parts) >= 3:
+                    row["platform"] = parts[2]
+            for attr in ("chat_id", "user_id"):
+                value = getattr(source, attr, None)
+                if value:
+                    row[attr] = value
+
+            if agent is not _AGENT_PENDING_SENTINEL:
+                session_id = getattr(agent, "session_id", "")
+                model = getattr(agent, "model", "")
+                if session_id:
+                    row["session_id"] = session_id
+                if model:
+                    row["model"] = model
+                if hasattr(agent, "get_activity_summary"):
+                    try:
+                        summary = agent.get_activity_summary() or {}
+                    except Exception:
+                        summary = {}
+                    for field in (
+                        "seconds_since_activity",
+                        "last_activity_desc",
+                        "current_tool",
+                        "api_call_count",
+                        "max_iterations",
+                    ):
+                        value = summary.get(field)
+                        if value not in (None, ""):
+                            row[field] = value
+            details.append(row)
+        return details
 
     # ── scale-to-zero idle detection / dormant-quiesce (Phase 0) ──────────────
     # The gateway-side BEHAVIOUR that consumes the relay scale-to-zero primitives
@@ -4574,11 +4651,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
             from gateway.status import write_runtime_status
+            active_work_counts = self._active_work_counts()
             write_runtime_status(
                 gateway_state=gateway_state,
                 exit_reason=exit_reason,
                 restart_requested=self._restart_requested,
-                active_agents=self._active_work_count(),
+                active_agents=sum(active_work_counts.values()),
+                active_work_counts=active_work_counts,
+                active_agent_details=self._active_agent_details(),
             )
         except Exception:
             pass
@@ -4593,15 +4673,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         between transitions is stale (a turn could start and finish without the
         file ever moving).
 
-        Deliberately passes ONLY ``active_agents`` — ``gateway_state`` and the
-        other fields stay ``_UNSET`` so ``write_runtime_status``'s
-        read-merge-write preserves the current lifecycle state (``running`` /
-        ``draining`` / …).  Passing ``gateway_state=None`` here would clobber it.
-        Best-effort: a failed status write must never disrupt a turn.
+        Deliberately leaves ``gateway_state`` and the other lifecycle fields
+        unset so ``write_runtime_status`` preserves the current state. The
+        source counts explain why the aggregate may exceed the per-session
+        messaging detail list when cron or API work is active. Best-effort: a
+        failed status write must never disrupt a turn.
         """
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(active_agents=self._active_work_count())
+            active_work_counts = self._active_work_counts()
+            write_runtime_status(
+                active_agents=sum(active_work_counts.values()),
+                active_work_counts=active_work_counts,
+                active_agent_details=self._active_agent_details(),
+            )
         except Exception:
             pass
 
@@ -20006,6 +20091,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if done:
                         response = _executor_task.result()
                         break
+                    self._persist_active_agents()
                     # Backup interrupt check: if the monitor task died or
                     # missed the interrupt, catch it here.
                     if not _interrupt_detected.is_set() and session_key:
@@ -20036,6 +20122,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if done:
                         response = _executor_task.result()
                         break
+                    self._persist_active_agents()
                     # Agent still running — check inactivity.
                     _agent_ref = agent_holder[0]
                     _idle_secs = 0.0

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -13,6 +13,7 @@ concurrently under distinct configurations).
 
 import hashlib
 import json
+import math
 import os
 import shlex
 import signal
@@ -430,6 +431,12 @@ def _build_runtime_status_record() -> dict[str, Any]:
         "exit_reason": None,
         "restart_requested": False,
         "active_agents": 0,
+        "active_work_counts": {
+            "messaging": 0,
+            "cron": 0,
+            "api_server": 0,
+        },
+        "active_agent_details": [],
         "platforms": {},
         "updated_at": _utc_now_iso(),
     })
@@ -800,6 +807,8 @@ def write_runtime_status(
     exit_reason: Any = _UNSET,
     restart_requested: Any = _UNSET,
     active_agents: Any = _UNSET,
+    active_work_counts: Any = _UNSET,
+    active_agent_details: Any = _UNSET,
     platform: Any = _UNSET,
     platform_state: Any = _UNSET,
     error_code: Any = _UNSET,
@@ -824,7 +833,20 @@ def write_runtime_status(
     if restart_requested is not _UNSET:
         payload["restart_requested"] = bool(restart_requested)
     if active_agents is not _UNSET:
-        payload["active_agents"] = parse_active_agents(active_agents)
+        active_count = parse_active_agents(active_agents)
+        payload["active_agents"] = active_count
+        if active_work_counts is _UNSET:
+            payload["active_work_counts"] = parse_active_work_counts(
+                {"messaging": active_count}
+            )
+        if active_agent_details is _UNSET and active_count == 0:
+            payload["active_agent_details"] = []
+    if active_work_counts is not _UNSET:
+        counts = parse_active_work_counts(active_work_counts)
+        payload["active_work_counts"] = counts
+        payload["active_agents"] = sum(counts.values())
+    if active_agent_details is not _UNSET:
+        payload["active_agent_details"] = parse_active_agent_details(active_agent_details)
     if served_profiles is not _UNSET:
         # Profiles this gateway multiplexes (multi-profile mode). Absent/empty
         # for a single-profile gateway. Lets `hermes status` show per-profile
@@ -869,6 +891,78 @@ def parse_active_agents(raw: Any) -> int:
         return max(0, int(raw))
     except (TypeError, ValueError):
         return 0
+
+
+_ACTIVE_WORK_SOURCES = ("messaging", "cron", "api_server")
+
+
+def parse_active_work_counts(raw: Any) -> dict[str, int]:
+    """Normalize the fixed set of gateway-owned active-work source counts."""
+    source = raw if isinstance(raw, dict) else {}
+    return {
+        name: parse_active_agents(source.get(name, 0))
+        for name in _ACTIVE_WORK_SOURCES
+    }
+
+
+_ACTIVE_AGENT_DETAIL_LIMIT = 32
+_ACTIVE_AGENT_DETAIL_STRING_FIELDS = {
+    "session_key": 256,
+    "session_id": 128,
+    "platform": 64,
+    "chat_id": 128,
+    "user_id": 128,
+    "state": 32,
+    "model": 160,
+    "current_tool": 128,
+    "last_activity_desc": 160,
+}
+_ACTIVE_AGENT_DETAIL_NUMBER_FIELDS = {
+    "elapsed_seconds",
+    "seconds_since_activity",
+    "api_call_count",
+    "max_iterations",
+}
+
+
+def _runtime_status_text(raw: Any, *, limit: int) -> str:
+    text = " ".join(str(raw).split())
+    return text[:limit]
+
+
+def _runtime_status_number(raw: Any) -> Optional[float]:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return max(0.0, value)
+
+
+def parse_active_agent_details(raw: Any) -> list[dict[str, Any]]:
+    """Normalize bounded, content-free diagnostics for active gateway turns."""
+    if not isinstance(raw, (list, tuple)):
+        return []
+
+    details: list[dict[str, Any]] = []
+    for item in raw[:_ACTIVE_AGENT_DETAIL_LIMIT]:
+        if not isinstance(item, dict):
+            continue
+        row: dict[str, Any] = {}
+        for field, limit in _ACTIVE_AGENT_DETAIL_STRING_FIELDS.items():
+            value = item.get(field)
+            if value in (None, ""):
+                continue
+            row[field] = _runtime_status_text(value, limit=limit)
+        for field in _ACTIVE_AGENT_DETAIL_NUMBER_FIELDS:
+            value = _runtime_status_number(item.get(field))
+            if value is None:
+                continue
+            row[field] = int(value) if value.is_integer() else value
+        if row:
+            details.append(row)
+    return details
 
 
 # States in which the gateway is alive and could be asked to drain.  Anything

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -81,7 +81,9 @@ from gateway.status import (
     get_running_pid_cached,
     get_running_pid,
     get_runtime_status_running_pid,
+    parse_active_agent_details,
     parse_active_agents,
+    parse_active_work_counts,
     read_runtime_status,
 )
 from hermes_cli.memory_providers import (
@@ -2816,6 +2818,26 @@ async def get_status(profile: Optional[str] = None):
     finally:
         if status_scope is not None:
             status_scope.__exit__(*sys.exc_info())
+
+
+@app.get("/api/status/active-work")
+async def get_active_work_status(request: Request):
+    """Return authenticated, content-free diagnostics for live agent work."""
+    _require_token(request)
+    runtime = read_runtime_status() or {}
+    raw_counts = runtime.get("active_work_counts")
+    counts = parse_active_work_counts(raw_counts)
+    if not isinstance(raw_counts, dict):
+        counts["messaging"] = parse_active_agents(runtime.get("active_agents", 0))
+    return {
+        "active_agents": sum(counts.values()),
+        "active_work_counts": counts,
+        "active_agent_details": parse_active_agent_details(
+            runtime.get("active_agent_details", [])
+        ),
+        "gateway_state": runtime.get("gateway_state"),
+        "updated_at": runtime.get("updated_at"),
+    }
 
 
 _WINDOWS_11_MIN_BUILD = 22000

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -750,7 +750,20 @@ class TestHealthDetailedEndpoint:
         with patch("gateway.status.read_runtime_status", return_value={
             "gateway_state": "running",
             "platforms": {"telegram": {"state": "connected"}},
-            "active_agents": 2,
+            "active_agents": 4,
+            "active_work_counts": {
+                "messaging": 2,
+                "cron": 1,
+                "api_server": 1,
+            },
+            "active_agent_details": [
+                {
+                    "session_key": "agent:main:feishu:dm:c1:u1",
+                    "platform": "feishu",
+                    "seconds_since_activity": 367.5,
+                    "last_activity_desc": "api_call",
+                }
+            ],
             "exit_reason": None,
             "updated_at": "2026-04-14T00:00:00Z",
         }), patch("gateway.run._resolve_gateway_model", return_value="test/model"):
@@ -762,9 +775,22 @@ class TestHealthDetailedEndpoint:
                 assert data["platform"] == "hermes-agent"
                 assert data["gateway_state"] == "running"
                 assert data["platforms"] == {"telegram": {"state": "connected"}}
-                assert data["active_agents"] == 2
+                assert data["active_agents"] == 4
+                assert data["active_work_counts"] == {
+                    "messaging": 2,
+                    "cron": 1,
+                    "api_server": 1,
+                }
+                assert data["active_agent_details"] == [
+                    {
+                        "session_key": "agent:main:feishu:dm:c1:u1",
+                        "platform": "feishu",
+                        "seconds_since_activity": 367.5,
+                        "last_activity_desc": "api_call",
+                    }
+                ]
                 # Derived busy/drainable: this endpoint is served BY the live
-                # gateway, so running + 2 agents ⇒ busy and drainable.
+                # gateway, so running + active work means busy and drainable.
                 assert data["gateway_busy"] is True
                 assert data["gateway_drainable"] is True
                 assert isinstance(data["pid"], int)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1613,6 +1613,163 @@ class TestActiveAgentsTurnBoundaryWrite:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         status.write_runtime_status(gateway_state="running", active_agents=-5)
         assert status.read_runtime_status()["active_agents"] == 0
+
+    def test_active_work_counts_are_bounded_and_define_the_total(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="running",
+            active_agents=99,
+            active_work_counts={
+                "messaging": "2",
+                "cron": -1,
+                "api_server": 3,
+                "unknown": 100,
+            },
+        )
+
+        rec = status.read_runtime_status()
+        assert rec["active_agents"] == 5
+        assert rec["active_work_counts"] == {
+            "messaging": 2,
+            "cron": 0,
+            "api_server": 3,
+        }
+
+    def test_legacy_aggregate_write_is_reported_as_messaging_work(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(gateway_state="running", active_agents=2)
+
+        rec = status.read_runtime_status()
+        assert rec["active_work_counts"] == {
+            "messaging": 2,
+            "cron": 0,
+            "api_server": 0,
+        }
+
+    def test_active_agent_details_are_bounded_and_sanitized(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="running",
+            active_agents=1,
+            active_agent_details=[
+                {
+                    "session_key": "agent:main:feishu:dm:c1:u1\nextra",
+                    "platform": "feishu",
+                    "chat_id": "c1",
+                    "state": "running",
+                    "current_tool": "web_search\nlatest",
+                    "last_activity_desc": "api_call",
+                    "seconds_since_activity": "367.5",
+                    "elapsed_seconds": -2,
+                    "ignored": "not persisted",
+                }
+            ],
+        )
+
+        details = status.read_runtime_status()["active_agent_details"]
+        assert details == [
+            {
+                "session_key": "agent:main:feishu:dm:c1:u1 extra",
+                "platform": "feishu",
+                "chat_id": "c1",
+                "state": "running",
+                "current_tool": "web_search latest",
+                "last_activity_desc": "api_call",
+                "seconds_since_activity": 367.5,
+                "elapsed_seconds": 0,
+            }
+        ]
+
+    def test_active_agent_details_clear_when_count_drops_to_zero(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="running",
+            active_agents=1,
+            active_agent_details=[{"session_key": "agent:main:feishu:dm:c1:u1"}],
+        )
+        status.write_runtime_status(active_agents=0)
+
+        rec = status.read_runtime_status()
+        assert rec["active_agents"] == 0
+        assert rec["active_agent_details"] == []
+
+    def test_runner_persists_active_agent_details(self, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        session_key = "agent:main:feishu:dm:c1:u1"
+
+        runner = object.__new__(GatewayRunner)
+        runner._running_agents = {
+            session_key: SimpleNamespace(
+                session_id="sess-1",
+                model="openrouter/test",
+                get_activity_summary=lambda: {
+                    "seconds_since_activity": 42.2,
+                    "last_activity_desc": "api_call",
+                    "current_tool": "web_search",
+                    "api_call_count": 3,
+                    "max_iterations": 90,
+                },
+            )
+        }
+        runner._running_agents_ts = {session_key: 100.0}
+        runner.session_store = SimpleNamespace(
+            _entries={
+                session_key: SimpleNamespace(
+                    origin=SessionSource(
+                        platform=Platform.FEISHU,
+                        chat_id="c1",
+                        user_id="u1",
+                        chat_type="dm",
+                    )
+                )
+            }
+        )
+        runner._active_cron_job_count = lambda: 1
+        runner._active_api_run_count = lambda: 2
+        monkeypatch.setattr("gateway.run.time.time", lambda: 150.0)
+
+        runner._persist_active_agents()
+
+        rec = status.read_runtime_status()
+        assert rec["active_agents"] == 4
+        assert rec["active_work_counts"] == {
+            "messaging": 1,
+            "cron": 1,
+            "api_server": 2,
+        }
+        assert rec["active_agent_details"] == [
+            {
+                "session_key": session_key,
+                "session_id": "sess-1",
+                "platform": "feishu",
+                "chat_id": "c1",
+                "user_id": "u1",
+                "state": "running",
+                "model": "openrouter/test",
+                "current_tool": "web_search",
+                "last_activity_desc": "api_call",
+                "elapsed_seconds": 50,
+                "seconds_since_activity": 42.2,
+                "api_call_count": 3,
+                "max_iterations": 90,
+            }
+        ]
+
+
 class TestGatewayBusyDerivation:
     """Pure contract for derive_gateway_busy / derive_gateway_drainable — the
     single shared definition both /api/status and /health/detailed consume."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5767,15 +5767,56 @@ class TestGatewayBusyReadout:
         monkeypatch.setattr(ws, "read_runtime_status", lambda: {
             "gateway_state": "running",
             "platforms": {},
-            "active_agents": 2,
+            "active_agents": 4,
+            "active_work_counts": {
+                "messaging": 2,
+                "cron": 1,
+                "api_server": 1,
+            },
+            "active_agent_details": [
+                {
+                    "session_key": "agent:main:feishu:dm:c1:u1",
+                    "platform": "feishu",
+                    "seconds_since_activity": 367.5,
+                    "last_activity_desc": "api_call",
+                }
+            ],
             # A deliberately stale timestamp: busy must NOT depend on it.
             "updated_at": "2020-01-01T00:00:00+00:00",
         })
 
         data = self.client.get("/api/status").json()
-        assert data["active_agents"] == 2
+        assert data["active_agents"] == 4
+        assert "active_agent_details" not in data
+        assert "active_work_counts" not in data
         assert data["gateway_busy"] is True
         assert data["gateway_drainable"] is True
+
+        private = self.client.get("/api/status/active-work")
+        assert private.status_code == 200
+        assert private.json()["active_work_counts"] == {
+            "messaging": 2,
+            "cron": 1,
+            "api_server": 1,
+        }
+        assert private.json()["active_agent_details"] == [
+            {
+                "session_key": "agent:main:feishu:dm:c1:u1",
+                "platform": "feishu",
+                "seconds_since_activity": 367.5,
+                "last_activity_desc": "api_call",
+            }
+        ]
+
+    def test_active_work_details_require_auth(self):
+        from starlette.testclient import TestClient
+
+        from hermes_cli.web_server import app
+
+        client = TestClient(app)
+        response = client.get("/api/status/active-work")
+
+        assert response.status_code == 401
 
     def test_idle_running_is_drainable_but_not_busy(self, monkeypatch):
         """A running gateway with zero in-flight turns is drainable, not busy."""


### PR DESCRIPTION
## Summary
- Persist fixed source counts for messaging, cron, and API work alongside the aggregate active count.
- Keep public `/api/status` aggregate-only and expose bounded per-session details through authenticated `/api/status/active-work` and `/health/detailed`.
- Refresh diagnostics through the current long-running turn and drain polling paths.
- Preserve compatibility for aggregate-only runtime-status writers.

## Problem
A live gateway could stall while its PID health check remained healthy, but status exposed only one aggregate count. The first diagnostics implementation put session, chat, and user identifiers on the public status endpoint and described only messaging work even though the aggregate also included cron and API runs.

## Validation
- `python -m pytest -q tests/gateway/test_status.py tests/gateway/test_api_server.py tests/hermes_cli/test_web_server.py tests/gateway/test_external_drain_control.py tests/gateway/test_cron_active_work_drain.py tests/gateway/test_api_server_active_work_drain.py` (741 passed)
- `python -m ruff check gateway/status.py gateway/run.py gateway/platforms/api_server.py hermes_cli/web_server.py tests/gateway/test_status.py tests/gateway/test_api_server.py tests/hermes_cli/test_web_server.py`

Refs #53995