### PR TITLE
fix(session): show more browse results

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2294,7 +2294,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 _session_search(
                     query=next_args.get("query", ""),
                     role_filter=next_args.get("role_filter"),
-                    limit=next_args.get("limit", 3),
+                    limit=next_args.get("limit"),
                     session_id=next_args.get("session_id"),
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1272,7 +1272,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 return _session_search(
                     query=next_args.get("query", ""),
                     role_filter=next_args.get("role_filter"),
-                    limit=next_args.get("limit", 3),
+                    limit=next_args.get("limit"),
                     session_id=next_args.get("session_id"),
                     around_message_id=next_args.get("around_message_id"),
                     window=next_args.get("window", 5),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2342,6 +2342,29 @@ class TestExecuteToolCalls:
         assert messages[0]["role"] == "tool"
         assert "search result" in messages[0]["content"]
 
+    @pytest.mark.parametrize(
+        "executor_name",
+        ["_execute_tool_calls_sequential", "_execute_tool_calls_concurrent"],
+    )
+    def test_session_search_no_args_preserves_browse_default(
+        self, agent, executor_name
+    ):
+        """Both live dispatchers must let session_search select its browse limit."""
+        tc = _mock_tool_call(name="session_search", arguments="{}", call_id="s1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        agent._get_session_db_for_recall = MagicMock(return_value=object())
+
+        with patch(
+            "tools.session_search_tool.session_search",
+            return_value=json.dumps({"success": True, "mode": "browse"}),
+        ) as mock_search:
+            getattr(agent, executor_name)(mock_msg, messages, "task-1")
+
+        mock_search.assert_called_once()
+        assert mock_search.call_args.kwargs["limit"] is None
+        assert messages[-1]["tool_call_id"] == "s1"
+
     def test_sequential_memory_remove_notifies_provider_with_tool_result(self, agent):
         old_text = "stale preference entry"
         tc = _mock_tool_call(

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -58,6 +58,20 @@ def _seed_modpack_sessions(db):
     db._conn.commit()
 
 
+def _seed_browse_sessions(db, count=10):
+    now = int(time.time())
+    for idx in range(count):
+        session_id = f"s_browse_{idx}"
+        db.create_session(session_id, source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+            (now - idx, f"Browse Session {idx}", session_id),
+        )
+        db.append_message(session_id, role="user", content=f"browse topic {idx}")
+        db.append_message(session_id, role="assistant", content=f"browse reply {idx}")
+    db._conn.commit()
+
+
 # =========================================================================
 # Schema invariants
 # =========================================================================
@@ -137,6 +151,26 @@ class TestBrowseShape:
         assert result["mode"] == "browse"
         assert result["count"] >= 3
 
+    def test_no_args_browse_defaults_to_ten_sessions(self, db):
+        _seed_browse_sessions(db, count=10)
+
+        result = json.loads(session_search(db=db))
+
+        assert result["success"] is True
+        assert result["mode"] == "browse"
+        assert result["count"] == 10
+        assert len(result["results"]) == 10
+
+    def test_browse_respects_explicit_limit(self, db):
+        _seed_browse_sessions(db, count=10)
+
+        result = json.loads(session_search(db=db, limit=4))
+
+        assert result["success"] is True
+        assert result["mode"] == "browse"
+        assert result["count"] == 4
+        assert len(result["results"]) == 4
+
     def test_browse_excludes_current_session(self, db):
         _seed_modpack_sessions(db)
         result = json.loads(session_search(db=db, current_session_id="s_newest"))
@@ -161,6 +195,15 @@ class TestDiscoveryShape:
         assert result["success"] is True
         assert result["mode"] == "discover"
         assert result["count"] >= 1
+
+    def test_discovery_default_stays_three_sessions(self, db):
+        _seed_browse_sessions(db, count=5)
+
+        result = json.loads(session_search(query="browse", db=db))
+
+        assert result["success"] is True
+        assert result["mode"] == "discover"
+        assert result["count"] == 3
 
     def test_discovery_result_has_bookends_and_window(self, db):
         _seed_modpack_sessions(db)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -54,6 +54,24 @@ _DEMOTED_SESSION_SOURCES = ("cron",)
 # interactive matches buried under a wall of cron hits, so this is well above
 # the handful of distinct sessions a typical query returns.
 _DISCOVER_SCAN_LIMIT = 300
+_DEFAULT_DISCOVERY_LIMIT = 3
+_DEFAULT_BROWSE_LIMIT = 10
+_MAX_SESSION_SEARCH_LIMIT = 10
+
+
+def _coerce_session_limit(
+    raw_limit: Optional[int],
+    *,
+    default: int,
+    maximum: int = _MAX_SESSION_SEARCH_LIMIT,
+) -> int:
+    """Clamp a caller-provided session count, preserving mode-specific defaults."""
+    if not isinstance(raw_limit, int):
+        try:
+            raw_limit = int(raw_limit)
+        except (TypeError, ValueError):
+            raw_limit = default
+    return max(1, min(raw_limit, maximum))
 
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
@@ -261,7 +279,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
     """Return metadata for the most recent sessions (no LLM calls, no FTS5)."""
     try:
         sessions = db.list_sessions_rich(
-            limit=limit + 5,
+            limit=max(limit + 5, limit * 2),
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
         )  # fetch extra so we can skip current
@@ -619,7 +637,7 @@ def _discover(
 def session_search(
     query: str = "",
     role_filter: str = None,
-    limit: int = 3,
+    limit: Optional[int] = None,
     db=None,
     current_session_id: str = None,
     # Scroll shape
@@ -706,17 +724,12 @@ def session_search(
                 return json.dumps(found, ensure_ascii=False)
         return result
 
-    # Limit clamp [1, 10]
-    if not isinstance(limit, int):
-        try:
-            limit = int(limit)
-        except (TypeError, ValueError):
-            limit = 3
-    limit = max(1, min(limit, 10))
-
     # Browse shape: no query → recent sessions.
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id)
+        browse_limit = _coerce_session_limit(limit, default=_DEFAULT_BROWSE_LIMIT)
+        return _list_recent_sessions(db, browse_limit, current_session_id)
+
+    limit = _coerce_session_limit(limit, default=_DEFAULT_DISCOVERY_LIMIT)
 
     # Parse role_filter
     role_list: Optional[List[str]] = None
@@ -830,11 +843,11 @@ SESSION_SEARCH_SCHEMA = {
             "limit": {
                 "type": "integer",
                 "description": (
-                    "Discovery shape only. Max sessions to return (default 3, max 10). "
-                    "Bump to 5–10 when the topic likely spans several sessions and you "
-                    "want to pick the right one to scroll into."
+                    "Max sessions to return. Discovery defaults to 3; browse/no-args "
+                    "defaults to 10. Max 10. Bump discovery to 5–10 when the topic "
+                    "likely spans several sessions and you want to pick the right one "
+                    "to scroll into."
                 ),
-                "default": 3,
             },
             "sort": {
                 "type": "string",
@@ -907,7 +920,7 @@ registry.register(
     handler=lambda args, **kw: session_search(
         query=args.get("query") or "",
         role_filter=args.get("role_filter"),
-        limit=args.get("limit", 3),
+        limit=args.get("limit"),
         session_id=args.get("session_id"),
         around_message_id=args.get("around_message_id"),
         window=args.get("window", 5),


### PR DESCRIPTION
## Summary
- Give no-argument `session_search` browse mode its intended 10-session default.
- Pass an omitted limit through both sequential and concurrent live agent dispatchers instead of forcing 3.
- Preserve explicit limits and the existing discovery-mode default.
- Cover direct search behavior and both live execution paths.

## Problem
The tool implementation had a larger browse default, but both live dispatchers replaced an omitted limit with 3 before calling it. A normal no-argument model tool call therefore still returned only three sessions.

## Validation
- `python -m pytest -q tests/tools/test_session_search.py` (56 passed)
- `python -m pytest -q tests/run_agent/test_run_agent.py` (433 passed)
- `python -m ruff check agent/agent_runtime_helpers.py agent/tool_executor.py tools/session_search_tool.py tests/run_agent/test_run_agent.py tests/tools/test_session_search.py`

Fixes #57606