### PR TITLE
 fix(skills-hub): support multi-word AND search in local skill sources

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1718,6 +1718,74 @@ class TestHermesIndexSearch:
         assert any(h.name == "cuda" for h in hits)
         assert hits[0].name == "cuda"
 
+    def test_search_multi_word_and_semantics(self):
+        """Multi-word queries must find skills where words appear
+        non-contiguously and in any order."""
+        skills = [
+            {
+                "name": "Disk Cleanup",
+                "description": "Automated disk space cleanup and maintenance.",
+                "source": "clawhub",
+                "identifier": "clawhub/disk-cleanup",
+                "tags": ["disk", "cleanup"],
+            },
+            {
+                "name": "Windows Disk Cleaner",
+                "description": "Safe Windows disk cleanup assistant.",
+                "source": "clawhub",
+                "identifier": "clawhub/windows-disk-cleaner",
+                "tags": ["windows", "disk"],
+            },
+            {
+                "name": "Disk Space Analyzer",
+                "description": "Analyze disk usage and find large files.",
+                "source": "clawhub",
+                "identifier": "clawhub/disk-analyzer",
+                "tags": ["disk", "analysis"],
+            },
+            {
+                "name": "Cleanup Dashboards",
+                "description": "Audit HubSpot reporting dashboards.",
+                "source": "clawhub",
+                "identifier": "clawhub/cleanup-dashboards",
+                "tags": ["hubspot"],
+            },
+            {
+                "name": "unrelated",
+                "description": "nothing here",
+                "source": "clawhub",
+                "identifier": "clawhub/unrelated",
+                "tags": [],
+            },
+        ]
+        src = _make_index_source(skills)
+
+        # "disk cleanup" — both words present non-contiguously in Disk Cleanup
+        # (name="Disk Cleanup" has "Disk", description has "cleanup")
+        # and Windows Disk Cleaner (name has both).
+        hits = src.search("disk cleanup", limit=25)
+        ids = [h.identifier for h in hits]
+        assert "clawhub/disk-cleanup" in ids, (
+            f"Expected disk-cleanup found, got: {ids}")
+        assert "clawhub/windows-disk-cleaner" in ids, (
+            f"Expected windows-disk-cleaner found, got: {ids}")
+        assert "clawhub/unrelated" not in ids
+
+        # "disk" alone (single word) must still work
+        hits = src.search("disk", limit=25)
+        ids = [h.identifier for h in hits]
+        assert "clawhub/disk-cleanup" in ids
+        assert "clawhub/windows-disk-cleaner" in ids
+        assert "clawhub/disk-analyzer" in ids
+        assert "clawhub/cleanup-dashboards" not in ids  # no "disk" in name/desc/tags
+
+        # Order independence: "cleanup disk" must find the same skills
+        hits = src.search("cleanup disk", limit=25)
+        ids = [h.identifier for h in hits]
+        assert "clawhub/disk-cleanup" in ids
+        assert "clawhub/windows-disk-cleaner" in ids
+        assert "clawhub/unrelated" not in ids
+
 
 class TestProviderFilter:
     def test_filter_results_by_provider_narrows_exactly(self):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -560,17 +560,26 @@ class GitHubSource(SkillSource):
         return "community"
 
     def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        """Search all taps for skills matching the query."""
+        """Search all taps for skills matching the query.
+
+        Multi-word queries use AND semantics — every word must match
+        somewhere, regardless of order.
+        """
         results: List[SkillMeta] = []
         query_lower = query.lower()
+        query_words = query_lower.split()
 
         for tap in self.taps:
             try:
                 skills = self._list_skills_in_repo(tap["repo"], tap.get("path", ""))
                 for skill in skills:
                     searchable = f"{skill.name} {skill.description} {' '.join(skill.tags)}".lower()
-                    if query_lower in searchable:
-                        results.append(skill)
+                    if len(query_words) > 1:
+                        if not all(w in searchable for w in query_words):
+                            continue
+                    elif query_lower not in searchable:
+                        continue
+                    results.append(skill)
             except Exception as e:
                 logger.debug(f"Failed to search {tap['repo']}: {e}")
                 continue
@@ -2729,6 +2738,7 @@ class LobeHubSource(SkillSource):
             return []
 
         query_lower = query.lower()
