### PR TITLE
feat(state): opt-out flag for the trigram FTS index (HERMES_FTS_TRIGRAM=0)

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -550,6 +550,11 @@ class GatewayAuthorizationMixin:
         check_ids = {user_id}
         if "@" in user_id:
             check_ids.add(user_id.split("@")[0])
+        user_id_alt = str(getattr(source, "user_id_alt", "") or "").strip()
+        if user_id_alt:
+            check_ids.add(user_id_alt)
+            if "@" in user_id_alt:
+                check_ids.add(user_id_alt.split("@")[0])
 
         # WhatsApp: resolve phone↔LID aliases from bridge session mapping files
         if source.platform == Platform.WHATSAPP:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4605,6 +4605,7 @@ class BasePlatformAdapter(ABC):
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            profile=event.source.profile,
         )
 
         # On-entry self-heal: if the adapter still has an _active_sessions

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,6 +17,7 @@ Key design decisions:
 import asyncio
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -166,14 +167,30 @@ _last_init_error_lock = threading.Lock()
 _wal_fallback_warned_paths: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
-_FTS_TRIGGERS = (
+_BASE_FTS_TRIGGERS = (
     "messages_fts_insert",
     "messages_fts_delete",
     "messages_fts_update",
+)
+_TRIGRAM_TRIGGERS = (
     "messages_fts_trigram_insert",
     "messages_fts_trigram_delete",
     "messages_fts_trigram_update",
 )
+_FTS_TRIGGERS = _BASE_FTS_TRIGGERS + _TRIGRAM_TRIGGERS
+
+
+def _trigram_fts_enabled() -> bool:
+    """Whether the trigram FTS index (CJK/substring search) should exist.
+
+    Opt-out via HERMES_FTS_TRIGRAM=0.  The trigram index stores overlapping
+    3-byte tokens for every message and can dominate state.db size (>50 %
+    observed on large DBs).  Deployments that never search CJK text can
+    disable it; substring/CJK queries then fall back to LIKE.  When disabled,
+    existing trigram artifacts are dropped on init — freed pages are reused
+    by SQLite; run VACUUM to shrink the file itself.
+    """
+    return os.environ.get("HERMES_FTS_TRIGRAM", "1") != "0"
 
 
 def _set_last_init_error(msg: Optional[str]) -> None:
@@ -1046,12 +1063,34 @@ class SessionDB:
                 pass
 
     @staticmethod
-    def _fts_trigger_count(cursor: sqlite3.Cursor) -> int:
-        placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+    def _drop_trigram_artifacts(cursor: sqlite3.Cursor) -> None:
+        """Drop the trigram FTS table and its triggers (HERMES_FTS_TRIGRAM=0).
+
+        Only trigram artifacts are touched — the base messages_fts table and
+        its triggers keep maintaining the primary search index.
+        """
+        for trigger in _TRIGRAM_TRIGGERS:
+            try:
+                cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            except sqlite3.OperationalError:
+                pass
+        try:
+            cursor.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+        except sqlite3.OperationalError:
+            # Dropping an FTS5 vtable can fail when the module/tokenizer is
+            # unavailable in this runtime; leave the artifacts for a capable one.
+            pass
+
+    @staticmethod
+    def _fts_trigger_count(
+        cursor: sqlite3.Cursor,
+        triggers: tuple = _FTS_TRIGGERS,
+    ) -> int:
+        placeholders = ",".join("?" for _ in triggers)
         row = cursor.execute(
             f"SELECT COUNT(*) FROM sqlite_master "
             f"WHERE type = 'trigger' AND name IN ({placeholders})",
-            _FTS_TRIGGERS,
+            triggers,
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
@@ -1464,7 +1503,7 @@ class SessionDB:
                                 "COALESCE(tool_calls, '') "
                                 "FROM messages"
                             )
-                        trigram_ok = self._ensure_fts_schema(
+                        trigram_ok = _trigram_fts_enabled() and self._ensure_fts_schema(
                             cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                         )
                         if trigram_ok:
@@ -1541,16 +1580,32 @@ class SessionDB:
             # FTS5 setup. Run the DDL even when the virtual table exists so
             # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
             # an earlier no-FTS5 runtime.
-            triggers_need_repair = self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+            # Judge trigger completeness against the triggers this
+            # configuration expects: with trigram opted out, its three
+            # triggers are deliberately absent and must not trip the repair
+            # heuristic (which would trigger a full FTS rebuild every boot).
+            expected_triggers = (
+                _FTS_TRIGGERS if _trigram_fts_enabled() else _BASE_FTS_TRIGGERS
+            )
+            triggers_need_repair = (
+                self._fts_trigger_count(cursor, expected_triggers)
+                < len(expected_triggers)
+            )
             self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
 
             # Trigram FTS5 for CJK/substring search. This is optional relative
             # to the main FTS table; if it cannot be created, CJK search falls
-            # back to LIKE.
+            # back to LIKE.  Opt-out via HERMES_FTS_TRIGRAM=0 drops existing
+            # trigram artifacts so the index stops consuming space and write
+            # triggers stop firing.
             if self._fts_enabled:
-                trigram_enabled = self._ensure_fts_schema(
-                    cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-                )
+                if _trigram_fts_enabled():
+                    trigram_enabled = self._ensure_fts_schema(
+                        cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                    )
+                else:
+                    self._drop_trigram_artifacts(cursor)
+                    trigram_enabled = False
                 self._trigram_available = trigram_enabled
                 if triggers_need_repair:
                     self._rebuild_fts_indexes(

--- a/plugins/platforms/nextcloud_talk/__init__.py
+++ b/plugins/platforms/nextcloud_talk/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/nextcloud_talk/adapter.py
+++ b/plugins/platforms/nextcloud_talk/adapter.py
@@ -1,0 +1,1063 @@
+"""Nextcloud Talk/Spreed gateway platform adapter.
+
+Native Hermes platform adapter for the local Nextcloud Talk bot integration.
+It accepts signed Talk bot webhooks and sends replies through the Talk Bot OCS
+API.  It intentionally stays dependency-light: stdlib HTTP server + urllib.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+import time
+import threading
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Iterable, Optional, Set, Tuple
+from urllib.parse import quote, urlencode, urlparse, urlunparse
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import build_session_key
+
+logger = logging.getLogger(__name__)
+
+MAX_MESSAGE_LENGTH = 30000
+DEFAULT_WEBHOOK_HOST = "127.0.0.1"
+DEFAULT_WEBHOOK_PORT = 8767
+DEFAULT_WEBHOOK_PATH = "/nextcloud-talk/webhook"
+_DEFAULT_CHAT_HISTORY_LIMIT = 60
+_INDICATOR_REFERENCE_LOOKUP_ATTEMPTS = 5
+_INDICATOR_REFERENCE_LOOKUP_DELAY_SECONDS = 0.25
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.getenv(name, default).strip()
+
+
+def _short_id(value: Any) -> str:
+    """Return a log-safe identifier preview without dumping room/user tokens."""
+    text = str(value or "")
+    if len(text) <= 8:
+        return text
+    return f"{text[:4]}…{text[-4:]}"
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(_env(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _boolish(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().casefold() in {"1", "true", "yes", "on"}
+
+
+def _session_safe_actor_id(value: Any) -> str:
+    """Return a Nextcloud actor id that is safe for Hermes session keys."""
+    actor_id = str(value or "").strip()
+    if not actor_id:
+        return ""
+    return actor_id.replace("/", "_").replace("\\", "_").replace("..", "__")
+
+
+def _floatish(value: Any, default: float) -> float:
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _basic_auth_header(username: str, password: str) -> str:
+    import base64
+
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def _json_bytes(data: Dict[str, Any]) -> bytes:
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def _hmac_hex(secret: str, random_header: str, body: bytes) -> str:
+    return hmac.new(secret.encode("utf-8"), random_header.encode("utf-8") + body, hashlib.sha256).hexdigest()
+
+
+def _verify_incoming_signature(headers: Dict[str, str], body: bytes, secret: str) -> bool:
+    random_header = headers.get("x-nextcloud-talk-random", "")
+    signature = headers.get("x-nextcloud-talk-signature", "")
+    if not random_header or not signature or not secret:
+        return False
+    expected = _hmac_hex(secret, random_header, body)
+    return hmac.compare_digest(expected, signature.lower())
+
+
+def _extract_message(payload: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
+    actor_raw = payload.get("actor")
+    obj_raw = payload.get("object")
+    target_raw = payload.get("target")
+    actor: Dict[str, Any] = actor_raw if isinstance(actor_raw, dict) else {}
+    obj: Dict[str, Any] = obj_raw if isinstance(obj_raw, dict) else {}
+    target: Dict[str, Any] = target_raw if isinstance(target_raw, dict) else {}
+    reply_raw = obj.get("inReplyTo")
+    in_reply_to: Dict[str, Any] = reply_raw if isinstance(reply_raw, dict) else {}
+
+    meta = {
+        "event_type": payload.get("type", ""),
+        "actor_id": actor.get("id", ""),
+        "actor_name": actor.get("name", ""),
+        "actor_type": actor.get("type", ""),
+        "message_id": obj.get("id", ""),
+        "message_name": obj.get("name", ""),
+        "conversation_token": target.get("id") or obj.get("id", ""),
+        "conversation_name": target.get("name", ""),
+        "reply_to_message_id": in_reply_to.get("id", ""),
+    }
+
+    if payload.get("type") != "Create" or obj.get("name") != "message":
+        return None, meta
+
+    content = obj.get("content", "")
+    if isinstance(content, dict):
+        return str(content.get("message", "")).strip(), meta
+    if isinstance(content, str):
+        try:
+            rich = json.loads(content)
+            if isinstance(rich, dict):
+                return str(rich.get("message", "")).strip(), meta
+        except json.JSONDecodeError:
+            return content.strip(), meta
+    return None, meta
+
+
+@dataclass
+class NextcloudTalkSettings:
+    base_url: str
+    bot_secret: str
+    webhook_host: str = DEFAULT_WEBHOOK_HOST
+    webhook_port: int = DEFAULT_WEBHOOK_PORT
+    webhook_path: str = DEFAULT_WEBHOOK_PATH
+    home_channel: str = ""
+    request_timeout: int = 60
+    processing_indicator_enabled: bool = False
+    processing_indicator_delay_seconds: float = 0.6
+    processing_indicator_text: str = "Tron verarbeitet …"
+    control_user: str = ""
+    control_password: str = ""
+    native_typing_enabled: bool = True
+
+
+def _websocket_url_from_signaling_server(server_url: str) -> str:
+    """Return the Spreed HPB websocket URL for a Talk signaling server."""
+    parsed = urlparse((server_url or "").rstrip("/"))
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    scheme = "wss" if parsed.scheme == "https" else "ws" if parsed.scheme == "http" else parsed.scheme
+    path = parsed.path.rstrip("/")
+    if not path.endswith("/spreed"):
+        path = f"{path}/spreed" if path else "/spreed"
+    return urlunparse((scheme, parsed.netloc, path, "", "", ""))
+
+
+class _NextcloudTalkTypingClient:
+    """HPB signaling client that makes the real Nextcloud user appear typing."""
+
+    def __init__(self, adapter: "NextcloudTalkAdapter", token: str):
+        self.adapter = adapter
+        self.token = str(token)
+        self._task: Optional[asyncio.Task] = None
+        self._stop_event: asyncio.Event = asyncio.Event()
+        self._participants: Set[str] = set()
+        self._own_signaling_session_id = ""
+        self._websocket: Any = None
+
+    async def ensure_started(self) -> None:
+        if self._task and not self._task.done():
+            logger.info("Nextcloud Talk native typing already running for room=%s", _short_id(self.token))
+            return
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._run(), name=f"nextcloud-talk-typing:{self.token}")
+        logger.info("Nextcloud Talk native typing start requested for room=%s", _short_id(self.token))
+
+    async def stop(self, timeout: float = 2.0) -> None:
+        self._stop_event.set()
+        task = self._task
+        if task and not task.done():
+            logger.info("Nextcloud Talk native typing stop requested for room=%s", _short_id(self.token))
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+            except asyncio.TimeoutError:
+                logger.warning("Nextcloud Talk native typing stop timed out; cancelling room=%s", _short_id(self.token))
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        self._task = None
+
+    async def _run(self) -> None:
+        try:
+            await self._connect_join_and_relay_typing()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Nextcloud Talk native typing client failed for room=%s", _short_id(self.token), exc_info=True)
+
+    async def _connect_join_and_relay_typing(self) -> None:
+        import websockets
+
+        room = await asyncio.to_thread(self.adapter._join_room_as_control_user, self.token)
+        nextcloud_session_id = str(room.get("sessionId") or room.get("sessionid") or "")
+        logger.info(
+            "Nextcloud Talk native typing room join: room=%s session_id_present=%s",
+            _short_id(self.token),
+            bool(nextcloud_session_id),
+        )
+        settings = await asyncio.to_thread(self.adapter._get_signaling_settings, self.token)
+        websocket_url = _websocket_url_from_signaling_server(str(settings.get("server") or ""))
+        raw_hello_auth_params = settings.get("helloAuthParams")
+        hello_auth_params: Dict[str, Any] = raw_hello_auth_params if isinstance(raw_hello_auth_params, dict) else {}
+        logger.info(
+            "Nextcloud Talk native typing signaling settings: room=%s mode=%s websocket_url_present=%s hello_versions=%s",
+            _short_id(self.token),
+            settings.get("signalingMode"),
+            bool(websocket_url),
+            sorted(hello_auth_params.keys()),
+        )
+        if not nextcloud_session_id or not websocket_url or not hello_auth_params:
+            logger.warning(
+                "Nextcloud Talk native typing prerequisites missing: room=%s session_id=%s websocket_url=%s hello_auth=%s",
+                _short_id(self.token),
+                bool(nextcloud_session_id),
+                bool(websocket_url),
+                bool(hello_auth_params),
+            )
+            return
+
+        async with websockets.connect(websocket_url, open_timeout=10, close_timeout=2) as websocket:
+            self._websocket = websocket
+            logger.info("Nextcloud Talk native typing websocket connected for room=%s", _short_id(self.token))
+            welcome = await asyncio.wait_for(websocket.recv(), timeout=10)
+            welcome_payload = json.loads(welcome) if isinstance(welcome, str) else json.loads(welcome.decode("utf-8"))
+            features = set(welcome_payload.get("welcome", {}).get("features", [])) if isinstance(welcome_payload, dict) else set()
+            hello_version = "2.0" if "hello-v2" in features and hello_auth_params.get("2.0") else "1.0"
+            auth_params = hello_auth_params.get(hello_version)
+            if not auth_params:
+                logger.warning(
+                    "Nextcloud Talk native typing missing hello auth params: room=%s hello_version=%s",
+                    _short_id(self.token),
+                    hello_version,
+                )
+                return
+            await websocket.send(json.dumps({
+                "id": "1",
+                "type": "hello",
+                "hello": {
+                    "version": hello_version,
+                    "auth": {
+                        "url": f"{self.adapter.settings.base_url}/ocs/v2.php/apps/spreed/api/v3/signaling/backend",
+                        "params": auth_params,
+                    },
+                    "features": ["chat-relay"],
+                },
+            }, separators=(",", ":")))
+            hello_response = await self._recv_until_type(websocket, "hello")
+            self._own_signaling_session_id = str(hello_response.get("hello", {}).get("sessionid") or "")
+            logger.info(
+                "Nextcloud Talk native typing hello accepted: room=%s own_session_present=%s",
+                _short_id(self.token),
+                bool(self._own_signaling_session_id),
+            )
+            await websocket.send(json.dumps({
+                "id": "2",
+                "type": "room",
+                "room": {"roomid": self.token, "sessionid": nextcloud_session_id},
+            }, separators=(",", ":")))
+            await self._recv_until_type(websocket, "room")
+            logger.info(
+                "Nextcloud Talk native typing room relay joined: room=%s participants=%d",
+                _short_id(self.token),
+                len(self._participants),
+            )
+            await self._broadcast_typing(True)
+            await self._receive_events_until_stopped(websocket)
+        self._websocket = None
+
+    async def _recv_until_type(self, websocket: Any, expected_type: str) -> Dict[str, Any]:
+        while True:
+            raw = await asyncio.wait_for(websocket.recv(), timeout=10)
+            payload = json.loads(raw) if isinstance(raw, str) else json.loads(raw.decode("utf-8"))
+            if isinstance(payload, dict):
+                self._handle_signaling_payload(payload)
+                if payload.get("type") == expected_type:
+                    return payload
+
+    async def _receive_events_until_stopped(self, websocket: Any) -> None:
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    raw = await asyncio.wait_for(websocket.recv(), timeout=0.5)
+                except asyncio.TimeoutError:
+                    continue
+                payload = json.loads(raw) if isinstance(raw, str) else json.loads(raw.decode("utf-8"))
+                if isinstance(payload, dict):
+                    before = set(self._participants)
+                    self._handle_signaling_payload(payload)
+                    for session_id in sorted(self._participants - before):
+                        logger.info(
+                            "Nextcloud Talk native typing participant appeared: room=%s participant=%s",
+                            _short_id(self.token),
+                            _short_id(session_id),
+                        )
+                        await self._send_typing_to(session_id, True)
+        finally:
+            await self._broadcast_typing(False)
+            with contextlib.suppress(Exception):
+                await websocket.send(json.dumps({"type": "bye", "bye": {}}, separators=(",", ":")))
+
+    def _handle_signaling_payload(self, payload: Dict[str, Any]) -> None:
+        event = payload.get("event") if isinstance(payload.get("event"), dict) else None
+        if event and event.get("target") == "room":
+            event_type = event.get("type")
+            if event_type == "join":
+                self._add_participants(event.get("join") or [])
+            elif event_type == "leave":
+                self._remove_participants(event.get("leave") or [])
+            return
+
+        # Some Talk/HPB deployments do not emit a separate ``event: join`` for
+        # users that were already present when the relay joins.  The initial
+        # ``type: room`` response may still carry participant/session objects,
+        # and ignoring those leaves native typing technically connected but
+        # with zero recipients — a particularly elegant no-op, naturally.
+        if payload.get("type") == "room":
+            self._add_participants(self._extract_session_ids(payload))
+
+    def _extract_session_ids(self, value: Any) -> Set[str]:
+        session_ids: Set[str] = set()
+        if isinstance(value, dict):
+            session_id = str(value.get("sessionid") or value.get("sessionId") or "")
+            if session_id:
+                session_ids.add(session_id)
+            for child in value.values():
+                session_ids.update(self._extract_session_ids(child))
+        elif isinstance(value, list):
+            for item in value:
+                session_ids.update(self._extract_session_ids(item))
+        return session_ids
+
+    def _add_participants(self, participants: Iterable[Any]) -> None:
+        for participant in participants:
+            if isinstance(participant, dict):
+                session_id = str(participant.get("sessionid") or participant.get("sessionId") or "")
+            else:
+                session_id = str(participant or "")
+            if session_id and session_id != self._own_signaling_session_id:
+                self._participants.add(session_id)
+
+    def _remove_participants(self, participants: Iterable[Any]) -> None:
+        for participant in participants:
+            if isinstance(participant, dict):
+                session_id = str(participant.get("sessionid") or "")
+            else:
+                session_id = str(participant or "")
+            if session_id:
+                self._participants.discard(session_id)
+
+    async def _broadcast_typing(self, typing: bool) -> None:
+        if not self._websocket:
+            logger.info(
+                "Nextcloud Talk native typing broadcast skipped (no websocket): room=%s typing=%s",
+                _short_id(self.token),
+                typing,
+            )
+            return
+        event_type = "startedTyping" if typing else "stoppedTyping"
+        logger.info(
+            "Nextcloud Talk native typing broadcast: room=%s typing=%s participants_known=%d recipient=room",
+            _short_id(self.token),
+            typing,
+            len(self._participants),
+        )
+        # Broadcast to the room instead of unicasting to the locally observed
+        # participants set. Existing participants usually do not emit a fresh
+        # join event after this relay joins, so the set can legitimately be
+        # empty while the user is already watching the room. Room-recipient
+        # signaling is the protocol-supported way to reach those sessions.
+        await self._websocket.send(json.dumps({
+            "type": "message",
+            "message": {
+                "recipient": {"type": "room"},
+                "data": {"type": event_type},
+            },
+        }, separators=(",", ":")))
+
+    async def _send_typing_to(self, session_id: str, typing: bool) -> None:
+        if not self._websocket or not session_id:
+            return
+        event_type = "startedTyping" if typing else "stoppedTyping"
+        logger.info(
+            "Nextcloud Talk native typing send event: room=%s participant=%s event=%s",
+            _short_id(self.token),
+            _short_id(session_id),
+            event_type,
+        )
+        await self._websocket.send(json.dumps({
+            "type": "message",
+            "message": {
+                "recipient": {"type": "session", "sessionid": session_id},
+                "data": {"type": event_type, "to": session_id},
+            },
+        }, separators=(",", ":")))
+
+
+class NextcloudTalkAdapter(BasePlatformAdapter):
+    """Webhook-based Nextcloud Talk platform adapter."""
+
+    supports_code_blocks = True
+    supports_async_delivery = True
+    splits_long_messages = True
+    typed_command_prefix = "/"
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform("nextcloud_talk"))
+        extra = getattr(config, "extra", {}) or {}
+        base_url = (
+            _env("NEXTCLOUD_TALK_BASE_URL")
+            or _env("NEXTCLOUD_BASE_URL")
+            or str(extra.get("base_url") or extra.get("server_url") or "")
+        ).rstrip("/")
+        self.settings = NextcloudTalkSettings(
+            base_url=base_url,
+            bot_secret=_env("NEXTCLOUD_TALK_BOT_SECRET") or str(extra.get("bot_secret") or ""),
+            webhook_host=_env("NEXTCLOUD_TALK_WEBHOOK_HOST") or str(extra.get("webhook_host") or DEFAULT_WEBHOOK_HOST),
+            webhook_port=_env_int("NEXTCLOUD_TALK_WEBHOOK_PORT", int(extra.get("webhook_port") or DEFAULT_WEBHOOK_PORT)),
+            webhook_path=_env("NEXTCLOUD_TALK_WEBHOOK_PATH") or str(extra.get("webhook_path") or DEFAULT_WEBHOOK_PATH),
+            home_channel=_env("NEXTCLOUD_TALK_HOME_CHANNEL") or str(extra.get("home_channel") or ""),
+            request_timeout=_env_int("NEXTCLOUD_TALK_REQUEST_TIMEOUT_SECONDS", int(extra.get("request_timeout") or 60)),
+            processing_indicator_enabled=_boolish(
+                extra.get("processing_indicator_enabled"),
+                _boolish(_env("NEXTCLOUD_TALK_PROCESSING_INDICATOR_ENABLED") or None, False),
+            ),
+            processing_indicator_delay_seconds=max(
+                0.0,
+                _floatish(
+                    extra.get("processing_indicator_delay_seconds")
+                    or _env("NEXTCLOUD_TALK_PROCESSING_INDICATOR_DELAY_SECONDS"),
+                    0.6,
+                ),
+            ),
+            processing_indicator_text=str(
+                extra.get("processing_indicator_text")
+                or _env("NEXTCLOUD_TALK_PROCESSING_INDICATOR_TEXT")
+                or "Tron verarbeitet …"
+            ),
+            control_user=_env("NEXTCLOUD_TALK_CONTROL_USER") or _env("NEXTCLOUD_WEBUI_USER"),
+            control_password=_env("NEXTCLOUD_TALK_CONTROL_PASSWORD") or _env("NEXTCLOUD_WEBUI_PASSWORD"),
+            native_typing_enabled=_boolish(
+                extra.get("native_typing_enabled"),
+                _boolish(_env("NEXTCLOUD_TALK_NATIVE_TYPING_ENABLED") or None, True),
+            ),
+        )
+        self._typing_clients: Dict[str, _NextcloudTalkTypingClient] = {}
+        self._typing_config_skip_logged = False
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._server_thread: Optional[threading.Thread] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        if not self.settings.base_url or not self.settings.bot_secret:
+            self._set_fatal_error("missing_config", "NEXTCLOUD_TALK_BASE_URL/NEXTCLOUD_BASE_URL and NEXTCLOUD_TALK_BOT_SECRET are required", retryable=False)
+            return False
+        self._loop = asyncio.get_running_loop()
+        handler = self._make_handler()
+        try:
+            self._server = ThreadingHTTPServer((self.settings.webhook_host, self.settings.webhook_port), handler)
+        except OSError as exc:
+            self._set_fatal_error("bind_failed", f"Could not bind Nextcloud Talk webhook: {exc}", retryable=False)
+            return False
+        self._server_thread = threading.Thread(target=self._server.serve_forever, kwargs={"poll_interval": 0.5}, daemon=True)
+        self._server_thread.start()
+        self._mark_connected()
+        logger.info(
+            "[Nextcloud Talk] Webhook listening on http://%s:%s%s",
+            self.settings.webhook_host,
+            self.settings.webhook_port,
+            self.settings.webhook_path,
+        )
+        logger.info(
+            "[Nextcloud Talk] native typing config: enabled=%s control_user_present=%s control_password_present=%s fallback_indicator_enabled=%s fallback_delay=%.2fs",
+            self.settings.native_typing_enabled,
+            bool(self.settings.control_user),
+            bool(self.settings.control_password),
+            self.settings.processing_indicator_enabled,
+            self.settings.processing_indicator_delay_seconds,
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+        await self._stop_all_native_typing_clients()
+        if self._server:
+            await asyncio.to_thread(self._server.shutdown)
+            self._server.server_close()
+        self._server = None
+        self._server_thread = None
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        chunks = self.truncate_message(content or "", MAX_MESSAGE_LENGTH)
+        last_id: Optional[str] = None
+        continuations = []
+        sent_count = 0
+        try:
+            for idx, chunk in enumerate(chunks or [""]):
+                result = await asyncio.to_thread(self._send_one, chat_id, chunk, reply_to if idx == 0 else None)
+                sent_count += 1
+                last_id = result.get("message_id") or last_id
+                if idx > 0 and last_id:
+                    continuations.append(last_id)
+            return SendResult(success=True, message_id=last_id, raw_response={"chunks": len(chunks)}, continuation_message_ids=tuple(continuations))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")[:500]
+            raw_response: Dict[str, Any] = {"detail": detail, "chunks_sent": sent_count, "total_chunks": len(chunks or [""])}
+            if sent_count:
+                raw_response["partial_delivery"] = True
+            return SendResult(
+                success=False,
+                error=f"HTTP {exc.code}: {detail}",
+                raw_response=raw_response,
+                retryable=False,
+            )
+        except Exception as exc:
+            raw_response = {"chunks_sent": sent_count, "total_chunks": len(chunks or [""])}
+            if sent_count:
+                raw_response["partial_delivery"] = True
+            return SendResult(success=False, error=str(exc), raw_response=raw_response, retryable=not bool(sent_count))
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"id": chat_id, "name": chat_id, "type": "group"}
+
+    def _control_headers(self) -> Dict[str, str]:
+        if not (self.settings.control_user and self.settings.control_password):
+            raise RuntimeError("Nextcloud Talk control credentials are not configured")
+        return {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "OCS-APIRequest": "true",
+            "Authorization": _basic_auth_header(self.settings.control_user, self.settings.control_password),
+        }
+
+    def _control_request_json(self, path: str, method: str = "GET", payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        body = _json_bytes(payload) if payload is not None else None
+        request = urllib.request.Request(
+            f"{self.settings.base_url}{path}",
+            data=body,
+            headers=self._control_headers(),
+            method=method,
+        )
+        with urllib.request.urlopen(request, timeout=self.settings.request_timeout) as resp:
+            raw = resp.read()
+        return json.loads(raw.decode("utf-8")) if raw else {}
+
+    def _join_room_as_control_user(self, token: str) -> Dict[str, Any]:
+        quoted_token = quote(str(token), safe="")
+        data = self._control_request_json(
+            f"/ocs/v2.php/apps/spreed/api/v4/room/{quoted_token}/participants/active?format=json",
+            method="POST",
+            payload={"force": False},
+        )
+        ocs = data.get("ocs", {}) if isinstance(data, dict) else {}
+        room = ocs.get("data") if isinstance(ocs, dict) else None
+        return room if isinstance(room, dict) else {}
+
+    def _get_signaling_settings(self, token: str) -> Dict[str, Any]:
+        quoted_token = quote(str(token), safe="")
+        data = self._control_request_json(
+            f"/ocs/v2.php/apps/spreed/api/v3/signaling/settings?format=json&token={quoted_token}",
+            method="GET",
+        )
+        ocs = data.get("ocs", {}) if isinstance(data, dict) else {}
+        settings = ocs.get("data") if isinstance(ocs, dict) else None
+        return settings if isinstance(settings, dict) else {}
+
+    def _can_native_type(self) -> bool:
+        return bool(self.settings.native_typing_enabled and self.settings.control_user and self.settings.control_password)
+
+    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        if not chat_id:
+            logger.info("Nextcloud Talk native typing skipped: missing chat_id")
+            return
+        if not self._can_native_type():
+            if not self._typing_config_skip_logged:
+                self._typing_config_skip_logged = True
+                logger.warning(
+                    "Nextcloud Talk native typing skipped: enabled=%s control_user_present=%s control_password_present=%s",
+                    self.settings.native_typing_enabled,
+                    bool(self.settings.control_user),
+                    bool(self.settings.control_password),
+                )
+            return
+        client = self._typing_clients.get(str(chat_id))
+        if client is None:
+            client = _NextcloudTalkTypingClient(self, str(chat_id))
+            self._typing_clients[str(chat_id)] = client
+            logger.info("Nextcloud Talk native typing client created for room=%s", _short_id(chat_id))
+        else:
+            logger.info("Nextcloud Talk native typing client reused for room=%s", _short_id(chat_id))
+        await client.ensure_started()
+
+    async def stop_typing(self, chat_id: str) -> None:
+        client = self._typing_clients.pop(str(chat_id), None)
+        if client is not None:
+            logger.info("Nextcloud Talk native typing client stopping for room=%s", _short_id(chat_id))
+            await client.stop()
+        elif chat_id:
+            logger.info("Nextcloud Talk native typing stop requested but no client exists for room=%s", _short_id(chat_id))
+
+    async def _stop_all_native_typing_clients(self) -> None:
+        clients = list(self._typing_clients.items())
+        self._typing_clients.clear()
+        for _chat_id, client in clients:
+            with contextlib.suppress(Exception):
+                await client.stop()
+
+    def _send_one(
+        self,
+        token: str,
+        message: str,
+        reply_to: Optional[str] = None,
+        _resolve_reference_id: bool = False,
+    ) -> Dict[str, Any]:
+        message = (message or "").strip()
+        reference_id = secrets.token_hex(32)
+        payload: Dict[str, Any] = {"message": message, "referenceId": reference_id}
+        if reply_to:
+            try:
+                payload["replyTo"] = int(reply_to)
+            except (TypeError, ValueError):
+                pass
+        body = _json_bytes(payload)
+        random_header = secrets.token_hex(32)
+        # Spreed/Talk 23 validates bot sends against random + plain message,
+        # not random + JSON body.
+        signature = _hmac_hex(self.settings.bot_secret, random_header, message.encode("utf-8"))
+        request = urllib.request.Request(
+            f"{self.settings.base_url}/ocs/v2.php/apps/spreed/api/v1/bot/{token}/message",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "OCS-APIRequest": "true",
+                "X-Nextcloud-Talk-Bot-Random": random_header,
+                "X-Nextcloud-Talk-Bot-Signature": signature,
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=self.settings.request_timeout) as resp:
+            raw = resp.read()
+            status = getattr(resp, "status", 200)
+        data = json.loads(raw.decode("utf-8")) if raw else {}
+        message_id = None
+        try:
+            message_id = str(data.get("ocs", {}).get("data", {}).get("id") or "") or None
+        except AttributeError:
+            message_id = None
+        # Bot responses can be data=null, so message id must be resolved from chat
+        # history by reference ID using control credentials.
+        if not message_id and self._can_cleanup_indicator_messages() and _resolve_reference_id:
+            message_id = self._resolve_message_id_by_reference_id(token, reference_id)
+        return {
+            "status": status,
+            "response": data,
+            "message_id": message_id,
+            "reference_id": reference_id,
+        }
+
+    def _can_cleanup_indicator_messages(self) -> bool:
+        return bool(self.settings.control_user and self.settings.control_password)
+
+    def _resolve_message_id_by_reference_id(
+        self,
+        token: str,
+        reference_id: str,
+        attempts: int = _INDICATOR_REFERENCE_LOOKUP_ATTEMPTS,
+        retry_delay_seconds: float = _INDICATOR_REFERENCE_LOOKUP_DELAY_SECONDS,
+    ) -> Optional[str]:
+        if not self._can_cleanup_indicator_messages():
+            return None
+        if not reference_id:
+            return None
+        quoted_token = quote(str(token), safe="")
+        limit = _DEFAULT_CHAT_HISTORY_LIMIT
+        params = urlencode(
+            {
+                "lookIntoFuture": "0",
+                "setReadMarker": "0",
+                "limit": str(limit),
+            },
+        )
+        headers = {
+            "Accept": "application/json",
+            "OCS-APIRequest": "true",
+            "Authorization": _basic_auth_header(self.settings.control_user, self.settings.control_password),
+        }
+        max_attempts = max(1, attempts)
+        for attempt in range(max_attempts):
+            try:
+                request = urllib.request.Request(
+                    f"{self.settings.base_url}/ocs/v2.php/apps/spreed/api/v1/chat/{quoted_token}?{params}",
+                    headers=headers,
+                    method="GET",
+                )
+                with urllib.request.urlopen(request, timeout=self.settings.request_timeout) as resp:
+                    raw = resp.read()
+                if not raw:
+                    # Empty body: transient; can happen with 304-like reverse-proxy
+                    # behaviour.  Retry or exhaust attempts (implicit None return).
+                    if attempt + 1 < max_attempts:
+                        time.sleep(retry_delay_seconds)
+                    continue
+                data = json.loads(raw.decode("utf-8"))
+                ocs_payload = data.get("ocs", {})
+                messages = ocs_payload.get("data") if isinstance(ocs_payload, dict) else None
+                if isinstance(messages, list):
+                    for item in messages:
+                        if not isinstance(item, dict):
+                            continue
+                        if str(item.get("referenceId") or "") == reference_id:
+                            candidate = item.get("id")
+                            if candidate is not None:
+                                return str(candidate)
+            except urllib.error.HTTPError as exc:
+                status = exc.code
+                if status in (401, 403, 404, 412):
+                    return None
+                if status == 304:
+                    logger.debug("Nextcloud Talk chat message history lookup returned 304; retrying reference lookup.")
+                else:
+                    logger.debug("Nextcloud Talk reference lookup failed with status %s", status)
+                if attempt + 1 >= max_attempts:
+                    return None
+            except (OSError, ValueError, KeyError, TypeError):
+                logger.debug(
+                    "Nextcloud Talk reference lookup failed for token=%s reference=%s",
+                    quoted_token,
+                    reference_id[:8],
+                )
+                if attempt + 1 >= max_attempts:
+                    return None
+            if attempt + 1 < max_attempts:
+                time.sleep(retry_delay_seconds)
+        return None
+
+    def _delete_message(self, token: str, message_id: str) -> Dict[str, Any]:
+        """Delete a Talk message via the normal chat API using control credentials.
+
+        The bot endpoint can create messages but does not expose edit/delete in
+        Talk 23.  If configured, we use a real Talk participant credential to
+        remove our temporary processing indicator after the final Hermes reply
+        lands.  Without those credentials the caller should simply skip the
+        indicator rather than leave chat litter behind. A butler cleans up his
+        tray, after all.
+        """
+        if not (self.settings.control_user and self.settings.control_password):
+            raise RuntimeError("Nextcloud Talk control credentials are not configured")
+        quoted_token = quote(str(token), safe="")
+        quoted_message_id = quote(str(message_id), safe="")
+        request = urllib.request.Request(
+            f"{self.settings.base_url}/ocs/v2.php/apps/spreed/api/v1/chat/{quoted_token}/{quoted_message_id}",
+            headers={
+                "Accept": "application/json",
+                "OCS-APIRequest": "true",
+                "Authorization": _basic_auth_header(self.settings.control_user, self.settings.control_password),
+            },
+            method="DELETE",
+        )
+        with urllib.request.urlopen(request, timeout=self.settings.request_timeout) as resp:
+            raw = resp.read()
+            status = getattr(resp, "status", 200)
+        data = json.loads(raw.decode("utf-8")) if raw else {}
+        return {"status": status, "response": data}
+
+    async def _await_message_processing_complete(self, event: MessageEvent) -> None:
+        """Wait for the background task that BasePlatformAdapter spawned.
+
+        ``handle_message()`` intentionally returns immediately after scheduling
+        ``_process_message_background``.  The Talk status indicator, however,
+        must wrap the actual agent turn rather than that dispatcher call.
+        Follow ownership hand-offs so queued follow-up drain tasks do not leave
+        the temporary indicator behind the final response.
+        """
+        session_store = getattr(self, "_session_store", None)
+        if session_store is not None and hasattr(session_store, "_generate_session_key"):
+            session_key = session_store._generate_session_key(event.source)
+        else:
+            session_key = build_session_key(
+                event.source,
+                group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+                thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+                profile=event.source.profile,
+            )
+        seen: set[asyncio.Task] = set()
+        while True:
+            task = self._session_tasks.get(session_key)
+            if task is None or task in seen:
+                return
+            seen.add(task)
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # The background task logs/sends user-visible failures itself;
+                # the indicator cleanup should still run.
+                logger.debug("Nextcloud Talk background processing finished with error", exc_info=True)
+
+    async def _handle_message_with_processing_indicator(self, event: MessageEvent) -> None:
+        indicator_task: Optional[asyncio.Task] = None
+        indicator_message_id: Optional[str] = None
+        indicator_reference_id: Optional[str] = None
+
+        async def _send_indicator_after_delay() -> Tuple[Optional[str], Optional[str]]:
+            await asyncio.sleep(self.settings.processing_indicator_delay_seconds)
+            result = await asyncio.to_thread(
+                self._send_one,
+                event.source.chat_id,
+                self.settings.processing_indicator_text,
+                event.message_id,
+                True,
+            )
+            reference_id = result.get("reference_id")
+            return result.get("message_id") or None, reference_id
+
+        # The removable chat-message indicator is now opt-in only. Native Talk
+        # typing is the preferred user-visible progress signal; the temporary
+        # "Tron verarbeitet …" message remains available as a fallback for
+        # deployments where native typing is unavailable or unreliable.
+        can_cleanup = self._can_cleanup_indicator_messages()
+        use_message_fallback = True
+        if (
+            use_message_fallback
+            and self.settings.processing_indicator_enabled
+            and can_cleanup
+            and event.source.chat_id
+            and self.settings.processing_indicator_text.strip()
+        ):
+            indicator_task = asyncio.create_task(_send_indicator_after_delay())
+
+        try:
+            await self.handle_message(event)
+            await self._await_message_processing_complete(event)
+        finally:
+            if indicator_task:
+                if indicator_task.done():
+                    try:
+                        indicator_message_id, indicator_reference_id = indicator_task.result()
+                    except Exception:
+                        logger.debug("Nextcloud Talk processing indicator send failed", exc_info=True)
+                else:
+                    indicator_task.cancel()
+                    try:
+                        await indicator_task
+                    except asyncio.CancelledError:
+                        pass
+
+            if not indicator_message_id and indicator_reference_id:
+                indicator_message_id = await asyncio.to_thread(
+                    self._resolve_message_id_by_reference_id,
+                    event.source.chat_id,
+                    indicator_reference_id,
+                    attempts=6,
+                    retry_delay_seconds=_INDICATOR_REFERENCE_LOOKUP_DELAY_SECONDS * 0.5,
+                )
+            if indicator_message_id:
+                try:
+                    await asyncio.to_thread(self._delete_message, event.source.chat_id, indicator_message_id)
+                except Exception:
+                    logger.debug("Nextcloud Talk processing indicator cleanup failed", exc_info=True)
+
+    def _make_handler(self):
+        adapter = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def _send_json(self, status: int, payload: Dict[str, Any]) -> None:
+                raw = _json_bytes(payload)
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def do_GET(self) -> None:  # noqa: N802
+                if self.path == "/health":
+                    self._send_json(200, {"ok": True, "service": "nextcloud-talk-platform"})
+                    return
+                self._send_json(404, {"ok": False, "error": "not found"})
+
+            def do_POST(self) -> None:  # noqa: N802
+                if self.path.rstrip("/") != adapter.settings.webhook_path.rstrip("/"):
+                    self._send_json(404, {"ok": False, "error": "not found"})
+                    return
+                try:
+                    length = int(self.headers.get("Content-Length", "0"))
+                except ValueError:
+                    self._send_json(411, {"ok": False, "error": "invalid content length"})
+                    return
+                body = self.rfile.read(length)
+                headers = {key.lower(): value for key, value in self.headers.items()}
+                status, payload = adapter._handle_webhook_sync(headers, body)
+                self._send_json(status, payload)
+
+            def log_message(self, format: str, *args: Any) -> None:
+                logger.debug("Nextcloud Talk webhook: " + format, *args)
+
+        return Handler
+
+    def _handle_webhook_sync(self, headers: Dict[str, str], body: bytes) -> Tuple[int, Dict[str, Any]]:
+        if not self.settings.bot_secret:
+            return 503, {"ok": False, "error": "webhook not configured"}
+        if not _verify_incoming_signature(headers, body, self.settings.bot_secret):
+            return 401, {"ok": False, "error": "invalid signature"}
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            return 400, {"ok": False, "error": "invalid json"}
+        text, meta = _extract_message(payload)
+        if not text:
+            return 202, {"ok": True, "ignored": "no visible user message"}
+        actor_id = str(meta.get("actor_id", ""))
+        actor_type = str(meta.get("actor_type", ""))
+        if actor_id.startswith("bots/") or actor_type == "Application":
+            return 202, {"ok": True, "ignored": "bot/application message"}
+        token = str(meta.get("conversation_token") or "")
+        if not token:
+            return 202, {"ok": True, "ignored": "missing conversation token"}
+        if not self._loop or self._loop.is_closed():
+            return 503, {"ok": False, "error": "adapter event loop not ready"}
+        source = self.build_source(
+            chat_id=token,
+            chat_name=str(meta.get("conversation_name") or token),
+            chat_type="group",
+            user_id=_session_safe_actor_id(actor_id) or None,
+            user_id_alt=actor_id or None,
+            user_name=str(meta.get("actor_name") or ""),
+            message_id=str(meta.get("message_id") or ""),
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=payload,
+            message_id=str(meta.get("message_id") or "") or None,
+            reply_to_message_id=str(meta.get("reply_to_message_id") or "") or None,
+        )
+        def _schedule() -> None:
+            task = asyncio.create_task(self._handle_message_with_processing_indicator(event))
+
+            def _log_failure(done: asyncio.Task) -> None:
+                try:
+                    done.result()
+                except Exception:
+                    logger.exception("Nextcloud Talk message dispatch failed")
+
+            task.add_done_callback(_log_failure)
+
+        self._loop.call_soon_threadsafe(_schedule)
+        return 202, {"ok": True, "accepted": True}
+
+
+def check_requirements() -> bool:
+    return bool((_env("NEXTCLOUD_TALK_BASE_URL") or _env("NEXTCLOUD_BASE_URL")) and _env("NEXTCLOUD_TALK_BOT_SECRET"))
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    return bool(
+        (_env("NEXTCLOUD_TALK_BASE_URL") or _env("NEXTCLOUD_BASE_URL") or extra.get("base_url") or extra.get("server_url"))
+        and (_env("NEXTCLOUD_TALK_BOT_SECRET") or extra.get("bot_secret"))
+    )
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> Optional[dict]:
+    base_url = _env("NEXTCLOUD_TALK_BASE_URL") or _env("NEXTCLOUD_BASE_URL")
+    secret = _env("NEXTCLOUD_TALK_BOT_SECRET")
+    if not (base_url and secret):
+        return None
+    home_channel = _env("NEXTCLOUD_TALK_HOME_CHANNEL")
+    seed: Dict[str, Any] = {
+        "base_url": base_url,
+        "webhook_host": _env("NEXTCLOUD_TALK_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST),
+        "webhook_port": _env("NEXTCLOUD_TALK_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT)),
+        "webhook_path": _env("NEXTCLOUD_TALK_WEBHOOK_PATH", DEFAULT_WEBHOOK_PATH),
+        # Do not echo secret into config status surfaces.
+    }
+    if home_channel:
+        seed["home_channel"] = {"chat_id": home_channel, "name": _env("NEXTCLOUD_TALK_HOME_CHANNEL_NAME", "Tron")}
+    return seed
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id=None,
+    media_files=None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Out-of-process delivery for cron/send_message.
+
+    Matches the platform registry standalone_sender_fn contract:
+    ``(pconfig, chat_id, message, *, thread_id=None, media_files=None,
+    force_document=False)``.  Media attachments are currently unsupported by
+    the Talk bot endpoint, so they are ignored rather than causing text
+    delivery to fail.
+    """
+    cfg = pconfig if isinstance(pconfig, PlatformConfig) else PlatformConfig(enabled=True, extra={})
+    adapter = NextcloudTalkAdapter(cfg)
+    result = await adapter.send(chat_id, message, reply_to=thread_id)
+    return {"success": result.success, "message_id": result.message_id, "error": result.error}
+
+
+def _build_adapter(config: PlatformConfig):
+    return NextcloudTalkAdapter(config)
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="nextcloud_talk",
+        label="Nextcloud Talk",
+        adapter_factory=_build_adapter,
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["NEXTCLOUD_TALK_BOT_SECRET", "NEXTCLOUD_TALK_BASE_URL"],
+        install_hint="No extra Python dependencies required; configure NEXTCLOUD_TALK_BASE_URL or NEXTCLOUD_BASE_URL.",
+        env_enablement_fn=_env_enablement,
+        standalone_sender_fn=_standalone_send,
+        cron_deliver_env_var="NEXTCLOUD_TALK_HOME_CHANNEL",
+        allowed_users_env="NEXTCLOUD_TALK_ALLOWED_USERS",
+        allow_all_env="NEXTCLOUD_TALK_ALLOW_ALL_USERS",
+        max_message_length=MAX_MESSAGE_LENGTH,
+        emoji="💬",
+        allow_update_command=True,
+        pii_safe=True,
+        platform_hint=(
+            "You are communicating through Nextcloud Talk. Slash commands use plain text; "
+            "Talk has no Telegram-style inline keyboard callbacks, so render choices as numbered lists."
+        ),
+    )

--- a/plugins/platforms/nextcloud_talk/plugin.yaml
+++ b/plugins/platforms/nextcloud_talk/plugin.yaml
@@ -1,0 +1,44 @@
+name: nextcloud_talk
+label: Nextcloud Talk
+kind: platform
+version: 0.1.0
+description: >
+  Native Hermes gateway platform adapter for Nextcloud Talk/Spreed. Receives
+  signed Talk bot webhooks and sends replies through the Talk bot OCS API, so
+  Hermes gateway slash commands, sessions and delivery flows can run without
+  the compatibility bridge.
+author: Hermes Agent
+requires_env:
+  - name: NEXTCLOUD_TALK_BASE_URL
+    description: "Nextcloud base URL, e.g. https://nc.example.com"
+    prompt: "Nextcloud base URL"
+    password: false
+  - name: NEXTCLOUD_TALK_BOT_SECRET
+    description: "Talk bot shared secret"
+    prompt: "Talk bot secret"
+    password: true
+optional_env:
+  - name: NEXTCLOUD_TALK_WEBHOOK_HOST
+    description: "Webhook listen host (default: 127.0.0.1)"
+    prompt: "Webhook listen host"
+    password: false
+  - name: NEXTCLOUD_TALK_WEBHOOK_PORT
+    description: "Webhook listen port (default: 8767)"
+    prompt: "Webhook listen port"
+    password: false
+  - name: NEXTCLOUD_TALK_WEBHOOK_PATH
+    description: "Webhook path (default: /nextcloud-talk/webhook)"
+    prompt: "Webhook path"
+    password: false
+  - name: NEXTCLOUD_TALK_HOME_CHANNEL
+    description: "Default Talk room token for cron/notifications"
+    prompt: "Home Talk room token"
+    password: false
+  - name: NEXTCLOUD_TALK_ALLOWED_USERS
+    description: "Comma-separated Talk actor IDs allowed by gateway"
+    prompt: "Allowed Talk actor IDs"
+    password: false
+  - name: NEXTCLOUD_TALK_ALLOW_ALL_USERS
+    description: "Allow all Talk users (dev only)"
+    prompt: "Allow all Talk users?"
+    password: false

--- a/tests/gateway/platforms/test_nextcloud_talk_indicator.py
+++ b/tests/gateway/platforms/test_nextcloud_talk_indicator.py
@@ -1,0 +1,674 @@
+"""Tests for Nextcloud Talk processing-indicator lifecycle.
+
+Covers:
+  1. Fast handler: indicator task is cancelled before the delay fires — no send, no delete.
+  2. Slow handler: send returns a message_id → delete called with that id.
+  3. Slow handler: send returns data=null (message_id=None) → reference_id fallback
+     lookup resolves the id → delete called with the resolved id.
+  4. Slow handler: indicator send throws → no delete called (no phantom cleanup).
+  5. Indicator disabled via settings → no send.
+  6. Constructor default keeps the chat-message indicator disabled.
+  7. Missing control credentials → indicator suppressed entirely.
+  8. _resolve_message_id_by_reference_id unit tests:
+       a. reference found on first attempt
+       b. not found after all attempts → None
+       c. empty body on first attempt, found on second (retry path)
+       d. HTTP 401 → None immediately (no retry)
+       e. HTTP 304 → retries → found on second attempt
+       f. no control credentials → None (guard check)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_mod = load_plugin_adapter("nextcloud_talk")
+NextcloudTalkAdapter = _mod.NextcloudTalkAdapter
+NextcloudTalkSettings = _mod.NextcloudTalkSettings
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter(
+    *,
+    indicator_delay: float = 0.0,
+    indicator_enabled: bool = True,
+    indicator_text: str = "thinking…",
+    control_user: str = "admin",
+    control_password: str = "secret",
+    native_typing_enabled: bool = False,
+) -> NextcloudTalkAdapter:
+    from gateway.config import PlatformConfig
+
+    adapter = NextcloudTalkAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter.settings = NextcloudTalkSettings(
+        base_url="https://nc.example.com",
+        bot_secret="s3cr3t",
+        processing_indicator_enabled=indicator_enabled,
+        processing_indicator_delay_seconds=indicator_delay,
+        processing_indicator_text=indicator_text,
+        control_user=control_user,
+        control_password=control_password,
+        native_typing_enabled=native_typing_enabled,
+    )
+    return adapter
+
+
+def _make_event(adapter: NextcloudTalkAdapter, chat_id: str = "room123", message_id: str = "42") -> Any:
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    source = adapter.build_source(
+        chat_id=chat_id,
+        chat_name="Test Room",
+        chat_type="group",
+        user_id="users/alice",
+        user_name="Alice",
+    )
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id=message_id,
+    )
+
+
+async def _fake_to_thread(func, *args, **kwargs):
+    """Drop-in replacement for asyncio.to_thread that runs the callable inline.
+
+    Used in indicator tests so the indicator task completes predictably
+    within a single asyncio.sleep(0) yield rather than racing against a
+    real thread-pool submission.
+    """
+    return func(*args, **kwargs)
+
+
+class _FakeHTTPResp:
+    """Minimal stand-in for a urllib response used as a context manager."""
+
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def _ocs_chat_response(messages: list) -> bytes:
+    return json.dumps({"ocs": {"meta": {"status": "ok"}, "data": messages}}).encode()
+
+
+def _ocs_message(ref_id: str, msg_id: int) -> Dict[str, Any]:
+    return {"id": msg_id, "referenceId": ref_id, "message": "hello"}
+
+
+# ---------------------------------------------------------------------------
+# Indicator lifecycle tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fast_handler_cancels_indicator_before_send():
+    """Handler completes before the delay fires → indicator never sent or deleted."""
+    adapter = _make_adapter(indicator_delay=100.0)
+    event = _make_event(adapter)
+
+    send_one = MagicMock(return_value={"message_id": "99", "reference_id": "ref99"})
+    delete_msg = MagicMock()
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+    adapter.handle_message = AsyncMock()  # returns immediately
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        await adapter._handle_message_with_processing_indicator(event)
+
+    send_one.assert_not_called()
+    delete_msg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slow_handler_sends_and_deletes_indicator_with_message_id():
+    """Bot send returns message_id → delete is called with that id."""
+    adapter = _make_adapter(indicator_delay=0.0)
+    event = _make_event(adapter)
+
+    send_one = MagicMock(return_value={"message_id": "55", "reference_id": "ref55"})
+    delete_msg = MagicMock(return_value={"status": 200})
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+
+    # Two yields needed:
+    # yield 1 → indicator task advances past asyncio.sleep(0.0) to its own yield
+    # yield 2 → indicator task's sleep resolves, _fake_to_thread runs inline, task done
+    async def _slow_handle(ev):
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    adapter.handle_message = _slow_handle
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        await adapter._handle_message_with_processing_indicator(event)
+
+    assert send_one.called
+    # _send_one is called with _resolve_reference_id=True (4th positional arg).
+    call_args = send_one.call_args[0]
+    assert call_args[-1] is True, "indicator send must pass _resolve_reference_id=True"
+    delete_msg.assert_called_once_with(event.source.chat_id, "55")
+
+
+@pytest.mark.asyncio
+async def test_slow_handler_data_null_resolves_via_reference_id():
+    """Send returns data=null (message_id=None) → fallback lookup finds id → delete called."""
+    adapter = _make_adapter(indicator_delay=0.0)
+    event = _make_event(adapter)
+
+    # Simulates the Talk bot API returning data=null: message_id is None.
+    send_one = MagicMock(return_value={"message_id": None, "reference_id": "refABC"})
+    delete_msg = MagicMock(return_value={"status": 200})
+    resolve_mock = MagicMock(return_value="77")
+
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+    adapter._resolve_message_id_by_reference_id = resolve_mock
+
+    async def _slow_handle(ev):
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    adapter.handle_message = _slow_handle
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        await adapter._handle_message_with_processing_indicator(event)
+
+    # Fallback resolve must be called.
+    assert resolve_mock.called
+    # First arg is chat_id, second is reference_id from send.
+    resolve_call_args = resolve_mock.call_args[0]
+    assert resolve_call_args[0] == event.source.chat_id
+    assert resolve_call_args[1] == "refABC"
+    # Delete must use the resolved id.
+    delete_msg.assert_called_once_with(event.source.chat_id, "77")
+
+
+@pytest.mark.asyncio
+async def test_slow_handler_indicator_send_fails_no_delete():
+    """Indicator send throws → no delete called (avoids phantom cleanup)."""
+    adapter = _make_adapter(indicator_delay=0.0)
+    event = _make_event(adapter)
+
+    send_one = MagicMock(side_effect=OSError("connection refused"))
+    delete_msg = MagicMock()
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+
+    async def _slow_handle(ev):
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    adapter.handle_message = _slow_handle
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        await adapter._handle_message_with_processing_indicator(event)
+
+    delete_msg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_indicator_disabled_no_send():
+    """processing_indicator_enabled=False → indicator task is never created."""
+    adapter = _make_adapter(indicator_delay=0.0, indicator_enabled=False)
+    event = _make_event(adapter)
+
+    send_one = MagicMock()
+    delete_msg = MagicMock()
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+    adapter.handle_message = AsyncMock()
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        await adapter._handle_message_with_processing_indicator(event)
+
+    send_one.assert_not_called()
+    delete_msg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_constructor_default_disables_processing_message_fallback(monkeypatch):
+    """Default configuration relies on native typing, not a temporary chat message."""
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("NEXTCLOUD_TALK_PROCESSING_INDICATOR_ENABLED", raising=False)
+    adapter = NextcloudTalkAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "base_url": "https://nc.example.com",
+                "bot_secret": "s3cr3t",
+            },
+        )
+    )
+    event = _make_event(adapter)
+    adapter.settings.control_user = "tron"
+    adapter.settings.control_password = "secret"
+
+    send_one = MagicMock()
+    delete_msg = MagicMock()
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+    adapter.handle_message = AsyncMock()
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        await adapter._handle_message_with_processing_indicator(event)
+
+    assert adapter.settings.processing_indicator_enabled is False
+    send_one.assert_not_called()
+    delete_msg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_control_credentials_suppresses_indicator():
+    """Indicator is gated on control credentials; without them nothing is sent."""
+    adapter = _make_adapter(indicator_delay=0.0, control_user="", control_password="")
+    event = _make_event(adapter)
+
+    send_one = MagicMock()
+    delete_msg = MagicMock()
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+    adapter.handle_message = AsyncMock()
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        await adapter._handle_message_with_processing_indicator(event)
+
+    send_one.assert_not_called()
+    delete_msg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_native_typing_does_not_suppress_processing_message_fallback(monkeypatch):
+    """Native HPB typing is best-effort; keep the removable chat indicator visible."""
+    adapter = _make_adapter(indicator_delay=0.0, control_user="tron", control_password="secret")
+    event = _make_event(adapter)
+
+    send_one = MagicMock(return_value={"message_id": "88", "reference_id": "ref88"})
+    delete_msg = MagicMock(return_value={"status": 200})
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+
+    async def _slow_handle(ev):
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    adapter.handle_message = _slow_handle
+    monkeypatch.setattr(adapter, "_can_native_type", lambda: True)
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        await adapter._handle_message_with_processing_indicator(event)
+
+    send_one.assert_called()
+    delete_msg.assert_called_once_with(event.source.chat_id, "88")
+
+
+@pytest.mark.asyncio
+async def test_real_handle_message_path_keeps_indicator_until_background_finishes():
+    """Regression: BasePlatformAdapter.handle_message returns after scheduling
+    background processing; the indicator must stay alive until that task exits."""
+    adapter = _make_adapter(indicator_delay=0.0)
+    event = _make_event(adapter)
+
+    send_one = MagicMock(return_value={"message_id": "88", "reference_id": "ref88"})
+    delete_msg = MagicMock(return_value={"status": 200})
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+    adapter._send_with_retry = AsyncMock(return_value=MagicMock(success=True, message_id="final"))
+
+    background_started = asyncio.Event()
+    release_background = asyncio.Event()
+
+    async def _slow_message_handler(ev):
+        background_started.set()
+        await release_background.wait()
+        return "final response"
+
+    adapter._message_handler = _slow_message_handler
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        task = asyncio.create_task(adapter._handle_message_with_processing_indicator(event))
+        await asyncio.wait_for(background_started.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert send_one.called, "indicator should be visible while background processing is running"
+        delete_msg.assert_not_called()
+        release_background.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    delete_msg.assert_called_once_with(event.source.chat_id, "88")
+
+
+@pytest.mark.asyncio
+async def test_real_handle_message_path_waits_with_profile_namespaced_session_key(tmp_path):
+    """Multiplexed profile keys must be resolved through SessionStore, not the legacy fallback."""
+    from gateway.config import GatewayConfig
+    from gateway.session import SessionStore
+
+    adapter = _make_adapter(indicator_delay=0.0)
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig(multiplex_profiles=True))
+    adapter.set_session_store(store)
+    event = _make_event(adapter)
+    event.source.profile = "coder"
+
+    send_one = MagicMock(return_value={"message_id": "89", "reference_id": "ref89"})
+    delete_msg = MagicMock(return_value={"status": 200})
+    adapter._send_one = send_one
+    adapter._delete_message = delete_msg
+    adapter._send_with_retry = AsyncMock(return_value=MagicMock(success=True, message_id="final"))
+
+    background_started = asyncio.Event()
+    release_background = asyncio.Event()
+
+    async def _slow_message_handler(ev):
+        background_started.set()
+        await release_background.wait()
+        return "final response"
+
+    adapter._message_handler = _slow_message_handler
+
+    with patch("asyncio.to_thread", _fake_to_thread):
+        task = asyncio.create_task(adapter._handle_message_with_processing_indicator(event))
+        await asyncio.wait_for(background_started.wait(), timeout=1.0)
+        for _ in range(20):
+            if send_one.called:
+                break
+            await asyncio.sleep(0)
+        assert send_one.called
+        delete_msg.assert_not_called()
+        release_background.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    delete_msg.assert_called_once_with(event.source.chat_id, "89")
+
+
+def test_native_typing_room_response_collects_existing_participant_sessions():
+    """Initial HPB room responses may include already-present sessions without a join event."""
+    adapter = _make_adapter()
+    client = _mod._NextcloudTalkTypingClient(adapter, "room123")
+    client._own_signaling_session_id = "own-session"
+
+    client._handle_signaling_payload({
+        "type": "room",
+        "room": {
+            "sessions": [
+                {"sessionid": "own-session"},
+                {"sessionid": "user-session-1"},
+                {"sessionId": "user-session-2"},
+            ]
+        },
+    })
+
+    assert client._participants == {"user-session-1", "user-session-2"}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_message_id_by_reference_id unit tests
+# ---------------------------------------------------------------------------
+
+def _make_ctrl_adapter() -> NextcloudTalkAdapter:
+    return _make_adapter(control_user="admin", control_password="secret")
+
+
+def test_resolve_reference_found_on_first_attempt():
+    adapter = _make_ctrl_adapter()
+    ref_id = "abc123"
+    body = _ocs_chat_response([_ocs_message(ref_id, 42)])
+
+    with patch("urllib.request.urlopen", return_value=_FakeHTTPResp(body)):
+        result = adapter._resolve_message_id_by_reference_id("tok1", ref_id)
+
+    assert result == "42"
+
+
+def test_resolve_reference_not_in_history_returns_none():
+    adapter = _make_ctrl_adapter()
+    body = _ocs_chat_response([_ocs_message("other-ref", 99)])
+
+    with patch("urllib.request.urlopen", return_value=_FakeHTTPResp(body)):
+        result = adapter._resolve_message_id_by_reference_id("tok1", "missing", attempts=1)
+
+    assert result is None
+
+
+def test_resolve_empty_body_retries_then_finds():
+    """An empty response body is treated as transient; retry finds the message."""
+    adapter = _make_ctrl_adapter()
+    ref_id = "xyz789"
+    good_body = _ocs_chat_response([_ocs_message(ref_id, 55)])
+
+    call_count = [0]
+
+    def _urlopen(req, timeout=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return _FakeHTTPResp(b"")
+        return _FakeHTTPResp(good_body)
+
+    with patch("urllib.request.urlopen", side_effect=_urlopen):
+        with patch("time.sleep"):  # skip real delays
+            result = adapter._resolve_message_id_by_reference_id("tok1", ref_id, attempts=3)
+
+    assert result == "55"
+    assert call_count[0] == 2
+
+
+def test_resolve_http_401_returns_none_immediately():
+    """HTTP 401 is not retried — credentials are wrong, not transient."""
+    adapter = _make_ctrl_adapter()
+
+    err = urllib.error.HTTPError("url", 401, "Unauthorized", {}, None)
+
+    with patch("urllib.request.urlopen", side_effect=err):
+        result = adapter._resolve_message_id_by_reference_id("tok1", "ref", attempts=5)
+
+    assert result is None
+
+
+def test_resolve_http_304_retries_then_finds():
+    """HTTP 304 from chat history endpoint is retried; second attempt returns the message."""
+    adapter = _make_ctrl_adapter()
+    ref_id = "ref304"
+    good_body = _ocs_chat_response([_ocs_message(ref_id, 77)])
+
+    call_count = [0]
+
+    def _urlopen(req, timeout=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise urllib.error.HTTPError("url", 304, "Not Modified", {}, None)
+        return _FakeHTTPResp(good_body)
+
+    with patch("urllib.request.urlopen", side_effect=_urlopen):
+        with patch("time.sleep"):
+            result = adapter._resolve_message_id_by_reference_id("tok1", ref_id, attempts=3)
+
+    assert result == "77"
+    assert call_count[0] == 2
+
+
+def test_resolve_no_control_credentials_returns_none():
+    """Guard check: if control creds are not configured, skip lookup entirely."""
+    adapter = _make_adapter(control_user="", control_password="")
+    result = adapter._resolve_message_id_by_reference_id("tok1", "someref")
+    assert result is None
+
+
+def test_nextcloud_actor_ids_are_sanitized_for_session_keys():
+    """Nextcloud actor IDs use slashes; Hermes session keys must not."""
+    from gateway.session import build_session_key
+
+    adapter = _make_adapter()
+    source = adapter.build_source(
+        chat_id="room123",
+        chat_name="Test Room",
+        chat_type="group",
+        user_id=_mod._session_safe_actor_id("users/alice"),
+        user_name="Alice",
+    )
+
+    session_key = build_session_key(source)
+
+    assert source.user_id == "users_alice"
+    assert "/" not in session_key
+    assert "\\" not in session_key
+    assert "users_alice" in session_key
+
+
+# ---------------------------------------------------------------------------
+# Native HPB typing indicator tests
+# ---------------------------------------------------------------------------
+
+def test_websocket_url_from_signaling_server_normalizes_spreed_path():
+    build_url = _mod._websocket_url_from_signaling_server
+
+    assert build_url("https://nc.example.com/standalone-signaling/") == "wss://nc.example.com/standalone-signaling/spreed"
+    assert build_url("http://nc.example.com/standalone-signaling") == "ws://nc.example.com/standalone-signaling/spreed"
+    assert build_url("https://nc.example.com/standalone-signaling/spreed") == "wss://nc.example.com/standalone-signaling/spreed"
+    assert build_url("") == ""
+
+
+@pytest.mark.asyncio
+async def test_send_typing_starts_native_client_and_stop_typing_stops(monkeypatch):
+    adapter = _make_adapter(control_user="tron", control_password="secret", native_typing_enabled=True)
+    created = []
+
+    class FakeTypingClient:
+        def __init__(self, adapter_arg, token):
+            self.adapter = adapter_arg
+            self.token = token
+            self.started = False
+            self.stopped = False
+            created.append(self)
+
+        async def ensure_started(self):
+            self.started = True
+
+        async def stop(self):
+            self.stopped = True
+
+    monkeypatch.setattr(_mod, "_NextcloudTalkTypingClient", FakeTypingClient)
+
+    await adapter.send_typing("room123")
+    await adapter.send_typing("room123")
+
+    assert len(created) == 1
+    assert created[0].started is True
+    assert created[0].token == "room123"
+    assert adapter._typing_clients["room123"] is created[0]
+
+    await adapter.stop_typing("room123")
+
+    assert created[0].stopped is True
+    assert "room123" not in adapter._typing_clients
+
+
+@pytest.mark.asyncio
+async def test_send_typing_noops_without_control_credentials(monkeypatch):
+    adapter = _make_adapter(control_user="", control_password="")
+
+    class ExplodingTypingClient:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("native typing client should not be created")
+
+    monkeypatch.setattr(_mod, "_NextcloudTalkTypingClient", ExplodingTypingClient)
+    await adapter.send_typing("room123")
+
+    assert adapter._typing_clients == {}
+
+
+@pytest.mark.asyncio
+async def test_native_typing_client_sends_started_and_stopped_payloads():
+    adapter = _make_adapter(control_user="tron", control_password="secret")
+    client = _mod._NextcloudTalkTypingClient(adapter, "room123")
+
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, payload):
+            self.sent.append(json.loads(payload))
+
+    websocket = FakeWebSocket()
+    client._websocket = websocket
+    client._own_signaling_session_id = "own-session"
+    client._handle_signaling_payload({
+        "type": "event",
+        "event": {
+            "target": "room",
+            "type": "join",
+            "join": [
+                {"sessionid": "own-session"},
+                {"sessionid": "ronny-session"},
+            ],
+        },
+    })
+
+    assert client._participants == {"ronny-session"}
+
+    await client._broadcast_typing(True)
+    await client._broadcast_typing(False)
+
+    assert [item["message"]["data"]["type"] for item in websocket.sent] == ["startedTyping", "stoppedTyping"]
+    assert websocket.sent[0]["message"]["recipient"] == {"type": "room"}
+    assert "to" not in websocket.sent[0]["message"]["data"]
+    assert websocket.sent[1]["message"]["recipient"] == {"type": "room"}
+
+    client._handle_signaling_payload({
+        "type": "event",
+        "event": {"target": "room", "type": "leave", "leave": [{"sessionid": "ronny-session"}]},
+    })
+    assert client._participants == set()
+
+
+@pytest.mark.asyncio
+async def test_native_typing_room_broadcast_reaches_empty_observed_participants():
+    """Room-recipient broadcast covers users already present before relay join."""
+    adapter = _make_adapter(control_user="tron", control_password="secret")
+    client = _mod._NextcloudTalkTypingClient(adapter, "room123")
+
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, payload):
+            self.sent.append(json.loads(payload))
+
+    websocket = FakeWebSocket()
+    client._websocket = websocket
+    assert client._participants == set()
+
+    await client._broadcast_typing(True)
+    await client._broadcast_typing(False)
+
+    assert [item["message"]["recipient"] for item in websocket.sent] == [{"type": "room"}, {"type": "room"}]
+    assert [item["message"]["data"]["type"] for item in websocket.sent] == ["startedTyping", "stoppedTyping"]
+
+
+@pytest.mark.asyncio
+async def test_native_typing_room_broadcast_noops_without_websocket():
+    adapter = _make_adapter(control_user="tron", control_password="secret")
+    client = _mod._NextcloudTalkTypingClient(adapter, "room123")
+    client._websocket = None
+
+    await client._broadcast_typing(True)
+    await client._broadcast_typing(False)

--- a/tests/gateway/test_user_id_alt_authz.py
+++ b/tests/gateway/test_user_id_alt_authz.py
@@ -1,0 +1,53 @@
+"""Authorization regression tests for alternate platform user IDs."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gateway.session import Platform, SessionSource
+
+
+def _make_bare_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def test_allowlist_matches_user_id_alt(monkeypatch):
+    """Adapters may sanitize user_id for session keys while preserving raw IDs in user_id_alt."""
+    runner = _make_bare_runner()
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "users/ronny")
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="room1",
+        chat_type="group",
+        user_id="users_ronny",
+        user_id_alt="users/ronny",
+        user_name="ronny",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_allowlist_still_denies_when_neither_user_id_nor_alt_match(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "users/ronny")
+    monkeypatch.delenv("FEISHU_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="room1",
+        chat_type="group",
+        user_id="users_eve",
+        user_id_alt="users/eve",
+        user_name="eve",
+    )
+
+    assert runner._is_user_authorized(source) is False

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4881,3 +4881,117 @@ def test_refresh_compression_lock_requires_holder_and_preserves_reclaimability(d
 
     monkeypatch.setattr(hermes_state.time, "time", lambda: 1016.0)
     assert db.try_acquire_compression_lock("s1", "holder-b", ttl_seconds=10.0) is True
+
+
+# =========================================================================
+# Trigram FTS opt-out (HERMES_FTS_TRIGRAM=0)
+# =========================================================================
+
+
+class TestTrigramOptOut:
+    """HERMES_FTS_TRIGRAM=0 opts out of the trigram FTS index.
+
+    The trigram index exists for CJK/substring search and can dominate
+    state.db size. Opting out must: skip creation on fresh DBs, drop
+    existing trigram artifacts on init, leave base FTS fully intact, and
+    not trip the trigger-repair heuristic into rebuilding every boot.
+    """
+
+    @staticmethod
+    def _names(db, kind):
+        rows = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = ?", (kind,)
+        ).fetchall()
+        return {row[0] for row in rows}
+
+    def test_default_keeps_trigram(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            assert "messages_fts_trigram" in self._names(db, "table")
+            assert db._trigram_available is True
+        finally:
+            db.close()
+
+    def test_optout_fresh_db_skips_trigram(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_FTS_TRIGRAM", "0")
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            assert "messages_fts_trigram" not in self._names(db, "table")
+            triggers = self._names(db, "trigger")
+            assert not any("trigram" in t for t in triggers)
+            # Base FTS keeps working end to end.
+            assert {
+                "messages_fts_insert",
+                "messages_fts_delete",
+                "messages_fts_update",
+            } <= triggers
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(session_id="s1", role="user", content="hello trigram optout")
+            results = db.search_messages("hello")
+            assert results
+            assert db._trigram_available is False
+        finally:
+            db.close()
+
+    def test_optout_drops_existing_trigram_artifacts(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(session_id="s1", role="user", content="indexed before optout")
+        assert "messages_fts_trigram" in self._names(db, "table")
+        db.close()
+
+        monkeypatch.setenv("HERMES_FTS_TRIGRAM", "0")
+        db = SessionDB(db_path=db_path)
+        try:
+            assert "messages_fts_trigram" not in self._names(db, "table")
+            assert not any("trigram" in t for t in self._names(db, "trigger"))
+            # Base index survived the drop and still serves search.
+            assert db.search_messages("indexed")
+        finally:
+            db.close()
+
+    def test_optout_does_not_trip_repair_rebuild(self, tmp_path, monkeypatch):
+        """Missing trigram triggers must not look like trigger degradation.
+
+        Otherwise every startup would run a full FTS rebuild (DELETE +
+        re-INSERT of the whole messages table).
+        """
+        monkeypatch.setenv("HERMES_FTS_TRIGRAM", "0")
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(session_id="s1", role="user", content="steady state")
+        db.close()
+
+        calls = []
+        orig = SessionDB._rebuild_fts_indexes
+        monkeypatch.setattr(
+            SessionDB,
+            "_rebuild_fts_indexes",
+            staticmethod(lambda *a, **kw: calls.append(1) or orig(*a, **kw)),
+        )
+        db = SessionDB(db_path=db_path)
+        try:
+            assert calls == []
+        finally:
+            db.close()
+
+    def test_reenable_recreates_and_backfills(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "state.db"
+        monkeypatch.setenv("HERMES_FTS_TRIGRAM", "0")
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(session_id="s1", role="user", content="written while opted out")
+        db.close()
+
+        monkeypatch.delenv("HERMES_FTS_TRIGRAM")
+        db = SessionDB(db_path=db_path)
+        try:
+            assert "messages_fts_trigram" in self._names(db, "table")
+            count = db._conn.execute(
+                "SELECT COUNT(*) FROM messages_fts_trigram"
+            ).fetchone()[0]
+            assert count >= 1  # backfilled via the repair rebuild
+        finally:
+            db.close()


### PR DESCRIPTION
## Problem

The trigram FTS5 index (`messages_fts_trigram`) enables CJK/substring search, but it stores overlapping 3-byte tokens for every message. On large databases it can dominate `state.db` size — observed: **1.17 GB of a 2.2 GB DB (53%)**. Deployments that never search CJK text pay that cost for nothing, and there is currently no way to turn it off.

## Fix

`HERMES_FTS_TRIGRAM=0` opts out of the trigram index. **Default behavior is unchanged** (trigram stays on).

When opted out:

- fresh DBs skip trigram table/trigger creation (both the init path and the v11 schema-migration backfill path)
- existing trigram artifacts are dropped on init — only the trigram triggers and table; base FTS stays fully intact (freed pages are reused by SQLite; `VACUUM` shrinks the file)
- the trigger-repair heuristic counts only the triggers the active configuration expects, so the deliberately absent trigram triggers do **not** trip a full FTS rebuild on every boot
- CJK/substring queries fall back to `LIKE` (same behavior as when the trigram tokenizer is unavailable)
- re-enabling recreates and backfills the index via the existing repair path

## Testing

New `TestTrigramOptOut` (5 tests: fresh-DB opt-out, artifact dropping, no-rebuild-loop, re-enable backfill, default unchanged); full `tests/test_hermes_state.py` suite green (308 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
