### PR TITLE
fix(gateway): allow Telegram DM topic resume

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -723,11 +723,39 @@ class GatewaySlashCommandsMixin:
         """
         if origin is None or current is None:
             return False
+        chat_type = (getattr(current, "chat_type", "") or "").lower()
         if origin.platform != current.platform:
             return False
         if origin.chat_id != current.chat_id:
             return False
-        # thread_id is part of the session key for every chat type when present
+        # DM-like chats are always per-user.
+        if chat_type in {"dm", "direct", "private", ""}:
+            # chat_id was already required equal above and, when present, IS the
+            # DM session key — so an equal non-empty chat_id is sufficient.
+            #
+            # Telegram Direct Messages topics are modeled as DM ``thread_id``
+            # lanes under the same private chat. Users intentionally use
+            # ``/resume`` to move their own transcript between those lanes; that
+            # is same-user/same-DM access, not the cross-room/group IDOR this
+            # guard prevents. Therefore DM-like chats do NOT require thread
+            # equality when chat_id is present. Non-DM threads remain scoped
+            # below before any sharing logic.
+            # build_session_key only falls back to the participant id
+            # (``user_id_alt or user_id`` — Signal/Feishu key on user_id_alt)
+            # when there is NO chat_id; mirror that and fail closed on a
+            # missing/different participant so two no-chat_id DM origins are
+            # never conflated (was: compared user_id only and allowed when
+            # either side was missing).
+            if str(getattr(current, "chat_id", "") or ""):
+                return True
+            if str(getattr(current, "thread_id", "") or "") != str(
+                getattr(origin, "thread_id", "") or ""
+            ):
+                return False
+            cur_pid = str(current.user_id_alt or current.user_id or "")
+            org_pid = str(origin.user_id_alt or origin.user_id or "")
+            return bool(cur_pid) and cur_pid == org_pid
+        # thread_id is part of the session key for non-DM chats when present
         # (build_session_key appends it unconditionally), so a session in one
         # thread is a DIFFERENT session from another thread of the same parent
         # chat. is_shared_multi_user_session only decides participant sharing
@@ -738,22 +766,6 @@ class GatewaySlashCommandsMixin:
             getattr(origin, "thread_id", "") or ""
         ):
             return False
-        chat_type = (getattr(current, "chat_type", "") or "").lower()
-        # DM-like chats are always per-user.
-        if chat_type in {"dm", "direct", "private", ""}:
-            # chat_id was already required equal above and, when present, IS the
-            # DM session key — so an equal non-empty chat_id is sufficient.
-            # build_session_key only falls back to the participant id
-            # (``user_id_alt or user_id`` — Signal/Feishu key on user_id_alt)
-            # when there is NO chat_id; mirror that and fail closed on a
-            # missing/different participant so two no-chat_id DM origins are
-            # never conflated (was: compared user_id only and allowed when
-            # either side was missing).
-            if str(getattr(current, "chat_id", "") or ""):
-                return True
-            cur_pid = str(current.user_id_alt or current.user_id or "")
-            org_pid = str(origin.user_id_alt or origin.user_id or "")
-            return bool(cur_pid) and cur_pid == org_pid
         # Non-DM: scope by participant whenever the session key for this source
         # is per-user. is_shared_multi_user_session mirrors build_session_key's
         # isolation rules exactly, so the guard stays in lock-step with the key.
@@ -870,13 +882,15 @@ class GatewaySlashCommandsMixin:
             # NULL-chat rows are intentionally not resumable this way; use a
             # live session or an explicit admin override.)
             # Common origin proof for any identity-bearing caller: a non-blank
-            # source that matches the caller's platform, and the same thread. A
-            # blank/legacy source can't prove the platform; a different thread is
-            # a different session (build_session_key appends thread_id).
+            # source that matches the caller's platform. A blank/legacy source
+            # can't prove the platform. For non-DM chats, a different thread is
+            # a different origin and is checked below. DM-like chats (notably
+            # Telegram Direct Messages topics) may intentionally resume the same
+            # user's transcript across thread lanes in the same private chat.
             origin_ok = (
-                bool(row_src) and bool(caller_src)
+                bool(row_src)
+                and bool(caller_src)
                 and str(row_src) == str(caller_src)
-                and row_thread == caller_thread
             )
             if not origin_ok:
                 return False
@@ -894,10 +908,18 @@ class GatewaySlashCommandsMixin:
                 # apply there.
                 if caller_keys_on_alt and not (bool(row_chat) and bool(caller_chat)):
                     return False
+                # With a real DM chat_id (Telegram private chat), thread lanes
+                # are user-visible topics that may resume each other. Without a
+                # chat_id, build_session_key falls back to participant+thread, so
+                # the thread remains part of the provenance proof.
+                if not (bool(row_chat) and bool(caller_chat)) and row_thread != caller_thread:
+                    return False
                 return (
                     bool(row_uid) and row_uid == caller_uid
                     and row_chat == caller_chat
                 )
+            if row_thread != caller_thread:
+                return False
             # Non-DM (group/channel/forum/thread): build_session_key includes
             # chat_id, so a row (or caller) with NO chat provenance cannot prove
             # same-chat. Require both sides non-blank and equal — a legacy

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1035,11 +1035,39 @@ class GatewaySlashCommandsMixin:
         """
         if origin is None or current is None:
             return False
