### PR TITLE
feat(kanban): add recurring routines

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -769,6 +769,51 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_asg.add_argument("--json", action="store_true")
 
+    # --- routines ---
+    p_routine = sub.add_parser(
+        "routine",
+        help="Manage recurring task templates that materialize normal Kanban tasks",
+    )
+    rsub = p_routine.add_subparsers(dest="routine_action")
+
+    r_create = rsub.add_parser("create", help="Create a recurring task routine")
+    r_create.add_argument("title", help="Routine task title")
+    r_create.add_argument("--cron", required=True, dest="cron_expr",
+                          help="5-field cron schedule, e.g. '0 9 * * 1'")
+    r_create.add_argument("--body", default=None, help="Task body template")
+    r_create.add_argument("--assignee", default=None, help="Profile name to assign")
+    r_create.add_argument("--priority", type=int, default=0, help="Task priority")
+    r_create.add_argument("--skill", action="append", default=[], dest="skills",
+                          help="Skill to force-load into materialized workers")
+    r_create.add_argument(
+        "--concurrency",
+        choices=sorted(kb.VALID_ROUTINE_CONCURRENCY),
+        default="skip_if_active",
+        help="How to behave when a previous routine task is still live",
+    )
+    r_create.add_argument(
+        "--catch-up",
+        choices=sorted(kb.VALID_ROUTINE_CATCH_UP),
+        default="skip_missed",
+        help="How to handle missed windows after downtime",
+    )
+    r_create.add_argument("--json", action="store_true")
+
+    r_list = rsub.add_parser("list", aliases=["ls"], help="List routines")
+    r_list.add_argument("--active-only", action="store_true",
+                        help="Hide paused routines")
+    r_list.add_argument("--json", action="store_true")
+
+    r_pause = rsub.add_parser("pause", help="Pause a routine")
+    r_pause.add_argument("routine_id", type=int)
+    r_resume = rsub.add_parser("resume", help="Resume a routine")
+    r_resume.add_argument("routine_id", type=int)
+    r_run = rsub.add_parser("run-now", help="Materialize a routine immediately")
+    r_run.add_argument("routine_id", type=int)
+    r_run.add_argument("--json", action="store_true")
+    r_delete = rsub.add_parser("delete", aliases=["rm"], help="Delete a routine")
+    r_delete.add_argument("routine_id", type=int)
+
     # --- context --- (for spawned workers)
     p_ctx = sub.add_parser(
         "context",
@@ -967,6 +1012,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "runs":     _cmd_runs,
             "heartbeat": _cmd_heartbeat,
             "assignees": _cmd_assignees,
+            "routine":  _dispatch_routine,
             "notify-subscribe":   _cmd_notify_subscribe,
             "notify-list":        _cmd_notify_list,
             "notify-unsubscribe": _cmd_notify_unsubscribe,
@@ -1299,6 +1345,139 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
         counts = entry["counts"] or {}
         count_str = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "(idle)"
         print(f"{entry['name']:20s}  {on_disk:8s}  {count_str}")
+    return 0
+
+
+def _routine_to_dict(r: kb.Routine) -> dict:
+    return {
+        "id": r.id,
+        "board_id": r.board_id,
+        "title": r.title,
+        "body": r.body,
+        "assignee": r.assignee,
+        "priority": r.priority,
+        "skills": r.skills or [],
+        "cron_expr": r.cron_expr,
+        "status": r.status,
+        "concurrency": r.concurrency,
+        "catch_up": r.catch_up,
+        "last_materialized_at": r.last_materialized_at,
+        "created_at": r.created_at,
+        "updated_at": r.updated_at,
+    }
+
+
+def _dispatch_routine(args: argparse.Namespace) -> int:
+    action = getattr(args, "routine_action", None)
+    if not action:
+        print("usage: hermes kanban routine <create|list|pause|resume|run-now|delete>")
+        return 0
+    if action == "ls":
+        action = "list"
+    if action == "rm":
+        action = "delete"
+    handlers = {
+        "create": _cmd_routine_create,
+        "list": _cmd_routine_list,
+        "pause": _cmd_routine_pause,
+        "resume": _cmd_routine_resume,
+        "run-now": _cmd_routine_run_now,
+        "delete": _cmd_routine_delete,
+    }
+    handler = handlers.get(action)
+    if handler is None:
+        print(f"kanban routine: unknown action {action!r}", file=sys.stderr)
+        return 2
+    return handler(args)
+
+
+def _cmd_routine_create(args: argparse.Namespace) -> int:
+    try:
+        with kb.connect_closing() as conn:
+            rid = kb.create_routine(
+                conn,
+                title=args.title,
+                cron_expr=args.cron_expr,
+                body=args.body,
+                assignee=args.assignee,
+                priority=args.priority,
+                skills=getattr(args, "skills", None) or None,
+                concurrency=args.concurrency,
+                catch_up=args.catch_up,
+            )
+            routine = kb.get_routine(conn, rid)
+    except ValueError as exc:
+        print(f"kanban routine create: {exc}", file=sys.stderr)
+        return 2
+    if routine is None:
+        print("kanban routine create: failed to load created routine", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(_routine_to_dict(routine), indent=2, ensure_ascii=False))
+    else:
+        assignee = routine.assignee or "-"
+        print(f"Created routine {routine.id}  ({routine.status}, assignee={assignee})")
+    return 0
+
+
+def _cmd_routine_list(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        routines = kb.list_routines(conn, include_paused=not args.active_only)
+    if getattr(args, "json", False):
+        print(json.dumps([_routine_to_dict(r) for r in routines], indent=2, ensure_ascii=False))
+        return 0
+    if not routines:
+        print("(no routines)")
+        return 0
+    print(f"{'ID':>4s}  {'STATUS':8s}  {'ASSIGNEE':16s}  {'CRON':16s}  TITLE")
+    for r in routines:
+        print(
+            f"{r.id:>4d}  {r.status:8s}  {(r.assignee or '-'):16s}  "
+            f"{r.cron_expr:16s}  {r.title}"
+        )
+    return 0
+
+
+def _cmd_routine_pause(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        ok = kb.set_routine_status(conn, args.routine_id, "paused")
+    if not ok:
+        print(f"no such routine: {args.routine_id}", file=sys.stderr)
+        return 1
+    print(f"Paused routine {args.routine_id}")
+    return 0
+
+
+def _cmd_routine_resume(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        ok = kb.set_routine_status(conn, args.routine_id, "active")
+    if not ok:
+        print(f"no such routine: {args.routine_id}", file=sys.stderr)
+        return 1
+    print(f"Resumed routine {args.routine_id}")
+    return 0
+
+
+def _cmd_routine_run_now(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        task_id = kb.materialize_routine(conn, args.routine_id, manual=True)
+    if not task_id:
+        print(f"routine {args.routine_id} did not materialize", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps({"routine_id": args.routine_id, "task_id": task_id}, indent=2))
+    else:
+        print(f"Materialized routine {args.routine_id} as task {task_id}")
+    return 0
+
+
+def _cmd_routine_delete(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        ok = kb.delete_routine(conn, args.routine_id)
+    if not ok:
+        print(f"no such routine: {args.routine_id}", file=sys.stderr)
+        return 1
+    print(f"Deleted routine {args.routine_id}")
     return 0
 
 
@@ -2174,6 +2353,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "workspace": ws}
                 for (tid, who, ws) in res.spawned
             ],
+            "materialized_routines": [
+                {"routine_id": rid, "task_id": tid}
+                for (rid, tid) in res.materialized_routines
+            ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
             "skipped_per_profile_capped": [
@@ -2197,6 +2380,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     if res.auto_blocked:
         print(f"  {', '.join(res.auto_blocked)}")
     print(f"Promoted:     {res.promoted}")
+    print(f"Routines:     {len(res.materialized_routines)}")
+    for rid, tid in res.materialized_routines:
+        print(f"  - routine {rid} -> {tid}")
     print(f"Spawned:      {len(res.spawned)}")
     for tid, who, ws in res.spawned:
         tag = " (dry)" if args.dry_run else ""
@@ -2757,6 +2943,7 @@ Common subcommands:
   `block <id> [reason]` Mark blocked; `schedule <id> [reason]` parks time-delay work; `unblock <id>` to revive
   `assign <id> <profile>`  Reassign
   `boards list`         Show all boards
+  `routine list`        Recurring task templates
   `assignees`           Known profiles + counts
   `context <id>`        Full worker-context dump
   `runs <id>`           Attempt history

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -86,6 +86,7 @@ import logging
 import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -133,6 +134,9 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+VALID_ROUTINE_STATUSES = {"active", "paused"}
+VALID_ROUTINE_CONCURRENCY = {"skip_if_active", "allow"}
+VALID_ROUTINE_CATCH_UP = {"skip_missed", "run_once"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
@@ -1003,6 +1007,57 @@ class Task:
 
 
 @dataclass
+class Routine:
+    """Recurring task template stored in the board DB."""
+
+    id: int
+    board_id: str
+    title: str
+    body: Optional[str]
+    assignee: Optional[str]
+    priority: int
+    skills: Optional[list[str]]
+    cron_expr: str
+    status: str
+    concurrency: str
+    catch_up: str
+    last_materialized_at: Optional[int]
+    created_at: int
+    updated_at: int
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "Routine":
+        skills_value: Optional[list[str]] = None
+        if row["skills"]:
+            try:
+                parsed = json.loads(row["skills"])
+                if isinstance(parsed, list):
+                    skills_value = [str(s) for s in parsed if s]
+            except Exception:
+                skills_value = None
+        return cls(
+            id=int(row["id"]),
+            board_id=row["board_id"] or DEFAULT_BOARD,
+            title=row["title"],
+            body=row["body"],
+            assignee=row["assignee"],
+            priority=int(row["priority"] or 0),
+            skills=skills_value,
+            cron_expr=row["cron_expr"],
+            status=row["status"],
+            concurrency=row["concurrency"],
+            catch_up=row["catch_up"],
+            last_materialized_at=(
+                int(row["last_materialized_at"])
+                if row["last_materialized_at"] is not None
+                else None
+            ),
+            created_at=int(row["created_at"]),
+            updated_at=int(row["updated_at"]),
+        )
+
+
+@dataclass
 class Run:
     """In-memory view of a ``task_runs`` row.
 
@@ -1179,6 +1234,23 @@ CREATE TABLE IF NOT EXISTS tasks (
     block_recurrences    INTEGER NOT NULL DEFAULT 0
 );
 
+CREATE TABLE IF NOT EXISTS routines (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    board_id             TEXT NOT NULL DEFAULT 'default',
+    title                TEXT NOT NULL,
+    body                 TEXT,
+    assignee             TEXT,
+    priority             INTEGER NOT NULL DEFAULT 0,
+    skills               TEXT,
+    cron_expr            TEXT NOT NULL,
+    status               TEXT NOT NULL DEFAULT 'active',
+    concurrency          TEXT NOT NULL DEFAULT 'skip_if_active',
+    catch_up             TEXT NOT NULL DEFAULT 'skip_missed',
+    last_materialized_at INTEGER,
+    created_at           INTEGER NOT NULL,
+    updated_at           INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
@@ -1266,6 +1338,7 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
 
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
+CREATE INDEX IF NOT EXISTS idx_routines_status       ON routines(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
 CREATE INDEX IF NOT EXISTS idx_links_parent          ON task_links(parent_id);
 CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, created_at);
@@ -2688,6 +2761,276 @@ def create_task(
             # Retry with a fresh id.
             continue
     raise RuntimeError("unreachable")
+
+
+def _normalize_routine_skills(skills: Optional[Iterable[str]]) -> Optional[list[str]]:
+    if skills is None:
+        return None
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    toolset_typos: list[str] = []
+    for item in skills:
+        if not item:
+            continue
+        name = str(item).strip()
+        if not name:
+            continue
+        if "," in name:
+            raise ValueError(
+                f"skill name cannot contain comma: {name!r} "
+                f"(pass a list of separate names instead of a comma-joined string)"
+            )
+        if name.casefold() in KNOWN_TOOLSET_NAMES:
+            toolset_typos.append(name)
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        cleaned.append(name)
+    if toolset_typos:
+        quoted = ", ".join(repr(n) for n in toolset_typos)
+        noun = "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
+        raise ValueError(
+            f"{quoted} {noun}, not skill name(s). "
+            "Put toolsets in the assignee profile's `toolsets:` config "
+            "instead of routine skills."
+        )
+    return cleaned
+
+
+def _validate_routine_cron(cron_expr: str) -> str:
+    expr = str(cron_expr or "").strip()
+    if len(expr.split()) != 5:
+        raise ValueError("routine --cron must be a 5-field cron expression")
+    try:
+        from croniter import croniter
+        croniter(expr, datetime.fromtimestamp(int(time.time())))
+    except ImportError as exc:
+        raise ValueError("routine schedules require the croniter package") from exc
+    except Exception as exc:
+        raise ValueError(f"invalid routine cron expression {expr!r}: {exc}") from exc
+    return expr
+
+
+def create_routine(
+    conn: sqlite3.Connection,
+    *,
+    title: str,
+    cron_expr: str,
+    body: Optional[str] = None,
+    assignee: Optional[str] = None,
+    priority: int = 0,
+    skills: Optional[Iterable[str]] = None,
+    concurrency: str = "skip_if_active",
+    catch_up: str = "skip_missed",
+    status: str = "active",
+    board: Optional[str] = None,
+) -> int:
+    """Create a recurring Kanban task template."""
+    if not title or not str(title).strip():
+        raise ValueError("title is required")
+    assignee = _canonical_assignee(assignee)
+    expr = _validate_routine_cron(cron_expr)
+    if status not in VALID_ROUTINE_STATUSES:
+        raise ValueError(f"status must be one of {sorted(VALID_ROUTINE_STATUSES)}")
+    if concurrency not in VALID_ROUTINE_CONCURRENCY:
+        raise ValueError(
+            f"concurrency must be one of {sorted(VALID_ROUTINE_CONCURRENCY)}"
+        )
+    if catch_up not in VALID_ROUTINE_CATCH_UP:
+        raise ValueError(f"catch_up must be one of {sorted(VALID_ROUTINE_CATCH_UP)}")
+    skills_list = _normalize_routine_skills(skills)
+    now = int(time.time())
+    board_id = _normalize_board_slug(board) or get_current_board()
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            INSERT INTO routines (
+                board_id, title, body, assignee, priority, skills, cron_expr,
+                status, concurrency, catch_up, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                board_id,
+                str(title).strip(),
+                body,
+                assignee,
+                int(priority),
+                json.dumps(skills_list) if skills_list is not None else None,
+                expr,
+                status,
+                concurrency,
+                catch_up,
+                now,
+                now,
+            ),
+        )
+    return int(cur.lastrowid)
+
+
+def get_routine(conn: sqlite3.Connection, routine_id: int) -> Optional[Routine]:
+    row = conn.execute("SELECT * FROM routines WHERE id = ?", (int(routine_id),)).fetchone()
+    return Routine.from_row(row) if row else None
+
+
+def list_routines(
+    conn: sqlite3.Connection,
+    *,
+    include_paused: bool = True,
+) -> list[Routine]:
+    if include_paused:
+        rows = conn.execute(
+            "SELECT * FROM routines ORDER BY status ASC, id ASC"
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM routines WHERE status = 'active' ORDER BY id ASC"
+        ).fetchall()
+    return [Routine.from_row(row) for row in rows]
+
+
+def set_routine_status(conn: sqlite3.Connection, routine_id: int, status: str) -> bool:
+    if status not in VALID_ROUTINE_STATUSES:
+        raise ValueError(f"status must be one of {sorted(VALID_ROUTINE_STATUSES)}")
+    now = int(time.time())
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE routines SET status = ?, updated_at = ? WHERE id = ?",
+            (status, now, int(routine_id)),
+        )
+    return cur.rowcount > 0
+
+
+def delete_routine(conn: sqlite3.Connection, routine_id: int) -> bool:
+    with write_txn(conn):
+        cur = conn.execute("DELETE FROM routines WHERE id = ?", (int(routine_id),))
+    return cur.rowcount > 0
+
+
+def _routine_window_start(cron_expr: str, now_ts: Optional[int] = None) -> int:
+    from croniter import croniter
+
+    now = int(now_ts if now_ts is not None else time.time())
+    base = datetime.fromtimestamp(now) + timedelta(seconds=1)
+    return int(croniter(cron_expr, base).get_prev(datetime).timestamp())
+
+
+def _next_routine_window_start(cron_expr: str, after_ts: int) -> int:
+    from croniter import croniter
+
+    base = datetime.fromtimestamp(int(after_ts))
+    return int(croniter(cron_expr, base).get_next(datetime).timestamp())
+
+
+def _routine_has_live_instance(conn: sqlite3.Connection, routine_id: int) -> Optional[str]:
+    prefix = f"routine-{int(routine_id)}-%"
+    row = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key LIKE ? "
+        "AND status NOT IN ('done', 'archived') "
+        "ORDER BY created_at DESC LIMIT 1",
+        (prefix,),
+    ).fetchone()
+    return row["id"] if row else None
+
+
+def _mark_routine_materialized(
+    conn: sqlite3.Connection,
+    routine_id: int,
+    window_start: int,
+) -> None:
+    now = int(time.time())
+    conn.execute(
+        "UPDATE routines SET last_materialized_at = ?, updated_at = ? WHERE id = ?",
+        (int(window_start), now, int(routine_id)),
+    )
+
+
+def materialize_routine(
+    conn: sqlite3.Connection,
+    routine_id: int,
+    *,
+    manual: bool = False,
+    now_ts: Optional[int] = None,
+    board: Optional[str] = None,
+) -> Optional[str]:
+    """Create a normal task from one routine, returning the task id or None."""
+    routine = get_routine(conn, int(routine_id))
+    if routine is None:
+        return None
+
+    window_start = int(now_ts if now_ts is not None else time.time()) if manual else (
+        _routine_window_start(routine.cron_expr, now_ts=now_ts)
+    )
+    if not manual and routine.last_materialized_at is not None:
+        if int(routine.last_materialized_at) >= window_start:
+            return None
+        if routine.catch_up == "skip_missed":
+            next_window = _next_routine_window_start(
+                routine.cron_expr,
+                int(routine.last_materialized_at),
+            )
+            if next_window < window_start:
+                # More than one schedule boundary elapsed since the last tick.
+                # Acknowledge the latest boundary without creating backlog; the
+                # next on-time boundary can materialize normally.
+                with write_txn(conn):
+                    _mark_routine_materialized(conn, routine.id, window_start)
+                return None
+
+    if routine.concurrency == "skip_if_active":
+        live_task = _routine_has_live_instance(conn, routine.id)
+        if live_task:
+            if not manual:
+                with write_txn(conn):
+                    _mark_routine_materialized(conn, routine.id, window_start)
+            return None
+
+    key_suffix = f"manual-{window_start}" if manual else str(window_start)
+    idempotency_key = f"routine-{routine.id}-{key_suffix}"
+    task_id = create_task(
+        conn,
+        title=routine.title,
+        body=routine.body,
+        assignee=routine.assignee,
+        created_by=f"routine:{routine.id}",
+        priority=routine.priority,
+        idempotency_key=idempotency_key,
+        skills=routine.skills,
+        board=board or routine.board_id,
+    )
+    with write_txn(conn):
+        _mark_routine_materialized(conn, routine.id, window_start)
+        _append_event(
+            conn,
+            task_id,
+            "routine_materialized",
+            {
+                "routine_id": routine.id,
+                "window_start": window_start,
+                "manual": bool(manual) or None,
+            },
+        )
+    return task_id
+
+
+def materialize_due_routines(
+    conn: sqlite3.Connection,
+    *,
+    now_ts: Optional[int] = None,
+    board: Optional[str] = None,
+) -> list[tuple[int, str]]:
+    """Materialize every due active routine for this board tick."""
+    created: list[tuple[int, str]] = []
+    for routine in list_routines(conn, include_paused=False):
+        task_id = materialize_routine(
+            conn,
+            routine.id,
+            now_ts=now_ts,
+            board=board,
+        )
+        if task_id:
+            created.append((routine.id, task_id))
+    return created
 
 
 def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> list[str]:
@@ -5962,6 +6305,8 @@ class DispatchResult:
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
     counting a failure. These never trip the circuit breaker — a long quota
     window just makes the task bounce cheaply until the window clears."""
+    materialized_routines: list[tuple[int, str]] = field(default_factory=list)
+    """Routine materializations created this tick, as ``(routine_id, task_id)``."""
     skipped_locked: bool = False
     """True when this tick was skipped because another process already held
     the board's dispatch lock (issue #35240). A losing dispatcher does no
@@ -7461,6 +7806,8 @@ def _dispatch_once_locked(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    if not dry_run:
+        result.materialized_routines = materialize_due_routines(conn, board=board)
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -91,6 +91,18 @@ def test_run_slash_create_and_list(kanban_home):
     assert "alice" in out
 
 
+def test_run_slash_routine_create_and_list(kanban_home):
+    out = kc.run_slash(
+        "routine create 'weekly note' --cron '* * * * *' "
+        "--assignee scribe --body 'Draft the weekly note.'"
+    )
+    assert "Created routine" in out
+
+    out = kc.run_slash("routine list")
+    assert "weekly note" in out
+    assert "scribe" in out
+
+
 def test_run_slash_create_worktree_path_and_branch(kanban_home, tmp_path):
     target = tmp_path / ".worktrees" / "t6-wire"
     target_arg = target.as_posix()

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -90,6 +90,197 @@ def test_no_idempotency_key_never_collides(kanban_home):
 
 
 # ---------------------------------------------------------------------------
+# Routines
+# ---------------------------------------------------------------------------
+
+def test_routine_materializes_due_task_once(kanban_home):
+    conn = kb.connect()
+    try:
+        rid = kb.create_routine(
+            conn,
+            title="weekly report",
+            cron_expr="* * * * *",
+            assignee="scribe",
+            body="Draft the field note.",
+        )
+
+        created = kb.materialize_due_routines(conn, now_ts=1_700_000_100)
+        assert len(created) == 1
+        assert created[0][0] == rid
+
+        task = kb.get_task(conn, created[0][1])
+        assert task is not None
+        assert task.title == "weekly report"
+        assert task.body == "Draft the field note."
+        assert task.assignee == "scribe"
+        assert task.created_by == f"routine:{rid}"
+        assert task.idempotency_key.startswith(f"routine-{rid}-")
+
+        again = kb.materialize_due_routines(conn, now_ts=1_700_000_100)
+        assert again == []
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_routine_skip_if_active_does_not_stack_instances(kanban_home):
+    conn = kb.connect()
+    try:
+        rid = kb.create_routine(
+            conn,
+            title="nightly sweep",
+            cron_expr="* * * * *",
+            assignee="ops",
+        )
+        first = kb.materialize_due_routines(conn, now_ts=1_700_000_100)
+        assert first
+
+        second = kb.materialize_due_routines(conn, now_ts=1_700_000_220)
+        assert second == []
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+        routine = kb.get_routine(conn, rid)
+        assert routine is not None
+        assert routine.last_materialized_at == kb._routine_window_start(
+            "* * * * *",
+            now_ts=1_700_000_220,
+        )
+    finally:
+        conn.close()
+
+
+def test_routine_skip_missed_discards_downtime_window(kanban_home):
+    conn = kb.connect()
+    try:
+        rid = kb.create_routine(
+            conn,
+            title="minute sweep",
+            cron_expr="* * * * *",
+            concurrency="allow",
+            catch_up="skip_missed",
+        )
+        first = kb.materialize_routine(conn, rid, now_ts=1_700_000_100)
+        assert first is not None
+
+        # Three cron boundaries elapsed. skip_missed acknowledges the latest
+        # one without creating a delayed task, then resumes on the next window.
+        assert kb.materialize_routine(conn, rid, now_ts=1_700_000_280) is None
+        routine = kb.get_routine(conn, rid)
+        assert routine is not None
+        assert routine.last_materialized_at == kb._routine_window_start(
+            "* * * * *", now_ts=1_700_000_280
+        )
+
+        resumed = kb.materialize_routine(conn, rid, now_ts=1_700_000_340)
+        assert resumed is not None
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_routine_run_once_materializes_one_latest_window_after_downtime(
+    kanban_home,
+):
+    conn = kb.connect()
+    try:
+        rid = kb.create_routine(
+            conn,
+            title="minute report",
+            cron_expr="* * * * *",
+            concurrency="allow",
+            catch_up="run_once",
+        )
+        assert kb.materialize_routine(conn, rid, now_ts=1_700_000_100)
+
+        caught_up = kb.materialize_routine(conn, rid, now_ts=1_700_000_280)
+        assert caught_up is not None
+        assert kb.materialize_routine(conn, rid, now_ts=1_700_000_280) is None
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_routine_rejects_unsupported_coalesce_policy(kanban_home):
+    conn = kb.connect()
+    try:
+        with pytest.raises(ValueError, match="concurrency"):
+            kb.create_routine(
+                conn,
+                title="unsupported routine",
+                cron_expr="* * * * *",
+                concurrency="coalesce",
+            )
+    finally:
+        conn.close()
+
+
+def test_paused_routine_does_not_materialize(kanban_home):
+    conn = kb.connect()
+    try:
+        rid = kb.create_routine(
+            conn,
+            title="paused routine",
+            cron_expr="* * * * *",
+            assignee="ops",
+        )
+        assert kb.set_routine_status(conn, rid, "paused") is True
+        assert kb.materialize_due_routines(conn, now_ts=1_700_000_100) == []
+    finally:
+        conn.close()
+
+
+def test_routine_run_now_materializes_manual_task(kanban_home):
+    conn = kb.connect()
+    try:
+        rid = kb.create_routine(
+            conn,
+            title="manual routine",
+            cron_expr="0 9 * * 1",
+            assignee="ops",
+            concurrency="allow",
+        )
+        task_id = kb.materialize_routine(
+            conn,
+            rid,
+            manual=True,
+            now_ts=1_700_000_100,
+        )
+        assert task_id is not None
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.idempotency_key == f"routine-{rid}-manual-1700000100"
+    finally:
+        conn.close()
+
+
+def test_dispatch_once_materializes_due_routine_before_spawn(
+    kanban_home,
+    all_assignees_spawnable,
+):
+    spawned = []
+
+    def _spawn(task, workspace):
+        spawned.append(task.id)
+        return 12345
+
+    conn = kb.connect()
+    try:
+        rid = kb.create_routine(
+            conn,
+            title="dispatch routine",
+            cron_expr="* * * * *",
+            assignee="worker",
+        )
+
+        res = kb.dispatch_once(conn, spawn_fn=_spawn)
+
+        assert res.materialized_routines
+        assert res.materialized_routines[0][0] == rid
+        assert res.materialized_routines[0][1] in spawned
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # Spawn-failure circuit breaker
 # ---------------------------------------------------------------------------
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -247,6 +247,44 @@ hermes kanban create "nightly ops review" \
     --json
 ```
 
+### Recurring routines
+
+Routines are scheduled task templates. The dispatcher checks them on its
+existing tick and materializes ordinary Kanban tasks, so normal assignee,
+workspace, concurrency-cap, retry, and audit behavior still applies.
+
+```bash
+hermes kanban routine create "Draft weekly field note" \
+    --cron "0 9 * * 1" \
+    --assignee scribe \
+    --body "Summarize this week's field notes." \
+    --concurrency skip_if_active \
+    --catch-up skip_missed
+
+hermes kanban routine list
+hermes kanban routine pause 1
+hermes kanban routine resume 1
+hermes kanban routine run-now 1
+hermes kanban routine delete 1
+```
+
+Concurrency policies:
+
+- `skip_if_active` (default) consumes a due window without creating another
+  task while an earlier task from the same routine is still live.
+- `allow` creates each due task even when an earlier instance is still live;
+  dispatcher caps still govern how many workers can run.
+
+Catch-up policies never replay every missed window:
+
+- `skip_missed` (default) creates nothing when more than one schedule boundary
+  elapsed between dispatcher ticks. It resumes at the next on-time boundary.
+- `run_once` creates one task for the latest missed boundary, regardless of how
+  many boundaries elapsed.
+
+`run-now` creates a manually keyed task immediately. Routine schedules use the
+host's local timezone and standard five-field cron expressions.
+
 ### Bulk CLI verbs
 
 All the lifecycle verbs accept multiple ids so you can clean up a batch


### PR DESCRIPTION
## Summary
- Add board-native recurring task templates that materialize ordinary Kanban tasks on the existing dispatcher tick.
- Implement distinct `skip_missed` and `run_once` downtime behavior with deterministic missed-window coverage.
- Keep `skip_if_active` and `allow` as the supported concurrency policies; remove the duplicate `coalesce` option until it has real semantics.
- Add routine create, list, pause, resume, run-now, and delete commands plus user documentation.

## Problem
Kanban only supported one-shot work. The initial routines implementation persisted catch-up choices without reading them, and `coalesce` behaved exactly like `skip_if_active`, so advertised policies were not real behavior.

## Validation
- `python -m pytest -q tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_cli.py` (228 passed, 1 skipped)
- `python -m ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py`

Refs #57609