### PR TITLE
fix(compression): skip session rotation when compression yields no reduction

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -617,6 +617,19 @@ def compress_context(
         finally:
             _release_lock()
 
+    # Compression succeeded but produced no message reduction — the session
+    # would keep rotating indefinitely.  Exit early, same as the abort path.
+    if len(compressed) == len(messages):
+        logger.info(
+            "Compression yielded no message reduction — "
+            "skipping session rotation to avoid infinite compression loop"
+        )
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        _release_lock()
+        return messages, _existing_sp
+
     try:
         summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
         if summary_error:


### PR DESCRIPTION
## Summary

When `compress()` succeeds but produces the **same number of messages** as the input (e.g. all messages are within budget or protected), the session rotates indefinitely on every auto-compress tick. Each rotation forks a new session with the same content, creating an infinite chain of empty sessions.

## Fix

Add an early return path after compression completes: if `len(compressed) == len(messages)`, log a warning and return the original messages with a freshly-built system prompt, **skipping session rotation entirely**.

This mirrors the existing abort-path guard (lines 603-618) and prevents the infinite loop.

## Closes

Closes #57771

## Credit

Patch authored by **V0aRyn** in the issue comments. They couldn't open a PR due to PAT scope limitations on their fork — this is a salvage of their work.