### PR TITLE
fix(sessions): warn operators when auto_prune is off by default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1792,6 +1792,7 @@ def _run_state_db_auto_maintenance(session_db) -> None:
 
         cfg = (_load_full_config().get("sessions") or {})
         if not cfg.get("auto_prune", False):
+            session_db.maybe_warn_auto_prune_disabled()
             return
         session_db.maybe_auto_prune_and_vacuum(
             retention_days=int(cfg.get("retention_days", 90)),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2945,6 +2945,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         vacuum=bool(_sess_cfg.get("vacuum_after_prune", True)),
                         sessions_dir=self.config.sessions_dir,
                     )
+                else:
+                    self._session_db._db.maybe_warn_auto_prune_disabled()
             except Exception as exc:
                 logger.debug("state.db auto-maintenance skipped: %s", exc)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2946,6 +2946,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         sessions_dir=self.config.sessions_dir,
                     )
                 else:
+                    # Construction-time, before the loop serves traffic; sync DB is fine.
                     self._session_db._db.maybe_warn_auto_prune_disabled()
             except Exception as exc:
                 logger.debug("state.db auto-maintenance skipped: %s", exc)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5715,17 +5715,28 @@ class SessionDB:
         without this, operators get no signal that ended sessions and
         state.db will grow unbounded until they opt in. Fires once per
         HERMES_HOME (tracked via state_meta); never raises.
