### PR TITLE
fix: allow MoA Anthropic slots to use Claude OAuth

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2392,12 +2392,16 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
         return None, None
 
     pool_present, entry = _select_pool_entry("anthropic")
-    if pool_present:
-        if entry is None:
-            return None, None
+    if pool_present and entry is not None:
         token = explicit_api_key or _pool_runtime_api_key(entry)
     else:
         entry = None
+        # A configured-but-unavailable pool entry must not shadow other valid
+        # Anthropic credential sources.  This happens when a stale/exhausted
+        # claude_code pool row exists while the user has a fresh env/API-key or
+        # refreshable Claude Code credential available.  Mirror the canonical
+        # runtime resolver: try the pool first, then fall through to the normal
+        # Anthropic token chain.
         token = explicit_api_key or resolve_anthropic_token()
     if not token:
         return None, None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1466,7 +1466,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     except Exception:
         pass
 
-    # 2. Check config.yaml model.provider
+    # 2. Check config.yaml model.provider and other explicit provider slots.
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
@@ -1475,6 +1475,37 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
             cfg_provider = (model_cfg.get("provider") or "").strip().lower()
             if cfg_provider == normalized:
                 return True
+
+        # MoA presets are explicit model selections too.  A user who configured
+        # ``provider: anthropic`` as a MoA advisor/aggregator has opted Hermes
+        # into using Anthropic credentials for that slot even when the main
+        # session model is another provider.  Without this, Claude Code OAuth
+        # entries are pruned/ignored by credential_pool.load_pool("anthropic"),
+        # so MoA Anthropic advisors fail with "no ANTHROPIC_API_KEY" while the
+        # normal model picker says Anthropic is logged in.
+        def _slot_matches_provider(slot):
+            return (
+                isinstance(slot, dict)
+                and (slot.get("provider") or "").strip().lower() == normalized
+            )
+
+        moa_cfg = cfg.get("moa")
+        if isinstance(moa_cfg, dict):
+            for slot in moa_cfg.get("reference_models") or []:
+                if _slot_matches_provider(slot):
+                    return True
+            if _slot_matches_provider(moa_cfg.get("aggregator")):
+                return True
+            presets = moa_cfg.get("presets")
+            if isinstance(presets, dict):
+                for preset in presets.values():
+                    if not isinstance(preset, dict):
+                        continue
+                    for slot in preset.get("reference_models") or []:
+                        if _slot_matches_provider(slot):
+                            return True
+                    if _slot_matches_provider(preset.get("aggregator")):
+                        return True
     except Exception:
         pass
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -110,6 +110,48 @@ class TestAuxiliaryMaxTokensParam:
             assert auxiliary_max_tokens_param(2048) == {"max_completion_tokens": 2048}
 
 
