### PR TITLE
fix(tts): coerce direct-only OpenAI model on the managed audio gateway

### DIFF
--- a/tests/tools/test_managed_media_gateways.py
+++ b/tests/tools/test_managed_media_gateways.py
@@ -244,6 +244,46 @@ def test_openai_tts_uses_managed_audio_gateway_when_direct_key_absent(monkeypatc
     assert captured["close_calls"] == 1
 
 
+def test_openai_tts_coerces_direct_only_model_on_managed_gateway(monkeypatch, tmp_path):
+    """A tts.openai.model valid only for direct OpenAI (e.g. tts-1-hd) must be
+    coerced to a managed-supported model, else the gateway 400s with
+    'Unsupported managed OpenAI speech model'."""
+    captured = {}
+    _install_fake_tools_package()
+    _install_fake_openai_module(captured)
+    monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("TOOL_GATEWAY_DOMAIN", "nousresearch.com")
+    monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+
+    tts_tool = _load_tool_module("tools.tts_tool", "tts_tool.py")
+    output_path = tmp_path / "speech.mp3"
+    tts_tool._generate_openai_tts(
+        "hello world", str(output_path), {"openai": {"model": "tts-1-hd"}}
+    )
+
+    assert captured["base_url"] == "https://openai-audio-gateway.nousresearch.com/v1"
+    assert captured["speech_kwargs"]["model"] == "gpt-4o-mini-tts"
+
+
+def test_openai_tts_keeps_direct_only_model_with_direct_key(monkeypatch, tmp_path):
+    """With a direct key, the user's tts-1-hd is honored (not coerced)."""
+    captured = {}
+    _install_fake_tools_package()
+    _install_fake_openai_module(captured)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-direct-key")
+    monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+
+    tts_tool = _load_tool_module("tools.tts_tool", "tts_tool.py")
+    output_path = tmp_path / "speech.mp3"
+    tts_tool._generate_openai_tts(
+        "hello world", str(output_path), {"openai": {"model": "tts-1-hd"}}
+    )
+
+    assert captured["base_url"] == "https://api.openai.com/v1"
+    assert captured["speech_kwargs"]["model"] == "tts-1-hd"
+
+
 def test_openai_tts_accepts_openai_api_key_as_direct_fallback(monkeypatch, tmp_path):
     captured = {}
     _install_fake_tools_package()

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -78,7 +78,7 @@ class TestOpenaiTtsSpeed:
 
         with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
              patch("tools.tts_tool._resolve_openai_audio_client_config",
-                   return_value=("test-key", None)):
+                   return_value=("test-key", None, False)):
             from tools.tts_tool import _generate_openai_tts
             _generate_openai_tts("Hello", str(tmp_path / "out.mp3"), tts_config)
         return mock_client.audio.speech.create

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -172,6 +172,11 @@ DEFAULT_ELEVENLABS_VOICE_ID = "pNInz6obpgDQGcFmaJgB"  # Adam
 DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
 DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