+        chat_type = (getattr(current, "chat_type", "") or "").lower()
         if origin.platform != current.platform:
             return False
         if origin.chat_id != current.chat_id:
             return False
-        # thread_id is part of the session key for every chat type when present
+        # DM-like chats are always per-user.
+        if chat_type in {"dm", "direct", "private", ""}:
+            # chat_id was already required equal above and, when present, IS the
+            # DM session key — so an equal non-empty chat_id is sufficient.
+            #
+            # Telegram Direct Messages topics are modeled as DM ``thread_id``
+            # lanes under the same private chat. Users intentionally use
+            # ``/resume`` to move their own transcript between those lanes; that
+            # is same-user/same-DM access, not the cross-room/group IDOR this
+            # guard prevents. Therefore DM-like chats do NOT require thread
+            # equality when chat_id is present. Non-DM threads remain scoped
+            # below before any sharing logic.
+            # build_session_key only falls back to the participant id
+            # (``user_id_alt or user_id`` — Signal/Feishu key on user_id_alt)
+            # when there is NO chat_id; mirror that and fail closed on a
+            # missing/different participant so two no-chat_id DM origins are
+            # never conflated (was: compared user_id only and allowed when
+            # either side was missing).
+            if str(getattr(current, "chat_id", "") or ""):
+                return True
+            if str(getattr(current, "thread_id", "") or "") != str(
+                getattr(origin, "thread_id", "") or ""
+            ):
+                return False
+            cur_pid = str(current.user_id_alt or current.user_id or "")
+            org_pid = str(origin.user_id_alt or origin.user_id or "")
+            return bool(cur_pid) and cur_pid == org_pid
+        # thread_id is part of the session key for non-DM chats when present
         # (build_session_key appends it unconditionally), so a session in one
         # thread is a DIFFERENT session from another thread of the same parent
         # chat. is_shared_multi_user_session only decides participant sharing
@@ -1050,22 +1078,6 @@ class GatewaySlashCommandsMixin:
             getattr(origin, "thread_id", "") or ""
         ):
             return False
-        chat_type = (getattr(current, "chat_type", "") or "").lower()
-        # DM-like chats are always per-user.
-        if chat_type in {"dm", "direct", "private", ""}:
-            # chat_id was already required equal above and, when present, IS the
-            # DM session key — so an equal non-empty chat_id is sufficient.
-            # build_session_key only falls back to the participant id
-            # (``user_id_alt or user_id`` — Signal/Feishu key on user_id_alt)
-            # when there is NO chat_id; mirror that and fail closed on a
-            # missing/different participant so two no-chat_id DM origins are
-            # never conflated (was: compared user_id only and allowed when
-            # either side was missing).
-            if str(getattr(current, "chat_id", "") or ""):
-                return True
-            cur_pid = str(current.user_id_alt or current.user_id or "")
-            org_pid = str(origin.user_id_alt or origin.user_id or "")
-            return bool(cur_pid) and cur_pid == org_pid
         # Non-DM: scope by participant whenever the session key for this source
         # is per-user. is_shared_multi_user_session mirrors build_session_key's
         # isolation rules exactly, so the guard stays in lock-step with the key.
