### PR TITLE
fix(cron): deliver no_agent job output verbatim without the response wrapper

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1402,6 +1402,25 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _should_wrap_cron_response(job: dict, user_cfg: Optional[dict]) -> bool:
+    """Whether to wrap cron delivery in the ``Cronjob Response`` header/footer.
+
+    Precedence:
+      1. ``no_agent`` jobs are delivered *unwrapped*. Their script stdout is
+         contractually delivered verbatim (see ``cron.jobs.create_job``), so
+         the cron header/footer must not pollute the payload — and the footer's
+         "send me a new message to manage this job" instruction implies an
+         agent conversation that a no_agent job doesn't have (#57647).
+      2. Otherwise fall back to the global ``cron.wrap_response`` (default True).
+    """
+    if job.get("no_agent"):
+        return False
+    try:
+        return bool((user_cfg or {}).get("cron", {}).get("wrap_response", True))
+    except Exception:
+        return True
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -1440,14 +1459,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
-    wrap_response = True
+    # in config.yaml (or wrap_response: false on the job) for clean output, and
+    # no_agent jobs deliver their script stdout verbatim (see _should_wrap_cron_response).
     user_cfg = None
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
     except Exception:
         pass
+    wrap_response = _should_wrap_cron_response(job, user_cfg)
 
     if wrap_response:
         task_name = job.get("name", job["id"])

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2853,6 +2853,25 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _should_wrap_cron_response(job: dict, user_cfg: Optional[dict]) -> bool:
+    """Whether to wrap cron delivery in the ``Cronjob Response`` header/footer.
+
+    Precedence:
+      1. ``no_agent`` jobs are delivered *unwrapped*. Their script stdout is
+         contractually delivered verbatim (see ``cron.jobs.create_job``), so
+         the cron header/footer must not pollute the payload — and the footer's
+         "send me a new message to manage this job" instruction implies an
+         agent conversation that a no_agent job doesn't have (#57647).
+      2. Otherwise fall back to the global ``cron.wrap_response`` (default True).
+    """
+    if job.get("no_agent"):
+        return False
+    try:
+        return bool((user_cfg or {}).get("cron", {}).get("wrap_response", True))
+    except Exception:
+        return True
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -2891,14 +2910,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
-    wrap_response = True
+    # in config.yaml (or wrap_response: false on the job) for clean output, and
+    # no_agent jobs deliver their script stdout verbatim (see _should_wrap_cron_response).
     user_cfg = None
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
     except Exception:
         pass
+    wrap_response = _should_wrap_cron_response(job, user_cfg)
 
     if wrap_response:
         task_name = job.get("name", job["id"])

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets, _should_wrap_cron_response
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -553,8 +553,61 @@ class TestRoutingIntents:
             assert platforms == ["discord", "telegram"], f"token={token!r} -> {platforms}"
 
 
