### PR TITLE
fix(web): light up web tools when a registered custom provider is available but none configured

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -812,6 +812,58 @@ class TestNonBuiltinProviderAvailability:
             assert web_extract_entry is not None, \
                 "web_extract tool was filtered out despite custom provider being available"
 
+    @staticmethod
+    def _create_named_provider(name, *, search=True, extract=True):
+        """Create an available WebSearchProvider with a caller-chosen name.
+
+        Lets a test register more than one distinct custom provider (the
+        shared ``_create_fake_provider`` hardcodes a single name).
+        """
+        from agent.web_search_provider import WebSearchProvider
+
+        class NamedPluginProvider(WebSearchProvider):
+            @property
+            def name(self):
+                return name
+
+            def is_available(self):
+                return True
+
+            def supports_search(self):
+                return search
+
+            def supports_extract(self):
+                return extract
+
+        return NamedPluginProvider()
+
+    def test_check_web_api_key_true_for_multiple_custom_providers_none_configured(self):
+        """Two available custom providers, no built-in creds, no web.backend
+        config key: check_web_api_key() must still return True.
+
+        Regression for the a9cd0e07c refactor. The registry's single-active
+        ``_resolve()`` only returns a fallback provider when exactly one is
+        eligible (``len(eligible) == 1``) or the name is a built-in legacy
+        name, so with 2+ registered custom providers and no config key it
+        returns None for both capabilities — which previously made this gate
+        return False and hid ``web_search`` / ``web_extract`` even though
+        ``_get_backend()`` resolves one of them. The gate must mirror
+        ``_get_backend()``'s registered-provider walk so the two agree.
+        """
+        from agent.web_search_registry import _reset_for_tests, register_provider
+
+        _reset_for_tests()
+        register_provider(self._create_named_provider("custom-a"))
+        register_provider(self._create_named_provider("custom-b"))
+        # No web.backend / web.*_backend config key is set (fixture strips env).
+        with patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch("tools.web_tools._peek_nous_access_token", return_value=None), \
+             patch("tools.web_tools._load_web_config", return_value={}):
+            from tools.web_tools import check_web_api_key, _get_backend
+            assert check_web_api_key() is True
+            # Gate agrees with the router: _get_backend() resolves one of them.
+            assert _get_backend() in {"custom-a", "custom-b"}
+
 
 class TestFirecrawlEnvResolution:
     """Verify Firecrawl reads env values from hermes_cli.config.get_env_value,

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1076,13 +1076,12 @@ def check_web_api_key() -> bool:
     for provider in _list_registered_web_providers():
         if provider.name in _LEGACY_WEB_BACKENDS:
             continue
-        try:
-            if provider.is_available():
-                return True
-        except Exception as exc:  # noqa: BLE001 — a broken provider is skipped
-            logger.debug(
-                "web provider %r.is_available() raised: %s", provider.name, exc
-            )
+        # Route through the shared helper so broken-provider handling (the
+        # is_available() try/except + debug log) stays identical to backend
+        # selection. It re-fetches by name, but registry lookups are cheap and
+        # the single source of truth is worth more than saving one dict access.
+        if _registered_web_provider_available(provider.name):
+            return True
     return False
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1066,23 +1066,24 @@ def check_web_api_key() -> bool:
     # unlike _get_backend() the probe order is irrelevant.
     if any(_is_backend_available(backend) for backend in _LEGACY_WEB_BACKENDS):
         return True
-    # Any plugin-registered provider the registry considers active for either
-    # capability. Delegating to the registry's own availability-filtered
-    # resolvers keeps a single authority for "is a custom provider usable"
-    # rather than re-implementing the walk here.
-    try:
-        from agent.web_search_registry import (
-            get_active_search_provider,
-            get_active_extract_provider,
-        )
-
-        return (
-            get_active_search_provider() is not None
-            or get_active_extract_provider() is not None
-        )
-    except Exception as exc:  # noqa: BLE001 — registry optional; never fatal
-        logger.debug("web provider registry availability check failed: %s", exc)
-        return False
+    # Any plugin-registered provider (outside the built-in set) that reports
+    # itself available. Mirror _get_backend()'s final fallback walk so this
+    # gate agrees with the router: the registry's single-active _resolve()
+    # returns None when >1 custom provider is registered and none is
+    # configured (len(eligible) != 1 and custom names are absent from the
+    # legacy preference order), which would wrongly hide the web tools even
+    # though _get_backend() resolves one of them.
+    for provider in _list_registered_web_providers():
+        if provider.name in _LEGACY_WEB_BACKENDS:
+            continue
+        try:
+            if provider.is_available():
+                return True
+        except Exception as exc:  # noqa: BLE001 — a broken provider is skipped
+            logger.debug(
+                "web provider %r.is_available() raised: %s", provider.name, exc
+            )
+    return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

`check_web_api_key()` is the `check_fn` gate that decides whether `web_search` and `web_extract` appear in the toolset. Today's refactor (`a9cd0e07c`, "single registry authority for custom-provider availability") changed the plugin-provider branch of that gate to delegate to the registry's single-active resolvers:

```python
from agent.web_search_registry import (
    get_active_search_provider,
    get_active_extract_provider,
)
return (
    get_active_search_provider() is not None
    or get_active_extract_provider() is not None
)
```

`get_active_*_provider()` calls `_resolve(None, capability=...)` (no config key). With `explicit=None`, `_resolve` only returns a provider when **exactly one** is eligible (`len(eligible) == 1`) or the name matches the `_LEGACY_PREFERENCE` order — and custom plugin names never appear in that legacy order. So when **2+ registered custom providers** are available and capable and **no `web.backend` config key is set**, `_resolve` returns `None` for both capabilities, `check_web_api_key()` returns `False`, and `web_search` / `web_extract` are filtered out of the toolset entirely.

Meanwhile `_get_backend()` (the router) has a final fallback loop that walks `_list_registered_web_providers()` and returns the first available non-legacy provider — so it **does** resolve one of them. The gate and the router now diverge: the tools are hidden even though the router would dispatch to a custom provider without issue. This is exactly the "second resolution path that could diverge" the refactor set out to remove, reintroduced in the opposite direction. `check_web_api_key`'s own docstring states the intended contract: a plugin-registered provider that reports `is_available()` must light the tools up even when no built-in backend has credentials (issues #28651, #31873).

The fix mirrors `_get_backend()`'s final registered-provider walk in the gate so the two agree. The single-custom-provider case already worked (and is covered by the test landed with the refactor); this closes the 2+ case.

## Related Issue

Code-originated regression from `a9cd0e07c` — no separate issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/web_tools.py` — in `check_web_api_key()`, replace the `get_active_search_provider()` / `get_active_extract_provider()` delegation tail with the same registered-provider walk `_get_backend()` uses (skip `_LEGACY_WEB_BACKENDS`; return `True` on the first `provider.is_available()`), so the gate and the router agree.
- `tests/tools/test_web_tools_config.py` — add a regression test registering two available custom providers with no config key, asserting `check_web_api_key()` is `True` and `_get_backend()` resolves one of them.

## How to Test

1. Register two distinct custom `WebSearchProvider`s (e.g. `custom-a`, `custom-b`), both `is_available() == True`, both search/extract-capable.
2. Strip all built-in web env keys and set **no** `web.backend` config key.
3. Before this change: `check_web_api_key()` returns `False` (tools hidden) while `_get_backend()` returns one of the two names — gate and router disagree.
4. After this change: `check_web_api_key()` returns `True`, matching `_get_backend()`.

Regression test `test_check_web_api_key_true_for_multiple_custom_providers_none_configured` fails before / passes after. Full touched-area suite (`tests/tools/test_web_tools_config.py`, `test_web_providers.py`, `test_web_tools_tavily.py`, `test_web_tools_truncate.py`) passes: 96 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python provider-registry logic, no platform-specific code — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A