### PR TITLE
security(browser): redact CDP endpoint token from browser_cdp tool_error text

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -194,6 +194,59 @@ def test_non_ws_endpoint_returns_error(monkeypatch):
     assert "WebSocket" in result["error"]
 
 
+_TOKEN_URL = "ws://127.0.0.1:9222/devtools/browser/mock?token=SUPER-SECRET-TOKEN-12345"
+
+
+def test_non_ws_endpoint_error_redacts_token(monkeypatch):
+    """A CDP endpoint carrying a ?token= credential must never appear verbatim
+    in the tool_error returned to the model, even when it's merely malformed
+    (missing ws:// scheme) rather than unreachable."""
+    monkeypatch.setattr(
+        browser_cdp_tool,
+        "_resolve_cdp_endpoint",
+        lambda: "http://127.0.0.1:9222/devtools/browser/mock?token=SUPER-SECRET-TOKEN-12345",
+    )
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Target.getTargets"))
+    assert "SUPER-SECRET-TOKEN-12345" not in result["error"]
+    assert "***" in result["error"]
+
+
+def test_websocket_exception_redacts_token_in_endpoint_and_message(monkeypatch):
+    """A WebSocketException's own text can embed the raw CDP URL (the
+    ``websockets`` library bakes it into connect/handshake errors) — both the
+    directly-interpolated endpoint and the exception's message must be
+    redacted."""
+    monkeypatch.setattr(
+        browser_cdp_tool, "_resolve_cdp_endpoint", lambda: _TOKEN_URL
+    )
+
+    async def fake_call(*args, **kwargs):
+        raise browser_cdp_tool.WebSocketException(f"connection failed to {_TOKEN_URL}")
+
+    monkeypatch.setattr(browser_cdp_tool, "_cdp_call", fake_call)
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Target.getTargets"))
+    assert "SUPER-SECRET-TOKEN-12345" not in result["error"]
+    assert result["error"].count("***") == 2
+
+
+def test_generic_exception_redacts_token_in_message(monkeypatch):
+    """Non-WebSocketException failures (e.g. a TLS error) fall through to the
+    generic handler — its exception text must also be redacted."""
+    monkeypatch.setattr(
+        browser_cdp_tool, "_resolve_cdp_endpoint", lambda: _TOKEN_URL
+    )
+
+    async def fake_call(*args, **kwargs):
+        raise ValueError(f"unexpected failure connecting to {_TOKEN_URL}")
+
+    monkeypatch.setattr(browser_cdp_tool, "_cdp_call", fake_call)
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Target.getTargets"))
+    assert "SUPER-SECRET-TOKEN-12345" not in result["error"]
+    assert "***" in result["error"]
+
+
 def test_websockets_missing_returns_error(monkeypatch):
     monkeypatch.setattr(browser_cdp_tool, "_WS_AVAILABLE", False)
     result = json.loads(browser_cdp_tool.browser_cdp(method="Target.getTargets"))

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -247,6 +247,71 @@ def test_generic_exception_redacts_token_in_message(monkeypatch):
     assert "***" in result["error"]
 
 
+# ---------------------------------------------------------------------------
+# frame_id supervisor routing
+# ---------------------------------------------------------------------------
+
+
+def test_supervisor_dispatch_failure_redacts_token(monkeypatch):
+    """A frame_id call dispatched through the CDP supervisor's live WebSocket
+    (``_browser_cdp_via_supervisor``) can fail with an exception whose text
+    embeds the CDP endpoint's ``?token=`` credential — the same leak class as
+    the stateless paths above, but through a separate egress point that must
+    also route through ``_redact_cdp_error_text``."""
+    from tools import browser_supervisor
+
+    class _FakeLoop:
+        def is_running(self) -> bool:
+            return True
+
+    class _FakeSupervisor:
+        _loop = _FakeLoop()
+        _state_lock = threading.Lock()
+        _frames: Dict[str, Any] = {}
+
+        def snapshot(self):
+            return type(
+                "_Snap",
+                (),
+                {
+                    "frame_tree": {
+                        "top": {"frame_id": "top1"},
+                        "children": [{"frame_id": "f1", "session_id": "sess1"}],
+                    }
+                },
+            )()
+
+    monkeypatch.setattr(
+        browser_supervisor.SUPERVISOR_REGISTRY,
+        "_by_task",
+        {"default": _FakeSupervisor()},
+    )
+
+    class _FakeFuture:
+        def result(self, timeout=None):
+            raise RuntimeError(f"dispatch failed talking to {_TOKEN_URL}")
+
+    def fake_schedule(coro, loop):
+        coro.close()  # avoid "coroutine was never awaited" warning
+        return _FakeFuture()
+
+    monkeypatch.setattr(
+        "agent.async_utils.safe_schedule_threadsafe", fake_schedule
+    )
+
+    result = json.loads(
+        browser_cdp_tool._browser_cdp_via_supervisor(
+            task_id="default",
+            frame_id="f1",
+            method="Runtime.evaluate",
+            params={},
+            timeout=5.0,
+        )
+    )
+    assert "SUPER-SECRET-TOKEN-12345" not in result["error"]
+    assert "***" in result["error"]
+
+
 def test_websockets_missing_returns_error(monkeypatch):
     monkeypatch.setattr(browser_cdp_tool, "_WS_AVAILABLE", False)
     result = json.loads(browser_cdp_tool.browser_cdp(method="Target.getTargets"))

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -376,8 +376,11 @@ def _browser_cdp_via_supervisor(
             )
         result_msg = fut.result(timeout=timeout + 2)
     except Exception as exc:
