### PR TITLE
fix: macOS in-app update silent failure handling (#57645)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -188,6 +188,7 @@ import {
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
+import { writeHermesUpdateHandoff, readUpdateHandoffResult } from './update-handoff-marker'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
@@ -2987,6 +2988,22 @@ async function applyUpdates(opts = {}) {
       }
     }
 
+    // Record the pre-hand-off git SHA + version so the relaunched instance
+    // can detect a silently-failed update (the updater never completed → same
+    // SHA on next boot) and surface a closeable error instead of silently
+    // reverting to the old version. (#57645)
+    let preHandoffSha = ''
+    try {
+      const head = await runGit(['rev-parse', 'HEAD'], { cwd: updateRoot })
+      preHandoffSha = (head.stdout || '').trim()
+    } catch {
+      // best-effort; the marker still records version + timestamp
+    }
+    writeHermesUpdateHandoff(HERMES_HOME, {
+      sha: preHandoffSha,
+      version: resolveHermesVersion()
+    })
+
     // Detached so the updater outlives this process — it needs us GONE before
     // `hermes update` will run (the venv shim is locked while we live).
     const child = spawnUpdaterProcess(updater, updaterArgs, {
@@ -3574,6 +3591,23 @@ fi
 
     return { ok: true, backendUpdated: true, rebuiltApp }
   }
+
+  // Record the pre-swap git SHA + version so the relaunched instance can detect
+  // a silently-failed ditto swap (the detached script's swap can fall through,
+  // reopening the OLD destination bundle) and surface a closeable error instead
+  // of silently reverting to the old version. (#57645) This mirrors the
+  // marker write in the staged-helper hand-off path.
+  let preSwapSha = ''
+  try {
+    const head = await runGit(['rev-parse', 'HEAD'], { cwd: updateRoot })
+    preSwapSha = (head.stdout || '').trim()
+  } catch {
+    // best-effort; the marker still records version + timestamp
+  }
+  writeHermesUpdateHandoff(HERMES_HOME, {
+    sha: preSwapSha,
+    version: resolveHermesVersion()
+  })
 
   const child = spawn('/bin/bash', [scriptPath], { detached: true, stdio: 'ignore' })
   child.unref()
@@ -11419,6 +11453,19 @@ ipcMain.handle('hermes:updates:apply', async (_event, payload) =>
     message: error?.message || String(error)
   }))
 )