+        query_words = query_lower.split()
         results: List[SkillMeta] = []
 
         agents = index.get("agents", index) if isinstance(index, dict) else index
@@ -2742,7 +2752,11 @@ class LobeHubSource(SkillSource):
             tags = meta.get("tags", [])
 
             searchable = f"{title} {desc} {' '.join(tags) if isinstance(tags, list) else ''}".lower()
-            if query_lower in searchable:
+            if len(query_words) > 1:
+                if not all(w in searchable for w in query_words):
+                    continue
+            elif query_lower not in searchable:
+                continue
                 identifier = agent.get("identifier", title.lower().replace(" ", "-"))
                 results.append(SkillMeta(
                     name=identifier,
@@ -3772,6 +3786,11 @@ class HermesIndexSource(SkillSource):
         truncated at the first ``limit`` hits — that earlier break-at-limit
         behaviour returned an arbitrary file-order slice and buried the most
         relevant skills.
+
+        Multi-word queries use AND semantics — every word must match
+        somewhere in the haystack, in any order.  This fixes searches like
+        ``disk cleanup`` failing to find skills with description
+        ``clean up disk space``.
         """
         index = self._ensure_loaded()
         skills = index.get("skills", [])
@@ -3783,7 +3802,12 @@ class HermesIndexSource(SkillSource):
             return [self._to_meta(s) for s in skills[:limit]]
 
         query_lower = query.lower()
-        scored: List[Tuple[int, int, dict]] = []
+        # Split into words for AND search.  A single-word query behaves
+        # exactly like the old substring check.  Multi-word queries require
+        # every word to appear anywhere in the haystack (order-independent).
+        query_words = query_lower.split()
+
+        scored: List[Tuple[float, int, dict]] = []
         for i, s in enumerate(skills):
             name = str(s.get("name", "")).lower()
             provider = str((s.get("extra") or {}).get("provider", "")).lower()
@@ -3794,11 +3818,39 @@ class HermesIndexSource(SkillSource):
                 str(s.get("identifier", "")).lower(),
                 provider,
             ])
-            if query_lower not in haystack:
+
+            # AND search: all query words must match somewhere
+            if query_words and len(query_words) > 1:
+                if not all(w in haystack for w in query_words):
+                    continue
+            elif query_lower not in haystack:
                 continue
-            # Lower score sorts first.
+
+            # Lower score sorts first.  For multi-word queries the per-word
+            # matching quality is averaged so that a skill matching all words
+            # well (e.g. name match for one and description match for another)
+            # scores better than one matching them all poorly.
             if name == query_lower:
                 score = 0
+            elif len(query_words) > 1:
+                # Multi-word scoring: average the per-word match quality.
+                # This rewards skills that match each word solidly over those
+                # that barely scrape by on a substring.
+                total = 0
+                for w in query_words:
+                    if name == w:
+                        total += 0
+                    elif name.startswith(w):
+                        total += 1
+                    elif provider == w:
+                        total += 2
+                    elif w in name.split() or w in provider.split():
+                        total += 3
+                    elif w in name:
+                        total += 4
+                    else:
+                        total += 5
+                score = total / len(query_words)
             elif name.startswith(query_lower):
                 score = 1
             elif provider == query_lower:


### PR DESCRIPTION

    Multi-word queries like disk cleanup or windows disk used Python's in substring check (query_lower in haystack), which requires all words to appear contiguously and in order. A skill described as clean up disk space would not match disk cleanup.

    Fix: split the query into words and apply AND semantics — every word must appear somewhere in the haystack regardless of order. Single-word queries are unchanged.

    Affected sources:
    - HermesIndexSource.search() — also gets per-word averaged scoring so a skill matching all query words well ranks higher than one matching them poorly.
    - GitHubSource.search() — AND search only (no scoring change).
    - LobeHubSource.search() — AND search only (no scoring change).

    Remote API sources (SkillsShSource, ClawHubSource) already handled multi-word queries server-side and were unaffected.

    What does this PR do?

    When the user runs hermes skills search "disk cleanup", the query is passed through unified_search() → parallel_search_sources(). When the centralized hermes-index is available (the default), all external API sources (skills.sh, clawhub, GitHub, etc.) are skipped to avoid ~70 API calls per search — only HermesIndexSource.search() executes.

    The original search used Python's in operator to check if the raw query string is a substring of the concatenated skill metadata (name + description + tags + identifier). This works fine for single-word queries like "cleanup" or "disk", but fails for multi-word queries like "disk cleanup" — those words must appear contiguously and in the same order as typed. A skill named "Disk Cleaner" with description "clean up disk space" would not match "disk cleanup" because "disk cleanup" does not appear as a contiguous substring anywhere in the metadata.

    This fix splits the query into individual words and applies AND semantics: every word must appear somewhere in the concatenated metadata, regardless of position or order. Single-word queries are unaffected.

    Additionally, HermesIndexSource.search() now uses per-word averaged scoring for multi-word queries, so a skill matching every query word well (e.g., both words found in the skill name) ranks higher than one matching each word poorly.

    The same pattern also existed in GitHubSource.search() and LobeHubSource.search() — both are fixed with the same AND search logic. These sources are typically skipped when the index is available, but would have the same bug when queried directly (via --source github or when the index is unavailable).

    Related Issue

    No existing issue. The bug existed since the Skills Hub was introduced (Feb 2026, commit 14e59706b). Single-keyword searches always worked, so it went unnoticed through multiple refactors.

    Fixes #N/A

    Type of Change

    - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
    - [ ] ✨ New feature (non-breaking change that adds functionality)
    - [ ] 🔒 Security fix
    - [ ] 📝 Documentation update
    - [ ] ✅ Tests (adding or improving test coverage)
    - [ ] ♻️ Refactor (no behavior change)
    - [ ] 🎯 New skill (bundled or hub)

    Changes Made

    - tools/skills_hub.py::HermesIndexSource.search() — Changed substring match to AND word search. Added per-word averaged scoring for multi-word queries. Changed type annotation List[Tuple[int, ...]] → List[Tuple[float, ...]] to accommodate fractional scores.
    - tools/skills_hub.py::GitHubSource.search() — Changed substring match to AND word search.
    - tools/skills_hub.py::LobeHubSource.search() — Changed substring match to AND word search.
    - tests/tools/test_skills_hub.py::TestHermesIndexSearch — Added test_search_multi_word_and_semantics test.

    How to Test

    1. Run the existing test suite: pytest tests/tools/test_skills_hub.py -q (all 156 tests pass)
    2. Test multi-word search that previously returned 0 results:

       hermes skills search "disk cleanup"

       Expected: 10+ results including "Disk Cleanup", "Disk Sweeper", "Disk Watch", "Windows Disk Cleaner", "Storage Cleanup"
    3. Test another multi-word combination:

       hermes skills search "windows disk"

       Expected: 5+ results including "Windows Disk Cleaner"
    4. Verify single-word searches are unaffected:

       hermes skills search "cleanup"

       Expected: results unchanged from before the fix

    Checklist

    Code

    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [x] I've run pytest tests/ -q and all tests pass
    - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — added test_search_multi_word_and_semantics in TestHermesIndexSearch
    - [x] I've tested on my platform: WSL Debian 12 (Windows Subsystem for Linux)

    Documentation & Housekeeping

    - [x] Changes are pure string logic — no documentation, config, or cross-platform impact
    - [x] Only tools/skills_hub.py and tests/tools/test_skills_hub.py modified

    Screenshots / Logs


    === Before fix ===
    $ hermes skills search "disk cleanup"
    No skills found matching your query.

    === After fix ===
    $ hermes skills search "disk cleanup"
      Disk Cleanup                   | Automated disk space cleanup and maintenance
      Disk Sweeper                   | Intelligent disk space analysis and cleanup tool
      Disk Watch                     | Monitor disk space across drives
      Windows Disk Cleaner           | Safe Windows disk cleanup assistant
      Storage Cleanup                | One-command disk cleanup for macOS and Linux
      ...

    $ hermes skills search "windows disk"
      Windows Disk Cleaner           | Safe Windows disk cleanup assistant
      Remote Disk Mount              | 远程磁盘挂载工具
      system-info-windows-skill      | Query system information including OS, CPU, memory, and disk
      ...

    $ hermes skills search "cleanup"
      Cleanup Dashboards             | Audit and consolidate HubSpot reporting dashboards
      ... (unchanged from before)