### PR TITLE
[codex] Add Mikrus Hermes ops overlay

### DIFF
--- a/deploy/mikrus-hermes/.gitattributes
+++ b/deploy/mikrus-hermes/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/deploy/mikrus-hermes/AGENTS.md
+++ b/deploy/mikrus-hermes/AGENTS.md
@@ -1,0 +1,61 @@
+# Hermes Mikrus operations
+
+- This Hermes runs in Docker and uses `/root/.hermes` mounted as `/opt/data`.
+- Do not ask the user to restart the container after changing `/opt/data/.env`.
+- From inside Hermes/container, use `hermesctl restart` or
+  `docker compose restart hermes`; these are safe shims that restart the Hermes
+  gateway and reload environment/config.
+- From the VPS host, use `hermesctl status`, `hermesctl restart`,
+  `hermesctl logs`, `hermesctl model-test`, and `hermesctl firecrawl-test`.
+- Full host compose lives at `/root/hermes/docker-compose.yml`; legacy
+  `docker-compose` is available as a wrapper for `docker compose`.
+- Never append duplicate keys to `/opt/data/.env`; replace an existing key in
+  place and verify duplicates before restarting.
+- Firecrawl web search uses direct Firecrawl cloud credentials: keep
+  `web.use_gateway: false` in `/opt/data/config.yaml` while
+  `FIRECRAWL_API_KEY` is present.
+- The running image is built locally from `/root/hermes/Dockerfile` as
+  `hermes-agent-tools-firecrawl:local` to pin `firecrawl-py==4.17.0`; do not
+  recreate from bare `hermes-agent-tools:latest` unless this dependency is
+  rebuilt.
+
+## STT / Voice
+
+- Voice transcription is configured for local faster-whisper: keep
+  `stt.enabled: true` and `stt.provider: local` in `/root/.hermes/config.yaml`.
+- The custom Docker image installs `faster-whisper` together with the pinned
+  Firecrawl dependency, so rebuild with
+  `docker compose -f /root/hermes/docker-compose.yml build hermes` after
+  changing the image.
+
+## Public Facebook Access
+
+- Do not assume public Facebook pages are unusable just because direct
+  extraction shows a login wall or bot block.
+- For city/gmina/powiat/news/event questions involving Facebook, first try
+  public indexed search: `web_search` with
+  `site:facebook.com/<page-or-name> <topic> aktualnosci wydarzenia`, or run
+  `facebook_public_search <topic-or-facebook-url>` in the terminal.
+- Use only public snippets, public URLs, and public pages. Do not use
+  credentials, cookies, private groups, CAPTCHA bypasses, or login workarounds.
+- If snippets are available but the full Facebook page is blocked, summarize
+  the snippets and include the Facebook URLs instead of saying only that
+  Facebook does not work.
+
+## Composio
+
+- Composio CLI is available as `composio` inside the Hermes container; it is a
+  terminal command, not a built-in Hermes toolset name.
+- When asked whether Hermes has new tools/capabilities, mention Composio CLI
+  explicitly and say it can be used via terminal.
+- Check the current Composio login with `composio whoami`; check app
+  connections with `composio connections list`.
+- Use it for connected external apps such as Gmail, Google Calendar, Notion,
+  Slack, GitHub, CRM tools, and other SaaS services.
+- If no app connections exist yet, run or suggest `composio link <toolkit>`
+  instead of saying Composio is unavailable.
+- Composio auth and user config must persist under `/opt/data` via the
+  wrapper's `HOME=/opt/data`; the CLI binary is mounted from
+  `/opt/composio-cli`.
+- Do not use cookies or copied browser sessions; use Composio OAuth/API-key
+  connection flows.

--- a/deploy/mikrus-hermes/Dockerfile
+++ b/deploy/mikrus-hermes/Dockerfile
@@ -1,0 +1,5 @@
+FROM hermes-agent-tools:base-806223de549b
+
+RUN uv pip install --python /opt/hermes/.venv/bin/python \
+    "firecrawl-py==4.17.0" \
+    "faster-whisper"

