### PR TITLE
fix(tools): honor plugin web providers in extract/search dispatch

### DIFF
--- a/tests/tools/test_web_plugin_provider_dispatch.py
+++ b/tests/tools/test_web_plugin_provider_dispatch.py
@@ -1,0 +1,148 @@
+"""Regression tests for #57581 — plugin-registered web providers in config.
+
+When ``web.extract_backend`` / ``web.search_backend`` names a provider
+registered by a plugin (not in the legacy hardcoded allow-list), dispatch
+must honor that name via the registry instead of silently auto-detecting a
+different built-in backend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from agent.web_search_provider import WebSearchProvider
+from agent.web_search_registry import _reset_for_tests, register_provider
+
+
+class _PagepruneProvider(WebSearchProvider):
+    """Extract-only plugin provider used to mimic custom plugin backends."""
+
+    @property
+    def name(self) -> str:
+        return "pageprune"
+
+    @property
+    def display_name(self) -> str:
+        return "PagePrune"
+
+    def is_available(self) -> bool:
+        return True
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        return [
+            {
+                "url": urls[0],
+                "title": "PagePrune title",
+                "content": "from-pageprune",
+                "raw_content": "from-pageprune",
+            }
+        ]
+
+
+class _CustomSearchProvider(WebSearchProvider):
+    """Search-only plugin provider."""
+
+    @property
+    def name(self) -> str:
+        return "customsearch"
+
+    def is_available(self) -> bool:
+        return True
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        return {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "custom",
+                        "url": "https://example.com",
+                        "description": query,
+                        "position": 1,
+                    }
+                ]
+            },
+        }
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    yield
+    _reset_for_tests()
+
+
+@pytest.fixture
+def _allow_ssrf(monkeypatch):
+    async def _allow(_url: str) -> bool:
+        return True
+
+    from tools import web_tools
+
+    monkeypatch.setattr(web_tools, "async_is_safe_url", _allow)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+
+def test_web_extract_honors_plugin_extract_backend(monkeypatch, _allow_ssrf):
+    from tests.tools.conftest import register_all_web_providers
+    from tools import web_tools
+
+    register_all_web_providers()
+    register_provider(_PagepruneProvider())
+
+    monkeypatch.setattr(
+        web_tools,
+        "_load_web_config",
+        lambda: {
+            "backend": "",
+            "search_backend": "exa",
+            "extract_backend": "pageprune",
+        },
+    )
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-should-not-win")
+    monkeypatch.setenv("EXA_API_KEY", "exa-key")
+
+    result = json.loads(
+        asyncio.get_event_loop().run_until_complete(
+            web_tools.web_extract_tool(["https://example.com"])
+        )
+    )
+    assert result["results"][0]["content"] == "from-pageprune"
+
+
+def test_web_search_honors_plugin_search_backend(monkeypatch, _allow_ssrf):
+    from tests.tools.conftest import register_all_web_providers
+    from tools import web_tools
+
+    register_all_web_providers()
+    register_provider(_CustomSearchProvider())
+
+    monkeypatch.setattr(
+        web_tools,
+        "_load_web_config",
+        lambda: {
+            "backend": "tavily",
+            "search_backend": "customsearch",
+            "extract_backend": "tavily",
+        },
+    )
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-should-not-win")
+
+    result = json.loads(web_tools.web_search_tool("plugin query", limit=1))
+    assert result["success"] is True
+    assert result["data"]["web"][0]["description"] == "plugin query"

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -229,32 +229,33 @@ class TestDefaultConfig:
 
 
 class TestWebSearchUsesSearchBackend:
-    """web_search_tool dispatches through _get_search_backend not _get_backend."""
+    """web_search_tool dispatches through the web search registry."""
 
-    def test_search_tool_calls_search_backend(self, monkeypatch):
+    def test_search_tool_uses_configured_registry_provider(self, monkeypatch):
         from tools import web_tools
 
-        called_with = []
-        original_get_search = web_tools._get_search_backend
+        called = {"active": False}
 
-        def tracking_get_search():
-            result = original_get_search()
-            called_with.append(("search", result))
-            return result
+        def _track_active():
+            called["active"] = True
+            return None
 
-        monkeypatch.setattr(web_tools, "_get_search_backend", tracking_get_search)
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_search_provider",
+            _track_active,
+        )
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "firecrawl"})
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fake")
 
-        # The function will fail at Firecrawl client level but we just
-        # need to verify _get_search_backend was called
         try:
             web_tools.web_search_tool("test", 1)
         except Exception:
             pass
 
-        assert len(called_with) > 0
-        assert called_with[0][0] == "search"
+        # Explicit web.backend resolves directly via registry lookup; the
+        # availability-walk fallback is only used when no configured name
+        # maps to a registered provider.
+        assert called["active"] is False
 
 
 class TestUnconfiguredErrorEnvelopeParity:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -209,8 +209,30 @@ def _get_capability_backend(capability: str) -> str:
     return _get_backend()
 
 
+def _configured_web_backend(capability: str) -> str:
+    """Return the explicit backend name for *capability* from config."""
+    cfg = _load_web_config()
+    specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
+    if specific:
+        return specific
+    return (cfg.get("backend") or "").lower().strip()
+
+
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable."""
+    if not backend:
+        return False
+    try:
+        from agent.web_search_registry import get_provider
+
+        provider = get_provider(backend)
+        if provider is not None:
+            try:
+                return bool(provider.is_available())
+            except Exception:
+                return False
+    except Exception:
+        pass
     if backend == "exa":
         return _has_env("EXA_API_KEY")
     if backend == "parallel":
