### PR TITLE
fix(delegate): guard delegate_task against duplicate dispatch of one tool call

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1878,7 +1878,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
-            return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+            return _finish_agent_tool(
+                agent._dispatch_delegate_task(next_args, tool_call_id=tool_call_id),
+                next_args,
+            )
     else:
         def _execute(next_args: dict) -> Any:
             return _ra().handle_function_call(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1128,7 +1128,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _delegate_result = None
             try:
                 def _execute(next_args: dict) -> Any:
-                    return agent._dispatch_delegate_task(next_args)
+                    return agent._dispatch_delegate_task(
+                        next_args, tool_call_id=getattr(tool_call, "id", "") or ""
+                    )
                 function_result, function_args = _run_agent_tool_execution_middleware(
                     agent,
                     function_name=function_name,

--- a/run_agent.py
+++ b/run_agent.py
@@ -5208,7 +5208,7 @@ class AIAgent:
         finally:
             self._executing_tools = False
 
-    def _dispatch_delegate_task(self, function_args: dict) -> str:
+    def _dispatch_delegate_task(self, function_args: dict, tool_call_id: Optional[str] = None) -> str:
         """Single call site for delegate_task dispatch.
 
         New DELEGATE_TASK_SCHEMA fields only need to be added here to reach all
@@ -5238,6 +5238,7 @@ class AIAgent:
             role=function_args.get("role"),
             background=(not _is_subagent),
             parent_agent=self,
+            tool_call_id=tool_call_id,
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -199,6 +199,26 @@ class TestDelegateTask(unittest.TestCase):
         mock_run.assert_called_once()
 
     @patch("tools.delegate_tool._run_single_child")
+    def test_duplicate_tool_call_id_rejected(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done!", "api_calls": 3, "duration_seconds": 5.0
+        }
+        parent = _make_mock_parent()
+        first = json.loads(
+            delegate_task(goal="Fix tests", parent_agent=parent, tool_call_id="call-123")
+        )
+        self.assertIn("results", first)
+        mock_run.assert_called_once()
+
+        second = json.loads(
+            delegate_task(goal="Fix tests", parent_agent=parent, tool_call_id="call-123")
+        )
+        self.assertIn("error", second)
+        self.assertIn("call-123", second["error"])
+        mock_run.assert_called_once()  # no second child spawned
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode(self, mock_run):
         mock_run.side_effect = [
             {"task_index": 0, "status": "completed", "summary": "Result A", "api_calls": 2, "duration_seconds": 3.0},

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -162,6 +162,15 @@ _active_subagents_lock = threading.Lock()
 # for the lifetime of the run; _run_single_child is the owner.
 _active_subagents: Dict[str, Dict[str, Any]] = {}
 
+_dispatched_tool_call_ids_lock = threading.Lock()
+# tool_call_id -> True for every delegate_task call already accepted in this
+# process. Guards against double-dispatch of the SAME tool call (e.g. a
+# concurrent/sequential execution path invoking it twice, or a caller
+# retrying a tool_call_id it already submitted) spawning duplicate children.
+# Deliberately process-lifetime, not TTL'd: a tool_call_id is unique per API
+# response and never legitimately recurs within one process.
+_dispatched_tool_call_ids: Dict[str, bool] = {}
+
 
 def set_spawn_paused(paused: bool) -> bool:
     """Globally block/unblock new delegate_task spawns.
@@ -2082,6 +2091,7 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
+    tool_call_id: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -2095,10 +2105,25 @@ def delegate_task(
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
 
+    ``tool_call_id`` (when provided by the dispatcher) is used as an
+    idempotency key: a second delegate_task call carrying a tool_call_id
+    already seen in this process is rejected before any child is built,
+    so a duplicate dispatch of the same tool call can't spawn duplicate
+    children.
+
     Returns JSON with results array, one entry per task.
     """
     if parent_agent is None:
         return tool_error("delegate_task requires a parent agent context.")
+
+    if tool_call_id:
+        with _dispatched_tool_call_ids_lock:
+            if tool_call_id in _dispatched_tool_call_ids:
+                return tool_error(
+                    f"delegate_task already dispatched for tool_call_id={tool_call_id!r}; "
+                    "skipping duplicate spawn."
+                )
+            _dispatched_tool_call_ids[tool_call_id] = True
 
     # Operator-controlled kill switch — lets the TUI freeze new fan-out
     # when a runaway tree is detected, without interrupting already-running


### PR DESCRIPTION
## Summary

- `delegate_task` had no idempotency key: a second dispatch of the same logical tool call (e.g. a bug in a dispatch path, a future retry wrapper) could spawn a duplicate child-agent tree — doubling API cost and any tool side effects the child performs.
- Threads the provider-issued `tool_call_id` (already available at both dispatch call sites, just never forwarded) through to `delegate_task`, and adds a minimal process-lifetime dedup guard keyed on it.

Fixes #57767.

## Root cause

`tool_call_id` was in scope at both places `delegate_task` gets dispatched from, but was dropped before reaching it:

- `agent/agent_runtime_helpers.py:2211-2213` (concurrent path) — `tool_call_id` already used a few lines up for memory-write metadata, but not passed to `agent._dispatch_delegate_task(next_args)`.
- `agent/tool_executor.py:1310` (sequential path) — `tool_call.id` available on the enclosing object, not passed through.
- `run_agent.py:5620` `_dispatch_delegate_task` — the single funnel point into `tools/delegate_tool.py`'s `delegate_task(...)`, had no `tool_call_id` parameter to forward.

Scope note: a crash+replay path was also considered (stale `tool_call_id` resubmitted after a process crash) and ruled out — `agent/replay_cleanup.py` strips dangling/interrupted tool-call tails on resume rather than replaying them, so that path was already safe. This PR only closes the in-process double-dispatch gap.

## Change

- `tools/delegate_tool.py`: `delegate_task(...)` gains a `tool_call_id: Optional[str] = None` parameter. New module-level `_dispatched_tool_call_ids: Dict[str, bool]` + `_dispatched_tool_call_ids_lock`, checked-and-inserted atomically before any child agent is built (same pattern as `tools/async_delegation.py`'s own `_records`/`_records_lock`). A second call with a `tool_call_id` already seen in-process returns a `tool_error(...)` instead of spawning children.
- `run_agent.py`: `_dispatch_delegate_task` accepts and forwards `tool_call_id`.
- `agent/agent_runtime_helpers.py` / `agent/tool_executor.py`: both dispatch paths now pass the `tool_call_id` already in scope.
- `tests/tools/test_delegate.py`: new `test_duplicate_tool_call_id_rejected` — first call with a given `tool_call_id` spawns a child, second call with the same id is rejected and spawns nothing.

`tool_call_id` defaults to `None`, so callers that don't have one (internal/CLI callers not driven by a model tool call) are unaffected — dedup simply doesn't apply.

## Test plan

- [x] `pytest tests/tools/test_delegate.py::TestDelegateTask::test_duplicate_tool_call_id_rejected -v` — passes
- [x] `pytest tests/tools/test_delegate.py tests/tools/test_async_delegation.py -q` — 148 passed / 12 failed on this branch vs. 147 passed / 12 failed on `main` with the fix reverted (same pre-existing failures, +1 new passing test, no regressions)