--- a/deploy/mikrus-hermes/README.md
+++ b/deploy/mikrus-hermes/README.md
@@ -1,0 +1,104 @@
+# Mikrus Hermes Telegram operations overlay
+
+This directory captures a sanitized deployment overlay for running Hermes on a
+Mikrus/VPS host with Telegram as the primary control surface.
+
+It intentionally does not include `.env`, API keys, Telegram bot tokens, SSH
+credentials, Composio auth state, or provider secrets.
+
+## What This Overlay Covers
+
+- Persistent Hermes data mounted from the host into `/opt/data`.
+- A local Docker image that pins `firecrawl-py==4.17.0` and installs
+  `faster-whisper` for local Polish speech-to-text.
+- Safe in-container `docker` and `docker-compose` shims, so Telegram terminal
+  commands can restart or inspect Hermes without exposing the host Docker
+  daemon socket.
+- `hermesctl` for status, restart, logs, model tests, and Firecrawl checks.
+- `facebook_public_search` for public indexed Facebook results without login,
+  cookies, CAPTCHA bypasses, or copied browser sessions.
+- `composio` CLI mounting through the terminal tool, with auth/config persisted
+  under `/opt/data`.
+- Telegram prompt hints that tell Hermes to present Composio as a terminal
+  capability and to avoid approval-gate endings when concrete commands can be
+  given.
+
+## Host Layout
+
+The production layout this mirrors is:
+
+```text
+/root/hermes/
+  Dockerfile
+  docker-compose.yml
+
+/root/.hermes/
+  .env                  # secrets, not committed
+  config.yaml           # runtime config, keep secrets out
+  AGENTS.md
+  .local/bin/hermesctl
+  .local/bin/docker
+  .local/bin/docker-compose
+  .local/bin/facebook_public_search
+  .local/bin/composio
+  composio-cli/         # installed Composio CLI bundle
+```
+
+## Deploy
+
+Copy or sync these files to the matching host paths, then build and restart:
+
+```bash
+mkdir -p /root/hermes /root/.hermes/.local/bin
+cp Dockerfile /root/hermes/Dockerfile
+cp docker-compose.yml /root/hermes/docker-compose.yml
+cp AGENTS.md /root/.hermes/AGENTS.md
+cp scripts/* /root/.hermes/.local/bin/
+chmod +x /root/.hermes/.local/bin/*
+
+docker compose -f /root/hermes/docker-compose.yml build hermes
+docker compose -f /root/hermes/docker-compose.yml up -d hermes
+```
+
+Install Composio CLI into `/root/.hermes/composio-cli` before relying on the
+`composio` wrapper.
+
+## Config Snippet
+
+Merge `config.example.yaml` into `/root/.hermes/config.yaml`. Keep API keys and
+tokens in `/root/.hermes/.env` only.
+
+After changing config, clear cached Telegram system prompts if old instructions
+keep appearing:
+
+```bash
+python3 - <<'PY'
+import sqlite3
+con = sqlite3.connect('/root/.hermes/state.db')
+cur = con.cursor()
+cur.execute("update sessions set system_prompt=NULL where source='telegram'")
+print('cleared', cur.rowcount)
+con.commit()
+con.close()
+PY
+docker compose -f /root/hermes/docker-compose.yml restart hermes
+```
+
+## Verification
+
+Run these on the host:
+
+```bash
+docker exec hermes sh -lc 'hermesctl status'
+docker exec hermes sh -lc 'hermesctl model-test'
+docker exec --user 10000:10000 hermes sh -lc 'composio whoami && composio connections list'
+docker exec hermes sh -lc 'facebook_public_search "Brzeg Dolny wydarzenia" --limit 3'
+```
+
+Expected high-level results:
+
+- Telegram platform is `connected`.
+- `hermesctl model-test` prints `OK`.
+- `composio whoami` shows the logged-in Composio account.
+- `facebook_public_search` returns public indexed Facebook URLs or a clear
+  no-results message without asking for a Facebook login.

