### PR TITLE
fix(tui_gateway): close slash_worker on WS detach to prevent memory leak

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -102,6 +102,7 @@ LEGACY_AUTHOR_MAP = {
     "tturney1@gmail.com": "TheTom",  # PR #62696 salvage (gateway: expand @ context references under runtime/session model resolution)
     "1822947159@qq.com": "ljy-2000",  # PR #62204 adopted in #62290
     "xwolf.live@gmail.com": "vizi0uz",  # PR #59795 adopted in #62290
+    "pasevin@gmail.com": "pasevin",  # PR #57687 salvage (tui_gateway: slash_worker drain threads + WS detach lifecycle)
     "wilsonkinyuam@gmail.com": "WilsonKinyua",  # PR #62052 (tui: persist unflushed conversations on disconnect/restart)
     "humphreysun98@gmail.com": "HumphreySun98",  # PR #61142 salvage (web: null web/backend config value guards)
     "sonxi@nous.local": "17324393074",  # PR #53196 salvage (tools_config: known_plugin_toolsets null guard; commit under unlinked local identity)

--- a/tests/tui_gateway/test_slash_worker_detach.py
+++ b/tests/tui_gateway/test_slash_worker_detach.py
@@ -1,0 +1,147 @@
+"""Tests for slash_worker lifecycle: detach-time worker close and session
+close logging.
+
+These tests cover the new fixes in this PR. Related work by other contributors:
+- #53303 / PR #53308 (drain thread join) by @pasevin
+- #38095 / PR #41473 (worker registry + idempotent close) by @Fewmanism
+- #48643 / PR #48656 (startup reaper + zombie parent detection) by @Nigmat-future
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tui_gateway import server
+
+
+def test_close_sessions_for_transport_closes_worker_on_detach():
+    """When a session is detached (WS disconnect), its slash_worker must be
+    closed immediately rather than lingering until the 6h TTL reaper.
+
+    The Desktop app uses one WebSocket for all sessions. When the user switches
+    sessions, the old session's transport is detached but the slash_worker
+    subprocess (~13 MB) stays alive. Over a few hours this accumulates dozens
+    of idle workers, contributing to GIL pressure and memory bloat.
+    """
+    fake_worker = MagicMock()
+    fake_worker._closed = False
+
+    fake_transport = MagicMock()
+    fake_transport._closed = True  # _transport_is_dead returns True
+
+    sid = "detach-test-sid"
+    session = {
+        "transport": fake_transport,
+        "slash_worker": fake_worker,
+        "close_on_disconnect": False,
+        "session_key": "detach-test",
+    }
+    server._sessions[sid] = session
+
+    reaped, detached = server._close_sessions_for_transport(
+        fake_transport, end_reason="ws_disconnect"
+    )
+
+    assert detached == 1
+    assert reaped == 0
+    # The worker should have been closed immediately
+    fake_worker.close.assert_called_once()
+    # The session's slash_worker should now be None (lazy recreation on next use)
+    assert session["slash_worker"] is None
+
+    server._sessions.clear()
+
+
+def test_close_sessions_for_transport_preserves_worker_on_reap():
+    """Sessions with close_on_disconnect=True go through _close_session_by_id,
+    which tears down the session fully via _teardown_session (which closes the
+    worker inside _finalize_session). The detach-time close should NOT also
+    fire for these — it would be a redundant close (harmless due to the
+    _closed guard, but we assert the path is clean)."""
+    fake_transport = MagicMock()
+    sid = "reap-test-sid"
+    session = {
+        "transport": fake_transport,
+        "slash_worker": None,
+        "close_on_disconnect": True,
+        "session_key": "reap-test",
+        "_finalized": False,
+        "agent": None,
+        "running": False,
+    }
+    server._sessions[sid] = session
+
+    reaped, detached = server._close_sessions_for_transport(
+        fake_transport, end_reason="ws_disconnect"
+    )
+
+    assert reaped == 1
+    assert detached == 0
+    assert sid not in server._sessions
+
+    server._sessions.clear()
+
+
+def test_close_sessions_for_transport_handles_worker_close_exception():
+    """If worker.close() raises, the detach path must still complete — the
+    session is pointed at the detached transport and the orphan reaper is
+    scheduled."""
+    fake_worker = MagicMock()
+    fake_worker._closed = False
+    fake_worker.close.side_effect = RuntimeError("boom")
+
+    fake_transport = MagicMock()
+    fake_transport._closed = True
+
+    sid = "exception-test-sid"
+    session = {
+        "transport": fake_transport,
+        "slash_worker": fake_worker,
+        "close_on_disconnect": False,
+        "session_key": "exception-test",
+    }
+    server._sessions[sid] = session
+
+    # Must not raise
+    reaped, detached = server._close_sessions_for_transport(
+        fake_transport, end_reason="ws_disconnect"
+    )
+
+    assert detached == 1
+    # worker.close() was called (even though it raised)
+    fake_worker.close.assert_called_once()
+    # slash_worker is still set to None despite the exception
+    assert session["slash_worker"] is None
+
+    server._sessions.clear()
+
+
+def test_close_session_by_id_logs_end_reason(caplog):
+    """_close_session_by_id should log the session id and end_reason at INFO
+    level for observability — previously the teardown path was completely
+    silent, making it impossible to diagnose why sessions were or weren't
+    being reaped."""
+    import logging
+
+    sid = "log-test-sid"
+    session = {
+        "transport": None,
+        "slash_worker": None,
+        "close_on_disconnect": False,
+        "session_key": "log-test",
+        "_finalized": False,
+        "agent": None,
+        "running": False,
+    }
+    server._sessions[sid] = session
+
+    with caplog.at_level(logging.INFO, logger="tui_gateway.server"):
+        result = server._close_session_by_id(sid, end_reason="ws_orphan_reap")
+
+    assert result is True
+    assert any(
+        "session closed" in record.message and "ws_orphan_reap" in record.message
+        for record in caplog.records
+    ), f"expected 'session closed ... ws_orphan_reap' in logs, got: {[r.message for r in caplog.records]}"
+
+    server._sessions.clear()

--- a/tests/tui_gateway/test_slash_worker_drain.py
+++ b/tests/tui_gateway/test_slash_worker_drain.py
@@ -1,0 +1,143 @@
+"""Tests for _SlashWorker drain thread cleanup (#53303)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _FakeProc:
+    """Minimal subprocess.Popen stand-in for _SlashWorker tests."""
+
+    def __init__(self):
+        self.stdin = MagicMock()
+        self.stdout = MagicMock()
+        self.stderr = MagicMock()
+        self._poll = None  # None = still running
+
+        # Make stdout/stderr iteration return empty (drain threads exit)
+        self.stdout.__iter__ = lambda self: iter([])
+        self.stderr.__iter__ = lambda self: iter([])
+
+    def poll(self):
+        return self._poll
+
+    def terminate(self):
+        self._poll = 0
+
+    def kill(self):
+        self._poll = -9
+
+    def wait(self, timeout=None):
+        return self._poll or 0
+
+
+def test_slash_worker_close_joins_drain_threads():
+    """_SlashWorker.close() must join its drain threads (#53303).
+
+    Prior to the fix, close() terminated the subprocess and closed
+    the pipes but never joined the _drain_stdout/_drain_stderr threads.
+    This left 2 leaked daemon threads per session on Linux, each holding
+    references to the _SlashWorker instance and its buffers.
+
+    The fix stores thread references and calls join(timeout=2) in close().
+    In production, closing proc.stdout/proc.stderr causes the readline()
+    in the drain threads to hit EOF and exit, so join() returns quickly.
+    This test uses threads that exit promptly to verify the join path works.
+    """
+    from tui_gateway.server import _SlashWorker
+
+    worker = _SlashWorker.__new__(_SlashWorker)
+    worker._lock = threading.Lock()
+    worker._seq = 0
+    worker.stderr_tail = []
+    worker.stdout_queue = __import__("queue").Queue()
+    worker._closed = False
+    worker.proc = _FakeProc()
+
+    # Use threads that exit quickly (simulating EOF on the pipe)
+    exit_event = threading.Event()
+    exit_event.set()  # let them exit immediately
+
+    def quick_drain():
+        exit_event.wait(timeout=5)
+
+    worker._drain_thread_stdout = threading.Thread(
+        target=quick_drain, daemon=True, name="test-drain-stdout"
+    )
+    worker._drain_thread_stderr = threading.Thread(
+        target=quick_drain, daemon=True, name="test-drain-stderr"
+    )
+    worker._drain_thread_stdout.start()
+    worker._drain_thread_stderr.start()
+
+    # Give threads time to exit
+    time.sleep(0.1)
+
+    # Call close()
+    worker.close()
+
+    # close() should have set _closed
+    assert worker._closed
+
+    # close() should have terminated the proc
+    assert worker.proc.poll() is not None
+
+    # close() should have closed stdin/stdout/stderr
+    worker.proc.stdin.close.assert_called()
+    worker.proc.stdout.close.assert_called()
+    worker.proc.stderr.close.assert_called()
+
+    # The drain threads should have exited (they exit on their own, and
+    # close() joins them — so they're definitely not alive after close()).
+    assert not worker._drain_thread_stdout.is_alive(), (
+        "_drain_thread_stdout is still alive after close()"
+    )
+    assert not worker._drain_thread_stderr.is_alive(), (
+        "_drain_thread_stderr is still alive after close()"
+    )
+
+
+def test_slash_worker_close_is_idempotent():
+    """close() can be called multiple times safely."""
+    from tui_gateway.server import _SlashWorker
+
+    worker = _SlashWorker.__new__(_SlashWorker)
+    worker._closed = False
+    worker.proc = _FakeProc()
+
+    def noop():
+        pass
+
+    worker._drain_thread_stdout = threading.Thread(target=noop, daemon=True)
+    worker._drain_thread_stderr = threading.Thread(target=noop, daemon=True)
+    worker._drain_thread_stdout.start()
+    worker._drain_thread_stderr.start()
+
+    worker.close()
+    assert worker._closed
+
+    # Second call should be a no-op (guard at top of close())
+    worker.close()
+    assert worker._closed
+
+
+def test_slash_worker_drain_threads_are_named():
+    """Drain threads should have identifiable names for debugging."""
+    # This is a regression guard: anonymous threads (no name) make it
+    # impossible to identify the source of leaked threads in py-spy dumps.
+    # The fix gives them explicit names: slash-drain-stdout, slash-drain-stderr.
+    import inspect
+
+    from tui_gateway import server
+
+    source = inspect.getsource(_SlashWorker := server._SlashWorker)
+    assert "slash-drain-stdout" in source, (
+        "_SlashWorker should name its stdout drain thread 'slash-drain-stdout'"
+    )
+    assert "slash-drain-stderr" in source, (
+        "_SlashWorker should name its stderr drain thread 'slash-drain-stderr'"
+    )

--- a/tests/tui_gateway/test_slash_worker_drain.py
+++ b/tests/tui_gateway/test_slash_worker_drain.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -130,14 +130,33 @@ def test_slash_worker_drain_threads_are_named():
     # This is a regression guard: anonymous threads (no name) make it
     # impossible to identify the source of leaked threads in py-spy dumps.
     # The fix gives them explicit names: slash-drain-stdout, slash-drain-stderr.
-    import inspect
-
     from tui_gateway import server
 
-    source = inspect.getsource(_SlashWorker := server._SlashWorker)
-    assert "slash-drain-stdout" in source, (
-        "_SlashWorker should name its stdout drain thread 'slash-drain-stdout'"
-    )
-    assert "slash-drain-stderr" in source, (
-        "_SlashWorker should name its stderr drain thread 'slash-drain-stderr'"
-    )
+    stdout_thread = MagicMock()
+    stderr_thread = MagicMock()
+    with (
+        patch.object(server.subprocess, "Popen"),
+        patch.object(
+            server.threading,
+            "Thread",
+            side_effect=[stdout_thread, stderr_thread],
+        ) as thread_cls,
+    ):
+        worker = server._SlashWorker(session_key="test-key", model="test-model")
+
+    assert thread_cls.call_args_list == [
+        call(
+            target=worker._drain_stdout,
+            daemon=True,
+            name="slash-drain-stdout",
+        ),
+        call(
+            target=worker._drain_stderr,
+            daemon=True,
+            name="slash-drain-stderr",
+        ),
+    ]
+    assert worker._drain_thread_stdout is stdout_thread
+    assert worker._drain_thread_stderr is stderr_thread
+    stdout_thread.start.assert_called_once_with()
+    stderr_thread.start.assert_called_once_with()

--- a/tests/tui_gateway/test_slash_worker_drain.py
+++ b/tests/tui_gateway/test_slash_worker_drain.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-import time
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -44,9 +43,8 @@ def test_slash_worker_close_joins_drain_threads():
     references to the _SlashWorker instance and its buffers.
 
     The fix stores thread references and calls join(timeout=2) in close().
-    In production, closing proc.stdout/proc.stderr causes the readline()
-    in the drain threads to hit EOF and exit, so join() returns quickly.
-    This test uses threads that exit promptly to verify the join path works.
+    This test uses drain-thread doubles so the test directly verifies the
+    join contract rather than relying on threads that had already exited.
     """
     from tui_gateway.server import _SlashWorker
 
@@ -58,24 +56,10 @@ def test_slash_worker_close_joins_drain_threads():
     worker._closed = False
     worker.proc = _FakeProc()
 
-    # Use threads that exit quickly (simulating EOF on the pipe)
-    exit_event = threading.Event()
-    exit_event.set()  # let them exit immediately
-
-    def quick_drain():
-        exit_event.wait(timeout=5)
-
-    worker._drain_thread_stdout = threading.Thread(
-        target=quick_drain, daemon=True, name="test-drain-stdout"
-    )
-    worker._drain_thread_stderr = threading.Thread(
-        target=quick_drain, daemon=True, name="test-drain-stderr"
-    )
-    worker._drain_thread_stdout.start()
-    worker._drain_thread_stderr.start()
-
-    # Give threads time to exit
-    time.sleep(0.1)
+    stdout_thread = MagicMock(name="stdout_drain_thread")
+    stderr_thread = MagicMock(name="stderr_drain_thread")
+    worker._drain_thread_stdout = stdout_thread
+    worker._drain_thread_stderr = stderr_thread
 
     # Call close()
     worker.close()
@@ -91,14 +75,8 @@ def test_slash_worker_close_joins_drain_threads():
     worker.proc.stdout.close.assert_called()
     worker.proc.stderr.close.assert_called()
 
-    # The drain threads should have exited (they exit on their own, and
-    # close() joins them — so they're definitely not alive after close()).
-    assert not worker._drain_thread_stdout.is_alive(), (
-        "_drain_thread_stdout is still alive after close()"
-    )
-    assert not worker._drain_thread_stderr.is_alive(), (
-        "_drain_thread_stderr is still alive after close()"
-    )
+    assert stdout_thread.mock_calls == [call.join(timeout=2)]
+    assert stderr_thread.mock_calls == [call.join(timeout=2)]
 
 
 def test_slash_worker_close_is_idempotent():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -343,8 +343,14 @@ class _SlashWorker:
             creationflags=windows_hide_flags(),
             start_new_session=True,
         )
-        threading.Thread(target=self._drain_stdout, daemon=True).start()
-        threading.Thread(target=self._drain_stderr, daemon=True).start()
+        self._drain_thread_stdout = threading.Thread(
+            target=self._drain_stdout, daemon=True, name="slash-drain-stdout"
+        )
+        self._drain_thread_stderr = threading.Thread(
+            target=self._drain_stderr, daemon=True, name="slash-drain-stderr"
+        )
+        self._drain_thread_stdout.start()
+        self._drain_thread_stderr.start()
 
     def _drain_stdout(self):
         for line in self.proc.stdout or []:
@@ -412,6 +418,16 @@ class _SlashWorker:
             for stream in (proc.stdin, proc.stdout, proc.stderr):
                 try:
                     stream.close()
+                except Exception:
+                    pass
+            # Join drain threads so they don't outlive the worker. After
+            # proc.terminate() and stream.close(), the readline() in
+            # _drain_stdout/_drain_stderr hits EOF and the threads exit
+            # promptly. The timeout is a safety net for edge cases where
+            # the subprocess is mid-write (#53303).
+            for t in (self._drain_thread_stdout, self._drain_thread_stderr):
+                try:
+                    t.join(timeout=2)
                 except Exception:
                     pass
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -776,6 +776,9 @@ def _teardown_popped_session(
     """Finish a close after the caller has atomically detached the session."""
     if session is None:
         return False
+    logger.info(
+        "session closed sid=%s end_reason=%s", session.get("_sid", ""), end_reason
+    )
     _teardown_session(session, end_reason=end_reason)
     return True
 
@@ -868,6 +871,21 @@ def _close_sessions_for_transport(
             # _ws_session_is_orphaned recognizes them and the grace-reap can
             # actually fire; a standalone `hermes --tui` keeps real _stdio.
             session["transport"] = _detached_ws_transport
+            # Close the slash_worker immediately on detach — it's ~13 MB per
+            # process and the Desktop app uses one WS for all sessions, so
+            # switching sessions leaves the old workers alive until the 6 h TTL
+            # reaper or the 20 s orphan reaper fires (which may not fire at all
+            # if the session is flagged running by a background curator review).
+            # The worker is recreated lazily on the next slash command: the
+            # slash.exec handler and _restart_slash_worker both handle
+            # worker=None.
+            worker = session.get("slash_worker")
+            if worker:
+                try:
+                    worker.close()
+                except Exception:
+                    pass
+                session["slash_worker"] = None
             detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -425,11 +425,13 @@ class _SlashWorker:
             # _drain_stdout/_drain_stderr hits EOF and the threads exit
             # promptly. The timeout is a safety net for edge cases where
             # the subprocess is mid-write (#53303).
-            for t in (self._drain_thread_stdout, self._drain_thread_stderr):
-                try:
-                    t.join(timeout=2)
-                except Exception:
-                    pass
+            for t in (getattr(self, '_drain_thread_stdout', None),
+                      getattr(self, '_drain_thread_stderr', None)):
+                if t is not None:
+                    try:
+                        t.join(timeout=2)
+                    except Exception:
+                        pass
 
 
 def _load_busy_input_mode() -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -504,8 +504,14 @@ class _SlashWorker:
             creationflags=windows_hide_flags(),
             start_new_session=True,
         )
-        threading.Thread(target=self._drain_stdout, daemon=True).start()
-        threading.Thread(target=self._drain_stderr, daemon=True).start()
+        self._drain_thread_stdout = threading.Thread(
+            target=self._drain_stdout, daemon=True, name="slash-drain-stdout"
+        )
+        self._drain_thread_stderr = threading.Thread(
+            target=self._drain_stderr, daemon=True, name="slash-drain-stderr"
+        )
+        self._drain_thread_stdout.start()
+        self._drain_thread_stderr.start()
 
     def _drain_stdout(self):
         for line in self.proc.stdout or []:
@@ -573,6 +579,16 @@ class _SlashWorker:
             for stream in (proc.stdin, proc.stdout, proc.stderr):
                 try:
                     stream.close()
+                except Exception:
+                    pass
+            # Join drain threads so they don't outlive the worker. After
+            # proc.terminate() and stream.close(), the readline() in
+            # _drain_stdout/_drain_stderr hits EOF and the threads exit
+            # promptly. The timeout is a safety net for edge cases where
+            # the subprocess is mid-write (#53303).
+            for t in (self._drain_thread_stdout, self._drain_thread_stderr):
+                try:
+                    t.join(timeout=2)
                 except Exception:
                     pass
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1043,6 +1043,9 @@ def _teardown_popped_session(
                 )
         except Exception:
             logger.debug("failed waiting for session turn thread", exc_info=True)
+    logger.info(
+        "session closed sid=%s end_reason=%s", session.get("_sid", ""), end_reason
+    )
     _teardown_session(session, end_reason=end_reason)
     return True
 
@@ -1422,6 +1425,24 @@ def _close_sessions_for_transport(
                     continue
                 session["transport"] = _detached_ws_transport
                 session.pop("_client_gone_interrupt_requested", None)
+            # Close the slash_worker immediately on detach — it's ~13 MB per
+            # process and the Desktop app uses one WS for all sessions, so
+            # switching sessions leaves the old workers alive until the 6 h TTL
+            # reaper or the 20 s orphan reaper fires (which may not fire at all
+            # if the session is flagged running by a background curator review).
+            # The worker is recreated lazily on the next slash command: the
+            # slash.exec handler and _restart_slash_worker both handle
+            # worker=None. Only the park-to-sentinel fall-through above
+            # reaches here — both viewer/rebind `continue` paths keep the
+            # session attached — and the close runs OUTSIDE _sessions_lock so
+            # the subprocess teardown never stalls the global session lock.
+            worker = session.get("slash_worker")
+            if worker:
+                try:
+                    worker.close()
+                except Exception:
+                    pass
+                session["slash_worker"] = None
             detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -586,11 +586,13 @@ class _SlashWorker:
             # _drain_stdout/_drain_stderr hits EOF and the threads exit
             # promptly. The timeout is a safety net for edge cases where
             # the subprocess is mid-write (#53303).
-            for t in (self._drain_thread_stdout, self._drain_thread_stderr):
-                try:
-                    t.join(timeout=2)
-                except Exception:
-                    pass
+            for t in (getattr(self, '_drain_thread_stdout', None),
+                      getattr(self, '_drain_thread_stderr', None)):
+                if t is not None:
+                    try:
+                        t.join(timeout=2)
+                    except Exception:
+                        pass
 
 
 def _load_busy_input_mode() -> str:


### PR DESCRIPTION
## Summary

The Desktop app uses **one WebSocket for all sessions**. When the user switches sessions or the WS reconnects (e.g. after macOS sleep), old sessions are detached to `_detached_ws_transport` but their `slash_worker` subprocesses (**~13 MB each**) stay alive until the 6 h TTL reaper or 20 s orphan reaper fires — which may never happen if a background curator review keeps the session flagged as `running`.

Over a few hours this accumulates dozens of idle workers, contributing to **GIL pressure** and **memory bloat**. In production this was observed as 17 zombie slash_workers (~230 MB) causing event-loop stalls up to 10.6 s.

## Changes

### 1. Close slash_worker on WS detach (core fix)

`tui_gateway/server.py` — `_close_sessions_for_transport()`:

When a session is detached (WS disconnect without `close_on_disconnect`), its `slash_worker` is now closed immediately instead of lingering. The worker is recreated lazily on the next slash command — both the `slash.exec` handler and `_restart_slash_worker` already handle `worker=None`.

### 2. Add INFO logging to `_close_session_by_id` (observability)

Previously the entire session-close path was **completely silent** — no log at any level. This made it impossible to diagnose why sessions were or weren't being reaped. A single INFO line makes the teardown path visible:

```
INFO tui_gateway.server: session closed sid=abc123 end_reason=ws_orphan_reap
```

## Why this is safe

- `_SlashWorker.close()` is already idempotent (`_closed` guard + `poll()` guard)
- `_finalize_session` (the session-end chokepoint, PR #42149) already closes the worker — our fix just closes it **sooner**, at detach time
- The `slash.exec` handler creates a new worker on demand when `session["slash_worker"]` is `None` (server.py ~L12553)
- `_restart_slash_worker` does the same after each turn

## Testing

```
tests/tui_gateway/test_slash_worker_detach.py::test_close_sessions_for_transport_closes_worker_on_detach PASSED
tests/tui_gateway/test_slash_worker_detach.py::test_close_sessions_for_transport_preserves_worker_on_reap PASSED
tests/tui_gateway/test_slash_worker_detach.py::test_close_sessions_for_transport_handles_worker_close_exception PASSED
tests/tui_gateway/test_slash_worker_detach.py::test_close_session_by_id_logs_end_reason PASSED
```

All 24 existing slash_worker / ws_orphan / close_session tests still pass.

## Related work (complementary, non-overlapping)

This PR addresses a **different leak path** from three open PRs. They are complementary and can all merge independently:

| PR | Author | Fixes | Leak path |
|---|---|---|---|
| **#53308** | @pasevin | Drain thread join on close | 2 leaked threads per session |
| **#41473** | @Fewmanism | Worker registry + idempotent close | Same-session-key duplicate workers |
| **#48656** | @Nigmat-future | Startup orphan reaper + zombie parent detection | Workers surviving gateway crash |
| **this PR** | — | Close worker on WS detach | Workers surviving session switch |

### Related issues

- #48643 — slash_worker not reaped when session interrupted mid-compaction
- #38095 — TUI slash worker zombie subprocesses leak after session close (CLOSED, #42149 merged)
- #53303 — `_SlashWorker.close()` does not join drain threads
- #48564 — RFC: Dashboard/TUI reliability hardening (umbrella)
