### PR TITLE
fix(image-gen): guard local provider inputs against credential reads

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -147,6 +147,16 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
             ext = header.split("image/", 1)[1].split(";", 1)[0] or "png"
         return base64.b64decode(b64), f"image.{ext}"
     # Local file path.
+    try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(ref)
+        if blocked:
+            raise ValueError(blocked)
+    except ValueError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - preserve existing local-file behavior
+        logger.debug("OpenAI image input read guard unavailable: %s", exc)
     with open(ref, "rb") as fh:
         data = fh.read()
     name = os.path.basename(ref) or "image.png"

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -98,6 +98,16 @@ def _to_image_url_part(ref: str) -> Optional[str]:
         return ref
     path = Path(ref)
     try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(ref)
+        if blocked:
+            raise ValueError(blocked)
+    except ValueError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - keep local image refs best-effort
+        logger.debug("OpenRouter image input read guard unavailable: %s", exc)
+    try:
         raw = path.read_bytes()
     except OSError as exc:
         logger.debug("could not read reference image %s: %s", ref, exc)

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -124,6 +124,18 @@ class TestModelResolution:
 # ── Generate ────────────────────────────────────────────────────────────────
 
 
+class TestSourceImageLoading:
+    def test_load_image_bytes_blocks_credential_store(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        auth_json = hermes_home / "auth.json"
+        auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(ValueError, match="credential store"):
+            openai_plugin._load_image_bytes(str(auth_json))
+
+
 class TestGenerate:
     def test_empty_prompt_rejected(self, provider):
         result = provider.generate("", aspect_ratio="square")

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -169,6 +169,18 @@ class TestHelpers:
 
         assert _to_image_url_part("/no/such/file.png") is None
 
+    def test_to_image_url_part_blocks_credential_store(self, tmp_path, monkeypatch):
+        from plugins.image_gen.openrouter import _to_image_url_part
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        auth_json = hermes_home / "auth.json"
+        auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(ValueError, match="credential store"):
+            _to_image_url_part(str(auth_json))
+
     def test_extract_images(self):
         from plugins.image_gen.openrouter import _extract_images
 


### PR DESCRIPTION
## Summary

OpenAI and OpenRouter image-generation providers accepted local `image_url` / `reference_image_urls` inputs and read those paths before sending the bytes to the upstream provider.

Those local input paths did not use Hermes' existing `agent.file_safety.get_read_block_error()` guard. As a result, a model/tool-supplied path to a Hermes credential store could be read as source image input and leave the machine in the provider request.

The OpenAI Codex image provider already guards this same local-image path; this applies the same read boundary to the OpenAI and OpenRouter image providers.

## Changes

- Guard OpenAI image edit local source reads with `get_read_block_error()`.
- Guard OpenRouter local reference-image inlining with `get_read_block_error()`.
- Add regression coverage for `~/.hermes/auth.json` being rejected before local bytes are read/inlined.

## Security impact

This prevents image-generation reference inputs from bypassing Hermes' credential-file read denylist and sending local credential stores to external image providers.

## Tests

```text
python -m pytest tests/plugins/image_gen/test_openrouter_compat_provider.py -k "to_image_url_part" -q --timeout-method=thread
4 passed, 32 deselected

python -m pytest tests/plugins/image_gen/test_openai_provider.py -k "SourceImageLoading or b64_saves_to_cache" -q --timeout-method=thread
2 passed, 24 deselected