+# The managed OpenAI audio gateway (Nous portal proxy) only proxies these speech
+# models. A user's tts.openai.model set for *direct* OpenAI (e.g. "tts-1-hd")
+# is rejected with a 400 "Unsupported managed OpenAI speech model", so it must be
+# coerced to a supported model when routing through the gateway.
+MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
@@ -1019,13 +1024,28 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     Returns:
         Path to the saved audio file.
     """
-    api_key, base_url = _resolve_openai_audio_client_config()
+    api_key, base_url, is_managed = _resolve_openai_audio_client_config()
 
     oai_config = tts_config.get("openai", {})
     model = oai_config.get("model", DEFAULT_OPENAI_MODEL)
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
-    base_url = oai_config.get("base_url", base_url)
+    custom_base_url = oai_config.get("base_url")
+    if custom_base_url:
+        base_url = custom_base_url
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
+
+    # The managed OpenAI audio gateway only proxies MANAGED_OPENAI_TTS_MODELS.
+    # A model set for direct OpenAI (e.g. "tts-1-hd") 400s there with
+    # "Unsupported managed OpenAI speech model", so coerce it — unless the user
+    # redirected base_url to their own endpoint, in which case respect it.
+    if is_managed and not custom_base_url and model not in MANAGED_OPENAI_TTS_MODELS:
+        logger.warning(
+            "TTS: managed OpenAI audio gateway does not support model %r; "
+            "falling back to %s. Set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY "
+            "to use %r directly.",
+            model, DEFAULT_OPENAI_MODEL, model,
+        )
+        model = DEFAULT_OPENAI_MODEL
 
     # Determine response format from extension
     if output_path.endswith(".ogg"):
@@ -2502,15 +2522,17 @@ def check_tts_requirements() -> bool:
     return False
 
 
-def _resolve_openai_audio_client_config() -> tuple[str, str]:
-    """Return direct OpenAI audio config or a managed gateway fallback.
+def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
+    """Return ``(api_key, base_url, is_managed)`` for the OpenAI audio client.
 
-    When ``tts.use_gateway`` is set in config, the Tool Gateway is preferred
+    ``is_managed`` is True when the config resolves to the Nous managed audio
+    gateway (a restricted proxy), so callers can coerce the request to what the
+    gateway supports. When ``tts.use_gateway`` is set the gateway is preferred
     even if direct OpenAI credentials are present.
     """
     direct_api_key = resolve_openai_audio_api_key()
     if direct_api_key and not prefers_gateway("tts"):
-        return direct_api_key, DEFAULT_OPENAI_BASE_URL
+        return direct_api_key, DEFAULT_OPENAI_BASE_URL, False
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
@@ -2524,8 +2546,10 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
             )
         raise ValueError(message)
 
-    return managed_gateway.nous_user_token, urljoin(
-        f"{managed_gateway.gateway_origin.rstrip('/')}/", "v1"
+    return (
+        managed_gateway.nous_user_token,
+        urljoin(f"{managed_gateway.gateway_origin.rstrip('/')}/", "v1"),
+        True,
     )
 
 


### PR DESCRIPTION
## Repro / root cause

```
TTS generation failed (openai): Error code: 400 - {'error': {'code': 'VALIDATION_ERROR',
'message': 'Unsupported managed OpenAI speech model',
'details': {'model': 'tts-1-hd', 'supportedModels': ['gpt-4o-mini-tts']}}, ...}
```

`_generate_openai_tts` reads `tts.openai.model` and sends it verbatim. The desktop Settings enum offers `gpt-4o-mini-tts`, `tts-1`, and `tts-1-hd` (`constants.ts:258`), all valid for **direct** OpenAI. But when the user has no `VOICE_TOOLS_OPENAI_KEY`/`OPENAI_API_KEY` (or sets `tts.use_gateway`), `_resolve_openai_audio_client_config` falls back to the **managed Nous audio gateway**, a restricted proxy that only accepts `gpt-4o-mini-tts`. The user's `tts-1-hd` then 400s.

## Fix

- `_resolve_openai_audio_client_config` now returns `(api_key, base_url, is_managed)`.
- `_generate_openai_tts` coerces the model to `MANAGED_OPENAI_TTS_MODELS` (currently `gpt-4o-mini-tts`) when on the managed gateway and the user hasn't redirected `tts.openai.base_url` to their own endpoint — logging a warning that points at the direct-key escape hatch.
- Direct-key users keep `tts-1` / `tts-1-hd` unchanged.

## Tests

New in `tests/tools/test_managed_media_gateways.py`:
- `test_openai_tts_coerces_direct_only_model_on_managed_gateway` — `tts-1-hd` + managed gateway → sent as `gpt-4o-mini-tts`.
- `test_openai_tts_keeps_direct_only_model_with_direct_key` — `tts-1-hd` + direct key → honored.

`scripts/run_tests.sh tests/tools/test_managed_media_gateways.py tests/tools/test_tts_speed.py` → 33 passed.