### PR TITLE
fix(xai): guard local media inputs against credential reads

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -137,6 +137,17 @@ def _xai_image_field(source: str) -> Dict[str, str]:
     import base64
     import os as _os
 
+    try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(source)
+        if blocked:
+            raise ValueError(blocked)
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.debug("xAI image input read guard unavailable: %s", exc)
+
     with open(_os.path.expanduser(source), "rb") as fh:  # windows-footgun: ok
         raw = fh.read()
     ext = (_os.path.splitext(source)[1].lstrip(".") or "png").lower()

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -127,6 +127,19 @@ def _xai_headers(api_key: str) -> Dict[str, str]:
     }
 
 
+def _raise_if_blocked_local_input(ref: str) -> None:
+    try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(ref)
+        if blocked:
+            raise ValueError(blocked)
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.debug("xAI media input read guard unavailable: %s", exc)
+
+
 def _image_ref_to_xai_url(value: str) -> str:
     """Return a URL/data URI accepted by xAI for image inputs."""
     ref = (value or "").strip()
@@ -139,6 +152,8 @@ def _image_ref_to_xai_url(value: str) -> str:
     path = Path(ref).expanduser()
     if not path.is_file():
         return ref
+
+    _raise_if_blocked_local_input(ref)
 
     mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
     if not mime.startswith("image/"):
@@ -194,6 +209,8 @@ def _video_ref_to_xai_url(value: str) -> str:
     path = Path(ref).expanduser()
     if not path.is_file():
         return ref
+
+    _raise_if_blocked_local_input(ref)
 
     mime = mimetypes.guess_type(path.name)[0] or "video/mp4"
     if not mime.startswith("video/"):

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -492,3 +492,22 @@ def test_xai_image_field_expands_user_home(tmp_path, monkeypatch):
     field = _xai_image_field("~/pic.png")
     assert field["type"] == "image_url"
     assert field["url"].startswith("data:image/png;base64,")
+
+
+def test_xai_image_field_blocks_credential_store_symlink(tmp_path, monkeypatch):
+    from plugins.image_gen.xai import _xai_image_field
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+    image_link = hermes_home / "leak.png"
+    try:
+        image_link.symlink_to(auth_json)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="credential store"):
+        _xai_image_field(str(image_link))

--- a/tests/plugins/video_gen/test_xai_plugin.py
+++ b/tests/plugins/video_gen/test_xai_plugin.py
@@ -186,3 +186,41 @@ def test_video_input_from_public_url_rejects_bare_file_id():
         )
     )
     assert result is None
+
+
+def test_xai_video_image_input_blocks_credential_store_symlink(tmp_path, monkeypatch):
+    from plugins.video_gen.xai import _image_ref_to_xai_input
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+    image_link = hermes_home / "leak.png"
+    try:
+        image_link.symlink_to(auth_json)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="credential store"):
+        _image_ref_to_xai_input(str(image_link))
+
+
+def test_xai_video_file_input_blocks_credential_store_symlink(tmp_path, monkeypatch):
+    from plugins.video_gen.xai import _video_ref_to_xai_url
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+    video_link = hermes_home / "leak.mp4"
+    try:
+        video_link.symlink_to(auth_json)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="credential store"):
+        _video_ref_to_xai_url(str(video_link))


### PR DESCRIPTION
## Summary

xAI image/video generation accepted local `image_url` / `reference_image_urls` inputs and converted them to base64 data URIs before sending requests to xAI. Those local input paths did not use Hermes' existing read guard, unlike the OpenAI Codex image input path.

A symlink such as `~/.hermes/leak.png -> ~/.hermes/auth.json` could be treated as an image-looking local path and its target bytes would be embedded in the outbound xAI payload. The same issue applied to xAI video image and video inputs.

## Changes

- Apply `agent.file_safety.get_read_block_error()` before xAI image generation reads local image inputs.
- Apply the same guard before xAI video generation reads local image or video inputs.
- Add regression tests for symlinked `auth.json` paths with `.png` / `.mp4` names.

## Security impact

This prevents model/tool-provided local media inputs from turning Hermes credential stores into base64 payloads sent to the xAI API. It aligns xAI with the existing OpenAI Codex image-input guard.

## Tests

```text
python -m pytest tests/plugins/image_gen/test_xai_provider.py -k credential_store_symlink -q --timeout-method=thread
1 passed, 29 deselected

python -m pytest tests/plugins/video_gen/test_xai_plugin.py -k credential_store_symlink -q --timeout-method=thread
2 passed, 12 deselected

python -m pytest tests/plugins/video_gen/test_xai_plugin.py -q --timeout-method=thread
14 passed