### PR TITLE
fix(gateway): reasoning display is silently lost on every streamed turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10892,6 +10892,116 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    def _format_reasoning_block(self, source, last_reasoning) -> str:
+        """Format the model's reasoning as the displayable 💭 block, or "".
+
+        Shared by the normal send path and the streamed-turn reasoning fold:
+        resolves the per-platform ``show_reasoning`` switch (Mattermost
+        requires an explicit platform override because this is scratch text,
+        not ordinary final-answer content), collapses long reasoning to 15
+        lines, and renders the per-platform ``reasoning_style`` (code /
+        subtext / blockquote). Returns "" when display is off or there is no
+        reasoning to show.
+        """
+        try:
+            _show_reasoning_effective = _resolve_gateway_display_bool(
+                _load_gateway_config(),
+                _platform_config_key(source.platform),
+                "show_reasoning",
+                default=bool(getattr(self, "_show_reasoning", False)),
+                platform=source.platform,
+                require_platform_override_for={Platform.MATTERMOST},
+            )
+        except Exception:
+            _show_reasoning_effective = (
+                False
+                if source.platform == Platform.MATTERMOST
+                else getattr(self, "_show_reasoning", False)
+            )
+        if not _show_reasoning_effective or not last_reasoning:
+            return ""
+        # Collapse long reasoning to keep messages readable
+        lines = last_reasoning.strip().splitlines()
+        if len(lines) > 15:
+            display_reasoning = "\n".join(lines[:15])
+            display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
+        else:
+            display_reasoning = last_reasoning.strip()
+        # Render style is per-platform: Discord defaults to "-# " subtext
+        # (native small grey metadata text); other platforms keep the fenced
+        # code block.
+        try:
+            from gateway.display_config import resolve_display_setting
+            _reasoning_style = resolve_display_setting(
+                _load_gateway_config(),
+                _platform_config_key(source.platform),
+                "reasoning_style",
+                "code",
+            )
+        except Exception:
+            _reasoning_style = "code"
+        if _reasoning_style == "subtext":
+            _quoted = "\n".join(
+                f"-# {ln}" if ln else "-#" for ln in display_reasoning.splitlines()
+            )
+            return f"-# 💭 Reasoning\n{_quoted}"
+        if _reasoning_style == "blockquote":
+            _quoted = "\n".join(
+                f"> {ln}" if ln else ">" for ln in display_reasoning.splitlines()
+            )
+            return f"> 💭 **Reasoning:**\n{_quoted}"
+        return f"💭 **Reasoning:**\n```\n{display_reasoning}\n```"
+
+    async def _fold_reasoning_into_streamed_message(
+        self,
+        *,
+        source,
+        stream_consumer,
+        final_text,
+        last_reasoning,
+        session_key=None,
+    ) -> bool:
+        """Fold the 💭 reasoning block into an already-streamed final message.
+
+        The streamed commit bypasses the normal send path — the only place the
+        reasoning block is prepended — so turning streaming on silently
+        disabled reasoning display for every model and platform. Re-attach it
+        with one final edit routed through the stream consumer's
+        metadata-aware edit path (``_edit_message``), so the edit still carries
+        the routing metadata Slack uses to pick the workspace client and
+        Telegram uses for topic/thread routing — a raw ``adapter.edit_message``
+        would drop it and a non-default Slack workspace would lose the edit.
+
+        Best-effort: a failed edit only loses the reasoning display, never the
+        answer, and never un-suppresses the send. Returns True when an edit was
+        issued.
+        """
+        if stream_consumer is None or not final_text:
+            return False
+        try:
+            message_id = stream_consumer.message_id
+        except Exception:
+            message_id = None
+        if not message_id:
+            return False
+        try:
+            reasoning_block = self._format_reasoning_block(source, last_reasoning)
+            if not reasoning_block:
+                return False
+            await stream_consumer._edit_message(
+                message_id=message_id,
+                content=f"{reasoning_block}\n\n{final_text}",
+                finalize=True,
+            )
+            return True
+        except Exception as _reasoning_edit_err:
+            logger.warning(
+                "Failed to fold reasoning into streamed message for session %s: %s",
+                session_key or "?",
+                _reasoning_edit_err,
+            )
+            return False
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -11899,58 +12009,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
 
             # Prepend reasoning/thinking if display is enabled (per-platform).