+        from tools.browser_supervisor import _redact_cdp_error_text
+
         return tool_error(
-            f"CDP call via supervisor failed: {type(exc).__name__}: {exc}",
+            f"CDP call via supervisor failed: {type(exc).__name__}: "
+            f"{_redact_cdp_error_text(exc)}",
             cdp_docs=CDP_DOCS_URL,
         )
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -459,8 +459,10 @@ def browser_cdp(
         )
 
     if not endpoint.startswith(("ws://", "wss://")):
+        from agent.redact import redact_cdp_url
+
         return tool_error(
-            f"CDP endpoint is not a WebSocket URL: {endpoint!r}. "
+            f"CDP endpoint is not a WebSocket URL: {redact_cdp_url(endpoint)!r}. "
             "Expected ws://... or wss://... — the /browser connect "
             "resolver should have rewritten this. Check that a Chromium-family "
             "browser is actually listening on the debug port."
@@ -500,15 +502,21 @@ def browser_cdp(
     except RuntimeError as exc:
         return tool_error(str(exc), method=method)
     except WebSocketException as exc:
+        from agent.redact import redact_cdp_url
+        from tools.browser_supervisor import _redact_cdp_error_text
+
         return tool_error(
-            f"WebSocket error talking to CDP at {endpoint}: {exc}. The "
-            "browser may have disconnected — try '/browser connect' again.",
+            f"WebSocket error talking to CDP at {redact_cdp_url(endpoint)}: "
+            f"{_redact_cdp_error_text(exc)}. The browser may have "
+            "disconnected — try '/browser connect' again.",
             method=method,
         )
     except Exception as exc:  # pragma: no cover — unexpected
+        from tools.browser_supervisor import _redact_cdp_error_text
+
         logger.exception("browser_cdp unexpected error")
         return tool_error(
-            f"Unexpected error: {type(exc).__name__}: {exc}",
+            f"Unexpected error: {type(exc).__name__}: {_redact_cdp_error_text(exc)}",
             method=method,
         )
 


### PR DESCRIPTION
## Summary

`browser_cdp`'s three failure paths interpolate the raw endpoint URL (or an exception whose own text embeds it) directly into the `tool_error` string returned to the **model**:

1. A non-`ws://` endpoint (e.g. a misconfigured `browser.cdp_url`) is echoed verbatim in the "CDP endpoint is not a WebSocket URL" error.
2. A `WebSocketException`'s message can itself embed the full CDP URL — the `websockets` library bakes it into connect/handshake errors — in addition to the endpoint interpolated directly into the wrapping message.
3. A TLS failure or other non-`WebSocketException` error falls through to the generic `except Exception` handler, whose exception text can carry the same embedded URL (per `_redact_cdp_error_text`'s own docstring: "TLS failures all embed the full `self.cdp_url`").

A Browserbase-style CDP URL carries a `?token=` credential (or `user:pass@` userinfo). The prior CDP-URL log-redaction round (PR #56162, `refactor(redact): consolidate CDP-URL log redaction into one chokepoint` + `fix(browser): close remaining CDP-URL leak paths in supervisor`) only covered *log* lines inside `tools/browser_supervisor.py`. This is the same secret returned directly in the tool's JSON payload — i.e. into the model's own context/transcript, not just a log file — arguably a more severe exposure since it's visible to whatever the model does with its own output, not just an operator reading logs.

Verified live against current `main`: a `browser_cdp()` call against a token-bearing endpoint returns the token verbatim in the `"error"` field for all three code paths.

## Fix

Route the endpoint through `agent.redact.redact_cdp_url` (the existing single source of truth for CDP URL redaction — already masks `?token=` and `user:pass@`) at all three sites, and route exception text through `tools.browser_supervisor._redact_cdp_error_text` (which already handles credentials embedded inside an exception's own message, used elsewhere in the supervisor for exactly this purpose) for the two sites that also interpolate `{exc}`.

## Test plan

- [x] Live PoC against current `main` confirmed the leak at all three sites (`http://...?token=...` non-ws endpoint, a raised `WebSocketException` embedding the URL, and a generic exception embedding the URL) before the fix.
- [x] Added `test_non_ws_endpoint_error_redacts_token`, `test_websocket_exception_redacts_token_in_endpoint_and_message`, and `test_generic_exception_redacts_token_in_message` to `tests/tools/test_browser_cdp_tool.py`.
- [x] `uv run --frozen --extra dev python -m pytest tests/tools/test_browser_cdp_tool.py -x -q` — 26 passed (23 existing + 3 new).
- [x] `uv run --frozen --extra dev python -m pytest tests/tools/ -k browser -q` — 515 passed, 22 skipped (unrelated), no regressions.
- [x] `ruff check` on both changed files — clean.

## Note

`logger.exception("browser_cdp unexpected error")` in the generic handler still logs the raw (unredacted) exception traceback to the application log — that's a separate, log-file-only exposure distinct from the tool_error returned to the model that this PR fixes, and wasn't part of the verified finding here. Flagging for visibility in case it's worth a follow-up.