### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect()

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, **kwargs) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"


### PR DESCRIPTION
### Problem

`QQAdapter.connect()` does not accept the `is_reconnect` keyword argument that the gateway passes on reconnection attempts (`adapter.connect(is_reconnect=True/False)`). This causes a `TypeError` on reconnect and keeps QQ Bot permanently offline.

```
✗ qqbot error: QQAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

### Fix

One-line change: `async def connect(self) -> bool:` → `async def connect(self, **kwargs) -> bool:`

Other platform adapters (weixin, api_server, relay) already accept `**kwargs` in their `connect()` method. This brings QQAdapter in line with the base class contract.

### Related

33+ previous PRs attempted this same fix and were closed without merging (#57663, #57652, #57514, #57266, #57163, #56970, #56980, #55494, #54719, etc.). This is the same single-line patch that has been independently verified by multiple users.