+class TestAnthropicCredentialFallback:
+    def test_unavailable_pool_falls_back_to_resolver(self, monkeypatch):
+        """An exhausted Anthropic pool row must not shadow fresh fallback credentials."""
+        from agent import auxiliary_client as aux
+
+        built_client = MagicMock(name="anthropic-client")
+        monkeypatch.setattr(aux, "_select_pool_entry", lambda provider: (True, None))
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            lambda: "resolver-token",
+        )
+        build = MagicMock(return_value=built_client)
+        monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_client", build)
+        monkeypatch.setattr(aux, "_get_aux_model_for_provider", lambda provider: "claude-test")
+
+        client, model = aux._try_anthropic()
+
+        assert client is not None
+        assert model == "claude-test"
+        build.assert_called_once_with("resolver-token", aux._ANTHROPIC_DEFAULT_BASE_URL)
+
+    def test_unavailable_pool_preserves_explicit_api_key_fallback(self, monkeypatch):
+        """API-key users should still work when an old OAuth pool entry is exhausted."""
+        from agent import auxiliary_client as aux
+
+        built_client = MagicMock(name="anthropic-client")
+        monkeypatch.setattr(aux, "_select_pool_entry", lambda provider: (True, None))
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            lambda: None,
+        )
+        build = MagicMock(return_value=built_client)
+        monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_client", build)
+        monkeypatch.setattr(aux, "_get_aux_model_for_provider", lambda provider: "claude-test")
+
+        client, model = aux._try_anthropic(explicit_api_key="explicit-api-key")
+
+        assert client is not None
+        assert model == "claude-test"
+        build.assert_called_once_with("explicit-api-key", aux._ANTHROPIC_DEFAULT_BASE_URL)
+
+
 class TestResolveTaskProviderModel:
     @pytest.mark.parametrize(
         "provider",

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -3239,6 +3239,46 @@ def test_sync_anthropic_entry_tokens_unchanged_no_op(tmp_path, monkeypatch):
     assert synced is entry, "no-op sync must return the original entry object"
 
 
+def test_select_syncs_exhausted_anthropic_entry_from_fresh_credentials_file(tmp_path, monkeypatch):
+    """Selecting should recover an exhausted claude_code entry when the file is fresh."""
+    from dataclasses import replace as dc_replace
+    from agent.credential_pool import STATUS_EXHAUSTED
+
+    pool, entry = _make_anthropic_claude_code_pool(
+        tmp_path, monkeypatch,
+        access_token="stale-access",
+        refresh_token="stale-refresh",
+        expires_at_ms=int(time.time() * 1000) + 3_600_000,
+    )
+    now = time.time()
+    exhausted = dc_replace(
+        entry,
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=now,
+        last_error_code=401,
+        last_error_reason="token_expired",
+        last_error_message="Access token has expired",
+        last_error_reset_at=now + 3600,
+    )
+    pool._replace_entry(entry, exhausted)
+
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: {
+            "accessToken": "fresh-access",
+            "refreshToken": "fresh-refresh",
+            "expiresAt": int(time.time() * 1000) + 3_600_000,
+        },
+    )
+
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.access_token == "fresh-access"
+    assert selected.refresh_token == "fresh-refresh"
+    assert selected.last_status is None
+
+
 def test_sync_anthropic_entry_clears_all_error_fields(tmp_path, monkeypatch):
     """Syncing fresh tokens must clear all six error/status fields on the entry.
 

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -62,6 +62,69 @@ class TestSlotRuntimeApiMode:
         assert "api_mode" not in result
 
 
+def test_moa_anthropic_slot_can_seed_claude_code_oauth_when_main_provider_differs(tmp_path, monkeypatch):
+    """MoA Anthropic slots should use Claude Code OAuth even if main model is not Anthropic.
+
+    This reproduces the Telegram /moa failure mode: the main session is on
+    OpenAI/Codex, but the MoA preset explicitly asks for an Anthropic advisor.
+    The auth gate must treat that MoA slot as explicit consent to seed the
+    Anthropic pool from Claude Code credentials; otherwise _slot_runtime falls
+    back to a bare provider/model and the reference call later fails with a
+    misleading ANTHROPIC_API_KEY error.
+    """
+    import json
+    import yaml
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+
+    (hermes_home / "config.yaml").write_text(yaml.safe_dump({
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "moa": {
+            "presets": {
+                "default": {
+                    "reference_models": [
+                        {"provider": "anthropic", "model": "claude-opus-4-8"},
+                    ],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.5"},
+                }
+            }
+        },
+    }))
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "active_provider": "openai-codex",
+        "credential_pool": {},
+    }))
+
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: {
+            "accessToken": "cc-test-access-token",
+            "refreshToken": "cc-test-refresh-token",
+            "expiresAt": 9999999999999,
+            "source": "claude_code_credentials_file",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_hermes_oauth_credentials",
+        lambda: None,
+    )
+
+    from agent.moa_loop import _slot_runtime
+
+    result = _slot_runtime({"provider": "anthropic", "model": "claude-opus-4-8"})
+    assert result["provider"] == "anthropic"
+    assert result["model"] == "claude-opus-4-8"
+    assert result["api_mode"] == "anthropic_messages"
+    assert result["base_url"] == "https://api.anthropic.com"
+    assert result["api_key"] == "cc-test-access-token"
+
+
 class TestCallLlmApiMode:
     """call_llm should accept and forward api_mode parameter."""
 

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -77,8 +77,47 @@ def test_returns_true_when_anthropic_env_var_set(tmp_path, monkeypatch):
 def test_claude_code_oauth_token_does_not_count_as_explicit(tmp_path, monkeypatch):
     """CLAUDE_CODE_OAUTH_TOKEN is set by Claude Code, not the user — must not gate."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-auto-token")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "«redacted:sk-…»")
     (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
 
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("anthropic") is False
+
+
+def test_returns_true_when_moa_reference_slot_uses_provider(tmp_path, monkeypatch):
+    """MoA advisor slots are explicit provider selections for auth gating."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_config(tmp_path, {
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "moa": {
+            "presets": {
+                "default": {
+                    "reference_models": [
+                        {"provider": "anthropic", "model": "claude-opus-4-8"},
+                        {"provider": "opencode-go", "model": "glm-5.2"},
+                    ],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.5"},
+                }
+            }
+        },
+    })
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}, "active_provider": "openai-codex"})
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("anthropic") is True
+
+
+def test_returns_true_when_moa_aggregator_uses_provider(tmp_path, monkeypatch):
+    """MoA aggregator slots are explicit provider selections for auth gating."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_config(tmp_path, {
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "moa": {
+            "reference_models": [{"provider": "opencode-go", "model": "glm-5.2"}],
+            "aggregator": {"provider": "anthropic", "model": "claude-opus-4-8"},
+        },
+    })
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}, "active_provider": "openai-codex"})
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("anthropic") is True


### PR DESCRIPTION
## Summary

