### PR TITLE
fix(xai): guard local media inputs against credential reads

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -123,6 +123,26 @@ def _resolve_resolution() -> str:
     return DEFAULT_RESOLUTION
 
 
+def _raise_if_blocked_local_input(source: str) -> None:
+    """Refuse to read a local path that Hermes' read deny-list blocks.
+
+    Mirrors the video_gen/xai plugin and the openai-codex image path so all
+    local media inputs share one guard: a symlink such as
+    ``~/.hermes/leak.png -> ~/.hermes/auth.json`` must not be base64-encoded
+    into the outbound xAI payload. Fail-open if ``agent.file_safety`` is
+    unavailable (defense-in-depth, consistent with the sibling plugins).
+    """
+    try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(source)
+    except Exception as exc:
+        logger.debug("xAI image input read guard unavailable: %s", exc)
+        return
+    if blocked:
+        raise ValueError(blocked)
+
+
 def _xai_image_field(source: str) -> Dict[str, str]:
     """Build the xAI ``image`` field for an edit request.
 
@@ -137,16 +157,7 @@ def _xai_image_field(source: str) -> Dict[str, str]:
     import base64
     import os as _os
 
-    try:
-        from agent.file_safety import get_read_block_error
-
-        blocked = get_read_block_error(source)
-        if blocked:
-            raise ValueError(blocked)
-    except ValueError:
-        raise
-    except Exception as exc:
-        logger.debug("xAI image input read guard unavailable: %s", exc)
+    _raise_if_blocked_local_input(source)
 
     with open(_os.path.expanduser(source), "rb") as fh:  # windows-footgun: ok
         raw = fh.read()
@@ -308,6 +319,18 @@ class XAIImageGenProvider(ImageGenProvider):
             edit_model = "grok-imagine-image-quality"
             try:
                 image_fields = [_xai_image_field(source) for source in source_images]
+            except ValueError as exc:
+                # Read deny-list block (e.g. a credential-store symlink). Surface
+                # it as an access error rather than a generic I/O failure so the
+                # cause isn't mislabeled.
+                return error_response(
+                    error=str(exc),
+                    error_type="access_denied",
+                    provider=provider_name,
+                    model=edit_model,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
             except Exception as exc:
                 return error_response(
                     error=f"Could not load source image for editing: {exc}",

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -137,6 +137,17 @@ def _xai_image_field(source: str) -> Dict[str, str]:
     import base64
     import os as _os
 
+    try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(source)
+        if blocked:
+            raise ValueError(blocked)
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.debug("xAI image input read guard unavailable: %s", exc)
+
     with open(_os.path.expanduser(source), "rb") as fh:  # windows-footgun: ok
         raw = fh.read()
     ext = (_os.path.splitext(source)[1].lstrip(".") or "png").lower()

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -127,6 +127,19 @@ def _xai_headers(api_key: str) -> Dict[str, str]:
     }
 
 
+def _raise_if_blocked_local_input(ref: str) -> None:
+    try:
+        from agent.file_safety import get_read_block_error
+
+        blocked = get_read_block_error(ref)
+        if blocked:
+            raise ValueError(blocked)
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.debug("xAI media input read guard unavailable: %s", exc)
+
+
 def _image_ref_to_xai_url(value: str) -> str:
     """Return a URL/data URI accepted by xAI for image inputs."""
     ref = (value or "").strip()
@@ -139,6 +152,8 @@ def _image_ref_to_xai_url(value: str) -> str:
     path = Path(ref).expanduser()
     if not path.is_file():
         return ref
+
+    _raise_if_blocked_local_input(ref)
 
     mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
     if not mime.startswith("image/"):
@@ -194,6 +209,8 @@ def _video_ref_to_xai_url(value: str) -> str:
     path = Path(ref).expanduser()
     if not path.is_file():
         return ref
+
+    _raise_if_blocked_local_input(ref)
 
     mime = mimetypes.guess_type(path.name)[0] or "video/mp4"
     if not mime.startswith("video/"):

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -132,12 +132,11 @@ def _raise_if_blocked_local_input(ref: str) -> None:
         from agent.file_safety import get_read_block_error
 
         blocked = get_read_block_error(ref)
-        if blocked:
-            raise ValueError(blocked)
-    except ValueError:
-        raise
     except Exception as exc:
         logger.debug("xAI media input read guard unavailable: %s", exc)
+        return
+    if blocked:
+        raise ValueError(blocked)
 
 
 def _image_ref_to_xai_url(value: str) -> str:

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -492,3 +492,22 @@ def test_xai_image_field_expands_user_home(tmp_path, monkeypatch):
     field = _xai_image_field("~/pic.png")
     assert field["type"] == "image_url"
     assert field["url"].startswith("data:image/png;base64,")
+
+
+def test_xai_image_field_blocks_credential_store_symlink(tmp_path, monkeypatch):
+    from plugins.image_gen.xai import _xai_image_field
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+    image_link = hermes_home / "leak.png"
+    try:
+        image_link.symlink_to(auth_json)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="credential store"):
+        _xai_image_field(str(image_link))

--- a/tests/plugins/video_gen/test_xai_plugin.py
+++ b/tests/plugins/video_gen/test_xai_plugin.py
@@ -186,3 +186,41 @@ def test_video_input_from_public_url_rejects_bare_file_id():
         )
     )
     assert result is None
+
+
+def test_xai_video_image_input_blocks_credential_store_symlink(tmp_path, monkeypatch):
+    from plugins.video_gen.xai import _image_ref_to_xai_input
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+    image_link = hermes_home / "leak.png"
+    try:
+        image_link.symlink_to(auth_json)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="credential store"):
+        _image_ref_to_xai_input(str(image_link))
+
+
+def test_xai_video_file_input_blocks_credential_store_symlink(tmp_path, monkeypatch):
+    from plugins.video_gen.xai import _video_ref_to_xai_url
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    auth_json = hermes_home / "auth.json"
+    auth_json.write_text('{"api_key":"sk-secret"}', encoding="utf-8")
+    video_link = hermes_home / "leak.mp4"
+    try:
+        video_link.symlink_to(auth_json)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable on this platform: {exc}")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(ValueError, match="credential store"):
+        _video_ref_to_xai_url(str(video_link))


### PR DESCRIPTION
## Summary

xAI image/video generation reads local `image_url` / `reference_image_urls` inputs and base64-encodes them into the outbound xAI request without Hermes' read deny-list guard — so a symlink like `~/.hermes/leak.png -> ~/.hermes/auth.json` could have its credential-store target embedded in the payload. This applies the same `agent.file_safety.get_read_block_error()` guard the OpenAI Codex image path already uses, at every local-file byte-read chokepoint in both xAI plugins.

## Changes
- `plugins/image_gen/xai/__init__.py`: guard `_xai_image_field` (the image byte-read); read-deny blocks surface as `error_type=access_denied` in the edit path instead of a mislabeled `io_error`.
- `plugins/video_gen/xai/__init__.py`: guard `_image_ref_to_xai_url` and `_video_ref_to_xai_url` (video image + video byte-reads).
- Both plugins share the same `_raise_if_blocked_local_input` helper form; the guard fails open only if `agent.file_safety` is unavailable (defense-in-depth, consistent with the Codex sibling).
- Regression tests: symlinked `auth.json` with `.png` / `.mp4` names are blocked across all three read paths.

## Validation
| Input | Before | After |
|---|---|---|
| Local `.png`/`.mp4` symlink → `auth.json` | credential bytes base64'd into xAI payload | `ValueError: Access denied` — never read |
| Legitimate local `.png` | encoded to data URI | encoded to data URI (unchanged) |
| Public HTTPS URL / data URI | pass-through | pass-through (unchanged) |

- Premise confirmed live on `main`; guard verified to `.resolve()` symlinks and match the credential denylist.
- Aligns xAI with the existing Codex image-input guard (`plugins/image_gen/openai-codex/__init__.py`).
- Plugin-only diff (no core touches). Guards sit at the true byte-read chokepoints; all local-read sites covered.
- 44 targeted tests pass; mutation-checked (neutering the guards fails all 3 symlink tests); E2E-verified with real symlinks (all 3 attack vectors blocked, legit input still encodes).

Salvaged from #57695 by @necoweb3; authorship preserved via cherry-pick. Closes #57695.
