### PR TITLE
fix(agent): exclude sub-agent sessions from skill review nudge

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -687,8 +687,10 @@ def run_conversation(
 
         # Track tool-calling iterations for skill nudge.
         # Counter resets whenever skill_manage is actually used.
+        # Sub-agents are excluded — see turn_finalizer.py for rationale.
         if (agent._skill_nudge_interval > 0
-                and "skill_manage" in agent.valid_tool_names):
+                and "skill_manage" in agent.valid_tool_names
+                and getattr(agent, "_delegate_depth", 0) == 0):
             agent._iters_since_skill += 1
         
         # ── Pre-API-call /steer drain ──────────────────────────────────

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -452,10 +452,17 @@ def finalize_turn(
     agent._stream_callback = None
 
     # Check skill trigger NOW — based on how many tool iterations THIS turn used.
+    # Sub-agents (delegate_task children) must never trigger the skill review
+    # nudge — the foreground parent session handles skill curation.  Without
+    # this gate every long-running sub-agent (~30+ tool iterations) receives
+    # the ~6k-char "Review the conversation above and update the skill library"
+    # injection, hijacking its final turns with irrelevant skill_manage calls
+    # and polluting the skill library with unreviewed auto-generated content.
     _should_review_skills = False
     if (agent._skill_nudge_interval > 0
             and agent._iters_since_skill >= agent._skill_nudge_interval
-            and "skill_manage" in agent.valid_tool_names):
+            and "skill_manage" in agent.valid_tool_names
+            and getattr(agent, "_delegate_depth", 0) == 0):
         _should_review_skills = True
         agent._iters_since_skill = 0
 

--- a/tests/agent/test_subagent_skill_nudge_exclusion.py
+++ b/tests/agent/test_subagent_skill_nudge_exclusion.py
@@ -1,0 +1,151 @@
+"""Regression test for #57626.
+
+Sub-agent sessions spawned via ``delegate_task`` must never receive the skill
+library update injection.  The skill-review nudge is a foreground-only concern;
+letting it fire in sub-agents hijacks their final turns with irrelevant
+``skill_manage`` calls and pollutes the skill library with unreviewed content.
+
+The fix adds a ``_delegate_depth == 0`` guard to both the iteration counter
+(``conversation_loop.py``) and the trigger check (``turn_finalizer.py``).
+"""
+
+import pytest
+
+from agent.turn_finalizer import finalize_turn
+
+
+class _StubBudget:
+    used = 5
+    max_total = 100
+    remaining = 50
+
+
+class _StubCompressor:
+    last_prompt_tokens = 0
+
+
+class _StubAgent:
+    """Minimal agent surface for ``finalize_turn``."""
+
+    def __init__(self, *, delegate_depth=0):
+        self.max_iterations = 90
+        self.iteration_budget = _StubBudget()
+        self.context_compressor = _StubCompressor()
+        self.model = "stub/model"
+        self.provider = "stub"
+        self.base_url = "http://stub"
+        self.session_id = "sess-1"
+        self.quiet_mode = True
+        self.platform = "cli"
+        self._interrupt_requested = False
+        self._interrupt_message = None
+        self._tool_guardrail_halt_decision = None
+        self._response_was_previewed = False
+        self._delegate_depth = delegate_depth
+        self._skill_nudge_interval = 10
+        self._iters_since_skill = 10  # exactly at threshold
+        self.valid_tool_names = {"read_file", "skill_manage"}
+        self._background_review_spawned = False
+        for attr in (
+            "session_input_tokens",
+            "session_output_tokens",
+            "session_cache_read_tokens",
+            "session_cache_write_tokens",
+            "session_reasoning_tokens",
+            "session_prompt_tokens",
+            "session_completion_tokens",
+            "session_total_tokens",
+            "session_estimated_cost_usd",
+        ):
+            setattr(self, attr, 0)
+        self.session_cost_status = "ok"
+        self.session_cost_source = "stub"
+
+    def _spawn_background_review(self, **kwargs):
+        self._background_review_spawned = True
+
+    def _save_trajectory(self, *a, **k):
+        pass
+
+    def _cleanup_task_resources(self, *a, **k):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, *a, **k):
+        pass
+
+    def _persist_session(self, *a, **k):
+        pass
+
+    def _safe_print(self, *a, **k):
+        pass
+
+    def _handle_max_iterations(self, messages, n):
+        return "stub"
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **k):
+        pass
+
+
+_MESSAGES = [
+    {"role": "user", "content": "do a thing"},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "c1", "function": {"name": "read_file", "arguments": "{}"}}
+        ],
+    },
+    {"role": "tool", "tool_call_id": "c1", "content": "file contents"},
+]
+
+
+def _run_finalize(agent):
+    return finalize_turn(
+        agent,
+        final_response="done",
+        api_call_count=5,
+        interrupted=False,
+        failed=False,
+        messages=_MESSAGES,
+        conversation_history=None,
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="do a thing",
+        original_user_message="do a thing",
+        _should_review_memory=False,
+        _turn_exit_reason="stop",
+    )
+
+
+class TestSubagentSkillNudgeExclusion:
+    """Sub-agents must not trigger the background skill review."""
+
+    def test_foreground_agent_triggers_skill_review(self):
+        """Foreground agent (delegate_depth=0) at threshold triggers review."""
+        agent = _StubAgent(delegate_depth=0)
+        _run_finalize(agent)
+        assert agent._background_review_spawned is True
+
+    def test_subagent_does_not_trigger_skill_review(self):
+        """Sub-agent (delegate_depth=1) at threshold does NOT trigger review."""
+        agent = _StubAgent(delegate_depth=1)
+        _run_finalize(agent)
+        assert agent._background_review_spawned is False
+
+    def test_deeply_nested_subagent_does_not_trigger(self):
+        """Nested sub-agent (delegate_depth=3) also excluded."""
+        agent = _StubAgent(delegate_depth=3)
+        _run_finalize(agent)
+        assert agent._background_review_spawned is False


### PR DESCRIPTION
## What does this PR do?

Prevents the skill library update injection from being routed to sub-agent sessions spawned via `delegate_task`.  The background skill review nudge (~6k-char user-role prompt instructing the agent to "Review the conversation above and update the skill library") was firing in every long-running sub-agent that reached the iteration threshold (~30 tool calls), hijacking their final turns with irrelevant `skill_manage` calls and polluting the skill library with unreviewed auto-generated content.

## Related Issue

Fixes #57626

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_finalizer.py` — Added `getattr(agent, "_delegate_depth", 0) == 0` guard to the skill review trigger check so sub-agents skip the nudge entirely.
- `agent/conversation_loop.py` — Added the same `_delegate_depth == 0` guard to the `_iters_since_skill` iteration counter so sub-agents never accumulate toward the threshold.
- `tests/agent/test_subagent_skill_nudge_exclusion.py` — 3 regression tests: foreground agent triggers review, depth-1 sub-agent does not, depth-3 nested sub-agent does not.

## How to Test

1. Run the regression tests: `python -m pytest tests/agent/test_subagent_skill_nudge_exclusion.py -v`
2. Run existing turn_finalizer tests to confirm no regressions: `python -m pytest tests/agent/test_turn_finalizer_cleanup_guard.py tests/agent/test_turn_finalizer_interrupt_alternation.py tests/agent/test_turn_finalizer_final_response_persistence.py -v`
3. Run existing background review isolation tests: `python -m pytest tests/test_background_review_session_isolation.py -v`
4. All tests should pass (observed: 29 passed across the 4 test files).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
