### PR TITLE
fix(kanban): allow reassigned review handoffs after active PR comments

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6755,6 +6755,23 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def _has_handoff_after(conn: sqlite3.Connection, task_id: str, created_at: int) -> bool:
+    """Return True if an operator/automation handed off ``task_id`` after ``created_at``.
+
+    The active-PR respawn guard prevents duplicate implementation workers after
+    a worker opens a PR. A later assignment or explicit unblock is an intentional
+    routing/recovery action (for example Archer → CASEE/default review, or CASEE
+    changes-requested → Archer rework), so the PR guard must not keep the task
+    stranded in ready forever.
+    """
+    return conn.execute(
+        "SELECT id FROM task_events "
+        "WHERE task_id = ? AND kind IN ('assigned', 'unblocked') AND created_at > ? "
+        "ORDER BY created_at DESC LIMIT 1",
+        (task_id, int(created_at)),
+    ).fetchone() is not None
+
+
 def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
@@ -6793,8 +6810,10 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) and no later assignment/recovery
+        event exists.  A prior worker already opened a PR; re-spawning the same
+        lane risks a duplicate PR on the same task, but a later reassignment is
+        an explicit handoff/review action and must be allowed to spawn.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -6861,12 +6880,17 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    If the task was assigned after the PR comment, treat that as an
+    #    explicit handoff/recovery action (for example implementation worker →
+    #    reviewer) and allow dispatch instead of stranding review in ready.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            if _has_handoff_after(conn, task_id, int(c["created_at"] or 0)):
+                continue
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1905,6 +1905,50 @@ def test_respawn_guard_active_pr_in_comment(kanban_home):
     assert reason == "active_pr"
 
 
+def test_respawn_guard_active_pr_allows_later_reassignment(kanban_home, monkeypatch):
+    """A PR handoff should not strand a task once it is reassigned for review.
+
+    The active_pr guard is meant to prevent duplicate implementation workers,
+    not block a later Archer → CASEE/default review handoff.
+    """
+    now = int(time.time())
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="has-pr-for-review", assignee="archer")
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+        kb.add_comment(
+            conn, t, "archer",
+            "review-required: https://github.com/totemx-AI/subsidysmart/pull/42",
+        )
+        assert kb.check_respawn_guard(conn, t) == "active_pr"
+
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
+        assert kb.assign_task(conn, t, "default")
+        assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_active_pr_allows_later_unblock(kanban_home, monkeypatch):
+    """Changes-requested unblocks should not remain stranded by active_pr.
+
+    CASEE commonly blocks a PR-bearing task for review/change criteria, then
+    unblocks it for the same implementer to rework the existing PR. That explicit
+    unblock is a recovery handoff, not a duplicate-spawn hazard.
+    """
+    now = int(time.time())
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="has-pr-for-rework", assignee="archer")
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+        kb.add_comment(
+            conn, t, "archer",
+            "review-required: https://github.com/totemx-AI/subsidysmart/pull/43",
+        )
+        assert kb.check_respawn_guard(conn, t) == "active_pr"
+
+        kb.block_task(conn, t, reason="changes requested")
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
+        assert kb.unblock_task(conn, t)
+        assert kb.check_respawn_guard(conn, t) is None
+
+
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     """A GitHub PR URL in a comment older than the PR window does not block."""
     with kb.connect() as conn:
@@ -2013,6 +2057,35 @@ def test_dispatch_respawn_guard_skips_active_pr(
     assert t not in res.auto_blocked
     with kb.connect() as conn:
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_dispatch_active_pr_allows_later_reassignment(
+    kanban_home, all_assignees_spawnable, monkeypatch
+):
+    """A reassigned PR handoff is spawnable for the reviewer lane."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    now = int(time.time())
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="has-pr-review", assignee="archer")
+        monkeypatch.setattr(kb.time, "time", lambda: now)
+        kb.add_comment(
+            conn, t, "archer",
+            "review-required: https://github.com/totemx-AI/subsidysmart/pull/99",
+        )
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
+        assert kb.assign_task(conn, t, "default")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert not res.respawn_guarded
+    assert t in spawned_ids
+    with kb.connect() as conn:
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.status == "running"
 
 
 def test_dispatch_respawn_guard_dry_run_no_auto_block(


### PR DESCRIPTION
## Problem

The Kanban `active_pr` respawn guard prevents duplicate worker spawns when a recent task comment contains a GitHub PR URL. That is useful for avoiding duplicate implementation PRs, but it currently also blocks explicit review handoffs.

A common lifecycle is:

1. Worker opens a PR and comments with the PR URL.
2. Worker blocks/marks the task review-required.
3. Router or human reassigns the task to a reviewer profile.
4. Dispatcher should spawn the reviewer.

Today step 4 is skipped because `check_respawn_guard()` still returns `active_pr`, leaving the task stranded in `ready`.

## Fix

Treat assignment/reassignment after the PR comment as an explicit routing/recovery action. The `active_pr` guard still applies when the PR URL is the latest relevant signal, but no longer blocks a later reviewer handoff.

This preserves the original duplicate-PR protection while allowing implementer → reviewer Kanban flows.

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_db.py::test_respawn_guard_active_pr_in_comment tests/hermes_cli/test_kanban_db.py::test_respawn_guard_active_pr_allows_later_reassignment tests/hermes_cli/test_kanban_db.py::test_dispatch_respawn_guard_skips_active_pr tests/hermes_cli/test_kanban_db.py::test_dispatch_active_pr_allows_later_reassignment -q`
  - `4 passed in 0.95s`
- `python -m pytest tests/hermes_cli/test_kanban_db.py -q`
  - `225 passed in 29.26s`
