### PR TITLE
feat: add Fusion compaction-boundary routing + persistent sidekick

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -59,6 +59,62 @@ from utils import base_url_host_matches, is_truthy_value
 logger = logging.getLogger("run_agent")
 
 
+def _fusion_cfg_str(fusion_cfg: dict, key: str) -> str:
+    """Return a stripped string config value from the optional fusion block."""
+    return str((fusion_cfg or {}).get(key) or "").strip()
+
+
+def _build_fusion_frontier_runtime(agent: Any, fusion_cfg: dict) -> dict[str, Any]:
+    """Snapshot the frontier runtime once at session start for Fusion routing."""
+    return {
+        "model": _fusion_cfg_str(fusion_cfg, "frontier_model") or agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "api_key": getattr(agent, "api_key", ""),
+        "api_mode": agent.api_mode,
+    }
+
+
+def _build_fusion_routing_runtime(agent: Any, fusion_cfg: dict) -> dict[str, Any]:
+    """Resolve the MECHANICAL runtime for Fusion compaction routing.
+
+    Priority is route-specific config first, then sidekick config, then the
+    current runtime only when no alternate provider is requested. Avoiding a
+    blind cross-provider fallback prevents a cheap-route model from inheriting
+    the frontier provider's key/base URL by accident.
+    """
+    target_provider = (
+        _fusion_cfg_str(fusion_cfg, "routing_provider")
+        or _fusion_cfg_str(fusion_cfg, "sidekick_provider")
+        or str(getattr(agent, "provider", "") or "").strip()
+    )
+    current_provider = str(getattr(agent, "provider", "") or "").strip()
+    same_provider = not target_provider or target_provider == current_provider
+
+    return {
+        "model": (
+            _fusion_cfg_str(fusion_cfg, "routing_model")
+            or _fusion_cfg_str(fusion_cfg, "sidekick_model")
+        ),
+        "provider": target_provider,
+        "base_url": (
+            _fusion_cfg_str(fusion_cfg, "routing_base_url")
+            or _fusion_cfg_str(fusion_cfg, "sidekick_base_url")
+            or (str(getattr(agent, "base_url", "") or "").strip() if same_provider else "")
+        ),
+        "api_key": (
+            _fusion_cfg_str(fusion_cfg, "routing_api_key")
+            or _fusion_cfg_str(fusion_cfg, "sidekick_api_key")
+            or (getattr(agent, "api_key", "") if same_provider else "")
+        ),
+        "api_mode": (
+            _fusion_cfg_str(fusion_cfg, "routing_api_mode")
+            or _fusion_cfg_str(fusion_cfg, "sidekick_api_mode")
+            or (str(getattr(agent, "api_mode", "") or "").strip() if same_provider else "")
+        ),
+    }
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.OpenAI`` / ``run_agent.cleanup_vm`` / ... and have those
@@ -1216,6 +1272,19 @@ def init_agent(
         _agent_cfg = _load_agent_config()
     except Exception:
         _agent_cfg = {}
+    _fusion_cfg = _agent_cfg.get("fusion", {}) if isinstance(_agent_cfg, dict) else {}
+    if not isinstance(_fusion_cfg, dict):
+        _fusion_cfg = {}
+    agent._fusion_enabled = is_truthy_value(_fusion_cfg.get("enabled"), default=False)
+    agent._fusion_compaction_routing = bool(
+        agent._fusion_enabled
+        and is_truthy_value(_fusion_cfg.get("compaction_routing"), default=False)
+    )
+    agent._fusion_routing_verdict = None
+    agent._fusion_routing_suspended = False
+    agent._fusion_frontier_runtime = _build_fusion_frontier_runtime(agent, _fusion_cfg)
+    agent._fusion_routing_runtime = _build_fusion_routing_runtime(agent, _fusion_cfg)
+
     try:
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig.from_mapping(
@@ -1704,6 +1773,11 @@ def init_agent(
             _bind_session_state(session_db=session_db, session_id=agent.session_id)
         except Exception:
             pass
+    try:
+        setattr(agent.context_compressor, "_fusion_compaction_routing", agent._fusion_compaction_routing)
+        setattr(agent.context_compressor, "_fusion_verdict_owner", agent)
+    except Exception:
+        pass
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -39,6 +39,8 @@ HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"
 HISTORICAL_IN_PROGRESS_HEADING = "## Historical In-Progress State"
 HISTORICAL_PENDING_ASKS_HEADING = "## Historical Pending User Asks"
 HISTORICAL_REMAINING_WORK_HEADING = "## Historical Remaining Work"
+FUSION_WORK_COMPLEXITY_HEADING = "## Work Complexity Assessment"
+_FUSION_VERDICTS = ("MECHANICAL", "FRONTIER_JUDGMENT")
 
 
 SUMMARY_PREFIX = (
@@ -1076,6 +1078,11 @@ class ContextCompressor(ContextEngine):
         # succeeded.  Silent recovery would hide the broken config.
         self._last_aux_model_failure_error: Optional[str] = None
         self._last_aux_model_failure_model: Optional[str] = None
+        # Fusion compaction routing piggybacks a single deterministic verdict on
+        # the existing summary call.  The owning AIAgent is stored separately so
+        # tests and plugin engines can opt in without changing constructor shape.
+        self._fusion_compaction_routing: bool = False
+        self._fusion_verdict_owner: Any = None
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
@@ -1639,6 +1646,62 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         self.summary_model = ""  # empty = use main model
         self._clear_compression_failure_cooldown()  # no cooldown — retry immediately
 
+    def _fusion_routing_enabled(self) -> bool:
+        return bool(getattr(self, "_fusion_compaction_routing", False))
+
+    def _fusion_work_complexity_prompt_section(self) -> str:
+        if not self._fusion_routing_enabled():
+            return ""
+        return f"""
+{FUSION_WORK_COMPLEXITY_HEADING}
+[Choose exactly one label on the first line of this section:
+- MECHANICAL: the next work is mostly deterministic implementation, file edits,
+  tests, lint fixes, data gathering, or command execution that can run on the
+  cheaper sidekick/mechanical route.
+- FRONTIER_JUDGMENT: the next work requires subtle architectural judgment,
+  ambiguous tradeoff resolution, product/security reasoning, or final acceptance.
+After the label, add at most one short reason. Do not invent facts.]"""
+
+    def _extract_fusion_verdict(self, summary: str) -> Optional[str]:
+        if not summary:
+            return None
+        pattern = rf"{re.escape(FUSION_WORK_COMPLEXITY_HEADING)}\s*(.*?)(?:\n## |\Z)"
+        match = re.search(pattern, summary, flags=re.IGNORECASE | re.DOTALL)
+        if not match:
+            return None
+        section = match.group(1)
+        first_non_empty = ""
+        for line in section.splitlines():
+            stripped = line.strip().upper()
+            if stripped:
+                first_non_empty = stripped
+                break
+        for verdict in _FUSION_VERDICTS:
+            if re.search(rf"\b{re.escape(verdict)}\b", first_non_empty):
+                return verdict
+        return None
+
+    def _record_fusion_verdict(self, summary: str) -> None:
+        if not self._fusion_routing_enabled():
+            return
+        owner = getattr(self, "_fusion_verdict_owner", None)
+        if owner is None:
+            return
+        setattr(owner, "_fusion_routing_verdict", self._extract_fusion_verdict(summary))
+
+    def _strip_fusion_verdict_section(self, summary: str) -> str:
+        """Remove the Fusion verdict section from persisted summary text.
+
+        The verdict is consumed through ``_record_fusion_verdict`` before this
+        runs. Keeping the raw section would leak a stale routing label into the
+        next iterative-update prompt and into main-agent conversation history.
+        """
+        if not summary or not self._fusion_routing_enabled():
+            return summary
+        pattern = rf"{re.escape(FUSION_WORK_COMPLEXITY_HEADING)}\s*.*?(?=\n## |\Z)"
+        stripped = re.sub(pattern, "", summary, flags=re.IGNORECASE | re.DOTALL)
+        return re.sub(r"\n{3,}", "\n\n", stripped).strip()
+
     def _generate_summary(
         self,
         turns_to_summarize: List[Dict[str, Any]],
@@ -1668,6 +1731,10 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
                 self._summary_failure_cooldown_until - now,
             )
             return None
+        if self._fusion_routing_enabled():
+            owner = getattr(self, "_fusion_verdict_owner", None)
+            if owner is not None:
+                setattr(owner, "_fusion_routing_verdict", None)
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
         content_to_summarize = self._serialize_for_summary(turns_to_summarize)
@@ -1791,6 +1858,7 @@ Be specific with file paths, commands, line numbers, and results.]
 
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation. NEVER include API keys, tokens, passwords, or credentials — write [REDACTED] instead.]
+{self._fusion_work_complexity_prompt_section()}
 
 Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command outputs, error messages, line numbers, and specific values. Avoid vague descriptions like "made some changes" — say exactly what changed.
 {_temporal_anchoring_rule}
@@ -1886,6 +1954,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())
+            self._record_fusion_verdict(summary)
+            summary = self._strip_fusion_verdict_section(summary)
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._clear_compression_failure_cooldown()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -156,6 +156,102 @@ def _ra():
     return run_agent
 
 
+def _apply_fusion_routing_verdict(agent: Any) -> bool:
+    """Consume a compaction-time Fusion verdict and switch route if needed.
+
+    Returns True only when a switch_model call succeeded. The verdict is always
+    cleared, so a failed or skipped compaction cannot leak stale routing into a
+    later boundary.
+    """
+    if not (
+        getattr(agent, "_fusion_enabled", False)
+        and getattr(agent, "_fusion_compaction_routing", False)
+    ):
+        return False
+
+    verdict = getattr(agent, "_fusion_routing_verdict", None)
+    agent._fusion_routing_verdict = None
+    if not verdict or getattr(agent, "_fusion_routing_suspended", False):
+        return False
+
+    verdict = str(verdict).strip().upper()
+    if verdict == "MECHANICAL":
+        runtime = getattr(agent, "_fusion_routing_runtime", {}) or {}
+    elif verdict == "FRONTIER_JUDGMENT":
+        runtime = getattr(agent, "_fusion_frontier_runtime", {}) or {}
+    else:
+        return False
+
+    target_model = str(runtime.get("model") or "").strip()
+    if not target_model:
+        return False
+    target_provider = str(runtime.get("provider") or getattr(agent, "provider", "") or "").strip()
+    target_base_url = str(runtime.get("base_url") or "").strip()
+    target_api_mode = str(runtime.get("api_mode") or "").strip()
+    target_api_key = runtime.get("api_key") or ""
+    current_provider = str(getattr(agent, "provider", "") or "").strip()
+    if target_provider and target_provider != current_provider and (
+        not target_api_key or not target_base_url
+    ):
+        logger.warning(
+            "Fusion compaction routing skipped: routing provider %s needs explicit "
+            "credentials and endpoint; set fusion.routing_api_key/routing_base_url "
+            "or fusion.sidekick_api_key/sidekick_base_url to avoid inheriting the current runtime",
+            target_provider,
+        )
+        return False
+
+    if (
+        target_model == getattr(agent, "model", "")
+        and target_provider == getattr(agent, "provider", "")
+        and target_base_url == getattr(agent, "base_url", "")
+        and target_api_mode == getattr(agent, "api_mode", "")
+    ):
+        return False
+
+    try:
+        from agent import agent_runtime_helpers
+
+        switched = bool(
+            agent_runtime_helpers.switch_model(
+                agent,
+                target_model,
+                target_provider,
+                api_key=target_api_key,
+                base_url=target_base_url,
+                api_mode=target_api_mode,
+            )
+        )
+        if switched:
+            _persist_fusion_routed_runtime(agent)
+        return switched
+    except Exception as exc:
+        logger.warning("Fusion compaction routing switch skipped: %s", exc)
+        return False
+
+
+def _persist_fusion_routed_runtime(agent: Any) -> None:
+    """Persist current Fusion-routed runtime for later /resume restoration."""
+    session_db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None)
+    if not session_db or not session_id or not hasattr(session_db, "update_session_model_config_key"):
+        return
+    routed = {
+        "model": str(getattr(agent, "model", "") or ""),
+        "provider": str(getattr(agent, "provider", "") or ""),
+        "base_url": str(getattr(agent, "base_url", "") or ""),
+        "api_mode": str(getattr(agent, "api_mode", "") or ""),
+    }
+    try:
+        session_db.update_session_model_config_key(
+            session_id,
+            "_fusion_routed_runtime",
+            json.dumps(routed),
+        )
+    except Exception:
+        logger.debug("Fusion: failed to persist routed runtime to session DB", exc_info=True)
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -46,6 +46,26 @@ from agent.prompt_builder import (
 from agent.runtime_cwd import resolve_context_cwd
 
 
+FUSION_MAIN_AGENT_GUIDANCE = """
+## Fusion sidekick operating mode
+
+When Fusion is enabled, act as the architect and reviewer. Delegate by default
+for exploration, implementation, tests, lint, requested edits, bulk changes,
+and slow verification. Use delegate_task with sidekick=true for that work so the
+persistent sidekick keeps its own cached context across delegations.
+
+Keep direct main-agent actions minimal: gather only enough context to plan,
+resolve ambiguity, set acceptance criteria, and review the sidekick's output.
+You own architectural decisions, ambiguity resolution, subtle judgment calls,
+final acceptance, and tasks where judgment itself is the deliverable.
+
+Treat subagent summaries as self-reports, not proof. Before telling the user
+something succeeded, verify the relevant files, tests, commands, URLs, or other
+handles yourself. If review finds issues, delegate a precise follow-up edit to
+the sidekick rather than rebuilding the sidekick context from scratch.
+""".strip()
+
+
 def _ra():
     """Lazy reference to the ``run_agent`` module.
 
@@ -163,6 +183,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+
+    if getattr(agent, "_fusion_enabled", False):
+        stable_parts.append(FUSION_MAIN_AGENT_GUIDANCE)
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1026,6 +1026,34 @@ code_execution:
   max_tool_calls: 50   # Max RPC tool calls per execution (default: 50)
 
 # =============================================================================
+# Fusion (persistent sidekick + compaction-boundary routing)
+# =============================================================================
+# Disabled by default. When fusion.enabled is false, Hermes preserves existing
+# behavior: no sidekick parameter in delegate_task, no main-agent prompt change,
+# and no extra Work Complexity section in compression prompts.
+#
+# Sidekick pattern: the main agent plans/reviews/decides; a cheaper persistent
+# sidekick explores, edits, tests, and fixes with its own cached context. Long
+# sidekick sessions can compact their own history just like normal agents.
+# Process restarts do not rehydrate sidekick history; the next sidekick call
+# lazily creates a fresh child. No cache keep-alive pingers are used.
+fusion:
+  enabled: false            # Master switch — everything below is inert when false.
+  sidekick_model: ""        # "" = delegation.model, then parent model.
+  sidekick_provider: ""     # "" = delegation.provider, then parent provider.
+  sidekick_base_url: ""     # "" = delegation.base_url.
+  sidekick_api_key: ""      # "" = delegation.api_key, then parent key.
+  sidekick_api_mode: ""     # "" = auto-detect / delegation.api_mode.
+  sidekick_toolsets: []     # [] = same toolsets ephemeral delegate children get.
+  compaction_routing: false # Routing only fires at compaction. Sessions that never compact never route.
+  routing_model: ""         # MECHANICAL target ("" = sidekick_model; both "" = no switch).
+  routing_provider: ""      # "" = sidekick_provider, then current provider.
+  routing_base_url: ""      # "" = sidekick_base_url; only fall back to current base_url for same-provider routes.
+  routing_api_key: ""       # "" = sidekick_api_key; only fall back to current key for same-provider routes.
+  routing_api_mode: ""      # "" = sidekick_api_mode; only fall back to current api_mode for same-provider routes.
+  frontier_model: ""        # FRONTIER_JUDGMENT target ("" = session's starting model).
+
+# =============================================================================
 # Subagent Delegation
 # =============================================================================
 # The delegate_task tool spawns child agents with isolated context.

--- a/cli.py
+++ b/cli.py
@@ -6969,7 +6969,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
-            self.agent.reset_session_state()
+            self.agent.reset_session_state(old_session_id=old_session_id)
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -666,6 +666,92 @@ class CLICommandsMixin:
         _cprint("  Your CLI session is intact.")
         return True
 
+    def _restore_fusion_routed_runtime_for_session(self, session_id: str) -> bool:
+        """Best-effort restore of a session's persisted Fusion route.
+
+        Credentials are intentionally not stored in the session DB. Resolve them
+        from live provider config/credential pools, then switch through the low
+        level helper so this automatic restore does not mark routing suspended.
+        """
+        agent = getattr(self, "agent", None)
+        session_db = getattr(self, "_session_db", None)
+        if not agent or not session_db:
+            return False
+        if not (
+            getattr(agent, "_fusion_enabled", False)
+            and getattr(agent, "_fusion_compaction_routing", False)
+        ):
+            return False
+
+        try:
+            session_row = session_db.get_session(session_id)
+            raw_model_config = (session_row or {}).get("model_config")
+            if not raw_model_config:
+                return False
+            model_config = json.loads(raw_model_config)
+        except Exception:
+            return False
+        if not isinstance(model_config, dict):
+            return False
+
+        routed = model_config.get("_fusion_routed_runtime")
+        if not isinstance(routed, dict):
+            return False
+        target_model = str(routed.get("model") or "").strip()
+        target_provider = str(routed.get("provider") or "").strip()
+        if not target_model or not target_provider:
+            return False
+        stored_base_url = str(routed.get("base_url") or "").strip()
+        stored_api_mode = str(routed.get("api_mode") or "").strip()
+
+        api_key = ""
+        resolved_base_url = ""
+        resolved_api_mode = ""
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = resolve_runtime_provider(
+                requested=target_provider,
+                target_model=target_model,
+            )
+            api_key = runtime.get("api_key", "") or ""
+            resolved_base_url = runtime.get("base_url", "") or ""
+            resolved_api_mode = runtime.get("api_mode", "") or ""
+        except Exception:
+            # Some custom/direct-alias routes only have the persisted endpoint.
+            # Let switch_model fail/rollback cleanly if credentials cannot be
+            # resolved; resume should still succeed on the config default.
+            if target_provider in {"custom", "local"} or target_provider.startswith("custom:"):
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                    runtime = resolve_runtime_provider(
+                        requested=target_provider,
+                        explicit_base_url=stored_base_url or None,
+                        target_model=target_model,
+                    )
+                    api_key = runtime.get("api_key", "") or ""
+                    resolved_base_url = runtime.get("base_url", "") or ""
+                    resolved_api_mode = runtime.get("api_mode", "") or ""
+                except Exception:
+                    pass
+
+        try:
+            from agent import agent_runtime_helpers
+
+            return bool(
+                agent_runtime_helpers.switch_model(
+                    agent,
+                    target_model,
+                    target_provider,
+                    api_key=api_key,
+                    base_url=resolved_base_url or stored_base_url,
+                    api_mode=resolved_api_mode or stored_api_mode,
+                )
+            )
+        except Exception:
+            return False
+
     def _handle_resume_command(self, cmd_original: str) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
         from cli import _cprint, _sync_process_session_id
@@ -784,7 +870,8 @@ class CLICommandsMixin:
         # Sync the agent if already initialised
         if self.agent:
             self.agent.session_id = target_id
-            self.agent.reset_session_state()
+            self.agent.reset_session_state(old_session_id=old_session_id)
+            self._restore_fusion_routed_runtime_for_session(target_id)
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2083,6 +2083,26 @@ DEFAULT_CONFIG = {
         "provider": "",
     },
 
+    # Fusion — optional persistent sidekick + compaction-boundary model
+    # routing. Disabled by default: when fusion.enabled is false, the delegate
+    # tool schema, main system prompt, and compression prompt remain unchanged.
+    "fusion": {
+        "enabled": False,
+        "sidekick_model": "",      # "" = delegation.model, then parent model
+        "sidekick_provider": "",   # "" = delegation.provider, then parent provider
+        "sidekick_base_url": "",   # "" = delegation.base_url
+        "sidekick_api_key": "",    # "" = delegation.api_key, then parent key
+        "sidekick_api_mode": "",   # "" = auto-detect / delegation.api_mode
+        "sidekick_toolsets": [],    # [] = same toolsets ephemeral children get
+        "compaction_routing": False,  # routing only fires at context compaction; never without compaction
+        "routing_model": "",       # MECHANICAL target; "" = sidekick_model; both "" = no switch
+        "routing_provider": "",    # "" = sidekick_provider, then current provider
+        "routing_base_url": "",    # "" = sidekick_base_url, then current base_url when provider matches
+        "routing_api_key": "",     # "" = sidekick_api_key, then current key when provider matches
+        "routing_api_mode": "",    # "" = sidekick_api_mode, then current api_mode when provider matches
+        "frontier_model": "",      # FRONTIER_JUDGMENT target; "" = session start model
+    },
+
     # Subagent delegation — override the provider:model used by delegate_task
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
@@ -3124,7 +3144,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 33,
+    "_config_version": 34,
 }
 
 # =============================================================================
@@ -4983,7 +5003,7 @@ def check_config_version() -> Tuple[int, int]:
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
+    "agent", "terminal", "display", "compression", "delegation", "fusion",
     "auxiliary", "moa", "custom_providers", "context", "memory", "gateway",
     "sessions", "streaming", "updates", "mcp_servers",
 }

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2076,6 +2076,26 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_session_model_config_key(self, session_id: str, key: str, value_json: str) -> None:
+        """Set one key inside the session ``model_config`` JSON object.
+
+        This preserves existing metadata such as ``_delegate_from`` and
+        ``_branched_from`` while allowing narrowly scoped session runtime
+        snapshots. ``value_json`` must be a JSON fragment (for example ``null``
+        or ``{"model": "..."}``).
+        """
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key or ""):
+            raise ValueError(f"Invalid model_config key: {key!r}")
+        json_path = f"$.{key}"
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET model_config = json_set("
+                "COALESCE(model_config, '{}'), ?, json(?)) WHERE id = ?",
+                (json_path, value_json, session_id),
+            )
+        self._execute_write(_do)
+
     def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
         """Store the full assembled system prompt snapshot."""
         def _do(conn):

--- a/run_agent.py
+++ b/run_agent.py
@@ -718,6 +718,22 @@ class AIAgent:
         instead of a bare reset. Default callers pass nothing and keep the
         existing reset-only behavior.
         """
+        # Persistent Fusion sidekicks are keyed by parent session id. Session
+        # rotation updates ``self.session_id`` before this method runs, so only
+        # an explicit old_session_id is safe to close here; a bare reset must not
+        # accidentally tear down the active session's sidekick.
+        if old_session_id:
+            try:
+                from tools.delegate_tool import close_sidekick_for_session
+
+                close_sidekick_for_session(str(old_session_id))
+            except Exception:
+                logger.debug(
+                    "close_sidekick_for_session during reset: sid=%s",
+                    old_session_id,
+                    exc_info=True,
+                )
+
         # Token usage counters
         self.session_total_tokens = 0
         self.session_input_tokens = 0
@@ -734,6 +750,11 @@ class AIAgent:
         
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
+
+        # Reset per-session Fusion routing state. Manual /model suspension and
+        # compaction verdicts must not leak into /new, /resume, or /branch.
+        self._fusion_routing_verdict = None
+        self._fusion_routing_suspended = False
 
         # Context engine reset/transition (works for built-in compressor and plugins)
         self._transition_context_engine_session(
@@ -797,8 +818,27 @@ class AIAgent:
 
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Forwarder — see ``agent.agent_runtime_helpers.switch_model``."""
+        # User-facing /model switches are explicit runtime choices. Fusion's
+        # automatic compaction routing bypasses this wrapper and calls the
+        # helper directly, so marking here suspends only future automatic
+        # routing after a manual override.
+        self._fusion_routing_suspended = True
         from agent.agent_runtime_helpers import switch_model
-        return switch_model(self, new_model, new_provider, api_key, base_url, api_mode)
+
+        switched = switch_model(self, new_model, new_provider, api_key, base_url, api_mode)
+        if switched:
+            try:
+                session_db = getattr(self, "_session_db", None)
+                session_id = getattr(self, "session_id", None)
+                if session_db and session_id and hasattr(session_db, "update_session_model_config_key"):
+                    session_db.update_session_model_config_key(
+                        session_id,
+                        "_fusion_routed_runtime",
+                        "null",
+                    )
+            except Exception:
+                logger.debug("Failed to clear persisted Fusion routed runtime", exc_info=True)
+        return switched
 
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.
@@ -3444,6 +3484,17 @@ class AIAgent:
         """
         task_id = getattr(self, "session_id", None) or ""
 
+        closed_sidekick = None
+
+        # 0. Close any persistent Fusion sidekick registered for this parent
+        # session so process/session teardown does not leave a stale child in
+        # the module registry.
+        try:
+            from tools.delegate_tool import close_sidekick_for_session
+            closed_sidekick = close_sidekick_for_session(task_id)
+        except Exception:
+            pass
+
         # 1. Kill background processes for this task
         try:
             from tools.process_registry import process_registry
@@ -3466,8 +3517,12 @@ class AIAgent:
         # 4. Close active child agents
         try:
             with self._active_children_lock:
-                children = list(self._active_children)
-                self._active_children.clear()
+                active_children = getattr(self, "_active_children", [])
+                children = [
+                    child for child in active_children
+                    if closed_sidekick is None or child is not closed_sidekick
+                ]
+                active_children.clear()
             for child in children:
                 try:
                     child.close()
@@ -5550,11 +5605,19 @@ class AIAgent:
         ``force=False``.
         """
         from agent.conversation_compression import compress_context
-        return compress_context(
+        compressed_messages, new_system_prompt = compress_context(
             self, messages, system_message,
             approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic,
             force=force,
         )
+        try:
+            from agent.conversation_loop import _apply_fusion_routing_verdict
+            if _apply_fusion_routing_verdict(self):
+                new_system_prompt = self._build_system_prompt(system_message)
+                self._cached_system_prompt = new_system_prompt
+        except Exception:
+            logger.debug("Fusion compaction routing skipped", exc_info=True)
+        return compressed_messages, new_system_prompt
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:
         """Record the first guardrail decision that should stop this turn."""
@@ -5639,13 +5702,15 @@ class AIAgent:
         #     gateway session the async result would route back to.
         # The schema-level `background` param is intentionally ignored here.
         _is_subagent = getattr(self, "_delegate_depth", 0) > 0
+        _sidekick_requested = is_truthy_value(function_args.get("sidekick"), default=False)
         return _delegate_task(
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
-            background=(not _is_subagent),
+            background=(not _is_subagent and not _sidekick_requested),
+            sidekick=_sidekick_requested,
             parent_agent=self,
         )
 

--- a/tests/agent/test_fusion_routing.py
+++ b/tests/agent/test_fusion_routing.py
@@ -1,0 +1,690 @@
+"""Behavior-contract tests for Fusion compaction-boundary routing.
+
+Fusion routes only at cache-invalidating context-compaction boundaries. The
+summarizer LLM supplies a structured Work Complexity verdict; the conversation
+loop consumes and clears it before optionally switching through the existing
+switch_model helper.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+from agent.system_prompt import build_system_prompt_parts
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+def _response(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _messages() -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "Implement the clear mechanical edit."},
+        {"role": "assistant", "content": "I will inspect the files."},
+        {"role": "user", "content": "Continue."},
+        {"role": "assistant", "content": "Ran tests and found lint failures."},
+        {"role": "user", "content": "Fix them."},
+    ]
+
+
+def _make_compressor(owner: Any, *, routing: bool) -> ContextCompressor:
+    with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+        compressor = ContextCompressor(
+            model="frontier-model",
+            provider="frontier-provider",
+            api_mode="chat_completions",
+            quiet_mode=True,
+        )
+    # Attributes are set here so the test remains about behavior, not a
+    # constructor shape. AIAgent.__init__ will populate these in production.
+    compressor._fusion_compaction_routing = routing
+    compressor._fusion_verdict_owner = owner
+    return compressor
+
+
+def _minimal_prompt_agent(*, fusion_enabled: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        _fusion_enabled=fusion_enabled,
+        load_soul_identity=False,
+        skip_context_files=True,
+        context_compressor=None,
+        valid_tool_names=["delegate_task"],
+        _task_completion_guidance=False,
+        _parallel_tool_call_guidance=False,
+        _tool_use_enforcement=False,
+        _kanban_worker_guidance=False,
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4",
+        platform="cli",
+        _platform_hint_overrides={},
+        _auto_platform_hint_appends={},
+        _environment_probe=False,
+        _memory_store=None,
+        _memory_manager=None,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+        pass_session_id=False,
+        session_id="session-1",
+    )
+
+
+def _routing_agent(verdict: str | None = "MECHANICAL", *, suspended: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        _fusion_enabled=True,
+        _fusion_compaction_routing=True,
+        _fusion_routing_suspended=suspended,
+        _fusion_routing_verdict=verdict,
+        _fusion_routing_runtime={
+            "model": "cheap-mechanical-model",
+            "provider": "openrouter",
+            "api_key": "«redacted:sk-…»",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+        _fusion_frontier_runtime={
+            "model": "frontier-model",
+            "provider": "openrouter",
+            "api_key": "sk-frontier",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        },
+        model="frontier-model",
+        provider="openrouter",
+        api_key="sk-frontier",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+        _emit_warning=lambda message: None,
+    )
+
+
+class _ModelConfigDB:
+    def __init__(self, model_config: dict[str, Any] | None = None) -> None:
+        self.model_config = model_config or {}
+        self.calls: list[tuple[str, str, str]] = []
+
+    def get_session(self, session_id: str) -> dict[str, str]:
+        return {"id": session_id, "model_config": json.dumps(self.model_config)}
+
+    def update_session_model_config_key(self, session_id: str, key: str, value_json: str) -> None:
+        self.calls.append((session_id, key, value_json))
+
+
+def test_default_config_declares_disabled_fusion_block():
+    """Part D/E4: default fusion config exists but is fully inert."""
+
+    fusion = DEFAULT_CONFIG.get("fusion")
+    assert isinstance(fusion, dict), "fusion must be a dict in DEFAULT_CONFIG"
+    assert fusion.get("enabled") is False, "fusion.enabled must default to False"
+    assert fusion.get("compaction_routing") is False, "fusion.compaction_routing must default to False"
+    required_keys = {
+        "enabled", "compaction_routing",
+        "sidekick_model", "sidekick_provider", "sidekick_base_url",
+        "sidekick_api_key", "sidekick_api_mode", "sidekick_toolsets",
+        "routing_model", "routing_provider", "routing_base_url",
+        "routing_api_key", "routing_api_mode",
+        "frontier_model",
+    }
+    assert required_keys.issubset(fusion.keys()), f"missing keys: {required_keys - set(fusion.keys())}"
+    for key in required_keys - {"enabled", "compaction_routing", "sidekick_toolsets"}:
+        assert not fusion[key], f"fusion.{key} must be falsy by default (empty string)"
+    assert fusion["sidekick_toolsets"] == [], "fusion.sidekick_toolsets must default to empty list"
+
+
+def test_fusion_main_agent_directive_is_stable_and_gated():
+    """Part B/E4: prompt directive appears only when fusion is enabled."""
+
+    patches = [
+        patch("run_agent.load_soul_md", return_value="IDENTITY"),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+        patch("run_agent.build_skills_system_prompt", return_value=""),
+        patch("run_agent.get_toolset_for_tool", return_value=None),
+        patch("agent.file_safety._resolve_active_profile_name", return_value="fusion-test"),
+    ]
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        enabled = build_system_prompt_parts(_minimal_prompt_agent(fusion_enabled=True))
+        disabled = build_system_prompt_parts(_minimal_prompt_agent(fusion_enabled=False))
+
+    assert "Fusion sidekick" in enabled["stable"]
+    assert "architect and reviewer" in enabled["stable"].lower()
+    assert "Fusion sidekick" not in enabled["context"]
+    assert "Fusion sidekick" not in enabled["volatile"]
+    assert "Fusion sidekick" not in disabled["stable"]
+
+
+def test_compaction_prompt_adds_work_complexity_section_and_records_verdict():
+    """C1/C2: routing verdict is piggybacked on the existing summary LLM call."""
+
+    owner = SimpleNamespace(_fusion_routing_verdict=None)
+    compressor = _make_compressor(owner, routing=True)
+    captured: dict[str, str] = {}
+
+    def fake_call_llm(**kwargs):
+        captured["prompt"] = kwargs["messages"][0]["content"]
+        return _response(
+            "## Active Task\nUser asked: fix lint\n\n"
+            "## Critical Context\nTests are failing.\n\n"
+            "## Work Complexity Assessment\nMECHANICAL"
+        )
+
+    with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+        compressor._generate_summary(_messages())
+
+    assert "## Work Complexity Assessment" in captured["prompt"]
+    assert "MECHANICAL" in captured["prompt"]
+    assert "FRONTIER_JUDGMENT" in captured["prompt"]
+    assert owner._fusion_routing_verdict == "MECHANICAL"
+    assert "## Work Complexity Assessment" not in (compressor._previous_summary or "")
+
+
+def test_fusion_verdict_section_is_stripped_without_eating_following_heading():
+    """The routing verdict is state, not durable summary content."""
+
+    owner = SimpleNamespace(_fusion_routing_verdict=None)
+    compressor = _make_compressor(owner, routing=True)
+    summary = (
+        "## Active Task\nUser asked for a mechanical cleanup.\n\n"
+        "## Work Complexity Assessment\nMECHANICAL\nOne short reason.\n\n"
+        "## Critical Context\nKeep the existing public API.\n\n"
+        "## Historical Remaining Work\nRun focused tests."
+    )
+
+    compressor._record_fusion_verdict(summary)
+    stripped = compressor._strip_fusion_verdict_section(summary)
+
+    assert owner._fusion_routing_verdict == "MECHANICAL"
+    assert "## Work Complexity Assessment" not in stripped
+    assert "One short reason" not in stripped
+    assert "## Active Task" in stripped
+    assert "## Critical Context" in stripped
+    assert "## Historical Remaining Work" in stripped
+
+
+def test_fusion_verdict_strip_is_noop_when_routing_disabled():
+    owner = SimpleNamespace(_fusion_routing_verdict=None)
+    compressor = _make_compressor(owner, routing=False)
+    summary = "## Work Complexity Assessment\nMECHANICAL\n\n## Active Task\nKeep this text."
+
+    assert compressor._strip_fusion_verdict_section(summary) == summary
+
+
+def test_compaction_prompt_omits_work_complexity_section_when_routing_disabled():
+    """E4/C5: disabled routing must not alter the summarizer prompt."""
+
+    owner = SimpleNamespace(_fusion_routing_verdict=None)
+    compressor = _make_compressor(owner, routing=False)
+    captured: dict[str, str] = {}
+
+    def fake_call_llm(**kwargs):
+        captured["prompt"] = kwargs["messages"][0]["content"]
+        return _response("## Active Task\nNone.\n\n## Critical Context\nNone.")
+
+    with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+        compressor._generate_summary(_messages())
+
+    assert "## Work Complexity Assessment" not in captured["prompt"]
+    assert owner._fusion_routing_verdict is None
+
+
+def test_apply_fusion_routing_switches_to_mechanical_target_and_clears_verdict(monkeypatch):
+    """C2/C3/E5: MECHANICAL verdict switches once, then cannot be reused stale."""
+
+    import agent.conversation_loop as conversation_loop
+
+    helper = getattr(conversation_loop, "_apply_fusion_routing_verdict", None)
+    assert callable(helper)
+
+    calls: list[tuple[str, str, str, str, str]] = []
+
+    def fake_switch(agent, new_model, new_provider, api_key="", base_url="", api_mode=""):
+        calls.append((new_model, new_provider, api_key, base_url, api_mode))
+        agent.model = new_model
+        agent.provider = new_provider
+        agent.api_key = api_key
+        agent.base_url = base_url
+        agent.api_mode = api_mode
+        return True
+
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", fake_switch)
+    agent = _routing_agent("MECHANICAL")
+
+    helper(agent)
+    helper(agent)
+
+    assert calls == [
+        (
+            "cheap-mechanical-model",
+            "openrouter",
+            "«redacted:sk-…»",
+            "https://openrouter.ai/api/v1",
+            "chat_completions",
+        )
+    ]
+    assert agent._fusion_routing_verdict is None
+
+
+def test_apply_fusion_routing_persists_post_switch_runtime_without_credentials(monkeypatch):
+    """Resumed sessions should restart on routed runtime, but never store keys."""
+
+    import agent.conversation_loop as conversation_loop
+
+    helper = getattr(conversation_loop, "_apply_fusion_routing_verdict", None)
+    assert callable(helper)
+
+    def fake_switch(agent, new_model, new_provider, api_key="", base_url="", api_mode=""):
+        agent.model = new_model
+        agent.provider = new_provider
+        agent.api_key = api_key
+        agent.base_url = base_url
+        agent.api_mode = api_mode
+        return True
+
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", fake_switch)
+    agent = _routing_agent("MECHANICAL")
+    agent.session_id = "routed-session"
+    agent._session_db = _ModelConfigDB({"_branched_from": "parent-session"})
+
+    assert helper(agent) is True
+
+    assert agent._session_db.calls
+    session_id, key, value_json = agent._session_db.calls[-1]
+    assert session_id == "routed-session"
+    assert key == "_fusion_routed_runtime"
+    payload = json.loads(value_json)
+    assert payload == {
+        "model": "cheap-mechanical-model",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+    }
+    assert "api_key" not in payload
+
+
+def test_session_model_config_key_update_preserves_existing_metadata(tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(
+            "session",
+            source="cli",
+            model="frontier-model",
+            model_config={"_branched_from": "parent-session"},
+        )
+        routed = {
+            "model": "cheap-model",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        }
+        db.update_session_model_config_key(
+            "session",
+            "_fusion_routed_runtime",
+            json.dumps(routed),
+        )
+
+        row = db.get_session("session")
+        assert row is not None
+        model_config = json.loads(row["model_config"])
+        assert model_config["_branched_from"] == "parent-session"
+        assert model_config["_fusion_routed_runtime"] == routed
+
+        db.update_session_model_config_key("session", "_fusion_routed_runtime", "null")
+        row = db.get_session("session")
+        assert row is not None
+        model_config = json.loads(row["model_config"])
+        assert model_config["_branched_from"] == "parent-session"
+        assert model_config["_fusion_routed_runtime"] is None
+    finally:
+        db.close()
+
+
+def test_apply_fusion_routing_switches_frontier_and_skips_when_already_on_target(monkeypatch):
+    """E5: FRONTIER_JUDGMENT restores the recorded frontier runtime, unless already there."""
+
+    import agent.conversation_loop as conversation_loop
+
+    helper = getattr(conversation_loop, "_apply_fusion_routing_verdict", None)
+    assert callable(helper)
+
+    calls: list[tuple[str, str, str, str, str]] = []
+
+    def fake_switch(agent, new_model, new_provider, api_key="", base_url="", api_mode=""):
+        calls.append((new_model, new_provider, api_key, base_url, api_mode))
+        agent.model = new_model
+        agent.provider = new_provider
+        agent.api_key = api_key
+        agent.base_url = base_url
+        agent.api_mode = api_mode
+        return True
+
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", fake_switch)
+    agent = _routing_agent("FRONTIER_JUDGMENT")
+    agent.model = "cheap-mechanical-model"
+
+    assert helper(agent) is True
+    assert calls == [
+        (
+            "frontier-model",
+            "openrouter",
+            "sk-frontier",
+            "https://openrouter.ai/api/v1",
+            "chat_completions",
+        )
+    ]
+    assert agent._fusion_routing_verdict is None
+
+    agent._fusion_routing_verdict = "FRONTIER_JUDGMENT"
+    assert helper(agent) is False
+    assert calls == [
+        (
+            "frontier-model",
+            "openrouter",
+            "sk-frontier",
+            "https://openrouter.ai/api/v1",
+            "chat_completions",
+        )
+    ]
+    assert agent._fusion_routing_verdict is None
+
+
+def test_apply_fusion_routing_ignores_malformed_or_missing_targets_and_clears(monkeypatch):
+    """E5: malformed/missing verdicts never switch and never leak stale state."""
+
+    import agent.conversation_loop as conversation_loop
+
+    helper = getattr(conversation_loop, "_apply_fusion_routing_verdict", None)
+    assert callable(helper)
+
+    calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", lambda *args, **kwargs: calls.append(args))
+
+    malformed = _routing_agent("NOT_A_VERDICT")
+    assert helper(malformed) is False
+    assert malformed._fusion_routing_verdict is None
+
+    missing_target = _routing_agent("MECHANICAL")
+    missing_target._fusion_routing_runtime = {"model": ""}
+    assert helper(missing_target) is False
+    assert missing_target._fusion_routing_verdict is None
+
+    absent = _routing_agent(None)
+    assert helper(absent) is False
+    assert absent._fusion_routing_verdict is None
+    assert calls == []
+
+
+def test_apply_fusion_routing_skips_cross_provider_route_without_explicit_key_or_endpoint(monkeypatch):
+    """Provider safety: cross-provider cheap routes must not inherit frontier credentials/endpoints."""
+
+    import agent.conversation_loop as conversation_loop
+
+    helper = getattr(conversation_loop, "_apply_fusion_routing_verdict", None)
+    assert callable(helper)
+
+    calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", lambda *args, **kwargs: calls.append(args))
+
+    for runtime in (
+        {
+            "model": "cheap-model",
+            "provider": "cheap-provider",
+            "base_url": "https://cheap.example/v1",
+            "api_key": "",
+            "api_mode": "chat_completions",
+        },
+        {
+            "model": "cheap-model",
+            "provider": "cheap-provider",
+            "base_url": "",
+            "api_key": "sk-cheap",
+            "api_mode": "chat_completions",
+        },
+    ):
+        agent = _routing_agent("MECHANICAL")
+        agent.provider = "frontier-provider"
+        agent._fusion_routing_runtime = runtime
+
+        assert helper(agent) is False
+        assert agent._fusion_routing_verdict is None
+
+    assert calls == []
+
+
+def test_fusion_routing_runtime_uses_explicit_routing_provider_before_sidekick_provider():
+    """Provider ambiguity fix: routing credentials are explicit, then sidekick, then parent."""
+
+    from agent.agent_init import _build_fusion_routing_runtime
+
+    agent = SimpleNamespace(
+        model="frontier-model",
+        provider="frontier-provider",
+        base_url="https://frontier.example/v1",
+        api_key="sk-frontier",
+        api_mode="chat_completions",
+    )
+
+    runtime = _build_fusion_routing_runtime(
+        agent,
+        {
+            "routing_model": "cheap-model",
+            "routing_provider": "cheap-provider",
+            "routing_base_url": "https://cheap.example/v1",
+            "routing_api_key": "sk-cheap",
+            "routing_api_mode": "responses",
+            "sidekick_model": "sidekick-model",
+            "sidekick_provider": "sidekick-provider",
+            "sidekick_base_url": "https://sidekick.example/v1",
+            "sidekick_api_key": "sk-sidekick",
+            "sidekick_api_mode": "chat_completions",
+        },
+    )
+
+    assert runtime == {
+        "model": "cheap-model",
+        "provider": "cheap-provider",
+        "base_url": "https://cheap.example/v1",
+        "api_key": "sk-cheap",
+        "api_mode": "responses",
+    }
+
+    fallback = _build_fusion_routing_runtime(
+        agent,
+        {
+            "routing_model": "cheap-model",
+            "sidekick_provider": "sidekick-provider",
+            "sidekick_base_url": "https://sidekick.example/v1",
+            "sidekick_api_key": "sk-sidekick",
+            "sidekick_api_mode": "chat_completions",
+        },
+    )
+    assert fallback["provider"] == "sidekick-provider"
+    assert fallback["base_url"] == "https://sidekick.example/v1"
+    assert fallback["api_key"] == "sk-sidekick"
+    assert fallback["api_mode"] == "chat_completions"
+
+
+def test_resume_restores_persisted_fusion_route_with_live_credentials(monkeypatch):
+    """Resume uses the stored route shape but re-resolves credentials live."""
+
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    routed = {
+        "model": "cheap-model",
+        "provider": "openrouter",
+        "base_url": "https://stored.example/v1",
+        "api_mode": "stored-mode",
+    }
+    agent = SimpleNamespace(
+        _fusion_enabled=True,
+        _fusion_compaction_routing=True,
+        model="frontier-model",
+        provider="openrouter",
+        base_url="https://frontier.example/v1",
+        api_mode="chat_completions",
+    )
+
+    class _FakeCLI(CLICommandsMixin):
+        pass
+
+    cli = _FakeCLI()
+    cli.agent = agent
+    cli._session_db = _ModelConfigDB({"_fusion_routed_runtime": routed})
+    calls: list[dict[str, str]] = []
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "sk-live",
+            "base_url": "https://live-openrouter.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    def fake_switch(agent_arg, new_model, new_provider, api_key="", base_url="", api_mode=""):
+        calls.append(
+            {
+                "model": new_model,
+                "provider": new_provider,
+                "api_key": api_key,
+                "base_url": base_url,
+                "api_mode": api_mode,
+            }
+        )
+        return True
+
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", fake_switch)
+
+    assert CLICommandsMixin._restore_fusion_routed_runtime_for_session(cli, "resume-session") is True
+    assert calls == [
+        {
+            "model": "cheap-model",
+            "provider": "openrouter",
+            "api_key": "sk-live",
+            "base_url": "https://live-openrouter.example/v1",
+            "api_mode": "chat_completions",
+        }
+    ]
+
+
+def test_resume_without_persisted_fusion_route_does_not_switch(monkeypatch):
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    agent = SimpleNamespace(
+        _fusion_enabled=True,
+        _fusion_compaction_routing=True,
+        model="frontier-model",
+        provider="openrouter",
+    )
+
+    class _FakeCLI(CLICommandsMixin):
+        pass
+
+    cli = _FakeCLI()
+    cli.agent = agent
+    cli._session_db = _ModelConfigDB({"_branched_from": "parent"})
+    monkeypatch.setattr(
+        "agent.agent_runtime_helpers.switch_model",
+        lambda *args, **kwargs: pytest.fail("no persisted route should not switch"),
+    )
+
+    assert CLICommandsMixin._restore_fusion_routed_runtime_for_session(cli, "resume-session") is False
+
+
+def test_apply_fusion_routing_suspended_by_user_override(monkeypatch):
+    """C4/E8: user model choice wins; compaction verdicts are cleared but ignored."""
+
+    import agent.conversation_loop as conversation_loop
+
+    helper = getattr(conversation_loop, "_apply_fusion_routing_verdict", None)
+    assert callable(helper)
+
+    calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", lambda *args, **kwargs: calls.append(args))
+    agent = _routing_agent("MECHANICAL", suspended=True)
+
+    helper(agent)
+
+    assert calls == []
+    assert agent._fusion_routing_verdict is None
+
+
+def test_user_facing_switch_model_suspends_future_fusion_routing(monkeypatch):
+    """C4/E8: manual /model path sets a session-long fusion-routing suspension marker."""
+
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent._fusion_routing_suspended = False
+    agent.session_id = "manual-session"
+    agent._session_db = _ModelConfigDB({"_fusion_routed_runtime": {"model": "cheap"}})
+
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", lambda *args, **kwargs: True)
+
+    assert AIAgent.switch_model(agent, "manual-model", "openrouter") is True
+    assert agent._fusion_routing_suspended is True
+    assert agent._session_db.calls == [
+        ("manual-session", "_fusion_routed_runtime", "null")
+    ]
+
+
+def test_user_facing_switch_model_keeps_persisted_route_when_switch_fails(monkeypatch):
+    """A failed manual override should not erase the still-active Fusion route."""
+
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent._fusion_routing_suspended = False
+    agent.session_id = "manual-session"
+    agent._session_db = _ModelConfigDB({"_fusion_routed_runtime": {"model": "cheap"}})
+
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", lambda *args, **kwargs: False)
+
+    assert AIAgent.switch_model(agent, "manual-model", "openrouter") is False
+    assert agent._fusion_routing_suspended is True
+    assert agent._session_db.calls == []
+
+
+def test_suspended_routing_keeps_system_prompt_stable_between_compactions(monkeypatch):
+    """E8/C5: a suspended verdict does not rebuild prompt bytes between compactions."""
+
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    setattr(agent, "_fusion_enabled", True)
+    setattr(agent, "_fusion_compaction_routing", True)
+    setattr(agent, "_fusion_routing_suspended", True)
+    setattr(agent, "_fusion_routing_verdict", "MECHANICAL")
+    setattr(agent, "_cached_system_prompt", "stable prompt")
+    setattr(agent, "_build_system_prompt", lambda system_message=None: "rebuilt prompt")
+
+    monkeypatch.setattr(
+        "agent.conversation_compression.compress_context",
+        lambda *args, **kwargs: ([{"role": "system", "content": "stable prompt"}], "stable prompt"),
+    )
+    monkeypatch.setattr(
+        "agent.agent_runtime_helpers.switch_model",
+        lambda *args, **kwargs: pytest.fail("suspended path must not switch"),
+    )
+
+    compressed, prompt = AIAgent._compress_context(
+        agent,
+        [{"role": "user", "content": "hello"}],
+        "stable prompt",
+    )
+
+    assert compressed == [{"role": "system", "content": "stable prompt"}]
+    assert prompt == "stable prompt"
+    assert getattr(agent, "_cached_system_prompt") == "stable prompt"
+    assert getattr(agent, "_fusion_routing_verdict") is None

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -52,9 +52,11 @@ class _FakeAgent:
         self.session_cost_status = "estimated"
         self.session_cost_source = "openrouter"
         self.context_compressor = _FakeCompressor()
+        self.last_reset_old_session_id = None
 
-    def reset_session_state(self):
+    def reset_session_state(self, old_session_id=None):
         """Mirror the real AIAgent.reset_session_state()."""
+        self.last_reset_old_session_id = old_session_id
         self.session_total_tokens = 0
         self.session_input_tokens = 0
         self.session_output_tokens = 0
@@ -168,6 +170,7 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     cli._session_db.append_message(cli.session_id, role="user", content="next turn")
 
     assert cli.agent.session_id == cli.session_id
+    assert cli.agent.last_reset_old_session_id == old_session_id
     assert cli.agent._last_flushed_db_idx == 0
     assert cli.agent._todo_store.read() == []
     assert cli.session_start > old_session_start

--- a/tests/tools/test_fusion_sidekick.py
+++ b/tests/tools/test_fusion_sidekick.py
@@ -1,0 +1,714 @@
+"""Behavior-contract tests for Fusion persistent sidekick delegation.
+
+These are intentionally black-box around delegate_task and existing child-agent
+construction helpers. They encode the v1 contracts:
+`fusion.enabled: false` must be behavior-invisible, and `sidekick=true` must
+reuse one persistent child per parent session without per-call teardown.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import threading
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import tools.delegate_tool as delegate_tool
+
+
+def _delegation_config() -> dict[str, Any]:
+    return {
+        "max_iterations": 3,
+        "max_concurrent_children": 3,
+        "max_spawn_depth": 1,
+    }
+
+
+def _full_config(*, fusion_enabled: bool = True) -> dict[str, Any]:
+    return {
+        "delegation": _delegation_config(),
+        "fusion": {
+            "enabled": fusion_enabled,
+            "sidekick_model": "openai/gpt-4.1-mini",
+            "sidekick_provider": "openrouter",
+            "sidekick_base_url": "https://openrouter.ai/api/v1",
+            "sidekick_api_key": "«redacted:sk-…»",
+            "sidekick_api_mode": "chat_completions",
+            "sidekick_toolsets": ["terminal", "file"],
+            "compaction_routing": False,
+            "routing_model": "",
+            "routing_provider": "",
+            "routing_base_url": "",
+            "routing_api_key": "",
+            "routing_api_mode": "",
+            "frontier_model": "",
+        },
+    }
+
+
+def _make_parent(session_id: str = "parent-session") -> MagicMock:
+    parent = MagicMock()
+    parent.session_id = session_id
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "«redacted:sk-…»"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-sonnet-4"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent.openrouter_min_coding_score = None
+    parent.enabled_toolsets = ["terminal", "file", "delegation"]
+    parent.valid_tool_names = []
+    parent._session_db = None
+    parent._delegate_depth = 0
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._current_task_id = "parent-task"
+    parent._current_turn_id = "turn-1"
+    return parent
+
+
+class FakeSidekick:
+    """Small child-agent double that behaves like one persistent sidekick."""
+
+    def __init__(self) -> None:
+        self.session_id = "sidekick-session"
+        self.model = "openai/gpt-4.1-mini"
+        self.provider = "openrouter"
+        self.tool_progress_callback = None
+        self._credential_pool = None
+        self._delegate_role = "leaf"
+        self._delegate_depth = 1
+        self._subagent_id = "sidekick-subagent"
+        self._parent_subagent_id = None
+        self._delegate_saved_tool_names = []
+        self._is_persistent_sidekick = True
+        self._use_prompt_caching = True
+        self._cached_system_prompt = "stable-sidekick-prompt"
+        self.enabled_toolsets = ["terminal", "file"]
+        self.conversation_history: list[dict[str, str]] = []
+        self.run_inputs: list[str] = []
+        self.closed = False
+        self.close_count = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+
+    def run_conversation(self, user_message=None, task_id=None, stream_callback=None):
+        goal_text = str(user_message)
+        self.run_inputs.append(goal_text)
+        self.conversation_history.extend(
+            [
+                {"role": "user", "content": goal_text},
+                {"role": "assistant", "content": f"done: {goal_text}"},
+            ]
+        )
+        return {
+            "final_response": f"done: {goal_text}",
+            "completed": True,
+            "api_calls": 1,
+            "messages": list(self.conversation_history),
+        }
+
+    def get_activity_summary(self) -> dict[str, Any]:
+        return {"current_tool": None, "api_call_count": len(self.run_inputs), "max_iterations": 3}
+
+    def close(self) -> None:
+        self.close_count += 1
+        self.closed = True
+
+
+def _decode_tool_result(raw: str) -> dict[str, Any]:
+    return json.loads(raw)
+
+
+@pytest.fixture(autouse=True)
+def clear_sidekick_registries():
+    for name in ("_sidekick_agents", "_sidekick_locks"):
+        registry = getattr(delegate_tool, name, None)
+        if isinstance(registry, dict):
+            registry.clear()
+    yield
+    for name in ("_sidekick_agents", "_sidekick_locks"):
+        registry = getattr(delegate_tool, name, None)
+        if isinstance(registry, dict):
+            registry.clear()
+
+
+def test_sidekick_schema_is_advertised_only_when_fusion_enabled():
+    """E4: disabled means invisible; enabled exposes the single new parameter."""
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+    ):
+        enabled_schema = delegate_tool._build_dynamic_schema_overrides()
+
+    props = enabled_schema["parameters"]["properties"]
+    assert "sidekick" in props
+    assert props["sidekick"]["type"] == "boolean"
+    assert "persistent sidekick" in props["sidekick"]["description"].lower()
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=False)),
+    ):
+        disabled_schema = delegate_tool._build_dynamic_schema_overrides()
+
+    assert "sidekick" not in disabled_schema["parameters"]["properties"]
+    assert "sidekick" not in delegate_tool.DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+
+
+def test_delegate_task_accepts_sidekick_keyword():
+    """A1: sidekick is a runtime argument, not a separate core tool."""
+
+    assert "sidekick" in inspect.signature(delegate_tool.delegate_task).parameters
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_error"),
+    [
+        ({"tasks": [{"goal": "one"}], "sidekick": True}, "sidekick accepts a single goal"),
+        ({"goal": "one", "sidekick": True, "background": True}, "sidekick runs synchronously in v1"),
+        ({"goal": "one", "sidekick": True, "role": "orchestrator"}, "sidekick is a leaf"),
+    ],
+)
+def test_sidekick_validation_errors_are_tool_results(kwargs: dict[str, Any], expected_error: str):
+    """E7: invalid v1 combinations return clear tool-result errors, not exceptions."""
+
+    parent = _make_parent()
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+    ):
+        result = _decode_tool_result(delegate_tool.delegate_task(parent_agent=parent, **kwargs))
+
+    assert expected_error in result.get("error", "")
+
+
+def test_delegate_dispatch_treats_string_false_sidekick_as_false(monkeypatch):
+    """Tool-arg defensive parsing: provider string 'false' must not force sync sidekick mode."""
+
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    setattr(agent, "_delegate_depth", 0)
+    captured: dict[str, Any] = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"ok": True})
+
+    monkeypatch.setattr("tools.delegate_tool.delegate_task", fake_delegate_task)
+
+    result = AIAgent._dispatch_delegate_task(agent, {"goal": "normal child", "sidekick": "false"})
+
+    assert _decode_tool_result(result) == {"ok": True}
+    assert captured["sidekick"] is False
+    assert captured["background"] is True
+
+
+def test_sidekick_reuses_one_child_keeps_history_and_skips_per_call_close():
+    """E1/E2/E3: sequential sidekick calls share identity, prompt/tools, and resources."""
+
+    parent = _make_parent()
+    child = FakeSidekick()
+
+    def build_child(*args, **kwargs):
+        parent._active_children.append(child)
+        return child
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+        patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={"provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None},
+        ),
+        patch("tools.delegate_tool._build_child_agent", side_effect=build_child) as build_mock,
+    ):
+        first = _decode_tool_result(delegate_tool.delegate_task(goal="inspect failing tests", sidekick=True, parent_agent=parent))
+        prompt_hash = hash(child._cached_system_prompt)
+        toolsets = tuple(child.enabled_toolsets)
+        second = _decode_tool_result(delegate_tool.delegate_task(goal="apply lint fix", sidekick=True, parent_agent=parent))
+
+    assert first["results"][0]["status"] == "completed"
+    assert second["results"][0]["status"] == "completed"
+    assert build_mock.call_count == 1
+    assert child.run_inputs == ["inspect failing tests", "apply lint fix"]
+    assert len(child.conversation_history) == 4
+    assert hash(child._cached_system_prompt) == prompt_hash
+    assert tuple(child.enabled_toolsets) == toolsets
+    assert child.closed is False
+    assert child.close_count == 0
+    assert child in parent._active_children
+
+
+def test_sidekick_context_is_folded_into_each_call_goal_not_persistent_prompt():
+    """Per-call context must reach the sidekick via the user message on every
+    delegation, and must NOT be baked into the persistent system prompt (which
+    would pin the first call's context for the whole session)."""
+
+    parent = _make_parent()
+    child = FakeSidekick()
+    captured_kwargs: dict[str, Any] = {}
+
+    def build_child(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        parent._active_children.append(child)
+        return child
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+        patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={"provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None},
+        ),
+        patch("tools.delegate_tool._build_child_agent", side_effect=build_child),
+    ):
+        delegate_tool.delegate_task(
+            goal="fix the failing test",
+            context="tests/test_foo.py::test_bar fails with KeyError",
+            sidekick=True,
+            parent_agent=parent,
+        )
+        delegate_tool.delegate_task(
+            goal="run lint",
+            context="use ruff, config in pyproject.toml",
+            sidekick=True,
+            parent_agent=parent,
+        )
+
+    assert child.run_inputs[0].startswith("fix the failing test")
+    assert "KeyError" in child.run_inputs[0]
+    assert child.run_inputs[1].startswith("run lint")
+    assert "pyproject.toml" in child.run_inputs[1]
+    # Persistent system prompt was built without per-call context.
+    assert captured_kwargs.get("context") is None
+
+
+def test_sidekick_busy_lock_returns_status_without_second_run():
+    """E6: non-blocking lock prevents concurrent mutation of shared sidekick history."""
+
+    parent = _make_parent()
+    child = FakeSidekick()
+
+    def build_child(*args, **kwargs):
+        parent._active_children.append(child)
+        return child
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+        patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={"provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None},
+        ),
+        patch("tools.delegate_tool._build_child_agent", side_effect=build_child),
+    ):
+        _decode_tool_result(delegate_tool.delegate_task(goal="first", sidekick=True, parent_agent=parent))
+        lock = delegate_tool._sidekick_locks[parent.session_id]
+        assert lock.acquire(blocking=False) is True
+        try:
+            busy = _decode_tool_result(delegate_tool.delegate_task(goal="second", sidekick=True, parent_agent=parent))
+        finally:
+            lock.release()
+
+    assert busy["status"] == "sidekick_busy"
+    assert "working on another task" in busy["summary"]
+    assert child.run_inputs == ["first"]
+
+
+def test_sidekick_lock_released_when_child_build_raises():
+    """A failed sidekick build must not leave the per-session lock held —
+    otherwise every later sidekick call is a permanent 'sidekick_busy'."""
+
+    parent = _make_parent()
+    child = FakeSidekick()
+    build_attempts = {"n": 0}
+
+    def build_child(*args, **kwargs):
+        build_attempts["n"] += 1
+        if build_attempts["n"] == 1:
+            raise RuntimeError("transient build failure")
+        parent._active_children.append(child)
+        return child
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+        patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={"provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None},
+        ),
+        patch("tools.delegate_tool._build_child_agent", side_effect=build_child),
+    ):
+        with pytest.raises(RuntimeError, match="transient build failure"):
+            delegate_tool.delegate_task(goal="first", sidekick=True, parent_agent=parent)
+        # The lock must be free again: the retry runs instead of 'sidekick_busy'.
+        retry = _decode_tool_result(
+            delegate_tool.delegate_task(goal="retry", sidekick=True, parent_agent=parent)
+        )
+
+    assert retry["results"][0]["status"] == "completed"
+    assert child.run_inputs == ["retry"]
+
+
+def test_close_sidekick_for_session_closes_child_and_clears_registries():
+    """A4/E3: parent close tears down its persistent sidekick exactly once."""
+
+    parent = _make_parent()
+    child = FakeSidekick()
+
+    def build_child(*args, **kwargs):
+        parent._active_children.append(child)
+        return child
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+        patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={"provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None},
+        ),
+        patch("tools.delegate_tool._build_child_agent", side_effect=build_child),
+    ):
+        _decode_tool_result(delegate_tool.delegate_task(goal="first", sidekick=True, parent_agent=parent))
+        closed_child = delegate_tool.close_sidekick_for_session(parent.session_id)
+
+    assert closed_child is child
+    assert child.closed is True
+    assert child.close_count == 1
+    assert parent.session_id not in delegate_tool._sidekick_agents
+    assert parent.session_id not in delegate_tool._sidekick_locks
+
+
+def test_reset_session_state_closes_old_sidekick_and_resets_fusion_state():
+    """Session rotation must not orphan old sidekicks or leak routing state."""
+
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent.session_id = "new-session"
+    agent.context_compressor = None
+    agent._fusion_routing_suspended = True
+    agent._fusion_routing_verdict = "MECHANICAL"
+    transitions: list[dict[str, Any]] = []
+    agent._transition_context_engine_session = lambda **kwargs: transitions.append(kwargs)
+
+    child = FakeSidekick()
+    delegate_tool._sidekick_agents["old-session"] = child
+    delegate_tool._sidekick_locks["old-session"] = threading.Lock()
+
+    AIAgent.reset_session_state(agent, old_session_id="old-session")
+
+    assert child.closed is True
+    assert child.close_count == 1
+    assert "old-session" not in delegate_tool._sidekick_agents
+    assert "old-session" not in delegate_tool._sidekick_locks
+    assert agent._fusion_routing_verdict is None
+    assert agent._fusion_routing_suspended is False
+    assert transitions and transitions[-1]["old_session_id"] == "old-session"
+    assert transitions[-1]["new_session_id"] == "new-session"
+
+
+def test_agent_close_does_not_double_close_registered_sidekick(monkeypatch):
+    """E3: integrated AIAgent.close path closes the registered sidekick exactly once."""
+
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    setattr(agent, "session_id", "parent-session")
+    setattr(agent, "_active_children_lock", threading.Lock())
+    child = FakeSidekick()
+    setattr(agent, "_active_children", [child])
+    agent.client = None
+    setattr(agent, "_session_db", None)
+    setattr(agent, "_end_session_on_close", False)
+    setattr(agent, "_session_messages", [{"role": "user", "content": "hi"}])
+
+    delegate_tool._sidekick_agents[getattr(agent, "session_id")] = child
+    delegate_tool._sidekick_locks[getattr(agent, "session_id")] = threading.Lock()
+
+    monkeypatch.setattr("run_agent.cleanup_vm", lambda *args, **kwargs: None)
+    monkeypatch.setattr("run_agent.cleanup_browser", lambda *args, **kwargs: None)
+    monkeypatch.setattr("tools.process_registry.process_registry.kill_all", lambda *args, **kwargs: None)
+
+    AIAgent.close(agent)
+
+    assert child.closed is True
+    assert child.close_count == 1
+    assert getattr(agent, "_active_children") == []
+    assert delegate_tool._sidekick_agents == {}
+    assert delegate_tool._sidekick_locks == {}
+
+
+def test_sidekick_restart_lazy_rebuilds_after_module_registries_are_cleared():
+    """E9: process/module-dict reset loses old sidekick and next call builds a fresh one."""
+
+    parent = _make_parent()
+    first_child = FakeSidekick()
+    second_child = FakeSidekick()
+    second_child.session_id = "sidekick-session-2"
+    built_children = [first_child, second_child]
+
+    def build_child(*args, **kwargs):
+        child = built_children.pop(0)
+        parent._active_children.append(child)
+        return child
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+        patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={"provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None},
+        ),
+        patch("tools.delegate_tool._build_child_agent", side_effect=build_child) as build_mock,
+    ):
+        first = _decode_tool_result(delegate_tool.delegate_task(goal="first", sidekick=True, parent_agent=parent))
+        delegate_tool._sidekick_agents.clear()
+        delegate_tool._sidekick_locks.clear()
+        second = _decode_tool_result(delegate_tool.delegate_task(goal="second", sidekick=True, parent_agent=parent))
+
+    assert first["results"][0]["status"] == "completed"
+    assert second["results"][0]["status"] == "completed"
+    assert build_mock.call_count == 2
+    assert first_child.run_inputs == ["first"]
+    assert second_child.run_inputs == ["second"]
+    assert delegate_tool._sidekick_agents[parent.session_id] is second_child
+
+
+def test_sidekick_session_rows_cascade_delete_with_parent(tmp_path):
+    """E3b: delegate session rows marked with _delegate_from delete with the parent."""
+
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="cli", model="frontier-model")
+        db.create_session(
+            "sidekick",
+            source="subagent",
+            model="sidekick-model",
+            parent_session_id="parent",
+            model_config={"_delegate_from": "parent"},
+        )
+        db.append_message("sidekick", role="assistant", content="sidekick summary")
+
+        assert db.delete_session("parent") is True
+        assert db.get_session("parent") is None
+        assert db.get_session("sidekick") is None
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Upstream-readiness caveats
+# ---------------------------------------------------------------------------
+
+class _LongResponseSidekick:
+    """FakeSidekick variant that produces an over-budget final_response so the
+    summary budget path is exercised end-to-end through delegate_task."""
+
+    def __init__(self, long_text: str) -> None:
+        self.session_id = "sidekick-long"
+        self.model = "openai/gpt-4.1-mini"
+        self.provider = "openrouter"
+        self.tool_progress_callback = None
+        self._credential_pool = None
+        self._delegate_role = "leaf"
+        self._delegate_depth = 1
+        self._subagent_id = "sidekick-long-id"
+        self._parent_subagent_id = None
+        self._delegate_saved_tool_names = []
+        self._is_persistent_sidekick = True
+        self.enabled_toolsets = ["terminal", "file"]
+        self.run_inputs = []
+        self.closed = False
+        self.close_count = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self._long_text = long_text
+
+    def run_conversation(self, user_message=None, task_id=None, stream_callback=None):
+        goal_text = str(user_message)
+        self.run_inputs.append(goal_text)
+        return {
+            "final_response": self._long_text,
+            "completed": True,
+            "api_calls": 1,
+            "messages": [
+                {"role": "user", "content": goal_text},
+                {"role": "assistant", "content": self._long_text},
+            ],
+        }
+
+    def get_activity_summary(self):
+        return {"current_tool": None, "api_call_count": len(self.run_inputs), "max_iterations": 3}
+
+    def close(self):
+        self.close_count += 1
+        self.closed = True
+
+
+def test_sidekick_summary_budget_applied_in_real_delegate_path(tmp_path, monkeypatch):
+    """Caveat #1: persistent sidekick results must flow through
+    _apply_summary_budget on the actual delegate_task(sidekick=True) path.
+
+    The FakeSidekick produces a long final_response; delegation.max_summary_chars
+    is patched small enough to trigger trimming. HERMES_HOME is isolated to the
+    tmp_path so the spill file lands in the temp delegation cache.
+    """
+    parent = _make_parent()
+    head_marker = "UNIQUE_HEAD_MARKER_LINE_1\n"
+    tail_marker = "\nUNIQUE_TAIL_MARKER_LINE_END"
+    long_text = head_marker + ("Y" * 50_000) + tail_marker
+
+    child = _LongResponseSidekick(long_text)
+
+    def build_child(*args, **kwargs):
+        parent._active_children.append(child)
+        return child
+
+    fake_home = tmp_path / "hermes_home_budget"
+    fake_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(fake_home))
+
+    deleg_cfg = _delegation_config()
+    deleg_cfg["max_summary_chars"] = 2000
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=deleg_cfg),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+        patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={"provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None},
+        ),
+        patch("tools.delegate_tool._build_child_agent", side_effect=build_child),
+    ):
+        result = _decode_tool_result(
+            delegate_tool.delegate_task(goal="summarize the huge file", sidekick=True, parent_agent=parent)
+        )
+
+    entry = result["results"][0]
+    assert entry["status"] == "completed"
+    # The summary was trimmed (budget applied), not passed through verbatim.
+    assert entry.get("summary_truncated") is True
+    assert "summary_full_path" in entry
+    spill_path = entry["summary_full_path"]
+    assert os.path.exists(spill_path)
+    assert os.path.join("cache", "delegation") in spill_path
+    # Spill file holds the full original final_response — nothing is lost.
+    with open(spill_path, encoding="utf-8") as fh:
+        assert fh.read() == long_text
+    # Head + tail + footer markers all survive in the in-context summary.
+    assert "UNIQUE_HEAD_MARKER_LINE_1" in entry["summary"]
+    assert "UNIQUE_TAIL_MARKER_LINE_END" in entry["summary"]
+    assert "[SUMMARY TRUNCATED]" in entry["summary"]
+    assert "read_file" in entry["summary"]
+    assert "offset=" in entry["summary"]
+
+
+def test_sidekick_construction_uses_standard_child_path_with_compression():
+    """Caveat #2: persistent sidekick construction goes through the standard
+    _build_child_agent path (persistent_sidekick=True) and the cached child
+    retains compression_enabled=True + a context_compressor object, proving
+    Fusion does not bypass self-compression wiring.
+    """
+
+    class _ChildWithCompression(FakeSidekick):
+        """Persistent child double carrying the standard AIAgent compression contract."""
+
+        compression_enabled = True
+
+        def __init__(self):
+            super().__init__()
+            self.context_compressor = SimpleNamespace(context_length=200_000, max_tokens=8_000)
+            self.session_id = "sidekick-compression"
+            self._is_persistent_sidekick = True
+
+    parent = _make_parent()
+    child = _ChildWithCompression()
+
+    captured_kwargs = {}
+
+    def build_child(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        parent._active_children.append(child)
+        return child
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+        patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={"provider": None, "base_url": None, "api_key": None, "api_mode": None, "model": None},
+        ),
+        patch("tools.delegate_tool._build_child_agent", side_effect=build_child),
+    ):
+        first = _decode_tool_result(
+            delegate_tool.delegate_task(goal="first sidekick task", sidekick=True, parent_agent=parent)
+        )
+        # Second call reuses the cached child (proves retention across calls).
+        second = _decode_tool_result(
+            delegate_tool.delegate_task(goal="second sidekick task", sidekick=True, parent_agent=parent)
+        )
+
+    assert first["results"][0]["status"] == "completed"
+    assert second["results"][0]["status"] == "completed"
+    # The standard child-construction path was used with the sidekick flag.
+    assert captured_kwargs.get("persistent_sidekick") is True
+    # The cached child retains the standard compression wiring.
+    cached = delegate_tool._sidekick_agents[parent.session_id]
+    assert cached is child
+    assert getattr(cached, "compression_enabled", None) is True
+    assert getattr(cached, "context_compressor", None) is not None
+
+
+def test_fusion_enabled_schema_description_notes_sidekick_sync_exception():
+    """Caveat #3: when Fusion is enabled, the delegate schema top-level
+    description must not unconditionally claim BOTH modes run in the background
+    without noting the sidekick=true synchronous exception.
+
+    This test would have failed before the wording fix because the old
+    description stated 'BOTH MODES RUN IN THE BACKGROUND' with no sidekick
+    caveat.
+    """
+
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=True)),
+    ):
+        enabled_schema = delegate_tool._build_dynamic_schema_overrides()
+
+    desc = enabled_schema["description"]
+    # The synchronous sidekick exception is surfaced to the model.
+    assert "sidekick" in desc.lower()
+    assert "synchronous" in desc.lower() or "synchronously" in desc.lower()
+
+    # Disabled Fusion must NOT carry the sidekick exception note (and must not
+    # contain 'sidekick' at all in the top-level description).
+    with (
+        patch("tools.delegate_tool._load_config", return_value=_delegation_config()),
+        patch("hermes_cli.config.load_config", return_value=_full_config(fusion_enabled=False)),
+    ):
+        disabled_schema = delegate_tool._build_dynamic_schema_overrides()
+
+    disabled_desc = disabled_schema["description"]
+    assert "sidekick" not in disabled_desc.lower()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -16,6 +16,7 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import atexit
 import enum
 import json
 import logging
