### PR TITLE
fix(gateway): recover from WebSocket constructor failures

### DIFF
--- a/apps/desktop/src/lib/json-rpc-gateway.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { JsonRpcGatewayClient } from '@hermes/shared'
+
+describe('JsonRpcGatewayClient connect', () => {
+  it('resets state after a synchronous socket construction failure', async () => {
+    const socketFactory = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('bad socket url')
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('retry reached factory')
+      })
+    const client = new JsonRpcGatewayClient({ socketFactory })
+
+    await expect(client.connect('wss://example.invalid/ws')).rejects.toThrow('bad socket url')
+
+    expect(client.connectionState).toBe('error')
+
+    await expect(client.connect('wss://example.invalid/ws')).rejects.toThrow('retry reached factory')
+    expect(socketFactory).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -98,7 +98,15 @@ export class JsonRpcGatewayClient {
 
     this.setState('connecting')
 
-    const socket = this.options.socketFactory?.(wsUrl) ?? new WebSocket(wsUrl)
+    let socket: WebSocketLike
+    try {
+      socket = this.options.socketFactory?.(wsUrl) ?? new WebSocket(wsUrl)
+    } catch (error) {
+      this.socket = null
+      this.setState('error')
+      throw (error instanceof Error ? error : new Error(this.options.connectErrorMessage))
+    }
+
     this.socket = socket
 
     socket.addEventListener('message', message => {


### PR DESCRIPTION
## What does this PR do?

Fixes a JSON-RPC gateway state-machine bug where a synchronous WebSocket construction failure could leave the shared client stuck in `connecting` and block later retry attempts.

### What Problem This Solves

`JsonRpcGatewayClient.connect()` moved the client into `connecting` before constructing the WebSocket:

```ts
this.setState('connecting')
const socket = this.options.socketFactory?.(wsUrl) ?? new WebSocket(wsUrl)
```

If `socketFactory(wsUrl)` or `new WebSocket(wsUrl)` throws synchronously, no socket is assigned and none of the normal `open`, `error`, close, or timeout cleanup handlers are installed. The client can then remain in `connecting`.

That stale state matters because the next `connect()` call returns early when `this.state === 'connecting'`. For callers using the shared gateway client, including the desktop gateway path covered by the regression test, one construction error could turn later retry attempts into no-ops until the client is reset or the app/page is reloaded.

### Changes

This PR wraps WebSocket construction in a small `try/catch` inside `JsonRpcGatewayClient.connect()`.

On synchronous construction failure, the client now:

- clears `this.socket`
- moves the connection state to `error`
- rethrows the original `Error` when available
- falls back to the existing `connectErrorMessage` when the thrown value is not an `Error`
- preserves the existing async `open`, `error`, close, timeout, request, and pending-call behavior

The fix stays in `apps/shared/src/json-rpc-gateway.ts`, where the connection state transition is owned, instead of adding recovery logic in a desktop/web caller.

### Evidence

The added regression test simulates a socket factory that throws during construction. It verifies that the first failure moves the client to `error` and that a second `connect()` attempt reaches the factory again rather than being short-circuited by stale `connecting` state.

Validation passed locally on Windows:

```powershell
npm run --prefix apps/desktop test:ui -- src/lib/json-rpc-gateway.test.ts
npm run --prefix apps/shared typecheck
npm run --prefix apps/desktop typecheck
git diff --check
```

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

GitHub did not report a populated `statusCheckRollup` when this body text was prepared, so the evidence above is local author-run validation rather than a claim that remote CI has completed.

### Possible call chain / impact

```text
Desktop/shared gateway connect path
  -> JsonRpcGatewayClient.connect(wsUrl)
  -> socketFactory(wsUrl) or new WebSocket(wsUrl)
  -> synchronous construction error before listeners are registered
  -> stale connecting state blocks retry
```

This PR only changes the pre-socket construction failure path. It does not change successful connection behavior, async WebSocket `error` handling, timeout cleanup, close handling, JSON-RPC request/response dispatch, or pending request rejection.
## Related Issue

N/A - small gateway state-machine bug found during source review.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `apps/shared/src/json-rpc-gateway.ts`: reset client state to `error` if WebSocket construction throws synchronously.
- `apps/desktop/src/lib/json-rpc-gateway.test.ts`: add a focused regression proving a second `connect()` attempt reaches the socket factory instead of being short-circuited by stale `connecting` state.

## How to Test

1. Simulate a synchronous socket construction failure:
   ```ts
   const client = new JsonRpcGatewayClient({
     socketFactory: () => {
       throw new Error('bad socket url')
     }
   })
   ```
2. Before this fix, the first failure could leave `connectionState === 'connecting'`, causing the next connect attempt to no-op.
3. After this fix, `connectionState === 'error'` and the next connect attempt invokes the factory again.
4. Run:
   ```powershell
   npm run --prefix apps/desktop test:ui -- src/lib/json-rpc-gateway.test.ts
   npm run --prefix apps/shared typecheck
   npm run --prefix apps/desktop typecheck
   git diff --check
   ```

Validation results on Windows:

- `npm run --prefix apps/desktop test:ui -- src/lib/json-rpc-gateway.test.ts` - passed, 1 test
- `npm run --prefix apps/shared typecheck` - passed
- `npm run --prefix apps/desktop typecheck` - passed
- `git diff --check` - passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Node local environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Screenshots / Logs

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```
