### PR TITLE
fix(matrix): recover from rejected sync cursors

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2266,6 +2266,72 @@ class MatrixAdapter(BasePlatformAdapter):
         client = self._client
         # Resume from the token stored during the initial sync.
         next_batch = await client.sync_store.get_next_batch()
+
+        def _sync_error_status(error: Any) -> Optional[int]:
+            for attr in ("http_status", "status", "status_code"):
+                value = getattr(error, attr, None)
+                if value is None:
+                    continue
+                try:
+                    return int(value)
+                except (TypeError, ValueError):
+                    return None
+            message = getattr(error, "message", None)
+            text = message if isinstance(message, str) else str(error)
+            for pattern in (
+                r"\bHTTP(?:/\d(?:\.\d)?)?\s+(401|403)\b",
+                r"\bhttp_status\s*[=:]\s*(401|403)\b",
+                r"\bstatus(?:_code)?\s*[=:]\s*(401|403)\b",
+                r"\b(401|403)\s*[:,-]\s*(?:unauthorized|forbidden)\b",
+                r"\b(403)\s*[:,-]\s*access denied\b",
+            ):
+                match = re.search(pattern, text, re.IGNORECASE)
+                if match:
+                    return int(match.group(1))
+            return None
+
+        def _sync_error_code(error: Any) -> str:
+            value = getattr(error, "errcode", None) or getattr(error, "err_code", None)
+            return str(value or "").upper()
+
+        def _is_permanent_sync_auth_error(error: Any) -> bool:
+            status = _sync_error_status(error)
+            errcode = _sync_error_code(error)
+            if status == 401:
+                return True
+            if errcode in {"M_UNKNOWN_TOKEN", "M_MISSING_TOKEN", "M_UNAUTHORIZED"}:
+                return True
+            message = getattr(error, "message", None)
+            if isinstance(message, str):
+                lower = message.lower()
+                return (
+                    "m_unknown_token" in lower
+                    or "unknown_token" in lower
+                    or "unauthorized" in lower
+                )
+            return False
+
+        def _is_forbidden_sync_error(error: Any) -> bool:
+            status = _sync_error_status(error)
+            errcode = _sync_error_code(error)
+            return status == 403 or errcode == "M_FORBIDDEN"
+
+        async def _reset_rejected_sync_cursor(error: Any) -> None:
+            nonlocal next_batch
+            logger.warning(
+                "Matrix: sync cursor rejected (%s) — resetting cursor and retrying",
+                error,
+            )
+            next_batch = None
+            try:
+                await client.sync_store.put_next_batch(None)
+            except Exception as store_exc:
+                logger.warning(
+                    "Matrix: failed to persist cleared sync cursor: %s",
+                    store_exc,
+                )
+            await asyncio.sleep(5)
+
         while not self._closing:
             try:
                 # Wrap in asyncio.wait_for to guard against TCP-level hangs
@@ -2281,15 +2347,21 @@ class MatrixAdapter(BasePlatformAdapter):
 
                 # nio returns SyncError objects (not exceptions) for auth
                 # failures like M_UNKNOWN_TOKEN.  Detect and stop immediately.
-                _sync_msg = getattr(sync_data, "message", None)
-                if _sync_msg and isinstance(_sync_msg, str):
-                    _lower = _sync_msg.lower()
-                    if "m_unknown_token" in _lower or "unknown_token" in _lower:
-                        logger.error(
-                            "Matrix: permanent auth error from sync: %s — stopping",
-                            _sync_msg,
-                        )
-                        return
+                if _is_permanent_sync_auth_error(sync_data):
+                    logger.error(
+                        "Matrix: permanent auth error from sync: %s — stopping",
+                        sync_data,
+                    )
+                    return
+                if _is_forbidden_sync_error(sync_data):
+                    if next_batch:
+                        await _reset_rejected_sync_cursor(sync_data)
+                        continue
+                    logger.error(
+                        "Matrix: permanent permission error from sync: %s — stopping",
+                        sync_data,
+                    )
+                    return
 
                 if isinstance(sync_data, dict):
                     self._last_sync_ts = time.time()