-            # Mattermost requires explicit per-platform opt-in because this is
-            # scratch text, not ordinary final-answer content.
-            try:
-                _show_reasoning_effective = _resolve_gateway_display_bool(
-                    _load_gateway_config(),
-                    _platform_config_key(source.platform),
-                    "show_reasoning",
-                    default=bool(getattr(self, "_show_reasoning", False)),
-                    platform=source.platform,
-                    require_platform_override_for={Platform.MATTERMOST},
+            # Formatting/enablement lives in _format_reasoning_block so the
+            # streamed-turn fold below reuses the exact same rendering.
+            if response and not _intentional_silence:
+                _reasoning_block = self._format_reasoning_block(
+                    source, agent_result.get("last_reasoning")
                 )
-            except Exception:
-                _show_reasoning_effective = (
-                    False
-                    if source.platform == Platform.MATTERMOST
-                    else getattr(self, "_show_reasoning", False)
-                )
-            if _show_reasoning_effective and response and not _intentional_silence:
-                last_reasoning = agent_result.get("last_reasoning")
-                if last_reasoning:
-                    # Collapse long reasoning to keep messages readable
-                    lines = last_reasoning.strip().splitlines()
-                    if len(lines) > 15:
-                        display_reasoning = "\n".join(lines[:15])
-                        display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
-                    else:
-                        display_reasoning = last_reasoning.strip()
-                    # Render style is per-platform: Discord defaults to "-# "
-                    # subtext (native small grey metadata text); other
-                    # platforms keep the fenced code block.
-                    try:
-                        from gateway.display_config import resolve_display_setting
-                        _reasoning_style = resolve_display_setting(
-                            _load_gateway_config(),
-                            _platform_config_key(source.platform),
-                            "reasoning_style",
-                            "code",
-                        )
-                    except Exception:
-                        _reasoning_style = "code"
-                    if _reasoning_style == "subtext":
-                        _quoted = "\n".join(
-                            f"-# {ln}" if ln else "-#" for ln in display_reasoning.splitlines()
-                        )
-                        response = f"-# 💭 Reasoning\n{_quoted}\n\n{response}"
-                    elif _reasoning_style == "blockquote":
-                        _quoted = "\n".join(
-                            f"> {ln}" if ln else ">" for ln in display_reasoning.splitlines()
-                        )
-                        response = f"> 💭 **Reasoning:**\n{_quoted}\n\n{response}"
-                    else:
-                        response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                if _reasoning_block:
+                    response = f"{_reasoning_block}\n\n{response}"
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When
@@ -20337,6 +20403,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 previewed=_previewed,
             )
             if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
