### PR TITLE
typing(sqlite_util): annotate write_txn return type

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,7 +87,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Iterator, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -2304,7 +2304,7 @@ def _execute_boundary_with_retry(conn: sqlite3.Connection, sql: str) -> None:
 
 
 @contextlib.contextmanager
-def write_txn(conn: sqlite3.Connection):
+def write_txn(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
     """Context manager for an IMMEDIATE write transaction.
 
     Use for any multi-statement write (creating a task + link, claiming a

--- a/hermes_cli/sqlite_util.py
+++ b/hermes_cli/sqlite_util.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import sqlite3
+from collections.abc import Iterator
 
 
 def add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, ddl: str) -> bool:
@@ -29,7 +30,7 @@ def add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, ddl
 
 
 @contextlib.contextmanager
-def write_txn(conn: sqlite3.Connection):
+def write_txn(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
     """An IMMEDIATE write transaction: at most one concurrent writer wins.
 
     The explicit ROLLBACK is guarded so a SQLite auto-rollback (no active


### PR DESCRIPTION
## What does this PR do?

Adds the missing return annotation to the two `@contextlib.contextmanager` write-transaction helpers. Both `yield` the `conn` argument (already typed `sqlite3.Connection`), so the correct annotation is `Iterator[sqlite3.Connection]`.

- `hermes_cli/sqlite_util.py` — `write_txn`, used by the projects store (`hermes_cli/projects_db.py`) and its tests.
- `hermes_cli/kanban_db.py` — the kanban board's own separate `write_txn` (used by the kanban dashboard plugin and kanban tests), which was likewise unannotated.

```diff
 @contextlib.contextmanager
-def write_txn(conn: sqlite3.Connection):
+def write_txn(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
```

## Type of Change

- [x] Type annotation only — no runtime behavior change

## Why

Both helpers are used as `with write_txn(conn) as ...`. With the annotation, mypy/pyright and IDEs infer the context variable as `sqlite3.Connection` instead of falling back to `Any`. `sqlite_util.add_column_if_missing` is already fully annotated; this brings both transaction context managers to matching coverage.

## Validation

```bash
mypy hermes_cli/sqlite_util.py hermes_cli/kanban_db.py
```

Annotation-only; behavior unchanged. `sqlite_util.py` uses `collections.abc.Iterator`; `kanban_db.py` extends its existing `from typing import ...` line to match that file's style.