+
+        The claim is atomic (INSERT ... ON CONFLICT DO NOTHING inside
+        _execute_write's BEGIN IMMEDIATE transaction), so only the
+        process that actually inserts the marker logs — concurrent
+        CLI/gateway startups racing this call can't both warn.
         """
         try:
-            if self.get_meta("auto_prune_disabled_warned"):
-                return
-            logger.warning(
-                "sessions.auto_prune is disabled (the default): ended "
-                "sessions and state.db will not be pruned or VACUUMed "
-                "automatically. Set sessions.auto_prune=true in config.yaml, "
-                "or run `hermes sessions prune` manually, to reclaim space."
-            )
-            self.set_meta("auto_prune_disabled_warned", "1")
+            def _do(conn):
+                cur = conn.execute(
+                    "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO NOTHING",
+                    ("auto_prune_disabled_warned", "1"),
+                )
+                return cur.rowcount > 0
+
+            if self._execute_write(_do):
+                logger.warning(
+                    "sessions.auto_prune is disabled (the default): ended "
+                    "sessions and state.db will not be pruned or VACUUMed "
+                    "automatically. Set sessions.auto_prune=true in config.yaml, "
+                    "or run `hermes sessions prune` manually, to reclaim space."
+                )
         except Exception:
             pass
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5708,6 +5708,27 @@ class SessionDB:
 
         return result
 
+    def maybe_warn_auto_prune_disabled(self) -> None:
+        """Log a one-time warning when sessions.auto_prune is off.
+
+        Default is disabled (see hermes_cli/config.py DEFAULT_CONFIG), so
+        without this, operators get no signal that ended sessions and
+        state.db will grow unbounded until they opt in. Fires once per
+        HERMES_HOME (tracked via state_meta); never raises.
+        """
+        try:
+            if self.get_meta("auto_prune_disabled_warned"):
+                return
+            logger.warning(
+                "sessions.auto_prune is disabled (the default): ended "
+                "sessions and state.db will not be pruned or VACUUMed "
+                "automatically. Set sessions.auto_prune=true in config.yaml, "
+                "or run `hermes sessions prune` manually, to reclaim space."
+            )
+            self.set_meta("auto_prune_disabled_warned", "1")
+        except Exception:
+            pass
+
     # ── Handoff (cross-platform session transfer) ──────────────────────────
     #
     # State machine:

--- a/tests/gateway/test_async_session_db.py
+++ b/tests/gateway/test_async_session_db.py
@@ -125,8 +125,8 @@ _GATEWAY_FILES = ("gateway/run.py", "gateway/slash_commands.py")
 #   - self._session_db._db.<x>: the sync escape, allowed ONLY where the call is
 #     provably off the event loop — construction (__init__, before the loop
 #     serves) and the run_sync closure (executed in a thread-pool executor).
-#     Three such sites today; a fourth must be justified and this count bumped.
-_ALLOWED_SYNC_DB_ESCAPES = 3
+#     Four such sites today; a fifth must be justified and this count bumped.
+_ALLOWED_SYNC_DB_ESCAPES = 4
 
 # Sync helpers that touch SessionDB but are NEVER invoked bare on the loop:
 # every loop-side call wraps them in ``asyncio.to_thread(...)`` and the only

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import logging
 import sqlite3
 import time
 import pytest
@@ -4005,6 +4006,29 @@ class TestAutoMaintenance:
         assert marker is not None
         # Should parse as a float timestamp close to now.
         assert abs(float(marker) - time.time()) < 60
+
+    def test_warn_auto_prune_disabled_first_call_logs(self, db, caplog):
+        caplog.set_level(logging.WARNING, logger="hermes_state")
+        db.maybe_warn_auto_prune_disabled()
+        assert any(
+            "sessions.auto_prune is disabled" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_warn_auto_prune_disabled_second_call_silent(self, db, caplog):
+        caplog.set_level(logging.WARNING, logger="hermes_state")
+        db.maybe_warn_auto_prune_disabled()
+        caplog.clear()
+        db.maybe_warn_auto_prune_disabled()
+        assert not any(
+            "sessions.auto_prune is disabled" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_warn_auto_prune_disabled_marker_persists(self, db):
+        assert db.get_meta("auto_prune_disabled_warned") is None
+        db.maybe_warn_auto_prune_disabled()
+        assert db.get_meta("auto_prune_disabled_warned") == "1"
 
     def test_auto_prune_deletes_transcript_files(self, db, tmp_path):
         """Issue #3015: auto-prune must also delete on-disk transcript files."""


### PR DESCRIPTION
Fixes #57752

## Problem

`sessions.auto_prune` defaults to `false` (`hermes_cli/config.py:2878`).
When it's off, ended sessions and `state.db` are never pruned/VACUUMed
(`gateway/run.py:2930-2949`, `cli.py:1752-1803`,
`hermes_state.py:5638` `maybe_auto_prune_and_vacuum`), and — critically —
nothing tells the operator this is happening. The only way to find out is
to read the config defaults or notice disk usage creeping up over time.

The default itself is intentional (see the comment at
`hermes_cli/config.py:2873-2878`: session history has search-recall value,
so silent deletion is worse than slow growth). This PR does **not** change
that default — it closes the visibility gap.

## Fix

Added `SessionDB.maybe_warn_auto_prune_disabled()`
(`hermes_state.py:5711`): logs a single `WARNING` explaining that
auto-prune is off and how to enable it
(`sessions.auto_prune=true` in `config.yaml`, or `hermes sessions prune`
manually). Gated by a `state_meta` flag (`auto_prune_disabled_warned`) so
it fires exactly once per `HERMES_HOME`, mirroring the existing
`last_auto_prune` bookkeeping pattern already used by
`maybe_auto_prune_and_vacuum` — no log spam on every startup.

Wired into both places that currently early-return silently when the flag
is off:
- `cli.py:1794` (`_run_state_db_auto_maintenance`, used by CLI + gateway
  startup)
- `gateway/run.py:2949` (gateway's own startup maintenance block)

## Why this shape

- Minimal: no config default changes, no new config keys, no new
  scheduling logic — reuses the state_meta pattern already in the file.
- Doesn't spam: fires once ever per HERMES_HOME, not once per process
  start (a long-lived gateway process would otherwise be fine, but the
  CLI path runs on every interactive session).
- Never raises: wrapped in try/except like every other call in this
  maintenance path, consistent with "maintenance must never block
  startup."

## Testing

- `python -m pytest tests/test_hermes_state.py -k prune -q` → 9 passed
  (no regressions in existing prune/vacuum coverage)
- Manual smoke test: fresh `HERMES_HOME`, first call to
  `maybe_warn_auto_prune_disabled()` logs the warning; second call is
  silent; `state_meta["auto_prune_disabled_warned"] == "1"` after.

```
--- first call (should warn) ---
WARNING:hermes_state:sessions.auto_prune is disabled (the default): ended sessions and state.db will not be pruned or VACUUMed automatically. Set sessions.auto_prune=true in config.yaml, or run `hermes sessions prune` manually, to reclaim space.
--- second call (should be silent) ---
meta: 1
```

## Files changed

- `hermes_state.py` — new `SessionDB.maybe_warn_auto_prune_disabled()`
- `cli.py` — call it from the early-return branch of
  `_run_state_db_auto_maintenance`
- `gateway/run.py` — call it from the `else` branch of the gateway's
  startup maintenance block