@@ -568,12 +590,28 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             get_provider as _wsp_get_provider,
         )
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
+        configured = _configured_web_backend("search")
+        provider = None
+        if configured:
+            named = _wsp_get_provider(configured)
+            if named is not None and not named.supports_search():
+                response_data = {
+                    "success": False,
+                    "error": (
+                        f"{named.display_name} does not support web search. "
+                        "Set web.search_backend to a search-capable provider."
+                    ),
+                }
+                debug_call_data["error"] = response_data["error"]
+                result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+                debug_call_data["final_response_size"] = len(result_json)
+                _debug.log_call("web_search_tool", debug_call_data)
+                _debug.save()
+                return result_json
+            if named is not None:
+                provider = named
+
+        if provider is None:
             provider = get_active_search_provider()
 
         if provider is None:
@@ -706,35 +744,26 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
-
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
-            # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
-            # detect coroutine functions and await; sync functions run
-            # inline (the policy gate, SSRF re-check, etc. live inside the
-            # provider itself for the firecrawl per-URL loop).
+            # All web providers (built-in and plugin-registered) live in the
+            # registry. Resolve via get_active_extract_provider() so explicit
+            # web.extract_backend names are honored even when they are not in
+            # the legacy hardcoded allow-list (#57581).
             _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,
             )
 
-            provider = _wsp_get_provider(backend) if backend else None
-            if provider is None or not provider.supports_extract():
-                # When the configured name IS registered but doesn't support
-                # extract (search-only providers like brave-free / ddgs /
-                # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
-                if provider is not None and not provider.supports_extract():
+            configured = _configured_web_backend("extract")
+            provider = None
+            if configured:
+                named = _wsp_get_provider(configured)
+                if named is not None and not named.supports_extract():
                     return json.dumps(
                         {
                             "success": False,
                             "error": (
-                                f"{provider.display_name} is a search-only "
+                                f"{named.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
                                 "Set web.extract_backend to firecrawl, "
                                 "tavily, exa, or parallel."
@@ -742,19 +771,23 @@ async def web_extract_tool(
                         },
                         ensure_ascii=False,
                     )
+                if named is not None:
+                    provider = named
+
+            if provider is None:
                 provider = get_active_extract_provider()
-                if provider is None:
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                "No web extract provider configured. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
-                    )
+            if provider is None:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            "No web extract provider configured. "
+                            "Set web.extract_backend to firecrawl, "
+                            "tavily, exa, or parallel."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
 
             logger.info(
                 "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)


### PR DESCRIPTION
## Summary

- Route `web_search` / `web_extract` through the plugin-aware web provider registry so explicit `web.search_backend` / `web.extract_backend` names (including plugin-registered providers like `pageprune`) are honored instead of silently falling back to auto-detected built-ins.
- Make `_is_backend_available()` consult the registry first, so per-capability backend helpers recognize plugin providers once registered.
- Preserve the existing search-only misconfiguration error when a search backend is configured for extract (and vice versa).

Fixes #57581

## Test plan

- [x] `pytest tests/tools/test_web_plugin_provider_dispatch.py`
- [x] `pytest tests/tools/test_web_providers.py::TestPerCapabilityBackendSelection`
- [x] `pytest tests/tools/test_web_providers_searxng.py::TestSearXNGOnlyExtractCrawlErrors`
