### PR TITLE
fix(codex): use profile Codex home for app-server workers

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -18,11 +18,28 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
+
+
+def _profile_codex_home_override() -> str | None:
+    """Return a profile-local Codex home when the active profile defines one."""
+    hermes_home = (os.environ.get("HERMES_HOME") or "").strip()
+    if not hermes_home:
+        return None
+    try:
+        candidate = Path(hermes_home).expanduser() / "codex-home"
+        if (candidate / "config.toml").is_file():
+            return str(candidate)
+    except Exception:
+        logger.debug(
+            "codex app-server: profile Codex home lookup failed", exc_info=True
+        )
+    return None
 
 
 def _codex_note_to_tool_progress(note: dict) -> tuple[str, str, dict] | None:
@@ -286,6 +303,8 @@ def run_codex_app_server_turn(
                 exc_info=True,
             )
 
+        codex_home = _profile_codex_home_override()
+
         def _on_codex_event(note: dict) -> None:
             # Bridge Codex app-server item/started notifications to Hermes
             # tool-progress so gateways show verbose "running X" breadcrumbs
@@ -304,6 +323,7 @@ def run_codex_app_server_turn(
 
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            codex_home=codex_home,
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -17,19 +17,47 @@ runtime is not selected.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import queue
 import subprocess
 import threading
 import time
+import tomllib
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from tools.environments.local import hermes_subprocess_env
 
+logger = logging.getLogger(__name__)
+
 # Default minimum codex version we test against. The PR sets this from the
 # `codex --version` parsed at install time; bumping is a one-line change here.
 MIN_CODEX_VERSION = (0, 125, 0)
+
+_DANGER_DEFAULT_PERMISSIONS = ":danger-full-access"
+
+
+def _codex_home_default_permissions(codex_home: Optional[str]) -> Optional[str]:
+    """Read Codex's top-level ``default_permissions`` from CODEX_HOME."""
+    if not codex_home:
+        return None
+    config_path = os.path.join(codex_home, "config.toml")
+    try:
+        with open(config_path, "rb") as handle:
+            config = tomllib.load(handle)
+    except FileNotFoundError:
+        return None
+    except Exception:
+        logger.debug(
+            "codex app-server: failed to read Codex config %s",
+            config_path,
+            exc_info=True,
+        )
+        return None
+
+    value = config.get("default_permissions")
+    return value if isinstance(value, str) else None
 
 
 @dataclass
@@ -112,16 +140,26 @@ class CodexAppServerClient:
                     ),
                 )
             )
-            app_server_args.extend(
-                [
-                    "-c",
-                    'sandbox_mode="workspace-write"',
-                    "-c",
-                    f'sandbox_workspace_write.writable_roots=["{kanban_root}"]',
-                    "-c",
-                    "sandbox_workspace_write.network_access=false",
-                ]
+            default_permissions = _codex_home_default_permissions(
+                spawn_env.get("CODEX_HOME")
             )
+            if default_permissions == _DANGER_DEFAULT_PERMISSIONS:
+                logger.info(
+                    "codex app-server: using profile default_permissions for "
+                    "kanban worker (CODEX_HOME=%s)",
+                    spawn_env.get("CODEX_HOME"),
+                )
+            else:
+                app_server_args.extend(
+                    [
+                        "-c",
+                        'sandbox_mode="workspace-write"',
+                        "-c",
+                        f'sandbox_workspace_write.writable_roots=["{kanban_root}"]',
+                        "-c",
+                        "sandbox_workspace_write.network_access=false",
+                    ]
+                )
 
         cmd = [codex_bin, "app-server"] + app_server_args
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -296,6 +296,66 @@ class TestSpawnEnvIsolation:
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
 
+    def test_kanban_worker_honors_profile_danger_default_permissions(
+        self, monkeypatch, tmp_path
+    ):
+        """A profile-local Codex config may intentionally opt a kanban
+        worker into danger-full-access. In that case Hermes must not append
+        the workspace-write override that would silently narrow Codex back to
+        the default sandbox and re-block git refs writes.
+        """
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                captured["env"] = kwargs.get("env", {}).copy()
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        codex_home = tmp_path / "codex-home"
+        codex_home.mkdir()
+        (codex_home / "config.toml").write_text(
+            'default_permissions = ":danger-full-access"\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setenv("HOME", "/users/alice")
+        monkeypatch.setenv("HERMES_HOME", "/users/alice/.hermes/profiles/coder")
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv(
+            "HERMES_KANBAN_DB",
+            "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
+        )
+
+        client = cas.CodexAppServerClient(
+            codex_bin="codex", codex_home=str(codex_home)
+        )
+        client._closed = True
+
+        cmd = captured["cmd"]
+        assert cmd == ["codex", "app-server"]
+        assert captured["env"].get("CODEX_HOME") == str(codex_home)
+
 
 class TestSpawnEnvSecretStripping:
     """codex app-server routes its spawn env through hermes_subprocess_env(

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -351,6 +351,28 @@ class TestRunConversationCodexPath:
         )
         return captured
 
+    def test_uses_profile_codex_home_when_profile_defines_one(
+        self, monkeypatch, tmp_path
+    ):
+        captured = self._capture_routing_agent(monkeypatch)
+        profile_home = tmp_path / "profiles" / "coder-codex"
+        codex_home = profile_home / "codex-home"
+        codex_home.mkdir(parents=True)
+        (codex_home / "config.toml").write_text(
+            'default_permissions = ":danger-full-access"\n',
+            encoding="utf-8",
+        )
+        inherited_codex_home = tmp_path / "global-codex"
+        inherited_codex_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setenv("CODEX_HOME", str(inherited_codex_home))
+
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("work a kanban task")
+
+        assert captured.get("codex_home") == str(codex_home)
+
     def test_approvals_mode_off_auto_approves_codex_server_requests(
         self, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- Prefer `$HERMES_HOME/codex-home` for Codex app-server sessions when the active Hermes profile defines `codex-home/config.toml`.
- Keep existing behavior for profiles without a profile-local Codex home.
- Add a regression test covering a gateway/kanban-style worker that inherits a global `CODEX_HOME` but runs under a profile-scoped `HERMES_HOME`.

## Root Cause

Kanban workers are spawned as `hermes -p <profile> chat -q ...` from the long-lived gateway process. They inherit the gateway service environment, including any global `CODEX_HOME`, instead of going through profile-specific wrappers. As a result, Codex app-server workers could ignore profile-scoped Codex configuration, including permission profiles needed by coding workers.

## Fix

When the active profile home contains `codex-home/config.toml`, pass that directory as `codex_home` to `CodexAppServerSession`. This keeps the override profile-scoped and leaves profiles without `codex-home` on the existing inherited/global `CODEX_HOME` path.

## Validation

- Red/green regression test: `test_uses_profile_codex_home_when_profile_defines_one`
- `scripts/run_tests.sh tests/run_agent/test_codex_app_server_integration.py -q` -> 29 passed
- `ruff check agent/codex_runtime.py tests/run_agent/test_codex_app_server_integration.py` -> passed