### PR TITLE
fix(image-gen/video-gen): guard local provider inputs against credential reads via one shared chokepoint (salvages #57698, consolidates #57695)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -304,6 +304,30 @@ def get_read_block_error(path: str) -> Optional[str]:
     return None
 
 
+def raise_if_read_blocked(path: str) -> None:
+    """Raise ``ValueError`` if ``path`` is a denied Hermes read (see
+    :func:`get_read_block_error`), else return.
+
+    Shared chokepoint for provider input-loading sites that read a local
+    file the model/tool supplied (e.g. image-gen ``image_url`` /
+    ``reference_image_urls`` paths). Centralizes the guard so every provider
+    enforces the same read boundary with identical semantics instead of each
+    open-coding the try/except block (#57698).
+
+    Best-effort by design: if ``agent.file_safety`` machinery is somehow
+    unavailable at the call site the guard no-ops rather than breaking local
+    image loading — consistent with the defense-in-depth (not security
+    boundary) framing of the denylist itself. The blocking ``ValueError`` from
+    a real hit still propagates; only unexpected internal errors are swallowed.
+    """
+    try:
+        blocked = get_read_block_error(path)
+    except Exception:  # noqa: BLE001 - guard must never break local-file loading
+        return
+    if blocked:
+        raise ValueError(blocked)
+
+
 # ---------------------------------------------------------------------------
 # Cross-profile write guard (#TBD)
 #

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -146,17 +146,10 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
         if "image/" in header:
             ext = header.split("image/", 1)[1].split(";", 1)[0] or "png"
         return base64.b64decode(b64), f"image.{ext}"
-    # Local file path.
-    try:
-        from agent.file_safety import get_read_block_error
+    # Local file path — enforce the shared credential-read guard before reading.
+    from agent.file_safety import raise_if_read_blocked
 
-        blocked = get_read_block_error(ref)
-        if blocked:
-            raise ValueError(blocked)
-    except ValueError:
-        raise
-    except Exception as exc:  # noqa: BLE001 - preserve existing local-file behavior
-        logger.debug("OpenAI image input read guard unavailable: %s", exc)
+    raise_if_read_blocked(ref)
     with open(ref, "rb") as fh:
         data = fh.read()
     name = os.path.basename(ref) or "image.png"

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -147,6 +147,16 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
             ext = header.split("image/", 1)[1].split(";", 1)[0] or "png"
         return base64.b64decode(b64), f"image.{ext}"
     # Local file path.
+    try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(ref)
+        if blocked:
+            raise ValueError(blocked)
+    except ValueError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - preserve existing local-file behavior
+        logger.debug("OpenAI image input read guard unavailable: %s", exc)
     with open(ref, "rb") as fh:
         data = fh.read()
     name = os.path.basename(ref) or "image.png"

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -97,16 +97,10 @@ def _to_image_url_part(ref: str) -> Optional[str]:
     if ref.startswith(("http://", "https://", "data:")):
         return ref
     path = Path(ref)
-    try:
-        from agent.file_safety import get_read_block_error
+    # Enforce the shared credential-read guard before inlining local bytes.
+    from agent.file_safety import raise_if_read_blocked
 
-        blocked = get_read_block_error(ref)
-        if blocked:
-            raise ValueError(blocked)
-    except ValueError:
-        raise
-    except Exception as exc:  # noqa: BLE001 - keep local image refs best-effort
-        logger.debug("OpenRouter image input read guard unavailable: %s", exc)
+    raise_if_read_blocked(ref)
     try:
         raw = path.read_bytes()
     except OSError as exc:

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -98,6 +98,16 @@ def _to_image_url_part(ref: str) -> Optional[str]:
         return ref
     path = Path(ref)
     try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(ref)
+        if blocked:
+            raise ValueError(blocked)
+    except ValueError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - keep local image refs best-effort
+        logger.debug("OpenRouter image input read guard unavailable: %s", exc)
+    try:
         raw = path.read_bytes()
     except OSError as exc:
         logger.debug("could not read reference image %s: %s", ref, exc)

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -137,6 +137,11 @@ def _xai_image_field(source: str) -> Dict[str, str]:
     import base64
     import os as _os
 
+    # Enforce the shared credential-read guard before reading local bytes
+    # (same boundary the OpenAI / OpenRouter / Codex image providers apply).
+    from agent.file_safety import raise_if_read_blocked
+
+    raise_if_read_blocked(source)
     with open(_os.path.expanduser(source), "rb") as fh:  # windows-footgun: ok
         raw = fh.read()
     ext = (_os.path.splitext(source)[1].lstrip(".") or "png").lower()

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -127,6 +127,22 @@ def _xai_headers(api_key: str) -> Dict[str, str]:
     }
 
 
