### PR TITLE
feat(discord): searchable /model autocomplete

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3889,6 +3889,84 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("Discord interaction cleanup failed: %s", e)
 
+    def _model_autocomplete_entries(self) -> "list[tuple[str, str]]":
+        """Build (and briefly cache) the flat model list for ``/model`` autocomplete.
+
+        Returns ``(label, value)`` tuples where *value* is the argument
+        string handed to ``/model`` — a bare model id for the current
+        provider, or ``"<id> --provider <slug>"`` for other authenticated
+        providers. Sourced from the same authenticated-provider catalog the
+        interactive picker uses (``list_authenticated_providers``) but
+        uncapped, so every model is searchable instead of the picker's
+        first 50. Cached for a short window because the autocomplete
+        callback fires on every keystroke; the underlying read is served
+        from the on-disk provider-model cache, so a rebuild is cheap.
+        """
+        import time
+
+        now = time.time()
+        cached = getattr(self, "_model_entries_cache", None)
+        cached_at = getattr(self, "_model_entries_cache_at", 0.0)
+        if cached is not None and (now - cached_at) < 120:
+            return cached
+
+        entries: "list[tuple[str, str]]" = []
+        try:
+            from gateway.run import _load_gateway_config
+            from hermes_cli.model_switch import list_authenticated_providers
+
+            cfg = _load_gateway_config() or {}
+            model_cfg = cfg.get("model", {})
+            if not isinstance(model_cfg, dict):
+                model_cfg = {}
+            cur_provider = str(model_cfg.get("provider", "") or "")
+            cur_base_url = str(model_cfg.get("base_url", "") or "")
+            cur_model = str(model_cfg.get("default", "") or "")
+            try:
+                from hermes_cli.config import get_compatible_custom_providers
+
+                custom_provs = get_compatible_custom_providers(cfg)
+            except Exception:
+                custom_provs = cfg.get("custom_providers")
+
+            providers = list_authenticated_providers(
+                current_provider=cur_provider,
+                current_base_url=cur_base_url,
+                current_model=cur_model,
+                user_providers=cfg.get("providers"),
+                custom_providers=custom_provs,
+                max_models=1000,
+            )
+            # Current provider first so its models rank highest in the
+            # unfiltered (empty-query) view shown before the user types.
+            providers = sorted(
+                providers,
+                key=lambda p: 0
+                if str(p.get("slug", "")).lower() == cur_provider.lower()
+                else 1,
+            )
+            seen: "set[tuple[str, str]]" = set()
+            for p in providers:
+                slug = str(p.get("slug", "") or "")
+                pname = str(p.get("name", "") or slug)
+                is_current = slug.lower() == cur_provider.lower()
+                for mid in p.get("models", []) or []:
+                    mid = str(mid)
+                    key = (mid, slug)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    label = f"{mid} · {pname}"
+                    value = mid if is_current else f"{mid} --provider {slug}"
+                    entries.append((label, value))
+        except Exception:
+            # Keep the last good catalog rather than blanking autocomplete.
+            entries = cached or []
+
+        self._model_entries_cache = entries
+        self._model_entries_cache_at = now
+        return entries
+
     def _register_slash_commands(self) -> None:
         """Register Discord slash commands on the command tree."""
         if not self._client:
@@ -3904,8 +3982,50 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_reset(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/reset", "Session reset~")
 
+        async def _autocomplete_model(
+            interaction: "discord.Interaction", current: str,
+        ) -> list:
+            """Live-filter the full model catalog as the user types.
+
+            Sources every authenticated provider's model list — the local
+            LiteLLM proxy's full set plus any other configured providers —
+            and filters by the typed substring, so ``/model`` can search
+            *all* models rather than the 25/50 a select-menu dropdown can
+            show. Discord caps the returned list at 25 entries per
+            keystroke, and the current provider's models are ranked first
+            so an empty query still surfaces the local proxy catalog.
+
+            Authorization is pre-checked quietly (returns ``[]`` for
+            unauthorized users) so the catalog isn't leaked in the picker,
+            and the callback never raises — any failure yields an empty
+            suggestion list rather than a typing-time error popup.
+            """
+            try:
+                allowed, _reason = self._evaluate_slash_authorization(interaction)
+            except Exception:
+                return []
+            if not allowed:
+                return []
+            try:
+                entries = self._model_autocomplete_entries()
+            except Exception:
+                return []
+            q = (current or "").strip().lower()
+            choices: list = []
+            for label, value in entries:
+                if not q or q in label.lower():
+                    lbl = label if len(label) <= 100 else label[:97] + "..."
+                    val = value if len(value) <= 100 else value[:100]
+                    choices.append(
+                        discord.app_commands.Choice(name=lbl, value=val)
+                    )
+                    if len(choices) >= 25:
+                        break
+            return choices
+
         @tree.command(name="model", description="Show or change the model")
-        @discord.app_commands.describe(name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current.")
+        @discord.app_commands.describe(name="Start typing to search all models. Leave empty for the picker.")
+        @discord.app_commands.autocomplete(name=_autocomplete_model)
         async def slash_model(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/model {name}".strip())
 


### PR DESCRIPTION
## What
Adds type-to-filter **autocomplete** to the Discord `/model` slash command, so users can search the full set of authenticated models instead of scrolling a capped select menu.

## Why
`/model`'s picker is a Discord select menu, which Discord caps at 25 options (and the current picker surfaces only the first ~50). Once several providers are authenticated — each with dozens of models — the picker becomes impractical: no search, and most models aren't even shown.

## How
- **`_model_autocomplete_entries()`** builds a flat `(label, value)` catalog from `list_authenticated_providers()` (the same source the picker uses), uncapped, with the current provider ranked first. Cached ~120s since autocomplete fires on every keystroke; the underlying read is served from the on-disk provider-model cache.
- **`_autocomplete_model`** callback filters by the typed substring and returns up to Discord's 25-choice limit. It reuses the existing slash authorization (`_evaluate_slash_authorization`) so the catalog isn't leaked to unauthorized users, and it never raises — any failure yields an empty suggestion list.
- `@app_commands.autocomplete(name=...)` wired onto the `/model` command.

## Compatibility
Fully backward compatible. The stock select-menu picker remains as the fallback (empty query / no autocomplete client), and every failure path degrades to an empty suggestion list, so command registration and handling are unaffected.

## Testing
Verified across multiple agents and pulls all models from all wired providers. Typing filters live; an empty query surfaces the current provider's models first; unauthorized users get no suggestions.
