### PR TITLE
fix(feishu): allow bare @mention with no text to trigger bot response in group chats

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3187,10 +3187,13 @@ class FeishuAdapter(BasePlatformAdapter):
             if text.startswith("/"):
                 inbound_type = MessageType.COMMAND
 
-        # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
+        # Guard — drop truly empty messages (no text, no @mentions, no media).
+        # Pure @-mentions with empty text are kept so the agent can respond
+        # based on recent group context.
         if inbound_type == MessageType.TEXT and not text and not media_urls:
-            logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
-            return
+            if not mentions:
+                logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
+                return
 
         if inbound_type != MessageType.COMMAND:
             hint = _build_mention_hint(mentions)


### PR DESCRIPTION
### Problem

When a user sends a bare @mention with no text in a Feishu group chat (e.g. just `@Bot`), the gateway silently drops the message. The guard at `_process_inbound_message()` catches the empty string after mention stripping and returns early, leaving the user with no response or feedback.

This is especially noticeable now that the group context feature (PR #52908, also addressing #55530) lets the agent see prior discussion. A bare @mention is the natural way to re-engage the bot without repeating context — but the guard blocks it entirely.

### Root Cause

```python
# Old guard — drops ALL empty text, including pure @mentions
if inbound_type == MessageType.TEXT and not text and not media_urls:
    return
```

After `_strip_edge_self_mentions()` strips the @-mention prefix, a bare `@Bot` becomes empty string. The guard checks `not text` but never inspects the `mentions` list.

### Changes

**`plugins/platforms/feishu/adapter.py`** — 1 file, +6/-3 lines

Narrow the empty-text guard to only drop messages that have neither text content nor @mentions:

```python
if inbound_type == MessageType.TEXT and not text and not media_urls:
    if not mentions:
        logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
        return
```

When the guard passes, `_build_mention_hint()` builds a mention text (e.g. `@Bot`), and the pipeline proceeds normally.

### Relationship with PR #52908

Together with #52908 (group context via `_fetch_recent_group_context`), a bare @mention now produces a context-aware response instead of silence.

| PR | What it does |
|----|-------------|
| #52908 | Injects recent group messages as context when mentioned |
| This PR | Allows bare @mention (no text) to trigger response |

### Testing

- [x] Bare `@Bot` in group → bot responds with context
- [x] `@Bot with text` → unchanged behavior
- [x] DM (p2p) → unchanged behavior
- [x] `/command` → unchanged behavior
- [x] Truly empty message (no mention, no text, no media) → still dropped

Related: #55530, #52908