### PR TITLE
fix(signal): clean up AAC remux temp file on early write failure

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -160,37 +160,48 @@ def _remux_aac_to_m4a(aac_data: bytes) -> Optional[Tuple[bytes, str]]:
     if not ffmpeg:
         logger.debug("Signal: ffmpeg not found, skipping AAC→M4A remux")
         return None
+    src_path = None
+    dst_path = None
     try:
         with tempfile.NamedTemporaryFile(suffix=".aac", delete=False) as src:
-            src.write(aac_data)
+            # Capture the name before writing: NamedTemporaryFile has already
+            # created the file on disk, so if src.write() fails the finally
+            # below can still unlink it.
             src_path = src.name
+            src.write(aac_data)
         dst_path = src_path[:-4] + ".m4a"
-        try:
-            proc = subprocess.run(
-                [ffmpeg, "-y", "-loglevel", "error", "-i", src_path,
-                 "-c:a", "copy", "-movflags", "+faststart", dst_path],
-                capture_output=True, timeout=10,
+        proc = subprocess.run(
+            [ffmpeg, "-y", "-loglevel", "error", "-i", src_path,
+             "-c:a", "copy", "-movflags", "+faststart", dst_path],
+            capture_output=True, timeout=10,
+        )
+        if proc.returncode != 0:
+            logger.warning(
+                "Signal: AAC→M4A remux failed (ffmpeg exit %d): %s",
+                proc.returncode, proc.stderr.decode("utf-8", "replace")[:300],
             )
-            if proc.returncode != 0:
-                logger.warning(
-                    "Signal: AAC→M4A remux failed (ffmpeg exit %d): %s",
-                    proc.returncode, proc.stderr.decode("utf-8", "replace")[:300],
-                )
-                return None
-            with open(dst_path, "rb") as f:
-                return f.read(), ".m4a"
-        finally:
-            for p in (src_path, dst_path):
-                try:
-                    os.unlink(p)
-                except OSError:
-                    pass
+            return None
+        with open(dst_path, "rb") as f:
+            return f.read(), ".m4a"
     except subprocess.TimeoutExpired:
         logger.warning("Signal: AAC→M4A remux timed out (>10s)")
         return None
     except Exception:
         logger.exception("Signal: AAC→M4A remux error")
         return None
+    finally:
+        # Clean up temp files across the whole operation. The previous cleanup
+        # sat in an inner try/finally that was only entered after the ffmpeg
+        # subprocess started, so a failure in NamedTemporaryFile creation or
+        # src.write() (e.g. a disk-full IOError) left the .aac temp orphaned on
+        # disk. src_path/dst_path are None until each is created, so unlinking
+        # is skipped for whatever wasn't reached.
+        for p in (src_path, dst_path):
+            if p:
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
 
 
 def _render_mentions(text: str, mentions: list) -> str:

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -261,6 +261,44 @@ class TestSignalHelpers:
             m4a_bytes, ext = result
             assert ext == ".m4a"
 
+    def test_remux_cleans_up_temp_on_write_failure(self, monkeypatch):
+        """Regression: a failure writing the source temp file (e.g. disk full)
+        must not leak the .aac temp file.
+
+        The cleanup used to live in an inner try/finally that was only entered
+        after the ffmpeg subprocess started, so an IOError in ``src.write()``
+        (before that point) left the ``.aac`` temp orphaned on disk.
+        """
+        import os
+        import tempfile as _tempfile
+        import gateway.platforms.signal as sig
+
+        # Pretend ffmpeg exists so we reach the temp-file creation step.
+        monkeypatch.setattr(sig.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+        created = []
+        real_ntf = _tempfile.NamedTemporaryFile
+
+        def fake_ntf(*args, **kwargs):
+            f = real_ntf(*args, **kwargs)
+            created.append(f.name)
+
+            def _boom(_data):
+                raise OSError("No space left on device")
+
+            f.write = _boom
+            return f
+
+        monkeypatch.setattr(sig.tempfile, "NamedTemporaryFile", fake_ntf)
+
+        result = sig._remux_aac_to_m4a(b"\xff\xf1 aac payload")
+
+        assert result is None
+        assert created, "temp file was never created"
+        assert not os.path.exists(created[0]), (
+            f"temp .aac file leaked on write failure: {created[0]}"
+        )
+
     def test_guess_extension_unknown(self):
         from gateway.platforms.signal import _guess_extension
         assert _guess_extension(b"\x00\x01\x02\x03" * 10) == ".bin"


### PR DESCRIPTION
## What does this PR do?

`_remux_aac_to_m4a` creates the source temp file with
`NamedTemporaryFile(suffix=".aac", delete=False)`, but the `os.unlink` cleanup
lived in an **inner** `try/finally` that was only entered once the ffmpeg
subprocess step began:

```python
with tempfile.NamedTemporaryFile(suffix=".aac", delete=False) as src:
    src.write(aac_data)          # disk-full IOError here …
    src_path = src.name
dst_path = src_path[:-4] + ".m4a"
try:
    proc = subprocess.run(...)
    ...
finally:
    for p in (src_path, dst_path):   # … never reached
        os.unlink(p)
```

If `NamedTemporaryFile` creation or `src.write()` fails first (e.g. a disk-full
`IOError`), execution jumps straight to the outer `except Exception`, leaving
the `.aac` temp orphaned on disk. Every such failure leaks one file.

## Changes

- `gateway/platforms/signal.py` — capture the temp path before writing, hoist
  cleanup into a single outer `finally`, and guard each unlink with a `None`
  check so only files that were actually created are removed. The timeout /
  ffmpeg-failure paths already ran the old inner finally, so they're unchanged.
- `tests/gateway/test_signal.py` — regression test.

## Tests

```
pytest tests/gateway/test_signal.py -q
→ 136 passed, 1 skipped
```

The regression test forces `src.write()` to raise and asserts the `.aac` temp
file is gone afterwards (mutation-verified: the old inner-finally leaks it).