### PR TITLE
fix(acp): use daemon pool for agent turns

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 from collections import defaultdict, deque
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Deque, Optional
 from urllib.parse import unquote, urlparse
@@ -78,6 +77,7 @@ from tools.approval import (
     reset_hermes_interactive_context,
     set_hermes_interactive_context,
 )
+from tools.daemon_pool import DaemonThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ except Exception:
     HERMES_VERSION = "0.0.0"
 
 # Thread pool for running AIAgent (synchronous) in parallel.
-_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
+_executor = DaemonThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
 
 # Server-side page size for list_sessions. The ACP ListSessionsRequest schema
 # does not expose a client-side limit, so this is a fixed cap that clients

--- a/tests/acp_adapter/test_acp_executor.py
+++ b/tests/acp_adapter/test_acp_executor.py
@@ -1,0 +1,47 @@
+import subprocess
+import sys
+
+
+def test_acp_agent_executor_does_not_block_interpreter_exit():
+    script = """
+import sys
+import time
+import types
+sys.path.insert(0, {repo_root!r})
+acp = types.ModuleType('acp')
+acp.run_agent = lambda *args, **kwargs: None
+def _acp_getattr(name):
+    value = type(name, (), {{}})
+    setattr(acp, name, value)
+    return value
+acp.__getattr__ = _acp_getattr
+schema = types.ModuleType('acp.schema')
+def _schema_getattr(name):
+    value = type(name, (), {{}})
+    setattr(schema, name, value)
+    return value
+schema.__getattr__ = _schema_getattr
+sys.modules['acp'] = acp
+sys.modules['acp.schema'] = schema
+from acp_adapter import server
+server._executor.submit(time.sleep, 120)
+time.sleep(0.3)
+server._executor.shutdown(wait=False, cancel_futures=True)
+print('main-done', flush=True)
+""".format(repo_root=str(_repo_root()))
+
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert proc.returncode == 0
+    assert "main-done" in proc.stdout
+
+
+def _repo_root():
+    import pathlib
+
+    return pathlib.Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## What does this PR do?

Uses the shared `DaemonThreadPoolExecutor` for ACP agent turns so a wedged synchronous `AIAgent.run_conversation()` worker cannot keep the `hermes-acp` process alive after the editor/client closes.

This is a sibling reliability hardening follow-up to #57000. That PR fixed several non-daemon executor sites because stdlib `ThreadPoolExecutor` workers are joined by Python's atexit hook and can hold process exit forever. ACP still had the same pattern for agent turns.

## Related Issue

Follow-up sibling hardening for #57000.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`
  - Replaces the module-global stdlib `ThreadPoolExecutor` used for ACP agent turns with `tools.daemon_pool.DaemonThreadPoolExecutor`.
- `tests/acp_adapter/test_acp_executor.py`
  - Adds a subprocess regression test that submits a long-running ACP executor job, calls `shutdown(wait=False, cancel_futures=True)`, and verifies the interpreter exits promptly.

## How to Test

Red/green focused test:

```bash
uv run --frozen --extra dev python -m pytest tests/acp_adapter/test_acp_executor.py -q
```

Related daemon pool regression suite:

```bash
uv run --frozen --extra dev python -m pytest \
  tests/acp_adapter/test_acp_executor.py \
  tests/tools/test_daemon_pool.py \
  -q
```

Lint changed files:

```bash
uv run --frozen --extra dev ruff check \
  acp_adapter/server.py \
  tests/acp_adapter/test_acp_executor.py
```

Type-check command run on changed files:

```bash
uv run --frozen --extra dev ty check \
  acp_adapter/server.py \
  tests/acp_adapter/test_acp_executor.py
```

Observed locally:

- Red: the new ACP subprocess test timed out with stdlib `ThreadPoolExecutor`, after printing `main-done`, because the interpreter waited on the non-daemon worker.
- Green + related tests: 5 passed
- Ruff: all checks passed
- Ty: failed on pre-existing ACP optional dependency / typing diagnostics (`acp` import not installed in this environment, `HERMES_VERSION` literal assignment, existing `tool_call` narrowing diagnostics). No new daemon-pool-specific diagnostic.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused + related tests:

```text
.....                                                                    [100%]
5 passed in 0.92s
```

Ruff:

```text
All checks passed!
```

Duplicate check summary:

No open PR found directly fixing ACP's `_executor`, `acp-agent` pool, or ACP exit behavior. Related daemon-pool internals PRs (#57459, #50077) and ACP hang-source PRs (#50800) do not adopt the daemon pool at this ACP executor callsite.
