### PR TITLE
security(auth): validate portal_base_url in refresh_nous_oauth_pure

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5257,11 +5257,33 @@ def refresh_nous_oauth_pure(
     Callers that own persistent state can use it to save the newly rotated
     refresh token before later validation can fail.
     """
+    # HERMES_PORTAL_BASE_URL / NOUS_PORTAL_BASE_URL is the trusted
+    # operator/deployment override and must win outright, bypassing the host
+    # allowlist entirely — mirrors resolve_nous_access_token /
+    # resolve_nous_runtime_credentials. Only fall through to the caller-
+    # supplied (state-derived) value + allowlist gate when no override is
+    # set: that value can originate from the cross-profile shared store
+    # (_try_import_shared_nous_state), which this function has no way to
+    # know is untampered, so it must be re-validated here rather than
+    # trusted as-is.
+    env_portal_override = _nous_portal_env_override()
+    if env_portal_override:
+        validated_portal_base_url = env_portal_override.rstrip("/")
+    else:
+        validated_portal_base_url = (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+        parsed_portal_url = urlparse(validated_portal_base_url)
+        if parsed_portal_url.hostname and parsed_portal_url.hostname not in _NOUS_PORTAL_ALLOWED_HOSTS:
+            logger.warning(
+                "auth: ignoring invalid portal_base_url %r (host %r not in allowlist), using default",
+                validated_portal_base_url, parsed_portal_url.hostname,
+            )
+            validated_portal_base_url = DEFAULT_NOUS_PORTAL_URL
+
     state: Dict[str, Any] = {
         "access_token": access_token,
         "refresh_token": refresh_token,
         "client_id": client_id or DEFAULT_NOUS_CLIENT_ID,
-        "portal_base_url": (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/"),
+        "portal_base_url": validated_portal_base_url,
         "inference_base_url": (inference_base_url or DEFAULT_NOUS_INFERENCE_URL).rstrip("/"),
         "token_type": token_type or "Bearer",
         "scope": scope or DEFAULT_NOUS_SCOPE,

--- a/tests/hermes_cli/test_nous_portal_refresh_allowlist.py
+++ b/tests/hermes_cli/test_nous_portal_refresh_allowlist.py
@@ -1,0 +1,131 @@
+"""Regression tests for refresh_nous_oauth_pure's portal_base_url allowlist.
+
+resolve_nous_access_token() and resolve_nous_runtime_credentials() already
+validate a stored/network-sourced portal_base_url against
+_NOUS_PORTAL_ALLOWED_HOSTS before using it, healing to DEFAULT_NOUS_PORTAL_URL
+on rejection. refresh_nous_oauth_pure() -- the third distinct call site that
+POSTs the user's refresh_token to portal_base_url -- did not: it took
+whatever value the caller passed (falling back to the default only if
+empty/falsy) with no host check at all.
+
+The caller-supplied value can originate from the cross-profile shared store
+(_try_import_shared_nous_state -> refresh_nous_oauth_from_state ->
+refresh_nous_oauth_pure), which this function has no way to know is
+untampered -- so it must re-validate here, not trust it as-is. A poisoned
+portal_base_url in that file (a stale pre-allowlist write, a corrupted file,
+or local tampering) would otherwise have the refresh_token replayed to it on
+every subsequent rehydrate, forever.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+from hermes_cli.auth import (
+    DEFAULT_NOUS_PORTAL_URL,
+    _NOUS_PORTAL_ALLOWED_HOSTS,
+    refresh_nous_oauth_pure,
+)
+
+
+def _mock_refresh(monkeypatch, captured: dict):
+    def fake_refresh_access_token(*, client, portal_base_url, client_id, refresh_token):
+        captured["portal_base_url"] = portal_base_url
+        return {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 3600,
+        }
+
+    import hermes_cli.auth as auth_mod
+
+    monkeypatch.setattr(auth_mod, "_refresh_access_token", fake_refresh_access_token)
+    monkeypatch.setattr(auth_mod, "_nous_invoke_jwt_status", lambda *a, **k: "expired")
+    monkeypatch.setattr(auth_mod, "_assert_nous_inference_jwt_usable", lambda state: None)
+    monkeypatch.setattr(auth_mod, "_select_nous_invoke_jwt", lambda state: None)
+
+
+class TestPortalBaseUrlAllowlist:
+    def test_attacker_host_healed_to_default(self, monkeypatch, caplog):
+        """A poisoned portal_base_url must never receive the refresh_token —
+        the exact bug: previously it was POSTed there unconditionally."""
+        captured: dict = {}
+        _mock_refresh(monkeypatch, captured)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+            result = refresh_nous_oauth_pure(
+                access_token="old-token",
+                refresh_token="refresh-abc",
+                client_id="hermes-cli",
+                portal_base_url="https://attacker.evil.com",
+                inference_base_url="https://inference-api.nousresearch.com",
+            )
+
+        assert captured["portal_base_url"] == DEFAULT_NOUS_PORTAL_URL
+        assert result["portal_base_url"] == DEFAULT_NOUS_PORTAL_URL
+        assert any("attacker.evil.com" in rec.message for rec in caplog.records)
+
+    def test_legitimate_host_passes_through_unchanged(self, monkeypatch):
+        captured: dict = {}
+        _mock_refresh(monkeypatch, captured)
+
+        result = refresh_nous_oauth_pure(
+            access_token="old-token",
+            refresh_token="refresh-abc",
+            client_id="hermes-cli",
+            portal_base_url="https://portal.nousresearch.com",
+            inference_base_url="https://inference-api.nousresearch.com",
+        )
+
+        assert captured["portal_base_url"] == "https://portal.nousresearch.com"
+        assert result["portal_base_url"] == "https://portal.nousresearch.com"
+
+    def test_env_override_bypasses_allowlist_and_wins_outright(self, monkeypatch):
+        """HERMES_PORTAL_BASE_URL / NOUS_PORTAL_BASE_URL is the documented
+        dev/staging escape hatch -- must win even over an attacker-controlled
+        caller-supplied value, matching resolve_nous_access_token."""
+        captured: dict = {}
+        _mock_refresh(monkeypatch, captured)
+        monkeypatch.setenv(
+            "HERMES_PORTAL_BASE_URL", "https://portal.staging-nousresearch.com"
+        )
+
+        result = refresh_nous_oauth_pure(
+            access_token="old-token",
+            refresh_token="refresh-abc",
+            client_id="hermes-cli",
+            portal_base_url="https://attacker.evil.com",
+            inference_base_url="https://inference-api.nousresearch.com",
+        )
+
+        assert captured["portal_base_url"] == "https://portal.staging-nousresearch.com"
+        assert result["portal_base_url"] == "https://portal.staging-nousresearch.com"
+
+    def test_no_refresh_needed_skips_validation_path_harmlessly(self, monkeypatch):
+        """When the access token isn't expiring, no refresh POST happens at
+        all -- portal_base_url still ends up validated in the returned
+        state (it's computed unconditionally), so a poisoned value can't
+        silently survive untouched even on this path."""
+        import hermes_cli.auth as auth_mod
+
+        monkeypatch.setattr(auth_mod, "_nous_invoke_jwt_status", lambda *a, **k: None)
+        monkeypatch.setattr(auth_mod, "_assert_nous_inference_jwt_usable", lambda state: None)
+        monkeypatch.setattr(auth_mod, "_select_nous_invoke_jwt", lambda state: None)
+
+        result = refresh_nous_oauth_pure(
+            access_token="still-valid-token",
+            refresh_token="refresh-abc",
+            client_id="hermes-cli",
+            portal_base_url="https://attacker.evil.com",
+            inference_base_url="https://inference-api.nousresearch.com",
+        )
+
+        assert result["portal_base_url"] == DEFAULT_NOUS_PORTAL_URL
+
+    def test_default_portal_url_is_in_allowlist(self):
+        """Sanity check mirroring the inference-url suite: the default must
+        itself validate, or every install would get healed away from it."""
+        from urllib.parse import urlparse
+
+        assert urlparse(DEFAULT_NOUS_PORTAL_URL).hostname in _NOUS_PORTAL_ALLOWED_HOSTS


### PR DESCRIPTION
## Summary

`resolve_nous_access_token()` and `resolve_nous_runtime_credentials()` both validate a stored/network-sourced `portal_base_url` against `_NOUS_PORTAL_ALLOWED_HOSTS` before using it, healing to `DEFAULT_NOUS_PORTAL_URL` on rejection (see the `parsed_portal_url.hostname not in _NOUS_PORTAL_ALLOWED_HOSTS` check in each). `refresh_nous_oauth_pure()` — a third, distinct call site that POSTs the user's `refresh_token` to `portal_base_url` via `_refresh_access_token` — has no such check at all: it takes whatever value the caller passes, only falling back to the default when the value is empty/falsy.

```python
"portal_base_url": (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/"),
```

The caller-supplied value can originate from the cross-profile shared store: `_try_import_shared_nous_state()` reads `_read_shared_nous_state()` (`~/.hermes/shared/nous_oauth.json` or similar) directly into `state["portal_base_url"]` with no validation, then calls `refresh_nous_oauth_from_state(state, force_refresh=True, ...)` → `refresh_nous_oauth_pure(...)`, which is the ONLY place that value is used for the actual refresh POST.

`refresh_nous_oauth_pure` never overwrites or re-validates `portal_base_url` from the refresh response either — it's "sticky" across every subsequent refresh cycle. So a poisoned value in the shared store (a stale file predating the allowlist's introduction, a corrupted file, or local tampering) would have the `refresh_token` replayed to it on every subsequent rehydrate, forever — unlike the two sibling functions, which re-validate and self-heal on every call.