--- a/deploy/mikrus-hermes/config.example.yaml
+++ b/deploy/mikrus-hermes/config.example.yaml
@@ -1,0 +1,29 @@
+web:
+  backend: firecrawl
+  search_backend: ''
+  extract_backend: ''
+  use_gateway: false
+
+stt:
+  enabled: true
+  provider: local
+  local:
+    model: base
+    language: pl
+  openai:
+    model: whisper-1
+  mistral:
+    model: voxtral-mini-latest
+  elevenlabs:
+    model_id: scribe_v2
+    language_code: ''
+    tag_audio_events: false
+    diarize: false
+  use_gateway: true
+
+platform_hints:
+  telegram:
+    append: |
+      When a Telegram request involves Facebook pages, posts, city/gmina/powiat event pages, or says Facebook is blocked, do not conclude that Facebook requires login before trying public indexed access. First use web_search with queries like `site:facebook.com/<page> <topic> aktualnosci wydarzenia` or run the terminal helper `facebook_public_search <topic-or-facebook-url>`. Use only public results, snippets, and URLs; do not use cookies, credentials, private groups, CAPTCHA bypasses, or login workarounds. If direct extraction of a Facebook URL fails but public search snippets exist, summarize those snippets and include the Facebook URLs. Do not propose installing Chromium as the next step unless the user explicitly asks for a real browser path.
+
+      Composio is available in this Hermes container as a terminal command: `composio`. When a Telegram user asks whether you have new tools, new capabilities, `nowe narzedzia`, or `nowe mozliwosci`, answer first: `Tak - mam dostep do Composio CLI przez terminal.` Then clarify that the native Hermes tool list is unchanged, but Composio is an added terminal capability available through the `terminal` tool. Do not start with `Nie` and do not deny the capability just because Composio is not a formal Hermes tool name. Useful commands: `composio whoami`, `composio connections list`, `composio search <query>`, `composio link <toolkit>`, and `composio execute <tool_slug> -d <json>`. Use it through the terminal for external apps like Gmail, Google Calendar, Notion, Slack, GitHub, CRM tools and other SaaS services. If `composio connections list` is empty, explain that Composio itself is logged in but individual apps still need `composio link <toolkit>`. In Telegram, do not end with approval gates like `czy chcesz`, `daj OK`, or asking the user to choose an option; instead give one or two concrete next commands the user can paste or ask you to run.

--- a/deploy/mikrus-hermes/docker-compose.yml
+++ b/deploy/mikrus-hermes/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  hermes:
+    image: hermes-agent-tools-firecrawl:local
+    build:
+      context: /root/hermes
+    container_name: hermes
+    restart: unless-stopped
+    volumes:
+      - /root/.hermes:/opt/data
+      - /root/.hermes/.local/bin/hermesctl:/usr/local/bin/hermesctl:ro
+      - /root/.hermes/.local/bin/docker:/usr/local/bin/docker:ro
+      - /root/.hermes/.local/bin/docker-compose:/usr/local/bin/docker-compose:ro
+      - /root/.hermes/.local/bin/facebook_public_search:/usr/local/bin/facebook_public_search:ro
+      - /root/.hermes/composio-cli:/opt/composio-cli:ro
+      - /root/.hermes/.local/bin/composio:/usr/local/bin/composio:ro
+    environment:
+      HERMES_UID: "10000"
+      HERMES_GID: "10000"
+      TZ: Europe/Warsaw
+    command: ["gateway", "run"]

--- a/deploy/mikrus-hermes/scripts/composio
+++ b/deploy/mikrus-hermes/scripts/composio
@@ -1,0 +1,4 @@
+#!/bin/sh
+export HOME=/opt/data
+export COMPOSIO_INSTALL_DIR=/opt/composio-cli
+exec /opt/composio-cli/composio "$@"

