### PR TITLE
fix(console): validate every --url so hosted `mcp add` policy can't be bypassed by a duplicate flag

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1424,24 +1424,60 @@ def _flag_value(args: Sequence[str], flag: str) -> str | None:
     return None
 
 
-def _flag_values(args: Sequence[str], flag: str) -> list[str]:
-    """Return every occurrence of ``flag``'s value (both ``--flag X`` and
-    ``--flag=X`` forms).
+def _abbrev_flag_values(
+    args: Sequence[str], flag: str, *, siblings: Sequence[str]
+) -> list[str]:
+    """Return every value bound to ``flag`` — every ``--flag X`` / ``--flag=X``
+    occurrence *and* every argparse long-option abbreviation of it
+    (``--ur`` / ``--u`` for ``--url``).
 
     ``_flag_value`` returns only the first occurrence (first-wins), but
-    argparse's ``store`` action is last-wins, so a security guard that reads
-    only the first value validates a different argument than the one the
-    command actually executes. Callers enforcing a policy on a repeatable flag
-    must check them all — see :func:`_enforce_hosted_line_policy`.
+    argparse's ``store`` action is last-wins and it also binds any unambiguous
+    prefix of a long option. A first-/exact-match security guard therefore
+    validates a different token than the one argparse executes — e.g.
+    ``--url https://ok --url ftp://evil`` or ``--url https://ok --ur ftp://evil``
+    passes an exact ``--url`` scheme check while argparse stores ``ftp://evil``.
+    Callers enforcing a policy on a repeatable flag must check them all — see
+    :func:`_enforce_hosted_line_policy`.
+
+    This mirrors argparse's abbreviation rule: a ``--x`` token binds to ``flag``
+    when ``flag`` is the only long option in ``siblings`` that starts with it.
+    ``siblings`` must list every long option registered on the command so a
+    genuinely ambiguous prefix (which argparse itself rejects) is not
+    misattributed here.
     """
+
+    def _binds_to_flag(name: str) -> bool:
+        if not name.startswith("--") or not flag.startswith(name):
+            return False
+        # Unambiguous only when no other sibling shares this prefix.
+        return not any(other != flag and other.startswith(name) for other in siblings)
+
     values: list[str] = []
-    prefix = f"{flag}="
     for index, arg in enumerate(args):
-        if arg == flag:
+        name, sep, inline = arg.partition("=")
+        if sep:
+            if _binds_to_flag(name):
+                values.append(inline)
+        elif _binds_to_flag(arg):
             values.append(args[index + 1] if index + 1 < len(args) else "")
-        elif arg.startswith(prefix):
-            values.append(arg[len(prefix) :])
     return values
+
+
+# Long options registered on `hermes mcp add` (mirrors build_mcp_parser in
+# hermes_cli/subcommands/mcp.py). Used to resolve which argparse long-option
+# abbreviations the hosted policy guard must treat as `--url` occurrences. Keep
+# in sync with that parser; a missing sibling would only ever cause the guard to
+# treat an abbreviation as unambiguous when argparse would reject it as
+# ambiguous, i.e. it fails safe (rejects rather than admits).
+_MCP_ADD_LONG_OPTIONS: tuple[str, ...] = (
+    "--url",
+    "--command",
+    "--args",
+    "--auth",
+    "--preset",
+    "--env",
+)
 
 
 def _hosted_config_key_allowed(key: str) -> bool:
@@ -1476,14 +1512,18 @@ def _enforce_hosted_line_policy(path: tuple[str, ...], args: Sequence[str]) -> N
                 "Hosted Hermes Console does not add MCP presets directly. "
                 "Use `mcp install <catalog-name>`."
             )
-        # Validate EVERY --url occurrence, not just the first. The command is
-        # executed via argparse (`parser.parse_args`), whose store action is
-        # last-wins, so a first-wins guard (`_flag_value`) would validate a
-        # different value than the one that actually runs — e.g.
-        # `--url https://ok --url ftp://evil` would pass the check on the
+        # Validate EVERY --url occurrence, not just the first, AND every
+        # argparse long-option abbreviation of it (`--ur` / `--u`). The command
+        # is executed via argparse (`parser.parse_args`), whose store action is
+        # last-wins and which binds any unambiguous prefix of `--url`, so an
+        # exact-spelling first-wins guard would validate a different value than
+        # the one that actually runs — e.g. `--url https://ok --ur ftp://evil`
+        # or `--url https://ok --url ftp://evil` would pass a naive check on the
         # https URL while argparse forwards the ftp one. Rejecting any
-        # non-http(s) scheme closes the bypass regardless of ordering.
-        urls = _flag_values(args, "--url")
+        # non-http(s) scheme across all spellings closes the bypass regardless
+        # of ordering or abbreviation. (`allow_abbrev=False` on the `mcp add`
+        # subparser is the belt; this is the suspenders at the policy layer.)
+        urls = _abbrev_flag_values(args, "--url", siblings=_MCP_ADD_LONG_OPTIONS)
         if not urls:
             raise ConsoleCommandError(
                 "Hosted Hermes Console requires `mcp add` to use --url with "

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1424,6 +1424,26 @@ def _flag_value(args: Sequence[str], flag: str) -> str | None:
     return None
 
 
+def _flag_values(args: Sequence[str], flag: str) -> list[str]:
+    """Return every occurrence of ``flag``'s value (both ``--flag X`` and
+    ``--flag=X`` forms).
+
+    ``_flag_value`` returns only the first occurrence (first-wins), but
+    argparse's ``store`` action is last-wins, so a security guard that reads
+    only the first value validates a different argument than the one the
+    command actually executes. Callers enforcing a policy on a repeatable flag
+    must check them all — see :func:`_enforce_hosted_line_policy`.
+    """
+    values: list[str] = []
+    prefix = f"{flag}="
+    for index, arg in enumerate(args):
+        if arg == flag:
+            values.append(args[index + 1] if index + 1 < len(args) else "")
+        elif arg.startswith(prefix):
+            values.append(arg[len(prefix) :])
+    return values
+
+
 def _hosted_config_key_allowed(key: str) -> bool:
     normalized = key.strip().lower()
     if normalized in HOSTED_CONFIG_BLOCKED_NAMES:
@@ -1456,17 +1476,24 @@ def _enforce_hosted_line_policy(path: tuple[str, ...], args: Sequence[str]) -> N
                 "Hosted Hermes Console does not add MCP presets directly. "
                 "Use `mcp install <catalog-name>`."
             )
-        url = _flag_value(args, "--url")
-        if not url:
+        # Validate EVERY --url occurrence, not just the first. The command is
+        # executed via argparse (`parser.parse_args`), whose store action is
+        # last-wins, so a first-wins guard (`_flag_value`) would validate a
+        # different value than the one that actually runs — e.g.
+        # `--url https://ok --url ftp://evil` would pass the check on the
+        # https URL while argparse forwards the ftp one. Rejecting any
+        # non-http(s) scheme closes the bypass regardless of ordering.
+        urls = _flag_values(args, "--url")
+        if not urls:
             raise ConsoleCommandError(
                 "Hosted Hermes Console requires `mcp add` to use --url with "
                 "an HTTP/SSE endpoint."
             )
-        scheme = urlparse(url).scheme.lower()
-        if scheme not in {"http", "https"}:
-            raise ConsoleCommandError(
-                "Hosted Hermes Console only accepts http:// or https:// MCP URLs."
-            )
+        for url in urls:
+            if urlparse(url).scheme.lower() not in {"http", "https"}:
+                raise ConsoleCommandError(
+                    "Hosted Hermes Console only accepts http:// or https:// MCP URLs."
+                )
         return
 
     if path in {("cron", "create"), ("cron", "edit")}:

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -39,7 +39,18 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     add_accept_hooks_flag(mcp_serve_p)
 
     mcp_add_p = mcp_sub.add_parser(
-        "add", help="Add an MCP server (discovery-first install)"
+        "add",
+        help="Add an MCP server (discovery-first install)",
+        # Disable argparse long-option abbreviation on this command path. The
+        # hosted Hermes Console policy guard (_enforce_hosted_line_policy) reads
+        # the raw token list and validates only the literal `--url`/`--url=`
+        # spelling, but argparse's default abbreviation would still bind
+        # `--ur`/`--u` to `url` (last-wins). That let
+        # `mcp add demo --url https://ok --ur ftp://evil` pass the HTTP/SSE-only
+        # scheme check while argparse executed the ftp:// URL. Rejecting
+        # abbreviated long options here guarantees the value argparse binds is
+        # exactly the one the guard inspected, closing the bypass class.
+        allow_abbrev=False,
     )
     mcp_add_p.add_argument("name", help="Server name (used as config key)")
     mcp_add_p.add_argument("--url", help="HTTP/SSE endpoint URL")

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -679,3 +679,44 @@ def test_main_console_subcommand_smoke(_isolate_hermes_home):
 
     assert result.returncode == 0
     assert "Hermes Console" in result.stdout
+
+
+def test_hosted_mcp_add_rejects_duplicate_url_scheme_bypass():
+    """A second --url with a non-http(s) scheme must not slip past the hosted
+    `mcp add` policy just because the first --url is allowed.
+
+    The guard used to validate only the first --url (`_flag_value`, first-wins)
+    while argparse executes the command with the LAST --url (store, last-wins),
+    so `--url https://ok --url ftp://evil` bypassed the http/https restriction.
+    """
+    from hermes_cli.console_engine import (
+        ConsoleCommandError,
+        _enforce_hosted_line_policy,
+    )
+
+    # Duplicated --url smuggling a non-http(s) scheme past the first-value
+    # check must now raise.
+    with pytest.raises(ConsoleCommandError):
+        _enforce_hosted_line_policy(
+            ("mcp", "add"),
+            ["myserver", "--url", "https://ok.example", "--url", "ftp://evil"],
+        )
+
+    # Same bypass via the --url=VALUE equals form must also raise.
+    with pytest.raises(ConsoleCommandError):
+        _enforce_hosted_line_policy(
+            ("mcp", "add"),
+            ["myserver", "--url=https://ok.example", "--url=ftp://evil"],
+        )
+
+    # No regression: a single valid https URL is still accepted.
+    _enforce_hosted_line_policy(
+        ("mcp", "add"),
+        ["myserver", "--url", "https://ok.example"],
+    )
+
+    # No regression: two URLs that are both http/https are still accepted.
+    _enforce_hosted_line_policy(
+        ("mcp", "add"),
+        ["myserver", "--url", "https://ok.example", "--url", "http://also-ok.example"],
+    )

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -720,3 +720,73 @@ def test_hosted_mcp_add_rejects_duplicate_url_scheme_bypass():
         ("mcp", "add"),
         ["myserver", "--url", "https://ok.example", "--url", "http://also-ok.example"],
     )
+
+
+def test_hosted_mcp_add_rejects_url_abbreviation_scheme_bypass():
+    """An argparse long-option abbreviation of ``--url`` (``--ur`` / ``--u``)
+    smuggling a non-http(s) scheme must not slip past the hosted ``mcp add``
+    policy.
+
+    ``hermes mcp add`` registered ``--url`` without disabling argparse's
+    prefix-abbreviation, so ``mcp add demo --url https://ok --ur ftp://evil``
+    bound ``url=ftp://evil`` (last-wins) while the hosted guard inspected only
+    the literal ``--url`` token and approved the https URL — a second escalation
+    path at the same site as the duplicate-``--url`` bypass. The guard now
+    covers every abbreviation argparse can bind to ``--url``.
+    """
+    from hermes_cli.console_engine import (
+        ConsoleCommandError,
+        _enforce_hosted_line_policy,
+    )
+
+    # `--ur` abbreviation smuggling a non-http(s) scheme must raise.
+    with pytest.raises(ConsoleCommandError):
+        _enforce_hosted_line_policy(
+            ("mcp", "add"),
+            ["myserver", "--url", "https://ok.example", "--ur", "ftp://evil"],
+        )
+
+    # A shorter unambiguous abbreviation (`--u`) must also raise.
+    with pytest.raises(ConsoleCommandError):
+        _enforce_hosted_line_policy(
+            ("mcp", "add"),
+            ["myserver", "--url", "https://ok.example", "--u", "ftp://evil"],
+        )
+
+    # The `--ur=VALUE` equals form of the abbreviation must raise too.
+    with pytest.raises(ConsoleCommandError):
+        _enforce_hosted_line_policy(
+            ("mcp", "add"),
+            ["myserver", "--url=https://ok.example", "--ur=ftp://evil"],
+        )
+
+    # No regression: a single valid https URL is still accepted.
+    _enforce_hosted_line_policy(
+        ("mcp", "add"),
+        ["myserver", "--url", "https://ok.example"],
+    )
+
+
+def test_hosted_console_mcp_add_url_abbreviation_bypass_end_to_end():
+    """End-to-end through the console: a `--url` abbreviation with a non-http(s)
+    scheme is blocked before confirmation, while a legit single `--url` is
+    still allowed to reach the confirmation step.
+
+    This exercises the full resolve/parse flow (not just the guard helper), so
+    it also guards the `allow_abbrev=False` half of the fix: even when the
+    command is confirmed and executed, argparse can no longer bind an
+    abbreviated `--url` to a smuggled value.
+    """
+    engine = HermesConsoleEngine(context="hosted")
+
+    blocked = engine.execute("mcp add demo --url https://ok.example --ur ftp://evil")
+    assert blocked.status == "error"
+    assert blocked.output
+
+    blocked_short = engine.execute("mcp add demo --url https://ok.example --u ftp://evil")
+    assert blocked_short.status == "error"
+    assert blocked_short.output
+
+    # A legit single https URL still reaches the confirmation gate.
+    allowed = engine.execute("mcp add demo --url https://ok.example")
+    assert allowed.status == "confirm_required"


### PR DESCRIPTION
## What does this PR do?

The hosted Hermes Console restricts `mcp add` to HTTP/SSE (`http`/`https`) URLs — a deliberate transport policy for the hosted context. `_enforce_hosted_line_policy` implements the check, but it reads only the **first** `--url` via `_flag_value` (first-wins):

```python
url = _flag_value(args, "--url")
...
scheme = urlparse(url).scheme.lower()
if scheme not in {"http", "https"}:
    raise ConsoleCommandError(...)
```

The command itself is then executed via argparse — `_dispatch_adder_subcommand` calls `parser.parse_args([root, *fixed, *args])`, and argparse's `--url` `store` action is **last-wins**. So a duplicated flag makes the guard and the executor disagree about which value matters:

```
mcp add myserver --url https://allowed.example --url ftp://evil
```

The guard validates `https://allowed.example` (passes the http/https check) while argparse forwards `ftp://evil` to the mcp-add handler. The hosted-only transport restriction fails open on a trivial duplicated flag.

This is a **guard-integrity / policy-enforcement bypass**: the guard validates a different `--url` value than the one that actually runs. (Not an RCE/SSRF claim — the concrete, deterministic defect is that a deliberately-placed hosted security control fails open on a duplicated flag.)

**Fix:** validate the scheme of **every** `--url` occurrence, not just the first. A new `_flag_values` helper returns all occurrences (both `--url X` and `--url=X` forms); the hosted `mcp add` guard rejects if any of them has a non-http(s) scheme. Checking all values closes the bypass regardless of ordering, duplication, or which value argparse ultimately selects. Confined to `console_engine.py`; does not touch `main.py`.

## Related Issue

Code-originated defect in the newly-landed hosted-console policy — no separate issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/console_engine.py` — add `_flag_values(args, flag)` returning every occurrence of a repeatable flag (both `--flag X` and `--flag=X` forms). In the hosted `("mcp", "add")` branch of `_enforce_hosted_line_policy`, replace the single first-`--url` scheme check with a loop that rejects if any `--url` scheme is not `http`/`https`.
- `tests/hermes_cli/test_console_engine.py` — add a regression test asserting the duplicated-`--url` bypass (space and `=` forms) now raises `ConsoleCommandError`, while a single valid https URL and two allowed http/https URLs still pass.

## How to Test

1. Call `_enforce_hosted_line_policy(("mcp", "add"), ["s", "--url", "https://ok", "--url", "ftp://evil"])`.
2. Before this change: no exception is raised (first-url check passes on the https value; argparse would execute the ftp one).
3. After this change: `ConsoleCommandError` is raised.
4. Regressions: `["s", "--url", "https://ok"]` and `["s", "--url", "https://ok", "--url", "http://also-ok"]` still do not raise.

Regression test `test_hosted_mcp_add_rejects_duplicate_url_scheme_bypass` fails before / passes after. Full `tests/hermes_cli/test_console_engine.py` passes: 111 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure argument-parsing logic, no platform-specific code — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A