### PR TITLE
fix(state): preserve soft-archived rows in transcript rewrites

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3285,7 +3285,7 @@ class SessionDB:
         self,
         session_id: str,
         messages: List[Dict[str, Any]],
-        active_only: bool = False,
+        active_only: Optional[bool] = None,
     ) -> None:
         """Atomically replace the stored messages for a session.
 
@@ -3293,24 +3293,35 @@ class SessionDB:
         The delete + reinsert sequence must commit as one transaction so a
         mid-rewrite failure does not leave SQLite with a partial transcript.
 
-        DESTRUCTIVE by default: every row for the session is DELETEd (and drops
-        out of the FTS index). For compaction that must preserve the
-        pre-compaction transcript under the same id, use
-        :meth:`archive_and_compact` instead.
+        ``active_only=None`` (the default) preserves soft-archived rows
+        (``active = 0`` — e.g. the ``compacted = 1`` turns that
+        :meth:`archive_and_compact` keeps on disk for #38763 durability, or
+        rewind/undo rows) whenever the session has any: the rewrite then
+        replaces ONLY the live (``active = 1``) rows. A rewrite on a session
+        that was in-place-compacted would otherwise silently destroy the
+        archived pre-compaction transcript. The probe runs inside the same
+        write transaction as the delete, so the decision cannot race a
+        concurrent archive.
 
-        Pass ``active_only=True`` to replace ONLY the live (``active = 1``) rows,
-        leaving soft-archived rows (``active = 0`` — e.g. the ``compacted = 1``
-        turns that :meth:`archive_and_compact` keeps on disk for #38763
-        durability, or rewind/undo rows) untouched. Callers that share a session
-        id with an agent already running in-place compaction must use this so a
-        full-history rewrite doesn't wipe the rows the agent deliberately
-        archived. ``message_count``/``tool_call_count`` then track the live set,
+        Pass ``active_only=True`` to force live-rows-only semantics, or
+        ``active_only=False`` to force a full DESTRUCTIVE rewrite: every row
+        for the session is DELETEd (and drops out of the FTS index). For
+        compaction that must preserve the pre-compaction transcript under the
+        same id, use :meth:`archive_and_compact` instead.
+        ``message_count``/``tool_call_count`` track the live set either way,
         matching :meth:`archive_and_compact`.
         """
 
-        active_clause = " AND active = 1" if active_only else ""
-
         def _do(conn):
+            preserve = active_only
+            if preserve is None:
+                row = conn.execute(
+                    "SELECT 1 FROM messages WHERE session_id = ? AND active = 0"
+                    " LIMIT 1",
+                    (session_id,),
+                ).fetchone()
+                preserve = row is not None
+            active_clause = " AND active = 1" if preserve else ""
             conn.execute(
                 f"DELETE FROM messages WHERE session_id = ?{active_clause}",
                 (session_id,),

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -939,6 +939,80 @@ class TestMessageStorage:
         assert next(m for m in conv if m["role"] == "user").get("message_id") == "ext-1"
         assert "message_id" not in next(m for m in conv if m["role"] == "assistant")
 
+    def _archived_count(self, db, session_id):
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT COUNT(*) AS n FROM messages"
+                " WHERE session_id = ? AND active = 0",
+                (session_id,),
+            ).fetchone()
+        return row["n"]
+
+    def test_replace_messages_default_preserves_archived_rows(self, db):
+        """A transcript rewrite (/retry, /undo, /compress) on a session that
+        was in-place-compacted must NOT destroy the soft-archived
+        pre-compaction turns archive_and_compact() keeps for #38763."""
+        db.create_session(session_id="s_arc", source="cli")
+        db.append_message("s_arc", role="user", content="old turn 1")
+        db.append_message("s_arc", role="assistant", content="old answer 1")
+        db.archive_and_compact(
+            "s_arc", [{"role": "user", "content": "summary of old turns"}]
+        )
+        assert self._archived_count(db, "s_arc") == 2
+
+        db.replace_messages(
+            "s_arc",
+            [
+                {"role": "user", "content": "rewritten turn"},
+                {"role": "assistant", "content": "rewritten answer"},
+            ],
+        )
+
+        # Archived rows survived; the live set is exactly the rewrite.
+        assert self._archived_count(db, "s_arc") == 2
+        live = db.get_messages("s_arc")
+        assert [m["content"] for m in live] == [
+            "rewritten turn",
+            "rewritten answer",
+        ]
+        # Counters track the live set, matching archive_and_compact.
+        session = db.get_session("s_arc")
+        assert session["message_count"] == 2
+
+    def test_replace_messages_explicit_false_still_wipes(self, db):
+        """active_only=False keeps the old destructive semantics for callers
+        that really mean a full-history wipe."""
+        db.create_session(session_id="s_wipe", source="cli")
+        db.append_message("s_wipe", role="user", content="old turn")
+        db.archive_and_compact(
+            "s_wipe", [{"role": "user", "content": "summary"}]
+        )
+        assert self._archived_count(db, "s_wipe") == 1
+
+        db.replace_messages(
+            "s_wipe",
+            [{"role": "user", "content": "fresh"}],
+            active_only=False,
+        )
+
+        assert self._archived_count(db, "s_wipe") == 0
+        assert [m["content"] for m in db.get_messages("s_wipe")] == ["fresh"]
+
+    def test_replace_messages_no_archive_matches_old_behaviour(self, db):
+        """Sessions without soft-archived rows (the common case, incl. the
+        api_server fork path) behave byte-identically to the old default."""
+        db.create_session(session_id="s_plain", source="cli")
+        db.append_message("s_plain", role="user", content="a")
+        db.append_message("s_plain", role="assistant", content="b")
+
+        db.replace_messages(
+            "s_plain", [{"role": "user", "content": "only"}]
+        )
+
+        assert self._archived_count(db, "s_plain") == 0
+        assert [m["content"] for m in db.get_messages("s_plain")] == ["only"]
+        assert db.get_session("s_plain")["message_count"] == 1
+
     def test_get_messages_as_conversation_includes_ancestor_chain(self, db):
         db.create_session("root", "tui")
         db.append_message("root", role="user", content="first prompt")


