### PR TITLE
fix(dashboard-auth): skip auto-SSO for password providers

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,13 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    if getattr(provider, "supports_password", False):
+        # Password-only providers do not have an OAuth redirect to
+        # auto-start.  Falling back to /login lets the server-rendered
+        # credential form POST to /auth/password-login.  Without this guard,
+        # a single basic-auth provider is incorrectly sent to /auth/login,
+        # whose OAuth-only start_login() path raises NotImplementedError.
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -192,6 +192,19 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             status_code=404,
             detail=f"Provider does not support interactive login: {provider!r}",
         )
+    if getattr(p, "supports_password", False):
+        # /auth/login is the OAuth-start endpoint.  Password providers sign in
+        # through the server-rendered /login form, which POSTs credentials to
+        # /auth/password-login.  Be defensive for stale bookmarks or older
+        # middleware redirects and send the user to the correct page instead of
+        # calling a password provider's NotImplemented start_login().
+        from urllib.parse import quote
+
+        safe_next = _validate_post_login_target(next)
+        login_url = f"{_prefix(request)}/login"
+        if safe_next:
+            login_url = f"{login_url}?next={quote(safe_next, safe='')}"
+        return RedirectResponse(url=login_url, status_code=302)
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -221,6 +221,39 @@ class TestProviderListFlag:
 
 
 class TestPasswordLoginRoute:
+    def test_password_only_provider_html_load_renders_login_not_oauth_start(
+        self, gated_app
+    ):
+        """A single password provider must not be auto-started as OAuth.
+
+        Auto-SSO is only valid for redirect/OAuth providers. With only a
+        username/password provider registered, an unauthenticated HTML
+        navigation must fall back to the /login credential form. Otherwise the
+        gate redirects to /auth/login?provider=<password-provider>, which calls
+        start_login() on a password-only provider and 500s.
+        """
+        resp = gated_app.get("/sessions", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2Fsessions"
+        assert "/auth/login" not in resp.headers["location"]
+
+    def test_direct_auth_login_for_password_provider_redirects_to_form(
+        self, gated_app
+    ):
+        """Stale /auth/login links for password providers are safe.
+
+        The login page itself posts credentials to /auth/password-login; if an
+        old auto-SSO redirect or bookmark hits the OAuth-start route with a
+        password provider, redirect back to the form instead of surfacing a
+        server error.
+        """
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=%2Fsessions",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2Fsessions"
+
     def test_valid_credentials_set_session_cookies_and_return_next(
         self, gated_app
     ):


### PR DESCRIPTION
## Summary
- Skip dashboard auto-SSO when the only interactive provider is password-only (`supports_password=True`).
- Redirect stale `/auth/login?provider=<password-provider>` hits back to `/login` instead of calling a password provider's OAuth-only `start_login()` path.
- Add regression coverage for single password-provider HTML navigation and direct `/auth/login` hits.

## Root cause
`list_session_providers()` includes password providers because they are interactive login providers, but `_auto_sso_response()` assumed the single interactive provider always supports OAuth redirects. With only `basic` configured, an unauthenticated HTML load auto-redirected to `/auth/login?provider=basic`, which called `BasicAuthProvider.start_login()` and raised `NotImplementedError`.

## Test Plan
- RED proof: reversed the code fix with the new tests in place and confirmed both regression tests fail with `/auth/login?provider=testpw...` / `NotImplementedError`.
- `./scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_password_login.py tests/hermes_cli/test_dashboard_auth_401_reauth.py -q --tb=short`
  - 65 passed, 0 failed.
