### PR TITLE
fix(ssh): reject Windows ..\ traversal in _ssh_bulk_upload sync-base guard

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -50,6 +50,33 @@ class TestSSHBulkUpload:
             mock_run.assert_not_called()
             mock_popen.assert_not_called()
 
+    def test_remote_path_escaping_base_is_rejected(self, mock_env, tmp_path, monkeypatch):
+        """A remote_path that escapes the sync base is rejected on every platform.
+
+        Regression: the guard used ``rel_remote.startswith("../")``, which only
+        catches POSIX separators. On Windows ``os.path.relpath`` returns
+        ``..\\..\\``, slipping past it, so the staged ``os.symlink``/copy below
+        wrote outside the staging dir. ``has_traversal_component`` is
+        separator-agnostic, so the escape is caught on Windows too.
+        """
+        host = tmp_path / "payload.txt"
+        host.write_text("x")
+
+        # base is "/home/testuser/.hermes"; this remote_path escapes it.
+        files = [(str(host), "/home/testuser/.hermes/../../../etc/evil.txt")]
+
+        # Belt-and-braces: if the guard were bypassed, the staging writes must
+        # not touch the real filesystem outside the temp staging dir.
+        monkeypatch.setattr(ssh_env.os, "symlink", lambda *a, **k: None)
+        monkeypatch.setattr(ssh_env.os, "makedirs", lambda *a, **k: None)
+        monkeypatch.setattr(ssh_env.shutil, "copy2", lambda *a, **k: None)
+
+        with patch.object(subprocess, "run",
+                          return_value=subprocess.CompletedProcess([], 0)), \
+             patch.object(subprocess, "Popen", side_effect=lambda *a, **k: _mock_proc()):
+            with pytest.raises(RuntimeError, match="escapes sync base"):
+                mock_env._ssh_bulk_upload(files)
+
     def test_mkdir_batched_into_single_call(self, mock_env, tmp_path):
         """All parent directories should be created in one SSH call."""
         # Create test files

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -17,6 +17,7 @@ from tools.environments.file_sync import (
     quoted_rm_command,
     unique_parent_dirs,
 )
+from tools.path_security import has_traversal_component
 
 logger = logging.getLogger(__name__)
 
@@ -228,7 +229,13 @@ class SSHEnvironment(BaseEnvironment):
                         f"remote path {remote_path!r} is not under sync base {base!r}"
                     ) from exc
 
-                if rel_remote == "." or rel_remote.startswith("../"):
+                # Reject any escape out of the sync base. ``startswith("../")``
+                # only catches POSIX separators — on Windows os.path.relpath
+                # returns ``..\\..\\`` and slips past it, letting the staged
+                # os.symlink/copy below write outside the staging dir.
+                # has_traversal_component checks path components, so it catches
+                # ``..`` regardless of separator.
+                if rel_remote == "." or has_traversal_component(rel_remote):
                     raise RuntimeError(
                         f"remote path {remote_path!r} escapes sync base {base!r}"
                     )


### PR DESCRIPTION
## What does this PR do?

`_ssh_bulk_upload` guards against a `remote_path` escaping the sync base:

```python
rel_remote = os.path.relpath(remote_path, base)
if rel_remote == "." or rel_remote.startswith("../"):
    raise RuntimeError(f"remote path {remote_path!r} escapes sync base {base!r}")
staged = os.path.join(staging, rel_remote)
os.makedirs(os.path.dirname(staged), exist_ok=True)
os.symlink(os.path.abspath(host_path), staged)   # or copy2 fallback
```

`os.path.relpath` runs on the **local** host. On Windows it returns
`..\..\` (backslash separators), which does **not** start with `"../"`, so the
guard is bypassed. `os.path.join(staging, "..\\..\\…")` then resolves outside
the staging temp dir, and the subsequent `os.makedirs` + `os.symlink`/`copy2`
write there — a local file write outside the intended staging area.

## Changes

- `tools/environments/ssh.py` — replace the POSIX-only `startswith("../")`
  check with the repo's separator-agnostic `has_traversal_component`
  (`tools/path_security.py`), which inspects `..` path components and so
  catches Windows `..\` as well as POSIX `../`.
- `tests/tools/test_ssh_bulk_upload.py` — regression test.

## Tests

```
pytest tests/tools/test_ssh_bulk_upload.py -q
```

A `remote_path` escaping the sync base now raises `"escapes sync base"`
(mutation-verified on Windows — the old `startswith` check let `..\..\..`
through and the guard never fired).