--- a/deploy/mikrus-hermes/scripts/docker
+++ b/deploy/mikrus-hermes/scripts/docker
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Safe in-container shim: Hermes cannot and should not control the host Docker
+# daemon. Map common self-management commands to gateway operations that reload
+# /opt/data/.env.
+
+case "${1:-}" in
+  --version|version)
+    echo "Docker host daemon is not exposed inside Hermes. Use hermesctl inside the container, or host hermesctl over SSH."
+    exit 0
+    ;;
+  restart)
+    if [ "${2:-}" = "hermes" ] || [ "${2:-}" = "gateway" ] || [ -z "${2:-}" ]; then
+      exec hermesctl restart
+    fi
+    ;;
+  logs)
+    exec hermesctl logs "${2:-120}"
+    ;;
+  ps)
+    exec hermesctl status
+    ;;
+  compose)
+    shift
+    case "${1:-}" in
+      restart) exec hermesctl restart ;;
+      logs) exec hermesctl logs "${2:-120}" ;;
+      ps|status) exec hermesctl status ;;
+    esac
+    ;;
+esac
+
+echo "Docker daemon is unavailable inside Hermes. Supported safe commands: docker restart hermes, docker logs, docker ps, docker compose restart." >&2
+exit 2

--- a/deploy/mikrus-hermes/scripts/docker-compose
+++ b/deploy/mikrus-hermes/scripts/docker-compose
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+case "${1:-}" in
+  restart) exec hermesctl restart ;;
+  logs) exec hermesctl logs "${2:-120}" ;;
+  ps|status) exec hermesctl status ;;
+  --version|version)
+    echo "docker-compose shim inside Hermes: use hermesctl; host compose is available over SSH."
+    exit 0
+    ;;
+esac
+
+echo "docker-compose is a safe shim inside Hermes. Supported: restart, logs, ps/status." >&2
+exit 2

