### PR TITLE
fix(verify-stop): exempt rendered output artifacts and loose temp-dir files from the verify nudge

### DIFF
--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -35,6 +35,16 @@ _NON_CODE_VERIFY_EXTENSIONS = frozenset(
         ".log",
         ".csv",
         ".tsv",
+        # Rendered/prose output artifacts: HTML email bodies and message drafts
+        # (support-agent replies, notification templates written to disk before
+        # an API send). No test/build exercises them; the correct verification
+        # is delivery-side (e.g. re-fetching the sent message), which the nudge
+        # cannot know about. Without this, writing a throwaway reply .html in
+        # /tmp demanded the nearest package.json's `npm run test` (false
+        # positive observed on a Helper support webhook session, 2026-07-03).
+        ".html",
+        ".htm",
+        ".eml",
     }
 )
 
@@ -64,7 +74,74 @@ def _is_non_code_path(raw: str) -> bool:
         return True
     if not suffix and p.name.lower() in _NON_CODE_VERIFY_FILENAMES:
         return True
-    return False
+    return _is_tempdir_path(p)
+
+
+def _is_tempdir_path(p: Path) -> bool:
+    """Return True for *loose* files under the OS temp directory.
+
+    Temp-dir scratch artifacts — staged email bodies, ad-hoc payloads, the
+    guard's own suggested ``hermes-verify-*`` scripts — are throwaway by
+    construction. They belong to no project, so no project test/lint/build
+    command can exercise them; nudging "run ``npm run test``" (resolved from
+    whatever repo the session's cwd happens to fall in) for a ``/tmp`` file is
+    always a false positive.
+
+    A file is exempt only when NO project marker (manifest or ``.git``) exists
+    between it and the temp root: a real project checked out under the temp
+    dir (including pytest ``tmp_path`` fixtures) keeps full verification
+    semantics.
+    """
+    try:
+        candidate = p if p.is_absolute() else Path.cwd() / p
+        resolved = candidate.resolve()
+    except Exception:
+        return False
+    roots = []
+    try:
+        roots.append(Path(tempfile.gettempdir()).resolve())
+    except Exception:
+        pass
+    # Literal /tmp prefix too: on macOS /tmp symlinks to /private/tmp and
+    # TMPDIR points elsewhere entirely, so cover both spellings.
+    for extra in (Path("/tmp"), Path("/private/tmp")):
+        if extra not in roots:
+            roots.append(extra)
+    temp_root = None
+    for root in roots:
+        try:
+            if resolved.is_relative_to(root):
+                temp_root = root
+                break
+        except (ValueError, OSError):
+            continue
+    if temp_root is None:
+        return False
+    # Walk ancestors from the file's directory up to (but excluding) the temp
+    # root; any project marker means this is a real workspace, not scratch.
+    # The temp root itself is deliberately NOT checked: it's a shared dumping
+    # ground, and a stray /tmp/package.json must not turn every loose /tmp
+    # file into "project code".
+    markers = (
+        ".git",
+        "package.json",
+        "pyproject.toml",
+        "setup.py",
+        "Cargo.toml",
+        "go.mod",
+        "Gemfile",
+        "Makefile",
+    )
+    current = resolved.parent
+    try:
+        while current != temp_root and current.is_relative_to(temp_root):
+            for marker in markers:
+                if (current / marker).exists():
+                    return False
+            current = current.parent
+    except (ValueError, OSError):
+        return False
+    return True
 
 
 def _filter_verifiable_paths(paths: Iterable[str]) -> list[str]:

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -364,3 +364,73 @@ def test_is_non_code_path_classification():
     assert _is_non_code_path("src/app.ts") is False
     assert _is_non_code_path("config.yaml") is False
     assert _is_non_code_path("run_agent.py") is False
