### PR TITLE
fix(stt): render local STT command placeholders by quote context

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -425,6 +425,73 @@ class TestTranscribeLocalCommand:
         assert result["transcript"] == "hello from local command"
         assert result["provider"] == "local_command"
 
+    def test_command_fallback_quotes_placeholder_by_context(
+        self, monkeypatch, tmp_path
+    ):
+        """Regression: local command placeholders must be rendered by quote
+        context, not with raw ``shlex.quote``.
+
+        ``shlex.quote`` is POSIX-only and always adds its own single quotes, so
+        a template that already wraps ``{input_path}`` in quotes ends up with
+        doubled quotes and the path splits into two shell arguments; on Windows
+        the single quotes also break every path (cmd.exe treats them
+        literally). ``_render_command_stt_template`` renders by context
+        (``subprocess.list2cmdline`` on Windows), keeping a spaced path a single
+        argument.
+        """
+        import shlex
+
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+
+        # {input_path} sits INSIDE single quotes in the template.
+        monkeypatch.setenv(
+            "HERMES_LOCAL_STT_COMMAND",
+            "whisper '{input_path}' --model {model} --output_dir {output_dir}",
+        )
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", "en")
+
+        spaced_input = str(tmp_path / "my audio.wav")
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return _TempDir()
+
+        captured = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            (out_dir / "out.txt").write_text("ok\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(
+            "tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._prepare_local_audio",
+            lambda fp, wd: (spaced_input, None),
+        )
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(spaced_input, "base")
+
+        assert result["success"] is True
+        # HERMES_LOCAL_STT_COMMAND set → use_shell=True → command is a shell
+        # string. The spaced input path must survive as ONE argument.
+        cmd = captured["cmd"]
+        assert isinstance(cmd, str)
+        assert spaced_input in shlex.split(cmd), (
+            f"input path was mangled by quoting: {cmd!r}"
+        )
+
 
 # ============================================================================
 # _transcribe_local — additional tests

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1225,11 +1225,22 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             if prep_error:
                 return {"success": False, "transcript": "", "error": prep_error}
 
-            command = command_template.format(
-                input_path=shlex.quote(prepared_input),
-                output_dir=shlex.quote(output_dir),
-                language=shlex.quote(language),
-                model=shlex.quote(normalized_model),
+            # Render placeholders by their quote context (and platform):
+            # ``shlex.quote`` is POSIX-only — on Windows it single-quotes
+            # values, which cmd.exe treats literally, so spaced/back-slashed
+            # paths break Local STT and shell metacharacters in a filename are
+            # not neutralized. ``_render_command_stt_template`` uses
+            # ``subprocess.list2cmdline`` on Windows and honours whether the
+            # placeholder sits inside quotes, mirroring the command-STT
+            # provider path above and ``tools.tts_tool``.
+            command = _render_command_stt_template(
+                command_template,
+                {
+                    "input_path": prepared_input,
+                    "output_dir": output_dir,
+                    "language": str(language),
+                    "model": normalized_model,
+                },
             )
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())


### PR DESCRIPTION
## What does this PR do?

`_transcribe_local_command` builds the shell command by interpolating
placeholder values with raw `shlex.quote()` via `str.format()`:

```python
command = command_template.format(
    input_path=shlex.quote(prepared_input),
    ...
)
```

`shlex.quote` is POSIX-only. On Windows it single-quotes values, which `cmd.exe`
(used on the `shell=True` path) treats literally — so spaced or back-slashed
paths break Local STT entirely, and shell metacharacters in an
attacker-influenced audio filename are not neutralized. It also always adds its
own quotes, so a placeholder that already sits inside quotes in a user template
gets doubled quotes and the path splits into multiple shell arguments.

The file already has the correct, platform- and context-aware renderer
(`_render_command_stt_template` → `_quote_command_stt_placeholder`, which uses
`subprocess.list2cmdline` on Windows). The command-STT provider path and
`tools.tts_tool` already use it; this one call site was the exception.

## Changes

- `tools/transcription_tools.py` — render local STT placeholders via
  `_render_command_stt_template` instead of raw `shlex.quote`.
- `tests/tools/test_transcription_tools.py` — regression test.

## Tests

```
pytest tests/tools/test_transcription_tools.py \
  tests/tools/test_transcription_command_providers.py -q
→ 157 passed, 1 skipped
```

A template that wraps `{input_path}` in quotes with a spaced path now keeps the
path a single shell argument (mutation-verified: raw `shlex.quote` splits it).