### PR TITLE
fix(agent): gate exhaustion cooldown to bounded window, preserve #24996 replay throttle

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1402,10 +1402,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
         ):
             _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0
-            agent._rate_limited_until = max(
-                _existing_cooldown,
-                time.monotonic() + _FALLBACK_EXHAUSTED_COOLDOWN_S,
-            )
+            _now = time.monotonic()
+            # Only arm a fresh exhaustion cooldown when the existing window
+            # has already expired (first exhaustion or expired cooldown).
+            # This prevents repeated calls on an already-exhausted chain from
+            # re-arming the gate every sub-window turn and locking out the
+            # primary restore permanently.  Keeps the bounded-replay
+            # guarantee from #24996 (at most one full chain walk per cooldown
+            # window) while allowing the throttle to naturally expire so the
+            # chain resets for unrelated later failures (#57582).
+            if _now >= _existing_cooldown:
+                agent._rate_limited_until = _now + _FALLBACK_EXHAUSTED_COOLDOWN_S
         return False
     fb = agent._fallback_chain[agent._fallback_index]
     agent._fallback_index += 1

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -130,3 +130,54 @@ class TestExhaustionArmsCooldown:
             assert agent._try_activate_fallback() is False
             cooldown = getattr(agent, "_rate_limited_until", 0)
         assert cooldown == far_future
+
+    def test_exhaustion_does_not_extend_active_cooldown(self):
+        """Repeated calls on an already-exhausted chain must not re-arm the
+        exhaustion cooldown while it is still active.  This prevents a
+        sub-window retry loop from permanently locking out the primary
+        restore (#57582)."""
+        fbs = [
+            {"provider": "openai", "model": "gpt-4o"},
+            {"provider": "zai", "model": "glm-4.7"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent._rate_limited_until = 0
+        frozen = 1_000.0
+
+        # Walk to exhaustion and arm the cooldown.
+        with (
+            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(), "resolved"),
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is False
+        first_cooldown = getattr(agent, "_rate_limited_until", 0)
+        assert first_cooldown == frozen + _FALLBACK_EXHAUSTED_COOLDOWN_S
+
+        # Still within the cooldown window -- must NOT extend.
+        still_in_window = frozen + _FALLBACK_EXHAUSTED_COOLDOWN_S - 1.0
+        with (
+            patch("agent.chat_completion_helpers.time.monotonic", return_value=still_in_window),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(), "resolved"),
+            ),
+        ):
+            assert agent._try_activate_fallback() is False
+        assert getattr(agent, "_rate_limited_until", 0) == first_cooldown
+
+        # After cooldown expires -- a new window IS armed.
+        after_expiry = frozen + _FALLBACK_EXHAUSTED_COOLDOWN_S + 0.5
+        with (
+            patch("agent.chat_completion_helpers.time.monotonic", return_value=after_expiry),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(), "resolved"),
+            ),
+        ):
+            assert agent._try_activate_fallback() is False
+        assert getattr(agent, "_rate_limited_until", 0) == after_expiry + _FALLBACK_EXHAUSTED_COOLDOWN_S

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -675,6 +675,55 @@ class TestRateLimitCooldown:
         result = agent._restore_primary_runtime()
         assert result is False
         assert agent._fallback_activated is True  # still on fallback
+        assert agent._fallback_index == 1  # #24996: index preserved during cooldown
+
+    def test_exhausted_chain_preserves_index_during_cooldown(self):
+        """Prior-turn chain exhaustion must not reset _fallback_index while
+        cooldown is active (#24996 bounded-replay guarantee)."""
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "openrouter", "model": "model-a"},
+                {"provider": "anthropic", "model": "model-b"},
+            ],
+        )
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is False
+
+        assert agent._fallback_index == 2
+        assert agent._fallback_activated is True
+        agent._rate_limited_until = time.monotonic() + 60
+
+        assert agent._restore_primary_runtime() is False
+        assert agent._fallback_activated is True
+        assert agent._fallback_index == 2  # #24996: preserved, not reset
+        assert agent._has_pending_fallback() is False
+
+    def test_exhausted_chain_resets_index_after_cooldown_expires(self):
+        """Once cooldown expires, restore resets the chain for a fresh walk (#57582)."""
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "openrouter", "model": "model-a"},
+                {"provider": "anthropic", "model": "model-b"},
+            ],
+        )
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is False
+
+        assert agent._fallback_index == 2
+        assert agent._fallback_activated is True
+        agent._rate_limited_until = time.monotonic() - 1  # expired
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert agent._fallback_activated is False
+        assert agent._fallback_index == 0
+        assert agent._has_pending_fallback() is True
 
     def test_restore_allowed_after_cooldown_expires(self):
         """Once the cooldown window passes, restore proceeds normally."""


### PR DESCRIPTION
## Summary
- Fixes #57582
- The exhaustion cooldown in `_try_activate_fallback()` now only arms a fresh window when the existing one has already expired (`now >= existing`). This prevents repeated calls on an already-exhausted chain from re-arming the gate every sub-window turn and locking out the primary restore permanently in long-lived sessions.
- `restore_primary_runtime()` is untouched: the index reset stays gated behind cooldown expiry, preserving the bounded-replay guarantee from #24996.

## Root cause
On main, when `_try_activate_fallback()` is called on an already-exhausted chain inside the active cooldown window, the `max(existing, now + window)` expression re-arms the cooldown at every invocation. For a long-lived cron/gateway session with sub-window turn cadence this makes the window self-extending -- the restore gate never expires, `_fallback_index` never resets, and failover stays permanently disabled (#57582).

## Fix
- `agent/chat_completion_helpers.py` -- only arm the exhaustion cooldown when `now >= existing` (first exhaustion or cooldown already expired). A new window is still armed after expiry, so the throttle still gates at most one full-chain replay per cooldown window -- it just cannot self-extend.

## Test plan
- [x] All existing #24996 regression tests pass (including `test_cooldown_never_shrinks_existing_window`: a longer already-armed window is still never reduced)
- [x] `test_exhaustion_does_not_extend_active_cooldown` -- frozen-clock proof that an active window is NOT extended on repeated exhausted calls, and a new window IS armed after expiry
- [x] `test_exhausted_chain_preserves_index_during_cooldown` -- cooldown holds the index at chain length; `_has_pending_fallback()` returns False (#24996 contract)
- [x] `test_exhausted_chain_resets_index_after_cooldown_expires` -- full reset + fresh walk after expiry (#57582)
- [x] 43/43 tests pass in `tests/run_agent/test_24996_fallback_exhaustion_cooldown.py` + `tests/run_agent/test_primary_runtime_restore.py`