@@ -2323,16 +2395,17 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 if self._closing:
                     return
-                # Detect permanent auth/permission failures.
-                err_str = str(exc).lower()
-                if (
-                    "401" in err_str
-                    or "403" in err_str
-                    or "unauthorized" in err_str
-                    or "forbidden" in err_str
-                ):
+                if _is_permanent_sync_auth_error(exc):
                     logger.error(
                         "Matrix: permanent auth error: %s — stopping sync", exc
+                    )
+                    return
+                if _is_forbidden_sync_error(exc):
+                    if next_batch:
+                        await _reset_rejected_sync_cursor(exc)
+                        continue
+                    logger.error(
+                        "Matrix: permanent permission error: %s — stopping sync", exc
                     )
                     return
                 logger.warning("Matrix: sync error: %s — retrying in 5s", exc)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1891,6 +1891,142 @@ class TestMatrixSyncLoop:
         mock_sync_store.put_next_batch.assert_awaited_once_with("s1234")
 
     @pytest.mark.asyncio
+    async def test_sync_loop_resets_forbidden_incremental_sync_cursor(self):
+        """A rejected incremental cursor should reset and retry from fresh sync."""
+        adapter = _make_adapter()
+        adapter._closing = False
+
+        class ForbiddenSyncCursorError(Exception):
+            http_status = 403
+            errcode = "M_FORBIDDEN"
+
+            def __str__(self):
+                return "Access Denied"
+
+        sync_since = []
+
+        async def _sync(**kwargs):
+            sync_since.append(kwargs.get("since"))
+            if len(sync_since) == 1:
+                raise ForbiddenSyncCursorError()
+            adapter._closing = True
+            return {"rooms": {"join": {}}, "next_batch": "s-recovered"}
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value="s-poisoned")
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=_sync)
+        fake_client.sync_store = mock_sync_store
+        fake_client.handle_sync = MagicMock(return_value=[])
+        adapter._client = fake_client
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+        with patch.object(matrix_mod.asyncio, "sleep", AsyncMock()):
+            await adapter._sync_loop()
+
+        assert sync_since == ["s-poisoned", None]
+        assert [
+            call.args[0]
+            for call in mock_sync_store.put_next_batch.await_args_list
+        ] == [None, "s-recovered"]
+        fake_client.handle_sync.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_resets_access_denied_incremental_sync_cursor_text(self):
+        """A string-only 403 access-denied cursor rejection should recover."""
+        adapter = _make_adapter()
+        adapter._closing = False
+
+        sync_since = []
+
+        async def _sync(**kwargs):
+            sync_since.append(kwargs.get("since"))
+            if len(sync_since) == 1:
+                raise RuntimeError("403: Access Denied")
+            adapter._closing = True
+            return {"rooms": {"join": {}}, "next_batch": "s-recovered"}
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value="s-poisoned")
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=_sync)
+        fake_client.sync_store = mock_sync_store
+        fake_client.handle_sync = MagicMock(return_value=[])
+        adapter._client = fake_client
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+        with patch.object(matrix_mod.asyncio, "sleep", AsyncMock()):
+            await adapter._sync_loop()
+
+        assert sync_since == ["s-poisoned", None]
+        assert [
+            call.args[0]
+            for call in mock_sync_store.put_next_batch.await_args_list
+        ] == [None, "s-recovered"]
+        fake_client.handle_sync.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_stops_on_unknown_token(self):
+        """True token revocation should stay terminal."""
+        adapter = _make_adapter()
+        adapter._closing = False
+
+        class UnknownTokenError(Exception):
+            http_status = 401
+            errcode = "M_UNKNOWN_TOKEN"
+
+            def __str__(self):
+                return "M_UNKNOWN_TOKEN"
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value="s-current")
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=UnknownTokenError())
+        fake_client.sync_store = mock_sync_store
+        fake_client.handle_sync = MagicMock(return_value=[])
+        adapter._client = fake_client
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+        with patch.object(matrix_mod.asyncio, "sleep", AsyncMock()) as sleep_mock:
+            await adapter._sync_loop()
+
+        fake_client.sync.assert_awaited_once()
+        mock_sync_store.put_next_batch.assert_not_awaited()
+        fake_client.handle_sync.assert_not_called()
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_stops_on_http_401_exception_text(self):
+        """String-only HTTP 401 exceptions should stay terminal."""
+        adapter = _make_adapter()
+        adapter._closing = False
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value="s-current")
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=RuntimeError("HTTP 401 Unauthorized"))
+        fake_client.sync_store = mock_sync_store
+        fake_client.handle_sync = MagicMock(return_value=[])
+        adapter._client = fake_client
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+        with patch.object(matrix_mod.asyncio, "sleep", AsyncMock()) as sleep_mock:
+            await adapter._sync_loop()
+
+        fake_client.sync.assert_awaited_once()
+        mock_sync_store.put_next_batch.assert_not_awaited()
+        fake_client.handle_sync.assert_not_called()
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_sync_loop_reconciles_pending_invites(self):
         """Pending rooms.invite entries should be joined if callbacks were missed."""
         adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