### PR DESCRIPTION
## What does this PR do?

`replace_messages()` deletes **every** row for the session by default — including the `active = 0` soft-archived turns that `archive_and_compact()` deliberately keeps on disk for durability (#38763). The ACP adapter already guards against this (`acp_adapter/session.py`: probe `has_archived_messages()`, then pass `active_only=True`), but two other transcript-rewrite call sites don't:

- `gateway/session.py` — the /retry, /undo and /compress rewrite path;
- `tui_gateway/server.py` — history truncation in `prompt.submit`.

Any transcript rewrite on a session that has been in-place-compacted silently destroys the archived pre-compaction history. We hit this in production: an archived transcript segment vanished after a bulk rewrite, with nothing in the logs.

This PR makes the default safe instead of patching call sites one by one: `active_only` becomes `Optional[bool] = None`, where `None` means "preserve soft-archived rows when the session has any" (an `active = 0` existence probe). The probe runs **inside the same write transaction** as the delete, so the decision cannot race a concurrent archive. Passing `active_only=False` explicitly keeps the old full-wipe semantics for callers that really mean it; explicit `True` is unchanged.

Effects on existing callers:

- `acp_adapter/session.py` — its manual probe becomes redundant (kept as-is here to minimise the diff; can be simplified in a follow-up).
- `gateway/session.py`, `tui_gateway/server.py` — fixed by the new default.
- `gateway/platforms/api_server.py` (session fork) — unaffected: a freshly created fork session has no archived rows, so the probe short-circuits and behaviour is byte-identical.

If changing the default is undesirable, the fallback is to replicate the ACP guard at the two unprotected call sites — happy to rework the PR that way, but the auto-default also covers future callers.

## Related Issue

Same durability concern as #38763 (which introduced the soft-archive).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `replace_messages(active_only: Optional[bool] = None)`; `None` resolves via an `active = 0` existence probe inside the write transaction; docstring rewritten to document all three modes.
- `tests/test_hermes_state.py` — three new tests: rewrite with archived rows present preserves them (new default); explicit `active_only=False` still wipes; rewrite on a session without archived rows matches old behaviour (message_count included).

## How to Test

```bash
uv run --extra dev pytest tests/test_hermes_state.py -q
```

306 passed locally (303 pre-existing + 3 new). Also ran every other test file referencing `replace_messages` (`tests/test_tui_gateway_server.py`, `tests/run_agent/test_in_place_compaction.py`, `tests/gateway/test_session_api.py`, `tests/gateway/test_session.py`, `tests/hermes_cli/test_web_server.py`, `tests/acp/test_session.py`) before and after the change — pass/fail/skip counts are identical (the failures in my environment are missing optional deps, present on both runs).

Manual: create a session, force in-place compaction (soft-archived rows appear), run /undo or /retry, verify the archived rows survive (`SELECT count(*) FROM messages WHERE session_id=? AND active=0`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(state):`, one squashed commit)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files)
- [x] I've run pytest on the affected modules and all tests pass (306 passed in `tests/test_hermes_state.py`); full `pytest tests/` not re-run end-to-end (optional-dep env)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the docstring is the documentation surface for this internal method
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A**: no config keys
- [x] I've considered cross-platform impact — pure SQLite/stdlib change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**

🤖 Generated with [Claude Code](https://claude.com/claude-code)