### PR TITLE
fix(gateway): prevent macOS gateway restart loop on unexpected SIGTERM

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17566,11 +17566,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # `hermes gateway stop` and interactive Ctrl+C are handled above as
     # planned stops and should not trigger service-manager revival.
     if _signal_initiated_shutdown and not runner._restart_requested:
+        _is_under_systemd = bool(os.environ.get("INVOCATION_ID"))
+        if _is_under_systemd:
+            logger.info(
+                "Exiting with code 1 (signal-initiated shutdown without restart "
+                "request) so systemd Restart=on-failure can revive the gateway."
+            )
+            return False  # → sys.exit(1) in the caller
         logger.info(
-            "Exiting with code 1 (signal-initiated shutdown without restart "
-            "request) so systemd Restart=on-failure can revive the gateway."
+            "Signal-initiated shutdown without restart request — "
+            "exiting cleanly (non-systemd service manager)."
         )
-        return False  # → sys.exit(1) in the caller
+        return True
 
     # Older restart paths may reach here without ``runner.exit_code`` set.
     # Keep the historical non-zero fallback for service-managed restarts.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3372,7 +3372,6 @@ def generate_launchd_plist() -> str:
         [
             "<string>gateway</string>",
             "<string>run</string>",
-            "<string>--replace</string>",
         ]
     )
     prog_args_xml = "\n        ".join(prog_args)


### PR DESCRIPTION
## What does this PR do?

On macOS, the Hermes gateway enters an infinite restart loop when any external trigger kills the gateway process. Two source-level issues amplify this into a cycle.

**Issue 1:** The launchd plist template hardcodes `--replace`, a flag designed for systemd's `Restart=on-failure` that is unnecessary under launchd's `KeepAlive=true`.

**Issue 2:** The gateway exits with code 1 on all unexpected SIGTERMs. This is intended for systemd's `Restart=on-failure` (non-zero exit restarts), but the detection (`under_systemd = bool(INVOCATION_ID) or ppid == 1`) is too broad — macOS launchd is PID 1. While launchd's KeepAlive=true makes restart happen regardless, the non-zero exit creates confusion.

## Related Issue

Closes #57739

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- **`hermes_cli/gateway.py`** — Removed `--replace` from `generate_launchd_plist()` template
- **`gateway/run.py`** — Check for actual systemd via `INVOCATION_ID` env var (set by systemd, not by launchd). Systemd path preserves exit 1; non-systemd paths exit 0.

## How to Test

1. On macOS: `hermes gateway install && hermes gateway start`
2. Verify plist has no `--replace`
3. Trigger `launchctl kickstart -k "gui/$(id -u)/ai.hermes.gateway"` and confirm no restart loop

## Checklist

- [x] Only Python files modified (no workflow/config changes)
- [x] Tested on macOS (Sequoia 15.7.3)
- [x] systemd path preserved for Linux users