### PR TITLE
fix(cron): run jobs under the profile secret scope (salvage #57692)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3114,7 +3114,26 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             )
             return True  # not an error — already handled/removed
 
-        success, output, final_response, error = run_job(job)
+        # Run the job under the profile's secret scope. get_secret() fails
+        # closed outside a scope once profile isolation is in play (multiple
+        # gateway profiles / room→profile multiplexing), and cron fires from
+        # the ticker thread where no per-turn scope is installed — so
+        # resolve_runtime_provider() raised UnscopedSecretError before model
+        # selection, breaking every cron job. Mirrors the per-turn pattern in
+        # gateway/run.py (_profile_runtime_scope).
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            reset_secret_scope,
+            set_secret_scope,
+        )
+
+        _scope_token = set_secret_scope(
+            build_profile_secret_scope(_get_hermes_home())
+        )
+        try:
+            success, output, final_response, error = run_job(job)
+        finally:
+            reset_secret_scope(_scope_token)
 
         output_file = save_job_output(job["id"], output)
         if verbose:

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -117,3 +117,46 @@ def test_run_one_job_exception_marks_failure(monkeypatch):
 
     assert ok is False
     assert marks == [("j6", False)]
+
+
+def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):
+    """Regression: under profile isolation (multiplex active), run_one_job must
+    execute run_job inside a profile secret scope so credential reads
+    (resolve_runtime_provider -> get_secret) don't fail-close with
+    UnscopedSecretError, and must tear the scope down afterward.
+
+    Behavior contract: a scope is present during run_job and absent after,
+    regardless of the concrete secret values.
+    """
+    from agent import secret_scope as ss
+
+    # Point cron's home resolution at a profile whose .env carries a secret.
+    (tmp_path / ".env").write_text("OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+
+    scope_during_run = {}
+
+    def fake_run_job(job):
+        # This is where resolve_runtime_provider() would read a secret. Prove a
+        # scope is installed and the profile's secret resolves without raising.
+        scope_during_run["scope"] = ss.current_secret_scope()
+        scope_during_run["base_url"] = ss.get_secret("OPENROUTER_BASE_URL")
+        return (True, "out", "final", None)
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    ss.set_multiplex_active(True)
+    try:
+        ok = s.run_one_job({"id": "j7", "name": "t"})
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert ok is True
+    # Scope was installed during run_job and the profile secret resolved.
+    assert scope_during_run["scope"] is not None
+    assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
+    # And it was torn down after run_one_job returned (no leak).
+    assert ss.current_secret_scope() is None


### PR DESCRIPTION
## Summary

Cron jobs no longer crash with `UnscopedSecretError` under gateway profile isolation.

Once profile isolation (multi-profile gateway / room→profile multiplexing) is active, `get_secret()` fails closed outside an installed scope. The cron ticker fires jobs from its own thread where no per-turn scope is installed, so `run_job()` died inside `resolve_runtime_provider()` before model selection:

```
UnscopedSecretError: get_secret('OPENROUTER_BASE_URL') ... no profile secret scope active
```

Every cron job failed with this while interactive turns worked fine (the message path installs the scope per turn via `_profile_runtime_scope` in `gateway/run.py`).

**Root cause:** the cron firing body had no secret scope; the fail-closed guard in `agent/secret_scope.get_secret()` raised before model selection.

## Changes

- `cron/scheduler.py`: wrap the `run_job(job)` call in `run_one_job` with `set_secret_scope(build_profile_secret_scope(_get_hermes_home()))` + a `finally` reset — the same pattern the per-turn gateway path uses. `run_one_job` is the single shared firing body, so both the built-in ticker and external providers (Chronos `fire_due`) get the scope. Cron correctly installs only the *secret scope* (not the gateway's `set_hermes_home_override`) since cron is single-home per process.
- `tests/cron/test_run_one_job.py`: regression test (our follow-up commit) asserting the behavior contract — a scope is present during `run_job` and torn down after. Mutation-verified: fails on unmodified `main` with the exact `UnscopedSecretError`, passes with the fix.

## Validation

| | Before | After |
|---|---|---|
| Cron job under profile isolation | `UnscopedSecretError`, job dies before model selection | Runs; profile `.env` secrets resolve inside `run_job` |
| Single-profile install (multiplex off) | Reads `os.environ` | Unchanged — reads `os.environ` |
| `tests/cron/` suite | 612 passed | 613 passed (adds 1 regression test, 0 regressions) |

Integration E2E through the real `run_one_job` path confirms the job fires, the profile secret resolves inside `run_job`, and the scope is torn down afterward.

**Note (latent coupling, not a bug today):** the delivery path (`_deliver_result`) resolves platform tokens from the already-loaded gateway config, not via `get_secret`, so cron delivery is not scope-protected — which is correct for single-home cron. If a future refactor routes platform-token resolution through `get_secret`, the scope would need to extend past `run_job` to cover `_deliver_result`.

Closes #57692. Fix authored by @CocaKova (commit cherry-picked with authorship preserved); regression test added on top.

Depends on #57728 (AUTHOR_MAP entry for the contributor's email — merge that first).
