### PR TITLE
feat(discord): sync thread names from session titles

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -844,6 +844,11 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   auto_rename_threads:             # Visible thread names follow Hermes session titles (default: disabled)
+#     enabled: false
+#     mode: session_title
+#     sync_title_command: false      # /title <name> sync; requires enabled=true and mode=session_title
+#     max_length: 100                # Discord thread-name cap; values above 100 are clamped
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1093,6 +1093,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.DISCORD and "auto_rename_threads" in platform_cfg:
+                    bridged["auto_rename_threads"] = platform_cfg["auto_rename_threads"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3434,6 +3434,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
         return True
 
+    def _is_discord_thread_lane(self, source: SessionSource) -> bool:
+        """True for a Discord thread-backed conversation lane."""
+        if _gateway_platform_value(getattr(source, "platform", None)) != "discord":
+            return False
+        if getattr(source, "chat_type", None) != "thread":
+            return False
+        return bool(str(getattr(source, "thread_id", None) or "").strip())
+
     _TELEGRAM_LOBBY_REMINDER_COOLDOWN_S = 30.0
 
     def _should_send_telegram_lobby_reminder(self, source: SessionSource) -> bool:
@@ -13157,6 +13165,112 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return value.strip().lower() in {"1", "true", "yes", "on"}
         return bool(value)
 
+    def _discord_auto_rename_thread_settings(self, source: SessionSource) -> dict:
+        """Return Discord thread auto-rename settings for enum or raw-string platform keys."""
+        if _gateway_platform_value(getattr(source, "platform", None)) != "discord":
+            return {}
+        platforms = getattr(getattr(self, "config", None), "platforms", None) or {}
+        platform_cfg = None
+        for key, cfg in platforms.items():
+            if _gateway_platform_value(key) == "discord":
+                platform_cfg = cfg
+                break
+        if platform_cfg is None:
+            return {}
+        extra = getattr(platform_cfg, "extra", None) or {}
+        settings = extra.get("auto_rename_threads")
+        return settings if isinstance(settings, dict) else {}
+
+    def _discord_thread_auto_rename_enabled(self, source: SessionSource) -> bool:
+        """Return True when Discord thread auto-rename is explicitly enabled for session titles."""
+        settings = self._discord_auto_rename_thread_settings(source)
+        enabled = settings.get("enabled")
+        if isinstance(enabled, str):
+            enabled = enabled.strip().lower() in {"1", "true", "yes", "on"}
+        if not bool(enabled):
+            return False
+        return str(settings.get("mode") or "").strip().lower() == "session_title"
+
+    def _sanitize_discord_thread_title(self, title: str, max_length: Any = 100) -> str:
+        """Return a Discord-safe thread name from a generated session title."""
+        cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
+        if not cleaned:
+            cleaned = "Hermes Chat"
+        try:
+            limit = int(max_length)
+        except (TypeError, ValueError):
+            limit = 100
+        limit = max(1, min(limit, 100))
+        if len(cleaned) > limit:
+            cleaned = cleaned[:limit].rstrip() or "Hermes Chat"[:limit]
+        return cleaned
+
+    async def _rename_discord_thread_for_session_title(
+        self,
+        source: SessionSource,
+        title: str,
+    ) -> None:
+        """Best-effort rename of a Discord thread when Hermes auto-titles a session."""
+        if not self._is_discord_thread_lane(source):
+            return
+        adapters = getattr(self, "adapters", None) or {}
+        adapter = None
+        for key, candidate in adapters.items():
+            if _gateway_platform_value(key) == "discord":
+                adapter = candidate
+                break
+        if adapter is None:
+            return
+        rename_thread = getattr(adapter, "rename_thread", None)
+        if rename_thread is None:
+            return
+        settings = self._discord_auto_rename_thread_settings(source)
+        thread_name = self._sanitize_discord_thread_title(
+            title,
+            settings.get("max_length", 100),
+        )
+        try:
+            await rename_thread(thread_id=str(source.thread_id), name=thread_name)
+        except Exception:
+            logger.debug("Failed to rename Discord thread for auto-generated title", exc_info=True)
+
+    def _schedule_discord_thread_title_rename(
+        self,
+        source: SessionSource,
+        title: str,
+    ) -> None:
+        """Schedule a Discord thread rename from the auto-title background thread."""
+        if not title or not self._is_discord_thread_lane(source):
+            return
+        if not self._discord_thread_auto_rename_enabled(source):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = getattr(self, "_gateway_loop", None)
+        if loop is None or loop.is_closed():
+            return
+        try:
+            copied_source = dataclasses.replace(source)
+        except Exception:
+            copied_source = source
+        future = safe_schedule_threadsafe(
+            self._rename_discord_thread_for_session_title(copied_source, title),
+            loop,
+            logger=logger,
+            log_message="Discord thread title rename failed to schedule",
+        )
+        if future is None:
+            return
+
+        def _log_rename_failure(fut) -> None:
+            try:
+                fut.result()
+            except Exception:
+                logger.debug("Discord thread title rename failed", exc_info=True)
+
+        future.add_done_callback(_log_rename_failure)
+
     def _schedule_telegram_topic_title_rename(
         self,
         source: SessionSource,
@@ -18360,6 +18474,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
                             source,
                             effective_session_id,
+                            title,
+                        )
+                    elif self._is_discord_thread_lane(source) and self._discord_thread_auto_rename_enabled(source):
+                        maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_discord_thread_title_rename(
+                            source,
                             title,
                         )
                     maybe_auto_title(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3469,6 +3469,20 @@ class GatewaySlashCommandsMixin:
                                 "Failed to rename Telegram topic from /title",
                                 exc_info=True,
                             )
+                    if self._discord_thread_title_command_sync_enabled(source):
+                        schedule_discord_rename = getattr(
+                            self,
+                            "_schedule_discord_thread_title_rename",
+                            None,
+                        )
+                        if callable(schedule_discord_rename):
+                            try:
+                                schedule_discord_rename(source, sanitized)
+                            except Exception:
+                                logger.debug(
+                                    "Failed to rename Discord thread from /title",
+                                    exc_info=True,
+                                )
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")
@@ -3481,6 +3495,20 @@ class GatewaySlashCommandsMixin:
                 return t("gateway.title.current_with_title", session_id=session_id, title=title)
             else:
                 return t("gateway.title.current_no_title", session_id=session_id)
+
+    def _discord_thread_title_command_sync_enabled(self, source: SessionSource) -> bool:
+        """Return True when /title should also sync the visible Discord thread name."""
+        is_discord_thread = getattr(self, "_is_discord_thread_lane", None)
+        if not callable(is_discord_thread) or not is_discord_thread(source):
+            return False
+        auto_rename_enabled = getattr(self, "_discord_thread_auto_rename_enabled", None)
+        if not callable(auto_rename_enabled) or not auto_rename_enabled(source):
+            return False
+        settings_for_source = getattr(self, "_discord_auto_rename_thread_settings", None)
+        settings = settings_for_source(source) if callable(settings_for_source) else {}
+        if not isinstance(settings, dict):
+            return False
+        return is_truthy_value(settings.get("sync_title_command"))
 
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — list or switch to a previous session."""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2319,6 +2319,14 @@ DEFAULT_CONFIG = {
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        # Opt-in visible Discord thread renames from Hermes session titles.
+        # Disabled by default so existing servers keep stable thread names.
+        "auto_rename_threads": {
+            "enabled": False,
+            "mode": "session_title",
+            "sync_title_command": False,
+            "max_length": 100,
+        },
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require
         # DISCORD_ALLOWED_USERS. Set dm_role_auth_guild to a guild ID to also

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -748,6 +748,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Discord message limits
     MAX_MESSAGE_LENGTH = 2000
+    MAX_THREAD_NAME_LENGTH = 100
     _SPLIT_THRESHOLD = 1900  # near the 2000-char split point
     supports_code_blocks = True  # Discord markdown renders fenced code blocks natively
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
@@ -1890,6 +1891,81 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._add_reaction(message, "✅")
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
+
+    @classmethod
+    def _sanitize_thread_name(cls, name: str) -> str:
+        """Return a Discord-safe thread name using Discord's hard cap."""
+        cleaned = re.sub(r"\s+", " ", str(name or "")).strip()
+        if not cleaned:
+            cleaned = "Hermes Chat"
+        if len(cleaned) > cls.MAX_THREAD_NAME_LENGTH:
+            cleaned = cleaned[: cls.MAX_THREAD_NAME_LENGTH].rstrip()
+        return cleaned or "Hermes Chat"[: cls.MAX_THREAD_NAME_LENGTH]
+
+    @staticmethod
+    def _is_thread_rename_expected_failure(exc: BaseException) -> bool:
+        if DISCORD_AVAILABLE and discord is not None:
+            for attr_name in ("Forbidden", "HTTPException"):
+                cls = getattr(discord, attr_name, None)
+                if isinstance(cls, type) and isinstance(exc, cls):
+                    return True
+        message = str(exc).lower()
+        return any(token in message for token in ("forbidden", "permission", "archived", "locked"))
+
+    async def rename_thread(self, thread_id: str, name: str) -> None:
+        """Best-effort rename of an existing Discord thread.
+
+        Discord permits thread name edits only with MANAGE_THREADS or when the
+        bot created the thread, and archived threads cannot be edited. This is
+        intentionally non-fatal so visible title sync cannot interrupt normal
+        message delivery.
+        """
+        if not DISCORD_AVAILABLE or discord is None:
+            logger.debug("[%s] Cannot rename Discord thread: discord.py unavailable", self.name)
+            return
+        if not self._client:
+            logger.debug("[%s] Cannot rename Discord thread %s: client unavailable", self.name, thread_id)
+            return
+
+        try:
+            snowflake = int(str(thread_id).strip())
+        except (TypeError, ValueError):
+            logger.debug("[%s] Cannot rename Discord thread with invalid id %r", self.name, thread_id)
+            return
+
+        cleaned = self._sanitize_thread_name(name)
+        try:
+            thread = None
+            get_channel = getattr(self._client, "get_channel", None)
+            if callable(get_channel):
+                thread = get_channel(snowflake)
+            if thread is None:
+                fetch_channel = getattr(self._client, "fetch_channel", None)
+                if callable(fetch_channel):
+                    thread = await fetch_channel(snowflake)
+            if thread is None:
+                logger.debug("[%s] Discord thread %s not found for rename", self.name, snowflake)
+                return
+            edit = getattr(thread, "edit", None)
+            if not callable(edit):
+                logger.debug("[%s] Discord channel %s cannot be renamed as a thread", self.name, snowflake)
+                return
+            await edit(name=cleaned)
+        except Exception as exc:
+            if self._is_thread_rename_expected_failure(exc):
+                logger.warning(
+                    "[%s] Discord thread %s rename skipped: %s",
+                    self.name,
+                    snowflake,
+                    exc,
+                )
+            else:
+                logger.debug(
+                    "[%s] Failed to rename Discord thread %s",
+                    self.name,
+                    snowflake,
+                    exc_info=True,
+                )
 
     async def send(
         self,

--- a/tests/gateway/test_discord_thread_title_rename.py
+++ b/tests/gateway/test_discord_thread_title_rename.py
@@ -1,0 +1,359 @@
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+from tests.gateway.test_discord_slash_commands import _ensure_discord_mock
+
+
+_ensure_discord_mock()
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+class _AutoTitleAgent:
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+        self.model = "fake-model"
+        self.provider = "fake-provider"
+        self.base_url = "https://example.invalid"
+        self.api_key = "***"
+        self.api_mode = "chat_completions"
+
+    def run_conversation(
+        self,
+        user_message,
+        conversation_history=None,
+        task_id=None,
+        persist_user_message=None,
+        persist_user_timestamp=None,
+    ):
+        return {
+            "final_response": "ok",
+            "messages": [
+                {"role": "user", "content": user_message},
+                {"role": "assistant", "content": "ok"},
+            ],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+
+class _DiscordRunnerAdapter:
+    supports_code_blocks = False
+
+    def __init__(self):
+        self.rename_thread = AsyncMock()
+        self.sent = []
+        self._active_sessions = {}
+
+    async def send(self, chat_id, content, **kwargs):
+        self.sent.append((chat_id, content, kwargs))
+        return SimpleNamespace(success=True, message_id="m1")
+
+    def get_pending_message(self, session_key):
+        return None
+
+
+@pytest.fixture
+def adapter():
+    return DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+
+def _make_source(**overrides):
+    values = dict(
+        platform=Platform.DISCORD,
+        user_id="42",
+        chat_id="999",
+        user_name="tester",
+        chat_type="thread",
+        thread_id="999",
+        parent_chat_id="800",
+    )
+    values.update(overrides)
+    return SessionSource(**values)
+
+
+def _make_runner(*, auto_rename_threads=None, include_adapter=True):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    discord_cfg = PlatformConfig(enabled=True, token="***")
+    if auto_rename_threads is not None:
+        discord_cfg.extra["auto_rename_threads"] = auto_rename_threads
+    runner.config = GatewayConfig(platforms={Platform.DISCORD: discord_cfg})
+    adapter = _DiscordRunnerAdapter()
+    runner.adapters = {Platform.DISCORD: adapter} if include_adapter else {}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = SimpleNamespace(_db=object())
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda session_id: [],
+    )
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    return runner
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _AutoTitleAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+async def _run_agent_and_capture_auto_title_kwargs(monkeypatch, tmp_path, runner, source):
+    _install_fake_agent(monkeypatch)
+    captured = {}
+
+    def fake_maybe_auto_title(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    import agent.title_generator as title_generator
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(title_generator, "maybe_auto_title", fake_maybe_auto_title)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"tool_progress": "off"}},
+    )
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "fake-model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "api_mode": "chat_completions"},
+    )
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+        session_key="agent:main:discord:thread:999",
+    )
+    return captured["kwargs"]
+
+
+@pytest.mark.asyncio
+async def test_config_disabled_does_not_install_discord_title_callback(monkeypatch, tmp_path):
+    runner = _make_runner(
+        auto_rename_threads={"enabled": False, "mode": "session_title", "max_length": 100}
+    )
+
+    kwargs = await _run_agent_and_capture_auto_title_kwargs(
+        monkeypatch,
+        tmp_path,
+        runner,
+        _make_source(),
+    )
+
+    assert "title_callback" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_enabled_discord_thread_auto_title_installs_callback(monkeypatch, tmp_path):
+    runner = _make_runner(
+        auto_rename_threads={"enabled": True, "mode": "session_title", "max_length": 100}
+    )
+    runner._schedule_discord_thread_title_rename = MagicMock()
+    source = _make_source()
+
+    kwargs = await _run_agent_and_capture_auto_title_kwargs(
+        monkeypatch,
+        tmp_path,
+        runner,
+        source,
+    )
+
+    callback = kwargs.get("title_callback")
+    assert callable(callback)
+    callback("Investigate Discord Thread Titles")
+    runner._schedule_discord_thread_title_rename.assert_called_once_with(
+        source,
+        "Investigate Discord Thread Titles",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_generated_title_renames_discord_thread():
+    runner = _make_runner()
+
+    await runner._rename_discord_thread_for_session_title(
+        _make_source(),
+        "Investigate Discord Thread Titles",
+    )
+
+    runner.adapters[Platform.DISCORD].rename_thread.assert_awaited_once_with(
+        thread_id="999",
+        name="Investigate Discord Thread Titles",
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_thread_rename_ignores_non_discord_source():
+    runner = _make_runner()
+
+    await runner._rename_discord_thread_for_session_title(
+        _make_source(platform=Platform.TELEGRAM),
+        "Ignored",
+    )
+
+    runner.adapters[Platform.DISCORD].rename_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_discord_thread_rename_ignores_non_thread_source():
+    runner = _make_runner()
+
+    await runner._rename_discord_thread_for_session_title(
+        _make_source(chat_type="channel", thread_id=None),
+        "Ignored",
+    )
+
+    runner.adapters[Platform.DISCORD].rename_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_discord_thread_rename_ignores_missing_adapter():
+    runner = _make_runner(include_adapter=False)
+
+    await runner._rename_discord_thread_for_session_title(
+        _make_source(),
+        "Ignored",
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_adapter_rename_thread_edits_resolved_thread(adapter):
+    thread = SimpleNamespace(edit=AsyncMock())
+    adapter._client = SimpleNamespace(get_channel=MagicMock(return_value=thread))
+
+    await adapter.rename_thread(thread_id="999", name="  Build   Discord Search Titles  ")
+
+    thread.edit.assert_awaited_once_with(name="Build Discord Search Titles")
+
+
+@pytest.mark.asyncio
+async def test_discord_adapter_rename_thread_fetches_when_cache_misses(adapter):
+    thread = SimpleNamespace(edit=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=None),
+        fetch_channel=AsyncMock(return_value=thread),
+    )
+
+    await adapter.rename_thread(thread_id="999", name="Fetched Thread Title")
+
+    adapter._client.get_channel.assert_called_once_with(999)
+    adapter._client.fetch_channel.assert_awaited_once_with(999)
+    thread.edit.assert_awaited_once_with(name="Fetched Thread Title")
+
+
+@pytest.mark.asyncio
+async def test_discord_adapter_rename_thread_invalid_id_returns_quietly(adapter):
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(),
+        fetch_channel=AsyncMock(),
+    )
+
+    await adapter.rename_thread(thread_id="not-a-snowflake", name="Ignored")
+
+    adapter._client.get_channel.assert_not_called()
+    adapter._client.fetch_channel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_discord_adapter_rename_thread_missing_client_returns_quietly(adapter):
+    adapter._client = None
+
+    await adapter.rename_thread(thread_id="999", name="Ignored")
+
+
+@pytest.mark.asyncio
+async def test_discord_adapter_rename_thread_caps_title_without_ellipsis_churn(adapter):
+    thread = SimpleNamespace(edit=AsyncMock())
+    adapter._client = SimpleNamespace(get_channel=MagicMock(return_value=thread))
+
+    await adapter.rename_thread(thread_id="999", name=("A" * 100) + "...")
+
+    thread.edit.assert_awaited_once_with(name="A" * 100)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [PermissionError("forbidden"), RuntimeError("archived")])
+async def test_discord_adapter_rename_thread_errors_do_not_raise(adapter, exc):
+    thread = SimpleNamespace(edit=AsyncMock(side_effect=exc))
+    adapter._client = SimpleNamespace(get_channel=MagicMock(return_value=thread))
+
+    await adapter.rename_thread(thread_id="999", name="Best Effort Title")
+
+    thread.edit.assert_awaited_once_with(name="Best Effort Title")
+
+
+@pytest.mark.parametrize("attr_name", ["Forbidden", "HTTPException"])
+def test_discord_adapter_expected_rename_failure_recognizes_discord_api_errors(
+    monkeypatch,
+    attr_name,
+):
+    class FakeDiscordRenameError(Exception):
+        pass
+
+    monkeypatch.setattr(
+        sys.modules["discord"],
+        attr_name,
+        FakeDiscordRenameError,
+        raising=False,
+    )
+
+    assert DiscordAdapter._is_thread_rename_expected_failure(
+        FakeDiscordRenameError("api denied")
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attr_name", ["Forbidden", "HTTPException"])
+async def test_discord_adapter_rename_thread_real_discord_exceptions_do_not_raise(
+    monkeypatch,
+    adapter,
+    attr_name,
+):
+    class FakeDiscordRenameError(Exception):
+        pass
+
+    monkeypatch.setattr(
+        sys.modules["discord"],
+        attr_name,
+        FakeDiscordRenameError,
+        raising=False,
+    )
+    thread = SimpleNamespace(
+        edit=AsyncMock(side_effect=FakeDiscordRenameError("api denied"))
+    )
+    adapter._client = SimpleNamespace(get_channel=MagicMock(return_value=thread))
+
+    await adapter.rename_thread(thread_id="999", name="Best Effort Title")
+
+    thread.edit.assert_awaited_once_with(name="Best Effort Title")

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -4,6 +4,7 @@ Tests the _handle_title_command handler (set/show session titles)
 across all gateway messenger platforms.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -14,14 +15,22 @@ from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource
 
 
-def _make_event(text="/title", platform=Platform.TELEGRAM,
-                user_id="12345", chat_id="67890"):
+def _make_event(
+    text="/title",
+    platform=Platform.TELEGRAM,
+    user_id="12345",
+    chat_id="67890",
+    chat_type="dm",
+    thread_id=None,
+):
     """Build a MessageEvent for testing."""
     source = SessionSource(
         platform=platform,
         user_id=user_id,
         chat_id=chat_id,
         user_name="testuser",
+        chat_type=chat_type,
+        thread_id=thread_id,
     )
     return MessageEvent(text=text, source=source)
 
@@ -30,6 +39,12 @@ def _make_runner(session_db=None):
     """Create a bare GatewayRunner with a mock session_store and optional session_db."""
     from gateway.run import GatewayRunner
     runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+        }