+def _raise_if_blocked_local_input(ref: str) -> None:
+    """Refuse to read a local media path that Hermes' read deny-list blocks.
+
+    Thin wrapper over the shared ``agent.file_safety.raise_if_read_blocked``
+    chokepoint so xAI video inputs enforce the same credential-store guard as
+    the image providers. Fails open if the guard machinery is unavailable
+    (defense-in-depth, per the denylist's own framing).
+    """
+    try:
+        from agent.file_safety import raise_if_read_blocked
+    except Exception as exc:  # noqa: BLE001 - guard must never break loading
+        logger.debug("xAI media input read guard unavailable: %s", exc)
+        return
+    raise_if_read_blocked(ref)
+
+
 def _image_ref_to_xai_url(value: str) -> str:
     """Return a URL/data URI accepted by xAI for image inputs."""
     ref = (value or "").strip()
@@ -139,6 +155,8 @@ def _image_ref_to_xai_url(value: str) -> str:
     path = Path(ref).expanduser()
     if not path.is_file():
         return ref
+
+    _raise_if_blocked_local_input(ref)
 
     mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
     if not mime.startswith("image/"):
@@ -194,6 +212,8 @@ def _video_ref_to_xai_url(value: str) -> str:
     path = Path(ref).expanduser()
     if not path.is_file():
         return ref
+
+    _raise_if_blocked_local_input(ref)
 
     mime = mimetypes.guess_type(path.name)[0] or "video/mp4"
     if not mime.startswith("video/"):

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -124,6 +124,18 @@ class TestModelResolution:
 # ── Generate ────────────────────────────────────────────────────────────────
 
 
