### PR TITLE
fix(kanban): signal worker process group on reclaim, not just leader pid

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5942,9 +5942,36 @@ def _terminate_reclaimed_worker(
     if kill is None:
         return info
 
+    # Workers are spawned with ``start_new_session=True`` (see the spawn path),
+    # so each worker is its own process-group / session leader (pgid == pid).
+    # Signalling only the leader pid leaves its child subprocesses — backtest
+    # runners, and ``scp``/``ssh`` during deploy — orphaned and still running.
+    # Because the leader then dies, the reclaim path releases the claim and the
+    # dispatcher spawns a fresh worker beside those survivors: subprocess-level
+    # duplicate execution (on a deploy task, a double registration risk).
+    # Deliver to the whole group so the worker and its descendants die together.
+    # Only on the real ``os.kill`` path — an injected ``signal_fn`` (tests) is a
+    # single-pid hook and must be preserved as-is.
+    _use_group = (
+        signal_fn is None
+        and hasattr(os, "killpg")
+        and hasattr(os, "getpgid")
+    )
+
+    def _deliver(sig) -> None:
+        if _use_group:
+            try:
+                os.killpg(os.getpgid(int(pid)), sig)
+                return
+            except (ProcessLookupError, OSError):
+                # Group already gone, or getpgid raced the exit — fall back to
+                # the leader pid so the outer handlers see the right outcome.
+                pass
+        kill(int(pid), sig)
+
     info["termination_attempted"] = True
     try:
-        kill(int(pid), signal.SIGTERM)
+        _deliver(signal.SIGTERM)
     except ProcessLookupError:
         # Process is already gone — that's a successful termination, not a
         # survival. Leaving terminated=False here would make the reclaim guard
@@ -5965,7 +5992,7 @@ def _terminate_reclaimed_worker(
             # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
             # (which maps to TerminateProcess via the stdlib shim).
             _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-            kill(int(pid), _sigkill)
+            _deliver(_sigkill)
             info["sigkill"] = True
         except (ProcessLookupError, OSError):
             return info

--- a/tests/hermes_cli/test_kanban_terminate_group.py
+++ b/tests/hermes_cli/test_kanban_terminate_group.py
@@ -1,0 +1,55 @@
+"""Focused tests for the killpg group-termination patch in
+_terminate_reclaimed_worker. Run against the patched module."""
+import os
+import signal
+import types
+
+import hermes_cli.kanban_db as kb
+
+
+def _claimer_host():
+    # claim_lock must start with "<host>:" for host-local termination.
+    return kb._claimer_id().split(":", 1)[0]
+
+
+def test_group_kill_used_on_real_path(monkeypatch):
+    """signal_fn=None → deliver via killpg(getpgid(pid)), not os.kill."""
+    pgid_calls = []
+    monkeypatch.setattr(kb.os, "getpgid", lambda pid: 4242)
+    monkeypatch.setattr(kb.os, "killpg", lambda pgid, sig: pgid_calls.append((pgid, sig)))
+    # os.kill must NOT be used on the group path; make it explode if called.
+    monkeypatch.setattr(kb.os, "kill", lambda *a: (_ for _ in ()).throw(AssertionError("os.kill used")))
+    # Leader reported dead after first SIGTERM → terminated True, no SIGKILL.
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+
+    info = kb._terminate_reclaimed_worker(1234, f"{_claimer_host()}:999")
+    assert info["terminated"] is True
+    assert pgid_calls == [(4242, signal.SIGTERM)]
+
+
+def test_falls_back_to_leader_pid_when_group_gone(monkeypatch):
+    """killpg raising ProcessLookupError → fall back to os.kill(pid)."""
+    kill_calls = []
+    def _boom_pgid(pgid, sig):
+        raise ProcessLookupError
+    monkeypatch.setattr(kb.os, "getpgid", lambda pid: 4242)
+    monkeypatch.setattr(kb.os, "killpg", _boom_pgid)
+    monkeypatch.setattr(kb.os, "kill", lambda pid, sig: kill_calls.append((pid, sig)))
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+
+    info = kb._terminate_reclaimed_worker(1234, f"{_claimer_host()}:999")
+    # Fallback kill(pid) raised nothing → then _pid_alive False → terminated.
+    assert info["terminated"] is True
+    assert kill_calls == [(1234, signal.SIGTERM)]
+
+
+def test_signal_fn_hook_preserved_single_pid(monkeypatch):
+    """Injected signal_fn (tests) stays single-pid — killpg never touched."""
+    monkeypatch.setattr(kb.os, "killpg", lambda *a: (_ for _ in ()).throw(AssertionError("killpg used")))
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+    seen = []
+    info = kb._terminate_reclaimed_worker(
+        1234, f"{_claimer_host()}:999", signal_fn=lambda p, s: seen.append((p, s))
+    )
+    assert info["terminated"] is True
+    assert seen == [(1234, signal.SIGTERM)]


### PR DESCRIPTION
Reclaim signalled only the process-group leader pid; child subprocesses in the same group were left running. Deliver the signal to the whole group via `killpg(getpgid(pid))` with a `kill(pid)` fallback. Withdrawing this PR.