### PR TITLE
salvage(#55954): Hermes Console REPL + perf follow-ups (NS-574)

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -71,6 +71,7 @@ Examples:
     hermes logs errors            View errors.log
     hermes logs --since 1h        Lines from the last hour
     hermes debug share             Upload debug report for support
+    hermes console                Open the safe Hermes command console
     hermes update                 Update to latest version
     hermes dashboard              Start web UI dashboard (port 9119)
     hermes dashboard --stop       Stop running dashboard processes

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import difflib
+import functools
 import importlib
 import io
 import json
@@ -291,6 +292,13 @@ def _noop_console_command(_args: argparse.Namespace) -> None:
     return None
 
 
+# The CLI surface these helpers reflect is process-static: they import a
+# subcommand module and build a throwaway argparse tree purely to extract help
+# summaries. Nothing about the result changes across engine instances, but the
+# dashboard opens a fresh HermesConsoleEngine per /api/console connection, so
+# without memoization every reconnect re-imports + re-parses the whole surface.
+# Cache by args (all hashable strings); callers only read the returned map.
+@functools.lru_cache(maxsize=None)
 def _extracted_summaries(
     module_name: str,
     builder_name: str,
@@ -306,6 +314,7 @@ def _extracted_summaries(
         return {}
 
 
+@functools.lru_cache(maxsize=None)
 def _registered_summaries(
     root: str,
     module_name: str,
@@ -322,6 +331,7 @@ def _registered_summaries(
         return {}
 
 
+@functools.lru_cache(maxsize=None)
 def _builder_summaries(
     module_name: str,
     builder_name: str,
@@ -335,6 +345,7 @@ def _builder_summaries(
         return {}
 
 
+@functools.lru_cache(maxsize=None)
 def _adder_summaries(module_name: str, add_name: str) -> dict[tuple[str, ...], str]:
     try:
         parser, subparsers = _parser_root()

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -13,6 +13,7 @@ import importlib
 import difflib
 import io
 import json
+import re
 import shlex
 import sys
 from dataclasses import dataclass, replace
@@ -70,6 +71,51 @@ def _capture_output(fn: Callable[[], object]) -> str:
     if code:
         raise ConsoleCommandError(text.strip() or f"Command exited with status {code}")
     return text.rstrip()
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _is_status_footer_rule(line: str) -> bool:
+    stripped = _strip_ansi(line).strip()
+    if len(stripped) < 8:
+        return False
+    normalized = stripped.replace("\u2500", "-")
+    return set(normalized) <= {"-"}
+
+
+def _strip_console_status_footer(text: str) -> str:
+    lines = text.splitlines()
+    while lines and not _strip_ansi(lines[-1]).strip():
+        lines.pop()
+    if len(lines) < 2:
+        return text.rstrip()
+
+    last = _strip_ansi(lines[-1]).strip()
+    prev = _strip_ansi(lines[-2]).strip()
+    if not (
+        prev.startswith("Run 'hermes doctor'")
+        and last.startswith("Run 'hermes setup'")
+    ):
+        return text.rstrip()
+
+    lines = lines[:-2]
+    while lines and not _strip_ansi(lines[-1]).strip():
+        lines.pop()
+    if lines and _is_status_footer_rule(lines[-1]):
+        lines.pop()
+    return "\n".join(lines).rstrip()
+
+
+def _table_summary(summary: str, *, limit: int = 76) -> str:
+    summary = " ".join(summary.split())
+    if len(summary) <= limit:
+        return summary
+    return f"{summary[: limit - 3].rstrip()}..."
 
 
 def _split_line(line: str) -> list[str]:
@@ -197,6 +243,112 @@ def _parser_root() -> tuple[_ArgumentParser, argparse._SubParsersAction]:
     parser = _ArgumentParser(prog="hermes", add_help=False)
     subparsers = parser.add_subparsers(dest="_console_command")
     return parser, subparsers
+
+
+def _subparser_actions(parser: argparse.ArgumentParser) -> list[argparse._SubParsersAction]:
+    return [
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    ]
+
+
+def _choice_help(action: argparse._SubParsersAction, name: str) -> str:
+    for choice in action._choices_actions:
+        if getattr(choice, "dest", None) == name or getattr(choice, "metavar", None) == name:
+            help_text = getattr(choice, "help", None)
+            if help_text and help_text is not argparse.SUPPRESS:
+                return str(help_text)
+    return ""
+
+
+def _clean_summary(text: str | None) -> str:
+    if not text:
+        return ""
+    if text is argparse.SUPPRESS:
+        return ""
+    summary = " ".join(str(text).split())
+    if not summary:
+        return ""
+    if summary.startswith("Run `hermes "):
+        return ""
+    return summary
+
+
+def _summaries_from_parser(parser: argparse.ArgumentParser) -> dict[tuple[str, ...], str]:
+    summaries: dict[tuple[str, ...], str] = {}
+
+    def walk(current: argparse.ArgumentParser, path: tuple[str, ...]) -> None:
+        for action in _subparser_actions(current):
+            for name, child in action.choices.items():
+                child_path = (*path, name)
+                summary = _clean_summary(_choice_help(action, name)) or _clean_summary(
+                    child.description
+                )
+                if summary:
+                    summaries.setdefault(child_path, summary)
+                walk(child, child_path)
+
+    walk(parser, ())
+    return summaries
+
+
+def _noop_console_command(_args: argparse.Namespace) -> None:
+    return None
+
+
+def _extracted_summaries(
+    module_name: str,
+    builder_name: str,
+    main_handler_name: str,
+) -> dict[tuple[str, ...], str]:
+    try:
+        parser, subparsers = _parser_root()
+        module = importlib.import_module(module_name)
+        builder = getattr(module, builder_name)
+        builder(subparsers, **{main_handler_name: _noop_console_command})
+        return _summaries_from_parser(parser)
+    except Exception:
+        return {}
+
+
+def _registered_summaries(
+    root: str,
+    module_name: str,
+    register_name: str,
+) -> dict[tuple[str, ...], str]:
+    try:
+        parser, subparsers = _parser_root()
+        module = importlib.import_module(module_name)
+        top_parser = subparsers.add_parser(root)
+        register = getattr(module, register_name)
+        register(top_parser)
+        return _summaries_from_parser(parser)
+    except Exception:
+        return {}
+
+
+def _builder_summaries(
+    module_name: str,
+    builder_name: str,
+) -> dict[tuple[str, ...], str]:
+    try:
+        parser, subparsers = _parser_root()
+        module = importlib.import_module(module_name)
+        getattr(module, builder_name)(subparsers)
+        return _summaries_from_parser(parser)
+    except Exception:
+        return {}
+
+
+def _adder_summaries(module_name: str, add_name: str) -> dict[tuple[str, ...], str]:
+    try:
+        parser, subparsers = _parser_root()
+        module = importlib.import_module(module_name)
+        getattr(module, add_name)(subparsers)
+        return _summaries_from_parser(parser)
+    except Exception:
+        return {}
 
 
 def _invoke_namespace(args: argparse.Namespace) -> object:
@@ -399,6 +551,7 @@ def _register_command_family(
     mutating: Iterable[Sequence[str]] = (),
     hosted: Iterable[Sequence[str]] = (),
     summary: str = "",
+    summaries: dict[tuple[str, ...], str] | None = None,
     confirmation: str = "",
 ) -> None:
     mutating_paths = {tuple(path) for path in mutating}
@@ -407,10 +560,11 @@ def _register_command_family(
         child_key = tuple(child_path)
         full_path = (root, *tuple(child_path))
         usage = " ".join(full_path)
+        command_summary = summary or (summaries or {}).get(full_path) or f"Run `hermes {usage}`."
         engine.register(
             full_path,
             usage,
-            summary or f"Run `hermes {usage}`.",
+            command_summary,
             handler_factory(tuple(child_path)),
             mutating=child_key in mutating_paths,
             confirmation=confirmation or f"Run `hermes {usage}`?",
@@ -485,7 +639,7 @@ class HermesConsoleEngine:
             if self.context not in command.contexts:
                 continue
             marker = " *" if command.mutating else "  "
-            lines.append(f"{marker} {command.usage:<32} {command.summary}")
+            lines.append(f"{marker} {command.usage:<32} {_table_summary(command.summary)}")
         lines.extend(
             [
                 "",
@@ -790,11 +944,13 @@ class HermesConsoleEngine:
         }
 
         for root, (module, builder, main_handler, paths, mutating) in extracted.items():
+            summaries = _extracted_summaries(module, builder, main_handler)
             _register_command_family(
                 self,
                 root=root,
                 paths=paths,
                 mutating=mutating,
+                summaries=summaries,
                 handler_factory=lambda fixed, root=root, module=module, builder=builder, main_handler=main_handler: _extracted_handler(
                     root,
                     fixed,
@@ -866,6 +1022,7 @@ class HermesConsoleEngine:
             self,
             root="portal",
             paths=portal_paths,
+            summaries=_adder_summaries("hermes_cli.portal_cli", "add_parser"),
             handler_factory=lambda fixed: _adder_handler(
                 "portal",
                 fixed,
@@ -890,6 +1047,7 @@ class HermesConsoleEngine:
                 ("restore",),
                 ("bind-board",),
             ],
+            summaries=_builder_summaries("hermes_cli.projects_cmd", "build_parser"),
             mutating=[
                 ("create",),
                 ("add-folder",),
@@ -946,6 +1104,7 @@ class HermesConsoleEngine:
                 ("assignments",),
                 ("context",),
             ],
+            summaries=_builder_summaries("hermes_cli.kanban", "build_parser"),
             mutating=[
                 ("init",),
                 ("boards", "create"),
@@ -1033,11 +1192,13 @@ class HermesConsoleEngine:
             ),
         }
         for root, (module, register, handler_name, paths, mutating) in registered.items():
+            summaries = _registered_summaries(root, module, register)
             _register_command_family(
                 self,
                 root=root,
                 paths=paths,
                 mutating=mutating,
+                summaries=summaries,
                 handler_factory=lambda fixed, root=root, module=module, register=register, handler_name=handler_name: _registered_handler(
                     root,
                     fixed,
@@ -1349,7 +1510,8 @@ def _status(_engine: HermesConsoleEngine, args: list[str]) -> str:
 
     from hermes_cli.status import show_status
 
-    return _capture_output(lambda: show_status(SimpleNamespace(all=False, deep=False)))
+    output = _capture_output(lambda: show_status(SimpleNamespace(all=False, deep=False)))
+    return _strip_console_status_footer(output)
 
 
 def _doctor(_engine: HermesConsoleEngine, args: list[str]) -> str:

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1,0 +1,1709 @@
+"""Safe Hermes Console command engine.
+
+This module backs ``hermes console`` and is intentionally narrower than the
+full Hermes CLI. It exposes a curated set of native adapters that can later be
+shared by the dashboard console websocket without becoming a raw shell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib
+import difflib
+import io
+import json
+import shlex
+import sys
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Callable, Iterable, Literal, NoReturn, Sequence
+from urllib.parse import urlparse
+
+
+ConsoleStatus = Literal["ok", "error", "confirm_required", "exit", "clear"]
+ConsoleContext = Literal["local", "hosted"]
+ALL_CONTEXTS: frozenset[ConsoleContext] = frozenset({"local", "hosted"})
+LOCAL_CONTEXTS: frozenset[ConsoleContext] = frozenset({"local"})
+
+
+class ConsoleCommandError(RuntimeError):
+    """User-facing console command failure."""
+
+
+@dataclass(frozen=True)
+class ConsoleResult:
+    status: ConsoleStatus
+    output: str = ""
+    command: str = ""
+    confirmation_message: str = ""
+
+
+@dataclass(frozen=True)
+class ConsoleCommand:
+    path: tuple[str, ...]
+    usage: str
+    summary: str
+    handler: Callable[["HermesConsoleEngine", list[str]], str]
+    mutating: bool = False
+    confirmation: str = ""
+    contexts: frozenset[ConsoleContext] = LOCAL_CONTEXTS
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> NoReturn:  # pragma: no cover - argparse hook
+        raise ConsoleCommandError(f"{self.prog}: {message}")
+
+
+def _capture_output(fn: Callable[[], object]) -> str:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = 0
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            result = fn()
+            if isinstance(result, int) and result:
+                raise SystemExit(result)
+        except SystemExit as exc:
+            code = int(exc.code or 0)
+    text = stdout.getvalue() + stderr.getvalue()
+    if code:
+        raise ConsoleCommandError(text.strip() or f"Command exited with status {code}")
+    return text.rstrip()
+
+
+def _split_line(line: str) -> list[str]:
+    try:
+        return shlex.split(line, comments=False, posix=True)
+    except ValueError as exc:
+        raise ConsoleCommandError(f"Could not parse command: {exc}") from exc
+
+
+def _contains_shell_syntax(line: str, tokens: Sequence[str]) -> bool:
+    if "$(" in line or "`" in line:
+        return True
+    shell_tokens = {"|", "||", "&", "&&", ";", ">", ">>", "<", "<<", "2>", "2>>"}
+    if any(token in shell_tokens for token in tokens):
+        return True
+    return any(ch in line for ch in "|<>;")
+
+
+def _format_sessions(sessions: Sequence[dict]) -> str:
+    if not sessions:
+        return "No sessions found."
+    lines = [f"{'ID':<32} {'Source':<12} {'Msgs':>5}  Title / Preview"]
+    lines.append("-" * 82)
+    for session in sessions:
+        sid = str(session.get("id") or "")[:32]
+        source = str(session.get("source") or "-")[:12]
+        messages = session.get("message_count") or 0
+        title = session.get("title") or session.get("preview") or ""
+        title = str(title).replace("\n", " ")[:60]
+        lines.append(f"{sid:<32} {source:<12} {messages:>5}  {title}")
+    return "\n".join(lines)
+
+
+def _format_job(job: dict, action: str) -> str:
+    job_id = job.get("id") or job.get("job_id") or "?"
+    name = job.get("name") or "(unnamed)"
+    state = job.get("state") or ("scheduled" if job.get("enabled", True) else "paused")
+    return f"{action} job: {name} ({job_id}) [{state}]"
+
+
+EXPECTED_HOSTED_PATHS: tuple[tuple[str, ...], ...] = (
+    ("status",),
+    ("doctor",),
+    ("logs",),
+    ("version",),
+    ("prompt-size",),
+    ("insights",),
+    ("security", "audit"),
+    ("portal", "info"),
+    ("portal", "tools"),
+    ("send",),
+    ("config", "show"),
+    ("config", "path"),
+    ("config", "env-path"),
+    ("config", "check"),
+    ("config", "migrate"),
+    ("config", "set"),
+    ("sessions", "list"),
+    ("sessions", "stats"),
+    ("sessions", "export"),
+    ("sessions", "rename"),
+    ("sessions", "optimize"),
+    ("sessions", "repair"),
+    ("cron", "list"),
+    ("cron", "status"),
+    ("cron", "create"),
+    ("cron", "edit"),
+    ("cron", "pause"),
+    ("cron", "resume"),
+    ("cron", "run"),
+    ("cron", "remove"),
+    ("cron", "tick"),
+    ("profile",),
+    ("profile", "list"),
+    ("profile", "show"),
+    ("profile", "info"),
+    ("tools", "list"),
+    ("tools", "enable"),
+    ("tools", "disable"),
+    ("tools", "post-setup"),
+    ("skills", "browse"),
+    ("skills", "search"),
+    ("skills", "inspect"),
+    ("skills", "list"),
+    ("skills", "check"),
+    ("skills", "list-modified"),
+    ("skills", "diff"),
+    ("skills", "install"),
+    ("skills", "update"),
+    ("skills", "audit"),
+    ("skills", "uninstall"),
+    ("skills", "reset"),
+    ("skills", "opt-in"),
+    ("skills", "opt-out"),
+    ("skills", "repair-official"),
+    ("skills", "snapshot", "export"),
+    ("skills", "tap", "list"),
+    ("mcp", "list"),
+    ("mcp", "catalog"),
+    ("mcp", "test"),
+    ("mcp", "add"),
+    ("mcp", "remove"),
+    ("mcp", "install"),
+    ("mcp", "login"),
+    ("mcp", "reauth"),
+    ("mcp", "configure"),
+    ("mcp", "picker"),
+    ("memory", "status"),
+    ("auth", "list"),
+    ("auth", "status"),
+    ("auth", "reset"),
+    ("auth", "spotify", "status"),
+    ("pairing", "list"),
+    ("pairing", "approve"),
+    ("pairing", "revoke"),
+    ("pairing", "clear-pending"),
+    ("webhook", "list"),
+    ("webhook", "subscribe"),
+    ("webhook", "remove"),
+    ("webhook", "test"),
+)
+
+
+def _parser_root() -> tuple[_ArgumentParser, argparse._SubParsersAction]:
+    parser = _ArgumentParser(prog="hermes", add_help=False)
+    subparsers = parser.add_subparsers(dest="_console_command")
+    return parser, subparsers
+
+
+def _invoke_namespace(args: argparse.Namespace) -> object:
+    func = getattr(args, "func", None)
+    if not callable(func):
+        raise ConsoleCommandError("No handler is available for that console command.")
+    return func(args)
+
+
+def _set_attrs(args: argparse.Namespace, **attrs: object) -> argparse.Namespace:
+    for name, value in attrs.items():
+        setattr(args, name, value)
+    return args
+
+
+def _dispatch_extracted_subcommand(
+    *,
+    root: str,
+    fixed: Sequence[str],
+    args: Sequence[str],
+    module_name: str,
+    builder_name: str,
+    main_handler_name: str,
+    console_context: ConsoleContext,
+    namespace_update: Callable[[argparse.Namespace, ConsoleContext], None] | None = None,
+) -> str:
+    parser, subparsers = _parser_root()
+    module = importlib.import_module(module_name)
+    main_module = importlib.import_module("hermes_cli.main")
+    builder = getattr(module, builder_name)
+    main_handler = getattr(main_module, main_handler_name)
+    builder(subparsers, **{main_handler_name: main_handler})
+    namespace = parser.parse_args([root, *fixed, *args])
+    if namespace_update:
+        namespace_update(namespace, console_context)
+    return _capture_output(lambda: _invoke_namespace(namespace))
+
+
+def _dispatch_registered_subcommand(
+    *,
+    root: str,
+    fixed: Sequence[str],
+    args: Sequence[str],
+    module_name: str,
+    register_name: str,
+    handler_name: str | None = None,
+    console_context: ConsoleContext,
+    namespace_update: Callable[[argparse.Namespace, ConsoleContext], None] | None = None,
+) -> str:
+    parser, subparsers = _parser_root()
+    module = importlib.import_module(module_name)
+    top_parser = subparsers.add_parser(root)
+    register = getattr(module, register_name)
+    register(top_parser)
+    if handler_name:
+        top_parser.set_defaults(func=getattr(module, handler_name))
+    namespace = parser.parse_args([root, *fixed, *args])
+    if namespace_update:
+        namespace_update(namespace, console_context)
+    return _capture_output(lambda: _invoke_namespace(namespace))
+
+
+def _dispatch_builder_subcommand(
+    *,
+    root: str,
+    fixed: Sequence[str],
+    args: Sequence[str],
+    module_name: str,
+    builder_name: str,
+    main_handler_name: str,
+    console_context: ConsoleContext,
+    namespace_update: Callable[[argparse.Namespace, ConsoleContext], None] | None = None,
+) -> str:
+    parser, subparsers = _parser_root()
+    module = importlib.import_module(module_name)
+    main_module = importlib.import_module("hermes_cli.main")
+    top_parser = getattr(module, builder_name)(subparsers)
+    top_parser.set_defaults(func=getattr(main_module, main_handler_name))
+    namespace = parser.parse_args([root, *fixed, *args])
+    if namespace_update:
+        namespace_update(namespace, console_context)
+    return _capture_output(lambda: _invoke_namespace(namespace))
+
+
+def _dispatch_adder_subcommand(
+    *,
+    root: str,
+    fixed: Sequence[str],
+    args: Sequence[str],
+    module_name: str,
+    add_name: str,
+    console_context: ConsoleContext,
+    namespace_update: Callable[[argparse.Namespace, ConsoleContext], None] | None = None,
+) -> str:
+    parser, subparsers = _parser_root()
+    module = importlib.import_module(module_name)
+    getattr(module, add_name)(subparsers)
+    namespace = parser.parse_args([root, *fixed, *args])
+    if namespace_update:
+        namespace_update(namespace, console_context)
+    return _capture_output(lambda: _invoke_namespace(namespace))
+
+
+def _extracted_handler(
+    root: str,
+    fixed: Sequence[str],
+    module_name: str,
+    builder_name: str,
+    main_handler_name: str,
+    namespace_update: Callable[[argparse.Namespace, ConsoleContext], None] | None = None,
+) -> Callable[["HermesConsoleEngine", list[str]], str]:
+    def handler(_engine: HermesConsoleEngine, args: list[str]) -> str:
+        return _dispatch_extracted_subcommand(
+            root=root,
+            fixed=fixed,
+            args=args,
+            module_name=module_name,
+            builder_name=builder_name,
+            main_handler_name=main_handler_name,
+            console_context=_engine.context,
+            namespace_update=namespace_update,
+        )
+
+    return handler
+
+
+def _registered_handler(
+    root: str,
+    fixed: Sequence[str],
+    module_name: str,
+    register_name: str,
+    handler_name: str | None = None,
+    namespace_update: Callable[[argparse.Namespace, ConsoleContext], None] | None = None,
+) -> Callable[["HermesConsoleEngine", list[str]], str]:
+    def handler(_engine: HermesConsoleEngine, args: list[str]) -> str:
+        return _dispatch_registered_subcommand(
+            root=root,
+            fixed=fixed,
+            args=args,
+            module_name=module_name,
+            register_name=register_name,
+            handler_name=handler_name,
+            console_context=_engine.context,
+            namespace_update=namespace_update,
+        )
+
+    return handler
+
+
+def _builder_handler(
+    root: str,
+    fixed: Sequence[str],
+    module_name: str,
+    builder_name: str,
+    main_handler_name: str,
+    namespace_update: Callable[[argparse.Namespace, ConsoleContext], None] | None = None,
+) -> Callable[["HermesConsoleEngine", list[str]], str]:
+    def handler(_engine: HermesConsoleEngine, args: list[str]) -> str:
+        return _dispatch_builder_subcommand(
+            root=root,
+            fixed=fixed,
+            args=args,
+            module_name=module_name,
+            builder_name=builder_name,
+            main_handler_name=main_handler_name,
+            console_context=_engine.context,
+            namespace_update=namespace_update,
+        )
+
+    return handler
+
+
+def _adder_handler(
+    root: str,
+    fixed: Sequence[str],
+    module_name: str,
+    add_name: str,
+    namespace_update: Callable[[argparse.Namespace, ConsoleContext], None] | None = None,
+) -> Callable[["HermesConsoleEngine", list[str]], str]:
+    def handler(_engine: HermesConsoleEngine, args: list[str]) -> str:
+        return _dispatch_adder_subcommand(
+            root=root,
+            fixed=fixed,
+            args=args,
+            module_name=module_name,
+            add_name=add_name,
+            console_context=_engine.context,
+            namespace_update=namespace_update,
+        )
+
+    return handler
+
+
+def _register_command_family(
+    engine: "HermesConsoleEngine",
+    *,
+    root: str,
+    paths: Iterable[Sequence[str]],
+    handler_factory: Callable[[Sequence[str]], Callable[["HermesConsoleEngine", list[str]], str]],
+    mutating: Iterable[Sequence[str]] = (),
+    hosted: Iterable[Sequence[str]] = (),
+    summary: str = "",
+    confirmation: str = "",
+) -> None:
+    mutating_paths = {tuple(path) for path in mutating}
+    hosted_paths = {tuple(path) for path in hosted}
+    for child_path in paths:
+        child_key = tuple(child_path)
+        full_path = (root, *tuple(child_path))
+        usage = " ".join(full_path)
+        engine.register(
+            full_path,
+            usage,
+            summary or f"Run `hermes {usage}`.",
+            handler_factory(tuple(child_path)),
+            mutating=child_key in mutating_paths,
+            confirmation=confirmation or f"Run `hermes {usage}`?",
+            contexts=ALL_CONTEXTS if child_key in hosted_paths else LOCAL_CONTEXTS,
+        )
+
+
+class HermesConsoleEngine:
+    """Curated line-command executor for Hermes Console."""
+
+    def __init__(self, *, output_limit: int = 20000, context: ConsoleContext = "local"):
+        if context not in ALL_CONTEXTS:
+            raise ValueError(f"Unknown console context: {context}")
+        self.context = context
+        self.output_limit = output_limit
+        self.history: list[str] = []
+        self.commands: dict[tuple[str, ...], ConsoleCommand] = {}
+        self._register_defaults()
+
+    def execute(self, line: str, *, confirmed: bool = False) -> ConsoleResult:
+        raw_line = line.strip()
+        if not raw_line:
+            return ConsoleResult("ok")
+
+        try:
+            tokens = _split_line(raw_line)
+            if tokens and tokens[0] == "hermes":
+                tokens = tokens[1:]
+            if not tokens:
+                return self._help_result()
+
+            if _contains_shell_syntax(raw_line, tokens):
+                raise ConsoleCommandError(
+                    "Hermes Console does not run shell syntax. Use one supported "
+                    "Hermes command at a time."
+                )
+
+            builtin = self._execute_builtin(tokens)
+            if builtin is not None:
+                if raw_line not in {"history", "clear"}:
+                    self.history.append(raw_line)
+                return builtin
+
+            command, args = self._resolve_command(tokens)
+            if command.mutating and not confirmed:
+                return ConsoleResult(
+                    "confirm_required",
+                    command=raw_line,
+                    confirmation_message=command.confirmation
+                    or f"Run `{command.usage}`?",
+                )
+
+            output = command.handler(self, args).rstrip()
+            output = self._cap_output(output)
+            self.history.append(raw_line)
+            return ConsoleResult("ok", output=output, command=raw_line)
+        except ConsoleCommandError as exc:
+            return ConsoleResult("error", output=str(exc).strip(), command=raw_line)
+
+    def help_text(self, subject: str | None = None) -> str:
+        if subject:
+            tokens = subject.split()
+            command, _args = self._resolve_command(tokens)
+            return f"{command.usage}\n{command.summary}"
+
+        lines = [
+            "Hermes Console",
+            "",
+            "Supported commands:",
+        ]
+        for command in sorted(self.commands.values(), key=lambda c: c.usage):
+            if self.context not in command.contexts:
+                continue
+            marker = " *" if command.mutating else "  "
+            lines.append(f"{marker} {command.usage:<32} {command.summary}")
+        lines.extend(
+            [
+                "",
+                "* requires confirmation",
+                "Built-ins: help, help <command>, history, clear, exit, quit",
+            ]
+        )
+        return "\n".join(lines)
+
+    def _register_defaults(self) -> None:
+        self.register(("status",), "status", "Show Hermes component status.", _status, contexts=ALL_CONTEXTS)
+        self.register(("doctor",), "doctor", "Run diagnostics without auto-fix.", _doctor, contexts=ALL_CONTEXTS)
+        self.register(("logs",), "logs [name] [-n N]", "Show recent Hermes logs.", _logs, contexts=ALL_CONTEXTS)
+        self.register(("sessions", "list"), "sessions list [--limit N]", "List recent sessions.", _sessions_list, contexts=ALL_CONTEXTS)
+        self.register(("sessions", "stats"), "sessions stats", "Show session store statistics.", _sessions_stats, contexts=ALL_CONTEXTS)
+        self.register(("config", "show"), "config show", "Show current configuration.", _config_show, contexts=ALL_CONTEXTS)
+        self.register(("config", "path"), "config path", "Print config.yaml path.", _config_path, contexts=ALL_CONTEXTS)
+        self.register(
+            ("config", "set"),
+            "config set <key> <value>",
+            "Set a configuration value.",
+            _config_set,
+            mutating=True,
+            confirmation="Update Hermes configuration?",
+            contexts=ALL_CONTEXTS,
+        )
+        self.register(("cron", "list"), "cron list [--all]", "List scheduled jobs.", _cron_list, contexts=ALL_CONTEXTS)
+        self.register(("cron", "status"), "cron status", "Show cron scheduler status.", _cron_status, contexts=ALL_CONTEXTS)
+        self.register(
+            ("cron", "pause"),
+            "cron pause <job>",
+            "Pause a scheduled job.",
+            _cron_pause,
+            mutating=True,
+            confirmation="Pause this cron job?",
+            contexts=ALL_CONTEXTS,
+        )
+        self.register(
+            ("cron", "resume"),
+            "cron resume <job>",
+            "Resume a paused cron job.",
+            _cron_resume,
+            mutating=True,
+            confirmation="Resume this cron job?",
+            contexts=ALL_CONTEXTS,
+        )
+        self.register(
+            ("cron", "run"),
+            "cron run <job>",
+            "Run a job on the next scheduler tick.",
+            _cron_run,
+            mutating=True,
+            confirmation="Trigger this cron job?",
+            contexts=ALL_CONTEXTS,
+        )
+        self._register_broad_cli_surface()
+
+    def _register_broad_cli_surface(self) -> None:
+        """Register non-admin CLI commands that are safe for Hermes Console."""
+
+        extracted = {
+            "version": (
+                "hermes_cli.subcommands.version",
+                "build_version_parser",
+                "cmd_version",
+                [()],
+                set(),
+            ),
+            "dump": (
+                "hermes_cli.subcommands.dump",
+                "build_dump_parser",
+                "cmd_dump",
+                [()],
+                set(),
+            ),
+            "debug": (
+                "hermes_cli.subcommands.debug",
+                "build_debug_parser",
+                "cmd_debug",
+                [("share",), ("delete",)],
+                {("share",), ("delete",)},
+            ),
+            "prompt-size": (
+                "hermes_cli.subcommands.prompt_size",
+                "build_prompt_size_parser",
+                "cmd_prompt_size",
+                [()],
+                set(),
+            ),
+            "insights": (
+                "hermes_cli.subcommands.insights",
+                "build_insights_parser",
+                "cmd_insights",
+                [()],
+                set(),
+            ),
+            "security": (
+                "hermes_cli.subcommands.security",
+                "build_security_parser",
+                "cmd_security",
+                [("audit",)],
+                set(),
+            ),
+            "backup": (
+                "hermes_cli.subcommands.backup",
+                "build_backup_parser",
+                "cmd_backup",
+                [()],
+                {()},
+            ),
+            "import": (
+                "hermes_cli.subcommands.import_cmd",
+                "build_import_cmd_parser",
+                "cmd_import",
+                [()],
+                {()},
+            ),
+            "config": (
+                "hermes_cli.subcommands.config",
+                "build_config_parser",
+                "cmd_config",
+                [("env-path",), ("check",)],
+                set(),
+            ),
+            "tools": (
+                "hermes_cli.subcommands.tools",
+                "build_tools_parser",
+                "cmd_tools",
+                [("list",), ("enable",), ("disable",), ("post-setup",)],
+                {("enable",), ("disable",), ("post-setup",)},
+            ),
+            "plugins": (
+                "hermes_cli.subcommands.plugins",
+                "build_plugins_parser",
+                "cmd_plugins",
+                [("list",), ("enable",), ("disable",), ("install",), ("update",), ("remove",)],
+                {("enable",), ("disable",), ("install",), ("update",), ("remove",)},
+            ),
+            "skills": (
+                "hermes_cli.subcommands.skills",
+                "build_skills_parser",
+                "cmd_skills",
+                [
+                    ("browse",),
+                    ("search",),
+                    ("inspect",),
+                    ("list",),
+                    ("check",),
+                    ("list-modified",),
+                    ("diff",),
+                    ("install",),
+                    ("update",),
+                    ("audit",),
+                    ("uninstall",),
+                    ("reset",),
+                    ("opt-in",),
+                    ("opt-out",),
+                    ("repair-official",),
+                    ("snapshot", "export"),
+                    ("snapshot", "import"),
+                    ("tap", "list"),
+                    ("tap", "add"),
+                    ("tap", "remove"),
+                ],
+                {
+                    ("install",),
+                    ("update",),
+                    ("audit",),
+                    ("uninstall",),
+                    ("reset",),
+                    ("opt-in",),
+                    ("opt-out",),
+                    ("repair-official",),
+                    ("snapshot", "export"),
+                    ("snapshot", "import"),
+                    ("tap", "add"),
+                    ("tap", "remove"),
+                },
+            ),
+            "mcp": (
+                "hermes_cli.subcommands.mcp",
+                "build_mcp_parser",
+                "cmd_mcp",
+                [
+                    ("list",),
+                    ("catalog",),
+                    ("test",),
+                    ("add",),
+                    ("remove",),
+                    ("install",),
+                    ("login",),
+                    ("reauth",),
+                    ("configure",),
+                    ("picker",),
+                ],
+                {
+                    ("add",),
+                    ("remove",),
+                    ("install",),
+                    ("login",),
+                    ("reauth",),
+                    ("configure",),
+                    ("picker",),
+                },
+            ),
+            "memory": (
+                "hermes_cli.subcommands.memory",
+                "build_memory_parser",
+                "cmd_memory",
+                [("status",), ("off",), ("reset",)],
+                {("off",), ("reset",)},
+            ),
+            "auth": (
+                "hermes_cli.subcommands.auth",
+                "build_auth_parser",
+                "cmd_auth",
+                [
+                    ("list",),
+                    ("status",),
+                    ("reset",),
+                    ("add",),
+                    ("remove",),
+                    ("logout",),
+                    ("spotify", "status"),
+                    ("spotify", "login"),
+                    ("spotify", "logout"),
+                ],
+                {
+                    ("reset",),
+                    ("add",),
+                    ("remove",),
+                    ("logout",),
+                    ("spotify", "login"),
+                    ("spotify", "logout"),
+                },
+            ),
+            "pairing": (
+                "hermes_cli.subcommands.pairing",
+                "build_pairing_parser",
+                "cmd_pairing",
+                [("list",), ("approve",), ("revoke",), ("clear-pending",)],
+                {("approve",), ("revoke",), ("clear-pending",)},
+            ),
+            "webhook": (
+                "hermes_cli.subcommands.webhook",
+                "build_webhook_parser",
+                "cmd_webhook",
+                [("list",), ("subscribe",), ("remove",), ("test",)],
+                {("subscribe",), ("remove",)},
+            ),
+            "hooks": (
+                "hermes_cli.subcommands.hooks",
+                "build_hooks_parser",
+                "cmd_hooks",
+                [("list",), ("test",), ("doctor",), ("revoke",)],
+                {("test",), ("doctor",), ("revoke",)},
+            ),
+            "slack": (
+                "hermes_cli.subcommands.slack",
+                "build_slack_parser",
+                "cmd_slack",
+                [("manifest",)],
+                set(),
+            ),
+            "profile": (
+                "hermes_cli.subcommands.profile",
+                "build_profile_parser",
+                "cmd_profile",
+                [
+                    ("list",),
+                    ("show",),
+                    ("info",),
+                    ("create",),
+                    ("use",),
+                    ("describe",),
+                    ("rename",),
+                    ("delete",),
+                    ("export",),
+                    ("import",),
+                    ("install",),
+                    ("update",),
+                ],
+                {
+                    ("create",),
+                    ("use",),
+                    ("describe",),
+                    ("rename",),
+                    ("delete",),
+                    ("export",),
+                    ("import",),
+                    ("install",),
+                    ("update",),
+                },
+            ),
+            "cron": (
+                "hermes_cli.subcommands.cron",
+                "build_cron_parser",
+                "cmd_cron",
+                [("create",), ("edit",), ("remove",), ("tick",)],
+                {("create",), ("edit",), ("remove",), ("tick",)},
+            ),
+        }
+
+        for root, (module, builder, main_handler, paths, mutating) in extracted.items():
+            _register_command_family(
+                self,
+                root=root,
+                paths=paths,
+                mutating=mutating,
+                handler_factory=lambda fixed, root=root, module=module, builder=builder, main_handler=main_handler: _extracted_handler(
+                    root,
+                    fixed,
+                    module,
+                    builder,
+                    main_handler,
+                    namespace_update=_apply_confirmed_defaults,
+                ),
+            )
+
+        self.register(
+            ("config", "migrate"),
+            "config migrate",
+            "Update config with new options.",
+            _config_migrate,
+            mutating=True,
+            confirmation="Update Hermes configuration with missing defaults?",
+        )
+        self.register(
+            ("sessions", "export"),
+            "sessions export <output> [--source SOURCE] [--session-id ID]",
+            "Export sessions to JSONL.",
+            _sessions_export,
+            mutating=True,
+            confirmation="Export session data?",
+        )
+        self.register(
+            ("sessions", "rename"),
+            "sessions rename <session> <title>",
+            "Rename a session.",
+            _sessions_rename,
+            mutating=True,
+            confirmation="Rename this session?",
+        )
+        self.register(
+            ("sessions", "optimize"),
+            "sessions optimize",
+            "Optimize the session store.",
+            _sessions_optimize,
+            mutating=True,
+            confirmation="Optimize the session database?",
+        )
+        self.register(
+            ("sessions", "repair"),
+            "sessions repair [--check-only] [--no-backup]",
+            "Repair a malformed session database schema.",
+            _sessions_repair,
+            mutating=True,
+            confirmation="Repair the session database?",
+        )
+
+        self.register(
+            ("profile",),
+            "profile",
+            "Show active profile status.",
+            _profile_status,
+        )
+        self.register(
+            ("send",),
+            "send --to <target> <message>",
+            "Send a message to a configured platform.",
+            _adder_handler("send", (), "hermes_cli.send_cmd", "register_send_subparser"),
+            mutating=True,
+            confirmation="Send this message?",
+        )
+
+        portal_paths = [("info",), ("tools",)]
+        _register_command_family(
+            self,
+            root="portal",
+            paths=portal_paths,
+            handler_factory=lambda fixed: _adder_handler(
+                "portal",
+                fixed,
+                "hermes_cli.portal_cli",
+                "add_parser",
+            ),
+        )
+
+        _register_command_family(
+            self,
+            root="project",
+            paths=[
+                ("list",),
+                ("show",),
+                ("create",),
+                ("add-folder",),
+                ("remove-folder",),
+                ("rename",),
+                ("set-primary",),
+                ("use",),
+                ("archive",),
+                ("restore",),
+                ("bind-board",),
+            ],
+            mutating=[
+                ("create",),
+                ("add-folder",),
+                ("remove-folder",),
+                ("rename",),
+                ("set-primary",),
+                ("use",),
+                ("archive",),
+                ("restore",),
+                ("bind-board",),
+            ],
+            handler_factory=lambda fixed: _builder_handler(
+                "project",
+                fixed,
+                "hermes_cli.projects_cmd",
+                "build_parser",
+                "cmd_project",
+            ),
+        )
+
+        _register_command_family(
+            self,
+            root="kanban",
+            paths=[
+                ("init",),
+                ("boards", "list"),
+                ("boards", "create"),
+                ("boards", "rm"),
+                ("boards", "switch"),
+                ("boards", "current"),
+                ("boards", "rename"),
+                ("boards", "set-workdir"),
+                ("create",),
+                ("list",),
+                ("show",),
+                ("assign",),
+                ("reclaim",),
+                ("reassign",),
+                ("diagnose",),
+                ("link",),
+                ("unlink",),
+                ("claim",),
+                ("comment",),
+                ("complete",),
+                ("edit",),
+                ("block",),
+                ("schedule",),
+                ("unblock",),
+                ("promote",),
+                ("archive",),
+                ("stats",),
+                ("runs",),
+                ("heartbeat",),
+                ("assignments",),
+                ("context",),
+            ],
+            mutating=[
+                ("init",),
+                ("boards", "create"),
+                ("boards", "rm"),
+                ("boards", "switch"),
+                ("boards", "rename"),
+                ("boards", "set-workdir"),
+                ("create",),
+                ("assign",),
+                ("reclaim",),
+                ("reassign",),
+                ("link",),
+                ("unlink",),
+                ("claim",),
+                ("comment",),
+                ("complete",),
+                ("edit",),
+                ("block",),
+                ("schedule",),
+                ("unblock",),
+                ("promote",),
+                ("archive",),
+            ],
+            handler_factory=lambda fixed: _builder_handler(
+                "kanban",
+                fixed,
+                "hermes_cli.kanban",
+                "build_parser",
+                "cmd_kanban",
+            ),
+        )
+
+        registered = {
+            "bundles": (
+                "hermes_cli.bundles",
+                "register_cli",
+                "bundles_command",
+                [("list",), ("show",), ("create",), ("delete",), ("reload",)],
+                {("create",), ("delete",), ("reload",)},
+            ),
+            "checkpoints": (
+                "hermes_cli.checkpoints",
+                "register_cli",
+                None,
+                [("status",), ("list",), ("prune",), ("clear",), ("clear-legacy",)],
+                {("prune",), ("clear",), ("clear-legacy",)},
+            ),
+            "curator": (
+                "hermes_cli.curator",
+                "register_cli",
+                None,
+                [
+                    ("status",),
+                    ("run",),
+                    ("pause",),
+                    ("resume",),
+                    ("pin",),
+                    ("unpin",),
+                    ("restore",),
+                    ("list-archived",),
+                    ("archive",),
+                    ("prune",),
+                    ("backup",),
+                    ("rollback",),
+                ],
+                {
+                    ("run",),
+                    ("pause",),
+                    ("resume",),
+                    ("pin",),
+                    ("unpin",),
+                    ("restore",),
+                    ("archive",),
+                    ("prune",),
+                    ("backup",),
+                    ("rollback",),
+                },
+            ),
+            "pets": (
+                "hermes_cli.pets",
+                "register_cli",
+                None,
+                [("list",), ("install",), ("select",), ("show",), ("off",), ("scale",), ("remove",), ("doctor",)],
+                {("install",), ("select",), ("off",), ("scale",), ("remove",)},
+            ),
+        }
+        for root, (module, register, handler_name, paths, mutating) in registered.items():
+            _register_command_family(
+                self,
+                root=root,
+                paths=paths,
+                mutating=mutating,
+                handler_factory=lambda fixed, root=root, module=module, register=register, handler_name=handler_name: _registered_handler(
+                    root,
+                    fixed,
+                    module,
+                    register,
+                    handler_name=handler_name,
+                    namespace_update=_apply_confirmed_defaults,
+                ),
+            )
+
+        self._mark_hosted(EXPECTED_HOSTED_PATHS)
+
+    def register(
+        self,
+        path: Iterable[str],
+        usage: str,
+        summary: str,
+        handler: Callable[["HermesConsoleEngine", list[str]], str],
+        *,
+        mutating: bool = False,
+        confirmation: str = "",
+        contexts: Iterable[ConsoleContext] = LOCAL_CONTEXTS,
+    ) -> None:
+        key = tuple(path)
+        self.commands[key] = ConsoleCommand(
+            path=key,
+            usage=usage,
+            summary=summary,
+            handler=handler,
+            mutating=mutating,
+            confirmation=confirmation,
+            contexts=frozenset(contexts),
+        )
+
+    def _mark_hosted(self, paths: Iterable[Sequence[str]]) -> None:
+        for path in paths:
+            key = tuple(path)
+            command = self.commands.get(key)
+            if command is None:
+                raise RuntimeError(f"Hosted console policy references unknown command: {' '.join(key)}")
+            self.commands[key] = replace(
+                command,
+                contexts=command.contexts | frozenset({"hosted"}),
+            )
+
+    def _execute_builtin(self, tokens: list[str]) -> ConsoleResult | None:
+        head = tokens[0]
+        if head == "help":
+            subject = " ".join(tokens[1:]).strip() or None
+            try:
+                return ConsoleResult("ok", output=self.help_text(subject))
+            except ConsoleCommandError as exc:
+                return ConsoleResult("error", output=str(exc))
+        if head == "history":
+            output = "\n".join(f"{idx + 1}: {cmd}" for idx, cmd in enumerate(self.history))
+            return ConsoleResult("ok", output=output or "No history yet.")
+        if head == "clear":
+            return ConsoleResult("clear", output="\033[2J\033[H")
+        if head in {"exit", "quit"}:
+            return ConsoleResult("exit")
+        return None
+
+    def _resolve_command(self, tokens: Sequence[str]) -> tuple[ConsoleCommand, list[str]]:
+        rejected = self._rejection_for(tokens)
+        if rejected:
+            raise ConsoleCommandError(rejected)
+
+        for size in range(min(len(tokens), 3), 0, -1):
+            key = tuple(tokens[:size])
+            command = self.commands.get(key)
+            if command:
+                if self.context not in command.contexts:
+                    raise ConsoleCommandError(
+                        f"`hermes {command.usage}` is not available in "
+                        f"{self.context} Hermes Console."
+                    )
+                self._enforce_context_policy(command, list(tokens[size:]))
+                return command, list(tokens[size:])
+
+        available = [
+            " ".join(path)
+            for path, command in self.commands.items()
+            if self.context in command.contexts
+        ]
+        probe = " ".join(tokens[:2]) if len(tokens) > 1 else tokens[0]
+        suggestions = difflib.get_close_matches(probe, available, n=3, cutoff=0.45)
+        suffix = f" Did you mean: {', '.join(suggestions)}?" if suggestions else ""
+        raise ConsoleCommandError(f"Unsupported Hermes Console command: {probe}.{suffix}")
+
+    def _enforce_context_policy(self, command: ConsoleCommand, args: list[str]) -> None:
+        if self.context != "hosted":
+            return
+        _enforce_hosted_line_policy(command.path, args)
+
+    def _rejection_for(self, tokens: Sequence[str]) -> str:
+        first = tokens[0]
+        if first.startswith("-"):
+            return f"{first} is not available in Hermes Console."
+        blocked_top = {
+            "acp",
+            "chat",
+            "claw",
+            "completion",
+            "dashboard",
+            "desktop",
+            "fallback",
+            "gateway",
+            "gui",
+            "login",
+            "logout",
+            "model",
+            "moa",
+            "oneshot",
+            "postinstall",
+            "proxy",
+            "serve",
+            "setup",
+            "uninstall",
+            "update",
+            "whatsapp",
+            "whatsapp-cloud",
+        }
+        if first in blocked_top:
+            return f"`hermes {first}` is not available in Hermes Console."
+        blocked_pairs = {
+            ("config", "edit"): "`config edit` opens an editor and is not available in Hermes Console.",
+            ("mcp", "serve"): "`mcp serve` starts a server and is not available in Hermes Console.",
+            ("profile", "alias"): "`profile alias` creates shell wrappers and is not available in Hermes Console.",
+            ("skills", "config"): "`skills config` is interactive and is not available in Hermes Console.",
+            ("skills", "publish"): "`skills publish` is not available in Hermes Console.",
+            ("portal", "login"): "`portal login` is interactive and is not available in Hermes Console.",
+            ("portal", "open"): "`portal open` opens a browser and is not available in Hermes Console.",
+            ("kanban", "tail"): "`kanban tail` streams output and is not available in Hermes Console.",
+            ("kanban", "watch"): "`kanban watch` streams output and is not available in Hermes Console.",
+            ("kanban", "daemon"): "`kanban daemon` starts a service and is not available in Hermes Console.",
+            ("kanban", "dispatcher"): "`kanban dispatcher` starts a worker and is not available in Hermes Console.",
+            ("kanban", "swarm"): "`kanban swarm` starts agent work and is not available in Hermes Console.",
+            ("kanban", "decompose"): "`kanban decompose` starts agent work and is not available in Hermes Console.",
+            ("kanban", "specify"): "`kanban specify` starts agent work and is not available in Hermes Console.",
+            ("kanban", "gc"): "`kanban gc` is not available in Hermes Console.",
+        }
+        if len(tokens) >= 2:
+            pair = (tokens[0], tokens[1])
+            if pair in blocked_pairs:
+                return blocked_pairs[pair]
+        if tuple(tokens[:2]) in {("sessions", "delete"), ("sessions", "prune")}:
+            return "`sessions delete` and `sessions prune` are not available in Hermes Console."
+        return ""
+
+    def _help_result(self) -> ConsoleResult:
+        return ConsoleResult("ok", output=self.help_text())
+
+    def _cap_output(self, output: str) -> str:
+        if len(output) <= self.output_limit:
+            return output
+        omitted = len(output) - self.output_limit
+        return f"{output[:self.output_limit]}\n... output truncated ({omitted} bytes omitted)"
+
+
+def _expect_no_args(args: Sequence[str], usage: str) -> None:
+    if args:
+        raise ConsoleCommandError(f"Usage: {usage}")
+
+
+HOSTED_CONFIG_ALLOWED_PREFIXES = (
+    "display.",
+    "ui.",
+    "tts.",
+    "voice.",
+    "speech.",
+    "sessions.",
+    "cron.",
+)
+HOSTED_CONFIG_ALLOWED_KEYS = {
+    "display.interface",
+}
+HOSTED_CONFIG_BLOCKED_PREFIXES = (
+    "auth.",
+    "dashboard.",
+    "gateway.",
+    "managed.",
+    "model.",
+    "portal.",
+    "provider.",
+    "providers.",
+    "tool_gateway.",
+    "custom_providers.",
+    "mcp_servers.",
+)
+HOSTED_CONFIG_BLOCKED_NAMES = {
+    "portal_url",
+    "portal.url",
+    "portal.base_url",
+    "inference_url",
+    "inference.url",
+    "inference.base_url",
+    "nous.portal_url",
+    "nous.inference_url",
+    "openrouter_api_key",
+    "openai_api_key",
+    "anthropic_api_key",
+}
+
+
+def _flag_present(args: Sequence[str], flag: str) -> bool:
+    return any(arg == flag or arg.startswith(f"{flag}=") for arg in args)
+
+
+def _flag_value(args: Sequence[str], flag: str) -> str | None:
+    for index, arg in enumerate(args):
+        if arg == flag:
+            if index + 1 < len(args):
+                return args[index + 1]
+            return ""
+        prefix = f"{flag}="
+        if arg.startswith(prefix):
+            return arg[len(prefix) :]
+    return None
+
+
+def _hosted_config_key_allowed(key: str) -> bool:
+    normalized = key.strip().lower()
+    if normalized in HOSTED_CONFIG_BLOCKED_NAMES:
+        return False
+    if normalized.startswith(HOSTED_CONFIG_BLOCKED_PREFIXES):
+        return False
+    return normalized in HOSTED_CONFIG_ALLOWED_KEYS or normalized.startswith(
+        HOSTED_CONFIG_ALLOWED_PREFIXES
+    )
+
+
+def _enforce_hosted_line_policy(path: tuple[str, ...], args: Sequence[str]) -> None:
+    if path == ("config", "set"):
+        key = args[0] if args else ""
+        if key and not _hosted_config_key_allowed(key):
+            raise ConsoleCommandError(
+                f"`config set {key}` is not available in hosted Hermes Console. "
+                "Use the dashboard setting for hosted account/provider changes."
+            )
+        return
+
+    if path == ("mcp", "add"):
+        if _flag_present(args, "--command") or _flag_present(args, "--args"):
+            raise ConsoleCommandError(
+                "Hosted Hermes Console does not add stdio MCP servers. "
+                "Use catalog install or an HTTP/SSE URL."
+            )
+        if _flag_present(args, "--preset"):
+            raise ConsoleCommandError(
+                "Hosted Hermes Console does not add MCP presets directly. "
+                "Use `mcp install <catalog-name>`."
+            )
+        url = _flag_value(args, "--url")
+        if not url:
+            raise ConsoleCommandError(
+                "Hosted Hermes Console requires `mcp add` to use --url with "
+                "an HTTP/SSE endpoint."
+            )
+        scheme = urlparse(url).scheme.lower()
+        if scheme not in {"http", "https"}:
+            raise ConsoleCommandError(
+                "Hosted Hermes Console only accepts http:// or https:// MCP URLs."
+            )
+        return
+
+    if path in {("cron", "create"), ("cron", "edit")}:
+        for flag in ("--script", "--no-agent", "--workdir"):
+            if _flag_present(args, flag):
+                raise ConsoleCommandError(
+                    f"`cron {' '.join(path[1:])} {flag}` is not available in "
+                    "hosted Hermes Console."
+                )
+
+
+def _apply_confirmed_defaults(args: argparse.Namespace, context: ConsoleContext) -> None:
+    """Skip nested prompts after the console-level confirmation has happened."""
+
+    for attr in ("yes",):
+        if hasattr(args, attr):
+            setattr(args, attr, True)
+    if getattr(args, "_console_command", None) == "import":
+        setattr(args, "force", True)
+    if getattr(args, "checkpoints_command", None) in {"clear", "clear-legacy"}:
+        setattr(args, "force", True)
+    if getattr(args, "plugins_action", None) == "install":
+        if not getattr(args, "enable", False) and not getattr(args, "no_enable", False):
+            setattr(args, "no_enable", True)
+    if getattr(args, "auth_action", None) == "add":
+        auth_type = getattr(args, "auth_type", None)
+        if auth_type in {"api-key", "api_key"} and not getattr(args, "api_key", None):
+            raise ConsoleCommandError("auth add --type api-key requires --api-key in Hermes Console.")
+    if getattr(args, "import_name", None) is not None:
+        # profile import has no prompt flag; leave it alone.
+        return
+    if getattr(args, "skills_action", None) in {
+        "install",
+        "reset",
+        "opt-out",
+        "repair-official",
+    }:
+        setattr(args, "yes", True)
+    if getattr(args, "memory_command", None) == "reset":
+        setattr(args, "yes", True)
+
+
+def _status(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "status")
+    from types import SimpleNamespace
+
+    from hermes_cli.status import show_status
+
+    return _capture_output(lambda: show_status(SimpleNamespace(all=False, deep=False)))
+
+
+def _doctor(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "doctor")
+    from types import SimpleNamespace
+
+    from hermes_cli.doctor import run_doctor
+
+    return _capture_output(lambda: run_doctor(SimpleNamespace(fix=False, ack=None)))
+
+
+def _logs(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    if "-f" in args or "--follow" in args:
+        raise ConsoleCommandError("`logs -f` is not available in Hermes Console.")
+    parser = _ArgumentParser(prog="logs", add_help=False)
+    parser.add_argument("log_name", nargs="?", default="agent")
+    parser.add_argument("-n", "--lines", type=int, default=50)
+    parser.add_argument("--level")
+    parser.add_argument("--session")
+    parser.add_argument("--since")
+    parser.add_argument("--component")
+    ns = parser.parse_args(args)
+    if ns.lines < 1 or ns.lines > 500:
+        raise ConsoleCommandError("logs --lines must be between 1 and 500")
+
+    from hermes_cli.logs import list_logs, tail_log
+
+    if ns.log_name == "list":
+        return _capture_output(list_logs)
+    return _capture_output(
+        lambda: tail_log(
+            ns.log_name,
+            num_lines=ns.lines,
+            follow=False,
+            level=ns.level,
+            session=ns.session,
+            since=ns.since,
+            component=ns.component,
+        )
+    )
+
+
+def _sessions_list(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    parser = _ArgumentParser(prog="sessions list", add_help=False)
+    parser.add_argument("--limit", type=int, default=20)
+    ns = parser.parse_args(args)
+    if ns.limit < 1 or ns.limit > 200:
+        raise ConsoleCommandError("sessions list --limit must be between 1 and 200")
+
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        sessions = db.list_sessions_rich(
+            exclude_sources=["tool"],
+            limit=ns.limit,
+            order_by_last_active=True,
+        )
+    finally:
+        db.close()
+    return _format_sessions(sessions)
+
+
+def _sessions_stats(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "sessions stats")
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        total = db.session_count()
+        listable = db.session_count(exclude_children=True, exclude_sources=["tool"])
+        messages = db.message_count()
+        lines = [
+            f"Total sessions: {total}",
+            f"Listable sessions: {listable}",
+            f"Total messages: {messages}",
+        ]
+        for source in ["cli", "tui", "telegram", "discord", "slack", "cron"]:
+            count = db.session_count(source=source)
+            if count:
+                lines.append(f"  {source}: {count}")
+        return "\n".join(lines)
+    finally:
+        db.close()
+
+
+def _config_show(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "config show")
+    from hermes_cli.config import show_config
+
+    return _capture_output(show_config)
+
+
+def _config_path(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "config path")
+    from hermes_cli.config import get_config_path
+
+    return str(get_config_path())
+
+
+def _config_set(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    if len(args) < 2:
+        raise ConsoleCommandError("Usage: config set <key> <value>")
+    key = args[0]
+    value = " ".join(args[1:])
+    from hermes_cli.config import set_config_value
+
+    return _capture_output(lambda: set_config_value(key, value))
+
+
+def _config_migrate(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "config migrate")
+
+    def _run() -> None:
+        from hermes_cli.config import migrate_config
+
+        results = migrate_config(interactive=False, quiet=False)
+        if results.get("env_added") or results.get("config_added"):
+            print("Configuration updated.")
+        else:
+            print("Configuration is up to date.")
+        warnings = results.get("warnings") or []
+        for warning in warnings:
+            print(f"Warning: {warning}")
+
+    return _capture_output(_run)
+
+
+def _sessions_export(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    parser = _ArgumentParser(prog="sessions export", add_help=False)
+    parser.add_argument("output")
+    parser.add_argument("--source")
+    parser.add_argument("--session-id")
+    ns = parser.parse_args(args)
+
+    def _run() -> None:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            if ns.session_id:
+                resolved_session_id = db.resolve_session_id(ns.session_id)
+                if not resolved_session_id:
+                    raise ConsoleCommandError(f"Session '{ns.session_id}' not found.")
+                data = db.export_session(resolved_session_id)
+                if not data:
+                    raise ConsoleCommandError(f"Session '{ns.session_id}' not found.")
+                rows = [data]
+            else:
+                rows = db.export_all(source=ns.source)
+
+            lines = [json.dumps(row, ensure_ascii=False) for row in rows]
+            text = "\n".join(lines)
+            if text:
+                text += "\n"
+            if ns.output == "-":
+                sys.stdout.write(text)
+            else:
+                Path(ns.output).expanduser().write_text(text, encoding="utf-8")
+                print(f"Exported {len(rows)} session(s) to {ns.output}")
+        finally:
+            db.close()
+
+    return _capture_output(_run)
+
+
+def _sessions_rename(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    parser = _ArgumentParser(prog="sessions rename", add_help=False)
+    parser.add_argument("session_id")
+    parser.add_argument("title", nargs="+")
+    ns = parser.parse_args(args)
+
+    def _run() -> None:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            resolved_session_id = db.resolve_session_id(ns.session_id)
+            if not resolved_session_id:
+                raise ConsoleCommandError(f"Session '{ns.session_id}' not found.")
+            title = " ".join(ns.title)
+            if not db.set_session_title(resolved_session_id, title):
+                raise ConsoleCommandError(f"Session '{ns.session_id}' not found.")
+            print(f"Session '{resolved_session_id}' renamed to: {title}")
+        finally:
+            db.close()
+
+    return _capture_output(_run)
+
+
+def _sessions_optimize(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "sessions optimize")
+
+    def _run() -> None:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            count = db.vacuum()
+            print(f"Optimized {count} FTS index(es).")
+        finally:
+            db.close()
+
+    return _capture_output(_run)
+
+
+def _sessions_repair(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    parser = _ArgumentParser(prog="sessions repair", add_help=False)
+    parser.add_argument("--check-only", action="store_true")
+    parser.add_argument("--no-backup", action="store_true")
+    ns = parser.parse_args(args)
+
+    def _run() -> None:
+        from hermes_state import DEFAULT_DB_PATH, _db_opens_cleanly, repair_state_db_schema
+
+        db_path = DEFAULT_DB_PATH
+        if not db_path.exists():
+            print(f"No session database at {db_path} (nothing to repair).")
+            return
+        reason = _db_opens_cleanly(db_path)
+        if reason is None:
+            print(f"{db_path} opens cleanly; no repair needed.")
+            return
+        print(f"{db_path} does not open cleanly: {reason}")
+        if ns.check_only:
+            return
+        report = repair_state_db_schema(db_path, backup=not ns.no_backup)
+        if report.get("repaired"):
+            if report.get("backup_path"):
+                print(f"backup: {report['backup_path']}")
+            print(f"strategy: {report.get('strategy')}")
+            print("Repaired session database.")
+            return
+        raise ConsoleCommandError(f"Repair failed: {report.get('error')}")
+
+    return _capture_output(_run)
+
+
+def _profile_status(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "profile")
+    return _dispatch_extracted_subcommand(
+        root="profile",
+        fixed=(),
+        args=(),
+        module_name="hermes_cli.subcommands.profile",
+        builder_name="build_profile_parser",
+        main_handler_name="cmd_profile",
+        console_context=_engine.context,
+    )
+
+
+def _cron_list(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    parser = _ArgumentParser(prog="cron list", add_help=False)
+    parser.add_argument("--all", action="store_true")
+    ns = parser.parse_args(args)
+    from hermes_cli.cron import cron_list
+
+    return _capture_output(lambda: cron_list(show_all=ns.all))
+
+
+def _cron_status(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    _expect_no_args(args, "cron status")
+    from hermes_cli.cron import cron_status
+
+    return _capture_output(cron_status)
+
+
+def _cron_pause(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    if len(args) != 1:
+        raise ConsoleCommandError("Usage: cron pause <job>")
+    from cron.jobs import AmbiguousJobReference, pause_job
+
+    try:
+        job = pause_job(args[0], reason="paused from hermes console")
+    except AmbiguousJobReference as exc:
+        raise ConsoleCommandError(str(exc)) from exc
+    if not job:
+        raise ConsoleCommandError(f"Job not found: {args[0]}")
+    return _format_job(job, "Paused")
+
+
+def _cron_resume(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    if len(args) != 1:
+        raise ConsoleCommandError("Usage: cron resume <job>")
+    from cron.jobs import AmbiguousJobReference, resume_job
+
+    try:
+        job = resume_job(args[0])
+    except AmbiguousJobReference as exc:
+        raise ConsoleCommandError(str(exc)) from exc
+    if not job:
+        raise ConsoleCommandError(f"Job not found: {args[0]}")
+    return _format_job(job, "Resumed")
+
+
+def _cron_run(_engine: HermesConsoleEngine, args: list[str]) -> str:
+    if len(args) != 1:
+        raise ConsoleCommandError("Usage: cron run <job>")
+    from cron.jobs import AmbiguousJobReference, trigger_job
+
+    try:
+        job = trigger_job(args[0])
+    except AmbiguousJobReference as exc:
+        raise ConsoleCommandError(str(exc)) from exc
+    if not job:
+        raise ConsoleCommandError(f"Job not found: {args[0]}")
+    return _format_job(job, "Triggered")
+
+
+def run_console_repl(
+    *,
+    stdin=None,
+    stdout=None,
+    stderr=None,
+    interactive: bool | None = None,
+) -> int:
+    """Run the local ``hermes console`` REPL."""
+
+    stdin = stdin or sys.stdin
+    stdout = stdout or sys.stdout
+    stderr = stderr or sys.stderr
+    if interactive is None:
+        interactive = bool(getattr(stdin, "isatty", lambda: False)())
+
+    engine = HermesConsoleEngine()
+    if interactive:
+        print("Hermes Console. Type `help` for commands, `exit` to quit.", file=stdout)
+
+    while True:
+        if interactive:
+            print("hermes> ", end="", file=stdout, flush=True)
+        line = stdin.readline()
+        if line == "":
+            if interactive:
+                print(file=stdout)
+            return 0
+
+        result = engine.execute(line)
+        if result.status == "confirm_required":
+            if not interactive:
+                print(
+                    f"Confirmation required: {result.confirmation_message}",
+                    file=stderr,
+                )
+                return 1
+            print(f"{result.confirmation_message} [y/N] ", end="", file=stdout, flush=True)
+            answer = stdin.readline()
+            if answer.strip().lower() not in {"y", "yes"}:
+                print("Cancelled.", file=stdout)
+                continue
+            result = engine.execute(result.command, confirmed=True)
+
+        if result.output:
+            stream = stderr if result.status == "error" else stdout
+            print(result.output, file=stream)
+        if result.status == "exit":
+            return 0

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -9,17 +9,18 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import importlib
 import difflib
+import importlib
 import io
 import json
-import re
 import shlex
 import sys
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Callable, Iterable, Literal, NoReturn, Sequence
 from urllib.parse import urlparse
+
+from tools.ansi_strip import strip_ansi as _strip_ansi
 
 
 ConsoleStatus = Literal["ok", "error", "confirm_required", "exit", "clear"]
@@ -71,13 +72,6 @@ def _capture_output(fn: Callable[[], object]) -> str:
     if code:
         raise ConsoleCommandError(text.strip() or f"Command exited with status {code}")
     return text.rstrip()
-
-
-_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
-
-
-def _strip_ansi(text: str) -> str:
-    return _ANSI_RE.sub("", text)
 
 
 def _is_status_footer_rule(line: str) -> bool:

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -608,7 +608,8 @@ async def api_auth_ws_ticket(request: Request):
 
     Browsers cannot set ``Authorization`` on a WebSocket upgrade, so in
     gated mode the SPA POSTs this endpoint to get a ``?ticket=`` value to
-    append to ``/api/pty``, ``/api/ws``, ``/api/pub``, or ``/api/events``.
+    append to ``/api/pty``, ``/api/console``, ``/api/ws``, ``/api/pub``, or
+    ``/api/events``.
 
     The ticket has a 30-second TTL and is single-use. Calling this endpoint
     multiple times in quick succession (e.g. one ticket per WS) is the

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -287,6 +287,7 @@ from hermes_cli.subcommands.debug import build_debug_parser
 from hermes_cli.subcommands.backup import build_backup_parser
 from hermes_cli.subcommands.import_cmd import build_import_cmd_parser
 from hermes_cli.subcommands.config import build_config_parser
+from hermes_cli.subcommands.console import build_console_parser
 from hermes_cli.subcommands.version import build_version_parser
 from hermes_cli.subcommands.update import build_update_parser
 from hermes_cli.subcommands.uninstall import build_uninstall_parser
@@ -12150,6 +12151,13 @@ def cmd_logs(args):
     )
 
 
+def cmd_console(args):
+    """Open the safe Hermes command console."""
+    from hermes_cli.console_engine import run_console_repl
+
+    return run_console_repl()
+
+
 def _build_provider_choices() -> list[str]:
     """Build the --provider choices list from CANONICAL_PROVIDERS + 'auto'."""
     try:
@@ -12179,7 +12187,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
     {
         "acp", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
-        "config", "cron", "curator", "dashboard", "serve", "debug", "doctor",
+        "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
@@ -13001,6 +13009,11 @@ def main():
     # config command  (parser built in hermes_cli/subcommands/config.py)
     # =========================================================================
     build_config_parser(subparsers, cmd_config=cmd_config)
+
+    # =========================================================================
+    # console command  (parser built in hermes_cli/subcommands/console.py)
+    # =========================================================================
+    build_console_parser(subparsers, cmd_console=cmd_console)
 
     # =========================================================================
     # pairing command  (parser built in hermes_cli/subcommands/pairing.py)

--- a/hermes_cli/subcommands/console.py
+++ b/hermes_cli/subcommands/console.py
@@ -1,0 +1,18 @@
+"""``hermes console`` subcommand parser."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_console_parser(subparsers, *, cmd_console: Callable) -> None:
+    """Attach the safe Hermes Console REPL subcommand."""
+    console_parser = subparsers.add_parser(
+        "console",
+        help="Open the safe Hermes command console",
+        description=(
+            "Open a curated Hermes command REPL. This is not a raw shell and "
+            "does not expose the full Hermes CLI."
+        ),
+    )
+    console_parser.set_defaults(func=cmd_console)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12,8 +12,11 @@ Usage:
 from contextlib import asynccontextmanager, contextmanager
 
 import asyncio
+import atexit
 import base64
 import binascii
+import concurrent.futures
+import functools
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hmac
@@ -12640,6 +12643,36 @@ _CONSOLE_PROMPT = "hermes> "
 _CONSOLE_COMMAND_TIMEOUT_SECONDS = 60.0
 _CONSOLE_OUTPUT_LIMIT = 50000
 
+# Console commands run in a worker thread. On a timeout, asyncio.wait_for cancels
+# the *awaitable*, but Python threads aren't preemptible, so a genuinely stuck
+# worker keeps running to completion. To keep that from exhausting the shared
+# default thread pool (asyncio.to_thread), we run console commands on a small
+# dedicated, bounded pool: a leaked worker is capped, and concurrent console
+# execution is bounded to a fixed number of threads regardless of reconnects.
+_CONSOLE_EXECUTOR_MAX_WORKERS = 4
+_console_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_console_executor_lock = threading.Lock()
+
+
+def _get_console_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Lazily create the bounded console worker pool (once per process)."""
+    global _console_executor
+    if _console_executor is None:
+        with _console_executor_lock:
+            if _console_executor is None:
+                _console_executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=_CONSOLE_EXECUTOR_MAX_WORKERS,
+                    thread_name_prefix="hermes-console",
+                )
+                # Ensure the pool is torn down on interpreter exit. Don't wait on
+                # in-flight workers: a stuck 60s console command must not block
+                # shutdown (cancel_futures drops anything not yet started).
+                atexit.register(
+                    lambda: _console_executor
+                    and _console_executor.shutdown(wait=False, cancel_futures=True)
+                )
+    return _console_executor
+
 
 def _dashboard_console_context() -> str:
     """Choose local vs hosted command policy for the dashboard console."""
@@ -12916,13 +12949,17 @@ async def console_ws(ws: WebSocket) -> None:
     async def run_command(line: str, *, confirmed: bool, command_id: int) -> None:
         nonlocal active_task, pending_confirmation, command_generation
         try:
+            loop = asyncio.get_running_loop()
             result = await asyncio.wait_for(
-                asyncio.to_thread(
-                    _execute_console_line,
-                    engine,
-                    line,
-                    confirmed=confirmed,
-                    profile=profile,
+                loop.run_in_executor(
+                    _get_console_executor(),
+                    functools.partial(
+                        _execute_console_line,
+                        engine,
+                        line,
+                        confirmed=confirmed,
+                        profile=profile,
+                    ),
                 ),
                 timeout=_CONSOLE_COMMAND_TIMEOUT_SECONDS,
             )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12628,6 +12628,548 @@ def _ws_close_reason(text: str) -> str:
     return encoded[:120].decode("utf-8", "ignore") + "..."
 
 
+# ---------------------------------------------------------------------------
+# /api/console — safe Hermes Console command WebSocket.
+#
+# Unlike /api/pty, this endpoint never spawns a PTY, shell, or full Hermes CLI
+# subprocess. It runs the curated console engine in-process and exchanges
+# structured JSON frames with the dashboard xterm overlay.
+# ---------------------------------------------------------------------------
+
+_CONSOLE_PROMPT = "hermes> "
+_CONSOLE_COMMAND_TIMEOUT_SECONDS = 60.0
+_CONSOLE_OUTPUT_LIMIT = 50000
+
+
+def _dashboard_console_context() -> str:
+    """Choose local vs hosted command policy for the dashboard console."""
+    return "hosted" if _default_hermes_root_is_opt_data() else "local"
+
+
+def _console_profile_from_ws(ws: WebSocket) -> Optional[str]:
+    profile = (ws.query_params.get("profile") or "").strip()
+    return profile or None
+
+
+def _execute_console_line(
+    engine: Any,
+    line: str,
+    *,
+    confirmed: bool,
+    profile: Optional[str],
+) -> Any:
+    # _profile_scope swaps process-global skill module paths; keep it inside
+    # the worker thread and never hold it across awaits.
+    with _profile_scope(profile):
+        return engine.execute(line, confirmed=confirmed)
+
+
+async def _console_send(
+    ws: WebSocket,
+    send_lock: asyncio.Lock,
+    payload: Dict[str, Any],
+) -> None:
+    async with send_lock:
+        await ws.send_json(payload)
+
+
+async def _console_send_result(
+    ws: WebSocket,
+    send_lock: asyncio.Lock,
+    result: Any,
+    *,
+    command_id: int,
+) -> None:
+    command = result.command or ""
+    status = result.status
+    if status == "ok":
+        if result.output:
+            await _console_send(
+                ws,
+                send_lock,
+                {
+                    "type": "output",
+                    "id": command_id,
+                    "stream": "stdout",
+                    "data": result.output,
+                    "command": command,
+                },
+            )
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "complete",
+                "id": command_id,
+                "status": "ok",
+                "command": command,
+                "prompt": _CONSOLE_PROMPT,
+            },
+        )
+        return
+
+    if status == "error":
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "error",
+                "id": command_id,
+                "message": result.output or "Command failed.",
+                "command": command,
+            },
+        )
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "complete",
+                "id": command_id,
+                "status": "error",
+                "command": command,
+                "prompt": _CONSOLE_PROMPT,
+            },
+        )
+        return
+
+    if status == "confirm_required":
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "confirm_required",
+                "id": command_id,
+                "command": command,
+                "message": result.confirmation_message or f"Run `{command}`?",
+                "prompt": _CONSOLE_PROMPT,
+            },
+        )
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "complete",
+                "id": command_id,
+                "status": "confirm_required",
+                "command": command,
+                "prompt": _CONSOLE_PROMPT,
+            },
+        )
+        return
+
+    if status == "clear":
+        await _console_send(ws, send_lock, {"type": "clear", "id": command_id})
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "complete",
+                "id": command_id,
+                "status": "clear",
+                "command": command,
+                "prompt": _CONSOLE_PROMPT,
+            },
+        )
+        return
+
+    if status == "exit":
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "complete",
+                "id": command_id,
+                "status": "exit",
+                "command": command,
+                "prompt": "",
+            },
+        )
+        return
+
+    await _console_send(
+        ws,
+        send_lock,
+        {
+            "type": "error",
+            "id": command_id,
+            "message": f"Unknown console result status: {status}",
+            "command": command,
+        },
+    )
+
+
+def _console_json_payload(msg: Any) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    raw: str | bytes | None = msg.get("text")
+    if raw is None:
+        raw = msg.get("bytes")
+    if raw is None:
+        return None, None
+    if isinstance(raw, bytes):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return None, "Console frames must be UTF-8 JSON."
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None, "Console frames must be JSON objects."
+    if not isinstance(payload, dict):
+        return None, "Console frames must be JSON objects."
+    return payload, None
+
+
+@app.websocket("/api/console")
+async def console_ws(ws: WebSocket) -> None:
+    peer = ws.client.host if ws.client else "?"
+
+    if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
+        _log.info("console refused: embedded chat disabled peer=%s", peer)
+        await ws.close(code=4404, reason="embedded chat disabled")
+        return
+
+    auth_reason, cred = _ws_auth_reason(ws)
+    mode = _ws_auth_mode()
+    if auth_reason is not None:
+        _log.warning(
+            "console auth rejected reason=%s mode=%s cred=%s peer=%s",
+            auth_reason, mode, cred, peer,
+        )
+        await ws.close(code=4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
+        return
+
+    host_origin_reason = _ws_host_origin_reason(ws)
+    if host_origin_reason is not None:
+        _log.warning("console refused: %s peer=%s", host_origin_reason, peer)
+        await ws.close(code=4403, reason=_ws_close_reason(host_origin_reason))
+        return
+
+    client_reason = _ws_client_reason(ws)
+    if client_reason is not None:
+        _log.warning("console refused: %s", client_reason)
+        await ws.close(code=4408, reason=_ws_close_reason(client_reason))
+        return
+
+    await ws.accept()
+
+    profile = _console_profile_from_ws(ws)
+    context = _dashboard_console_context()
+    send_lock = asyncio.Lock()
+
+    try:
+        from hermes_cli.console_engine import HermesConsoleEngine
+
+        engine = HermesConsoleEngine(
+            output_limit=_CONSOLE_OUTPUT_LIMIT,
+            context=context,  # type: ignore[arg-type]
+        )
+        if profile and profile.lower() != "current":
+            _resolve_profile_dir(profile)
+    except HTTPException as exc:
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "error",
+                "message": str(exc.detail),
+                "prompt": "",
+            },
+        )
+        await ws.close(code=4400, reason=_ws_close_reason(str(exc.detail)))
+        return
+    except Exception as exc:
+        _log.exception("console failed to initialize")
+        await _console_send(
+            ws,
+            send_lock,
+            {
+                "type": "error",
+                "message": f"Console unavailable: {exc}",
+                "prompt": "",
+            },
+        )
+        await ws.close(code=1011)
+        return
+
+    _log.info(
+        "console accepted peer=%s mode=%s cred=%s context=%s profile=%s",
+        peer,
+        mode,
+        cred,
+        context,
+        profile or "current",
+    )
+    await _console_send(
+        ws,
+        send_lock,
+        {
+            "type": "ready",
+            "context": context,
+            "profile": profile or "current",
+            "prompt": _CONSOLE_PROMPT,
+        },
+    )
+
+    active_task: asyncio.Task | None = None
+    pending_confirmation: Optional[str] = None
+    command_generation = 0
+
+    async def run_command(line: str, *, confirmed: bool, command_id: int) -> None:
+        nonlocal active_task, pending_confirmation, command_generation
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    _execute_console_line,
+                    engine,
+                    line,
+                    confirmed=confirmed,
+                    profile=profile,
+                ),
+                timeout=_CONSOLE_COMMAND_TIMEOUT_SECONDS,
+            )
+        except asyncio.CancelledError:
+            raise
+        except asyncio.TimeoutError:
+            if command_id == command_generation:
+                pending_confirmation = None
+                await _console_send(
+                    ws,
+                    send_lock,
+                    {
+                        "type": "error",
+                        "id": command_id,
+                        "message": (
+                            "Command timed out. Hermes Console returned to the prompt."
+                        ),
+                        "command": line,
+                    },
+                )
+                await _console_send(
+                    ws,
+                    send_lock,
+                    {
+                        "type": "complete",
+                        "id": command_id,
+                        "status": "timeout",
+                        "command": line,
+                        "prompt": _CONSOLE_PROMPT,
+                    },
+                )
+        except Exception as exc:
+            if command_id == command_generation:
+                pending_confirmation = None
+                _log.exception("console command failed")
+                await _console_send(
+                    ws,
+                    send_lock,
+                    {
+                        "type": "error",
+                        "id": command_id,
+                        "message": str(exc) or exc.__class__.__name__,
+                        "command": line,
+                    },
+                )
+                await _console_send(
+                    ws,
+                    send_lock,
+                    {
+                        "type": "complete",
+                        "id": command_id,
+                        "status": "error",
+                        "command": line,
+                        "prompt": _CONSOLE_PROMPT,
+                    },
+                )
+        else:
+            if command_id != command_generation:
+                return
+            pending_confirmation = (
+                result.command if result.status == "confirm_required" else None
+            )
+            await _console_send_result(
+                ws,
+                send_lock,
+                result,
+                command_id=command_id,
+            )
+            if result.status == "exit":
+                await ws.close(code=1000)
+        finally:
+            if command_id == command_generation:
+                active_task = None
+
+    async def start_command(line: str, *, confirmed: bool = False) -> None:
+        nonlocal active_task, command_generation
+        command_generation += 1
+        command_id = command_generation
+        active_task = asyncio.create_task(
+            run_command(line, confirmed=confirmed, command_id=command_id)
+        )
+
+    try:
+        while True:
+            try:
+                msg = await ws.receive()
+            except RuntimeError:
+                break
+            msg_type = msg.get("type")
+            if msg_type == "websocket.disconnect":
+                break
+
+            payload, error = _console_json_payload(msg)
+            if error:
+                await _console_send(
+                    ws,
+                    send_lock,
+                    {
+                        "type": "error",
+                        "message": error,
+                        "prompt": _CONSOLE_PROMPT,
+                    },
+                )
+                continue
+            if payload is None:
+                continue
+
+            frame_type = str(payload.get("type") or "").strip().lower()
+            if frame_type == "ping":
+                await _console_send(
+                    ws,
+                    send_lock,
+                    {
+                        "type": "pong",
+                        "prompt": _CONSOLE_PROMPT,
+                    },
+                )
+                continue
+
+            if frame_type == "cancel":
+                if active_task and not active_task.done():
+                    command_generation += 1
+                    active_task.cancel()
+                    active_task = None
+                    pending_confirmation = None
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "complete",
+                            "status": "cancelled",
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                elif pending_confirmation:
+                    pending_confirmation = None
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "complete",
+                            "status": "cancelled",
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                else:
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "complete",
+                            "status": "idle",
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                continue
+
+            if active_task and not active_task.done():
+                await _console_send(
+                    ws,
+                    send_lock,
+                    {
+                        "type": "error",
+                        "message": "A console command is already running.",
+                        "prompt": _CONSOLE_PROMPT,
+                    },
+                )
+                continue
+
+            if frame_type == "confirm":
+                command = str(payload.get("command") or pending_confirmation or "").strip()
+                if not pending_confirmation:
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "error",
+                            "message": "No command is waiting for confirmation.",
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                    continue
+                if command != pending_confirmation:
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "error",
+                            "message": "Confirmation does not match the pending command.",
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                    continue
+                pending_confirmation = None
+                await start_command(command, confirmed=True)
+                continue
+
+            if frame_type in {"input", "command"}:
+                line = str(payload.get("line") or payload.get("command") or "").strip()
+                if not line:
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "complete",
+                            "status": "ok",
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                    continue
+                if pending_confirmation:
+                    await _console_send(
+                        ws,
+                        send_lock,
+                        {
+                            "type": "error",
+                            "message": (
+                                "Confirm or cancel the pending command before "
+                                "running another one."
+                            ),
+                            "prompt": _CONSOLE_PROMPT,
+                        },
+                    )
+                    continue
+                await start_command(line)
+                continue
+
+            await _console_send(
+                ws,
+                send_lock,
+                {
+                    "type": "error",
+                    "message": f"Unsupported console frame: {frame_type or '?'}",
+                    "prompt": _CONSOLE_PROMPT,
+                },
+            )
+    except WebSocketDisconnect:
+        pass
+    finally:
+        if active_task and not active_task.done():
+            active_task.cancel()
+            try:
+                await active_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+
 @app.websocket("/api/pty")
 async def pty_ws(ws: WebSocket) -> None:
     peer = ws.client.host if ws.client else "?"

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -243,6 +243,63 @@ def test_console_parses_bare_and_hermes_prefixed_commands(_isolate_hermes_home):
     assert bare.output.endswith("config.yaml")
 
 
+def test_console_status_hides_cli_next_step_footer(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_hermes_home,
+):
+    import hermes_cli.status as status_mod
+
+    def fake_show_status(_args):
+        print("◆ Sessions")
+        print("Active: 3 session(s)")
+        print()
+        rule = "\u2500" * 60
+        print(f"\x1b[2m{rule}\x1b[0m")
+        print("\x1b[2m  Run 'hermes doctor' for detailed diagnostics\x1b[0m")
+        print("\x1b[2m  Run 'hermes setup' to configure\x1b[0m")
+        print()
+
+    monkeypatch.setattr(status_mod, "show_status", fake_show_status)
+
+    result = HermesConsoleEngine().execute("status")
+
+    assert result.status == "ok"
+    assert "Sessions" in result.output
+    assert "Active: 3 session(s)" in result.output
+    assert "hermes doctor" not in result.output
+    assert "hermes setup" not in result.output
+    assert "\u2500" not in result.output
+
+
+def test_console_help_uses_cli_subcommand_summaries():
+    help_text = HermesConsoleEngine().help_text()
+
+    assert "skills list" in help_text
+    assert "List installed skills" in help_text
+    assert "Show all tools and their enabled/disabled status" in help_text
+    assert "Remove an MCP server" in help_text
+    assert "Check pet setup + terminal graphics support" in help_text
+    assert "Run `hermes skills list`" not in help_text
+    assert "Run `hermes tools list`" not in help_text
+
+
+def test_console_help_table_keeps_long_summaries_compact():
+    help_text = HermesConsoleEngine().help_text()
+
+    slack_line = next(
+        line for line in help_text.splitlines() if line.strip().startswith("slack manifest")
+    )
+
+    assert len(slack_line) <= 112
+    assert slack_line.endswith("...")
+
+
+def test_console_help_for_command_uses_cli_summary():
+    help_text = HermesConsoleEngine().help_text("skills list")
+
+    assert help_text == "skills list\nList installed skills"
+
+
 def test_console_registry_covers_non_admin_cli_surface():
     registered = set(HermesConsoleEngine().commands)
 

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.console_engine import HermesConsoleEngine, run_console_repl
+
+
+EXPECTED_CONSOLE_COMMANDS = {
+    ("status",),
+    ("doctor",),
+    ("logs",),
+    ("version",),
+    ("dump",),
+    ("debug", "share"),
+    ("debug", "delete"),
+    ("prompt-size",),
+    ("insights",),
+    ("security", "audit"),
+    ("portal", "info"),
+    ("portal", "tools"),
+    ("backup",),
+    ("import",),
+    ("send",),
+    ("config", "show"),
+    ("config", "path"),
+    ("config", "env-path"),
+    ("config", "check"),
+    ("config", "migrate"),
+    ("config", "set"),
+    ("sessions", "list"),
+    ("sessions", "stats"),
+    ("sessions", "export"),
+    ("sessions", "rename"),
+    ("sessions", "optimize"),
+    ("sessions", "repair"),
+    ("cron", "list"),
+    ("cron", "status"),
+    ("cron", "create"),
+    ("cron", "edit"),
+    ("cron", "pause"),
+    ("cron", "resume"),
+    ("cron", "run"),
+    ("cron", "remove"),
+    ("cron", "tick"),
+    ("profile",),
+    ("profile", "list"),
+    ("profile", "show"),
+    ("profile", "info"),
+    ("profile", "create"),
+    ("profile", "use"),
+    ("profile", "describe"),
+    ("profile", "rename"),
+    ("profile", "delete"),
+    ("profile", "export"),
+    ("profile", "import"),
+    ("profile", "install"),
+    ("profile", "update"),
+    ("tools", "list"),
+    ("tools", "enable"),
+    ("tools", "disable"),
+    ("tools", "post-setup"),
+    ("plugins", "list"),
+    ("plugins", "enable"),
+    ("plugins", "disable"),
+    ("plugins", "install"),
+    ("plugins", "update"),
+    ("plugins", "remove"),
+    ("skills", "browse"),
+    ("skills", "search"),
+    ("skills", "inspect"),
+    ("skills", "list"),
+    ("skills", "check"),
+    ("skills", "list-modified"),
+    ("skills", "diff"),
+    ("skills", "install"),
+    ("skills", "update"),
+    ("skills", "audit"),
+    ("skills", "uninstall"),
+    ("skills", "reset"),
+    ("skills", "opt-in"),
+    ("skills", "opt-out"),
+    ("skills", "repair-official"),
+    ("skills", "snapshot", "export"),
+    ("skills", "snapshot", "import"),
+    ("skills", "tap", "list"),
+    ("skills", "tap", "add"),
+    ("skills", "tap", "remove"),
+    ("mcp", "list"),
+    ("mcp", "catalog"),
+    ("mcp", "test"),
+    ("mcp", "add"),
+    ("mcp", "remove"),
+    ("mcp", "install"),
+    ("mcp", "login"),
+    ("mcp", "reauth"),
+    ("mcp", "configure"),
+    ("mcp", "picker"),
+    ("memory", "status"),
+    ("memory", "off"),
+    ("memory", "reset"),
+    ("auth", "list"),
+    ("auth", "status"),
+    ("auth", "reset"),
+    ("auth", "add"),
+    ("auth", "remove"),
+    ("auth", "logout"),
+    ("auth", "spotify", "status"),
+    ("auth", "spotify", "login"),
+    ("auth", "spotify", "logout"),
+    ("pairing", "list"),
+    ("pairing", "approve"),
+    ("pairing", "revoke"),
+    ("pairing", "clear-pending"),
+    ("webhook", "list"),
+    ("webhook", "subscribe"),
+    ("webhook", "remove"),
+    ("webhook", "test"),
+    ("hooks", "list"),
+    ("hooks", "test"),
+    ("hooks", "doctor"),
+    ("hooks", "revoke"),
+    ("slack", "manifest"),
+    ("project", "list"),
+    ("project", "show"),
+    ("project", "create"),
+    ("project", "add-folder"),
+    ("project", "remove-folder"),
+    ("project", "rename"),
+    ("project", "set-primary"),
+    ("project", "use"),
+    ("project", "archive"),
+    ("project", "restore"),
+    ("project", "bind-board"),
+    ("kanban", "init"),
+    ("kanban", "boards", "list"),
+    ("kanban", "boards", "create"),
+    ("kanban", "boards", "rm"),
+    ("kanban", "boards", "switch"),
+    ("kanban", "boards", "current"),
+    ("kanban", "boards", "rename"),
+    ("kanban", "boards", "set-workdir"),
+    ("kanban", "create"),
+    ("kanban", "list"),
+    ("kanban", "show"),
+    ("kanban", "assign"),
+    ("kanban", "reclaim"),
+    ("kanban", "reassign"),
+    ("kanban", "diagnose"),
+    ("kanban", "link"),
+    ("kanban", "unlink"),
+    ("kanban", "claim"),
+    ("kanban", "comment"),
+    ("kanban", "complete"),
+    ("kanban", "edit"),
+    ("kanban", "block"),
+    ("kanban", "schedule"),
+    ("kanban", "unblock"),
+    ("kanban", "promote"),
+    ("kanban", "archive"),
+    ("kanban", "stats"),
+    ("kanban", "runs"),
+    ("kanban", "heartbeat"),
+    ("kanban", "assignments"),
+    ("kanban", "context"),
+    ("bundles", "list"),
+    ("bundles", "show"),
+    ("bundles", "create"),
+    ("bundles", "delete"),
+    ("bundles", "reload"),
+    ("checkpoints", "status"),
+    ("checkpoints", "list"),
+    ("checkpoints", "prune"),
+    ("checkpoints", "clear"),
+    ("checkpoints", "clear-legacy"),
+    ("curator", "status"),
+    ("curator", "run"),
+    ("curator", "pause"),
+    ("curator", "resume"),
+    ("curator", "pin"),
+    ("curator", "unpin"),
+    ("curator", "restore"),
+    ("curator", "list-archived"),
+    ("curator", "archive"),
+    ("curator", "prune"),
+    ("curator", "backup"),
+    ("curator", "rollback"),
+    ("pets", "list"),
+    ("pets", "install"),
+    ("pets", "select"),
+    ("pets", "show"),
+    ("pets", "off"),
+    ("pets", "scale"),
+    ("pets", "remove"),
+    ("pets", "doctor"),
+}
+
+
+MUTATING_CONFIRMATION_SMOKE_COMMANDS = [
+    "config set console.test true",
+    "config migrate",
+    "sessions rename abc123 new title",
+    "sessions optimize",
+    "cron create 'every 1h' 'say hello'",
+    "cron remove abc123",
+    "profile create tester --no-alias --no-skills",
+    "profile delete tester",
+    "tools disable web",
+    "plugins install owner/repo --no-enable",
+    "skills install openai/skills/example",
+    "mcp add demo --url https://example.com/sse",
+    "mcp configure github",
+    "mcp picker",
+    "backup --quick -o /tmp/hermes-console-test.zip",
+    "import /tmp/hermes-console-test.zip",
+    "send --to telegram hello",
+    "memory reset --target memory",
+    "auth remove openrouter 1",
+    "pairing approve abc123",
+    "webhook subscribe test --prompt hello",
+    "hooks test pre_tool_call",
+    "project create demo",
+    "kanban create 'demo task'",
+    "bundles create demo --skill skill-a",
+    "checkpoints prune",
+    "curator pause",
+    "pets install cat",
+]
+
+
+def test_console_parses_bare_and_hermes_prefixed_commands(_isolate_hermes_home):
+    engine = HermesConsoleEngine()
+
+    bare = engine.execute("config path")
+    prefixed = engine.execute("hermes config path")
+
+    assert bare.status == "ok"
+    assert prefixed.status == "ok"
+    assert bare.output == prefixed.output
+    assert bare.output.endswith("config.yaml")
+
+
+def test_console_registry_covers_non_admin_cli_surface():
+    registered = set(HermesConsoleEngine().commands)
+
+    missing = EXPECTED_CONSOLE_COMMANDS - registered
+
+    assert missing == set()
+
+
+EXPECTED_HOSTED_CONSOLE_COMMANDS = {
+    ("status",),
+    ("doctor",),
+    ("logs",),
+    ("version",),
+    ("prompt-size",),
+    ("insights",),
+    ("security", "audit"),
+    ("portal", "info"),
+    ("portal", "tools"),
+    ("send",),
+    ("config", "show"),
+    ("config", "path"),
+    ("config", "env-path"),
+    ("config", "check"),
+    ("config", "migrate"),
+    ("config", "set"),
+    ("sessions", "list"),
+    ("sessions", "stats"),
+    ("sessions", "export"),
+    ("sessions", "rename"),
+    ("sessions", "optimize"),
+    ("sessions", "repair"),
+    ("cron", "list"),
+    ("cron", "status"),
+    ("cron", "create"),
+    ("cron", "edit"),
+    ("cron", "pause"),
+    ("cron", "resume"),
+    ("cron", "run"),
+    ("cron", "remove"),
+    ("cron", "tick"),
+    ("profile",),
+    ("profile", "list"),
+    ("profile", "show"),
+    ("profile", "info"),
+    ("tools", "list"),
+    ("tools", "enable"),
+    ("tools", "disable"),
+    ("tools", "post-setup"),
+    ("skills", "browse"),
+    ("skills", "search"),
+    ("skills", "inspect"),
+    ("skills", "list"),
+    ("skills", "check"),
+    ("skills", "list-modified"),
+    ("skills", "diff"),
+    ("skills", "install"),
+    ("skills", "update"),
+    ("skills", "audit"),
+    ("skills", "uninstall"),
+    ("skills", "reset"),
+    ("skills", "opt-in"),
+    ("skills", "opt-out"),
+    ("skills", "repair-official"),
+    ("skills", "snapshot", "export"),
+    ("skills", "tap", "list"),
+    ("mcp", "list"),
+    ("mcp", "catalog"),
+    ("mcp", "test"),
+    ("mcp", "add"),
+    ("mcp", "remove"),
+    ("mcp", "install"),
+    ("mcp", "login"),
+    ("mcp", "reauth"),
+    ("mcp", "configure"),
+    ("mcp", "picker"),
+    ("memory", "status"),
+    ("auth", "list"),
+    ("auth", "status"),
+    ("auth", "reset"),
+    ("auth", "spotify", "status"),
+    ("pairing", "list"),
+    ("pairing", "approve"),
+    ("pairing", "revoke"),
+    ("pairing", "clear-pending"),
+    ("webhook", "list"),
+    ("webhook", "subscribe"),
+    ("webhook", "remove"),
+    ("webhook", "test"),
+}
+
+
+def test_hosted_console_registry_exposes_only_hosted_safe_surface():
+    engine = HermesConsoleEngine(context="hosted")
+    hosted = {
+        path for path, command in engine.commands.items() if "hosted" in command.contexts
+    }
+
+    assert hosted == EXPECTED_HOSTED_CONSOLE_COMMANDS
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "portal login",
+        "auth add nous --type oauth",
+        "auth logout nous",
+        "profile create tester",
+        "profile use default",
+        "plugins list",
+        "plugins install owner/repo",
+        "kanban list",
+        "hooks list",
+        "checkpoints clear",
+        "curator pause",
+        "pets install cat",
+        "backup --quick",
+        "import /tmp/hermes-console-test.zip",
+        "mcp serve",
+        "model",
+        "setup",
+        "dashboard",
+        "gateway restart",
+        "update",
+        "uninstall",
+    ],
+)
+def test_hosted_console_rejects_local_only_or_dangerous_commands(line):
+    result = HermesConsoleEngine(context="hosted").execute(line)
+
+    assert result.status == "error"
+    assert result.output
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "mcp add demo --url https://example.com/sse",
+        "mcp install n8n",
+        "mcp configure github",
+        "mcp picker",
+        "config set display.interface cli",
+        "cron create 'every 1h' 'say hello'",
+    ],
+)
+def test_hosted_console_allows_guarded_useful_commands_before_confirmation(line):
+    result = HermesConsoleEngine(context="hosted").execute(line)
+
+    assert result.status == "confirm_required"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "mcp add local --command npx --args foo",
+        "mcp add local --preset unsafe",
+        "mcp add local --url file:///tmp/server",
+        "config set model.provider openrouter",
+        "config set portal.url https://evil.example",
+        "cron create 'every 1h' 'say hello' --script scripts/ping.py",
+        "cron create 'every 1h' 'say hello' --no-agent",
+        "cron edit abc123 --workdir /tmp/project",
+    ],
+)
+def test_hosted_console_blocks_known_footgun_arguments_before_confirmation(line):
+    result = HermesConsoleEngine(context="hosted").execute(line)
+
+    assert result.status == "error"
+    assert result.output
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "sessions delete abc123",
+        "sessions prune --older-than 1",
+        "chat",
+        "--cli",
+        "--tui",
+        "oneshot hello",
+        "model",
+        "setup",
+        "postinstall",
+        "fallback add",
+        "moa configure",
+        "claw migrate",
+        "gateway restart",
+        "gateway start",
+        "gateway stop",
+        "dashboard",
+        "serve",
+        "proxy start",
+        "mcp serve",
+        "skills config",
+        "skills publish ./skill",
+        "completion bash",
+        "acp",
+        "update",
+        "uninstall",
+        "gui",
+        "desktop",
+        "login",
+        "logout",
+        "--tui",
+        "logs | cat",
+        "config show > out.txt",
+    ],
+)
+def test_console_rejects_destructive_and_shell_like_commands(line):
+    result = HermesConsoleEngine().execute(line)
+
+    assert result.status == "error"
+    assert result.output
+
+
+@pytest.mark.parametrize("line", MUTATING_CONFIRMATION_SMOKE_COMMANDS)
+def test_mutating_console_commands_require_confirmation(line):
+    result = HermesConsoleEngine().execute(line)
+
+    assert result.status == "confirm_required"
+    assert result.confirmation_message
+
+
+def test_help_lists_supported_commands_and_not_full_cli():
+    result = HermesConsoleEngine().execute("help")
+
+    assert result.status == "ok"
+    assert "sessions list" in result.output
+    assert "config set" in result.output
+    assert "dashboard" not in result.output
+    assert "gateway restart" not in result.output
+
+
+def test_config_set_requires_confirmation_then_writes(_isolate_hermes_home):
+    engine = HermesConsoleEngine()
+
+    pending = engine.execute("config set console.test true")
+    assert pending.status == "confirm_required"
+
+    from hermes_cli.config import read_raw_config
+
+    assert read_raw_config() == {}
+
+    result = engine.execute("config set console.test true", confirmed=True)
+
+    assert result.status == "ok"
+    assert "console.test" in result.output
+    assert read_raw_config()["console"]["test"] is True
+
+
+def test_sessions_list_and_stats_use_isolated_session_store(_isolate_hermes_home):
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        db.create_session("chat-session", source="cli", model="test/model")
+        db.create_session("tool-session", source="tool", model="test/model")
+    finally:
+        db.close()
+
+    engine = HermesConsoleEngine()
+    listed = engine.execute("sessions list --limit 10")
+    stats = engine.execute("sessions stats")
+
+    assert listed.status == "ok"
+    assert "chat-session" in listed.output
+    assert "tool-session" not in listed.output
+    assert "Total sessions: 2" in stats.output
+    assert "Listable sessions: 1" in stats.output
+
+
+def test_cron_pause_resume_and_run_require_confirmation(_isolate_hermes_home):
+    from cron.jobs import create_job, get_job
+
+    job = create_job(prompt="say hello", schedule="every 1h", name="alpha")
+    engine = HermesConsoleEngine()
+
+    pending = engine.execute(f"cron pause {job['id']}")
+    assert pending.status == "confirm_required"
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["state"] == "scheduled"
+
+    paused = engine.execute(f"cron pause {job['id']}", confirmed=True)
+    assert paused.status == "ok"
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["state"] == "paused"
+
+    resumed = engine.execute("cron resume alpha", confirmed=True)
+    assert resumed.status == "ok"
+    stored = get_job(job["id"])
+    assert stored is not None
+    assert stored["state"] == "scheduled"
+
+    triggered = engine.execute("cron run alpha", confirmed=True)
+    assert triggered.status == "ok"
+    assert "Triggered job" in triggered.output
+
+
+def test_repl_runs_non_interactive_lines_without_prompts(_isolate_hermes_home):
+    stdin = io.StringIO("help\nexit\n")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    code = run_console_repl(
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        interactive=False,
+    )
+
+    assert code == 0
+    assert "Hermes Console" in stdout.getvalue()
+    assert "hermes>" not in stdout.getvalue()
+    assert stderr.getvalue() == ""
+
+
+def test_repl_refuses_non_interactive_confirmation(_isolate_hermes_home):
+    stdin = io.StringIO("config set console.test true\n")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    code = run_console_repl(
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        interactive=False,
+    )
+
+    assert code == 1
+    assert "Confirmation required" in stderr.getvalue()
+
+
+def test_main_console_subcommand_smoke(_isolate_hermes_home):
+    import subprocess
+
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "console"],
+        cwd=Path(__file__).resolve().parents[2],
+        input="help\nexit\n",
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Hermes Console" in result.stdout

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -271,6 +271,37 @@ def test_console_status_hides_cli_next_step_footer(
     assert "\u2500" not in result.output
 
 
+def test_console_status_hides_osc_linked_cli_next_step_footer(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_hermes_home,
+):
+    import hermes_cli.status as status_mod
+
+    def osc_link(text: str) -> str:
+        return f"\x1b]8;;https://example.test\x1b\\{text}\x1b]8;;\x1b\\"
+
+    def fake_show_status(_args):
+        print("◆ Sessions")
+        print("Active: 3 session(s)")
+        print()
+        print(osc_link("\u2500" * 60))
+        print(osc_link("  Run 'hermes doctor' for detailed diagnostics"))
+        print(osc_link("  Run 'hermes setup' to configure"))
+        print()
+
+    monkeypatch.setattr(status_mod, "show_status", fake_show_status)
+
+    result = HermesConsoleEngine().execute("status")
+
+    assert result.status == "ok"
+    assert "Sessions" in result.output
+    assert "Active: 3 session(s)" in result.output
+    assert "hermes doctor" not in result.output
+    assert "hermes setup" not in result.output
+    assert "https://example.test" not in result.output
+    assert "\u2500" not in result.output
+
+
 def test_console_help_uses_cli_subcommand_summaries():
     help_text = HermesConsoleEngine().help_text()
 

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -1,9 +1,9 @@
 """Tests for the WS-upgrade auth helper (Phase 5 task 5.2).
 
-The dashboard's four WS endpoints (``/api/pty``, ``/api/ws``, ``/api/pub``,
-``/api/events``) share an auth gate: ``_ws_auth_ok``. In loopback mode it
-accepts ``?token=<_SESSION_TOKEN>``; in gated mode it accepts a single-use
-``?ticket=`` minted by ``POST /api/auth/ws-ticket``.
+The dashboard's WS endpoints (``/api/pty``, ``/api/console``, ``/api/ws``,
+``/api/pub``, ``/api/events``) share an auth gate: ``_ws_auth_ok``. In
+loopback mode it accepts ``?token=<_SESSION_TOKEN>``; in gated mode it accepts
+a single-use ``?ticket=`` minted by ``POST /api/auth/ws-ticket``.
 
 These tests exercise the helper at the unit level (no actual WS upgrade)
 plus the ticket-mint endpoint under realistic gated-mode setup. We don't
@@ -315,9 +315,10 @@ class TestWsRequestIsAllowedGated:
     (intended only for unauthenticated loopback dev) must not also reject
     those upgrades: the OAuth gate + single-use ticket is the auth.
 
-    Regression coverage: every WS endpoint (``/api/pty``, ``/api/ws``,
-    ``/api/pub``, ``/api/events``) calls ``_ws_request_is_allowed`` after
-    ``_ws_auth_ok``. If the peer-IP check rejects gated mode, the chat
+    Regression coverage: every WS endpoint (``/api/pty``, ``/api/console``,
+    ``/api/ws``, ``/api/pub``, ``/api/events``) calls
+    ``_ws_request_is_allowed`` after ``_ws_auth_ok``. If the peer-IP check
+    rejects gated mode, the chat
     tab + sidebar tool feed silently fail to connect even after a
     successful OAuth login.
     """

--- a/tests/hermes_cli/test_web_server_console_ws.py
+++ b/tests/hermes_cli/test_web_server_console_ws.py
@@ -1,0 +1,134 @@
+"""Dashboard Hermes Console websocket tests."""
+
+from __future__ import annotations
+
+import time
+from urllib.parse import urlencode
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from hermes_cli import web_server
+
+
+@pytest.fixture
+def console_client(monkeypatch, _isolate_hermes_home):
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    previous_bound_host = getattr(web_server.app.state, "bound_host", None)
+    web_server.app.state.auth_required = False
+    web_server.app.state.bound_host = None
+    monkeypatch.setattr(web_server, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+
+    client = TestClient(web_server.app)
+    try:
+        yield client
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            close()
+        if previous_auth_required is None:
+            if hasattr(web_server.app.state, "auth_required"):
+                delattr(web_server.app.state, "auth_required")
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+        if previous_bound_host is None:
+            if hasattr(web_server.app.state, "bound_host"):
+                delattr(web_server.app.state, "bound_host")
+        else:
+            web_server.app.state.bound_host = previous_bound_host
+
+
+def _url(token: str | None = None, **params: str) -> str:
+    query = {"token": web_server._SESSION_TOKEN, **params}
+    if token is not None:
+        query["token"] = token
+    return f"/api/console?{urlencode(query)}"
+
+
+def _recv_until(conn, frame_type: str, *, status: str | None = None) -> dict:
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        frame = conn.receive_json()
+        if frame.get("type") != frame_type:
+            continue
+        if status is not None and frame.get("status") != status:
+            continue
+        return frame
+    raise AssertionError(f"Timed out waiting for {frame_type} frame")
+
+
+def test_console_ws_rejects_missing_or_bad_token(console_client):
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with console_client.websocket_connect("/api/console"):
+            pass
+    assert exc.value.code == 4401
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with console_client.websocket_connect(_url(token="wrong")):
+            pass
+    assert exc.value.code == 4401
+
+
+def test_console_ws_runs_read_only_command(console_client):
+    with console_client.websocket_connect(_url()) as conn:
+        ready = conn.receive_json()
+        assert ready["type"] == "ready"
+        assert ready["context"] == "local"
+        assert ready["prompt"] == "hermes> "
+
+        conn.send_json({"type": "input", "line": "help"})
+
+        output = _recv_until(conn, "output")
+        assert "Hermes Console" in output["data"]
+        complete = _recv_until(conn, "complete", status="ok")
+        assert complete["prompt"] == "hermes> "
+
+
+def test_console_ws_confirmed_command_executes_after_confirmation(console_client):
+    from hermes_cli.config import load_config
+
+    with console_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "ready"
+        conn.send_json({"type": "input", "line": "config set display.interface cli"})
+
+        confirmation = _recv_until(conn, "confirm_required")
+        assert confirmation["command"] == "config set display.interface cli"
+        assert confirmation["message"]
+
+        conn.send_json({"type": "confirm", "command": confirmation["command"]})
+        _recv_until(conn, "complete", status="ok")
+
+    assert load_config()["display"]["interface"] == "cli"
+
+
+def test_console_ws_uses_hosted_context_for_opt_data_policy(console_client, monkeypatch):
+    monkeypatch.setattr(web_server, "_default_hermes_root_is_opt_data", lambda: True)
+
+    with console_client.websocket_connect(_url()) as conn:
+        ready = conn.receive_json()
+        assert ready["type"] == "ready"
+        assert ready["context"] == "hosted"
+
+        conn.send_json({"type": "input", "line": "profile create nope"})
+
+        error = _recv_until(conn, "error")
+        assert "hosted Hermes Console" in error["message"]
+
+
+def test_console_ws_cancel_returns_to_prompt(console_client, monkeypatch):
+    from hermes_cli.console_engine import ConsoleResult, HermesConsoleEngine
+
+    def slow_execute(self, line: str, *, confirmed: bool = False):
+        time.sleep(0.5)
+        return ConsoleResult("ok", output="late", command=line)
+
+    monkeypatch.setattr(HermesConsoleEngine, "execute", slow_execute)
+
+    with console_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "ready"
+        conn.send_json({"type": "input", "line": "status"})
+        conn.send_json({"type": "cancel"})
+
+        complete = _recv_until(conn, "complete", status="cancelled")
+        assert complete["prompt"] == "hermes> "

--- a/web/src/components/HermesConsoleModal.tsx
+++ b/web/src/components/HermesConsoleModal.tsx
@@ -1,0 +1,538 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { FitAddon } from "@xterm/addon-fit";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import { Terminal as XtermTerminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import { Terminal, X } from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { useModalBehavior } from "@/hooks/useModalBehavior";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { api } from "@/lib/api";
+import { cn, themedBody } from "@/lib/utils";
+import { useTheme } from "@/themes";
+
+type ConsoleFrame =
+  | {
+      type: "ready";
+      context?: string;
+      profile?: string;
+      prompt?: string;
+    }
+  | {
+      type: "output";
+      data?: string;
+      stream?: string;
+    }
+  | {
+      type: "error";
+      message?: string;
+    }
+  | {
+      type: "confirm_required";
+      command?: string;
+      message?: string;
+      prompt?: string;
+    }
+  | {
+      type: "complete";
+      status?: string;
+      prompt?: string;
+    }
+  | {
+      type: "clear";
+    }
+  | {
+      type: "pong";
+    };
+
+type ConnectionState = "connecting" | "ready" | "running" | "closed" | "error";
+
+interface HermesConsoleModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function buildTerminalTheme(background: string, foreground: string) {
+  return {
+    background,
+    foreground,
+    cursor: foreground,
+    cursorAccent: background,
+    selectionBackground: "rgba(255, 255, 255, 0.25)",
+    black: "#000000",
+    red: "#ff5f67",
+    green: "#5fffb0",
+    yellow: "#ffd166",
+    blue: "#7aa2ff",
+    magenta: "#d597ff",
+    cyan: "#58e6ff",
+    white: foreground,
+    brightBlack: "#666666",
+    brightRed: "#ff8b90",
+    brightGreen: "#8dffc8",
+    brightYellow: "#ffe08a",
+    brightBlue: "#9dbaff",
+    brightMagenta: "#e4b7ff",
+    brightCyan: "#8ef0ff",
+    brightWhite: "#ffffff",
+  };
+}
+
+function normalizeTerminalText(text: string): string {
+  return text.replace(/\r?\n/g, "\r\n");
+}
+
+function writeLine(term: XtermTerminal, text = ""): void {
+  term.write(`${normalizeTerminalText(text)}\r\n`);
+}
+
+function writeBlock(term: XtermTerminal, text: string): void {
+  const normalized = normalizeTerminalText(text);
+  term.write(normalized.endsWith("\r\n") ? normalized : `${normalized}\r\n`);
+}
+
+function isPrintable(data: string): boolean {
+  return data >= " " || data === "\t";
+}
+
+export function HermesConsoleModal({ open, onClose }: HermesConsoleModalProps) {
+  const modalRef = useModalBehavior({ open, onClose });
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<XtermTerminal | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const lineRef = useRef("");
+  const promptRef = useRef("hermes> ");
+  const inputPromptRef = useRef("hermes> ");
+  const historyRef = useRef<string[]>([]);
+  const historyIndexRef = useRef<number | null>(null);
+  const activeCommandRef = useRef(false);
+  const pendingCommandRef = useRef<string | null>(null);
+  const hasReadyFrameRef = useRef(false);
+  const [connectionState, setConnectionState] =
+    useState<ConnectionState>("connecting");
+  const [consoleContext, setConsoleContext] = useState("pending");
+  const [consoleProfile, setConsoleProfile] = useState("current");
+  const { profile } = useProfileScope();
+  const { theme } = useTheme();
+
+  const redrawInput = useCallback((line = lineRef.current) => {
+    const term = termRef.current;
+    if (!term) return;
+    lineRef.current = line;
+    term.write(`\r\x1b[2K${inputPromptRef.current}${line}`);
+  }, []);
+
+  const showPrompt = useCallback(() => {
+    const term = termRef.current;
+    if (!term) return;
+    lineRef.current = "";
+    historyIndexRef.current = null;
+    inputPromptRef.current = promptRef.current;
+    term.write(inputPromptRef.current);
+  }, []);
+
+  const sendFrame = useCallback((payload: Record<string, unknown>) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+    ws.send(JSON.stringify(payload));
+    return true;
+  }, []);
+
+  const cancelCommand = useCallback(() => {
+    pendingCommandRef.current = null;
+    activeCommandRef.current = false;
+    sendFrame({ type: "cancel" });
+  }, [sendFrame]);
+
+  const submitLine = useCallback(
+    (rawLine: string) => {
+      const term = termRef.current;
+      if (!term) return;
+      const line = rawLine.trim();
+      term.write("\r\n");
+      lineRef.current = "";
+      historyIndexRef.current = null;
+
+      const pending = pendingCommandRef.current;
+      if (pending) {
+        const answer = line.toLowerCase();
+        if (answer === "y" || answer === "yes") {
+          pendingCommandRef.current = null;
+          activeCommandRef.current = true;
+          setConnectionState("running");
+          sendFrame({ type: "confirm", command: pending });
+          return;
+        }
+        cancelCommand();
+        return;
+      }
+
+      if (!line) {
+        showPrompt();
+        return;
+      }
+
+      historyRef.current = [...historyRef.current, line].slice(-200);
+      activeCommandRef.current = true;
+      setConnectionState("running");
+      if (!sendFrame({ type: "input", line })) {
+        activeCommandRef.current = false;
+        writeLine(term, "\x1b[31mConsole is not connected.\x1b[0m");
+        showPrompt();
+      }
+    },
+    [cancelCommand, sendFrame, showPrompt],
+  );
+
+  const recallHistory = useCallback(
+    (direction: -1 | 1) => {
+      const history = historyRef.current;
+      if (!history.length) return;
+      const current = historyIndexRef.current;
+      if (current === null) {
+        if (direction > 0) return;
+        historyIndexRef.current = history.length - 1;
+      } else {
+        const next = current + direction;
+        if (next < 0) historyIndexRef.current = 0;
+        else if (next >= history.length) {
+          historyIndexRef.current = null;
+          redrawInput("");
+          return;
+        } else {
+          historyIndexRef.current = next;
+        }
+      }
+      const idx = historyIndexRef.current;
+      redrawInput(idx === null ? "" : history[idx] ?? "");
+    },
+    [redrawInput],
+  );
+
+  const handleInputData = useCallback(
+    (data: string) => {
+      const term = termRef.current;
+      if (!term) return;
+
+      if (data === "\x1b[A") {
+        recallHistory(-1);
+        return;
+      }
+      if (data === "\x1b[B") {
+        recallHistory(1);
+        return;
+      }
+
+      for (const ch of data) {
+        if (ch === "\u0003") {
+          term.write("^C\r\n");
+          if (activeCommandRef.current || pendingCommandRef.current) {
+            cancelCommand();
+          } else {
+            showPrompt();
+          }
+          continue;
+        }
+        if (ch === "\u000c") {
+          term.clear();
+          showPrompt();
+          continue;
+        }
+        if (activeCommandRef.current) {
+          term.write("\x07");
+          continue;
+        }
+        if (ch === "\r" || ch === "\n") {
+          submitLine(lineRef.current);
+          continue;
+        }
+        if (ch === "\u007f" || ch === "\b") {
+          if (lineRef.current.length > 0) {
+            lineRef.current = lineRef.current.slice(0, -1);
+            term.write("\b \b");
+          }
+          continue;
+        }
+        if (ch === "\x1b") {
+          continue;
+        }
+        if (isPrintable(ch)) {
+          lineRef.current += ch;
+          term.write(ch);
+        }
+      }
+    },
+    [cancelCommand, recallHistory, showPrompt, submitLine],
+  );
+
+  const handleFrame = useCallback(
+    (frame: ConsoleFrame) => {
+      const term = termRef.current;
+      if (!term) return;
+
+      if (frame.type === "ready") {
+        const nextPrompt = frame.prompt || "hermes> ";
+        promptRef.current = nextPrompt;
+        inputPromptRef.current = nextPrompt;
+        hasReadyFrameRef.current = true;
+        setConsoleContext(frame.context || "local");
+        setConsoleProfile(frame.profile || "current");
+        activeCommandRef.current = false;
+        setConnectionState("ready");
+        term.clear();
+        showPrompt();
+        return;
+      }
+
+      if (frame.type === "output") {
+        if (frame.data) writeBlock(term, frame.data);
+        return;
+      }
+
+      if (frame.type === "error") {
+        writeLine(term, `\x1b[31m${frame.message || "Command failed."}\x1b[0m`);
+        return;
+      }
+
+      if (frame.type === "confirm_required") {
+        pendingCommandRef.current = frame.command || "";
+        activeCommandRef.current = false;
+        setConnectionState("ready");
+        if (frame.message) {
+          writeLine(term, `\x1b[33m${frame.message}\x1b[0m`);
+        }
+        inputPromptRef.current = "Confirm? [y/N] ";
+        lineRef.current = "";
+        term.write(inputPromptRef.current);
+        return;
+      }
+
+      if (frame.type === "complete") {
+        activeCommandRef.current = false;
+        if (frame.prompt) promptRef.current = frame.prompt;
+        if (frame.status === "confirm_required") return;
+        if (frame.status === "exit") {
+          setConnectionState("closed");
+          wsRef.current?.close();
+          return;
+        }
+        if (frame.status === "timeout") {
+          writeLine(term, "\x1b[31mCommand timed out.\x1b[0m");
+        }
+        if (frame.status === "cancelled") {
+          writeLine(term, "\x1b[33mCancelled.\x1b[0m");
+        }
+        pendingCommandRef.current = null;
+        setConnectionState("ready");
+        showPrompt();
+        return;
+      }
+
+      if (frame.type === "clear") {
+        term.clear();
+        showPrompt();
+      }
+    },
+    [showPrompt],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const host = hostRef.current;
+    if (!host) return;
+
+    let cancelled = false;
+    let resizeFrame = 0;
+    const term = new XtermTerminal({
+      allowProposedApi: true,
+      cursorBlink: true,
+      fontFamily:
+        "'JetBrains Mono', 'Cascadia Mono', 'Fira Code', 'MesloLGS NF', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
+      fontSize: 13,
+      lineHeight: 1.25,
+      letterSpacing: 0,
+      macOptionIsMeta: true,
+      scrollback: 3000,
+      theme: buildTerminalTheme(
+        theme.terminalBackground ?? "#000000",
+        theme.terminalForeground ?? "#f0e6d2",
+      ),
+    });
+    termRef.current = term;
+
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    const unicode11 = new Unicode11Addon();
+    term.loadAddon(unicode11);
+    term.unicode.activeVersion = "11";
+    term.loadAddon(new WebLinksAddon());
+    term.open(host);
+    term.focus();
+
+    const fitTerminal = () => {
+      if (!host.isConnected || host.clientWidth <= 0 || host.clientHeight <= 0) {
+        return;
+      }
+      try {
+        fit.fit();
+      } catch {
+        /* fit can fail while the modal is closing */
+      }
+    };
+    const scheduleFit = () => {
+      if (resizeFrame) return;
+      resizeFrame = requestAnimationFrame(() => {
+        resizeFrame = 0;
+        fitTerminal();
+      });
+    };
+    const ro = new ResizeObserver(scheduleFit);
+    ro.observe(host);
+    scheduleFit();
+
+    const dataDisposable = term.onData(handleInputData);
+    setConnectionState("connecting");
+    setConsoleContext("pending");
+    setConsoleProfile(profile || "current");
+    hasReadyFrameRef.current = false;
+    writeLine(term, "\x1b[2mConnecting to Hermes Console...\x1b[0m");
+
+    void (async () => {
+      try {
+        const params = profile ? { profile } : undefined;
+        const url = await api.buildWsUrl("/api/console", params);
+        if (cancelled) return;
+        const ws = new WebSocket(url);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          setConnectionState("connecting");
+        };
+
+        ws.onmessage = (ev) => {
+          try {
+            const frame = JSON.parse(String(ev.data)) as ConsoleFrame;
+            handleFrame(frame);
+          } catch {
+            writeLine(term, "\x1b[31mMalformed console frame.\x1b[0m");
+          }
+        };
+
+        ws.onerror = () => {
+          setConnectionState("error");
+          writeLine(term, "\x1b[31mConsole websocket error.\x1b[0m");
+        };
+
+        ws.onclose = (ev) => {
+          wsRef.current = null;
+          activeCommandRef.current = false;
+          pendingCommandRef.current = null;
+          if (cancelled) return;
+          setConnectionState(ev.code === 1000 ? "closed" : "error");
+          const reason = ev.reason ? ` ${ev.reason}` : "";
+          const message =
+            ev.code === 1006 && !hasReadyFrameRef.current
+              ? "Console connection failed before the server handshake. Check that this dashboard is connected to a backend with /api/console."
+              : `Console closed (${ev.code}).${reason}`;
+          writeLine(term, `\x1b[31m${message}\x1b[0m`);
+        };
+      } catch (err) {
+        if (cancelled) return;
+        setConnectionState("error");
+        writeLine(term, `\x1b[31mConsole unavailable: ${err}\x1b[0m`);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      dataDisposable.dispose();
+      ro.disconnect();
+      if (resizeFrame) cancelAnimationFrame(resizeFrame);
+      wsRef.current?.close();
+      wsRef.current = null;
+      term.dispose();
+      termRef.current = null;
+      lineRef.current = "";
+      pendingCommandRef.current = null;
+      activeCommandRef.current = false;
+      hasReadyFrameRef.current = false;
+    };
+  }, [handleFrame, handleInputData, open, profile, theme]);
+
+  useEffect(() => {
+    if (!open) return;
+    const term = termRef.current;
+    if (!term) return;
+    term.options.theme = buildTerminalTheme(
+      theme.terminalBackground ?? "#000000",
+      theme.terminalForeground ?? "#f0e6d2",
+    );
+  }, [open, theme]);
+
+  if (!open) return null;
+
+  const statusTone =
+    connectionState === "ready"
+      ? "success"
+      : connectionState === "running"
+        ? "warning"
+        : connectionState === "connecting"
+          ? "secondary"
+          : "destructive";
+
+  return createPortal(
+    <div
+      ref={modalRef}
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 p-3 sm:p-4"
+      onClick={(event) => event.target === event.currentTarget && onClose()}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="hermes-console-title"
+    >
+      <div
+        className={cn(
+          themedBody,
+          "relative flex h-[min(82dvh,760px)] w-full max-w-5xl flex-col border border-border bg-card shadow-2xl",
+        )}
+      >
+        <header className="flex min-h-14 items-center gap-3 border-b border-border px-4 py-3">
+          <div className="flex h-9 w-9 items-center justify-center border border-border bg-background/60 text-primary">
+            <Terminal className="h-4 w-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2
+              id="hermes-console-title"
+              className="font-mondwest text-display text-base tracking-wider"
+            >
+              Hermes Console
+            </h2>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <Badge tone={statusTone}>{connectionState}</Badge>
+              <span className="font-mono">{consoleContext}</span>
+              <span className="font-mono">{consoleProfile}</span>
+            </div>
+          </div>
+          <Button
+            ghost
+            size="icon"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Close console"
+          >
+            <X />
+          </Button>
+        </header>
+        <div className="min-h-0 flex-1 bg-black">
+          <div
+            ref={hostRef}
+            className="h-full min-h-0 w-full overflow-hidden p-2 [&_.xterm]:h-full [&_.xterm-viewport]:!bg-transparent"
+          />
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/pages/SystemPage.tsx
+++ b/web/src/pages/SystemPage.tsx
@@ -42,6 +42,7 @@ import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
 import { ConfirmDialog } from "@nous-research/ui/ui/components/confirm-dialog";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
+import { HermesConsoleModal } from "@/components/HermesConsoleModal";
 import { cn, themedBody } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type {
@@ -186,6 +187,7 @@ export default function SystemPage() {
   const [loading, setLoading] = useState(true);
 
   const [activeAction, setActiveAction] = useState<string | null>(null);
+  const [consoleOpen, setConsoleOpen] = useState(false);
 
   // Add-credential form.
   const [credProvider, setCredProvider] = useState("openrouter");
@@ -680,6 +682,10 @@ export default function SystemPage() {
         description="Remove this hook from config and revoke its consent? It stops firing on the next restart."
         loading={hookDelete.isDeleting}
       />
+      <HermesConsoleModal
+        open={consoleOpen}
+        onClose={() => setConsoleOpen(false)}
+      />
 
       {/* Create-hook modal */}
       {hookModalOpen && (
@@ -1162,6 +1168,9 @@ export default function SystemPage() {
         </H2>
         <Card>
           <CardContent className="flex flex-wrap gap-2 py-4">
+            <Button size="sm" ghost prefix={<Terminal className="h-3.5 w-3.5" />} onClick={() => setConsoleOpen(true)}>
+              Open console
+            </Button>
             <Button size="sm" ghost prefix={<Stethoscope className="h-3.5 w-3.5" />} onClick={() => runOp(api.runDoctor, "Doctor")}>
               Run doctor
             </Button>


### PR DESCRIPTION
## Summary

Salvages @shannonsands' Hermes Console REPL (NS-574, #55954) onto current `main` and lands two perf fixes for the non-blocking review notes.

The console gives hosted/managed users a curated, safe subset of `hermes` operations (MCP mgmt, config, etc.) via CLI + dashboard websocket + xterm UI — without raw shell access.

## Changes

- **Contributor work (4 commits, authorship preserved via cherry-pick):** console REPL engine, dashboard console websocket, dashboard console UI, and shared-ANSI-stripping fix (the one blocking review note — @shannonsands already addressed it by switching to `tools.ansi_strip.strip_ansi`).
- **Our follow-up (1 commit):** the two remaining non-blocking review notes:
  - `console_engine`: memoize the 4 process-static `_*_summaries` builders with `functools.lru_cache`. The dashboard opens a fresh engine per `/api/console` connection, so every reconnect was re-importing + re-parsing the whole CLI surface. Callers only read the returned map.
  - `web_server`: run console commands on a dedicated bounded `ThreadPoolExecutor(max_workers=4)` instead of `asyncio.to_thread`. On the 60s command timeout, `wait_for` cancels the awaitable but the non-preemptible worker thread keeps running — the shared default pool would accumulate leaked threads. Bounding caps that. Executor is torn down at exit via `atexit` (`cancel_futures=True`, no wait).

## Validation

| | Result |
|---|---|
| `test_console_engine.py` + `test_web_server_console_ws.py` + `test_dashboard_auth_ws_auth.py` | 165 passed, 0 failed |
| ruff (console_engine, web_server) | clean |
| E2E: 2nd engine construction | 21 cache hits, 0 new imports/parses (per-connection cost eliminated) |
| E2E: console executor | `max_workers=4`, singleton, `atexit` shutdown registered |

## Review notes addressed (from the original #55954 review)

1. ANSI strip → use canonical `strip_ansi` — **done by @shannonsands.**
2. Thread leak on timeout → **fixed** (bounded executor).
3. Per-connection CLI-surface re-import → **fixed** (lru_cache).
4. Dispatcher factoring (~150 LOC) → **deferred** as a follow-up; it's a pure structural refactor of the dispatch core (low value / higher risk on an internal keystone file), not landed here.

Salvage of #55954. Contributor commits cherry-picked with authorship preserved; perf follow-up by @kshitijk4poor.
