### PR TITLE
fix(secret_scope): strip inline # comments from .env values

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -187,6 +187,20 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
         if not key:
             continue
         value = value.strip()
+        # Strip inline # comments (only # outside quotes)
+        in_quote = None
+        comment_at = -1
+        for i, c in enumerate(value):
+            if c in ("'", '"') and (i == 0 or value[i - 1] != "\\"):
+                if in_quote is None:
+                    in_quote = c
+                elif c == in_quote:
+                    in_quote = None
+            elif c == "#" and in_quote is None:
+                comment_at = i
+                break
+        if comment_at >= 0:
+            value = value[:comment_at].rstrip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
             value = value[1:-1]
         secrets[key] = value


### PR DESCRIPTION
## Problem

`load_env_file` parses `.env` files but has no logic to strip inline `#` comments. A line like `KEY=value # comment` loads `value # comment` as the secret value, including the comment text and trailing whitespace.

This is a common `.env` pattern - `python-dotenv` and every other parser handle it. Without it, users who add an inline comment after a value silently get wrong credentials.

## Fix

Add a character-by-character scanner that tracks single/double-quote state and strips only `#` characters that appear outside quotes. Quoted values containing literal `#` (e.g. `PASSWORD="pass#word"`) are preserved correctly.

## Test cases
| Input | Expected |
|-------|----------|
| `KEY=value # comment` | `value` |
| `KEY="value with # inside" # trailing` | `value with # inside` |
| `KEY=plainvalue` | `plainvalue` |
| `KEY=foo#bar # comment` | `foo` |