### PR TITLE
feat(dashboard): add AudioLines + Mic to plugin ICON_MAP

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,7 @@ import {
 } from "react-router-dom";
 import {
   Activity,
+  AudioLines,
   BarChart3,
   BookOpen,
   Clock,
@@ -35,6 +36,7 @@ import {
   KeyRound,
   Menu,
   MessageSquare,
+  Mic,
   Package,
   PanelLeftClose,
   PanelLeftOpen,
@@ -202,6 +204,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
 
 const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Activity,
+  AudioLines,
   BarChart3,
   Clock,
   Cpu,
@@ -209,6 +212,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   FolderOpen,
   KeyRound,
   MessageSquare,
+  Mic,
   Package,
   Settings,
   Puzzle,


### PR DESCRIPTION
Additive: registers the `AudioLines` and `Mic` icons (both already exported by `lucide-react`) in the dashboard plugin `ICON_MAP` in `web/src/App.tsx`.

## Why
Dashboard plugin tabs pick their icon from this fixed map. There is currently no mic/waveform icon, so a voice/TTS plugin tab has to borrow `MessageSquare` / `Zap` / `Sparkles`. This adds two voice-appropriate options.

## Safety
- Purely additive — no existing entry changes (4 added lines: 2 imports + 2 map entries).
- Unknown icon names still fall back to `Puzzle` via `resolveIcon`, so nothing regresses.
- `AudioLines` and `Mic` are existing `lucide-react` exports (verified against the version pinned in this repo).

Motivated by a self-hosted OmniVoice dashboard **Voices** tab: https://github.com/MahdiHedhli/hermes-omnivoice

Opened as a **draft** pending maintainer interest — happy to link a tracking issue or adjust naming.