@@ -1182,13 +1194,15 @@ class GatewaySlashCommandsMixin:
             # NULL-chat rows are intentionally not resumable this way; use a
             # live session or an explicit admin override.)
             # Common origin proof for any identity-bearing caller: a non-blank
-            # source that matches the caller's platform, and the same thread. A
-            # blank/legacy source can't prove the platform; a different thread is
-            # a different session (build_session_key appends thread_id).
+            # source that matches the caller's platform. A blank/legacy source
+            # can't prove the platform. For non-DM chats, a different thread is
+            # a different origin and is checked below. DM-like chats (notably
+            # Telegram Direct Messages topics) may intentionally resume the same
+            # user's transcript across thread lanes in the same private chat.
             origin_ok = (
-                bool(row_src) and bool(caller_src)
+                bool(row_src)
+                and bool(caller_src)
                 and str(row_src) == str(caller_src)
-                and row_thread == caller_thread
             )
             if not origin_ok:
                 return False
@@ -1206,10 +1220,18 @@ class GatewaySlashCommandsMixin:
                 # apply there.
                 if caller_keys_on_alt and not (bool(row_chat) and bool(caller_chat)):
                     return False
+                # With a real DM chat_id (Telegram private chat), thread lanes
+                # are user-visible topics that may resume each other. Without a
+                # chat_id, build_session_key falls back to participant+thread, so
+                # the thread remains part of the provenance proof.
+                if not (bool(row_chat) and bool(caller_chat)) and row_thread != caller_thread:
+                    return False
                 return (
                     bool(row_uid) and row_uid == caller_uid
                     and row_chat == caller_chat
                 )
+            if row_thread != caller_thread:
+                return False
             # Non-DM (group/channel/forum/thread): build_session_key includes
             # chat_id, so a row (or caller) with NO chat provenance cannot prove
             # same-chat. Require both sides non-blank and equal — a legacy

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -33,7 +33,7 @@ def _session_key_for_event(event):
 
 def _make_runner(session_db=None, current_session_id="current_session_001",
                  event=None):
-    """Create a bare GatewayRunner with a mock session_store and optional session_db."""
+    """Create a bare GatewayRunner with mocked sync/async session stores."""
     from gateway.run import GatewayRunner
     runner = object.__new__(GatewayRunner)
     runner.adapters = {}
