### PR TITLE
fix(cron): run jobs under the profile secret scope (UnscopedSecretError broke every cron job under profile isolation)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3114,7 +3114,26 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             )
             return True  # not an error — already handled/removed
 
-        success, output, final_response, error = run_job(job)
+        # Run the job under the profile's secret scope. get_secret() fails
+        # closed outside a scope once profile isolation is in play (multiple
+        # gateway profiles / room→profile multiplexing), and cron fires from
+        # the ticker thread where no per-turn scope is installed — so
+        # resolve_runtime_provider() raised UnscopedSecretError before model
+        # selection, breaking every cron job. Mirrors the per-turn pattern in
+        # gateway/run.py (_profile_runtime_scope).
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            reset_secret_scope,
+            set_secret_scope,
+        )
+
+        _scope_token = set_secret_scope(
+            build_profile_secret_scope(_get_hermes_home())
+        )
+        try:
+            success, output, final_response, error = run_job(job)
+        finally:
+            reset_secret_scope(_scope_token)
 
         output_file = save_job_output(job["id"], output)
         if verbose:


### PR DESCRIPTION
## Problem

Once profile isolation is in play (multiple gateway profiles / room→profile multiplexing), `get_secret()` fails closed outside an installed scope. The cron ticker fires jobs from its own thread where no per-turn scope is installed, so `run_job()` died inside `resolve_runtime_provider()` before model selection:

```
UnscopedSecretError: get_secret('OPENROUTER_BASE_URL') ... no profile secret scope active
```

Every cron job failed with this while interactive turns worked fine (the message path installs the scope per turn via `_profile_runtime_scope` in `gateway/run.py`).

## Fix

Wrap the `run_job(job)` call in `run_one_job` with `set_secret_scope(build_profile_secret_scope(_get_hermes_home()))` and a `finally` reset — the same pattern the per-turn gateway path already uses. Because `run_one_job` is the shared firing body, both the built-in ticker and external providers (Chronos `fire_due`) get the scope.

Single-profile installs are unaffected: the scope is just the profile's own `.env`, matching what the unscoped fallback used to read before fail-closed isolation landed.

## Testing

- `tests/cron`: 611 passed. One failure (`TestRoutingIntents::test_all_token_case_insensitive`) is pre-existing full-suite test pollution: it fails identically on unmodified `main` when the whole `tests/cron` suite runs, and passes in isolation on both trees.
- Running in production on my multi-profile install since 2026-06-26 (originally applied as a local patch); it un-broke all cron jobs.

Contact for CLA/CI: jonathan.kovacs999@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)