### PR TITLE
fix(gateway): match profile by whole token in _matches_current_profile (kill-path mirror of #52536)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -356,11 +356,21 @@ def _scan_gateway_pids(
     def _matches_current_profile(command: str) -> bool:
         command_lc = command.lower()
         if current_profile_name:
-            return (
-                f"--profile {current_profile_name_lc}" in command_lc
-                or f"-p {current_profile_name_lc}" in command_lc
-                or f"hermes_home={current_home_lc}" in command_lc
-            )
+            # Match the flag VALUE as a whole token, not a substring. "-p dev"
+            # is a substring of "-p dev-test", so a substring check scopes a
+            # live *sibling* profile's gateway to this profile: it reports a
+            # dead profile as running and, because find_gateway_pids() feeds
+            # kill_gateway(), lets a profile-scoped ``gateway stop`` terminate
+            # the WRONG profile's gateway. Mirrors the same fix in
+            # gateway.status._command_line_belongs_to_profile (#52536).
+            tokens = command_lc.split()
+            for idx in range(len(tokens) - 1):
+                if (
+                    tokens[idx] in ("--profile", "-p")
+                    and tokens[idx + 1] == current_profile_name_lc
+                ):
+                    return True
+            return any(tok == f"hermes_home={current_home_lc}" for tok in tokens)
 
         # Default-profile case: no profile flag in argv. Accept as long as
         # the command doesn't advertise *some other* profile. HERMES_HOME

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1169,3 +1169,50 @@ def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")
     assert gateway.logger.name == "hermes_cli.gateway"
+
+
+def test_scan_gateway_pids_rejects_sibling_prefix_profile(monkeypatch):
+    """A profile whose name is a prefix of a sibling ("dev" vs "dev-test") must
+    not scope the sibling's live gateway to itself.
+
+    Regression: ``_matches_current_profile`` used a substring check, so profile
+    "dev" matched ``--profile dev-test`` — reporting a dead "dev" profile as
+    running and, via ``find_gateway_pids`` → ``kill_gateway``, letting a
+    profile-scoped ``gateway stop`` terminate the WRONG profile's gateway.
+    """
+    import pathlib
+    import subprocess as _sp
+
+    # Current profile is "dev".
+    monkeypatch.setattr(
+        gateway, "get_hermes_home",
+        lambda: pathlib.Path("/home/u/.hermes/profiles/dev"),
+    )
+    monkeypatch.setattr(gateway, "_profile_arg", lambda *a, **k: "--profile dev")
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+
+    # Force the POSIX ``ps`` path so the scan is deterministic on any host.
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    _real_isdir = gateway.os.path.isdir
+    monkeypatch.setattr(
+        gateway.os.path, "isdir",
+        lambda p: False if str(p) == "/proc" else _real_isdir(p),
+    )
+
+    # One live gateway — belonging to the SIBLING profile "dev-test".
+    ps_out = (
+        "12345 python -m hermes_cli.main --profile dev-test gateway run --replace\n"
+    )
+    monkeypatch.setattr(
+        gateway.subprocess, "run",
+        lambda cmd, *a, **k: _sp.CompletedProcess(cmd, 0, stdout=ps_out, stderr=""),
+    )
+
+    # Profile-scoped scan: "dev" must NOT claim the "dev-test" gateway.
+    scoped = gateway._scan_gateway_pids(set(), all_profiles=False)
+    assert 12345 not in scoped, f"sibling-prefix profile matched: {scoped}"
+
+    # Sanity: the all-profiles sweep still finds it — proving the scan works and
+    # the exclusion above is the profile check, not an accidental no-op.
+    all_found = gateway._scan_gateway_pids(set(), all_profiles=True)
+    assert 12345 in all_found


### PR DESCRIPTION
## What does this PR do?

`_scan_gateway_pids._matches_current_profile` (in `hermes_cli/gateway.py`)
scopes a process to the current profile with a **substring** check:

```python
f"--profile {current_profile_name_lc}" in command_lc
```

Because `"--profile dev"` is a substring of `"--profile dev-test"`, a sibling
profile whose name is a prefix of another (`dev`/`dev-test`, `prod`/`prod2`) is
matched. `find_gateway_pids()` then:

1. reports a **dead** `dev` profile as running, off the `dev-test` gateway's
   OS-recycled PID, and
2. because it feeds `kill_gateway()`, lets a profile-scoped
   `hermes gateway stop` (under `dev`) **terminate the wrong profile's** live
   `dev-test` gateway.

## Relationship to #52536

`_matches_current_profile` and `gateway.status._command_line_belongs_to_profile`
are explicit mirrors (see their docstrings). #52536 fixes the same substring bug
on the **status.py** (dashboard-liveness) side; it does **not** touch this
CLI/kill-path mirror. This PR applies the identical whole-token approach here so
the two stay in sync.

## Changes

- `hermes_cli/gateway.py` — match the `--profile`/`-p` value (and `HERMES_HOME=`)
  as a whole argv token instead of a substring.
- `tests/hermes_cli/test_gateway.py` — regression test.

## Tests

```
pytest tests/hermes_cli/test_gateway.py::test_scan_gateway_pids_rejects_sibling_prefix_profile -q
→ 1 passed
```

Drives `_scan_gateway_pids` with a live `dev-test` gateway and the current
profile `dev`; the sibling PID is excluded from the profile-scoped scan but
still found by an all-profiles sweep (mutation-verified — the old substring
check matched it).