### PR TITLE
fix: stabilize websocket surrogate serialization and kanban sticky blockers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2680,6 +2680,13 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -3251,6 +3258,11 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       ``hermes kanban block <id>``).  This is a deliberate handoff that
       should stay blocked until an operator unblocks it.  The block tool
       emits a ``"blocked"`` event row in ``task_events``.
+
+    * **Creator-initiated hold** — a creator passed
+      ``initial_status="blocked"`` to park a task for human review.  Task
+      creation emits the same ``"blocked"`` event so the hold is sticky
+      until an explicit unblock.
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -49,8 +49,68 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Worker-initiated kanban_block must be sticky
+# Explicit human-review blocks must be sticky
 # ---------------------------------------------------------------------------
+
+
+def test_initial_status_blocked_is_not_auto_promoted_by_recompute_ready(kanban_home: Path) -> None:
+    """A task created with ``initial_status='blocked'`` is a deliberate
+    creator/operator hold, not a transient circuit-breaker block.  It must
+    stay blocked until somebody explicitly unblocks it."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="hold for human review",
+            initial_status="blocked",
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, "initial blocked hold must not auto-promote"
+            task = kb.get_task(conn, tid)
+            assert task is not None
+            assert task.status == "blocked"
+
+
+def test_initial_status_blocked_with_done_parents_is_still_sticky(kanban_home: Path) -> None:
+    """Even when dependency gates are satisfied, ``initial_status='blocked'``
+    must behave like a human-review hold rather than entering the dispatcher."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        kb.complete_task(conn, parent, result="ok")
+        child = kb.create_task(
+            conn,
+            title="child hold",
+            parents=[parent],
+            initial_status="blocked",
+        )
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "blocked"
+
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "blocked"
+
+
+def test_unblock_clears_initial_status_blocked_hold(kanban_home: Path) -> None:
+    """The normal explicit unblock path is the escape hatch for tasks
+    initially parked in blocked status."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="parked hold",
+            initial_status="blocked",
+        )
+        assert kb.unblock_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "ready"
 
 
 def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path) -> None:

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -162,3 +162,28 @@ def test_ws_write_loop_stall_does_not_latch_transport(monkeypatch):
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=2)
         loop.close()
+
+
+def test_ws_safe_json_replaces_lone_surrogates():
+    line = ws_mod._json_dumps_ws_safe({"jsonrpc": "2.0", "result": {"path": "bad\udc90name"}})
+    assert "\udc90" not in line
+    assert "bad�name" in line
+    line.encode("utf-8")
+
+
+def test_ws_write_async_sends_surrogate_payload_without_closing():
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            line.encode("utf-8")
+            sent.append(line)
+
+    async def run():
+        transport = ws_mod.WSTransport(FakeWS(), asyncio.get_running_loop(), peer="surrogate-test")
+        assert await transport.write_async({"result": {"path": "bad\udc90name"}}) is True
+        assert transport._closed is False
+
+    asyncio.run(run())
+    assert len(sent) == 1
+    assert "bad�name" in sent[0]

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import copy
 import json
 import logging
 import socket
@@ -115,7 +116,7 @@ class WSTransport:
         if self._closed:
             return False
 
-        line = json.dumps(obj, ensure_ascii=False)
+        line = _json_dumps_ws_safe(obj)
 
         try:
             on_loop = asyncio.get_running_loop() is self._loop
@@ -217,7 +218,7 @@ class WSTransport:
             self._pending_tokens = []
         if pending:
             await self._safe_send_many(pending)
-        await self._safe_send(json.dumps(obj, ensure_ascii=False))
+        await self._safe_send(_json_dumps_ws_safe(obj))
         return not self._closed
 
     async def _safe_send(self, line: str) -> None:
@@ -250,6 +251,28 @@ class WSTransport:
         if handle is not None:
             handle.cancel()
             self._token_flush_handle = None
+
+
+def _json_dumps_ws_safe(obj: dict) -> str:
+    """Serialize a JSON-RPC frame without emitting invalid UTF-8 surrogates.
+
+    Starlette's ``send_text`` encodes the returned string as UTF-8. A payload
+    containing a lone surrogate can be represented by ``json.dumps`` when
+    ``ensure_ascii=False`` is used, but the later websocket send then raises
+    ``UnicodeEncodeError: surrogates not allowed`` and closes the Desktop / TUI
+    websocket. Replace those invalid code points with U+FFFD before the frame
+    reaches the socket while keeping normal non-ASCII text readable on the wire.
+    """
+    payload = copy.deepcopy(obj)
+    try:
+        from agent.message_sanitization import _sanitize_structure_surrogates
+
+        _sanitize_structure_surrogates(payload)
+    except Exception:
+        # Last-ditch fallback: ensure_ascii=True guarantees any remaining
+        # surrogate is escaped into ASCII rather than crashing send_text.
+        return json.dumps(obj, ensure_ascii=True)
+    return json.dumps(payload, ensure_ascii=False)
 
 
 def _ws_peer_label(ws: Any) -> str:


### PR DESCRIPTION
## Summary
- sanitize websocket surrogate payloads before send so unsupported objects do not break JSON serialization
- keep initially blocked Kanban tasks sticky in the blocked lane instead of immediately clearing their sticky placement

## Testing
- previously tested locally before auth handoff; this command only pushes the already-prepared branch and opens the PR
