### PR TITLE
fix(tools): remove redundant parent_session_id filter in session_search browse mode

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -273,9 +273,12 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             sid = s.get("id", "")
             if current_root and (sid == current_root or sid == current_session_id):
                 continue
-            # Skip child / delegation sessions
-            if s.get("parent_session_id"):
-                continue
+            # NOTE: child / delegation sessions are already excluded at
+            # SQL level by ``_LISTABLE_CHILD_SQL`` inside
+            # ``list_sessions_rich()``.  A Python-side
+            # ``parent_session_id`` filter here would incorrectly remove
+            # branch sessions that the SQL layer intentionally includes
+            # (branches have a parent_session_id but are listable).
             results.append({
                 "session_id": sid,
                 "title": s.get("title") or None,


### PR DESCRIPTION
## Problem
`session_search()` with no arguments (browse mode) returns only 3 sessions when the DB has 10. Discovery mode (with query) correctly returns 7-8. (Fixes #57606)

## Root Cause
`_list_recent_sessions()` has a Python-side `parent_session_id` filter that skips any session with a parent. But `list_sessions_rich()` already excludes sub-agent runs and compression continuations at SQL level via `_LISTABLE_CHILD_SQL`, while **correctly including branch sessions** (which have a parent_session_id).

The redundant Python filter incorrectly removes branch sessions from browse results.

## Fix
Remove the `if s.get('parent_session_id'): continue` guard in `_list_recent_sessions()`. The SQL-level filter in `list_sessions_rich()` already handles the correct scoping.

## Files Changed
- `tools/session_search_tool.py` — removed redundant Python-side parent filter

## Testing
- `ruff check` passes
- Browse mode now returns the same set of sessions the SQL layer considers listable