+class TestShouldWrapCronResponse:
+    """#57647: no_agent jobs deliver script stdout verbatim — no header/footer."""
+
+    def test_agent_job_wraps_by_default(self):
+        assert _should_wrap_cron_response({"id": "j"}, None) is True
+        assert _should_wrap_cron_response({"id": "j"}, {"cron": {}}) is True
+
+    def test_no_agent_job_is_unwrapped_by_default(self):
+        assert _should_wrap_cron_response({"id": "j", "no_agent": True}, None) is False
+        # Even when the global default is on.
+        assert _should_wrap_cron_response(
+            {"id": "j", "no_agent": True}, {"cron": {"wrap_response": True}}
+        ) is False
+
+    def test_global_disable_still_honored_for_agent_jobs(self):
+        assert _should_wrap_cron_response(
+            {"id": "j"}, {"cron": {"wrap_response": False}}
+        ) is False
+
+    def test_global_disable_does_not_override_no_agent_default(self):
+        # no_agent stays unwrapped regardless of the global default value.
+        assert _should_wrap_cron_response(
+            {"id": "j", "no_agent": True}, {"cron": {"wrap_response": False}}
+        ) is False
+
+
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
+
+    def test_no_agent_delivery_is_verbatim(self):
+        """#57647: a no_agent job's stdout is delivered without the cron wrapper."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            job = {
+                "id": "scan-1",
+                "name": "coin-scan",
+                "no_agent": True,
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "SIGNAL: BTC breakout")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "SIGNAL: BTC breakout"
+        assert "Cronjob Response" not in sent_content
+        assert "To stop or manage this job" not in sent_content
 
     def _safe_media_path(self, tmp_path, monkeypatch, name, data=b"media"):
         root = tmp_path / "media-cache"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -18,6 +18,7 @@ from cron.scheduler import (
     _resolve_delivery_target,
     _resolve_origin,
     _send_media_via_adapter,
+    _should_wrap_cron_response,
     _summarize_cron_failure_for_delivery,
     run_job,
 )
@@ -335,8 +336,61 @@ class TestRoutingIntents:
         assert "matrix" not in platforms
 
 
+class TestShouldWrapCronResponse:
+    """#57647: no_agent jobs deliver script stdout verbatim — no header/footer."""
+
+    def test_agent_job_wraps_by_default(self):
+        assert _should_wrap_cron_response({"id": "j"}, None) is True
+        assert _should_wrap_cron_response({"id": "j"}, {"cron": {}}) is True
+
+    def test_no_agent_job_is_unwrapped_by_default(self):
+        assert _should_wrap_cron_response({"id": "j", "no_agent": True}, None) is False
+        # Even when the global default is on.
+        assert _should_wrap_cron_response(
+            {"id": "j", "no_agent": True}, {"cron": {"wrap_response": True}}
+        ) is False
+
+    def test_global_disable_still_honored_for_agent_jobs(self):
+        assert _should_wrap_cron_response(
+            {"id": "j"}, {"cron": {"wrap_response": False}}
+        ) is False
+
+    def test_global_disable_does_not_override_no_agent_default(self):
+        # no_agent stays unwrapped regardless of the global default value.
+        assert _should_wrap_cron_response(
+            {"id": "j", "no_agent": True}, {"cron": {"wrap_response": False}}
+        ) is False
+
+
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
+
+    def test_no_agent_delivery_is_verbatim(self):
+        """#57647: a no_agent job's stdout is delivered without the cron wrapper."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            job = {
+                "id": "scan-1",
+                "name": "coin-scan",
+                "no_agent": True,
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "SIGNAL: BTC breakout")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "SIGNAL: BTC breakout"
+        assert "Cronjob Response" not in sent_content
+        assert "To stop or manage this job" not in sent_content
 
     def _safe_media_path(self, tmp_path, monkeypatch, name, data=b"media"):
         root = tmp_path / "media-cache"

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -265,6 +265,8 @@ By default (`cron.wrap_response: true`), cron deliveries are wrapped with:
 - A header identifying the cron job name and task
 - A footer noting the agent cannot see the delivered message in conversation
 
+`_should_wrap_cron_response(job, user_cfg)` decides this per delivery: a `no_agent` job is always delivered unwrapped (its stdout is contractually verbatim, and the footer implies an agent conversation it doesn't have), so `cron.wrap_response` applies only to agent-driven jobs.
+
 The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful for jobs that only need to write to files or perform side effects.
 
 ### Session Isolation

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -270,6 +270,8 @@ By default (`cron.wrap_response: true`), cron deliveries are wrapped with:
 - A header identifying the cron job name and task
 - A footer noting the agent cannot see the delivered message in conversation
 
+`_should_wrap_cron_response(job, user_cfg)` decides this per delivery: a `no_agent` job is always delivered unwrapped (its stdout is contractually verbatim, and the footer implies an agent conversation it doesn't have), so `cron.wrap_response` applies only to agent-driven jobs.
+
 The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful for jobs that only need to write to files or perform side effects.
 
 ### Session Isolation

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -298,6 +298,8 @@ cron:
   wrap_response: false
 ```
 
+**No-agent jobs are always unwrapped.** A [`no_agent`](#no-agent-mode-script-only-jobs) job's stdout is delivered verbatim regardless of `cron.wrap_response`, since the wrapper's header and "the agent cannot see this message" footer don't apply to a script-only job with no agent conversation behind it. The `cron.wrap_response` setting only affects agent-driven jobs.
+
 ### Continuable jobs (reply to a cron delivery)
 
 By default a cron delivery is fire-and-forget: the message is sent, but it does

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -433,6 +433,8 @@ cron:
   wrap_response: false
 ```
 
+**No-agent jobs are always unwrapped.** A [`no_agent`](#no-agent-mode-script-only-jobs) job's stdout is delivered verbatim regardless of `cron.wrap_response`, since the wrapper's header and "the agent cannot see this message" footer don't apply to a script-only job with no agent conversation behind it. The `cron.wrap_response` setting only affects agent-driven jobs.
+
 ### Continuable jobs (reply to a cron delivery)
 
 By default a cron delivery is fire-and-forget: the message is sent, but it does


### PR DESCRIPTION
## What does this PR do?

`no_agent` cron jobs are documented to deliver their script's stdout **verbatim** (`cron.jobs.create_job`: *"the script IS the job — its stdout is delivered verbatim"*), but `_deliver_result` wrapped every delivery in the `Cronjob Response: <name>` / `(job_id: …)` header and a `To stop or manage this job, send me a new message …` footer.

For a `no_agent` signal bot (the reporter's Telegram alpha-scanner) that pollutes every push with system noise the user should never see — and the footer implies an agent conversation a `no_agent` job doesn't have.

## Fix

Extract the wrap decision into `_should_wrap_cron_response(job, user_cfg)` with two rules:

1. `no_agent` jobs are delivered **unwrapped** (honoring the documented verbatim contract).
2. Otherwise fall back to the global `cron.wrap_response` (default `True`).

Agent-job behavior is unchanged; the existing global `cron.wrap_response: false` still works.

> Scope note: an earlier revision also allowed a per-job `wrap_response` override. That branch was reachable through no supported interface (`jobs.create_job` / `cronjob_tools` neither accept nor expose it), so per review feedback it was removed to keep the change focused on the no-agent default.

## Related Issue

Fixes #57647

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: add `_should_wrap_cron_response()` and use it in `_deliver_result()` in place of the inline global-only check.
- `tests/cron/test_scheduler.py`: `TestShouldWrapCronResponse` (agent wraps by default, no_agent unwrapped even with the global default on, global-disable honored, global-disable does not override the no_agent default) + a `_deliver_result` integration test asserting a `no_agent` job is sent verbatim.
- `website/docs/user-guide/features/cron.md` + `website/docs/developer-guide/cron-internals.md`: document that `cron.wrap_response` applies only to agent-driven jobs and no_agent stdout is always delivered verbatim.

## How to Test

1. `uv run python -m pytest tests/cron/test_scheduler.py -q` → 220 passed, ruff clean.
2. Manual: a `no_agent: true` job delivers its stdout with no header/footer; an agent job still wraps unless `cron.wrap_response: false`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — user-guide + developer-guide cron docs
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (delivery-path logic, platform-agnostic)