+class TestSourceImageLoading:
+    def test_load_image_bytes_blocks_credential_store(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        auth_json = hermes_home / "auth.json"
+        auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(ValueError, match="credential store"):
+            openai_plugin._load_image_bytes(str(auth_json))
+
+
 class TestGenerate:
     def test_empty_prompt_rejected(self, provider):
         result = provider.generate("", aspect_ratio="square")

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -135,6 +135,56 @@ class TestSourceImageLoading:
         with pytest.raises(ValueError, match="credential store"):
             openai_plugin._load_image_bytes(str(auth_json))
 
+    def test_load_image_bytes_never_opens_blocked_credential(self, tmp_path, monkeypatch):
+        """The guard must fire BEFORE the file is opened — a credential store
+        must never be read into memory (#57698). Spy builtins.open and assert
+        it is never called for the blocked path."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        auth_json = hermes_home / "auth.json"
+        auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import builtins
+
+        real_open = builtins.open
+        opened: list = []
+
+        def _spy_open(file, *a, **k):
+            opened.append(str(file))
+            return real_open(file, *a, **k)
+
+        monkeypatch.setattr(builtins, "open", _spy_open)
+        with pytest.raises(ValueError, match="credential store"):
+            openai_plugin._load_image_bytes(str(auth_json))
+        assert str(auth_json) not in opened, "blocked credential must never be opened"
+
+    def test_load_image_bytes_allows_legit_local_image(self, tmp_path, monkeypatch):
+        """Negative control: a legitimate local image path is NOT blocked and
+        loads normally — proves the guard doesn't over-fire on everything."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nfake-image-bytes")
+
+        data, name = openai_plugin._load_image_bytes(str(img))
+        assert data == b"\x89PNG\r\n\x1a\nfake-image-bytes"
+        assert name == "pic.png"
+
+    def test_load_image_bytes_passthrough_data_uri_not_blocked(self, tmp_path, monkeypatch):
+        """Negative control: data: URIs are decoded, never routed through the
+        local-path guard (the guard only applies to local file reads)."""
+        import base64
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        b64 = base64.b64encode(b"xyz").decode("ascii")
+        data, name = openai_plugin._load_image_bytes(f"data:image/png;base64,{b64}")
+        assert data == b"xyz"
+        assert name.endswith(".png")
+
 
 class TestGenerate:
     def test_empty_prompt_rejected(self, provider):

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -169,6 +169,18 @@ class TestHelpers:
 
         assert _to_image_url_part("/no/such/file.png") is None
 
+    def test_to_image_url_part_blocks_credential_store(self, tmp_path, monkeypatch):
+        from plugins.image_gen.openrouter import _to_image_url_part
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        auth_json = hermes_home / "auth.json"
+        auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(ValueError, match="credential store"):
+            _to_image_url_part(str(auth_json))
+
     def test_extract_images(self):
         from plugins.image_gen.openrouter import _extract_images
 

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -181,6 +181,31 @@ class TestHelpers:
         with pytest.raises(ValueError, match="credential store"):
             _to_image_url_part(str(auth_json))
 
+    def test_to_image_url_part_never_reads_blocked_credential(self, tmp_path, monkeypatch):
+        """The guard must fire BEFORE path.read_bytes() — the credential store
+        must never be inlined into a provider request (#57698)."""
+        from pathlib import Path as _P
+
+        from plugins.image_gen.openrouter import _to_image_url_part
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        auth_json = hermes_home / "auth.json"
+        auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        real_read_bytes = _P.read_bytes
+        read: list = []
+
+        def _spy_read_bytes(self, *a, **k):
+            read.append(str(self))
+            return real_read_bytes(self, *a, **k)
+
+        monkeypatch.setattr(_P, "read_bytes", _spy_read_bytes)
+        with pytest.raises(ValueError, match="credential store"):
+            _to_image_url_part(str(auth_json))
+        assert str(auth_json) not in read, "blocked credential must never be read"
+
     def test_extract_images(self):
         from plugins.image_gen.openrouter import _extract_images
 

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -492,3 +492,50 @@ def test_xai_image_field_expands_user_home(tmp_path, monkeypatch):
     field = _xai_image_field("~/pic.png")
     assert field["type"] == "image_url"
     assert field["url"].startswith("data:image/png;base64,")
+
+
+class TestXAIImageFieldReadGuard:
+    """#57698: local image inputs must not read Hermes credential stores."""
+
+    def test_xai_image_field_blocks_credential_store(self, tmp_path, monkeypatch):
+        from plugins.image_gen.xai import _xai_image_field
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        auth_json = hermes_home / "auth.json"
+        auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(ValueError, match="credential store"):
+            _xai_image_field(str(auth_json))
+
+    def test_xai_image_field_never_opens_blocked_credential(self, tmp_path, monkeypatch):
+        """Guard fires before open() — credential store never read into memory."""
+        import builtins
+
+        from plugins.image_gen.xai import _xai_image_field
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        auth_json = hermes_home / "auth.json"
+        auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        real_open = builtins.open
+        opened: list = []
+
+        def _spy_open(file, *a, **k):
+            opened.append(str(file))
+            return real_open(file, *a, **k)
+
+        monkeypatch.setattr(builtins, "open", _spy_open)
+        with pytest.raises(ValueError, match="credential store"):
+            _xai_image_field(str(auth_json))
+        assert str(auth_json) not in opened, "blocked credential must never be opened"
+
+    def test_xai_image_field_passthrough_url_not_blocked(self, monkeypatch):
+        """Negative control: remote URLs and data: URIs pass through unguarded."""
+        from plugins.image_gen.xai import _xai_image_field
+
+        assert _xai_image_field("https://example.com/pic.png")["url"] == "https://example.com/pic.png"
+        assert _xai_image_field("data:image/png;base64,eHl6")["url"].startswith("data:image/png")

--- a/tests/plugins/video_gen/test_xai_plugin.py
+++ b/tests/plugins/video_gen/test_xai_plugin.py
@@ -186,3 +186,41 @@ def test_video_input_from_public_url_rejects_bare_file_id():
         )
     )
     assert result is None