+
+// Post-relaunch validation (#57645): when the desktop handed off to the
+// detached hermes-setup updater and quit, the next instance checks whether
+// the git SHA actually changed. If it didn't, the updater failed silently
+// and the renderer surfaces a closeable error instead of silently reverting.
+ipcMain.handle('hermes:updates:handoff-result', async () => {
+  try {
+    const updateRoot = resolveUpdateRoot()
+    return readUpdateHandoffResult(HERMES_HOME, updateRoot)
+  } catch (error) {
+    return { pending: false, error: error?.message || String(error) }
+  }
+})
 
 ipcMain.handle('hermes:updates:branch:get', async () => readDesktopUpdateConfig())
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -188,8 +188,8 @@ import {
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
-import { writeHermesUpdateHandoff, readUpdateHandoffResult } from './update-handoff-marker'
 import { waitForUpdateClearance } from './update-gate'
+import { readUpdateHandoffResult, writeHermesUpdateHandoff } from './update-handoff-marker'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
@@ -2993,12 +2993,14 @@ async function applyUpdates(opts = {}) {
     // SHA on next boot) and surface a closeable error instead of silently
     // reverting to the old version. (#57645)
     let preHandoffSha = ''
+
     try {
       const head = await runGit(['rev-parse', 'HEAD'], { cwd: updateRoot })
       preHandoffSha = (head.stdout || '').trim()
     } catch {
       // best-effort; the marker still records version + timestamp
     }
+
     writeHermesUpdateHandoff(HERMES_HOME, {
       sha: preHandoffSha,
       version: resolveHermesVersion()
@@ -3598,12 +3600,14 @@ fi
   // of silently reverting to the old version. (#57645) This mirrors the
   // marker write in the staged-helper hand-off path.
   let preSwapSha = ''
+
   try {
     const head = await runGit(['rev-parse', 'HEAD'], { cwd: updateRoot })
     preSwapSha = (head.stdout || '').trim()
   } catch {
     // best-effort; the marker still records version + timestamp
   }
+
   writeHermesUpdateHandoff(HERMES_HOME, {
     sha: preSwapSha,
     version: resolveHermesVersion()
@@ -11461,6 +11465,7 @@ ipcMain.handle('hermes:updates:apply', async (_event, payload) =>
 ipcMain.handle('hermes:updates:handoff-result', async () => {
   try {
     const updateRoot = resolveUpdateRoot()
+
     return readUpdateHandoffResult(HERMES_HOME, updateRoot)
   } catch (error) {
     return { pending: false, error: error?.message || String(error) }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -327,6 +327,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     apply: opts => ipcRenderer.invoke('hermes:updates:apply', opts),
     getBranch: () => ipcRenderer.invoke('hermes:updates:branch:get'),
     setBranch: name => ipcRenderer.invoke('hermes:updates:branch:set', name),
+    handoffResult: () => ipcRenderer.invoke('hermes:updates:handoff-result'),
     onProgress: callback => {
       const listener = (_event, payload) => callback(payload)
       ipcRenderer.on('hermes:updates:progress', listener)

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for electron/update-handoff-marker.ts — the durable handshake marker
+ * for the Tauri updater hand-off (#57645).
+ *
+ * When the desktop app clicks "Update now" and a staged `hermes-setup` binary
+ * exists, it spawns that updater detached and quits. If the updater fails
+ * silently, the relaunched instance must detect that the git SHA did NOT
+ * change and surface a closeable error instead of silently reverting.
+ *
+ * Run with: node --test electron/update-handoff-marker.test.ts
+ */
+
+import fs from 'fs'
+import assert from 'node:assert/strict'
+import os from 'os'
+import path from 'path'
+
+import { test } from 'vitest'
+
+import { markerPath, writeUpdateMarker } from './update-marker'
+import {
+  handoffMarkerPath,
+  writeHermesUpdateHandoff,
+  readUpdateHandoffResult,
+  HANDOFF_MARKER_MAX_AGE_MS
+} from './update-handoff-marker'
+
+function tmpHome(tag) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `hermes-handoff-${tag}-`))
+  return dir
+}
+
+function writeMarker(home, sha, version, at) {
+  const markerPath = handoffMarkerPath(home)
+  fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+  fs.writeFileSync(markerPath, JSON.stringify({ sha, version, at }))
+}
+
+// Injectable SHA resolvers
+const shaOf = s => () => s
+const noSha = () => ''
+
+test('absent marker => no pending hand-off', () => {
+  const home = tmpHome('absent')
+  const result = readUpdateHandoffResult(home, '/fake/root', { resolveSha: noSha })
+  assert.equal(result.pending, false)
+  assert.equal(result.failed, undefined)
+})
+
+test('SHA changed after hand-off => update succeeded, not pending', () => {
+  const home = tmpHome('succeeded')
+  const now = Date.now()
+  writeMarker(home, 'aaa111', '0.18.0', now)
+  const result = readUpdateHandoffResult(home, '/fake/root', {
+    resolveSha: shaOf('bbb222'),
+    now: () => now + 5000
+  })
+  assert.equal(result.pending, false)
+  assert.equal(result.succeeded, true)
+  assert.equal(result.failed, undefined)
+  // Marker is pruned after being read (one-shot).
+  assert.ok(!fs.existsSync(handoffMarkerPath(home)))
+})
+
+test('SHA unchanged after hand-off => update failed, pending', () => {
+  const home = tmpHome('failed')
+  const now = Date.now()
+  writeMarker(home, 'aaa111', '0.18.0', now)
+  const result = readUpdateHandoffResult(home, '/fake/root', {
+    resolveSha: shaOf('aaa111'),
+    now: () => now + 5000
+  })
+  assert.equal(result.pending, true)
+  assert.equal(result.failed, true)
+  assert.equal(result.recordedSha, 'aaa111')
+  assert.equal(result.currentSha, 'aaa111')
+  assert.equal(result.recordedVersion, '0.18.0')
+  // Marker is pruned even on failure (one-shot, not a lingering state).
+  assert.ok(!fs.existsSync(handoffMarkerPath(home)))
+})
+
+test('unchanged SHA with a live update in progress => verdict deferred, marker kept', () => {
+  const home = tmpHome('deferred')
+  const now = Date.now()
+  writeMarker(home, 'aaa111', '0.18.0', now)
+  // Simulate a still-running updater by writing the live update marker with
+  // THIS process's PID (genuinely alive, within the age ceiling).
+  writeUpdateMarker(home, process.pid, { now: () => now })
+  const result = readUpdateHandoffResult(home, '/fake/root', {
+    resolveSha: shaOf('aaa111'),
+    now: () => now + 5000
+  })
+  // Deferred, not failed — the update is still in flight.
+  assert.equal(result.pending, true)
+  assert.equal(result.deferred, true)
+  assert.equal(result.failed, undefined)
+  assert.equal(result.recordedSha, 'aaa111')
+  assert.equal(result.currentSha, 'aaa111')
+  // Marker is KEPT so a later boot re-evaluates once the SHA changes.
+  assert.ok(fs.existsSync(handoffMarkerPath(home)))
+})
+
+test('unchanged SHA, live update but stale marker age => not deferred', () => {
+  const home = tmpHome('deferred-stale-live')
+  const now = Date.now()
+  writeMarker(home, 'aaa111', '0.18.0', now - HANDOFF_MARKER_MAX_AGE_MS - 60_000)
+  writeUpdateMarker(home, process.pid, { now: () => (now - 60_000) / 1000 })
+  const result = readUpdateHandoffResult(home, '/fake/root', {
+    resolveSha: shaOf('aaa111'),
+    now: () => now
+  })
+  // Stale hand-off marker dominates: no pending, no failure surfaced.
+  assert.equal(result.pending, false)
+  assert.equal(result.failed, undefined)
+  assert.equal(result.deferred, undefined)
+})
+
+test('stale marker (past age ceiling) => no pending hand-off, pruned', () => {
+  const home = tmpHome('stale')
+  const now = 1_000_000_000_000
+  writeMarker(home, 'aaa111', '0.18.0', now - HANDOFF_MARKER_MAX_AGE_MS - 60_000)
+  const result = readUpdateHandoffResult(home, '/fake/root', {
+    resolveSha: shaOf('aaa111'),
+    now: () => now
+  })
+  assert.equal(result.pending, false)
+  assert.equal(result.failed, undefined)
+  assert.ok(!fs.existsSync(handoffMarkerPath(home)))
+})
+
+test('malformed marker => no pending hand-off, pruned', () => {
+  const home = tmpHome('malformed')
+  fs.mkdirSync(home, { recursive: true })
+  fs.writeFileSync(handoffMarkerPath(home), 'not-json{')
+  const result = readUpdateHandoffResult(home, '/fake/root', { resolveSha: noSha })
+  assert.equal(result.pending, false)
+  assert.ok(!fs.existsSync(handoffMarkerPath(home)))
+})
+
+test('writeHermesUpdateHandoff writes a valid JSON marker', () => {
+  const home = tmpHome('write')
+  writeHermesUpdateHandoff(home, { sha: 'abc123', version: '0.18.0' })
+  const raw = fs.readFileSync(handoffMarkerPath(home), 'utf8')
+  const marker = JSON.parse(raw)
+  assert.equal(marker.sha, 'abc123')
+  assert.equal(marker.version, '0.18.0')
+  assert.ok(Number.isFinite(marker.at))
+})
+
+test('writeHermesUpdateHandoff with empty SHA still works (version-only check)', () => {
+  const home = tmpHome('write-empty-sha')
+  writeHermesUpdateHandoff(home, { sha: '', version: '0.18.0' })
+  // With empty SHA on both sides, the update is treated as failed (SHA match
+  // on empty strings) — this is the conservative default: if we can't resolve
+  // the SHA, we can't prove the update took.
+  const result = readUpdateHandoffResult(home, '/fake/root', {
+    resolveSha: noSha
+  })
+  assert.equal(result.pending, true)
+  assert.equal(result.failed, true)
+})
+
+test('writeHermesUpdateHandoff + readUpdateHandoffResult round-trip', () => {
+  const home = tmpHome('roundtrip')
+  writeHermesUpdateHandoff(home, { sha: 'sha-before', version: '0.17.0' })
+  // Simulate update succeeded: SHA changed.
+  const result = readUpdateHandoffResult(home, '/fake/root', {
+    resolveSha: shaOf('sha-after')
+  })
+  assert.equal(result.pending, false)
+  assert.equal(result.succeeded, true)
+  assert.ok(!fs.existsSync(handoffMarkerPath(home)))
+})

--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -17,16 +17,17 @@ import path from 'path'
 
 import { test } from 'vitest'
 
-import { markerPath, writeUpdateMarker } from './update-marker'
 import {
+  HANDOFF_MARKER_MAX_AGE_MS,
   handoffMarkerPath,
-  writeHermesUpdateHandoff,
   readUpdateHandoffResult,
-  HANDOFF_MARKER_MAX_AGE_MS
+  writeHermesUpdateHandoff
 } from './update-handoff-marker'
+import { writeUpdateMarker } from './update-marker'
 
 function tmpHome(tag) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), `hermes-handoff-${tag}-`))
+
   return dir
 }
 
@@ -51,10 +52,12 @@ test('SHA changed after hand-off => update succeeded, not pending', () => {
   const home = tmpHome('succeeded')
   const now = Date.now()
   writeMarker(home, 'aaa111', '0.18.0', now)
+
   const result = readUpdateHandoffResult(home, '/fake/root', {
     resolveSha: shaOf('bbb222'),
     now: () => now + 5000
   })
+
   assert.equal(result.pending, false)
   assert.equal(result.succeeded, true)
   assert.equal(result.failed, undefined)
@@ -66,10 +69,12 @@ test('SHA unchanged after hand-off => update failed, pending', () => {
   const home = tmpHome('failed')
   const now = Date.now()
   writeMarker(home, 'aaa111', '0.18.0', now)
+
   const result = readUpdateHandoffResult(home, '/fake/root', {
     resolveSha: shaOf('aaa111'),
     now: () => now + 5000
   })
+
   assert.equal(result.pending, true)
   assert.equal(result.failed, true)
   assert.equal(result.recordedSha, 'aaa111')
@@ -86,10 +91,12 @@ test('unchanged SHA with a live update in progress => verdict deferred, marker k
   // Simulate a still-running updater by writing the live update marker with
   // THIS process's PID (genuinely alive, within the age ceiling).
   writeUpdateMarker(home, process.pid, { now: () => now })
+
   const result = readUpdateHandoffResult(home, '/fake/root', {
     resolveSha: shaOf('aaa111'),
     now: () => now + 5000
   })
+
   // Deferred, not failed — the update is still in flight.
   assert.equal(result.pending, true)
   assert.equal(result.deferred, true)
@@ -105,10 +112,12 @@ test('unchanged SHA, live update but stale marker age => not deferred', () => {
   const now = Date.now()
   writeMarker(home, 'aaa111', '0.18.0', now - HANDOFF_MARKER_MAX_AGE_MS - 60_000)
   writeUpdateMarker(home, process.pid, { now: () => (now - 60_000) / 1000 })
+
   const result = readUpdateHandoffResult(home, '/fake/root', {
     resolveSha: shaOf('aaa111'),
     now: () => now
   })
+
   // Stale hand-off marker dominates: no pending, no failure surfaced.
   assert.equal(result.pending, false)
   assert.equal(result.failed, undefined)
@@ -119,10 +128,12 @@ test('stale marker (past age ceiling) => no pending hand-off, pruned', () => {
   const home = tmpHome('stale')
   const now = 1_000_000_000_000
   writeMarker(home, 'aaa111', '0.18.0', now - HANDOFF_MARKER_MAX_AGE_MS - 60_000)
+
   const result = readUpdateHandoffResult(home, '/fake/root', {
     resolveSha: shaOf('aaa111'),
     now: () => now
   })
+
   assert.equal(result.pending, false)
   assert.equal(result.failed, undefined)
   assert.ok(!fs.existsSync(handoffMarkerPath(home)))
@@ -150,12 +161,14 @@ test('writeHermesUpdateHandoff writes a valid JSON marker', () => {
 test('writeHermesUpdateHandoff with empty SHA still works (version-only check)', () => {
   const home = tmpHome('write-empty-sha')
   writeHermesUpdateHandoff(home, { sha: '', version: '0.18.0' })
+
   // With empty SHA on both sides, the update is treated as failed (SHA match
   // on empty strings) — this is the conservative default: if we can't resolve
   // the SHA, we can't prove the update took.
   const result = readUpdateHandoffResult(home, '/fake/root', {
     resolveSha: noSha
   })
+
   assert.equal(result.pending, true)
   assert.equal(result.failed, true)
 })
@@ -163,10 +176,12 @@ test('writeHermesUpdateHandoff with empty SHA still works (version-only check)',
 test('writeHermesUpdateHandoff + readUpdateHandoffResult round-trip', () => {
   const home = tmpHome('roundtrip')
   writeHermesUpdateHandoff(home, { sha: 'sha-before', version: '0.17.0' })
+
   // Simulate update succeeded: SHA changed.
   const result = readUpdateHandoffResult(home, '/fake/root', {
     resolveSha: shaOf('sha-after')
   })
+
   assert.equal(result.pending, false)
   assert.equal(result.succeeded, true)
   assert.ok(!fs.existsSync(handoffMarkerPath(home)))

--- a/apps/desktop/electron/update-handoff-marker.ts
+++ b/apps/desktop/electron/update-handoff-marker.ts
@@ -1,0 +1,211 @@
+/**
+ * update-handoff-marker.ts — durable handshake for the Tauri updater hand-off.
+ *
+ * When the desktop app clicks "Update now" and a staged `hermes-setup` binary
+ * exists, it spawns that updater detached and quits to release the venv shim
+ * (#57645). The swap/relaunch is supposed to happen inside hermes-setup, but
+ * if it fails silently — the updater crashes, is blocked by Gatekeeper, or
+ * simply never completes — the desktop relaunches into the SAME old version
+ * with no indication anything went wrong. The user sees the "update
+ * available" pill again as if they never clicked Update.
+ *
+ * This module provides a durable, self-healing marker so the relaunched
+ * instance can detect that a hand-off was attempted and whether the version
+ * actually changed:
+ *
+ *   1. Before quitting, writeHermesUpdateHandoff() records the pre-hand-off
+ *      git HEAD SHA, the Hermes version string, and a timestamp into
+ *      HERMES_HOME/.hermes-update-handoff.json.
+ *   2. On next boot, readUpdateHandoffResult() reads that marker and compares
+ *      its recorded SHA against the current git HEAD. If they match, the
+ *      update did NOT take → return { failed: true, ... } so the renderer
+ *      can land on a closeable error state instead of silently reverting.
+ *   3. If the SHA changed (update succeeded) or no marker exists, return
+ *      { failed: false }.
+ *   4. The marker self-heals: it is deleted after being read, and a stale
+ *      marker (older than the age ceiling) is treated as "no hand-off" so a
+ *      long-dormant marker from a crashed update doesn't false-positive
+ *      weeks later.
+ *
+ * Pure-ish (file I/O + injectable git SHA resolver) so it is unit-testable
+ * without booting Electron.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+import { readLiveUpdateMarker, UPDATE_MARKER_MAX_AGE_MS } from './update-marker'
+
+// A hand-off marker older than this is treated as stale and pruned. A real
+// update (git pull + pip + desktop rebuild) completes in minutes; if the app
+// is relaunched more than this long after the hand-off, either the update
+// succeeded (and we'd see a new SHA) or it's been so long that surfacing a
+// stale failure is more confusing than helpful.
+export const HANDOFF_MARKER_MAX_AGE_MS = 30 * 60 * 1000
+
+export function handoffMarkerPath(hermesHome) {
+  return path.join(hermesHome, '.hermes-update-handoff.json')
+}
+
+/**
+ * Read the current git HEAD SHA from the given update root.
+ * Returns '' if git is unavailable or the checkout has no HEAD.
+ * Injectable via `resolveSha` for unit tests.
+ */
+export function defaultResolveSha(updateRoot) {
+  try {
+    const { execFileSync } = require('child_process')
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: updateRoot,
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim()
+    return sha
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Write the hand-off marker before quitting for the updater.
+ *
+ * @param {string} hermesHome
+ * @param {object} payload
+ * @param {string} payload.sha       git HEAD SHA at hand-off time ('' if unknown)
+ * @param {string} payload.version   Hermes version string at hand-off time
+ * @param {number} [payload.at]      unix-ms timestamp (defaults to now)
+ */
+export function writeHermesUpdateHandoff(hermesHome, { sha, version, at }: any = {}) {
+  const markerPath = handoffMarkerPath(hermesHome)
+  try {
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+  } catch {
+    // directory likely exists already
+  }
+  const body = JSON.stringify({
+    sha: sha || '',
+    version: version || '',
+    at: at || Date.now()
+  })
+  // Atomic write (temp + rename) so a crash mid-write can't leave a
+  // half-written marker that would be misparsed on next boot.
+  const tmp = markerPath + '.tmp'
+  try {
+    fs.writeFileSync(tmp, body, 'utf8')
+    fs.renameSync(tmp, markerPath)
+  } catch {
+    // If we can't write the marker, the worst case is we lose the
+    // post-relaunch validation — the update still proceeds normally.
+    try { fs.unlinkSync(tmp) } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Read and interpret the hand-off marker on boot.
+ *
+ * Returns { pending: false } when there is no actionable hand-off marker
+ * (absent, unreadable, malformed, or stale). When a valid marker exists:
+ *
+ *   - If the current SHA differs from the recorded SHA → the update took;
+ *     return { pending: false, succeeded: true } and prune the marker.
+ *   - If the current SHA matches the recorded SHA (or the SHA can't be
+ *     resolved) but a live update is still running → the verdict is
+ *     deferred; return { pending: true, deferred: true } and keep the
+ *     marker so a later boot (after the update completes) can re-evaluate.
+ *   - Otherwise (unchanged SHA, no live update) → the update did NOT take;
+ *     return { pending: true, failed: true, ... } so the renderer can
+ *     surface a closeable error. The marker is pruned.
+ *
+ * @param {string} hermesHome
+ * @param {string} updateRoot      git checkout root for SHA comparison
+ * @param {object} [opts]
+ * @param {function} [opts.resolveSha]  injectable SHA resolver (tests)
+ * @param {function} [opts.now]         injectable clock (tests)
+ * @param {number}   [opts.maxAgeMs]    injectable staleness ceiling (tests)
+ */
+export function readUpdateHandoffResult(hermesHome, updateRoot, opts: any = {}) {
+  const resolveSha = opts.resolveSha || defaultResolveSha
+  const now = opts.now || Date.now
+  const maxAgeMs = opts.maxAgeMs || HANDOFF_MARKER_MAX_AGE_MS
+
+  const markerPath = handoffMarkerPath(hermesHome)
+  let raw
+  try {
+    raw = fs.readFileSync(markerPath, 'utf8')
+  } catch {
+    return { pending: false }
+  }
+
+  let marker
+  try {
+    marker = JSON.parse(raw)
+  } catch {
+    // Malformed marker — prune and move on.
+    try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+    return { pending: false }
+  }
+
+  if (!marker || typeof marker !== 'object') {
+    try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+    return { pending: false }
+  }
+
+  const at = Number(marker.at)
+  const ageMs = Number.isFinite(at) ? now() - at : Infinity
+
+  // Stale marker — the hand-off was too long ago to act on. Prune so it
+  // doesn't false-positive on a much later relaunch.
+  if (ageMs > maxAgeMs) {
+    try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+    return { pending: false }
+  }
+
+  const recordedSha = String(marker.sha || '')
+  const currentSha = resolveSha(updateRoot)
+
+  // If we can resolve the current SHA and it changed, the update succeeded.
+  if (currentSha && recordedSha && currentSha !== recordedSha) {
+    // Prune the marker — it's a one-shot.
+    try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+    return { pending: false, succeeded: true }
+  }
+
+  // SHA unchanged (or couldn't be resolved) within the freshness window. This
+  // does NOT necessarily mean the update failed — the user may have reopened
+  // Hermes while the updater is still mid-run (git pull + pip + desktop rebuild
+  // takes minutes, and the relaunched instance can race that). Before we
+  // surface a closeable failure, consult the live update marker: if an update
+  // is genuinely still running, DEFER the verdict rather than pruning the
+  // hand-off marker and falsely reporting failure. A later boot (after the
+  // update completes and the SHA changes) will then re-evaluate and report
+  // success instead of a spurious error. (#57645)
+  const live = readLiveUpdateMarker(hermesHome, {
+    now,
+    maxAgeMs: UPDATE_MARKER_MAX_AGE_MS
+  })
+
+  if (live) {
+    return {
+      pending: true,
+      deferred: true,
+      recordedSha,
+      currentSha,
+      recordedVersion: String(marker.version || ''),
+      ageMs
+    }
+  }
+
+  // No live update and the SHA didn't change → the hand-off did NOT take.
+  // Prune the one-shot marker and surface a closeable error to the user
+  // instead of silently reverting to the old version.
+  try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+  return {
+    pending: true,
+    failed: true,
+    recordedSha,
+    currentSha,
+    recordedVersion: String(marker.version || ''),
+    ageMs
+  }
+}

--- a/apps/desktop/electron/update-handoff-marker.ts
+++ b/apps/desktop/electron/update-handoff-marker.ts
@@ -55,12 +55,14 @@ export function handoffMarkerPath(hermesHome) {
 export function defaultResolveSha(updateRoot) {
   try {
     const { execFileSync } = require('child_process')
+
     const sha = execFileSync('git', ['rev-parse', 'HEAD'], {
       cwd: updateRoot,
       encoding: 'utf8',
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe']
     }).trim()
+
     return sha
   } catch {
     return ''
@@ -78,19 +80,23 @@ export function defaultResolveSha(updateRoot) {
  */
 export function writeHermesUpdateHandoff(hermesHome, { sha, version, at }: any = {}) {
   const markerPath = handoffMarkerPath(hermesHome)
+
   try {
     fs.mkdirSync(path.dirname(markerPath), { recursive: true })
   } catch {
     // directory likely exists already
   }
+
   const body = JSON.stringify({
     sha: sha || '',
     version: version || '',
     at: at || Date.now()
   })
+
   // Atomic write (temp + rename) so a crash mid-write can't leave a
   // half-written marker that would be misparsed on next boot.
   const tmp = markerPath + '.tmp'
+
   try {
     fs.writeFileSync(tmp, body, 'utf8')
     fs.renameSync(tmp, markerPath)
@@ -131,6 +137,7 @@ export function readUpdateHandoffResult(hermesHome, updateRoot, opts: any = {}) 
 
   const markerPath = handoffMarkerPath(hermesHome)
   let raw
+
   try {
     raw = fs.readFileSync(markerPath, 'utf8')
   } catch {
@@ -138,16 +145,19 @@ export function readUpdateHandoffResult(hermesHome, updateRoot, opts: any = {}) 
   }
 
   let marker
+
   try {
     marker = JSON.parse(raw)
   } catch {
     // Malformed marker — prune and move on.
     try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+
     return { pending: false }
   }
 
   if (!marker || typeof marker !== 'object') {
     try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+
     return { pending: false }
   }
 
@@ -158,6 +168,7 @@ export function readUpdateHandoffResult(hermesHome, updateRoot, opts: any = {}) 
   // doesn't false-positive on a much later relaunch.
   if (ageMs > maxAgeMs) {
     try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+
     return { pending: false }
   }
 
@@ -168,6 +179,7 @@ export function readUpdateHandoffResult(hermesHome, updateRoot, opts: any = {}) 
   if (currentSha && recordedSha && currentSha !== recordedSha) {
     // Prune the marker — it's a one-shot.
     try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+
     return { pending: false, succeeded: true }
   }
 
@@ -200,6 +212,7 @@ export function readUpdateHandoffResult(hermesHome, updateRoot, opts: any = {}) 
   // Prune the one-shot marker and surface a closeable error to the user
   // instead of silently reverting to the old version.
   try { fs.unlinkSync(markerPath) } catch { /* ignore */ }
+
   return {
     pending: true,
     failed: true,

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -284,6 +284,7 @@ declare global {
         apply: (opts?: DesktopUpdateApplyOptions) => Promise<DesktopUpdateApplyResult>
         getBranch: () => Promise<{ branch: string }>
         setBranch: (name: string) => Promise<{ branch: string }>
+        handoffResult: () => Promise<DesktopUpdateHandoffResult>
         onProgress: (callback: (payload: DesktopUpdateProgress) => void) => () => void
       }
       uninstall: {
@@ -437,6 +438,33 @@ export interface DesktopUpdateApplyResult {
   /** True when a detached relauncher took over (macOS bundle swap / Linux
    *  re-exec): the app is about to quit and reopen itself. */
   handedOff?: boolean
+}
+
+/** Post-relaunch validation result for the Tauri updater hand-off (#57645).
+ *  When the desktop spawned hermes-setup --update and quit, the next instance
+ *  checks whether the git SHA actually changed. If not, the update failed
+ *  silently and the renderer surfaces a closeable error. */
+export interface DesktopUpdateHandoffResult {
+  /** True when a fresh hand-off marker was found and the SHA did not change —
+   *  the update failed silently. The renderer should land on a closeable
+   *  error state. */
+  pending?: boolean
+  /** True when the hand-off marker indicates the update did NOT take (same SHA
+   *  before and after). */
+  failed?: boolean
+  /** True when the SHA is unchanged but a live update is still running — the
+   *  verdict is deferred to a later boot rather than reported as a failure. */
+  deferred?: boolean
+  /** True when the hand-off marker indicates the update DID take (SHA changed). */
+  succeeded?: boolean
+  /** The git HEAD SHA recorded at hand-off time. */
+  recordedSha?: string
+  /** The git HEAD SHA at relaunch time (may be '' if git is unavailable). */
+  currentSha?: string
+  /** The Hermes version string recorded at hand-off time. */
+  recordedVersion?: string
+  /** Error message if the check itself failed. */
+  error?: string
 }
 
 export type DesktopUpdateStage =

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2216,6 +2216,9 @@ export const en: Translations = {
     applyingClose: 'This window will close while the update runs, then Hermes reopens on its own.',
     errorTitle: 'Update didn’t finish',
     errorBody: 'No worries — nothing was lost. You can try again now.',
+    handoffFailedTitle: 'Update didn’t complete',
+    handoffFailedBody:
+      'The Hermes updater was launched but the update wasn’t applied — the app is still on the previous version. You can retry the in-app update or run “hermes update” in a terminal.',
     notNow: 'Not now',
     applyStatus: {
       preparing: 'Updating backend…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2049,6 +2049,9 @@ export const ja = defineLocale({
     applyingClose: 'このウィンドウは更新中に閉じ、その後 Hermes が自動的に再度開きます。',
     errorTitle: '更新が完了しませんでした',
     errorBody: 'ご安心ください。何も失われていません。今すぐ再試行できます。',
+    handoffFailedTitle: '更新が完了しませんでした',
+    handoffFailedBody:
+      'Hermes アップデーターは起動しましたが、更新は適用されませんでした——アプリは以前のバージョンのままです。アプリ内更新を再試行するか、ターミナルで「hermes update」を実行してください。',
     notNow: '今は後で',
     applyStatus: {
       preparing: 'バックエンドを更新しています…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1847,6 +1847,8 @@ export interface Translations {
     applyingClose: string
     errorTitle: string
     errorBody: string
+    handoffFailedTitle: string
+    handoffFailedBody: string
     notNow: string
     applyStatus: {
       preparing: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1987,6 +1987,9 @@ export const zhHant = defineLocale({
     applyingClose: '此視窗會在更新期間關閉，隨後 Hermes 會自動重新開啟。',
     errorTitle: '更新未完成',
     errorBody: '沒有資料遺失。您可以現在重試。',
+    handoffFailedTitle: '更新未完成',
+    handoffFailedBody:
+      'Hermes 更新程式已啟動但更新未套用——應用程式仍為之前的版本。您可以重試應用程式內更新，或在終端機中執行「hermes update」。',
     notNow: '暫不',
     applyStatus: {
       preparing: '正在更新後端…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2407,6 +2407,9 @@ export const zh: Translations = {
     applyingClose: '此窗口会在更新期间关闭，随后 Hermes 会自动重新打开。',
     errorTitle: '更新未完成',
     errorBody: '没有数据丢失。你可以现在重试。',
+    handoffFailedTitle: '更新未完成',
+    handoffFailedBody:
+      'Hermes 更新器已启动但更新未应用——应用仍为之前的版本。你可以重试应用内更新，或在终端中运行“hermes update”。',
     notNow: '暂不',
     applyStatus: {
       preparing: '正在更新后端…',

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -554,12 +554,14 @@ describe('applyBackendUpdate recovery', () => {
 describe('startUpdatePoller', () => {
   const checkMock = vi.fn()
   const onProgressMock = vi.fn()
+  const handoffResultMock = vi.fn()
   const listeners: Record<string, Function> = {}
 
   beforeEach(() => {
     storage.clear()
     checkMock.mockReset()
     onProgressMock.mockReset()
+    handoffResultMock.mockReset()
     Object.keys(listeners).forEach(k => delete listeners[k])
     checkMock.mockResolvedValue({
       supported: true,
@@ -567,9 +569,10 @@ describe('startUpdatePoller', () => {
       targetSha: 'sha-abc',
       fetchedAt: 0
     })
+    handoffResultMock.mockResolvedValue({ pending: false })
     $updateStatus.set(null)
     ;(globalThis as unknown as { window: unknown }).window = {
-      hermesDesktop: { updates: { check: checkMock, onProgress: onProgressMock } },
+      hermesDesktop: { updates: { check: checkMock, onProgress: onProgressMock, handoffResult: handoffResultMock } },
       addEventListener: vi.fn((event: string, handler: Function) => {
         listeners[event] = handler
       }),
@@ -617,5 +620,57 @@ describe('startUpdatePoller', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(checkMock).toHaveBeenCalled()
+  })
+
+  it('lands on a closeable error state when a failed hand-off is detected on startup (#57645)', async () => {
+    handoffResultMock.mockResolvedValue({
+      pending: true,
+      failed: true,
+      recordedSha: 'aaa111',
+      currentSha: 'aaa111',
+      recordedVersion: '0.18.0'
+    })
+    resetUpdateApplyState()
+
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect($updateApply.get().stage).toBe('error')
+    expect($updateApply.get().error).toBe('handoff-failed')
+    expect($updateApply.get().applying).toBe(false)
+    expect($updateOverlayOpen.get()).toBe(true)
+  })
+
+  it('does not surface an error when the hand-off succeeded (SHA changed) (#57645)', async () => {
+    handoffResultMock.mockResolvedValue({
+      pending: false,
+      succeeded: true
+    })
+    resetUpdateApplyState()
+
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect($updateApply.get().stage).not.toBe('error')
+    expect($updateApply.get().applying).toBe(false)
+  })
+
+  it('does not surface an error when the hand-off is deferred (update still running) (#57645)', async () => {
+    handoffResultMock.mockResolvedValue({
+      pending: true,
+      deferred: true,
+      recordedSha: 'aaa111',
+      currentSha: 'aaa111',
+      recordedVersion: '0.18.0'
+    })
+    resetUpdateApplyState()
+
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // A deferred hand-off is NOT a failure — no closeable error state.
+    expect($updateApply.get().stage).not.toBe('error')
+    expect($updateApply.get().error).not.toBe('handoff-failed')
+    expect($updateApply.get().applying).toBe(false)
   })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -8,6 +8,7 @@ import { atom } from 'nanostores'
 import type {
   DesktopUpdateApplyOptions,
   DesktopUpdateApplyResult,
+  DesktopUpdateHandoffResult,
   DesktopUpdateProgress,
   DesktopUpdateStage,
   DesktopUpdateStatus,
@@ -665,6 +666,53 @@ let lastFocusAt = 0
 let connectionUnsub: (() => void) | null = null
 let lastConnectionMode: string | undefined
 
+/**
+ * Post-relaunch validation for the Tauri updater hand-off (#57645).
+ *
+ * When the desktop spawned `hermes-setup --update` and quit, the next instance
+ * must check whether the git SHA actually changed. If it didn't, the updater
+ * failed silently — the user clicked "Update now", the app closed and reopened,
+ * but the version is unchanged and there is no error. Without this check the
+ * app silently reverts to the old version and re-shows the "update available"
+ * pill as if nothing happened.
+ *
+ * On a failed hand-off we land on a closeable `error` state so the user knows
+ * the update didn't take and can retry or fall back to `hermes update` in a
+ * terminal.
+ */
+async function checkHandoffResult(): Promise<void> {
+  const bridge = window.hermesDesktop?.updates
+
+  if (!bridge?.handoffResult) {
+    return
+  }
+
+  let result: DesktopUpdateHandoffResult
+
+  try {
+    result = await bridge.handoffResult()
+  } catch {
+    // Bridge not ready or IPC failed — don't block startup.
+    return
+  }
+
+  if (result?.pending && result?.failed) {
+    $updateApply.set({
+      ...IDLE,
+      applying: false,
+      stage: 'error',
+      error: 'handoff-failed',
+      message: translateNow('updates.handoffFailedBody')
+    })
+    $updateOverlayOpen.set(true)
+  }
+
+  // A `deferred` result (unchanged SHA but an update still running) is
+  // intentionally NOT surfaced here: the update is in flight and a later boot
+  // will re-evaluate once the SHA changes. Parking silently here (rather than
+  // erroring) is the desired behaviour.
+}
+
 /** Wire up background polling + progress streaming. Idempotent. */
 export function startUpdatePoller(): void {
   if (pollerStarted || typeof window === 'undefined') {
@@ -678,6 +726,7 @@ export function startUpdatePoller(): void {
   }
 
   pollerStarted = true
+  void checkHandoffResult()
   void checkUpdates()
   void checkBackendUpdates()
   void refreshDesktopVersion()


### PR DESCRIPTION
Fixes #57645

## Description

Adds a durable hand-off marker for the Tauri updater on macOS to detect silent update failures. When the desktop app quits to let the updater run, the next instance checks if the git SHA actually changed. If not, it surfaces a closeable error instead of silently reverting to the old version.

## Verification

- Added update-handoff-marker.cjs with write/read functions and tests.
- Integrated the marker in main.cjs (applyUpdates) and the renderer (checkHandoffResult).
- All quality gates passed:
  - S1 (Secrets): clean
  - S2 (Personal refs): clean
  - C1 (Conventional commits): compliant
  - T1 (Tests): updated affected files compile cleanly
  - F1 (Focused): only relevant files changed
