### PR TITLE
fix(google-chat): scope service-account env per profile

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -48,6 +48,30 @@ import time
 from pathlib import Path as _Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from agent.secret_scope import (
+    UnscopedSecretError as _UnscopedSecretError,
+    get_secret as _get_secret,
+    is_multiplex_active,
+)
+
+
+def _get_scoped_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Scope-aware Google Chat credential read with the default-profile fallback.
+
+    Secondary profiles run under ``_profile_runtime_scope`` — the scope is
+    authoritative and a scoped miss returns ``default`` (no cross-profile
+    borrow from ``os.environ``). The DEFAULT profile's adapter constructs and
+    connects *unscoped* under multiplexing, where a bare ``get_secret`` would
+    raise ``UnscopedSecretError`` and crash its startup/reconnect path; there
+    ``os.environ`` is that profile's own value, so fall back to it. Same
+    pattern as ``whatsapp_common._get_wsecret`` (#59739).
+    """
+    try:
+        val = _get_secret(name, default)
+    except _UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
 # Heavy google-cloud + googleapiclient imports are deferred to first
 # adapter use. Importing them eagerly here added ~110ms wall and ~33MB
 # RSS to *every* CLI invocation (the plugin loader imports this module at
@@ -747,17 +771,17 @@ class GoogleChatAdapter(BasePlatformAdapter):
             self._max_bytes = 16 * 1024 * 1024
         self._http_events_url = (
             self.config.extra.get("http_events_url")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "")
+            or _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_URL", "")
             or ""
         ).strip()
         self._http_events_audience = (
             self.config.extra.get("http_events_audience")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "")
+            or _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "")
             or self._http_events_url
         ).strip()
         self._http_events_service_account_email = (
             self.config.extra.get("http_events_service_account_email")
-            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", "")
+            or _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", "")
             or ""
         ).strip().lower()
 
@@ -779,7 +803,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         """
         sa_path = (
             self.config.extra.get("service_account_json")
-            or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+            or _get_scoped_secret("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+            or _get_scoped_secret("GOOGLE_APPLICATION_CREDENTIALS")
         )
         if sa_path:
             # Inline JSON (rare, but supported).
@@ -822,6 +847,16 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 "or install google-auth to use Application Default Credentials."
             )
         try:
+            if is_multiplex_active() and (
+                os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+                or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+            ):
+                raise ValueError(
+                    "Google Chat ADC skipped for this profile: service-account "
+                    "credentials are set in the process environment but not in "
+                    "this profile's secret scope. Set "
+                    "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON in this profile's .env."
+                )
             credentials, _project = google_auth.default(scopes=_CHAT_SCOPES)
         except Exception as exc:
             raise ValueError(
@@ -951,8 +986,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         candidate_spaces: List[str] = []
         if self.config.home_channel and self.config.home_channel.chat_id:
             candidate_spaces.append(self.config.home_channel.chat_id)
-        # Env-configured allowed spaces (comma-separated). Optional.
-        extra_spaces = os.getenv("GOOGLE_CHAT_BOOTSTRAP_SPACES", "").strip()
+        # Profile-scoped allowed spaces (comma-separated). Optional.
+        extra_spaces = (_get_scoped_secret("GOOGLE_CHAT_BOOTSTRAP_SPACES") or "").strip()
         if extra_spaces:
             candidate_spaces.extend(
                 s.strip() for s in extra_spaces.split(",") if s.strip()
@@ -3360,14 +3395,14 @@ def _check_for_registry() -> bool:
     if not check_google_chat_requirements():
         return False
     project = (
-        os.getenv("GOOGLE_CHAT_PROJECT_ID")
-        or os.getenv("GOOGLE_CLOUD_PROJECT")
+        _get_scoped_secret("GOOGLE_CHAT_PROJECT_ID")
+        or _get_scoped_secret("GOOGLE_CLOUD_PROJECT")
     )
     subscription = (
-        os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME")
-        or os.getenv("GOOGLE_CHAT_SUBSCRIPTION")
+        _get_scoped_secret("GOOGLE_CHAT_SUBSCRIPTION_NAME")
+        or _get_scoped_secret("GOOGLE_CHAT_SUBSCRIPTION")
     )
-    http_events_url = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL")
+    http_events_url = _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_URL")
     return bool(http_events_url or (project and subscription))
 
 
@@ -3391,14 +3426,14 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
     ``PlatformConfig`` rather than being merged into ``extra``.
     """
     project = (
-        os.getenv("GOOGLE_CHAT_PROJECT_ID")
-        or os.getenv("GOOGLE_CLOUD_PROJECT")
+        _get_scoped_secret("GOOGLE_CHAT_PROJECT_ID")
+        or _get_scoped_secret("GOOGLE_CLOUD_PROJECT")
     )
     subscription = (
-        os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME")
-        or os.getenv("GOOGLE_CHAT_SUBSCRIPTION")
+        _get_scoped_secret("GOOGLE_CHAT_SUBSCRIPTION_NAME")
+        or _get_scoped_secret("GOOGLE_CHAT_SUBSCRIPTION")
     )
-    http_events_url = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL")
+    http_events_url = _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_URL")
     if not (http_events_url or (project and subscription)):
         return None
     seed: Dict[str, Any] = {}
@@ -3408,23 +3443,23 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
         seed["subscription_name"] = subscription
     if http_events_url:
         seed["http_events_url"] = http_events_url
-    http_events_audience = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE")
+    http_events_audience = _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE")
     if http_events_audience:
         seed["http_events_audience"] = http_events_audience
-    http_events_sa_email = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL")
+    http_events_sa_email = _get_scoped_secret("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL")
     if http_events_sa_email:
         seed["http_events_service_account_email"] = http_events_sa_email
     sa_json = (
-        os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
-        or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        _get_scoped_secret("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+        or _get_scoped_secret("GOOGLE_APPLICATION_CREDENTIALS")
     )
     if sa_json:
         seed["service_account_json"] = sa_json
-    home = os.getenv("GOOGLE_CHAT_HOME_CHANNEL")
+    home = _get_scoped_secret("GOOGLE_CHAT_HOME_CHANNEL")
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("GOOGLE_CHAT_HOME_CHANNEL_NAME", "Home"),
+            "name": _get_scoped_secret("GOOGLE_CHAT_HOME_CHANNEL_NAME", "Home") or "Home",
         }
     return seed
 
@@ -3574,8 +3609,8 @@ async def _standalone_send(
     extra = getattr(pconfig, "extra", {}) or {}
     sa_value = (
         extra.get("service_account_json")
-        or os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
-        or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        or _get_scoped_secret("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+        or _get_scoped_secret("GOOGLE_APPLICATION_CREDENTIALS")
     )
 
     if service_account is None:
@@ -3605,6 +3640,15 @@ async def _standalone_send(
                     return {"error": f"Google Chat standalone send: SA JSON file is invalid: {exc}"}
                 creds = service_account.Credentials.from_service_account_info(info, scopes=_CHAT_SCOPES)
         else:
+            if is_multiplex_active() and (
+                os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
+                or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+            ):
+                return {"error": (
+                    "Google Chat standalone send: ADC skipped for this profile: "
+                    "service-account credentials are set in the process environment "
+                    "but not in this profile's secret scope"
+                )}
             try:
                 import google.auth as _google_auth
             except ImportError:

--- a/tests/gateway/test_adapter_startup_secret_scope.py
+++ b/tests/gateway/test_adapter_startup_secret_scope.py
@@ -41,6 +41,7 @@ MIGRATED_ADAPTER_MODULES = [
     ("plugins.platforms.photon.adapter", "PHOTON_PROJECT_SECRET"),
     ("plugins.platforms.photon.auth", "PHOTON_PROJECT_SECRET"),
     ("plugins.platforms.buzz.adapter", "BUZZ_PRIVATE_KEY"),
+    ("plugins.platforms.google_chat.adapter", "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON"),
     ("gateway.platforms.bluebubbles", "BLUEBUBBLES_PASSWORD"),
     ("gateway.platforms.api_server", "API_SERVER_KEY"),
 ]

--- a/tests/plugins/platforms/google_chat/test_secret_scope.py
+++ b/tests/plugins/platforms/google_chat/test_secret_scope.py
@@ -1,0 +1,437 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent import secret_scope
+from plugins.platforms.google_chat import adapter as google_chat
+
+
+@pytest.fixture(autouse=True)
+def _reset_secret_scope():
+    secret_scope.set_multiplex_active(False)
+    yield
+    secret_scope.set_multiplex_active(False)
+
+
+def test_env_enablement_uses_profile_secret_scope_not_process_env(monkeypatch):
+    monkeypatch.setattr(google_chat, "check_google_chat_requirements", lambda: True)
+    monkeypatch.setenv("GOOGLE_CHAT_PROJECT_ID", "foreign-project")
+    monkeypatch.setenv(
+        "GOOGLE_CHAT_SUBSCRIPTION_NAME",
+        "projects/foreign-project/subscriptions/foreign-sub",
+    )
+    monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON", '{"project_id":"foreign"}')
+    monkeypatch.setenv("GOOGLE_CHAT_HOME_CHANNEL", "spaces/FOREIGN")
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "https://foreign.example/events")
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "foreign-audience")
+    monkeypatch.setenv(
+        "GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL",
+        "foreign@example.iam.gserviceaccount.com",
+    )
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({
+        "GOOGLE_CHAT_PROJECT_ID": "scoped-project",
+        "GOOGLE_CHAT_SUBSCRIPTION_NAME": "projects/scoped-project/subscriptions/scoped-sub",
+        "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON": '{"project_id":"scoped"}',
+        "GOOGLE_CHAT_HOME_CHANNEL": "spaces/SCOPED",
+        "GOOGLE_CHAT_HOME_CHANNEL_NAME": "Scoped Home",
+        "GOOGLE_CHAT_HTTP_EVENTS_URL": "https://scoped.example/events",
+        "GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE": "scoped-audience",
+        "GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL": "scoped@example.iam.gserviceaccount.com",
+    })
+    try:
+        seed = google_chat._env_enablement()
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert seed == {
+        "project_id": "scoped-project",
+        "subscription_name": "projects/scoped-project/subscriptions/scoped-sub",
+        "http_events_url": "https://scoped.example/events",
+        "http_events_audience": "scoped-audience",
+        "http_events_service_account_email": "scoped@example.iam.gserviceaccount.com",
+        "service_account_json": '{"project_id":"scoped"}',
+        "home_channel": {"chat_id": "spaces/SCOPED", "name": "Scoped Home"},
+    }
+
+
+def test_env_enablement_unscoped_multiplex_uses_own_process_env(monkeypatch):
+    """The DEFAULT profile's config path runs unscoped under multiplexing.
+
+    There ``os.environ`` holds that profile's own values (its ``.env`` was
+    loaded into the process env at gateway start), so ``_env_enablement``
+    must fall back to it instead of raising ``UnscopedSecretError`` — a
+    raise here would leave a configured default profile unserved.
+    """
+    monkeypatch.setattr(google_chat, "check_google_chat_requirements", lambda: True)
+    monkeypatch.setenv("GOOGLE_CHAT_PROJECT_ID", "own-project")
+    monkeypatch.setenv(
+        "GOOGLE_CHAT_SUBSCRIPTION_NAME",
+        "projects/own-project/subscriptions/own-sub",
+    )
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "https://own.example/events")
+
+    secret_scope.set_multiplex_active(True)
+
+    seed = google_chat._env_enablement()
+
+    assert seed == {
+        "project_id": "own-project",
+        "subscription_name": "projects/own-project/subscriptions/own-sub",
+        "http_events_url": "https://own.example/events",
+    }
+
+
+def test_registry_check_ignores_foreign_http_events_url(monkeypatch):
+    monkeypatch.setattr(google_chat, "check_google_chat_requirements", lambda: True)
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "https://foreign.example/events")
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({})
+    try:
+        enabled = google_chat._check_for_registry()
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert enabled is False
+
+
+def test_env_enablement_ignores_foreign_http_events_url_in_empty_scope(monkeypatch):
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "https://foreign.example/events")
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({})
+    try:
+        seed = google_chat._env_enablement()
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert seed is None
+
+
+def test_adapter_http_events_fallback_uses_profile_secret_scope(monkeypatch):
+    monkeypatch.setattr(google_chat, "_load_google_modules", lambda: True)
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "https://foreign.example/events")
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "foreign-audience")
+    monkeypatch.setenv(
+        "GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL",
+        "foreign@example.iam.gserviceaccount.com",
+    )
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({
+        "GOOGLE_CHAT_HTTP_EVENTS_URL": "https://scoped.example/events",
+        "GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE": "scoped-audience",
+        "GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL": "scoped@example.iam.gserviceaccount.com",
+    })
+    try:
+        adapter = google_chat.GoogleChatAdapter(google_chat.PlatformConfig(enabled=True))
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert adapter._http_events_url == "https://scoped.example/events"
+    assert adapter._http_events_audience == "scoped-audience"
+    assert adapter._http_events_service_account_email == "scoped@example.iam.gserviceaccount.com"
+
+
+def test_load_sa_credentials_uses_profile_secret_scope_not_process_env(monkeypatch):
+    class _FakeCredentials:
+        @staticmethod
+        def from_service_account_info(info, scopes):
+            return {"info": info, "scopes": scopes}
+
+    monkeypatch.setattr(
+        google_chat,
+        "service_account",
+        SimpleNamespace(Credentials=_FakeCredentials),
+    )
+    monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON", '{"project_id":"foreign"}')
+
+    instance = google_chat.GoogleChatAdapter.__new__(google_chat.GoogleChatAdapter)
+    instance.config = SimpleNamespace(extra={})
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({
+        "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON": '{"project_id":"scoped"}'
+    })
+    try:
+        credentials = google_chat.GoogleChatAdapter._load_sa_credentials(instance)
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert credentials["info"] == {"project_id": "scoped"}
+    assert credentials["scopes"] == google_chat._CHAT_SCOPES
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_skips_foreign_process_adc_in_multiplex(monkeypatch):
+    import google.auth
+
+    calls = []
+
+    def unexpected_default(**kwargs):
+        calls.append(kwargs)
+        raise AssertionError("foreign process ADC must not be used")
+
+    monkeypatch.setattr(
+        google_chat,
+        "service_account",
+        SimpleNamespace(Credentials=object()),
+    )
+    monkeypatch.setattr(google.auth, "default", unexpected_default)
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/foreign/profile.json")
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({})
+    try:
+        result = await google_chat._standalone_send(
+            SimpleNamespace(extra={}),
+            "spaces/SAFE",
+            "hello",
+        )
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert calls == []
+    assert "ADC skipped for this profile" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_allows_workload_identity_adc_in_multiplex(monkeypatch):
+    import google.auth
+
+    calls = []
+
+    def marker_default(**kwargs):
+        calls.append(kwargs)
+        raise RuntimeError("workload identity ADC reached")
+
+    monkeypatch.setattr(
+        google_chat,
+        "service_account",
+        SimpleNamespace(Credentials=object()),
+    )
+    monkeypatch.setattr(google.auth, "default", marker_default)
+    monkeypatch.delenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({})
+    try:
+        result = await google_chat._standalone_send(
+            SimpleNamespace(extra={}),
+            "spaces/SAFE",
+            "hello",
+        )
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert calls == [{"scopes": google_chat._CHAT_SCOPES}]
+    assert "workload identity ADC reached" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_bot_user_id_ignores_foreign_bootstrap_spaces_in_empty_scope(
+    monkeypatch,
+):
+    called_spaces = []
+
+    class _FakeMembers:
+        def list(self, parent, pageSize):
+            called_spaces.append(parent)
+            return self
+
+        def execute(self, http=None):
+            return {
+                "memberships": [
+                    {"member": {"type": "BOT", "name": "users/101234567890123456789"}}
+                ]
+            }
+
+    class _FakeSpaces:
+        def members(self):
+            return _FakeMembers()
+
+    class _FakeChatApi:
+        def spaces(self):
+            return _FakeSpaces()
+
+    monkeypatch.setenv("GOOGLE_CHAT_BOOTSTRAP_SPACES", "spaces/FOREIGN")
+
+    monkeypatch.setattr(google_chat, "_load_google_modules", lambda: True)
+    instance = google_chat.GoogleChatAdapter(google_chat.PlatformConfig(enabled=True))
+    instance._chat_api = _FakeChatApi()
+    instance._new_authed_http = lambda: None
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope({})
+    try:
+        bot_id = await instance._resolve_bot_user_id()
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert bot_id is None
+    assert called_spaces == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_bot_user_id_uses_scoped_bootstrap_spaces(monkeypatch):
+    called_spaces = []
+
+    class _FakeMembers:
+        def __init__(self, parent):
+            self._parent = parent
+
+        def list(self, parent, pageSize):
+            called_spaces.append(parent)
+            self._parent = parent
+            return self
+
+        def execute(self, http=None):
+            if self._parent == "spaces/SCOPED2":
+                return {
+                    "memberships": [
+                        {"member": {"type": "BOT", "name": "users/101234567890123456789"}}
+                    ]
+                }
+            return {"memberships": []}
+
+    class _FakeSpaces:
+        def members(self, parent=None):
+            return _FakeMembers(parent)
+
+    class _FakeChatApi:
+        def spaces(self):
+            return _FakeSpaces()
+
+    monkeypatch.setenv("GOOGLE_CHAT_BOOTSTRAP_SPACES", "spaces/FOREIGN")
+
+    monkeypatch.setattr(google_chat, "_load_google_modules", lambda: True)
+    instance = google_chat.GoogleChatAdapter(google_chat.PlatformConfig(enabled=True))
+    instance._chat_api = _FakeChatApi()
+    instance._new_authed_http = lambda: None
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope(
+        {"GOOGLE_CHAT_BOOTSTRAP_SPACES": "spaces/SCOPED, spaces/SCOPED2"}
+    )
+    try:
+        bot_id = await instance._resolve_bot_user_id()
+    finally:
+        secret_scope.reset_secret_scope(token)
+
+    assert bot_id == "users/101234567890123456789"
+    assert called_spaces == ["spaces/SCOPED", "spaces/SCOPED2"]
+
+
+def test_adapter_init_unscoped_multiplex_uses_own_process_env(monkeypatch):
+    """The DEFAULT profile constructs its adapter unscoped under multiplexing.
+
+    Its own values live in ``os.environ`` (loaded from its ``.env`` at
+    gateway start); a bare ``get_secret`` would raise
+    ``UnscopedSecretError`` and crash startup, so the reads must fall back
+    to the process env.
+    """
+    monkeypatch.setattr(google_chat, "_load_google_modules", lambda: True)
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "https://own.example/events")
+    monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "own-audience")
+    monkeypatch.setenv(
+        "GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL",
+        "own@example.iam.gserviceaccount.com",
+    )
+
+    secret_scope.set_multiplex_active(True)
+
+    adapter = google_chat.GoogleChatAdapter(google_chat.PlatformConfig(enabled=True))
+
+    assert adapter._http_events_url == "https://own.example/events"
+    assert adapter._http_events_audience == "own-audience"
+    assert adapter._http_events_service_account_email == "own@example.iam.gserviceaccount.com"
+
+
+def test_adapter_init_unscoped_multiplex_empty_optional_scope(monkeypatch):
+    """Default-profile multiplex startup with an empty optional secret scope.
+
+    No Google Chat secrets configured anywhere: construction must not raise
+    and the optional http-events values must default to empty — never crash
+    the default profile's startup over values that are all optional.
+    """
+    monkeypatch.setattr(google_chat, "_load_google_modules", lambda: True)
+    monkeypatch.delenv("GOOGLE_CHAT_HTTP_EVENTS_URL", raising=False)
+    monkeypatch.delenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", raising=False)
+    monkeypatch.delenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", raising=False)
+
+    secret_scope.set_multiplex_active(True)
+
+    adapter = google_chat.GoogleChatAdapter(google_chat.PlatformConfig(enabled=True))
+
+    assert adapter._http_events_url == ""
+    assert adapter._http_events_audience == ""
+    assert adapter._http_events_service_account_email == ""
+
+
+def test_load_sa_credentials_unscoped_multiplex_env_fallback(monkeypatch):
+    """DEFAULT profile's SA read falls back to its own process env."""
+
+    class _FakeCredentials:
+        @staticmethod
+        def from_service_account_info(info, scopes):
+            return {"info": info, "scopes": scopes}
+
+    monkeypatch.setattr(
+        google_chat,
+        "service_account",
+        SimpleNamespace(Credentials=_FakeCredentials),
+    )
+    monkeypatch.setenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON", '{"project_id":"own"}')
+
+    instance = google_chat.GoogleChatAdapter.__new__(google_chat.GoogleChatAdapter)
+    instance.config = SimpleNamespace(extra={})
+    secret_scope.set_multiplex_active(True)
+
+    credentials = google_chat.GoogleChatAdapter._load_sa_credentials(instance)
+
+    assert credentials["info"] == {"project_id": "own"}
+    assert credentials["scopes"] == google_chat._CHAT_SCOPES
+
+
+@pytest.mark.asyncio
+async def test_resolve_bot_user_id_unscoped_multiplex_uses_own_env_bootstrap_spaces(
+    monkeypatch,
+):
+    """DEFAULT profile's connect-time bootstrap read uses its own env value."""
+    called_spaces = []
+
+    class _FakeMembers:
+        def list(self, parent, pageSize):
+            called_spaces.append(parent)
+            return self
+
+        def execute(self, http=None):
+            return {
+                "memberships": [
+                    {"member": {"type": "BOT", "name": "users/101234567890123456789"}}
+                ]
+            }
+
+    class _FakeSpaces:
+        def members(self):
+            return _FakeMembers()
+
+    class _FakeChatApi:
+        def spaces(self):
+            return _FakeSpaces()
+
+    monkeypatch.setenv("GOOGLE_CHAT_BOOTSTRAP_SPACES", "spaces/OWN")
+
+    monkeypatch.setattr(google_chat, "_load_google_modules", lambda: True)
+    instance = google_chat.GoogleChatAdapter(google_chat.PlatformConfig(enabled=True))
+    instance._chat_api = _FakeChatApi()
+    instance._new_authed_http = lambda: None
+
+    secret_scope.set_multiplex_active(True)
+
+    bot_id = await instance._resolve_bot_user_id()
+
+    assert bot_id == "users/101234567890123456789"
+    assert called_spaces == ["spaces/OWN"]


### PR DESCRIPTION
## What does this PR do?

Routes Google Chat's profile-scoped service-account and platform env reads through `agent.secret_scope.get_secret()` so multiplex gateways do not pick up credentials or routing config from another profile's process environment.

This is a sibling hardening follow-up to #56680 (Vertex `GOOGLE_APPLICATION_CREDENTIALS` isolation) and the same credential-isolation class as #57624 for cloud browser providers. In multiplex mode, `os.environ` is process-global while the active profile boundary is `agent.secret_scope`; direct env reads can therefore authenticate or route a secondary profile with another profile's Google Chat service account/project/subscription.

## Related Issue

Follow-up sibling hardening for #56680.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/google_chat/adapter.py`
  - Uses `get_secret()` for Google Chat service-account credentials and profile-scoped platform config:
    - `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON`
    - `GOOGLE_APPLICATION_CREDENTIALS`
    - `GOOGLE_CHAT_PROJECT_ID` / `GOOGLE_CLOUD_PROJECT`
    - `GOOGLE_CHAT_SUBSCRIPTION_NAME` / `GOOGLE_CHAT_SUBSCRIPTION`
    - `GOOGLE_CHAT_HOME_CHANNEL*`
    - `GOOGLE_CHAT_HTTP_EVENTS_URL`
    - `GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE`
    - `GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL`
  - Applies the HTTP-events scope at env enablement, registry detection, and adapter construction so no sibling path can re-read another profile's process environment.
  - Keeps single-profile behavior unchanged because `get_secret()` falls back to `os.environ` outside multiplex secret-scope enforcement.
  - Adds an ADC guard mirroring the Vertex hardening: in multiplex mode, do not call `google.auth.default()` when process-global Google Chat credentials are present but this profile has no scoped value.
- `tests/plugins/platforms/google_chat/test_secret_scope.py`
  - Covers scoped Google Chat env enablement winning over foreign process env.
  - Covers fail-closed behavior for unscoped multiplex env reads.
  - Covers HTTP-events registry detection and adapter fallback with an empty or scoped profile boundary.
  - Covers `_load_sa_credentials()` using scoped inline service-account JSON over foreign process env.

## How to Test

Focused regression tests:

```bash
uv sync --extra dev --extra google
scripts/run_tests.sh \
  tests/plugins/platforms/google_chat/test_secret_scope.py \
  tests/gateway/test_google_chat.py -q
```

Lint changed files:

```bash
uv run --frozen --extra dev ruff check \
  plugins/platforms/google_chat/adapter.py \
  tests/plugins/platforms/google_chat/test_secret_scope.py
```

Type-check command run on changed files:

```bash
uv run --frozen --extra dev ty check \
  plugins/platforms/google_chat/adapter.py \
  tests/plugins/platforms/google_chat/test_secret_scope.py
```

Observed locally:

- Google Chat focused and related tests: 185 passed
- Ruff: all checks passed
- Ty: failed on pre-existing Google Chat optional-dependency / adapter typing diagnostics in `plugins/platforms/google_chat/adapter.py` (unresolved optional imports, existing override signatures, existing `Any | None` adapter fields). No new test-file diagnostic remained after updating the test instance construction.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests:

```text
8 focused secret-scope tests passed
177 Google Chat gateway tests passed
```

Ruff:

```text
All checks passed!
```

Duplicate search:

```text
"GOOGLE_CHAT_SERVICE_ACCOUNT_JSON" "secret_scope"
"Google Chat" "GOOGLE_APPLICATION_CREDENTIALS" "multiplex"
"google_chat" "profile secret"
```

No open duplicate PR found.

