### PR TITLE
fix: stop double-counting reasoning_tokens in session token totals

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -514,7 +514,8 @@ class GatewaySlashCommandsMixin:
                         + _int_value(row.get("output_tokens"))
                         + _int_value(row.get("cache_read_tokens"))
                         + _int_value(row.get("cache_write_tokens"))
-                        + _int_value(row.get("reasoning_tokens"))
+                        # reasoning_tokens is a subset of output_tokens
+                        # — do NOT add it again.  See #57565.
                     )
             except Exception:
                 db_total_tokens = 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1354,7 +1354,8 @@ def _print_tui_exit_summary(
             + output_tokens
             + cache_read_tokens
             + cache_write_tokens
-            + reasoning_tokens
+            # reasoning_tokens is a subset of output_tokens — do NOT add
+            # it again here or the total will be over-counted.  See #57565.
         )
     except Exception:
         return


### PR DESCRIPTION
Fixes #57565

`reasoning_tokens` is a **subset** of `output_tokens` (providers report it as a breakdown of completion tokens). Adding it separately over-counts the total by exactly `reasoning_tokens`.

Two callsites fixed:
- `hermes_cli/main.py:1352` — TUI-exit resume summary
- `gateway/slash_commands.py:512` — gateway `/status` cumulative tokens

The codebase's own `CanonicalUsage.total_tokens` already excludes reasoning from the sum — these two UI paths were the only outliers.

## Files Changed
- `hermes_cli/main.py` — removed `+ reasoning_tokens` from total
- `gateway/slash_commands.py` — same