### PR TITLE
fix(cron): a run that hit the iteration limit may not suppress delivery with [SILENT]

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2959,6 +2959,23 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Strip leaked placeholder text that upstream may inject on empty completions.
         if final_response.strip() == "(No response generated)":
             final_response = ""
+        # A run that exhausted its iteration budget cannot credibly claim
+        # "nothing to report": letting a silence sentinel through here would
+        # suppress delivery in run_one_job and the user would get SILENCE
+        # instead of a heads-up that their scheduled job is failing. Substitute
+        # a plain honest notice so a braked run is always delivered.
+        if max_iteration_summary and _is_cron_silence_response(final_response):
+            logger.warning(
+                "Job '%s': iteration-limit fallback response was a silence "
+                "sentinel — substituting an honest failure notice instead of "
+                "suppressing delivery",
+                job_name,
+            )
+            final_response = (
+                "This scheduled job hit its iteration limit before finishing and "
+                "did not produce a usable report — something in it is likely "
+                "failing repeatedly and needs a look."
+            )
         # Cron silence on abnormal empty turns.  The turn-completion explainer
         # (#34452) replaces a blank/empty model turn with a "⚠️ No reply: …"
         # string so interactive surfaces (CLI/gateway) explain why the box is

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1532,6 +1532,92 @@ class TestRunJobSessionPersistence:
         assert "final fallback report" in output
         assert "(FAILED)" not in output
 
+    def test_run_job_braked_run_never_returns_a_silence_sentinel(self, tmp_path):
+        """A run that exhausted its iteration budget cannot claim "nothing to
+        report" — a [SILENT] fallback would suppress delivery in run_one_job
+        and the user would get silence instead of a heads-up that their
+        scheduled job is failing. run_job substitutes an honest notice."""
+        from cron.scheduler import _is_cron_silence_response
+
+        job = {
+            "id": "silent-brake-job",
+            "name": "silent-brake",
+            "prompt": "do the thing",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "[SILENT]",
+                "completed": False,
+                "failed": False,
+                "turn_exit_reason": "max_iterations_reached(90/90)",
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        # The sentinel is gone: what remains is an honest, deliverable notice.
+        assert not _is_cron_silence_response(final_response)
+        assert "iteration limit" in final_response
+
+    def test_run_job_normal_silent_run_keeps_the_sentinel(self, tmp_path):
+        """The guard is scoped to braked runs only: a normally-completed
+        [SILENT] response stays a sentinel so run_one_job suppresses delivery
+        (the whole point of the cron silence contract)."""
+        job = {
+            "id": "silent-ok-job",
+            "name": "silent-ok",
+            "prompt": "check for news",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "[SILENT]",
+                "completed": True,
+                "failed": False,
+                "turn_exit_reason": "text_response(finish_reason=stop)",
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert final_response == "[SILENT]"
+
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,
         tick() should mark the job as error so last_status != 'ok'.


### PR DESCRIPTION
## Summary

The cron silence contract lets an agent suppress delivery with `[SILENT]` when there is genuinely nothing to report. But a run that **exhausted its iteration budget** cannot credibly make that claim — and when the max-iterations fallback summary comes back silence-shaped, `run_one_job`'s suppression swallows it: the user gets **silence instead of a heads-up that their scheduled job is failing**.

We hit this in production forensics: a reminder cron burned its entire iteration budget on fruitless tool retries, and the owner received nothing at all — day after day. (Sibling context: #57367 makes the fallback summary itself demand an honest failure report; this PR closes the remaining hole where that report is a silence sentinel.)

## Change

In `run_job`, when `max_iteration_summary` is set and the fallback response is silence-shaped (`_is_cron_silence_response`), substitute a plain honest notice — *"This scheduled job hit its iteration limit before finishing and did not produce a usable report — something in it is likely failing repeatedly and needs a look."* — so a braked run is always delivered.

Scoped strictly to braked runs: a normally-completed `[SILENT]` keeps the sentinel and stays suppressed — the silence contract for healthy nothing-to-report jobs is untouched.

## Tests

- Braked run + `[SILENT]` fallback → sentinel replaced by a deliverable notice (asserted via `_is_cron_silence_response`).
- Normally-completed `[SILENT]` → sentinel preserved (control).
- Full `tests/cron/test_scheduler.py` + `test_run_one_job.py`: 215 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)