### PR TITLE
fix(tui): prune catalog alias collisions with standalone commands

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4242,6 +4242,21 @@ def test_commands_catalog_includes_tui_mouse_command():
     assert "/mouse" in tui_pairs
 
 
+def test_commands_catalog_prunes_compact_alias_collision():
+    """/compact is both a TUI command and a /compress alias — prune canon (#57532)."""
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    pairs = dict(resp["result"]["pairs"])
+    canon = resp["result"]["canon"]
+
+    assert "/compact" in pairs
+    assert pairs["/compact"] == "Toggle compact display mode"
+    assert "/compact" not in canon
+    assert canon["/compress"] == "/compress"
+
+
 def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11201,6 +11201,26 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
 _WORKER_BLOCKED_COMMANDS: frozenset[str] = frozenset({"snapshot", "snap"})
 
 
+def _prune_catalog_alias_collisions(
+    pairs: list[list[str]], canon: dict[str, str]
+) -> dict[str, str]:
+    """Drop alias canon entries that collide with standalone catalog commands.
+
+    ``pairs`` lists concrete slash commands (including TUI extras like
+    ``/compact`` for display-mode toggle). ``canon`` maps aliases onto their
+    canonical command (e.g. ``/compact`` -> ``/compress``). When the same
+    slash text appears in both, clients that register pairs then aliases throw
+    "Duplicate slash command alias" (#57532).
+    """
+    standalone = {name.lower(): name for name, _desc in pairs}
+    pruned = dict(canon)
+    for alias_key, target in list(canon.items()):
+        existing = standalone.get(alias_key)
+        if existing is not None and existing != target:
+            del pruned[alias_key]
+    return pruned
+
+
 @method("commands.catalog")
 def _(rid, params: dict) -> dict:
     """Registry-backed slash metadata for the TUI — categorized, no aliases."""
@@ -11284,6 +11304,7 @@ def _(rid, params: dict) -> dict:
         for cat in cat_order:
             categories.append({"name": cat, "pairs": cat_map[cat]})
 
+        canon = _prune_catalog_alias_collisions(all_pairs, canon)
         sub = {k: v[:] for k, v in SUBCOMMANDS.items()}
         return _ok(
             rid,


### PR DESCRIPTION
## Summary
- Fixes #57532
- `commands.catalog` listed `/compact` as both a TUI display-toggle command (`pairs`) and a `/compress` alias (`canon`). Desktop/SDK clients that register pairs then aliases throw "Duplicate slash command alias".
- Add `_prune_catalog_alias_collisions()` to drop conflicting canon aliases while keeping standalone TUI commands.

## Test plan
- [x] `pytest tests/test_tui_gateway_server.py::test_commands_catalog_prunes_compact_alias_collision`