Verified live: constructing state with `portal_base_url="https://attacker.evil.com"` and calling `refresh_nous_oauth_pure` shows the refresh POST going to the attacker host before this fix.

**Threat model / severity note:** this is real but narrower than a remotely-exploitable bug — it requires a non-allowlisted value to already exist in the shared store (a defense-in-depth gap against a stale/legacy/tampered file), not an actively-controllable network path today. Framed here as closing the gap to match the two already-fixed sibling call sites, not as an active exploit.

## Fix

Apply the same env-override-first, then-allowlist-with-healing pattern already used by `resolve_nous_access_token`: `HERMES_PORTAL_BASE_URL`/`NOUS_PORTAL_BASE_URL` (the documented, trusted dev/staging escape hatch) wins outright and bypasses the allowlist; otherwise the caller-supplied value is validated against `_NOUS_PORTAL_ALLOWED_HOSTS` and healed to `DEFAULT_NOUS_PORTAL_URL` on rejection.

## Test plan

- [x] Live PoC against current `main` confirmed the refresh POST was sent to `https://attacker.evil.com` before this fix; confirmed healed to the default after.
- [x] Sanity-checked the env-override escape hatch (`HERMES_PORTAL_BASE_URL=https://portal.staging-nousresearch.com`) still bypasses the allowlist as documented/intentional, and a legitimate allowlisted host passes through unchanged.
- [x] Added `tests/hermes_cli/test_nous_portal_refresh_allowlist.py`: attacker host healed, legitimate host unchanged, env override still bypasses and wins outright, the no-refresh-needed path still validates the returned state, and a sanity check that `DEFAULT_NOUS_PORTAL_URL` itself is in the allowlist.
- [x] `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py tests/hermes_cli/test_auth_nous_provider.py tests/hermes_cli/test_nous_inference_url_validation.py tests/hermes_cli/test_nous_portal_refresh_allowlist.py -q` — 120 passed (115 existing + 5 new), no regressions. This specifically confirms `test_try_import_shared_rehydrates_on_success` (which asserts a non-allowlisted fixture host is preserved) is unaffected — it mocks `refresh_nous_oauth_from_state` entirely, so it doesn't exercise the real validation path this PR adds.
- [x] `uv run --frozen --extra dev python -m pytest tests/hermes_cli/ -k "nous or portal_base_url" -q` — same 4 pre-existing, unrelated failures present identically on a clean `main` checkout with none of this PR's changes (confirmed via `git stash`) — not a regression from this change.
- [x] `ruff check` on both changed files — clean.