Fix MoA Anthropic slots so Claude Code OAuth-backed Anthropic advisors/aggregators resolve credentials correctly when the main session model is another provider.

This PR now covers two related bugs in the MoA/auxiliary Anthropic credential path:

1. MoA Anthropic slots did not count as explicit Anthropic provider selections for Claude Code credential seeding.
2. In the auxiliary Anthropic resolver, an existing but unavailable/exhausted Anthropic pool entry shadowed fallback credential sources instead of falling through to `resolve_anthropic_token()` / explicit API-key paths.

## Root cause

Claude Code credential auto-discovery is intentionally gated by `is_provider_explicitly_configured("anthropic")`, so Hermes does not silently use Claude Code credentials unless the user explicitly opted into Anthropic.

Before this change, the gate only considered:

- `auth.json.active_provider`
- `config.yaml model.provider`
- provider env vars such as `ANTHROPIC_API_KEY`

A user can explicitly configure Anthropic only inside an MoA preset, e.g.:

```yaml
model:
  provider: openai-codex
  default: gpt-5.5
moa:
  presets:
    default:
      reference_models:
        - provider: anthropic
          model: claude-opus-4-8
```

In that case, MoA asks for an Anthropic reference slot, but the Anthropic auth gate said Anthropic was not explicitly configured. That prevented Claude Code OAuth credential seeding/resolution for the slot.

The second issue was in `agent.auxiliary_client._try_anthropic()`: if `load_pool("anthropic")` found any pool credentials but `pool.select()` returned `None` because all entries were exhausted/unavailable, `_try_anthropic()` returned `(None, None)` immediately. That meant one stale/exhausted OAuth pool row could shadow a valid fallback token or explicit API key and produce a misleading missing-credential failure in MoA/auxiliary paths.

## Fix

- Treat MoA reference and aggregator slots as explicit provider selections in `is_provider_explicitly_configured()`, including both top-level `moa.reference_models` / `moa.aggregator` and named `moa.presets.*`.
- Make `_try_anthropic()` fall through to `resolve_anthropic_token()` / explicit API key when the Anthropic pool exists but has no selectable entry.
- Add regression coverage for:
  - MoA Anthropic slot + Claude Code OAuth when the main provider is not Anthropic
  - MoA reference/aggregator slots counting as explicit Anthropic auth configuration
  - exhausted Anthropic pool row falling back to resolver credentials
  - exhausted Anthropic pool row preserving explicit API-key users
  - selecting an exhausted `claude_code` pool entry syncing from fresh credential-file tokens

This keeps the existing privacy/safety gate intact: `CLAUDE_CODE_OAUTH_TOKEN` by itself still does not count as explicit configuration, and API-key users keep working.

## Tests

Focused/adjacent:

```text
uv run --extra dev pytest \
  tests/agent/test_auxiliary_client.py::TestAnthropicCredentialFallback \
  tests/agent/test_credential_pool.py::test_select_syncs_exhausted_anthropic_entry_from_fresh_credentials_file \
  tests/agent/test_credential_pool.py::test_sync_anthropic_entry_clears_all_error_fields \
  tests/agent/test_moa_slot_api_mode.py \
  tests/hermes_cli/test_auth_provider_gate.py \
  tests/hermes_cli/test_anthropic_model_flow_stale_oauth.py \
  tests/hermes_cli/test_moa_config.py \
  tests/agent/test_moa_switch_api_mode.py \
  tests/run_agent/test_moa_loop_mode.py \
  -q
```

Result:

```text
76 passed in 2.97s
```

New focused tests:

```text
17 passed in 0.44s
16 passed in 0.24s
```

Broader adjacent run:

```text
462 passed, 1 failed in 20.39s
```

The single failure was a timing-sensitive existing Codex timeout test (`test_enforces_total_timeout_while_stream_keeps_emitting_events`) missing its wall-clock assertion by ~7 ms; rerunning that exact test passed:

```text
1 passed in 0.18s
```

Lint/diff checks:

```text
uv run --extra dev ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py tests/agent/test_credential_pool.py hermes_cli/auth.py tests/hermes_cli/test_auth_provider_gate.py tests/agent/test_moa_slot_api_mode.py
All checks passed!

git diff --check
# no output
```

## Live smoke note

A single direct MoA facade smoke with `max_tokens=8` returned `OK` from the aggregator. The script did not attach the MoA reference callback, so it did not capture per-advisor trace; I am therefore not claiming live Opus advisor participation from that smoke alone.

Non-live runtime probing with `~/.hermes/.env` loaded showed the Anthropic MoA slot now resolves:

```text
provider=anthropic
model=claude-opus-4-8
base_url=https://api.anthropic.com
api_mode=anthropic_messages
api_key_present=True
```

## Notes

This is adjacent to prior MoA/runtime drift fixes such as #54379 and #55268, but specifically covers the auth-gating and auxiliary fallback behavior for Claude Code OAuth-backed Anthropic slots.
