### PR TITLE
fix: surface lock-hold reason when /compress no-ops due to concurrent compression

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -500,6 +500,12 @@ def compress_context(
     # and proceed with compression.  Skipping the lock risks a rare
     # concurrent-compression session fork; an infinite no-progress loop
     # that never compresses at all is strictly worse.
+    # Clear any stale lock-skip signal from a prior call so this call's
+    # outcome alone determines what callers see.  Without this an
+    # auto-compress lock-skip followed by a successful manual /compress
+    # would falsely report "Compression already in progress" and discard
+    # the compression results.
+    agent._compression_skipped_due_to_lock = None
     try:
         _lock_ttl = float(getattr(agent, "_compression_lock_ttl_seconds", 300.0) or 300.0)
     except (TypeError, ValueError):

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -538,6 +538,11 @@ def compress_context(
                 _lock_sid, existing,
             )
             _lock_holder = None  # don't release a lock we don't own
+            # Signal to callers that this no-op is due to a concurrent lock,
+            # not a genuine "nothing to compress" or aux-model failure.
+            # Manual /compress callers can surface a clear status message
+            # instead of the misleading "No changes from compression" text.
+            agent._compression_skipped_due_to_lock = existing or True
             # Surface to the user once — quiet for downstream auto-compress loops
             if getattr(agent, "_last_compression_lock_warning_sid", None) != _lock_sid:
                 agent._last_compression_lock_warning_sid = _lock_sid

--- a/cli.py
+++ b/cli.py
@@ -9424,6 +9424,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     focus_topic=focus_topic or None,
                     force=True,
                 )
+
+                # If _compress_context returned unchanged because a
+                # concurrent compression lock is held, tell the user
+                # clearly instead of showing the misleading
+                # "No changes from compression" no-op text.
+                if getattr(self.agent, "_compression_skipped_due_to_lock", None):
+                    holder = self.agent._compression_skipped_due_to_lock
+                    if isinstance(holder, str):
+                        print(f"  ⏳ Compression already in progress for this "
+                              f"session (holder: {holder}). "
+                              f"Please wait for it to finish.")
+                    else:
+                        print(f"  ⏳ Compression already in progress for this "
+                              f"session. Please wait for it to finish.")
+                    self.agent._compression_skipped_due_to_lock = None
+                    return
+
                 # Re-append the verbatim tail after the compressed head.
                 # The split guarantees `tail` begins on a user turn, so the
                 # compressed-head -> tail boundary is normally valid

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3204,6 +3204,18 @@ class GatewaySlashCommandsMixin:
                     lambda: tmp_agent._compress_context(head, "", approx_tokens=approx_tokens, focus_topic=focus_topic, force=True)
                 )
 
+                # If _compress_context returned unchanged because a
+                # concurrent compression lock is held, tell the user
+                # clearly instead of showing the misleading
+                # "No changes from compression" no-op text.
+                _lock_skipped = getattr(tmp_agent, "_compression_skipped_due_to_lock", None)
+                if _lock_skipped:
+                    holder = _lock_skipped if isinstance(_lock_skipped, str) else "unknown"
+                    return (
+                        f"⏳ Compression already in progress for this session "
+                        f"(holder: {holder}). Please wait for it to finish."
+                    )
+
                 # Re-append the verbatim tail after the compressed head,
                 # guarding the seam against illegal role adjacency.
                 if partial and tail:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3210,10 +3210,11 @@ class GatewaySlashCommandsMixin:
                 # "No changes from compression" no-op text.
                 _lock_skipped = getattr(tmp_agent, "_compression_skipped_due_to_lock", None)
                 if _lock_skipped:
-                    holder = _lock_skipped if isinstance(_lock_skipped, str) else "unknown"
+                    holder = _lock_skipped if isinstance(_lock_skipped, str) else None
+                    holder_clause = f" (holder: {holder})" if holder else ""
                     return (
-                        f"⏳ Compression already in progress for this session "
-                        f"(holder: {holder}). Please wait for it to finish."
+                        f"⏳ Compression already in progress for this session"
+                        f"{holder_clause}. Please wait for it to finish."
                     )
 
                 # Re-append the verbatim tail after the compressed head,

