### PR TITLE
fix(sanitize): cover all content-part string fields, not just text

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -95,10 +95,10 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
         elif isinstance(content, list):
             for part in content:
                 if isinstance(part, dict):
-                    text = part.get("text")
-                    if isinstance(text, str) and _SURROGATE_RE.search(text):
-                        part["text"] = _SURROGATE_RE.sub('\ufffd', text)
-                        found = True
+                    for pkey, pval in part.items():
+                        if isinstance(pval, str) and _SURROGATE_RE.search(pval):
+                            part[pkey] = _SURROGATE_RE.sub('\ufffd', pval)
+                            found = True
         name = msg.get("name")
         if isinstance(name, str) and _SURROGATE_RE.search(name):
             msg["name"] = _SURROGATE_RE.sub('\ufffd', name)
@@ -341,12 +341,12 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
         elif isinstance(content, list):
             for part in content:
                 if isinstance(part, dict):
-                    text = part.get("text")
-                    if isinstance(text, str):
-                        sanitized = _strip_non_ascii(text)
-                        if sanitized != text:
-                            part["text"] = sanitized
-                            found = True
+                    for pkey, pval in part.items():
+                        if isinstance(pval, str):
+                            sanitized = _strip_non_ascii(pval)
+                            if sanitized != pval:
+                                part[pkey] = sanitized
+                                found = True
         # Sanitize name field (can contain non-ASCII in tool results)
         name = msg.get("name")
         if isinstance(name, str):


### PR DESCRIPTION
## Problem

Both `_sanitize_messages_surrogates` and `_sanitize_messages_non_ascii` hard-code `part.get("text")` when iterating content-part arrays. Content parts can carry other string-typed keys - `refusal`, `type`, `image_url`, etc. - that contain surrogate or non-ASCII characters. These slip through and crash `json.dumps` inside the OpenAI SDK at the wire boundary.

The message-level catch-all loops already handle non-text fields at the top level, but content-part keys are nested inside `content: [...]` and are not reached.

## Fix

Replace the `part.get("text")` field check with a loop over all keys in each content-part dict, matching the per-key approach already used at the message level in both functions.

This is the same class of bug as the `reasoning` / `reasoning_content` / `reasoning_details` fix in #11628, but for content-part arrays rather than message-level keys.