@@ -50,15 +50,19 @@ def _make_runner(session_db=None, current_session_id="current_session_001",
     # Compute the real session key if an event is provided
     session_key = build_session_key(event.source) if event else "agent:main:telegram:dm"
 
-    # Mock session_store that returns a session entry with a known session_id
+    # Keep the synchronous store for origin lookups, but mock the async boundary
+    # that slash handlers await directly.
     mock_session_entry = MagicMock()
     mock_session_entry.session_id = current_session_id
     mock_session_entry.session_key = session_key
     mock_store = MagicMock()
-    mock_store.get_or_create_session.return_value = mock_session_entry
-    mock_store.load_transcript.return_value = []
-    mock_store.switch_session.return_value = mock_session_entry
     runner.session_store = mock_store
+    runner._async_session_store = SimpleNamespace(
+        _store=mock_store,
+        get_or_create_session=AsyncMock(return_value=mock_session_entry),
+        load_transcript=AsyncMock(return_value=[]),
+        switch_session=AsyncMock(return_value=mock_session_entry),
+    )
 
     return runner
 
@@ -131,9 +135,9 @@ class TestHandleResumeCommand:
         result = await runner._handle_resume_command(event)
 
         assert "Resumed" in result
-        runner.session_store.switch_session.assert_called_once()
-        call_args = runner.session_store.switch_session.call_args
-        assert call_args[0][1] == "sess_001"
+        runner.async_session_store.switch_session.assert_awaited_once_with(
+            _session_key_for_event(event), "sess_001"
+        )
         db.close()
 
     @pytest.mark.asyncio
@@ -152,7 +156,7 @@ class TestHandleResumeCommand:
 
         assert "out of range" in result.lower()
         assert "/resume" in result
-        runner.session_store.switch_session.assert_not_called()
+        runner.async_session_store.switch_session.assert_not_awaited()
         db.close()
 
     @pytest.mark.asyncio
@@ -171,10 +175,9 @@ class TestHandleResumeCommand:
 
         assert "Resumed" in result
         assert "My Project" in result
-        # Verify switch_session was called with the old session ID
-        runner.session_store.switch_session.assert_called_once()
-        call_args = runner.session_store.switch_session.call_args
-        assert call_args[0][1] == "old_session_abc"
+        runner.async_session_store.switch_session.assert_awaited_once_with(
+            _session_key_for_event(event), "old_session_abc"
+        )
         db.close()
 
     @pytest.mark.asyncio
@@ -199,9 +202,15 @@ class TestHandleResumeCommand:
 
         assert "Resumed" in result
         assert "Topic A Work" in result
-        runner.session_store.switch_session.assert_called_once()
-        call_args = runner.session_store.switch_session.call_args
-        assert call_args[0][1] == "topic_a_session"
+        runner.async_session_store.get_or_create_session.assert_awaited_once_with(
+            event.source
+        )
+        runner.async_session_store.switch_session.assert_awaited_once_with(
+            _session_key_for_event(event), "topic_a_session"
+        )
+        runner.async_session_store.load_transcript.assert_awaited_once_with(
+            "topic_a_session"
+        )
         db.close()
 
     @pytest.mark.asyncio
@@ -313,8 +322,9 @@ class TestHandleResumeCommand:
 
         assert "Resumed" in result
         # Should resolve to #2 (latest in lineage)
-        call_args = runner.session_store.switch_session.call_args
-        assert call_args[0][1] == "sess_v2"
+        runner.async_session_store.switch_session.assert_awaited_once_with(
+            _session_key_for_event(event), "sess_v2"
+        )
         db.close()
 
     @pytest.mark.asyncio
@@ -336,7 +346,7 @@ class TestHandleResumeCommand:
             current_session_id="current_session_001",
             event=event,
         )