--- a/tests/agent/test_compress_signal_leak.py
+++ b/tests/agent/test_compress_signal_leak.py
@@ -1,0 +1,60 @@
+"""Invariant: stale signal leak between consecutive compress_context calls."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_signal_cleared_on_entry_between_calls(monkeypatch):
+    """Call 1: lock held → signal set. Call 2: lock available → signal must
+    be None after call 2 because the entry code cleared it. This prevents
+    a prior auto-compress lock-skip from causing a subsequent successful
+    manual /compress to falsely report 'Compression already in progress'."""
+    from agent.conversation_compression import compress_context
+
+    agent = MagicMock()
+    agent._cached_system_prompt = ""
+    agent.tools = None
+    agent._memory_manager = None
+    agent._build_system_prompt = MagicMock(return_value="sys prompt")
+    agent._emit_warning = MagicMock()
+
+    msgs = [
+        {"role": "user", "content": "a"}, {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"}, {"role": "assistant", "content": "d"},
+    ]
+
+    monkeypatch.setattr(
+        "agent.conversation_compression._compression_lock_holder",
+        lambda a: "pid=test:holder",
+    )
+
+    # --- Call 1: lock held ---
+    db1 = MagicMock()
+    db1.try_acquire_compression_lock.return_value = False
+    db1.get_compression_lock_holder.return_value = "pid=holder1"
+    agent._session_db = db1
+
+    compress_context(agent, msgs, "", approx_tokens=100, force=True)
+
+    # Call 1: signal set (lock was held).
+    assert agent._compression_skipped_due_to_lock is not None
+
+    # --- Call 2: lock available, compressor succeeds ---
+    db2 = MagicMock()
+    db2.try_acquire_compression_lock.return_value = True
+    agent._session_db = db2
+    agent.context_compressor = MagicMock()
+    compressed = [
+        {"role": "user", "content": "[summary]"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    agent.context_compressor.compress = MagicMock(return_value=compressed)
+    agent.context_compressor.compression_count = 0
+    agent.context_compressor.last_compression_rough_tokens = 0
+
+    compress_context(agent, msgs, "", approx_tokens=100, force=True)
+
+    # Call 2: signal must be None — entry code cleared stale Call 1 signal.
+    assert agent._compression_skipped_due_to_lock is None, (
+        "stale signal from lock-skip call 1 leaked into successful call 2"
+    )

--- a/tests/cli/test_compress_here.py
+++ b/tests/cli/test_compress_here.py
@@ -26,6 +26,7 @@ def _wire_agent(shell, compressed_head):
     shell.agent.session_id = None
     shell.agent.tools = None
     shell.agent._compress_context.return_value = (compressed_head, "")
+    shell.agent._compression_skipped_due_to_lock = False
 
 
 def test_compress_here_compresses_head_only(capsys):

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -24,6 +24,9 @@ def test_manual_compress_reports_noop_without_success_banner(capsys):
     shell.agent.tools = None
     shell.agent.session_id = shell.session_id  # no-op compression: no split
     shell.agent._compress_context.return_value = (list(history), "")
+    # Explicitly signal this is NOT a lock-skip to avoid MagicMock
+    # getattr returning a truthy mock for unset attributes.
+    shell.agent._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         assert messages == history
@@ -53,6 +56,7 @@ def test_manual_compress_explains_when_token_estimate_rises(capsys):
     shell.agent.tools = None
     shell.agent.session_id = shell.session_id  # no-op: no split
     shell.agent._compress_context.return_value = (compressed, "")
+    shell.agent._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -97,6 +101,7 @@ def test_manual_compress_syncs_session_id_after_split():
         shell.agent.session_id = new_child_id
         return (compressed, "")
     shell.agent._compress_context.side_effect = _fake_compress
+    shell.agent._compression_skipped_due_to_lock = False
     shell.agent.session_id = old_id  # starts in sync
     shell._pending_title = "stale title"
 
@@ -139,6 +144,7 @@ def test_manual_compress_flushes_compressed_history_to_child_session_db():
         return (compressed, "")
 
     shell.agent._compress_context.side_effect = _fake_compress
+    shell.agent._compression_skipped_due_to_lock = False
 
     with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=100):
         shell._manual_compress()
@@ -155,6 +161,7 @@ def test_manual_compress_does_not_flush_full_history_when_session_id_unchanged()
     shell.agent._cached_system_prompt = ""
     shell.agent.session_id = shell.session_id
     shell.agent._compress_context.return_value = (list(history), "")
+    shell.agent._compression_skipped_due_to_lock = False
 
     with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=100):
         shell._manual_compress()
@@ -175,6 +182,7 @@ def test_manual_compress_no_sync_when_session_id_unchanged():
     shell.agent.tools = None
     shell.agent.session_id = shell.session_id
     shell.agent._compress_context.return_value = (list(history), "")
+    shell.agent._compression_skipped_due_to_lock = False
     shell._pending_title = "keep me"
 
     with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
@@ -182,3 +190,61 @@ def test_manual_compress_no_sync_when_session_id_unchanged():
 
     # No split → pending title untouched.
     assert shell._pending_title == "keep me"
+
+
+def test_manual_compress_shows_lock_in_progress_when_skipped_due_to_lock(capsys):
+    """When _compress_context skips due to a concurrent compression lock,
+    _manual_compress must print a clear "already in progress" message,
+    NOT show the misleading "No changes from compression" no-op text."""
+    shell = _make_cli()
+    history = _make_history()
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = shell.session_id
+
+    # Simulate _compress_context setting the lock-skip signal and
+    # returning unchanged messages.
+    def _fake_compress(*args, **kwargs):
+        shell.agent._compression_skipped_due_to_lock = True
+        return (list(history), "")
+
+    shell.agent._compress_context.side_effect = _fake_compress
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    output = capsys.readouterr().out
+    assert "Compression already in progress" in output
+    assert "No changes from compression" not in output
+    # Signal should be cleared after use.
+    assert shell.agent._compression_skipped_due_to_lock is None
+
+
+def test_manual_compress_shows_lock_in_progress_with_holder(capsys):
+    """When the lock holder is a descriptive string, include it in the
+    status message so the user knows which process to investigate."""
+    shell = _make_cli()
+    history = _make_history()
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = shell.session_id
+
+    def _fake_compress(*args, **kwargs):
+        shell.agent._compression_skipped_due_to_lock = "pid=12345"
+        return (list(history), "")
+
+    shell.agent._compress_context.side_effect = _fake_compress
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    output = capsys.readouterr().out
+    assert "Compression already in progress" in output
+    assert "pid=12345" in output
+    assert "No changes from compression" not in output

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -70,6 +70,7 @@ async def test_compress_command_reports_noop_without_success_banner():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         assert messages == history
@@ -107,6 +108,7 @@ async def test_compress_command_explains_when_token_estimate_rises():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -157,6 +159,7 @@ async def test_compress_command_appends_warning_when_compression_aborts():
     )
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -219,6 +222,7 @@ async def test_compress_command_surfaces_aux_model_failure_even_when_recovered()
     )
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -277,6 +281,7 @@ async def test_compress_command_passes_session_db_and_persists_rotated_session()
         return compressed, ""
 
     agent_instance._compress_context.side_effect = _compress
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         if messages == history:
@@ -343,6 +348,7 @@ async def test_compress_command_does_not_repoint_session_when_transcript_write_f
         return compressed, ""
 
     agent_instance._compress_context.side_effect = _compress
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         return 100
@@ -395,6 +401,7 @@ async def test_compress_command_in_place_write_failure_reports_error():
     agent_instance._last_compaction_in_place = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages, **_kwargs):
         return 100
@@ -432,6 +439,7 @@ async def test_compress_command_preserves_platform_and_gateway_session_key():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     with (
         patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
@@ -467,6 +475,7 @@ async def test_compress_command_overrides_stale_resolver_identity():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     # Resolver injects a WRONG platform and a stale session key.
     runtime = {"api_key": "test-key", "platform": "discord", "gateway_session_key": "stale-key"}
@@ -483,3 +492,32 @@ async def test_compress_command_overrides_stale_resolver_identity():
     # Source-derived identity overrides the stale resolver values, passed once.
     assert kwargs["platform"] == "telegram"
     assert kwargs["gateway_session_key"] == runner._session_key_for_source(_make_source())
+
+
+@pytest.mark.asyncio
+async def test_compress_command_surfaces_lock_skip():
+    """When _compress_context skips due to a concurrent lock, the gateway
+    handler must surface a clear message, not the misleading no-op text."""
+    history = _make_history()
+    runner = _make_runner(history)
+    agent_instance = MagicMock()
+    agent_instance.shutdown_memory_provider = MagicMock()
+    agent_instance.close = MagicMock()
+    agent_instance._cached_system_prompt = ""
+    agent_instance.tools = None
+    agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.session_id = "sess-1"
+    agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = "pid=99999"
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+        patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100),
+    ):
+        result = await runner._handle_compress_command(_make_event())
+
+    assert "Compression already in progress" in result
+    assert "pid=99999" in result
+    assert "No changes from compression" not in result

--- a/tests/gateway/test_compress_focus.py
+++ b/tests/gateway/test_compress_focus.py
@@ -68,6 +68,7 @@ async def test_compress_focus_topic_passed_to_agent():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     def _estimate(messages):
         return 100
@@ -98,6 +99,7 @@ async def test_compress_no_focus_passes_none():
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     with (
         patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),

--- a/tests/gateway/test_compress_plugin_engine.py
+++ b/tests/gateway/test_compress_plugin_engine.py
@@ -127,6 +127,7 @@ async def test_compress_works_with_plugin_context_engine():
     agent_instance.context_compressor = plugin_engine
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
+    agent_instance._compression_skipped_due_to_lock = False
 
     with (
         patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),

--- a/tests/tui_gateway/test_compress_lock_skip.py
+++ b/tests/tui_gateway/test_compress_lock_skip.py
@@ -1,0 +1,84 @@
+"""Tests for TUI gateway /compress lock-hold signalling."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_compress_session_history_raises_on_lock_skip():
+    """When _compression_skipped_due_to_lock is set on the agent,
+    _compress_session_history must raise CompressionLockHeld with
+    the holder string so callers can surface a clear message."""
+    from tui_gateway.server import _compress_session_history, CompressionLockHeld
+
+    history = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+    agent = MagicMock()
+    agent._cached_system_prompt = ""
+    agent.tools = None
+    agent._compression_skipped_due_to_lock = "pid=99999:tid=1:agent=1:nonce=abc"
+
+    def _fake_compress(msgs=None, *_args, **_kwargs):
+        return (msgs or history, "")
+
+    agent._compress_context.side_effect = _fake_compress
+
+    session = {
+        "agent": agent,
+        "history_lock": MagicMock(),
+        "history": history,
+        "history_version": 1,
+    }
+
+    with (
+        patch(
+            "agent.model_metadata.estimate_request_tokens_rough", return_value=100
+        ),
+        pytest.raises(CompressionLockHeld) as exc_info,
+    ):
+        _compress_session_history(session)
+
+    assert exc_info.value.holder == "pid=99999:tid=1:agent=1:nonce=abc"
+
+
+def test_compress_session_history_clears_signal_after_raise():
+    """The signal attribute must be cleared when the exception is raised
+    so stale signals don't leak into subsequent operations."""
+    from tui_gateway.server import _compress_session_history, CompressionLockHeld
+
+    history = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+    agent = MagicMock()
+    agent._cached_system_prompt = ""
+    agent.tools = None
+    agent._compression_skipped_due_to_lock = True
+
+    def _fake_compress(msgs=None, *_args, **_kwargs):
+        return (msgs or history, "")
+
+    agent._compress_context.side_effect = _fake_compress
+
+    session = {
+        "agent": agent,
+        "history_lock": MagicMock(),
+        "history": history,
+        "history_version": 1,
+    }
+
+    with (
+        patch(
+            "agent.model_metadata.estimate_request_tokens_rough", return_value=100
+        ),
+        pytest.raises(CompressionLockHeld),
+    ):
+        _compress_session_history(session)
+
+    # Signal must be cleared after the raise.
+    assert agent._compression_skipped_due_to_lock is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2829,6 +2829,14 @@ def _sync_agent_model_with_config(sid: str, session: dict) -> None:
         )
 
 