+                # The streamed commit bypasses the normal send path (the only
+                # place the 💭 reasoning block is prepended), so before
+                # suppressing, fold the block into the already-streamed message
+                # with one final metadata-aware edit. Best-effort — a failed
+                # fold only loses the reasoning display, never the answer, and
+                # never un-suppresses the send.
+                await self._fold_reasoning_into_streamed_message(
+                    source=source,
+                    stream_consumer=_sc,
+                    final_text=_final,
+                    last_reasoning=response.get("last_reasoning"),
+                    session_key=session_key,
+                )
                 logger.info(
                     "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
                     session_key or "?",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21215,6 +21215,150 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    def _format_reasoning_block(self, source, last_reasoning) -> str:
+        """Format the model's reasoning as the displayable 💭 block, or "".
+
+        Shared by the normal send path and the streamed-turn reasoning fold:
+        resolves the per-platform ``show_reasoning`` switch (Mattermost
+        requires an explicit platform override because this is scratch text,
+        not ordinary final-answer content), collapses long reasoning to 15
+        lines, and renders the per-platform ``reasoning_style`` (code /
+        subtext / blockquote). Returns "" when display is off or there is no
+        reasoning to show.
+        """
+        try:
+            _show_reasoning_effective = _resolve_gateway_display_bool(
+                _load_gateway_config(),
+                _platform_config_key(source.platform),
+                "show_reasoning",
+                default=bool(getattr(self, "_show_reasoning", False)),
+                platform=source.platform,
+                require_platform_override_for={Platform.MATTERMOST},
+            )
+        except Exception:
+            _show_reasoning_effective = (
+                False
+                if source.platform == Platform.MATTERMOST
+                else getattr(self, "_show_reasoning", False)
+            )
+        if not _show_reasoning_effective or not last_reasoning:
+            return ""
+        from gateway.stream_consumer import escape_code_fences_for_display
+        # Collapse long reasoning to keep messages readable
+        lines = last_reasoning.strip().splitlines()
+        if len(lines) > 15:
+            display_reasoning = "\n".join(lines[:15])
+            display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
+        else:
+            display_reasoning = last_reasoning.strip()
+        # Render style is per-platform: Discord defaults to "-# " subtext
+        # (native small grey metadata text); other platforms keep the fenced
+        # code block.
+        try:
+            from gateway.display_config import resolve_display_setting
+            _reasoning_style = resolve_display_setting(
+                _load_gateway_config(),
+                _platform_config_key(source.platform),
+                "reasoning_style",
+                "code",
+            )
+        except Exception:
+            _reasoning_style = "code"
+        if _reasoning_style == "subtext":
+            _quoted = "\n".join(
+                f"-# {ln}" if ln else "-#" for ln in display_reasoning.splitlines()
+            )
+            return f"-# 💭 Reasoning\n{_quoted}"
+        if _reasoning_style == "blockquote":
+            _quoted = "\n".join(
+                f"> {ln}" if ln else ">" for ln in display_reasoning.splitlines()
+            )
+            return f"> 💭 **Reasoning:**\n{_quoted}"
+        # Escape ``` inside reasoning so inner fences don't break the outer
+        # code block used to render it.
+        display_reasoning = escape_code_fences_for_display(display_reasoning)
+        return f"💭 **Reasoning:**\n```\n{display_reasoning}\n```"
+
+    async def _fold_reasoning_into_streamed_message(
+        self,
+        *,
+        source,
+        stream_consumer,
+        final_text,
+        last_reasoning,
+        session_key=None,
+    ) -> bool:
+        """Fold the 💭 reasoning block into an already-streamed final message.
+
+        The streamed commit bypasses the normal send path — the only place the
+        reasoning block is prepended — so turning streaming on silently
+        disabled reasoning display for every model and platform. Re-attach it
+        with one final edit routed through the stream consumer's
+        metadata-aware edit path (``_edit_message``), so the edit still carries
+        the routing metadata Slack uses to pick the workspace client and
+        Telegram uses for topic/thread routing — a raw ``adapter.edit_message``
+        would drop it and a non-default Slack workspace would lose the edit.
+
+        Skipped (not attempted) when there is nothing editable: no consumer,
+        no committed message, the ``__no_edit__`` sentinel, a multi-message
+        split delivery (``message_id`` is only the LAST chunk, so editing it
+        with the complete response would repeat every sealed head chunk —
+        #78541), or when the folded text would exceed the chat's message
+        limit.
+
+        Best-effort: a failed edit only loses the reasoning display, never the
+        answer, and never un-suppresses the send. Returns True when the edit
+        was issued and reported success.
+        """
+        if stream_consumer is None or not final_text:
+            return False
+        try:
+            message_id = stream_consumer.message_id
+        except Exception:
+            message_id = None
+        if not message_id or message_id == "__no_edit__":
+            return False
+        if getattr(stream_consumer, "_turn_split_delivery", False):
+            return False
+        try:
+            reasoning_block = self._format_reasoning_block(source, last_reasoning)
+            if not reasoning_block:
+                return False
+            content = f"{reasoning_block}\n\n{final_text}"
+            adapter = getattr(stream_consumer, "adapter", None)
+            try:
+                _limit = int(adapter.max_message_length_for_chat(stream_consumer.chat_id))
+                _len_fn = adapter.message_len_fn_for_chat(stream_consumer.chat_id)
+            except Exception:
+                _limit = int(getattr(adapter, "MAX_MESSAGE_LENGTH", 4096) or 4096)
+                _len_fn = len
+            if _len_fn(content) > _limit:
+                logger.debug(
+                    "Skipping reasoning fold for session %s: folded text exceeds the chat limit (%d > %d).",
+                    session_key or "?", _len_fn(content), _limit,
+                )
+                return False
+            result = await stream_consumer._edit_message(
+                message_id=message_id,
+                content=content,
+                finalize=True,
+            )
+            if not getattr(result, "success", True):
+                logger.warning(
+                    "Reasoning fold edit failed for session %s (%s); reasoning display lost, answer already delivered.",
+                    session_key or "?",
+                    getattr(result, "error", None),
+                )
+                return False
+            return True
+        except Exception as _reasoning_edit_err:
+            logger.warning(
+                "Failed to fold reasoning into streamed message for session %s: %s",
+                session_key or "?",
+                _reasoning_edit_err,
+            )
+            return False
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -23333,62 +23477,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
 
             # Prepend reasoning/thinking if display is enabled (per-platform).
-            # Mattermost requires explicit per-platform opt-in because this is
-            # scratch text, not ordinary final-answer content.
-            try:
-                _show_reasoning_effective = _resolve_gateway_display_bool(
-                    _load_gateway_config(),
-                    _platform_config_key(source.platform),
-                    "show_reasoning",
-                    default=bool(getattr(self, "_show_reasoning", False)),
-                    platform=source.platform,
-                    require_platform_override_for={Platform.MATTERMOST},
+            # Formatting/enablement lives in _format_reasoning_block so the
+            # streamed-turn fold (suppression branch in _run_agent_inner)
+            # reuses the exact same rendering.
+            if response and not _intentional_silence:
+                _reasoning_block = self._format_reasoning_block(
+                    source, agent_result.get("last_reasoning")
                 )
-            except Exception:
-                _show_reasoning_effective = (
-                    False
-                    if source.platform == Platform.MATTERMOST
-                    else getattr(self, "_show_reasoning", False)
-                )
-            if _show_reasoning_effective and response and not _intentional_silence:
-                last_reasoning = agent_result.get("last_reasoning")
-                if last_reasoning:
-                    from gateway.stream_consumer import escape_code_fences_for_display
-                    # Collapse long reasoning to keep messages readable
-                    lines = last_reasoning.strip().splitlines()
-                    if len(lines) > 15:
-                        display_reasoning = "\n".join(lines[:15])
-                        display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
-                    else:
-                        display_reasoning = last_reasoning.strip()
-                    # Render style is per-platform: Discord defaults to "-# "
-                    # subtext (native small grey metadata text); other
-                    # platforms keep the fenced code block.
-                    try:
-                        from gateway.display_config import resolve_display_setting
-                        _reasoning_style = resolve_display_setting(
-                            _load_gateway_config(),
-                            _platform_config_key(source.platform),
-                            "reasoning_style",
-                            "code",
-                        )
-                    except Exception:
-                        _reasoning_style = "code"
-                    if _reasoning_style == "subtext":
-                        _quoted = "\n".join(
-                            f"-# {ln}" if ln else "-#" for ln in display_reasoning.splitlines()
-                        )
-                        response = f"-# 💭 Reasoning\n{_quoted}\n\n{response}"
-                    elif _reasoning_style == "blockquote":
-                        _quoted = "\n".join(
-                            f"> {ln}" if ln else ">" for ln in display_reasoning.splitlines()
-                        )
-                        response = f"> 💭 **Reasoning:**\n{_quoted}\n\n{response}"
-                    else:
-                        # Escape ``` inside reasoning so inner fences don't
-                        # break the outer code block used to render it.
-                        display_reasoning = escape_code_fences_for_display(display_reasoning)
-                        response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                if _reasoning_block:
+                    response = f"{_reasoning_block}\n\n{response}"
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When
@@ -32995,6 +33092,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 previewed=_previewed,
             )
             if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
+                # The streamed commit bypasses the normal send path (the only
+                # place the 💭 reasoning block is prepended), so before
+                # suppressing, fold the block into the already-streamed message
+                # with one final metadata-aware edit. Best-effort — a failed
+                # fold only loses the reasoning display, never the answer, and
+                # never un-suppresses the send.
+                await self._fold_reasoning_into_streamed_message(
+                    source=source,
+                    stream_consumer=_sc,
+                    final_text=_final,
+                    last_reasoning=response.get("last_reasoning"),
+                    session_key=session_key,
+                )
                 logger.info(
                     "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
                     session_key or "?",

--- a/tests/gateway/test_streamed_reasoning_fold.py
+++ b/tests/gateway/test_streamed_reasoning_fold.py
@@ -1,0 +1,240 @@
+"""Streamed-turn reasoning fold (#57693).
+
+With streaming on, the stream consumer commits the final message and the
+gateway suppresses the normal send (already_sent=True). The normal send path
+is the only place the 💭 reasoning block is prepended, so streaming silently
+disabled reasoning display for every model/platform. The fix folds the block
+into the already-streamed message with one final edit — routed through the
+stream consumer's *metadata-aware* edit path so the edit still carries the
+routing metadata Slack uses to select the workspace client (a raw
+adapter.edit_message would drop it and a non-default workspace would lose the
+reasoning).
+
+These tests assert, on real code:
+  - the final edit happens and carries the folded reasoning + answer,
+  - the routing metadata is preserved on that edit,
+  - the fold is a best-effort no-op when there is nothing to fold, and
+  - confirmed streamed delivery still sets already_sent (suppression).
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.run import GatewayRunner
+from gateway.stream_consumer import GatewayStreamConsumer
+
+
+class RecordingAdapter:
+    """Adapter whose edit_message accepts (and records) routing metadata."""
+
+    def __init__(self):
+        self.edits = []
+
+    async def edit_message(self, *, chat_id, message_id, content, finalize=False, metadata=None):
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+                "metadata": metadata,
+            }
+        )
+        return SimpleNamespace(success=True, message_id=message_id)
+
+
+class MetadataBlindAdapter:
+    """Adapter whose edit_message cannot accept metadata (no such param)."""
+
+    def __init__(self):
+        self.edits = []
+
+    async def edit_message(self, *, chat_id, message_id, content, finalize=False):
+        self.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        return SimpleNamespace(success=True, message_id=message_id)
+
+
+def _runner_with_block(block: str) -> GatewayRunner:
+    """A GatewayRunner with _format_reasoning_block stubbed to a fixed block,
+    isolating the fold wiring from gateway-config resolution."""
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._format_reasoning_block = lambda source, last_reasoning: (
+        block if last_reasoning else ""
+    )
+    return runner
+
+
+def _consumer(adapter, *, metadata=None, message_id="msg-1"):
+    sc = GatewayStreamConsumer(adapter, "chat-42", metadata=metadata)
+    sc._message_id = message_id
+    return sc
+
+
+# ---------------------------------------------------------------------------
+# _edit_message: metadata preservation on the path the fold uses
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_edit_message_forwards_metadata_when_supported():
+    adapter = RecordingAdapter()
+    sc = _consumer(adapter, metadata={"slack_team_id": "T999"})
+
+    await sc._edit_message(message_id="msg-1", content="hi", finalize=True)
+
+    assert adapter.edits[-1]["metadata"] == {"slack_team_id": "T999"}
+    assert adapter.edits[-1]["finalize"] is True
+
+
+@pytest.mark.asyncio
+async def test_edit_message_omits_metadata_when_unsupported():
+    adapter = MetadataBlindAdapter()
+    sc = _consumer(adapter, metadata={"slack_team_id": "T999"})
+
+    # Must not raise even though the adapter cannot accept metadata.
+    await sc._edit_message(message_id="msg-1", content="hi", finalize=True)
+
+    assert adapter.edits[-1] == {
+        "chat_id": "chat-42",
+        "message_id": "msg-1",
+        "content": "hi",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _fold_reasoning_into_streamed_message
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fold_edits_streamed_message_with_reasoning_and_metadata():
+    block = "💭 **Reasoning:**\n```\n27*43 = 1161\n```"
+    runner = _runner_with_block(block)
+    adapter = RecordingAdapter()
+    sc = _consumer(adapter, metadata={"slack_team_id": "T999"})
+
+    edited = await runner._fold_reasoning_into_streamed_message(
+        source=SimpleNamespace(platform="slack"),
+        stream_consumer=sc,
+        final_text="1161",
+        last_reasoning="27*43 = 1161",
+        session_key="sess-1",
+    )
+
+    assert edited is True
+    assert len(adapter.edits) == 1
+    edit = adapter.edits[0]
+    assert edit["content"] == f"{block}\n\n1161"       # block folded above answer
+    assert edit["message_id"] == "msg-1"                # the streamed message
+    assert edit["finalize"] is True
+    assert edit["metadata"] == {"slack_team_id": "T999"}  # routing preserved
+
+
+@pytest.mark.asyncio
+async def test_fold_noop_when_no_reasoning():
+    runner = _runner_with_block("💭 block")
+    adapter = RecordingAdapter()
+    sc = _consumer(adapter, metadata={"slack_team_id": "T999"})
+
+    edited = await runner._fold_reasoning_into_streamed_message(
+        source=SimpleNamespace(platform="slack"),
+        stream_consumer=sc,
+        final_text="1161",
+        last_reasoning=None,
+        session_key="sess-1",
+    )
+
+    assert edited is False
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_fold_noop_when_no_stream_consumer():
+    runner = _runner_with_block("💭 block")
+    edited = await runner._fold_reasoning_into_streamed_message(
+        source=SimpleNamespace(platform="slack"),
+        stream_consumer=None,
+        final_text="1161",
+        last_reasoning="thinking",
+        session_key="sess-1",
+    )
+    assert edited is False
+
+
+@pytest.mark.asyncio
+async def test_fold_noop_when_stream_message_not_yet_committed():
+    runner = _runner_with_block("💭 block")
+    adapter = RecordingAdapter()
+    sc = _consumer(adapter, metadata=None, message_id=None)
+
+    edited = await runner._fold_reasoning_into_streamed_message(
+        source=SimpleNamespace(platform="slack"),
+        stream_consumer=sc,
+        final_text="1161",
+        last_reasoning="thinking",
+        session_key="sess-1",
+    )
+    assert edited is False
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_fold_is_best_effort_on_edit_failure():
+    """A failed edit must not raise — it only loses the reasoning display."""
+    runner = _runner_with_block("💭 block")
+
+    class BoomAdapter:
+        async def edit_message(self, *, chat_id, message_id, content, finalize=False, metadata=None):
+            raise RuntimeError("workspace client unavailable")
+
+    sc = _consumer(BoomAdapter(), metadata={"slack_team_id": "T999"})
+
+    edited = await runner._fold_reasoning_into_streamed_message(
+        source=SimpleNamespace(platform="slack"),
+        stream_consumer=sc,
+        final_text="1161",
+        last_reasoning="thinking",
+        session_key="sess-1",
+    )
+    assert edited is False  # swallowed; answer already delivered by the stream
+
+
+# ---------------------------------------------------------------------------
+# Suppression gate — confirmed streamed delivery still sets already_sent, and
+# the fold's best-effort outcome does not change that (mirrors the reproduction
+# style in tests/gateway/test_duplicate_reply_suppression.py).
+# ---------------------------------------------------------------------------
+
+def _apply_suppression(response, sc):
+    _final = response.get("final_response") or ""
+    _is_empty_sentinel = not _final or _final == "(empty)"
+    _previewed = bool(response.get("response_previewed"))
+    _content_delivered = bool(sc and getattr(sc, "final_content_delivered", False))
+    _transformed = bool(response.get("response_transformed"))
+    _streamed = bool(sc and getattr(sc, "final_response_sent", False))
+    if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
+        # (fold runs here, best-effort, then:)
+        response["already_sent"] = True
+
+
+def test_confirmed_stream_delivery_sets_already_sent():
+    sc = SimpleNamespace(
+        final_response_sent=True,
+        final_content_delivered=True,
+    )
+    response = {"final_response": "1161", "response_previewed": False}
+    _apply_suppression(response, sc)
+    assert response.get("already_sent") is True
+
+
+def test_transformed_response_not_suppressed_here():
+    """A plugin-transformed response takes the sibling edit branch, not this
+    suppression path — already_sent must not be set by the fold branch."""
+    sc = SimpleNamespace(final_response_sent=True, final_content_delivered=True)
+    response = {
+        "final_response": "1161",
+        "response_previewed": False,
+        "response_transformed": True,
+    }
+    _apply_suppression(response, sc)
+    assert "already_sent" not in response

--- a/tests/gateway/test_streamed_reasoning_fold.py
+++ b/tests/gateway/test_streamed_reasoning_fold.py
@@ -1,0 +1,452 @@
+"""Streamed-turn reasoning fold (#57693).
+
+With streaming on, the stream consumer commits the final message and the
+gateway suppresses the normal send (``already_sent=True``). The normal send
+path is the only place the 💭 reasoning block is prepended, so streaming
+silently disabled reasoning display for every model/platform. The fix folds
+the block into the already-streamed message with one final edit, routed
+through the stream consumer's *metadata-aware* edit path so the edit still
+carries the routing metadata Slack uses to select the workspace client (a raw
+``adapter.edit_message`` would drop it and a non-default workspace would lose
+the reasoning).
+
+Coverage, on real code:
+  - gateway boundary (``GatewayRunner._run_agent`` with a live
+    ``GatewayStreamConsumer``): the streamed message is edited to carry the
+    reasoning block above the answer, ``already_sent`` still suppresses the
+    normal send, and there is no duplicate delivery;
+  - the fold's edit preserves the consumer's routing metadata;
+  - best-effort no-ops: no reasoning, no consumer, uncommitted stream,
+    ``__no_edit__``, split delivery (#78541), over-limit text, failing edit;
+  - ``_format_reasoning_block`` renders the same block the normal path did.
+"""
+
+import asyncio
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from gateway.config import Platform, PlatformConfig, StreamingConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+from gateway.stream_consumer import GatewayStreamConsumer
+
+
+# ---------------------------------------------------------------------------
+# Boundary-test fakes (same shape as tests/gateway/test_stale_finalize_suppression.py)
+# ---------------------------------------------------------------------------
+
+
+class FinalizeCaptureAdapter(BasePlatformAdapter):
+    """Adapter that records every send/edit, including routing metadata."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+        self.sent = []
+        self.edits = []
+        self._next_id = 0
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    def _mint_id(self) -> str:
+        self._next_id += 1
+        return f"m-{self._next_id}"
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SendResult(success=True, message_id=self._mint_id())
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+ANSWER = "27 times 43 is 1161."
+REASONING = "27*40 = 1080\n27*3 = 81\n1080 + 81 = 1161"
+REASONING_BLOCK = f"💭 **Reasoning:**\n```\n{REASONING}\n```"
+
+
+class ReasoningStreamAgent:
+    """Streams the complete answer and reports the reasoning it used."""
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback(ANSWER)
+        return {
+            "final_response": ANSWER,
+            "last_reasoning": REASONING,
+            "response_previewed": False,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.session_store = SimpleNamespace(_entries={}, _save=lambda: None)
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+        streaming=StreamingConfig.from_dict(
+            {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1}
+        ),
+    )
+    return runner
+
+
+async def _run_streaming_turn(monkeypatch, tmp_path, *, show_reasoning: bool, session_id: str):
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "display": {
+                    "tool_progress": "off",
+                    "interim_assistant_messages": False,
+                    "show_reasoning": show_reasoning,
+                },
+                "streaming": {
+                    "enabled": True,
+                    "edit_interval": 0.01,
+                    "buffer_threshold": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ReasoningStreamAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = FinalizeCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+    )
+    result = await runner._run_agent(
+        message="what is 27 times 43?",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id=session_id,
+        session_key="agent:main:telegram:group:-1001",
+    )
+    return adapter, result
+
+
+# ---------------------------------------------------------------------------
+# Gateway-boundary regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streamed_turn_folds_reasoning_and_still_suppresses(monkeypatch, tmp_path):
+    """A streamed turn with show_reasoning on ends with the streamed message
+    carrying the reasoning block above the answer, the normal send suppressed,
+    and no duplicate delivery."""
+    adapter, result = await _run_streaming_turn(
+        monkeypatch, tmp_path, show_reasoning=True, session_id="sess-57693-fold"
+    )
+
+    assert result["final_response"] == ANSWER
+    assert result.get("already_sent") is True
+
+    folded = [
+        e for e in adapter.edits
+        if e["content"] == f"{REASONING_BLOCK}\n\n{ANSWER}" and e["finalize"]
+    ]
+    assert folded, f"no finalize edit carried the reasoning block; edits: {adapter.edits!r}"
+    # The fold edits the message the stream committed (minted by the first
+    # send), not a new one.
+    assert folded[-1]["message_id"] == "m-1"
+    # Exactly one platform message holds the answer (streamed, then edited);
+    # the fold never triggers a second full send.
+    full_sends = [c for c in adapter.sent if ANSWER in c["content"]]
+    assert len(full_sends) <= 1, f"duplicate final delivery: {full_sends!r}"
+    assert not any("💭" in c["content"] for c in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_streamed_turn_without_show_reasoning_is_unchanged(monkeypatch, tmp_path):
+    """Control: with show_reasoning off no edit carries a reasoning block and
+    suppression still happens."""
+    adapter, result = await _run_streaming_turn(
+        monkeypatch, tmp_path, show_reasoning=False, session_id="sess-57693-control"
+    )
+
+    assert result.get("already_sent") is True
+    assert not any("💭" in e["content"] for e in adapter.edits)
+    assert not any("💭" in c["content"] for c in adapter.sent)
+
+
+# ---------------------------------------------------------------------------
+# Fold helper: metadata preservation + best-effort gates (real consumer)
+# ---------------------------------------------------------------------------
+
+
+class RecordingAdapter:
+    """Minimal adapter whose edit_message accepts (and records) metadata."""
+
+    MAX_MESSAGE_LENGTH = 4096
+
+    def __init__(self):
+        self.edits = []
+
+    async def edit_message(self, *, chat_id, message_id, content, finalize=False, metadata=None):
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+                "metadata": metadata,
+            }
+        )
+        return SimpleNamespace(success=True, message_id=message_id)
+
+
+class MetadataBlindAdapter:
+    """Adapter whose edit_message cannot accept metadata (no such param)."""
+
+    MAX_MESSAGE_LENGTH = 4096
+
+    def __init__(self):
+        self.edits = []
+
+    async def edit_message(self, *, chat_id, message_id, content, finalize=False):
+        self.edits.append(
+            {"chat_id": chat_id, "message_id": message_id, "content": content}
+        )
+        return SimpleNamespace(success=True, message_id=message_id)
+
+
+def _runner_with_block(block: str):
+    """A GatewayRunner with _format_reasoning_block stubbed to a fixed block,
+    isolating the fold wiring from gateway-config resolution."""
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._format_reasoning_block = lambda source, last_reasoning: (
+        block if last_reasoning else ""
+    )
+    return runner
+
+
+def _consumer(adapter, *, metadata=None, message_id="msg-1"):
+    sc = GatewayStreamConsumer(adapter, "chat-42", metadata=metadata)
+    sc._message_id = message_id
+    return sc
+
+
+def _fold(runner, sc, **overrides):
+    kwargs = dict(
+        source=SimpleNamespace(platform=Platform.SLACK),
+        stream_consumer=sc,
+        final_text="1161",
+        last_reasoning="27*43 = 1161",
+        session_key="sess-1",
+    )
+    kwargs.update(overrides)
+    return asyncio.run(runner._fold_reasoning_into_streamed_message(**kwargs))
+
+
+def test_fold_edits_streamed_message_with_reasoning_and_metadata():
+    runner = _runner_with_block(REASONING_BLOCK)
+    adapter = RecordingAdapter()
+    sc = _consumer(adapter, metadata={"slack_team_id": "T999"})
+
+    assert _fold(runner, sc) is True
+    assert len(adapter.edits) == 1
+    edit = adapter.edits[0]
+    assert edit["content"] == f"{REASONING_BLOCK}\n\n1161"   # block above answer
+    assert edit["message_id"] == "msg-1"                    # the streamed message
+    assert edit["finalize"] is True
+    assert edit["metadata"] == {"slack_team_id": "T999"}    # routing preserved
+
+
+def test_fold_omits_metadata_when_adapter_cannot_accept_it():
+    runner = _runner_with_block(REASONING_BLOCK)
+    adapter = MetadataBlindAdapter()
+    sc = _consumer(adapter, metadata={"slack_team_id": "T999"})
+
+    assert _fold(runner, sc) is True
+    assert adapter.edits == [
+        {"chat_id": "chat-42", "message_id": "msg-1", "content": f"{REASONING_BLOCK}\n\n1161"}
+    ]
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["no_reasoning", "no_consumer", "uncommitted", "no_edit_sentinel", "split_delivery"],
+)
+def test_fold_noops_when_nothing_editable(case):
+    runner = _runner_with_block(REASONING_BLOCK)
+    adapter = RecordingAdapter()
+    sc = _consumer(adapter, metadata={"slack_team_id": "T999"})
+    overrides = {}
+    if case == "no_reasoning":
+        overrides["last_reasoning"] = None
+    elif case == "no_consumer":
+        overrides["stream_consumer"] = None
+    elif case == "uncommitted":
+        sc._message_id = None
+    elif case == "no_edit_sentinel":
+        sc._message_id = "__no_edit__"
+    elif case == "split_delivery":
+        # message_id is only the LAST chunk; editing it with the complete
+        # response would repeat every sealed head chunk (#78541).
+        sc._turn_split_delivery = True
+
+    assert _fold(runner, sc, **overrides) is False
+    assert adapter.edits == []
+
+
+def test_fold_skips_when_folded_text_exceeds_chat_limit():
+    runner = _runner_with_block(REASONING_BLOCK)
+    adapter = RecordingAdapter()
+    adapter.MAX_MESSAGE_LENGTH = len(REASONING_BLOCK)  # no room for the answer
+    sc = _consumer(adapter)
+
+    assert _fold(runner, sc) is False
+    assert adapter.edits == []
+
+
+def test_fold_is_best_effort_on_edit_failure():
+    """A failed edit must not raise; it only loses the reasoning display."""
+    runner = _runner_with_block(REASONING_BLOCK)
+
+    class BoomAdapter:
+        MAX_MESSAGE_LENGTH = 4096
+
+        async def edit_message(self, *, chat_id, message_id, content, finalize=False, metadata=None):
+            raise RuntimeError("workspace client unavailable")
+
+    class FailingAdapter:
+        MAX_MESSAGE_LENGTH = 4096
+
+        async def edit_message(self, *, chat_id, message_id, content, finalize=False, metadata=None):
+            return SimpleNamespace(success=False, error="edit rejected")
+
+    assert _fold(runner, _consumer(BoomAdapter(), metadata={"slack_team_id": "T999"})) is False
+    assert _fold(runner, _consumer(FailingAdapter())) is False
+
+
+# ---------------------------------------------------------------------------
+# _format_reasoning_block: same rendering the normal send path used
+# ---------------------------------------------------------------------------
+
+
+def _runner_for_format(monkeypatch, config: dict):
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda *a, **k: config)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._show_reasoning = False
+    return runner
+
+
+def test_format_block_code_style_escapes_inner_fences(monkeypatch):
+    runner = _runner_for_format(monkeypatch, {"display": {"show_reasoning": True}})
+    block = runner._format_reasoning_block(
+        SimpleNamespace(platform=Platform.TELEGRAM), "use ```py\nx=1\n``` here"
+    )
+    assert block.startswith("💭 **Reasoning:**\n```\n")
+    assert block.endswith("\n```")
+    assert block.count("```") == 2  # only the outer fence survives
+
+
+def test_format_block_collapses_long_reasoning(monkeypatch):
+    runner = _runner_for_format(monkeypatch, {"display": {"show_reasoning": True}})
+    block = runner._format_reasoning_block(
+        SimpleNamespace(platform=Platform.TELEGRAM),
+        "\n".join(f"line {i}" for i in range(20)),
+    )
+    assert "line 14" in block and "line 15" not in block
+    assert "_... (5 more lines)_" in block
+
+
+@pytest.mark.parametrize(
+    "style, head, line_prefix",
+    [("subtext", "-# 💭 Reasoning", "-# "), ("blockquote", "> 💭 **Reasoning:**", "> ")],
+)
+def test_format_block_styles(monkeypatch, style, head, line_prefix):
+    runner = _runner_for_format(
+        monkeypatch, {"display": {"show_reasoning": True, "reasoning_style": style}}
+    )
+    block = runner._format_reasoning_block(
+        SimpleNamespace(platform=Platform.DISCORD), "a\nb"
+    )
+    assert block == f"{head}\n{line_prefix}a\n{line_prefix}b"
+
+
+def test_format_block_empty_when_display_off_or_no_reasoning(monkeypatch):
+    runner = _runner_for_format(monkeypatch, {"display": {"show_reasoning": False}})
+    src = SimpleNamespace(platform=Platform.TELEGRAM)
+    assert runner._format_reasoning_block(src, "thinking") == ""
+    runner = _runner_for_format(monkeypatch, {"display": {"show_reasoning": True}})
+    assert runner._format_reasoning_block(src, "") == ""
+    assert runner._format_reasoning_block(src, None) == ""
+
+
+def test_format_block_mattermost_requires_platform_override(monkeypatch):
+    src = SimpleNamespace(platform=Platform.MATTERMOST)
+    runner = _runner_for_format(monkeypatch, {"display": {"show_reasoning": True}})
+    assert runner._format_reasoning_block(src, "thinking") == ""
+    runner = _runner_for_format(
+        monkeypatch,
+        {"display": {"show_reasoning": True, "platforms": {"mattermost": {"show_reasoning": True}}}},
+    )
+    assert runner._format_reasoning_block(src, "thinking").startswith("💭 **Reasoning:**")


### PR DESCRIPTION
## Problem

With `streaming.enabled: true`, the stream consumer commits the final message and `_run_agent_inner` suppresses the normal send (`already_sent=True`). But the normal send path in `_handle_message_with_agent` is the **only** place the 💭 reasoning block is prepended (`show_reasoning` / `reasoning_style`). Net effect: enabling streaming silently turns off reasoning display for every model and every platform — the two features look independent but are mutually exclusive today.

Repro: any brain that emits `reasoning_content`, `display.show_reasoning: true`, `streaming.enabled: true` → the streamed final message arrives without the reasoning block; flip streaming off and it comes back.

## Fix

- Extract the block formatting into `_format_reasoning_block()` (per-platform `show_reasoning` resolution incl. the Mattermost explicit-override rule, 15-line collapse, `reasoning_style` rendering). The normal send path now calls it — behavior there is unchanged, this is a pure refactor.
- In the suppression branch, fold the block into the already-streamed message with one `edit_message(..., finalize=True)` — the exact pattern the plugin-transform branch directly below already uses for the same "content changed after streaming" situation.
- Best-effort: a failed edit only loses the reasoning display, never the answer, and never un-suppresses the send (no duplicate-message risk).

## Testing

- `tests/test_gateway_streaming_nested_config.py`: 3 passed.
- Live-verified on my install (Matrix platform, vLLM brains with `--reasoning-parser`): streamed turns now show the collapsed reasoning block again, identical to non-streamed turns. I've been running this fix in production since 2026-07-02 as a local patch.

Contact for CLA/CI: jonathan.kovacs999@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)