--- a/deploy/mikrus-hermes/scripts/facebook_public_search
+++ b/deploy/mikrus-hermes/scripts/facebook_public_search
@@ -1,0 +1,141 @@
+#!/opt/hermes/.venv/bin/python
+"""Search public Facebook pages/posts without logging in.
+
+This helper intentionally does not use Facebook credentials, cookies, or login
+workarounds. It asks Hermes' configured web backend for indexed public Facebook
+results and prints concise Markdown that an agent can cite or summarize.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+HERMES_ROOT = Path("/opt/hermes")
+DATA_ENV = Path("/opt/data/.env")
+
+if str(HERMES_ROOT) not in sys.path:
+    sys.path.insert(0, str(HERMES_ROOT))
+
+
+def _load_dotenv(path: Path = DATA_ENV) -> None:
+    if not path.exists():
+        return
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key or key in os.environ:
+            continue
+        os.environ[key] = value.strip().strip('"').strip("'")
+
+
+def _facebook_site_from_text(text: str) -> str:
+    match = re.search(
+        r"https?://(?:www\.|m\.|mbasic\.)?facebook\.com/([^\s?#]+)",
+        text,
+        re.I,
+    )
+    if not match:
+        return "site:facebook.com"
+    path = match.group(1).strip("/")
+    if not path:
+        return "site:facebook.com"
+    if path in {"groups", "pages", "events", "posts", "photos", "videos", "watch"}:
+        return "site:facebook.com"
+    return f"site:facebook.com/{path}"
+
+
+def _coerce_results(payload):
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return [], payload
+    if not isinstance(payload, dict):
+        return [], str(payload)
+    if payload.get("error"):
+        return [], str(payload.get("error"))
+    data = payload.get("data") or {}
+    if isinstance(data, dict):
+        web = data.get("web") or data.get("results") or []
+    else:
+        web = payload.get("results") or []
+    if not isinstance(web, list):
+        return [], json.dumps(payload, ensure_ascii=False)[:1000]
+    return web, ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Search indexed public Facebook posts/pages without logging in."
+    )
+    parser.add_argument(
+        "query",
+        nargs="+",
+        help="Topic, city/page name, or a public facebook.com URL",
+    )
+    parser.add_argument("--limit", type=int, default=8, help="Maximum results to return")
+    args = parser.parse_args()
+
+    _load_dotenv()
+    query_text = " ".join(args.query).strip()
+    site = _facebook_site_from_text(query_text)
+    cleaned = re.sub(r"https?://\S+", "", query_text).strip()
+    if not cleaned:
+        cleaned = query_text
+    search_query = f"{site} {cleaned} aktualnosci wydarzenia posty".strip()
+
+    try:
+        from tools.web_tools import web_search_tool
+
+        payload = web_search_tool(search_query, limit=max(1, min(args.limit, 20)))
+    except Exception as exc:
+        print(f"ERROR: facebook_public_search failed: {exc}")
+        return 2
+
+    results, error = _coerce_results(payload)
+    print("# Public Facebook results without login")
+    print(f"Query: `{search_query}`")
+    print(
+        "Source: public indexed Facebook results via the configured web_search "
+        "backend; no cookies and no login.\n"
+    )
+    if error:
+        print(f"Error: {error}")
+        return 1
+    if not results:
+        print("No public indexed Facebook results were found for this query.")
+        return 0
+
+    seen = set()
+    count = 0
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        if not url or "facebook.com" not in url.lower() or url in seen:
+            continue
+        seen.add(url)
+        title = re.sub(r"\s+", " ", str(item.get("title") or "Facebook")).strip()
+        desc = re.sub(r"\s+", " ", str(item.get("description") or "")).strip()
+        count += 1
+        print(f"{count}. {title}")
+        if desc:
+            print(f"   {desc}")
+        print(f"   {url}")
+        if count >= args.limit:
+            break
+    if count == 0:
+        print("Backend returned results, but no public facebook.com URLs.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/mikrus-hermes/scripts/hermesctl
+++ b/deploy/mikrus-hermes/scripts/hermesctl
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -eu
+
+cmd=${1:-status}
+shift || true
+
+case "$cmd" in
+  status)
+    /opt/hermes/bin/hermes gateway status || true
+    cat /opt/data/gateway_state.json 2>/dev/null || true
+    ;;
+  restart|gateway-restart|reload|reload-env)
+    /opt/hermes/bin/hermes gateway restart
+    ;;
+  logs)
+    tail -n "${1:-120}" /opt/data/logs/gateways/default/current 2>/dev/null || \
+      tail -n "${1:-120}" /opt/data/logs/gateway.log 2>/dev/null || true
+    ;;
+  model-test)
+    /opt/hermes/bin/hermes -z 'Odpowiedz dokladnie: OK'
+    ;;
+  firecrawl-test)
+    . /opt/hermes/.venv/bin/activate
+    python - <<'PY'
+from hermes_cli.env_loader import load_hermes_dotenv
+
+load_hermes_dotenv()
+
+import json
+import os
+import urllib.request
+
+key = os.environ.get("FIRECRAWL_API_KEY", "")
+print("key_len", len(key))
+req = urllib.request.Request(
+    "https://api.firecrawl.dev/v1/scrape",
+    data=json.dumps(
+        {
+            "url": "https://example.com",
+            "formats": ["markdown"],
+            "onlyMainContent": True,
+        }
+    ).encode(),
+    headers={
+        "Authorization": "Bearer " + key,
+        "Content-Type": "application/json",
+    },
+    method="POST",
+)
+with urllib.request.urlopen(req, timeout=30) as r:
+    body = json.loads(r.read().decode())
+    print(
+        "status",
+        r.status,
+        "success",
+        body.get("success"),
+        "has_markdown",
+        bool((body.get("data") or {}).get("markdown")),
+    )
+PY
+    ;;
+  *)
+    echo "Usage inside Hermes: hermesctl {status|restart|reload-env|logs [n]|model-test|firecrawl-test}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a sanitized Mikrus/VPS deployment overlay for Telegram-first Hermes operations
- capture the Firecrawl/faster-whisper Docker image, persistent data mount, safe docker shims, hermesctl, public Facebook search helper, and Composio terminal wrapper
- document the config snippets and verification commands needed to reproduce the running setup without committing secrets

## Validation
- python -m py_compile deploy/mikrus-hermes/scripts/facebook_public_search
- bash -n deploy/mikrus-hermes/scripts/hermesctl
- bash -n deploy/mikrus-hermes/scripts/docker
- bash -n deploy/mikrus-hermes/scripts/docker-compose
- bash -n deploy/mikrus-hermes/scripts/composio
- YAML safe-load for deploy/mikrus-hermes/docker-compose.yml and deploy/mikrus-hermes/config.example.yaml
- git diff --check
- secret scan over deploy/mikrus-hermes for known local credentials/API-key markers