### PR TITLE
fix(providers): pass extra_headers through model switch validation

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
+from ipaddress import ip_address
 from typing import Any, List, NamedTuple, Optional
+from urllib.parse import urlsplit
 
 from hermes_cli.providers import (
     ProviderDef,
@@ -1167,6 +1169,7 @@ def switch_model(
     api_key = current_api_key
     base_url = current_base_url
     api_mode = ""
+    validation_headers: dict[str, str] = {}
 
     if provider_changed or explicit_provider:
         import os
@@ -1184,6 +1187,7 @@ def switch_model(
         if _user_pdef is not None and _user_pdef.base_url:
             _ucfg = (user_providers or {}).get(explicit_provider.strip().lower()) \
                 or (user_providers or {}).get(target_provider) or {}
+            validation_headers = _extra_headers_from_config(_ucfg)
             _ukey = str(_ucfg.get("api_key", "") or "").strip()
             if _ukey.startswith("${") and _ukey.endswith("}"):
                 _ukey = os.environ.get(_ukey[2:-1], "").strip()
@@ -1218,6 +1222,7 @@ def switch_model(
                 api_key = runtime.get("api_key", "")
                 base_url = runtime.get("base_url", "")
                 api_mode = runtime.get("api_mode", "")
+                validation_headers = _extra_headers_from_config(runtime)
             except Exception as e:
                 return ModelSwitchResult(
                     success=False,
@@ -1242,6 +1247,7 @@ def switch_model(
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
             api_mode = runtime.get("api_mode", "")
+            validation_headers = _extra_headers_from_config(runtime)
         except Exception:
             pass
 
@@ -1250,8 +1256,12 @@ def switch_model(
         _ensure_direct_aliases()
         _da = DIRECT_ALIASES.get(resolved_alias)
         if _da is not None and _da.base_url:
+            endpoint_changed = not _same_validation_endpoint(_da.base_url, base_url)
+            if endpoint_changed:
+                validation_headers = {}
+                api_key = ""
+                api_mode = ""  # force URL-based re-detection for the new endpoint
             base_url = _da.base_url
-            api_mode = ""  # clear so determine_api_mode re-detects from URL
             if not api_key:
                 api_key = "no-key-required"
 
@@ -1266,6 +1276,7 @@ def switch_model(
             api_key=api_key,
             base_url=base_url,
             api_mode=api_mode or None,
+            request_headers=validation_headers or None,
         )
     except Exception as e:
         validation = {
@@ -1419,6 +1430,54 @@ def _extra_headers_from_config(entry: Any) -> dict[str, str]:
     from hermes_cli.config import normalize_extra_headers
 
     return normalize_extra_headers(entry.get("extra_headers"))
+
+
+def _same_validation_endpoint(left: str, right: str) -> bool:
+    """Compare endpoints without collapsing case-sensitive path/query data."""
+    def _normalized(value: str):
+        try:
+            parsed = urlsplit(str(value or "").strip())
+            hostname = parsed.hostname
+            port = parsed.port
+        except ValueError:
+            return None
+        if not parsed.scheme or not hostname:
+            return None
+        scheme = parsed.scheme.lower()
+        if "%" in hostname:
+            address, zone = hostname.split("%", 1)
+        else:
+            address, zone = hostname, ""
+        try:
+            normalized_address = ip_address(address).compressed.lower()
+        except ValueError:
+            normalized_address = address.lower()
+        normalized_hostname = (
+            f"{normalized_address}%{zone}" if zone else normalized_address
+        )
+        if (scheme, port) in {("http", 80), ("https", 443)}:
+            port = None
+        path = parsed.path
+        if path == "/":
+            path = ""
+        elif path.endswith("/"):
+            path = path[:-1]
+        return (
+            scheme,
+            normalized_hostname,
+            port,
+            parsed.username,
+            parsed.password,
+            path,
+            parsed.query,
+            parsed.fragment,
+        )
+
+    normalized_left = _normalized(left)
+    normalized_right = _normalized(right)
+    if normalized_left is None or normalized_right is None:
+        return str(left or "").strip() == str(right or "").strip()
+    return normalized_left == normalized_right
 
 
 def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4087,6 +4087,7 @@ def validate_requested_model(
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
+    request_headers: Optional[dict[str, str]] = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
@@ -4182,9 +4183,18 @@ def validate_requested_model(
     if normalized == "custom" or normalized.startswith("custom:"):
         # Try probing with correct auth for the api_mode.
         if api_mode == "anthropic_messages":
-            probe = probe_api_models(api_key, base_url, api_mode=api_mode)
+            probe = probe_api_models(
+                api_key,
+                base_url,
+                api_mode=api_mode,
+                request_headers=request_headers,
+            )
         else:
-            probe = probe_api_models(api_key, base_url)
+            probe = probe_api_models(
+                api_key,
+                base_url,
+                request_headers=request_headers,
+            )
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):
@@ -4415,7 +4425,12 @@ def validate_requested_model(
     # Anthropic Messages API: many proxies don't implement /v1/models.
     # Try probing with correct auth; if it fails, accept with a warning.
     if api_mode == "anthropic_messages":
-        api_models = fetch_api_models(api_key, base_url, api_mode=api_mode)
+        api_models = fetch_api_models(
+            api_key,
+            base_url,
+            api_mode=api_mode,
+            headers=request_headers,
+        )
         if api_models is not None:
             if requested_for_lookup in set(api_models):
                 return {
@@ -4448,7 +4463,7 @@ def validate_requested_model(
         }
 
     # Probe the live API to check if the model actually exists
-    api_models = fetch_api_models(api_key, base_url)
+    api_models = fetch_api_models(api_key, base_url, headers=request_headers)
 
     if api_models is not None:
         # Gemini's OpenAI-compat /v1beta/openai/models endpoint returns IDs

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -1048,6 +1048,67 @@ def test_custom_provider_live_model_probe_uses_extra_headers(monkeypatch):
     assert gateway_prov["models"] == ["gateway-model"]
 
 
+def test_switch_model_validation_uses_custom_provider_extra_headers(monkeypatch):
+    """Validation must use the selected tenant's headers and Anthropic auth."""
+    captured = {}
+    custom_providers = [
+        {
+            "name": "Tenant A",
+            "api_key": "local-key",
+            "base_url": "http://localhost:8081/v1",
+            "api_mode": "anthropic_messages",
+            "extra_headers": {"X-Tenant": "alpha"},
+        },
+        {
+            "name": "Tenant B",
+            "api_key": "local-key",
+            "base_url": "http://localhost:8081/v1",
+            "api_mode": "anthropic_messages",
+            "extra_headers": {"X-Tenant": "beta"},
+        },
+    ]
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return b'{"data":[{"id":"gateway-model"}]}'
+
+    def fake_urlopen(request, *, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("hermes_cli.models._urlopen_model_catalog_request", fake_urlopen)
+    monkeypatch.setattr("hermes_cli.models.detect_provider_for_model", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.load_config",
+        lambda: {"custom_providers": custom_providers},
+    )
+
+    result = switch_model(
+        raw_input="gateway-model",
+        current_provider="custom:tenant-b",
+        current_model="old-model",
+        current_base_url="http://localhost:8081/v1",
+        current_api_key="local-key",
+        custom_providers=custom_providers,
+    )
+
+    assert result.success is True
+    assert captured["request"].full_url == "http://localhost:8081/v1/models"
+    assert captured["request"].get_header("X-tenant") == "beta"
+    assert captured["request"].get_header("X-api-key") == "local-key"
+    assert captured["request"].get_header("Anthropic-version") == "2023-06-01"
+    assert captured["request"].get_header("Authorization") is None
+
+
 def test_same_endpoint_different_extra_headers_not_collapsed(monkeypatch):
     """Entries sharing (api_url, credential, api_mode) but declaring different
     extra_headers must NOT collapse into one picker row — each is a distinct

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -231,6 +231,293 @@ def test_user_provider_live_model_probe_uses_extra_headers(monkeypatch):
     assert user_prov["models"] == ["live-model"]
 
 
+def test_switch_model_validation_uses_user_provider_extra_headers(monkeypatch):
+    """Validation must preserve user-provider headers alongside bearer auth."""
+    captured = {}
+    user_providers = {
+        "tenant-proxy": {
+            "name": "Tenant proxy",
+            "api": "https://proxy.example.com/v1",
+            "api_key": "sk-proxy",
+            "models": {"tenant-model": {}, "tenant-model-2": {}},
+            "extra_headers": {"X-Tenant": "alpha"},
+        }
+    }
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return b'{"data":[{"id":"tenant-model"},{"id":"tenant-model-2"}]}'
+
+    def fake_urlopen(request, *, timeout):
+        captured.setdefault("requests", []).append(request)
+        captured.setdefault("timeouts", []).append(timeout)
+        return FakeResponse()
+
+    monkeypatch.setattr("hermes_cli.models._urlopen_model_catalog_request", fake_urlopen)
+    monkeypatch.setattr("hermes_cli.models.detect_provider_for_model", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.load_config",
+        lambda: {"providers": user_providers},
+    )
+    from hermes_cli import runtime_provider as runtime_provider_mod
+
+    runtime_calls = []
+    real_resolve_runtime_provider = runtime_provider_mod.resolve_runtime_provider
+
+    def tracked_resolve_runtime_provider(**kwargs):
+        runtime_calls.append(kwargs)
+        return real_resolve_runtime_provider(**kwargs)
+
+    monkeypatch.setattr(
+        runtime_provider_mod,
+        "resolve_runtime_provider",
+        tracked_resolve_runtime_provider,
+    )
+
+    result = switch_model(
+        raw_input="tenant-model",
+        current_provider="openrouter",
+        current_model="old-model",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="openrouter-key",
+        explicit_provider="tenant-proxy",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert runtime_calls == [
+        {
+            "requested": "tenant-proxy",
+            "explicit_api_key": "sk-proxy",
+            "explicit_base_url": "https://proxy.example.com/v1",
+            "target_model": "tenant-model",
+        }
+    ]
+    assert len(captured["requests"]) == 1
+    first_request = captured["requests"][-1]
+    assert first_request.full_url == "https://proxy.example.com/v1/models"
+    assert first_request.get_header("X-tenant") == "alpha"
+    assert first_request.get_header("Authorization") == "Bearer sk-proxy"
+
+    followup = switch_model(
+        raw_input="tenant-model-2",
+        current_provider=result.target_provider,
+        current_model=result.new_model,
+        current_base_url=result.base_url,
+        current_api_key=result.api_key,
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    assert followup.success is True
+    assert runtime_calls[-1] == {
+        "requested": "tenant-proxy",
+        "target_model": "tenant-model-2",
+    }
+    assert len(captured["requests"]) == 2
+    followup_request = captured["requests"][-1]
+    assert followup_request.full_url == "https://proxy.example.com/v1/models"
+    assert followup_request.get_header("X-tenant") == "alpha"
+    assert followup_request.get_header("Authorization") == "Bearer sk-proxy"
+
+
+def test_validation_headers_follow_runtime_not_same_named_config(monkeypatch):
+    """An unselected config entry must not inject headers into a runtime."""
+    captured = {}
+
+    def fake_validate(*args, **kwargs):
+        captured.update(kwargs)
+        return {"accepted": True, "persist": True, "recognized": True, "message": None}
+
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", fake_validate)
+    monkeypatch.setattr("hermes_cli.models.detect_provider_for_model", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+    same_named_config = {
+        "openrouter": {
+            "api": "https://proxy.example.com/v1",
+            "extra_headers": {"X-Tenant": "must-not-leak"},
+        }
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.load_config",
+        lambda: {"providers": same_named_config},
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
+
+    result = switch_model(
+        raw_input="unlisted-model",
+        current_provider="openrouter",
+        current_model="old-model",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="openrouter-key",
+        user_providers=same_named_config,
+    )
+
+    assert result.success is True
+    assert captured["request_headers"] is None
+
+
+def test_direct_alias_drops_headers_when_endpoint_changes(monkeypatch):
+    """Endpoint-specific headers must not follow an alias to another host."""
+    from hermes_cli.model_switch import DirectAlias
+    import hermes_cli.model_switch as model_switch_mod
+
+    captured = {}
+
+    def fake_validate(*args, **kwargs):
+        captured.update(kwargs)
+        return {"accepted": True, "persist": True, "recognized": True, "message": None}
+
+    monkeypatch.setattr(
+        model_switch_mod,
+        "DIRECT_ALIASES",
+        {
+            "cross-endpoint": DirectAlias(
+                "aliased-model",
+                "custom",
+                "https://proxy.example.com/TenantB/v1",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        model_switch_mod,
+        "resolve_alias",
+        lambda *a, **k: ("custom", "aliased-model", "cross-endpoint"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda *a, **k: {
+            "api_key": "proxy-key",
+            "base_url": "https://proxy.example.com/tenantb/v1",
+            "api_mode": "openai_chat",
+            "extra_headers": {"X-Tenant": "alpha"},
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", fake_validate)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="cross-endpoint",
+        current_provider="tenant-proxy",
+        current_model="old-model",
+        current_base_url="https://proxy.example.com/tenantb/v1",
+        current_api_key="proxy-key",
+    )
+
+    assert result.success is True
+    assert captured["base_url"] == "https://proxy.example.com/TenantB/v1"
+    assert captured["api_key"] == "no-key-required"
+    assert captured["request_headers"] is None
+
+
+def test_direct_alias_keeps_auth_for_equivalent_endpoint(monkeypatch):
+    """Equivalent aliases preserve tenant headers and Anthropic auth mode."""
+    from hermes_cli.model_switch import DirectAlias
+    import hermes_cli.model_switch as model_switch_mod
+
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return b'{"data":[{"id":"aliased-model"}]}'
+
+    def fake_urlopen(request, *, timeout):
+        captured["request"] = request
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        model_switch_mod,
+        "DIRECT_ALIASES",
+        {
+            "equivalent": DirectAlias(
+                "aliased-model",
+                "tenant-proxy",
+                "https://PROXY.example.com:443/v1/",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        model_switch_mod,
+        "resolve_alias",
+        lambda *a, **k: ("tenant-proxy", "aliased-model", "equivalent"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda *a, **k: {
+            "api_key": "proxy-key",
+            "base_url": "https://proxy.example.com/v1",
+            "api_mode": "anthropic_messages",
+            "extra_headers": {"X-Tenant": "alpha"},
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models._urlopen_model_catalog_request", fake_urlopen)
+    monkeypatch.setattr("hermes_cli.models.detect_provider_for_model", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="equivalent",
+        current_provider="tenant-proxy",
+        current_model="old-model",
+        current_base_url="https://proxy.example.com/v1",
+        current_api_key="proxy-key",
+    )
+
+    assert result.success is True
+    assert captured["request"].get_header("X-tenant") == "alpha"
+    assert captured["request"].get_header("X-api-key") == "proxy-key"
+    assert captured["request"].get_header("Anthropic-version") == "2023-06-01"
+    assert captured["request"].get_header("Authorization") is None
+
+
+def test_validation_endpoint_comparison_rejects_malformed_ipv6():
+    from hermes_cli.model_switch import _same_validation_endpoint
+
+    assert not _same_validation_endpoint(
+        "https://[::1/v1",
+        "https://[::1]/v1",
+    )
+
+
+def test_validation_endpoint_comparison_preserves_ipv6_zone_case():
+    from hermes_cli.model_switch import _same_validation_endpoint
+
+    assert not _same_validation_endpoint(
+        "https://[fe80::1%25ETH0]/v1",
+        "https://[fe80::1%25eth0]/v1",
+    )
+
+
+def test_validation_endpoint_comparison_canonicalizes_ipv6_address():
+    from hermes_cli.model_switch import _same_validation_endpoint
+
+    assert _same_validation_endpoint(
+        "https://[fe80::1%25ETH0]/v1",
+        "https://[fe80:0:0:0:0:0:0:1%25ETH0]:443/v1/",
+    )
+    assert _same_validation_endpoint(
+        "https://[2001:db8::1]/v1",
+        "https://[2001:0db8:0:0:0:0:0:1]:443/v1/",
+    )
+
+
 def test_list_authenticated_providers_dict_models_without_default_model(monkeypatch):
     """Dict-format ``models:`` without a ``default_model`` must still expose
     every dict key, not collapse to an empty list."""


### PR DESCRIPTION
## Summary

- pass configured `extra_headers` into model-switch validation probes
- keep user-provider matching tied to the resolved provider slug
- cover user-provider and custom-provider validation paths with regression tests

## Tests

```bash
python3 -m pytest tests/hermes_cli/test_user_providers_model_switch.py::test_switch_model_validation_uses_user_provider_extra_headers tests/hermes_cli/test_user_providers_model_switch.py::test_provider_extra_headers_use_resolved_provider_only tests/hermes_cli/test_model_switch_custom_providers.py::test_switch_model_validation_uses_custom_provider_extra_headers tests/hermes_cli/test_user_providers_model_switch.py::test_user_provider_live_model_probe_uses_extra_headers tests/hermes_cli/test_model_switch_custom_providers.py::test_custom_provider_live_model_probe_uses_extra_headers tests/hermes_cli/test_model_switch_custom_providers.py::test_same_endpoint_different_extra_headers_not_collapsed -q
```

Codex review initially flagged a possible header leak from alias matching. I reworked the lookup so validation only uses headers for the resolved provider, then re-ran the review to approval.
