### PR TITLE
security(environments): sanitize subprocess env for Singularity/Apptainer exec

### DIFF
--- a/tests/tools/test_singularity_env_isolation.py
+++ b/tests/tools/test_singularity_env_isolation.py
@@ -1,0 +1,113 @@
+"""Tests for Singularity/Apptainer subprocess env isolation.
+
+Apptainer/Singularity's ``exec`` inherits the calling process's FULL
+environment into the container by default -- ``--cleanenv`` (passed to
+``instance start``) is not repeated on the per-command ``exec`` that
+``SingularityEnvironment._run_bash`` actually spawns. Unlike LocalEnvironment
+(``_make_run_env``) and DockerEnvironment (explicit ``-e`` forwarding), the
+Singularity backend never filtered the env at all, so every hermes provider
+API key / session token / gateway secret in the host process's environment
+was inherited by the container on every terminal command.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments.singularity import (
+    SingularityEnvironment,
+    _filtered_container_env,
+)
+from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+
+class TestFilteredContainerEnv:
+    def test_strips_provider_api_keys(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-super-secret-12345")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+
+        result = _filtered_container_env({})
+
+        assert "ANTHROPIC_API_KEY" not in result
+        assert "OPENAI_API_KEY" not in result
+
+    def test_strips_hermes_internal_secrets(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "dashboard-secret-xyz")
+        monkeypatch.setenv("GH_TOKEN", "ghp_supersecrettoken")
+
+        result = _filtered_container_env({})
+
+        assert "HERMES_DASHBOARD_SESSION_TOKEN" not in result
+        assert "GH_TOKEN" not in result
+
+    def test_preserves_benign_vars(self, monkeypatch):
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        monkeypatch.setenv("LANG", "en_US.UTF-8")
+
+        result = _filtered_container_env({})
+
+        assert result.get("PATH") == "/usr/bin:/bin"
+        assert result.get("LANG") == "en_US.UTF-8"
+
+    def test_overrides_merge_over_os_environ(self, monkeypatch):
+        monkeypatch.setenv("SOME_VAR", "from-os-environ")
+
+        result = _filtered_container_env({"SOME_VAR": "from-overrides"})
+
+        assert result["SOME_VAR"] == "from-overrides"
+
+    def test_every_blocklisted_var_actually_stripped(self, monkeypatch):
+        """Direct regression against the real blocklist, not just a sample."""
+        for key in _HERMES_PROVIDER_ENV_BLOCKLIST:
+            monkeypatch.setenv(key, "leaked-if-present")
+
+        result = _filtered_container_env({})
+
+        leaked = set(_HERMES_PROVIDER_ENV_BLOCKLIST) & result.keys()
+        assert not leaked, f"blocklisted vars leaked into container env: {leaked}"
+
+
+def _bare_singularity_env(env_overrides: dict | None = None) -> SingularityEnvironment:
+    """Construct a SingularityEnvironment without running its real __init__
+    (which starts an actual apptainer/singularity instance)."""
+    instance = object.__new__(SingularityEnvironment)
+    instance.executable = "apptainer"
+    instance.instance_id = "hermes_test_instance"
+    instance._instance_started = True
+    instance.env = env_overrides or {}
+    return instance
+
+
+class TestRunBashEnvIsolation:
+    def test_run_bash_passes_filtered_env_to_popen(self, monkeypatch):
+        """The exact bug: _run_bash must not spawn with the unfiltered
+        (inherited) environment -- every terminal command run under
+        TERMINAL_ENV=singularity must be sanitized the same way Local and
+        Docker already are."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-super-secret-12345")
+
+        captured = {}
+
+        def fake_popen_bash(cmd, stdin_data=None, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return object()
+
+        env = _bare_singularity_env()
+        with patch("tools.environments.singularity._popen_bash", fake_popen_bash):
+            env._run_bash("echo hi")
+
+        assert "env" in captured["kwargs"], "_run_bash must pass env= explicitly"
+        assert "ANTHROPIC_API_KEY" not in captured["kwargs"]["env"]
+        assert captured["cmd"] == [
+            "apptainer", "exec", "instance://hermes_test_instance",
+            "bash", "-c", "echo hi",
+        ]
+
+    def test_run_bash_raises_when_instance_not_started(self):
+        env = _bare_singularity_env()
+        env._instance_started = False
+        with pytest.raises(RuntimeError, match="not started"):
+            env._run_bash("echo hi")

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -21,10 +21,35 @@ from tools.environments.base import (
     _popen_bash,
     _save_json_store,
 )
+from tools.environments.local import (
+    _HERMES_PROVIDER_ENV_BLOCKLIST,
+    _is_hermes_internal_secret,
+)
 
 logger = logging.getLogger(__name__)
 
 _SNAPSHOT_STORE = get_hermes_home() / "singularity_snapshots.json"
+
+
+def _filtered_container_env(overrides: dict) -> dict:
+    """Build a sanitized env for ``apptainer``/``singularity exec``.
+
+    Unlike Docker (which only forwards explicitly allowlisted ``-e`` vars),
+    Apptainer/Singularity's ``exec`` inherits the calling process's FULL
+    environment into the container by default — ``--cleanenv`` is passed to
+    ``instance start`` only, not to the per-command ``exec`` that actually
+    runs each terminal command. Passing this filtered dict as
+    ``subprocess.Popen``'s ``env=`` keeps every hermes provider API key /
+    session token / gateway secret out of the container, matching the same
+    blocklist ``LocalEnvironment`` and ``DockerEnvironment`` already apply
+    to their own subprocess spawns.
+    """
+    merged = dict(os.environ) | dict(overrides)
+    return {
+        k: v
+        for k, v in merged.items()
+        if k not in _HERMES_PROVIDER_ENV_BLOCKLIST and not _is_hermes_internal_secret(k)
+    }
 
 
 def _find_singularity_executable() -> str:
@@ -243,7 +268,7 @@ class SingularityEnvironment(BaseEnvironment):
         else:
             cmd.extend(["bash", "-c", cmd_string])
 
-        return _popen_bash(cmd, stdin_data)
+        return _popen_bash(cmd, stdin_data, env=_filtered_container_env(self.env))
 
     def cleanup(self):
         """Stop the instance. If persistent, the overlay dir survives."""


### PR DESCRIPTION
## Summary

`SingularityEnvironment._run_bash` spawns `apptainer/singularity exec instance://<id> bash -c <cmd>` via `_popen_bash` with **no `env=` argument at all**, so `subprocess.Popen` inherits the full, unfiltered gateway/agent process environment into the container.

`--containall` (which implies `--contain` + `--cleanenv` + `--no-home`) is passed to `instance start` (see `_start_instance`), but the per-command `exec` that `_run_bash` actually calls for every terminal command does **not** repeat `--cleanenv`, and Apptainer/Singularity's `exec` forwards the calling process's environment into the container by default (unlike Docker, which requires explicit `-e` flags to forward anything).

As a result, every terminal command run under `TERMINAL_ENV=singularity` receives every provider API key, `GH_TOKEN`, `GATEWAY_RELAY_*`, `HERMES_DASHBOARD_SESSION_TOKEN`, `AUXILIARY_*_API_KEY`, etc. from the host process, unfiltered. `LocalEnvironment` (via `_make_run_env`) and `DockerEnvironment` (via explicit `-e` forwarding) both already sanitize their own subprocess spawns — Singularity is the one backend that never did.

Verified live: constructing the filtered env with a set of provider secrets present in `os.environ` shows none of them survive into the dict that would be passed to the container.

## Fix

Add `_filtered_container_env`, which reuses the exact same `_HERMES_PROVIDER_ENV_BLOCKLIST` / `_is_hermes_internal_secret` primitives `DockerEnvironment` already imports from `tools.environments.local` (establishing that cross-module reuse is the existing convention in this package), and pass the result as `env=` to the `exec` call.

Scoped deliberately to just the blocklist/secret filtering — not the full `_make_run_env` (which also does PATH sanitization, Windows/MSYS defaults, and injects the *host's* `HERMES_HOME` path). Singularity is Linux-only and containerized, so those extras are either irrelevant or could point at a host path that isn't bind-mounted into the container; reusing them wasn't part of the verified bug and risked introducing new, untested behavior.

## Test plan

- [x] Added `tests/tools/test_singularity_env_isolation.py`: unit tests for `_filtered_container_env` (strips provider API keys, strips hermes-internal secrets, preserves benign vars like `PATH`/`LANG`, overrides merge correctly, and a direct sweep over every entry in `_HERMES_PROVIDER_ENV_BLOCKLIST`), plus a test that constructs a `SingularityEnvironment` (bypassing the real `__init__`, which would start an actual instance) and confirms `_run_bash` passes the filtered dict as `env=` to `_popen_bash`.
- [x] `uv run --frozen --extra dev python -m pytest tests/tools/test_singularity_preflight.py tests/tools/test_singularity_env_isolation.py -q` — 14 passed.
- [x] `uv run --frozen --extra dev python -m pytest tests/tools/ -k "environment or docker or local_env or hermes_subprocess" -q` — confirmed the only failures (`test_docker_config_migrate.py::test_docker_config_migrate_second_boot_preserves_env_byte_for_byte`, and intermittently `test_base_environment.py::test_concurrent_writes_never_tear_the_snapshot`) are pre-existing test-order/pollution flakes present identically on a clean `main` checkout with none of this PR's changes — not a regression.
- [x] `ruff check` on both changed files — clean.