+class CompressionLockHeld(Exception):
+    """Raised by _compress_session_history when compression skipped due
+    to a concurrent lock on the session's compression_locks row."""
+    def __init__(self, holder: str | None = None):
+        self.holder = holder
+        super().__init__(f"Compression lock held: {holder or 'unknown'}")
+
+
 def _compress_session_history(
     session: dict,
     focus_topic: str | None = None,
@@ -2870,6 +2878,17 @@ def _compress_session_history(
         approx_tokens=approx_tokens,
         focus_topic=focus_topic or None,
     )
+
+    # If _compress_context returned unchanged because a concurrent
+    # compression lock is held, raise so callers can surface a clear
+    # message instead of the misleading "No changes from compression" text.
+    _lock_skipped = getattr(agent, "_compression_skipped_due_to_lock", None)
+    if _lock_skipped:
+        agent._compression_skipped_due_to_lock = None
+        raise CompressionLockHeld(
+            _lock_skipped if isinstance(_lock_skipped, str) else None
+        )
+
     with session["history_lock"]:
         if int(session.get("history_version", 0)) != history_version:
             # External mutation during compaction — drop the compressed
@@ -7690,6 +7709,14 @@ def _(rid, params: dict) -> dict:
             # reverts to neutral whether compaction succeeded, was a
             # no-op, or raised.
             _status_update(sid, "ready")
+    except CompressionLockHeld as e:
+        _status_update(sid, "ready")
+        holder_msg = f" (holder: {e.holder})" if e.holder else ""
+        return _ok(rid, {
+            "compressed": False,
+            "lock_held": True,
+            "message": f"Compression already in progress for this session{holder_msg}. Please wait for it to finish."
+        })
     except Exception as e:
         return _err(rid, 5005, str(e))
 
@@ -12516,7 +12543,11 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 else 0
             )
 