+    # Rendered output artifacts (email bodies, message drafts) — no test suite
+    # exercises them; verification is delivery-side.
+    assert _is_non_code_path("reply_body.html") is True
+    assert _is_non_code_path("draft.htm") is True
+    assert _is_non_code_path("outbound.eml") is True
+
+
+# ---------------------------------------------------------------------------
+# Temp-dir artifacts are throwaway by construction: they belong to no project,
+# so no project verify command can exercise them. Editing one must never trip
+# the nudge — regardless of extension. (Real-world false positive: a support
+# agent wrote an HTML email body to /tmp and was nudged to run the nearest
+# repo's `npm run test`.)
+# ---------------------------------------------------------------------------
+
+def test_tempdir_path_is_exempt_regardless_of_extension():
+    from agent.verification_stop import _is_non_code_path
+
+    tmp = tempfile.gettempdir()
+    assert _is_non_code_path(f"{tmp}/reply_abc123.html") is True
+    assert _is_non_code_path(f"{tmp}/hermes-verify-scratch.py") is True
+    assert _is_non_code_path(f"{tmp}/staged_payload.json") is True
+    # Literal /tmp spelling must also match even where the OS temp dir
+    # resolves elsewhere (macOS: /tmp -> /private/tmp; TMPDIR is per-user).
+    assert _is_non_code_path("/tmp/reply_abc123.html") is True
+    assert _is_non_code_path("/tmp/scratch.sh") is True
+    # Non-temp code paths keep nudging.
+    assert _is_non_code_path("/Users/dev/project/src/app.ts") is False
+    # A path merely *containing* a tmp-like segment is not exempt.
+    assert _is_non_code_path("src/tmp_utils.py") is False
+
+
+def test_project_under_tempdir_is_not_exempt(tmp_path):
+    """A real project checked out under the temp dir keeps full verification.
+
+    The temp exemption is for LOOSE scratch files only; a project marker
+    (package.json, .git, ...) anywhere between the file and the temp root
+    disables it. This also keeps pytest tmp_path-based project fixtures
+    working.
+    """
+    from agent.verification_stop import _is_non_code_path
+
+    _node_project(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    code = src / "app.ts"
+    code.write_text("export {}\n")
+    assert _is_non_code_path(str(code)) is False
+
+
+def test_tempdir_only_edit_does_not_nudge(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    changed = str(Path(tempfile.gettempdir()) / "reply_ticket123.html")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[changed])
+
+    assert build_verify_on_stop_nudge(session_id="s1", changed_paths=[changed]) is None
+
+
+def test_mixed_tempdir_and_code_edit_still_nudges(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _node_project(tmp_path)
+    scratch = str(Path(tempfile.gettempdir()) / "hermes-verify-scratch.py")
+    code = str(tmp_path / "src" / "app.ts")
+    mark_workspace_edited(session_id="s1", cwd=tmp_path, paths=[code])
+
+    nudge = build_verify_on_stop_nudge(session_id="s1", changed_paths=[scratch, code])
+    assert nudge is not None
+    assert code in nudge
+    assert scratch not in nudge


### PR DESCRIPTION
## Symptom

A webhook-driven support session wrote an HTML email body to `/tmp/reply_<slug>.html`, sent it via a ticket API, verified delivery by re-fetching the conversation — and was then nudged (twice) by verify-on-stop to run `npm run test`. There is no npm project anywhere near that file; the suggested command came from an unrelated repo's `package.json` that the session's cwd happened to resolve into. The agent correctly refused and explained the blocker, but the rebuttal became the turn's user-facing response — chat noise at best, and structural pressure toward verification theater at worst.

## Root cause

Two gaps in `agent/verification_stop.py`'s non-code classification:
1. `.html` is not in `_NON_CODE_VERIFY_EXTENSIONS`, so writing a rendered email/message body counts as "edited code".
2. Nothing exempts the OS temp dir, even though temp scratch files belong to no project by construction — and the guard's own no-suite fallback *instructs* the model to write its ad-hoc verification scripts there, which would re-trigger the nudge.

## Fix

- Add `.html`/`.htm`/`.eml` to the non-code extension list (rendered prose artifacts; the meaningful verification for an email body is delivery-side, which the nudge can't know about).
- Exempt **loose** files under `tempfile.gettempdir()` (plus literal `/tmp` / `/private/tmp` for macOS symlink/TMPDIR divergence). Guarded so it can't over-fire: a project marker (`.git`, `package.json`, `pyproject.toml`, …) in any ancestor between the file and the temp root disables the exemption — real checkouts under /tmp and pytest `tmp_path` project fixtures keep full verification semantics. The shared temp root itself is deliberately not scanned, so a stray `/tmp/package.json` (present on the machine where this was caught!) can't reclassify everyone's scratch files.

## Verification

- 56/56 in `test_verification_stop.py` + `test_verification_stop_caching.py` (9 new assertions across 4 new/extended tests: extension classification, temp exemption both spellings, project-under-tempdir counter-case, temp-only edit silent, mixed temp+code still nudges on the code path).
- 111/111 including `test_coding_context.py`.
- E2E repro of the incident (write `/tmp/reply_*.html` with cwd in a node project): no nudge after fix; control case (real `src/app.ts` edit in the same project) still nudges with `npm run test`.
- One pre-existing failure on clean `main` (`test_file_tool_stales_evidence_by_session_id_for_absolute_edit`, `KeyError: 'files_modified'`) is unrelated — fails identically with this change stashed.