### PR TITLE
fix(utils): respect default fallback in env_bool when unset or empty

### DIFF
--- a/tests/test_utils_truthy_values.py
+++ b/tests/test_utils_truthy_values.py
@@ -1,6 +1,6 @@
 """Tests for shared truthy-value helpers."""
 
-from utils import env_var_enabled, is_truthy_value
+from utils import env_bool, env_var_enabled, is_truthy_value
 
 
 def test_is_truthy_value_accepts_common_truthy_strings():
@@ -27,3 +27,22 @@ def test_env_var_enabled_uses_shared_truthy_rules(monkeypatch):
 
     monkeypatch.setenv("HERMES_TEST_BOOL", "no")
     assert env_var_enabled("HERMES_TEST_BOOL") is False
+
+
+def test_env_bool_default_value_when_unset():
+    assert env_bool("HERMES_NON_EXISTENT_VAR", default=True) is True
+    assert env_bool("HERMES_NON_EXISTENT_VAR", default=False) is False
+
+
+def test_env_bool_whitespace_value_uses_default(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_BOOL", "   ")
+    assert env_bool("HERMES_TEST_BOOL", default=True) is True
+    assert env_bool("HERMES_TEST_BOOL", default=False) is False
+
+
+def test_env_bool_coercion_rules(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_BOOL", "true")
+    assert env_bool("HERMES_TEST_BOOL", default=False) is True
+
+    monkeypatch.setenv("HERMES_TEST_BOOL", "0")
+    assert env_bool("HERMES_TEST_BOOL", default=True) is False

--- a/utils.py
+++ b/utils.py
@@ -431,7 +431,10 @@ def env_float(key: str, default: float = 0.0) -> float:
 
 def env_bool(key: str, default: bool = False) -> bool:
     """Read an environment variable as a boolean."""
-    return is_truthy_value(os.getenv(key, ""), default=default)
+    raw = os.getenv(key, "").strip()
+    if not raw:
+        return default
+    return is_truthy_value(raw, default=default)
 
 
 # ─── Proxy Helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR fixes a bug in the \env_bool\ utility function in \utils.py\ where the \default\ fallback parameter was ignored when the environment variable was unset or empty. The implementation now correctly falls back to \default\ when the stripped environment variable is empty, aligning it with other environment helpers like \env_int\ and \env_float\.