@@ -147,6 +148,23 @@ _active_subagents_lock = threading.Lock()
 # subagent_id -> mutable record tracking the live child agent.  Stays only
 # for the lifetime of the run; _run_single_child is the owner.
 _active_subagents: Dict[str, Dict[str, Any]] = {}
+
+# Fusion persistent sidekick registry. One sidekick child is kept alive
+# per parent session so its conversation and provider-side prompt cache persist
+# across delegate_task(sidekick=True) calls. Dict mutation is protected by the
+# module lock; each sidekick has its own run lock to serialize history writes.
+_sidekick_registry_lock = threading.Lock()
+_sidekick_agents: Dict[str, Any] = {}
+_sidekick_locks: Dict[str, threading.Lock] = {}
+
+
+def _sidekick_session_key(parent_agent) -> str:
+    session_id = getattr(parent_agent, "session_id", None)
+    if session_id:
+        return str(session_id)
+    # AIAgent normally always has session_id. This fallback keeps direct unit
+    # callers from sharing a global sidekick by accident.
+    return f"agent:{id(parent_agent)}"
 
 
 def set_spawn_paused(paused: bool) -> bool:
@@ -666,6 +684,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    persistent_sidekick: bool = False,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -675,11 +694,21 @@ def _build_child_system_prompt(
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
     """
-    parts = [
-        "You are a focused subagent working on a specific delegated task.",
-        "",
-        f"YOUR TASK:\n{goal}",
-    ]
+    if persistent_sidekick:
+        parts = [
+            "You are the persistent Fusion sidekick for the main Hermes agent.",
+            "",
+            "YOUR ROLE:\n"
+            "Execute delegated work across this parent session. New tasks arrive "
+            "as user messages; your conversation context persists across those "
+            "delegations, so reference prior work instead of rediscovering it.",
+        ]
+    else:
+        parts = [
+            "You are a focused subagent working on a specific delegated task.",
+            "",
+            f"YOUR TASK:\n{goal}",
+        ]
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -702,6 +731,20 @@ def _build_child_system_prompt(
         "response is returned to the parent agent as a summary, and overlong "
         "summaries crowd out the parent's context window."
     )
+    if persistent_sidekick:
+        parts.append(
+            "\n## Fusion Sidekick Instructions\n"
+            "- Be the execution worker for the main agent: explore code, run "
+            "commands, write code/tests/lint fixes, and apply specific edit "
+            "requests.\n"
+            "- Return only relevant snippets, paths, commands, and verification "
+            "results; do not dump whole files unless asked.\n"
+            "- Surface architectural choices, ambiguity, risk, or judgment calls "
+            "back to the main agent instead of deciding them unilaterally.\n"
+            "- Your context persists across delegations. Reuse prior discoveries "
+            "and keep continuity, but treat each new user message as the current "
+            "delegated task.\n"
+        )
     if role == "orchestrator":
         child_note = (
             "Your own children MUST be leaves (cannot delegate further) "
@@ -1062,6 +1105,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    persistent_sidekick: bool = False,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1149,6 +1193,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        persistent_sidekick=persistent_sidekick,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -1339,6 +1384,8 @@ def _build_child_agent(
     # Stash the post-degrade role for introspection (leaf if the
     # kill switch or depth bounded the caller's requested role).
     child._delegate_role = effective_role
+    if persistent_sidekick:
+        child._is_persistent_sidekick = True
     # Stash subagent identity for nested-delegation event propagation and
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
@@ -2292,10 +2339,12 @@ def _run_single_child(
         if isinstance(saved_tool_names, list):
             model_tools._last_resolved_tool_names = list(saved_tool_names)
 
-        # Remove child from active tracking
+        is_persistent_sidekick = getattr(child, "_is_persistent_sidekick", False) is True
 
-        # Unregister child from interrupt propagation
-        if hasattr(parent_agent, "_active_children"):
+        # Remove child from active tracking. Persistent Fusion sidekicks stay
+        # registered for their parent session so interrupt propagation keeps
+        # working across delegate_task(sidekick=True) calls.
+        if not is_persistent_sidekick and hasattr(parent_agent, "_active_children"):
             try:
                 lock = getattr(parent_agent, "_active_children_lock", None)
                 if lock:
@@ -2308,9 +2357,10 @@ def _run_single_child(
 
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) so subagent subprocesses
-        # don't outlive the delegation.
+        # don't outlive the delegation. Persistent sidekicks are closed only at
+        # parent-session teardown via close_sidekick_for_session().
         try:
-            if hasattr(child, "close"):
+            if not is_persistent_sidekick and hasattr(child, "close"):
                 child.close()
         except Exception:
             logger.debug("Failed to close child agent after delegation")
@@ -2346,6 +2396,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    sidekick: bool = False,
     parent_agent=None,
 ) -> str:
     """
@@ -2417,15 +2468,8 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
+    fusion_cfg = _load_fusion_config()
+    sidekick_requested = is_truthy_value(sidekick, default=False)
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2436,6 +2480,8 @@ def delegate_task(
         tasks = recovered_tasks
 
     if tasks and isinstance(tasks, list):
+        if sidekick_requested:
+            return tool_error("Fusion sidekick accepts a single goal in v1; use normal delegation for task batches.")
         if len(tasks) > max_children:
             return tool_error(
                 f"Too many tasks: {len(tasks)} provided, but "
@@ -2452,6 +2498,14 @@ def delegate_task(
 
     if not task_list:
         return tool_error("No tasks provided.")
+
+    if sidekick_requested:
+        if not is_truthy_value(fusion_cfg.get("enabled"), default=False):
+            return tool_error("Fusion sidekick requires fusion.enabled=true in config.yaml.")
+        if background:
+            return tool_error("Fusion sidekick runs synchronously in v1; omit background=true.")
+        if top_role != "leaf" or any(_normalize_role(t.get("role") or top_role) != "leaf" for t in task_list):
+            return tool_error("Fusion sidekick is a leaf worker in v1; role='orchestrator' is not supported.")
 
     # Validate each task has a goal
     for i, task in enumerate(task_list):
@@ -2480,33 +2534,94 @@ def delegate_task(
     # Wrapped in try/finally so the global is always restored even if a
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
+    sidekick_lock: Optional[threading.Lock] = None
+    sidekick_lock_acquired = False
     try:
-        for i, t in enumerate(task_list):
-            # Per-task role beats top-level; normalise again so unknown
-            # per-task values warn and degrade to leaf uniformly.
-            effective_role = _normalize_role(t.get("role") or top_role)
-            child = _build_child_agent(
-                task_index=i,
-                goal=t["goal"],
-                context=t.get("context"),
-                # Subagents always inherit the parent's toolsets; the model
-                # cannot choose or narrow them (no model-facing toolsets arg).
-                toolsets=None,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
-                task_count=n_tasks,
+        if sidekick_requested:
+            session_key = _sidekick_session_key(parent_agent)
+            sidekick_lock = _get_sidekick_lock(session_key)
+            if not sidekick_lock.acquire(blocking=False):
+                return json.dumps(
+                    {
+                        "status": "sidekick_busy",
+                        "summary": (
+                            "Persistent Fusion sidekick is working on another task "
+                            "for this session; retry when it finishes."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+            sidekick_lock_acquired = True
+            try:
+                sidekick_creds = _resolve_delegation_credentials(
+                    _sidekick_delegation_config(cfg, fusion_cfg),
+                    parent_agent,
+                )
+            except ValueError as exc:
+                sidekick_lock.release()
+                sidekick_lock_acquired = False
+                return tool_error(str(exc))
+            t = task_list[0]
+            child = _get_or_create_sidekick(
+                session_key=session_key,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
-                role=effective_role,
+                creds=sidekick_creds,
+                fusion_cfg=fusion_cfg,
+                effective_max_iter=effective_max_iter,
             )
-            # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
-            children.append((i, t, child))
+            # Fold the per-call context into the user message so later
+            # sidekick delegations don't lose file paths, constraints, or
+            # error details. The sidekick's system prompt persists across
+            # calls; only the per-call user message varies.
+            ctx = t.get("context")
+            if ctx and str(ctx).strip():
+                t = dict(t)
+                t["goal"] = f"{t['goal']}\n\nCONTEXT:\n{ctx}"
+            children.append((0, t, child))
+        else:
+            # Resolve delegation credentials (provider:model pair). When
+            # delegation.provider is configured, this resolves the full
+            # credential bundle via the same runtime provider system used by
+            # CLI/gateway startup. When unconfigured, children inherit parent.
+            try:
+                creds = _resolve_delegation_credentials(cfg, parent_agent)
+            except ValueError as exc:
+                return tool_error(str(exc))
+            for i, t in enumerate(task_list):
+                # Per-task role beats top-level; normalise again so unknown
+                # per-task values warn and degrade to leaf uniformly.
+                effective_role = _normalize_role(t.get("role") or top_role)
+                child = _build_child_agent(
+                    task_index=i,
+                    goal=t["goal"],
+                    context=t.get("context"),
+                    # Subagents always inherit the parent's toolsets; the model
+                    # cannot choose or narrow them (no model-facing toolsets arg).
+                    toolsets=None,
+                    model=creds["model"],
+                    max_iterations=effective_max_iter,
+                    task_count=n_tasks,
+                    parent_agent=parent_agent,
+                    override_provider=creds["provider"],
+                    override_base_url=creds["base_url"],
+                    override_api_key=creds["api_key"],
+                    override_api_mode=creds["api_mode"],
+                    override_acp_command=creds.get("command"),
+                    override_acp_args=creds.get("args"),
+                    role=effective_role,
+                )
+                # Override with correct parent tool names (before child construction mutated global)
+                child._delegate_saved_tool_names = _parent_tool_names
+                children.append((i, t, child))
+    except BaseException:
+        # A raised child build must not leave the per-session sidekick lock
+        # held forever — that would turn every later sidekick call into a
+        # permanent "sidekick_busy" for this session.
+        if sidekick_lock_acquired and sidekick_lock is not None:
+            sidekick_lock.release()
+            sidekick_lock_acquired = False
+        raise
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
@@ -2885,7 +3000,12 @@ def delegate_task(
         return json.dumps(_cap_result, ensure_ascii=False)
 
     # ----- Synchronous path -----
-    return json.dumps(_execute_and_aggregate(), ensure_ascii=False)
+    try:
+        return json.dumps(_execute_and_aggregate(), ensure_ascii=False)
+    finally:
+        if sidekick_lock_acquired and sidekick_lock is not None:
+            sidekick_lock.release()
+            sidekick_lock_acquired = False
 
 
 def _resolve_child_credential_pool(
@@ -3122,6 +3242,135 @@ def _load_config() -> dict:
         return {}
 
 
+def _load_full_config() -> dict:
+    """Load the complete Hermes config for non-delegation feature flags."""
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config()
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception:
+        return {}
+
+
+def _load_fusion_config() -> dict:
+    cfg = _load_full_config().get("fusion", {})
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _fusion_enabled() -> bool:
+    return is_truthy_value(_load_fusion_config().get("enabled"), default=False)
+
+
+def _sidekick_delegation_config(base_cfg: dict, fusion_cfg: dict) -> dict:
+    """Merge sidekick-specific overrides over delegation config.
+
+    Priority: fusion.sidekick_* → delegation.* → parent
+    inheritance (implemented by _resolve_delegation_credentials returning None).
+    """
+    merged = dict(base_cfg or {})
+    mapping = {
+        "sidekick_model": "model",
+        "sidekick_provider": "provider",
+        "sidekick_base_url": "base_url",
+        "sidekick_api_key": "api_key",
+        "sidekick_api_mode": "api_mode",
+    }
+    for src, dst in mapping.items():
+        value = str((fusion_cfg or {}).get(src) or "").strip()
+        if value:
+            merged[dst] = value
+    return merged
+
+
+def _sidekick_toolsets(fusion_cfg: dict) -> Optional[List[str]]:
+    raw = (fusion_cfg or {}).get("sidekick_toolsets")
+    if not isinstance(raw, list):
+        return None
+    toolsets = [str(item).strip() for item in raw if str(item or "").strip()]
+    return toolsets or None
+
+
+def _get_sidekick_lock(session_key: str) -> threading.Lock:
+    with _sidekick_registry_lock:
+        lock = _sidekick_locks.get(session_key)
+        if lock is None:
+            lock = threading.Lock()
+            _sidekick_locks[session_key] = lock
+        return lock
+
+
+def _get_or_create_sidekick(
+    *,
+    session_key: str,
+    parent_agent,
+    creds: dict,
+    fusion_cfg: dict,
+    effective_max_iter: int,
+):
+    with _sidekick_registry_lock:
+        child = _sidekick_agents.get(session_key)
+        if child is not None:
+            return child
+        # context is deliberately NOT baked into the persistent system prompt:
+        # it is per-delegation data, folded into each call's user message by
+        # the caller. Baking the first call's context here would pin stale
+        # context for the whole session AND duplicate it on the first call.
+        child = _build_child_agent(
+            task_index=0,
+            goal="Persistent Fusion sidekick for this parent session",
+            context=None,
+            toolsets=_sidekick_toolsets(fusion_cfg),
+            model=creds.get("model"),
+            max_iterations=effective_max_iter,
+            task_count=1,
+            parent_agent=parent_agent,
+            override_provider=creds.get("provider"),
+            override_base_url=creds.get("base_url"),
+            override_api_key=creds.get("api_key"),
+            override_api_mode=creds.get("api_mode"),
+            override_acp_command=creds.get("command"),
+            override_acp_args=creds.get("args"),
+            role="leaf",
+            persistent_sidekick=True,
+        )
+        setattr(child, "_is_persistent_sidekick", True)
+        _sidekick_agents[session_key] = child
+        return child
+
+
+def close_sidekick_for_session(session_id: str) -> Optional[Any]:
+    """Close and forget the persistent sidekick for a parent session.
+
+    Returns the child object that was closed, if any, so parent teardown can
+    avoid closing the same sidekick a second time via its active-children list.
+    """
+    key = str(session_id or "")
+    if not key:
+        return None
+    with _sidekick_registry_lock:
+        child = _sidekick_agents.pop(key, None)
+        _sidekick_locks.pop(key, None)
+    if child is None:
+        return None
+    try:
+        if hasattr(child, "close"):
+            child.close()
+    except Exception:
+        logger.debug("Failed to close persistent sidekick for session %s", key, exc_info=True)
+    return child
+
+
+def _close_all_sidekicks() -> None:
+    with _sidekick_registry_lock:
+        keys = list(_sidekick_agents.keys())
+    for key in keys:
+        close_sidekick_for_session(key)
+
+
+atexit.register(_close_all_sidekicks)
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -3171,6 +3420,19 @@ def _build_top_level_description() -> str:
             f"config.yaml to enable nesting."
         )
 
+    try:
+        fusion_enabled = _fusion_enabled()
+    except Exception:
+        fusion_enabled = False
+    sidekick_background_clause = (
+        "FUSION SIDEKICK EXCEPTION: when the optional sidekick=true parameter "
+        "is available and used, the persistent sidekick runs synchronously in "
+        "v1; do not combine it with background=true. Use normal delegation for "
+        "background fan-out.\n\n"
+        if fusion_enabled
+        else ""
+    )
+
     return (
         "Spawn one or more subagents to work on tasks in isolated contexts. "
         "Each subagent gets its own conversation, terminal session, and toolset. "
@@ -3187,6 +3449,7 @@ def _build_top_level_description() -> str:
         "batch is just N independent background subagents (N handles, each "
         "completes on its own). Do NOT wait or poll; just continue with other "
         "work after dispatching.\n\n"
+        f"{sidekick_background_clause}"
         "WHEN TO USE delegate_task:\n"
         "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
         "- Tasks that would flood your context with intermediate data\n"
@@ -3297,6 +3560,16 @@ def _build_dynamic_schema_overrides() -> dict:
     }
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
+    if _fusion_enabled():
+        overrides_params["properties"]["sidekick"] = {
+            "type": "boolean",
+            "description": (
+                "Route to the persistent sidekick agent. It retains conversation "
+                "context across calls (cache-efficient). Use for exploration, "
+                "implementation, tests, lint, and requested edits. Do NOT use "
+                "for tasks where subtle judgment is the deliverable."
+            ),
+        }
 
     return {
         "description": _build_top_level_description(),
@@ -3398,10 +3671,13 @@ def _model_background_value(args: dict, parent_agent=None) -> bool:
     needs its workers' results within its own turn. The live path is
     ``run_agent._dispatch_delegate_task``; this lambda mirrors it for the rare
     case the intercept is bypassed. Direct Python callers of ``delegate_task``
-    keep the historical synchronous default.
+    keep the historical synchronous default. Sidekick delegations always run
+    synchronously (mirrors the live path), so auto-background must not fire
+    for them — otherwise sidekick=true would be spuriously rejected.
     """
     is_subagent = getattr(parent_agent, "_delegate_depth", 0) > 0
-    return not is_subagent
+    sidekick_requested = is_truthy_value(args.get("sidekick"), default=False)
+    return not is_subagent and not sidekick_requested
 
 
 _MODEL_HIDDEN_TASK_FIELDS = {"acp_command", "acp_args"}
@@ -3438,6 +3714,7 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
+        sidekick=args.get("sidekick"),
     ),
     check_fn=check_delegate_requirements,
     emoji="🔀",


### PR DESCRIPTION
## Fusion: persistent sidekick delegation + compaction-boundary model routing

### Summary

Adds an opt-in **Fusion** operating mode with two related, independently gated capabilities. Both are fully inert by default (`fusion.enabled: false`), preserving all existing behavior:

1. **Persistent sidekick delegation** (`delegate_task` with `sidekick=true`): one cheaper child agent is kept alive per parent session, so its conversation — and its provider-side prompt cache — persists across delegations. The main agent acts as architect/reviewer; the sidekick handles exploration, edits, tests, and verification. Process restarts do not rehydrate sidekick history; the next call lazily builds a fresh child.
2. **Compaction-boundary model routing** (`fusion.compaction_routing`): at context-compaction boundaries — the one place where the cached prefix is already invalidated — the summarizer LLM emits a structured Work Complexity verdict (`MECHANICAL` vs `FRONTIER_JUDGMENT`). The verdict is consumed exactly once and optionally switches between a cheaper routing runtime and the session's frontier runtime through the existing `switch_model` helper. Sessions that never compact never route.

### Motivation

Long agent sessions burn frontier-model tokens on work that is largely mechanical (file edits, running tests, lint fixes, bulk changes). Fusion lets the expensive model own judgment — planning, ambiguity resolution, review, acceptance — while routine execution runs on a cheaper model, without breaking prompt caching:

- The sidekick keeps a single persistent conversation, so its own cache prefix survives across delegations instead of being rebuilt per call.
- Routing only ever changes models at compaction boundaries, where the prefix is already invalidated — never mid-conversation.

### Config (all in `config.yaml`, no new env vars)

```yaml
fusion:
  enabled: false            # Master switch — everything below is inert when false.
  sidekick_model: ""        # "" = delegation.model, then parent model.
  sidekick_provider: ""     # "" = delegation.provider, then parent provider.
  sidekick_base_url: ""     # "" = delegation.base_url.
  sidekick_api_key: ""      # "" = delegation.api_key, then parent key.
  sidekick_api_mode: ""     # "" = auto-detect / delegation.api_mode.
  sidekick_toolsets: []     # [] = same toolsets ephemeral delegate children get.
  compaction_routing: false # Routing only fires at compaction boundaries.
  routing_model: ""         # MECHANICAL target ("" = sidekick_model; both "" = no switch).
  routing_provider: ""      # "" = sidekick_provider, then current provider.
  routing_base_url: ""      # Cross-provider routes require explicit endpoint + key —
  routing_api_key: ""       #   a cheap route never silently inherits frontier credentials.
  routing_api_mode: ""
  frontier_model: ""        # FRONTIER_JUDGMENT target ("" = session's starting model).
```

`_config_version` bumped 33 → 34.

### Implementation

- `tools/delegate_tool.py`: `sidekick` parameter on the existing `delegate_task` schema (advertised to the model only when Fusion is enabled — zero schema footprint otherwise). Per-session sidekick registry with a non-blocking per-session run lock (concurrent calls get a structured `sidekick_busy` result instead of corrupting shared history). Per-call `context` is folded into each delegation's user message — never baked into the persistent system prompt, keeping it byte-stable across calls. Sidekicks skip per-call teardown and are closed exactly once at parent-session teardown (`close_sidekick_for_session`) or interpreter exit.
- `agent/context_compressor.py`: when routing is enabled, the compression prompt gains a `## Work Complexity Assessment` section and the verdict is extracted from that heading only (strict: no keyword scanning of the whole summary). Extraction runs after summary redaction; any stale verdict is cleared at the start of each summary attempt.
- `agent/conversation_loop.py`: `_apply_fusion_routing_verdict` consumes-and-clears the verdict, skips no-op switches, refuses cross-provider routes that lack explicit credentials/endpoint, and defers entirely to a user-initiated `/model` override (session-long suspension).
- `agent/agent_init.py`: frontier/routing runtime snapshots resolved once at session start; routing credentials resolve route-specific config first, then sidekick config, and fall back to the current runtime only for same-provider routes.
- `agent/system_prompt.py`: architect/reviewer guidance paragraph, appended to the stable prompt section only when Fusion is enabled — applied at init time, never mid-conversation.
- `run_agent.py`: the user-facing `switch_model` wrapper marks routing as suspended (manual choice wins); `_compress_context` applies the verdict after compaction and rebuilds/caches the system prompt only when a switch actually happened; session teardown closes the registered sidekick without double-closing it via the active-children list.

### Design constraints

- **Default-off**: with `fusion.enabled: false` the delegate schema, system prompt, and compression prompt are byte-identical to main.
- **Cache-safe**: no mid-conversation prompt or toolset mutation; routing only acts where compaction already invalidated the prefix.
- **Narrow waist**: no new core tool — one boolean parameter on the existing `delegate_task`, visible only when the feature is on.
- **No new env vars**: all configuration lives in `config.yaml`.
- **Credential hygiene**: cross-provider routing/sidekick targets require explicit `base_url`/`api_key`; nothing inherits the frontier provider's credentials by accident.

### v1 scope limits (validated with clear tool-result errors)

- Sidekick accepts a single goal (no task batches), runs synchronously (no `background=true`), and is a leaf worker (no `orchestrator` role).
- A failed sidekick build releases the session lock (later calls retry instead of reporting a permanent `sidekick_busy`).

### Testing

- `tests/agent/test_fusion_routing.py` — 12 behavior-contract tests: disabled Fusion is prompt-invisible; verdict piggybacks on the existing summary call; verdicts are consumed once and never leak stale; malformed verdicts and credential-less cross-provider routes never switch; manual `/model` suspends routing; suspended routing keeps prompt bytes stable between compactions.
- `tests/tools/test_fusion_sidekick.py` — 19 tests: schema advertised only when enabled; one child reused across calls with history retained and no per-call close; busy-lock contract; build-failure lock release; per-call context reaches every delegation's user message without touching the persistent prompt; teardown closes exactly once; module-registry reset lazily rebuilds; summary-budget trimming exercised through the real `delegate_task` path; session rows cascade-delete with the parent.
- Full local run of `tests/tools/`, `tests/agent/`, `tests/run_agent/`, and config tests passes (the only failures are pre-existing on current `main`, verified by running the same files on a clean `origin/main` checkout).

---

Draft PR — feedback welcome, especially on the config schema naming and the verdict extraction contract.

### Follow-up fixes included

This clean PR also includes the reviewed follow-up fixes from the previous draft:

- Strip the Fusion Work Complexity verdict from persisted compaction summaries after consuming it.
- Reset per-session Fusion routing state and close the old persistent sidekick on `/new`, `/reset`, `/clear`, and `/resume` session changes.
- Persist only the routed runtime shape in session metadata, never API keys, and re-resolve credentials when resuming routed sessions.
- Preserve existing session model metadata while adding Fusion route metadata.
- Add regression tests for the fixes above.

