### PR TITLE
fix(file-ops): verify write_file content actually landed before reporting success

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -835,6 +835,80 @@ class TestPatchReplacePostWriteVerification:
         assert "could not re-read" in result.error.lower()
 
 
+class TestWriteFilePostWriteVerification:
+    """Tests for the post-write verification in ``write_file`` itself.
+
+    write_file re-reads the file through the same executor that performed
+    the write and compares real content (mirroring patch_replace's existing
+    verification) instead of trusting `mv`'s exit code or fabricating a
+    byte count. Confirms both the "can't confirm at all" and "confirmed,
+    but wrong" failure shapes surface as real errors instead of a fabricated
+    success for a write that never actually landed.
+    """
+
+    def test_write_file_fails_when_post_write_read_errors(self, mock_env):
+        def side_effect(command, stdin_data=None, **kwargs):
+            if stdin_data is not None:  # the atomic write itself
+                return {"output": "", "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("cat "):
+                # Simulate the file being unreadable right after the "successful" mv.
+                return {"output": "", "returncode": 1}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.write_file("/tmp/test/a.py", "hello world\n")
+
+        assert result.error is not None, (
+            "Unconfirmed post-write read must surface as error, got "
+            f"bytes_written={result.bytes_written}"
+        )
+        assert "could not re-read" in result.error.lower()
+
+    def test_write_file_fails_when_on_disk_content_differs(self, mock_env):
+        """`mv` reports success but the re-read comes back with different
+        bytes than what was written — must surface as an error, not a
+        fabricated success (the exact scenario the audit's PoC exploited
+        against the self-reported JSON)."""
+        def side_effect(command, stdin_data=None, **kwargs):
+            if stdin_data is not None:
+                return {"output": "", "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("cat "):
+                # Stale/pre-existing content — the write never actually landed.
+                return {"output": "old stale content\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.write_file("/tmp/test/a.py", "hello world\n")
+
+        assert result.error is not None
+        assert "did not persist" in result.error.lower()
+
+    def test_write_file_succeeds_when_post_write_read_confirms(self, mock_env):
+        content = "hello world\n"
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if stdin_data is not None:
+                return {"output": "", "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("cat "):
+                return {"output": content, "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.write_file("/tmp/test/a.py", content)
+
+        assert result.error is None
+        assert result.bytes_written == len(content.encode())
+
+
 # =========================================================================
 # Git baseline check for write_file warning
 # =========================================================================

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1425,14 +1425,40 @@ class ShellFileOperations(FileOperations):
         if write_result.exit_code != 0:
             return WriteResult(error=f"Failed to write file: {write_result.stdout}")
 
-        # Get bytes written (wc -c is POSIX, works on Linux + macOS)
-        stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
-        stat_result = self._exec(stat_cmd)
-
-        try:
-            bytes_written = int(stat_result.stdout.strip())
-        except ValueError:
-            bytes_written = len(content.encode('utf-8'))
+        # Post-write verification: re-read the file through the same
+        # executor (local/SSH/container — whichever backend actually did
+        # the write) and confirm the exact content landed. `mv` above can
+        # report exit 0 while the target ends up unreadable or different
+        # (race with another task, backend FS oddity, sandbox quirk);
+        # trusting the write's own exit code — or worse, falling back to
+        # len(content) when a lighter stat-only check fails — would
+        # fabricate a success result for a write that never actually
+        # happened. Mirrors the re-read-and-compare check patch_replace
+        # already does, so both mutation paths give real proof of landing
+        # instead of a self-report a caller could mistake for one.
+        verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+        verify_result = self._exec(verify_cmd)
+        if verify_result.exit_code != 0:
+            return WriteResult(
+                error=f"Post-write verification failed: could not re-read {path}"
+            )
+        # Normalize line endings before comparing — see patch_replace's
+        # identical check for why: some backends legitimately translate
+        # bare LF to CRLF between the write and the read-back (e.g. a
+        # Windows local backend's text-mode file handling), which would
+        # otherwise flag every multi-line write as a false-negative
+        # "did not persist" even though it landed correctly.
+        _verify_normalized = verify_result.stdout.replace("\r\n", "\n").replace("\r", "\n")
+        _content_normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+        if _verify_normalized != _content_normalized:
+            return WriteResult(error=(
+                f"Post-write verification failed for {path}: on-disk content "
+                f"differs from intended write (wrote {len(_content_normalized)} "
+                f"chars, read back {len(_verify_normalized)} chars after "
+                "normalizing line endings). The write did not persist. "
+                "Re-read the file and try again."
+            ))
+        bytes_written = len(content.encode('utf-8'))
 
         # Post-write lint with delta refinement.
         lint_result = self._check_lint_delta(path, pre_content=pre_content, post_content=content)


### PR DESCRIPTION
Fixes #57788

## Problem

`ShellFileOperations.write_file` (`tools/file_operations.py`) only confirmed a write by parsing `wc -c` byte-count output, and **silently fell back to `len(content)` when that check failed to parse** — reporting a fabricated success/byte-count for a write that may never have actually landed on disk (the atomic `mv` can exit `0` while the target ends up unreadable or wrong: a race with another task, backend FS oddity, sandbox quirk, or SSH hiccup).

This is the root cause behind an audit finding against `agent/tool_result_classification.py::file_mutation_result_landed`: that function only re-parses the tool's own self-reported JSON (`"bytes_written" in data` / `success is True`) to decide whether a `write_file`/`patch` call actually landed — used by the per-turn "file mutation" verifier footer (`run_agent.py::_record_file_mutation_result`) that tells the user which writes did/didn't really change files. The classification function has no independent filesystem check (and structurally can't reasonably have one there — writes happen through `_exec`, which may be a local shell, SSH session, or container, so the orchestrator process calling `os.stat()` on the reported path would be wrong for non-local backends). The actual gap was that `write_file`'s **own self-report was allowed to be wrong** in the first place.

## Fix

`write_file` now does a real **re-read-and-compare** through the same executor that performed the write (local/SSH/container — whichever backend actually owns the file), mirroring the verification `patch_replace` already does for its own writes:

- Re-reads the file via `cat` through `_exec` (same backend as the write).
- If the re-read fails → real error (`Post-write verification failed: could not re-read {path}`), not a fabricated success.
- If the re-read succeeds but content differs from what was written (after line-ending normalization, same rationale as `patch_replace`'s existing check) → real error (`... did not persist`).
- Only on confirmed match does it compute `bytes_written` and return success.

V4A patch mode (`patch_v4a` → `apply_v4a_operations`) writes files via `self.write_file(...)` internally for add/update operations, so it inherits this real verification for free.

**Known scope limit:** V4A *delete* operations aren't covered (delete success means "file no longer exists," a different check than "content matches" — left out to keep this fix minimal; noted in the issue).

## Testing

Added `TestWriteFilePostWriteVerification` to `tests/tools/test_file_operations.py`:
- [x] Re-read fails post-write → surfaced as real error, not success
- [x] `mv` "succeeds" but re-read returns different/stale content → surfaced as real error (the exact scenario the audit PoC exploited via the self-reported JSON)
- [x] Genuine successful write still reports success with correct `bytes_written`

Ran the full related suite before/after this change (`test_file_operations.py`, `test_file_operations_edge_cases.py`, `test_patch_parser.py`, `test_line_ending_preservation.py`, `test_file_tools.py`, `test_file_write_safety.py`, `test_file_staleness.py`, `test_patch_failure_tracking.py`, `test_tool_result_classification.py`, `test_file_mutation_verifier.py`): identical pre-existing failure set (18, unrelated Windows/macOS path-handling env issues on this dev box), zero regressions, 3 new tests passing.
 