-        runner.session_store.load_transcript.side_effect = (
+        runner.async_session_store.load_transcript.side_effect = (
             lambda session_id: [{"role": "user", "content": "hello from continuation"}]
             if session_id == "compressed_child"
             else []
@@ -346,9 +356,12 @@ class TestHandleResumeCommand:
 
         assert "Resumed session" in result
         assert "(1 message)" in result
-        call_args = runner.session_store.switch_session.call_args
-        assert call_args[0][1] == "compressed_child"
-        runner.session_store.load_transcript.assert_called_with("compressed_child")
+        runner.async_session_store.switch_session.assert_awaited_once_with(
+            _session_key_for_event(event), "compressed_child"
+        )
+        runner.async_session_store.load_transcript.assert_awaited_once_with(
+            "compressed_child"
+        )
         db.close()
 
     @pytest.mark.asyncio
@@ -579,7 +592,7 @@ class TestHandleSessionsCommand:
             runner = _make_runner(session_db=db, current_session_id="current_session_001",
                                   event=event)
             result = await runner._handle_resume_command(event)
-            runner.session_store.switch_session.assert_not_called()
+            runner.async_session_store.switch_session.assert_not_awaited()
             assert "Resumed" not in result, name
         db.close()
 
@@ -606,7 +619,7 @@ class TestHandleSessionsCommand:
             runner = _make_runner(session_db=db, current_session_id="current_session_001",
                                   event=event)
             result = await runner._handle_resume_command(event)
-            runner.session_store.switch_session.assert_not_called()
+            runner.async_session_store.switch_session.assert_not_awaited()
             assert "Resumed" not in result, name
         db.close()
 
@@ -629,7 +642,7 @@ class TestHandleSessionsCommand:
             runner = _make_runner(session_db=db, current_session_id="current_session_001",
                                   event=event)
             result = await runner._handle_resume_command(event)
-            runner.session_store.switch_session.assert_not_called()
+            runner.async_session_store.switch_session.assert_not_awaited()
             assert "Resumed" not in result, name
         db.close()
 
@@ -669,7 +682,7 @@ class TestHandleSessionsCommand:
             runner = _make_runner(session_db=db, current_session_id="current_session_001",
                                   event=event)
             result = await runner._handle_resume_command(event)
-            runner.session_store.switch_session.assert_not_called()
+            runner.async_session_store.switch_session.assert_not_awaited()
             assert "Resumed" not in result, name
         db.close()
 

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -178,6 +178,33 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_by_name_across_telegram_dm_topics(self, tmp_path):
+        """User-visible regression: a Telegram private-chat topic may resume the
+        same user's session from a neighboring DM topic/thread."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("topic_a_session", "telegram", user_id="12345",
+                          chat_id="67890", chat_type="dm", thread_id="topic-a")
+        db.set_session_title("topic_a_session", "Topic A Work")
+        db.create_session("current_session_001", "telegram", user_id="12345",
+                          chat_id="67890", chat_type="dm", thread_id="topic-b")
+
+        event = _make_event(text="/resume Topic A Work", user_id="12345", chat_id="67890")
+        event.source.chat_type = "dm"
+        event.source.thread_id = "topic-b"
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        assert "Topic A Work" in result
+        runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "topic_a_session"
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_clears_session_model_overrides(self, tmp_path):
         """Resume must not carry a previous session's /model override into the
         restored conversation, while leaving other chats' overrides intact (#10702)."""
@@ -692,6 +719,29 @@ class TestHandleSessionsCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_target_allowed_telegram_dm_topic_cross_thread(self, tmp_path):
+        """Telegram DM topics are private lanes under one user-owned chat. The
+        same user may resume a transcript from another DM topic/thread in that
+        same private chat, while a different private chat stays blocked."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("topic_a", "telegram", user_id="12345",
+                          chat_id="67890", chat_type="dm", thread_id="topic-a")
+        db.create_session("other_dm_chat", "telegram", user_id="12345",
+                          chat_id="99999", chat_type="dm", thread_id="topic-a")
+        runner = _make_runner(session_db=db)
+        runner._gateway_session_origin_for_id = lambda sid: None  # persisted-only
+
+        caller_topic_b = SessionSource(platform=Platform.TELEGRAM, chat_id="67890",
+                                       chat_type="dm", user_id="12345",
+                                       thread_id="topic-b")
+        assert await runner._resume_target_allowed(caller_topic_b, "topic_a",
+                                                   allow_override=False) is True
+        assert await runner._resume_target_allowed(caller_topic_b, "other_dm_chat",
+                                                   allow_override=False) is False
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_target_allowed_shared_group_no_user_match(self, tmp_path):
         """egilewski probe: with group_sessions_per_user=False a non-DM group
         session is shared, so a co-member (different user_id) in the SAME chat
@@ -853,6 +903,23 @@ class TestSameOriginChatGroupScoping:
         a = self._src("alice", chat_type="dm", chat_id="dm-1")
         b = self._src("alice", chat_type="dm", chat_id="dm-1")
         assert runner._same_origin_chat(a, b) is True
+
+    def test_dm_same_chat_id_cross_thread_is_same_origin(self):
+        # Telegram DM topics carry thread_id, but still belong to the same
+        # private chat/user. /resume is allowed to move the user's own transcript
+        # between those private lanes.
+        runner = _make_runner()
+        a = self._src("alice", chat_type="dm", chat_id="dm-1", thread_id="topic-a")
+        b = self._src("alice", chat_type="dm", chat_id="dm-1", thread_id="topic-b")
+        assert runner._same_origin_chat(a, b) is True
+
+    def test_dm_no_chat_id_cross_thread_blocked(self):
+        # Without chat_id, a DM key falls back to participant+thread, so the
+        # thread is still part of the origin proof.
+        runner = _make_runner()
+        a = self._src("alice", chat_type="dm", chat_id=None, thread_id="topic-a")
+        b = self._src("alice", chat_type="dm", chat_id=None, thread_id="topic-b")
+        assert runner._same_origin_chat(a, b) is False
 
     @pytest.mark.asyncio
     async def test_resume_target_allowed_blocks_cross_user_live_group(self):

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -33,7 +33,7 @@ def _session_key_for_event(event):
 
 def _make_runner(session_db=None, current_session_id="current_session_001",
                  event=None):
-    """Create a bare GatewayRunner with a mock session_store and optional session_db."""
+    """Create a bare GatewayRunner with mocked sync/async session stores."""
     from gateway.run import GatewayRunner
     runner = object.__new__(GatewayRunner)
     runner.adapters = {}
@@ -47,18 +47,18 @@ def _make_runner(session_db=None, current_session_id="current_session_001",
     runner._running_agents = {}
     runner._is_user_authorized = lambda _source: True
 
-    # Compute the real session key if an event is provided
     session_key = build_session_key(event.source) if event else "agent:main:telegram:dm"
-
-    # Mock session_store that returns a session entry with a known session_id
     mock_session_entry = MagicMock()
     mock_session_entry.session_id = current_session_id
     mock_session_entry.session_key = session_key
     mock_store = MagicMock()
-    mock_store.get_or_create_session.return_value = mock_session_entry
-    mock_store.load_transcript.return_value = []
-    mock_store.switch_session.return_value = mock_session_entry
     runner.session_store = mock_store
+    runner._async_session_store = SimpleNamespace(
+        _store=mock_store,
+        get_or_create_session=AsyncMock(return_value=mock_session_entry),
+        load_transcript=AsyncMock(return_value=[]),
+        switch_session=AsyncMock(return_value=mock_session_entry),
+    )
 
     return runner
 
@@ -107,6 +107,40 @@ class TestHandleResumeCommand:
         assert "/resume 1" in result
         db.close()
 
+    @pytest.mark.asyncio
+    async def test_resume_by_name_across_telegram_dm_topics(self, tmp_path):
+        """The same Telegram user/private chat may move work across DM topics."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "topic_a_session", "telegram", user_id="12345",
+            chat_id="67890", chat_type="dm", thread_id="topic-a",
+        )
+        db.set_session_title("topic_a_session", "Topic A Work")
+        db.create_session(
+            "current_session_001", "telegram", user_id="12345",
+            chat_id="67890", chat_type="dm", thread_id="topic-b",
+        )
+        event = _make_event(
+            text="/resume Topic A Work", user_id="12345", chat_id="67890"
+        )
+        event.source.chat_type = "dm"
+        event.source.thread_id = "topic-b"
+        runner = _make_runner(
+            session_db=db, current_session_id="current_session_001", event=event
+        )
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        assert "Topic A Work" in result
+        runner.async_session_store.get_or_create_session.assert_awaited_once_with(event.source)
+        runner.async_session_store.switch_session.assert_awaited_once_with(
+            _session_key_for_event(event), "topic_a_session"
+        )
+        runner.async_session_store.load_transcript.assert_awaited_once_with("topic_a_session")
+        db.close()
 
     @pytest.mark.asyncio
     async def test_resume_clears_session_model_overrides(self, tmp_path):
@@ -191,7 +225,7 @@ class TestHandleResumeCommand:
             current_session_id="current_session_001",
             event=event,
         )
-        runner.session_store.load_transcript.side_effect = (
+        runner.async_session_store.load_transcript.side_effect = (
             lambda session_id: [{"role": "user", "content": "hello from continuation"}]
             if session_id == "compressed_child"
             else []
@@ -201,9 +235,12 @@ class TestHandleResumeCommand:
 
         assert "Resumed session" in result
         assert "(1 message)" in result
-        call_args = runner.session_store.switch_session.call_args
-        assert call_args[0][1] == "compressed_child"
-        runner.session_store.load_transcript.assert_called_with("compressed_child")
+        runner.async_session_store.switch_session.assert_awaited_once_with(
+            _session_key_for_event(event), "compressed_child"
+        )
+        runner.async_session_store.load_transcript.assert_awaited_once_with(
+            "compressed_child"
+        )
         db.close()
 
 
@@ -323,8 +360,9 @@ class TestHandleResumeCommand:
         result = await runner._handle_resume_command(event)
 
         assert "Resumed" in result
-        runner.session_store.switch_session.assert_called_once()
-        assert runner.session_store.switch_session.call_args[0][1] == "lane_older"
+        runner.async_session_store.switch_session.assert_awaited_once_with(
+            _session_key_for_event(event), "lane_older"
+        )
         db.close()
 
     @pytest.mark.asyncio
@@ -759,6 +797,34 @@ class TestHandleSessionsCommand:
         tg_db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_target_allowed_telegram_dm_topic_cross_thread(self, tmp_path):
+        """Same-user DM topics may cross threads, but not private chats."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "topic_a", "telegram", user_id="12345",
+            chat_id="67890", chat_type="dm", thread_id="topic-a",
+        )
+        db.create_session(
+            "other_dm_chat", "telegram", user_id="12345",
+            chat_id="99999", chat_type="dm", thread_id="topic-a",
+        )
+        runner = _make_runner(session_db=db)
+        runner._gateway_session_origin_for_id = lambda sid: None
+        caller_topic_b = SessionSource(
+            platform=Platform.TELEGRAM, chat_id="67890", chat_type="dm",
+            user_id="12345", thread_id="topic-b",
+        )
+        assert await runner._resume_target_allowed(
+            caller_topic_b, "topic_a", allow_override=False
+        ) is True
+        assert await runner._resume_target_allowed(
+            caller_topic_b, "other_dm_chat", allow_override=False
+        ) is False
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_gateway_dispatches_sessions_command(self, tmp_path):
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
@@ -797,6 +863,18 @@ class TestSameOriginChatGroupScoping:
         runner = _make_runner()
         a = self._src("alice", chat_type="dm", chat_id=None)
         b = self._src("bob", chat_type="dm", chat_id=None)
+        assert runner._same_origin_chat(a, b) is False
+
+    def test_dm_same_chat_id_cross_thread_is_same_origin(self):
+        runner = _make_runner()
+        a = self._src("alice", chat_type="dm", chat_id="dm-1", thread_id="topic-a")
+        b = self._src("alice", chat_type="dm", chat_id="dm-1", thread_id="topic-b")
+        assert runner._same_origin_chat(a, b) is True
+
+    def test_dm_no_chat_id_cross_thread_blocked(self):
+        runner = _make_runner()
+        a = self._src("alice", chat_type="dm", chat_id=None, thread_id="topic-a")
+        b = self._src("alice", chat_type="dm", chat_id=None, thread_id="topic-b")
         assert runner._same_origin_chat(a, b) is False
 
 


### PR DESCRIPTION
## Summary
- Allows Telegram private-chat DM topics to `/resume` the same user's session from a neighboring DM topic lane.
- Keeps strict `thread_id` isolation for non-DM group/forum/channel sessions.
- Keeps no-chat-id DM sources scoped by participant/thread, since those do not have a private chat id to prove ownership.
- Adds regression coverage for the user-visible `/resume` path, persisted fallback, live-origin helper, and negative cases.

Fixes #57821

## Rationale
Recent `/resume` origin-scoping hardening correctly prevented cross-room/cross-thread session attachment for multi-user contexts, but it also applied `thread_id` equality before the DM-specific ownership check.

That breaks a personal Telegram bot workflow: Telegram DM topics are user-visible lanes inside the same private chat with the bot. A user may keep separate topics for tasks and then continue an existing Hermes conversation in the current topic via `/resume <title|id>`. In that surface, the security boundary is the private chat/user, not the individual DM topic lane.

This PR narrows the relaxation to DM-like chats with a real `chat_id`:
- same platform + same private chat id is allowed across DM topic `thread_id`s;
- no-chat-id DM sources still require thread equality;
- non-DM sessions still require thread equality before shared/per-user group logic.

## Test plan
- `python3 -m pytest tests/gateway/test_resume_command.py -q -o 'addopts='`
- `python3 -m py_compile gateway/slash_commands.py tests/gateway/test_resume_command.py`
- `git diff --check`
