### PR TITLE
fix(desktop): surface slash command aliases on exact input match

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -173,7 +173,7 @@ export function useSlashCompletions(options: {
 
             return { ...item, text: `${prefix}${argText}` }
           })
-          .filter(item => isArgCompletion || isDesktopSlashSuggestion(item.text))
+          .filter(item => isArgCompletion || isDesktopSlashSuggestion(item.text, query))
           .map(item => ({
             ...item,
             // Arg suggestions (e.g. `/handoff <platform>`) live under one

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -90,6 +90,19 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashCommand('/reset')).toBe(true)
   })
 
+  it('surfaces aliases on exact match when query is provided', () => {
+    // Without query — aliases stay hidden to avoid popover clutter.
+    expect(isDesktopSlashSuggestion('/reset')).toBe(false)
+    // With exact-match query — user typed /reset, show it.
+    expect(isDesktopSlashSuggestion('/reset', 'reset')).toBe(true)
+    expect(isDesktopSlashSuggestion('/reset', '/reset')).toBe(true)
+    // Partial match — still hidden (user is browsing).
+    expect(isDesktopSlashSuggestion('/reset', 're')).toBe(false)
+    expect(isDesktopSlashSuggestion('/reset', '')).toBe(false)
+    // Other aliases still hidden when query targets a different command.
+    expect(isDesktopSlashSuggestion('/fork', 'reset')).toBe(false)
+  })
+
   it('filters built-in catalog noise but keeps skill / quick-command extensions', () => {
     const filtered = filterDesktopCommandsCatalog({
       categories: [

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -300,11 +300,16 @@ export function isDesktopSlashCommand(command: string): boolean {
 }
 
 /** Gates discovery in the popover/completions. */
-export function isDesktopSlashSuggestion(command: string): boolean {
+export function isDesktopSlashSuggestion(command: string, query?: string): boolean {
   const normalized = normalizeCommand(command)
 
-  // Aliases stay hidden so the popover isn't cluttered with duplicates.
+  // Aliases stay hidden so the popover isn't cluttered with duplicates,
+  // but surface them when the user typed an exact match (e.g. /reset).
   if (ALIAS_TO_CANONICAL.has(normalized)) {
+    if (query != null) {
+      const normalizedQuery = normalizeCommand(query)
+      return normalized === normalizedQuery
+    }
     return false
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop slash command autocomplete showing "no matches" when a user types an alias like `/reset`. The completions popover previously filtered out all aliases unconditionally to avoid cluttering the discovery popover with duplicates — but this also prevented aliases from appearing when the user typed the exact alias name.

The fix adds an optional `query` parameter to `isDesktopSlashSuggestion()`. When the normalized query exactly matches an alias, the function returns `true`, allowing the alias to appear in the completions list. Without a query (browsing mode), aliases remain hidden as before.

## Related Issue

Fixes #57641

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/desktop-slash-commands.ts` — Added optional `query` parameter to `isDesktopSlashSuggestion()`. When query is provided and exactly matches an alias, return `true` instead of `false`.
- `apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts` — Pass the current `query` to `isDesktopSlashSuggestion()` in the completion filter.
- `apps/desktop/src/lib/desktop-slash-commands.test.ts` — Added test case verifying exact-match alias surfacing, partial-match hiding, and cross-alias isolation.

## How to Test

1. Run `npx vitest run apps/desktop/src/lib/desktop-slash-commands.test.ts` — all 17 tests should pass
2. In the desktop app, type `/reset` in the chat input — the completions popover should show `/reset` (mapped to `/new`)
3. Type `/re` (partial) — `/reset` should NOT appear in suggestions (only canonical commands shown while browsing)
4. Type `/fork` — should appear as a completion for `/branch`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx vitest run apps/desktop/src/lib/desktop-slash-commands.test.ts` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact — or N/A (desktop-only change)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