+    )
     runner.adapters = {}
     runner._voice_mode = {}
     # Gateway holds the async facade; the slash handlers await it.
@@ -203,6 +218,170 @@ class TestHandleTitleCommand:
         await runner._handle_title_command(event)
 
         runner._schedule_telegram_topic_title_rename.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_syncs_discord_thread_when_enabled(self, tmp_path):
+        """/title <name> renames the visible Discord thread when sync is enabled."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "discord")
+
+        runner = _make_runner(session_db=db)
+        runner.config.platforms[Platform.DISCORD].extra["auto_rename_threads"] = {
+            "enabled": True,
+            "mode": "session_title",
+            "sync_title_command": True,
+            "max_length": 100,
+        }
+        runner._schedule_discord_thread_title_rename = MagicMock()
+
+        event = _make_event(
+            text="/title My Discord Thread",
+            platform=Platform.DISCORD,
+            chat_id="800",
+            chat_type="thread",
+            thread_id="999",
+        )
+        result = await runner._handle_title_command(event)
+
+        assert "My Discord Thread" in result
+        runner._schedule_discord_thread_title_rename.assert_called_once_with(
+            event.source,
+            "My Discord Thread",
+        )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_syncs_discord_thread_through_real_scheduler(self, tmp_path):
+        """/title <name> exercises the real Discord scheduler body from the gateway loop."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "discord")
+
+        runner = _make_runner(session_db=db)
+        runner.config.platforms[Platform.DISCORD].extra["auto_rename_threads"] = {
+            "enabled": True,
+            "mode": "session_title",
+            "sync_title_command": True,
+            "max_length": 100,
+        }
+        adapter = MagicMock()
+        adapter.rename_thread = AsyncMock()
+        runner.adapters = {Platform.DISCORD: adapter}
+
+        event = _make_event(
+            text="/title Real Scheduler Discord Thread",
+            platform=Platform.DISCORD,
+            chat_id="800",
+            chat_type="thread",
+            thread_id="999",
+        )
+        result = await runner._handle_title_command(event)
+        for _ in range(10):
+            if adapter.rename_thread.await_count:
+                break
+            await asyncio.sleep(0)
+
+        assert "Real Scheduler Discord Thread" in result
+        adapter.rename_thread.assert_awaited_once_with(
+            thread_id="999",
+            name="Real Scheduler Discord Thread",
+        )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_swallow_discord_thread_sync_failure(self, tmp_path):
+        """/title still updates the DB when Discord visible rename scheduling fails."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "discord")
+
+        runner = _make_runner(session_db=db)
+        runner.config.platforms[Platform.DISCORD].extra["auto_rename_threads"] = {
+            "enabled": True,
+            "mode": "session_title",
+            "sync_title_command": True,
+            "max_length": 100,
+        }
+        runner._schedule_discord_thread_title_rename = MagicMock(
+            side_effect=RuntimeError("loop closed")
+        )
+
+        event = _make_event(
+            text="/title My Resilient Discord Thread",
+            platform=Platform.DISCORD,
+            chat_id="800",
+            chat_type="thread",
+            thread_id="999",
+        )
+        result = await runner._handle_title_command(event)
+
+        assert "My Resilient Discord Thread" in result
+        assert db.get_session_title("test_session_123") == "My Resilient Discord Thread"
+        runner._schedule_discord_thread_title_rename.assert_called_once_with(
+            event.source,
+            "My Resilient Discord Thread",
+        )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_set_title_does_not_sync_discord_thread_when_command_sync_disabled(self, tmp_path):
+        """/title <name> only renames Discord when sync_title_command is true."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "discord")
+
+        runner = _make_runner(session_db=db)
+        runner.config.platforms[Platform.DISCORD].extra["auto_rename_threads"] = {
+            "enabled": True,
+            "mode": "session_title",
+            "sync_title_command": False,
+            "max_length": 100,
+        }
+        runner._schedule_discord_thread_title_rename = MagicMock()
+
+        event = _make_event(
+            text="/title My Discord Thread",
+            platform=Platform.DISCORD,
+            chat_id="800",
+            chat_type="thread",
+            thread_id="999",
+        )
+        result = await runner._handle_title_command(event)
+
+        assert "My Discord Thread" in result
+        runner._schedule_discord_thread_title_rename.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_show_title_does_not_sync_discord_thread(self, tmp_path):
+        """/title with no args is read-only and must not rename Discord."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "discord")
+        db.set_session_title("test_session_123", "Existing Discord Title")
+
+        runner = _make_runner(session_db=db)
+        runner.config.platforms[Platform.DISCORD].extra["auto_rename_threads"] = {
+            "enabled": True,
+            "mode": "session_title",
+            "sync_title_command": True,
+            "max_length": 100,
+        }
+        runner._schedule_discord_thread_title_rename = MagicMock()
+
+        event = _make_event(
+            text="/title",
+            platform=Platform.DISCORD,
+            chat_id="800",
+            chat_type="thread",
+            thread_id="999",
+        )
+        await runner._handle_title_command(event)
+
+        runner._schedule_discord_thread_title_rename.assert_not_called()
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/test_gateway_streaming_nested_config.py
+++ b/tests/test_gateway_streaming_nested_config.py
@@ -41,3 +41,38 @@ class TestStreamingConfigNested:
         })
         assert cfg.streaming.enabled is True
         assert cfg.streaming.transport == "edit"
+
+
+class TestDiscordAutoRenameThreadsConfig:
+    def test_default_config_keeps_discord_thread_rename_disabled(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["discord"]["auto_rename_threads"] == {
+            "enabled": False,
+            "mode": "session_title",
+            "sync_title_command": False,
+            "max_length": 100,
+        }
+
+    def test_top_level_discord_auto_rename_threads_bridges_to_platform_extra(self):
+        from gateway.config import Platform
+
+        cfg = _load_with_yaml_dict(
+            {
+                "discord": {
+                    "auto_rename_threads": {
+                        "enabled": True,
+                        "mode": "session_title",
+                        "sync_title_command": True,
+                        "max_length": 80,
+                    }
+                }
+            }
+        )
+
+        assert cfg.platforms[Platform.DISCORD].extra["auto_rename_threads"] == {
+            "enabled": True,
+            "mode": "session_title",
+            "sync_title_command": True,
+            "max_length": 80,
+        }

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -322,6 +322,11 @@ discord:
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
   channel_prompts: {}             # Per-channel ephemeral system prompts
+  auto_rename_threads:            # Visible thread names follow Hermes session titles
+    enabled: false                # Disabled by default for existing servers
+    mode: session_title
+    sync_title_command: false     # /title <name> sync; requires enabled=true and mode=session_title
+    max_length: 100               # Discord thread-name cap; values above 100 are clamped
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
     everyone: false               # @everyone / @here pings (default: false)
     roles: false                  # @role pings (default: false)
@@ -331,6 +336,12 @@ discord:
 # Session isolation (applies to all gateway platforms, not just Discord)
 group_sessions_per_user: true     # Isolate sessions per user in shared channels
 ```
+
+`discord.auto_rename_threads.sync_title_command` only has an effect when
+`enabled: true` and `mode: session_title` are also set. Values above Discord's
+100-character thread-name cap are clamped to 100. Discord rate-limits thread
+name edits, so repeated generated-title or `/title` renames may be delayed by
+discord.py while it waits on the rate-limit bucket.
 
 #### `discord.require_mention`
 


### PR DESCRIPTION
## What does this PR do?

Fixes #18430.

Hermes-created Discord threads already get generated session titles, but the visible Discord thread name stays as the original user-message snippet. That makes Discord's native thread list hard to scan because threads keep cryptic or truncated names even after Hermes has a better session title.

This PR syncs Hermes-generated session titles to visible Discord thread names, behind an opt-in config gate. It reuses the existing session-title flow and the existing `maybe_auto_title(..., title_callback=...)` seam. It does not add a new model tool, model schema, or environment variable.

## Mapping to #18430

| Issue requirement | Where implemented |
|---|---|
| Config option to enable the behavior | `discord.auto_rename_threads.enabled`, default `false` |
| Detect title generation after `maybe_auto_title` | Existing `title_callback` seam; `agent/title_generator.py` untouched |
| Sanitize/truncate to Discord's 100-char thread-name limit | Gateway sanitizer plus adapter-level cap (defense in depth); values above 100 clamped |
| Graceful failure without permissions / archived threads | Three-layer error isolation; a rename failure cannot interrupt response delivery |
| Guardrail: conservative default (off) | Disabled by default; zero behavior change for existing deployments |
| Guardrail: `/title` renames only behind a separate option | `sync_title_command`, default `false` (requires `enabled: true` and `mode: session_title`) |
| Guardrail: don't overwrite manually renamed threads | Not implemented in this PR — see Limitations |

## Limitations

This PR renames the thread whenever a session title is generated while the feature is enabled; it does not detect that a user manually renamed the thread in the meantime. This is a deliberate scope cut to keep the diff minimal and avoid per-thread initial-name state. If maintainers want the guard in this PR, I'm happy to add an initial-name check as a follow-up commit; #35420's `thread_initial_name` approach shows one viable shape.

## Relationship to existing Discord thread-title PRs

Several PRs target #18430 or adjacent thread-naming behavior. This PR is the narrow, strictly opt-in implementation of the issue's proposed solution.

- #35420 (open): closest prior work. Session-title sync with a default-on `summary` mode, new environment variables, bidirectional Discord-to-session title sync, an initial-name guard, and changes to the platform base interface and title-generator internals. This PR is strictly opt-in per the issue's guardrails, keeps all config in `config.yaml` with no env vars, and does not touch `agent/title_generator.py`, session internals, or the platform base interface. Smaller reviewable surface: one commit on the existing callback seam.
- #15757 (open): also syncs generated session titles and `/title` to Discord thread names, but polls the session DB (up to 15s latency) against an older gateway layout. This PR is event-driven via the existing callback and targets the current plugin-based Discord adapter layout.
- #29983 (open): auto-rename plus periodic retitling. This PR performs a single rename per title generation, avoiding recurring edit traffic against Discord's channel-edit rate limit.
- #26477 and #30559: additional attempts in the same area (referenced in the #33862 discussion); listed for completeness.
- #13915 (closed): combined smarter initial thread names with post-first-exchange retitling behind an env-var-facing gate. This PR keeps the scope narrower: session-title sync only, no new env var, disabled defaults.
- #3009 (closed): generates a better Discord thread name before creating the thread. This PR updates the thread after Hermes has generated the session title, so it is not a pre-create title-generation path.
- #33862 (open): deterministic ingress cleanup for generic/truncated thread names, no model/session-title dependency. Complementary: #33862 improves initial names, this PR syncs generated titles afterward. The two can coexist if config names/modes stay compatible.

So the claim is not "nobody has proposed this." The claim is "this is the current, tested, strictly opt-in implementation matching the issue's proposed guardrails, with the smallest blast radius of the open attempts."

## Related Issue

Fixes #18430

Related: #35420, #15757, #29983, #26477, #30559, #13915, #3009, #33862

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  * Detects Discord thread lanes and schedules best-effort title sync through the existing generated-title callback path.
  * Keeps response delivery isolated from Discord rename failures.
- `plugins/platforms/discord/adapter.py`
  * Adds `DiscordAdapter.rename_thread(thread_id, name)`.
  * Resolves thread/channel IDs with `get_channel` first and `fetch_channel` fallback.
  * Handles invalid IDs, permission/API errors, archived/locked threads, and unexpected exceptions without propagating into the response path.
- `gateway/slash_commands.py`
  * Extends `/title Name` so manual session titles can also sync the visible Discord thread name when explicitly enabled.
  * Leaves read-only `/title` behavior unchanged.
- `gateway/config.py`, `hermes_cli/config.py`, `cli-config.yaml.example`
  * Adds `discord.auto_rename_threads` config with disabled defaults:

```
discord:
  auto_rename_threads:
    enabled: false
    mode: session_title
    sync_title_command: false
    max_length: 100
```

- `website/docs/user-guide/messaging/discord.md`
  * Documents the opt-in config, `/title` coupling, 100-character Discord name cap, and rate-limit considerations.
- Tests
  * Adds Discord title-sync coverage, `/title` coverage (including a test that exercises the real `/title` → scheduler → adapter path, RED on pre-fix code), config-default coverage, adversarial cases (invalid thread IDs, missing adapter/client, cache-miss fetch fallback), and regression checks for existing Discord/Telegram behavior.

## How to Test

Automated checks run locally:

```
scripts/run_tests.sh \
  tests/gateway/test_discord_thread_title_rename.py \
  tests/gateway/test_title_command.py \
  tests/test_gateway_streaming_nested_config.py \
  tests/gateway/test_discord_slash_commands.py \
  tests/gateway/test_telegram_topic_mode.py
```

Result:

```
122 passed, 0 failed
```

Syntax check:

```
python -m py_compile \
  gateway/run.py \
  gateway/slash_commands.py \
  gateway/config.py \
  hermes_cli/config.py \
  plugins/platforms/discord/adapter.py
```

Result:

```
PASS
```

Manual rollout check performed on a Discord gateway instance after enabling:

```
discord:
  auto_rename_threads:
    enabled: true
    mode: session_title
    sync_title_command: true
    max_length: 100
```

Verified behavior:

1. A newly created Discord auto-thread was renamed from the initial message snippet to the generated Hermes session title.
2. `/title Manual English Title` updated both the stored Hermes session title and the visible Discord thread name.
3. Gateway stayed active after restart and did not report fatal rename errors.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see Relationship section)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux gateway service with Discord enabled

Note: I ran the targeted gateway/config regression suite above, not the full `pytest tests/ -q` suite.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshots attached to keep the PR focused on code and tests.

Relevant verification summary:

```
122 passed, 0 failed
py_compile PASS
gateway rollout verified locally with Discord thread rename and /title rename
```

## Privacy/data guardrails

- No outbound telemetry, analytics, or third-party identifier tagging.
- Uses the existing Discord bot token already configured for the gateway. No new credentials.
- Session title generation behavior is unchanged and stays in the existing `agent/title_generator.py` path.
- No user PII is sent beyond what the bot already sends in normal Discord message delivery.
- Config defaults are disabled, so no existing Discord server is affected unless an operator explicitly opts in.
- No `.env` variable added. Behavioral config lives in `config.yaml`.
