### PR TITLE
fix(model-switch): skip providers not in PROVIDER_REGISTRY from /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1628,11 +1628,18 @@ def list_authenticated_providers(
         # source of truth.  models.dev can have wrong mappings (e.g.
         # minimax-cn → MINIMAX_API_KEY instead of MINIMAX_CN_API_KEY).
         pconfig = PROVIDER_REGISTRY.get(hermes_id)
+        # Providers not in PROVIDER_REGISTRY cannot be resolved by
+        # resolve_provider_full() — they appear in the picker via
+        # models.dev but selecting them fails with "Unknown provider".
+        # Skip them; the user's custom_providers entry (if any) covers
+        # the same vendor under a routable slug.  See #57503.
+        if pconfig is None:
+            continue
         # Skip non-API-key auth providers here — they are handled in
         # section 2 (HERMES_OVERLAYS) with proper auth store checking.
-        if pconfig and pconfig.auth_type != "api_key":
+        if pconfig.auth_type != "api_key":
             continue
-        if pconfig and pconfig.api_key_env_vars:
+        if pconfig.api_key_env_vars:
             env_vars = list(pconfig.api_key_env_vars)
         else:
             env_vars = pdata.get("env", [])


### PR DESCRIPTION
Fixes #57503

Providers in `PROVIDER_TO_MODELS_DEV` (models.dev) that have no entry in `PROVIDER_REGISTRY` (auth.py) cannot be resolved by `resolve_provider_full()`. Selecting them in the `/model` picker fails with `Unknown provider '<name>'`.

This affected `mistral` (72 models from models.dev, 0 routable). When a user also had a `custom_providers` entry for Mistral, two entries appeared — one broken (built-in) and one working (custom).

## Fix
Skip any `PROVIDER_TO_MODELS_DEV` entry whose `hermes_id` is not in `PROVIDER_REGISTRY`. The user's `custom_providers` entry (if any) covers the same vendor under a routable slug.

## Files Changed
- `hermes_cli/model_switch.py` — added `PROVIDER_REGISTRY` presence check before listing provider in picker