### PR TITLE
fix(compression): silence Codex gpt-5.5 autoraise notice

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -68,24 +68,6 @@ def _ra():
     return run_agent
 
 
-def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
-    """Build the one-time notice shown when Codex gpt-5.5 raises compaction.
-
-    ``autoraise`` is ``{"from": <old_ratio>, "to": <new_ratio>}``. The same
-    text is printed inline for CLI users and replayed via ``status_callback``
-    for gateway users, so it must be self-contained and include the exact
-    opt-back-out command.
-    """
-    from_pct = int(round(autoraise["from"] * 100))
-    to_pct = int(round(autoraise["to"] * 100))
-    return (
-        f"ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
-        f"to {to_pct}% (from {from_pct}%) to use more of the window before "
-        f"summarizing.\n"
-        f"  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
-    )
-
-
 def _normalized_custom_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -1401,17 +1383,15 @@ def init_agent(
     # Per-model/route compaction-threshold override. Codex gpt-5.5 raises to
     # 85% (the Codex backend caps the window at 272K, so the default 50% would
     # compact at ~136K — half the usable context). Gated by an opt-out config
-    # flag so the user can fall back to the global threshold; when the override
-    # fires we stash a one-time notification (replayed on the first turn) that
-    # tells the user what changed and how to revert.
+    # flag so the user can fall back to the global threshold. The override is
+    # intentionally silent: this is an internal runtime optimization, not a
+    # user-actionable status message that should appear in messaging channels.
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
     ).lower() in {"true", "1", "yes"}
-    agent._compression_threshold_autoraised = None
     try:
         from agent.auxiliary_client import (
             _compression_threshold_for_model as _cthresh_fn,
-            _is_codex_gpt55 as _is_codex_gpt55_fn,
         )
         _model_cthresh = _cthresh_fn(
             agent.model,
@@ -1419,20 +1399,7 @@ def init_agent(
             allow_codex_gpt55_autoraise=_codex_gpt55_autoraise,
         )
         if _model_cthresh is not None:
-            _prev_threshold = compression_threshold
             compression_threshold = _model_cthresh
-            # Notify only for the Codex gpt-5.5 autoraise (the Arcee Trinity
-            # override is a long-standing silent default). Skip the notice when
-            # the user's global threshold already meets/exceeds the raised
-            # value, since nothing actually changed for them.
-            if (
-                _is_codex_gpt55_fn(agent.model, agent.provider)
-                and _model_cthresh > _prev_threshold + 1e-9
-            ):
-                agent._compression_threshold_autoraised = {
-                    "from": _prev_threshold,
-                    "to": _model_cthresh,
-                }
     except Exception:
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
@@ -1886,24 +1853,11 @@ def init_agent(
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
-        _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
-            print(_build_codex_gpt55_autoraise_notice(_autoraise))
 
     # Check immediately so CLI users see the warning at startup.
     # Gateway status_callback is not yet wired, so any warning is stored
     # in _compression_warning and replayed in the first run_conversation().
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -157,3 +157,28 @@ def test_compression_threshold_opt_out_does_not_disable_trinity() -> None:
         )
         == 0.75
     )
+
+
+def test_codex_gpt55_autoraise_is_silent_runtime_override() -> None:
+    """The 85% autoraise is internal state, not a gateway lifecycle warning.
+
+    The configured global threshold remains 50%, so every new gateway agent used
+    to recompute the Codex gpt-5.5 override and replay a non-actionable
+    ``_compression_warning`` into Telegram/Discord/Weixin/etc. Keep the useful
+    runtime override, but do not store it as a user-visible warning.
+    """
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="gpt-5.5",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="test-token",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert agent.context_compressor.threshold_percent == 0.85
+    assert agent._compression_warning is None


### PR DESCRIPTION
## Summary

Suppress the one-time user-facing notice emitted when the Codex OAuth route for `gpt-5.5` silently raises the effective context-compaction threshold from the configured global default to 85%.

The runtime optimization remains unchanged:

- `gpt-5.5` on `provider=openai-codex` still uses the 85% effective threshold.
- `compression.codex_gpt55_autoraise: false` still opts back out to the global threshold.
- Other providers/models are unchanged.

What changes is only the delivery path: the internal threshold override is no longer stored in `_compression_warning`, so gateway surfaces do not replay it as a `lifecycle` chat message on the first turn of every newly-created agent/session.

## Why

The global config can remain at `compression.threshold: 0.5` while the Codex `gpt-5.5` route computes an effective runtime threshold of 0.85 on each new agent initialization. Because the previous implementation converted that recomputed internal override into `_compression_warning`, users on gateway platforms (Telegram, Discord, Weixin, etc.) could repeatedly receive a non-actionable implementation-detail message after session resets, gateway restarts, or new sessions.

That message is useful context for the original implementation, but it is not user-actionable in normal chat channels and can be mistaken for a persistent config mutation.

## Tests

```bash
scripts/run_tests.sh tests/agent/test_arcee_trinity_overrides.py tests/run_agent/test_compression_feasibility.py -q
```

Result: 58 passed.