### PR TITLE
fix(qqbot): accept is_reconnect parameter in QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
## Description

`QQAdapter.connect()` overrides `BasePlatformAdapter.connect()` but drops the `is_reconnect` keyword-only argument that the base class supports (and passes to every adapter on reconnection attempts).

When the gateway disconnects and attempts to reconnect, it calls `adapter.connect(is_reconnect=True)`, which raises:
```
TypeError: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

The adapter never connects, and the gateway loops forever with 5-minute reconnect intervals.

## Fix

Add `*, is_reconnect: bool = False` to the `connect()` signature, matching the base class pattern already used by `api_server.py` and `bluebubbles.py`.

## Testing

Confirmed on a live Hermes 0.18.0 gateway. Before the patch, the log shows 23 failed reconnect attempts with the TypeError. After the patch:

```
✓ [QQBot] Connected
✓ [QQBot] Identify sent
✓ [QQBot] Ready, session_id=...
✓ qqbot connected
Gateway running with 3 platform(s)
```

Closes #...