-            _compress_session_history(session, arg)
+            try:
+                _compress_session_history(session, arg)
+            except CompressionLockHeld as e:
+                holder_msg = f" (holder: {e.holder})" if e.holder else ""
+                return f"⏳ Compression already in progress for this session{holder_msg}. Please wait for it to finish."
             _sync_session_key_after_compress(sid, session)
 
             with session["history_lock"]:


### PR DESCRIPTION
**Closes:** #57631

## The lie

`/compress` says "No changes from compression" when compression never ran. Another Hermes process holds the session lock — the command silently returns messages unchanged and three callsites all report a no-op that never happened.

## Fix

**5 commits, 6 files:**

1. **`agent/conversation_compression.py`** — Sets `agent._compression_skipped_due_to_lock` when lock acquisition fails so callers can distinguish lock-held from genuine no-op. Clears the signal to `None` at entry to prevent stale-signal leak (auto-compress skip → later manual false positive).

2. **`cli.py`** — `_manual_compress` checks the signal and prints:
   ```
   ⏳ Compression already in progress for this session (holder: pid=NNN).
   Please wait for it to finish.
   ```

3. **`gateway/slash_commands.py`** — Same check, same message.

4. **`tui_gateway/server.py`** — New `CompressionLockHeld` exception. Both RPC and slash handler catch it and surface the correct message.

5. **Tests** — 7 files, 30 tests (0 failures):
   - `tests/cli/test_manual_compress.py`: +2 lock-skip tests (8 total)
   - `tests/gateway/test_compress_command.py`: +1 lock-skip test (10 total)
   - `tests/tui_gateway/test_compress_lock_skip.py`: 2 new tests
   - `tests/agent/test_compress_signal_leak.py`: 1 stale-signal-leak invariant test
   - 3 sibling files with MagicMock opt-outs

## Auto-compress

Unchanged, correctly retries — the preflight path was never affected.

## Cache safety

No message mutation, no prompt change, no role insertion. Lock-skip path is CLI `print` + `return` / gateway `return` string / TUI `raise` + catch.

## Reproduction

macOS 26.5, dashboard `serve` + TUI:

**Before:** `🗜️ No changes from compression: 208 messages` (lie — dashboard held the lock)  
**After:** `⏳ Compression already in progress for this session (holder: pid=26322).`