### PR TITLE
fix(gateway): normalize MSYS paths in validate_media_delivery_path

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1268,6 +1268,10 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if not candidate:
         return None
 
+    from tools.environments.local import _msys_to_windows_path
+
+    candidate = _msys_to_windows_path(candidate)
+
     try:
         expanded = Path(os.path.expanduser(candidate))
     except (OSError, RuntimeError, ValueError):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -928,6 +928,30 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(notes)) == str(notes.resolve())
 
+    def test_accepts_msys_path_after_windows_normalization(
+        self, tmp_path, monkeypatch,
+    ):
+        """Git Bash ``MEDIA:/c/Users/...`` must normalize before pathlib (#47767)."""
+        self._patch_roots(monkeypatch)
+        media = tmp_path / "photo.png"
+        media.write_bytes(b"png")
+
+        import tools.environments.local as local_mod
+
+        msys_input = "/c/Users/test/photo.png"
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        def _fake_msys(path: str) -> str:
+            assert path == msys_input
+            return str(media)
+
+        monkeypatch.setattr(local_mod, "_msys_to_windows_path", _fake_msys)
+
+        assert (
+            BasePlatformAdapter.validate_media_delivery_path(msys_input)
+            == str(media.resolve())
+        )
+
     def test_accepts_any_extension_not_on_denylist(self, tmp_path, monkeypatch):
         """No extension allowlist — .md, .txt, .json, .py all deliver."""
         self._patch_roots(monkeypatch)


### PR DESCRIPTION
## Summary
- Fixes #47767
- `MEDIA:/c/Users/...` paths from Git Bash were rejected by `validate_media_delivery_path()` because `pathlib` on Windows does not treat MSYS paths as absolute.
- Reuse the existing `_msys_to_windows_path()` helper from `tools.environments.local` (same normalization already used for terminal cwd resolution).

## Test plan
- [x] `pytest tests/gateway/test_platform_base.py::TestMediaDeliveryDefaultMode::test_accepts_msys_path_after_windows_normalization`
