### PR TITLE
fix(platforms/google_chat): use Unicode PUA delimiter and restore nested placeholders in reverse order

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2042,7 +2042,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         counter = [0]
 
         def _ph(value: str) -> str:
-            key = f"\x00GC{counter[0]}\x00"
+            key = f"\U000F0000{counter[0]}\U000F0000"
             counter[0] += 1
             placeholders[key] = value
             return key
@@ -2091,8 +2091,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # Collapse double spaces left over from stripped chars.
         text = re.sub(r"  +", " ", text)
 
-        # Restore protected regions.
-        for key, value in placeholders.items():
+        # Restore protected regions in reverse insertion order so nested
+        # placeholders (e.g. bold wrapping inline code: **`code`**) are
+        # resolved outermost first, then inner.
+        for key, value in reversed(list(placeholders.items())):
             text = text.replace(key, value)
 
         return text

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2424,7 +2424,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         counter = [0]
 
         def _ph(value: str) -> str:
-            key = f"\x00GC{counter[0]}\x00"
+            key = f"\U000F0000{counter[0]}\U000F0000"
             counter[0] += 1
             placeholders[key] = value
             return key
@@ -2473,8 +2473,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # Collapse double spaces left over from stripped chars.
         text = re.sub(r"  +", " ", text)
 
-        # Restore protected regions.
-        for key, value in placeholders.items():
+        # Restore protected regions in reverse insertion order so nested
+        # placeholders (e.g. bold wrapping inline code: **`code`**) are
+        # resolved outermost first, then inner.
+        for key, value in reversed(list(placeholders.items())):
             text = text.replace(key, value)
 
         return text

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2501,6 +2501,18 @@ class TestFormatMessage:
         out = GoogleChatAdapter.format_message("rate is ** TBD")
         assert "**" in out  # not converted
 
+    def test_bold_wrapping_inline_code_restores_correctly(self):
+        """Bold wrapping inline code (**`code`**) must resolve outermost
+        first — insertion-order restoration buries the inner placeholder
+        inside the outer one before it's replaced. Also guards against
+        the null-byte delimiter regressing: Chat's API strips \x00, so
+        it would surface as literal text instead of the real content.
+        """
+        src = "**`hello world`**"
+        out = GoogleChatAdapter.format_message(src)
+        assert out == "*`hello world`*"
+        assert "\x00" not in out
+
 
 class TestADCFallback:
     """When no SA JSON is configured, fall back to Application Default Credentials.

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1472,6 +1472,18 @@ class TestFormatMessage:
         assert "\U0001f469" in out
         assert "\U0001f467" in out
 
+    def test_bold_wrapping_inline_code_restores_correctly(self):
+        """Bold wrapping inline code (**`code`**) must resolve outermost
+        first — insertion-order restoration buries the inner placeholder
+        inside the outer one before it's replaced. Also guards against
+        the null-byte delimiter regressing: Chat's API strips \x00, so
+        it would surface as literal text instead of the real content.
+        """
+        src = "**`hello world`**"
+        out = GoogleChatAdapter.format_message(src)
+        assert out == "*`hello world`*"
+        assert "\x00" not in out
+
 
 class TestADCFallback:
     """When no SA JSON is configured, fall back to Application Default Credentials.


### PR DESCRIPTION
## Problem

Google Chat's REST API strips null bytes (`\x00`) from message payloads. The `format_message()` method uses null-byte-delimited placeholders like `\x00GC0\x00` to protect formatted text during Markdown-to-Chat dialect conversion. After the API strips the null bytes, these arrive as visible `GC0`, `GC1`, etc. in the rendered message.

A secondary issue: placeholders are restored in insertion order (inner first). When formatting is nested (e.g. bold wrapping inline code: **\`code\`**), the inner key is buried inside the outer key at restoration time. The outer key gets restored first, exposing the inner key — but it was already processed and stays unreplaced.

## Fix

1. **Delimiter**: Replace `\x00GC{n}\x00` with `\U000F0000{n}\U000F0000` (Unicode Supplementary Private Use Area codepoint U+F0000), which Google Chat passes through unchanged.

2. **Restoration order**: Iterate `placeholders` in reverse insertion order (`reversed(list(placeholders.items()))`) so outermost formatting is resolved first, then inner.

## Testing

- Verified the null-byte delimiter causes visible `GC0` artifacts in Google Chat messages
- Verified U+F0000 delimiter survives the REST API round-trip
- Verified nested bold+inline-code formatting now renders correctly after the restoration order fix