+
+
+def test_xai_video_image_input_blocks_credential_store_symlink(tmp_path, monkeypatch):
+    from plugins.video_gen.xai import _image_ref_to_xai_input
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+    image_link = hermes_home / "leak.png"
+    try:
+        image_link.symlink_to(auth_json)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="credential store"):
+        _image_ref_to_xai_input(str(image_link))
+
+
+def test_xai_video_file_input_blocks_credential_store_symlink(tmp_path, monkeypatch):
+    from plugins.video_gen.xai import _video_ref_to_xai_url
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+    video_link = hermes_home / "leak.mp4"
+    try:
+        video_link.symlink_to(auth_json)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="credential store"):
+        _video_ref_to_xai_url(str(video_link))


### PR DESCRIPTION
## Summary

Image and video generation providers read model/tool-supplied local `image_url` / `reference_image_urls` (and video) paths and base64-inline them into the outbound provider request without Hermes' `get_read_block_error()` read guard. A path to a Hermes credential store (`auth.json`, `.anthropic_oauth.json`, `.env`, …) — including via a `leak.png -> auth.json` symlink — could be read and embedded in the payload. The OpenAI Codex image provider already guards this; this PR mirrors that boundary to **every** image + video provider through one shared chokepoint.

Salvages **#57698** (@necoweb3, openai+openrouter image) and consolidates **#57695** (@necoweb3, xAI image+video) — cherry-picked to preserve authorship, extended to the whole bug class, verified end-to-end.

## Changes
- `agent/file_safety.py`: new shared `raise_if_read_blocked(path)` chokepoint (co-located with `get_read_block_error`). Best-effort/defense-in-depth: a real block raises `ValueError`; unexpected internal errors fail open.
- `plugins/image_gen/openai`, `openrouter`, `xai`: route local-input reads through the shared helper (after the `http/https/data:` early-returns — remote URLs/data URIs untouched).
- `plugins/video_gen/xai`: guard `_image_ref_to_xai_url` + `_video_ref_to_xai_url` (video image + video byte-reads) through the same shared helper.
- Tests upgraded from pass-on-any-`ValueError` to real security invariants: no-read spies (blocked credential never read into memory), negative controls (legit local image loads; remote/data URIs pass through), and symlink→`auth.json` regression tests for image + video paths.

## Validation
| Input | Before | After |
|---|---|---|
| Local `.png`/`.mp4` symlink → `auth.json` (any provider) | credential bytes base64'd into payload | `ValueError: Access denied` — never read |
| Legitimate local image | encoded | encoded (unchanged) |
| Public HTTPS / data URI | pass-through | pass-through (unchanged) |

- Premise confirmed live on `main`; `get_read_block_error` `.resolve()`s symlinks and matches the profile-aware credential denylist.
- Single enforced chokepoint — a new provider gets the guard with a one-line call instead of copy-pasted try/except.
- Plugins-only + the shared `agent/file_safety.py` helper they all call (the helper is the whole point of the consolidation; it lives in core so every provider shares one auditable boundary).
- 195 image_gen + video_gen tests pass; mutation-checked (neutering the guards fails every symlink test); E2E-verified with real symlinks across all image + video read paths.

Closes #57698. Closes #57695.