This PR makes the Matrix sync loop recover from a rejected incremental `/sync` cursor without weakening terminal auth handling.

When Matrix `/sync?since=<next_batch>` returns a 403 / `M_FORBIDDEN`-style cursor rejection, Hermes now clears the stored sync cursor and retries from a fresh sync path instead of stopping the listener permanently. This handles the case where the access token is still valid, but the homeserver rejects the stored incremental cursor.

Fresh-sync 403 responses remain terminal, and token failures such as 401, `M_UNKNOWN_TOKEN`, `M_MISSING_TOKEN`, and `M_UNAUTHORIZED` still stop the sync loop immediately.

## Related context

No dedicated issue was opened for this operational failure. Related Matrix auth-error work exists in #57375 and #56532, but this PR targets a separate recovery case: a valid Matrix token with a rejected incremental sync cursor.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `plugins/platforms/matrix/adapter.py`
  - Adds Matrix sync-error helpers for HTTP status and Matrix errcode handling.
  - Preserves terminal handling for real token/auth failures.
  - Handles exact HTTP-status exception text such as `HTTP 401 Unauthorized` and `403: Access Denied`.
  - Resets and persists a cleared sync cursor only when a forbidden error occurs while using an existing incremental cursor.
  - Keeps fresh-sync 403 / `M_FORBIDDEN` terminal so forbidden accounts do not retry forever.

- `tests/gateway/test_matrix.py`
  - Adds regression coverage for recovering from a rejected incremental sync cursor.
  - Adds regression coverage for string-only `403: Access Denied` cursor rejection.
  - Adds regression coverage that `M_UNKNOWN_TOKEN` and string-only `HTTP 401 Unauthorized` still stop immediately.

## How to Test

- `.venv/bin/python -m pytest tests/gateway/test_matrix.py::TestMatrixSyncLoop tests/gateway/test_ws_auth_retry.py -q`
- `.venv/bin/python -m pytest tests/gateway/test_matrix.py -q`
- `.venv/bin/python -m pytest tests/gateway/test_matrix*.py -q`
- `.venv/bin/python -m py_compile plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- `.venv/bin/python -m ruff check plugins/platforms/matrix/adapter.py tests/gateway/test_matrix.py`
- `git diff --check`

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] I searched for related PRs/issues before opening this PR.
- [x] My changes are scoped to the Matrix sync-loop bug.
- [x] I added regression tests for the new behavior.
- [x] I ran focused Matrix gateway tests locally.
- [x] I ran the previously failing auth-retry test file locally.
- [x] I ran lint/compile/whitespace checks locally.
- [ ] I ran the full repository test suite locally.
