### PR TITLE
security(vision): route local-file inputs through the shared credential-read guard

### DIFF
--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -193,6 +193,29 @@ class TestVideoAnalyzeTool:
         assert data["success"] is True
         assert "demo" in data["analysis"].lower()
 
+    def test_local_file_read_guard_blocks_env_via_video_extension(self, tmp_path):
+        """A .env file symlinked with a video extension must still be blocked.
+
+        _detect_video_mime_type only checks the file extension, not file
+        content, so without a read guard a model could point video_url at
+        any credential-store file (renamed/symlinked to look like a video)
+        and have its raw bytes base64-encoded and sent to the vision
+        provider. Regression for the shared agent.file_safety chokepoint
+        added to video_analyze_tool's local-file branch.
+        """
+        secret = tmp_path / ".env"
+        secret.write_text("OPENAI_API_KEY=sk-super-secret\n", encoding="utf-8")
+        disguised = tmp_path / "video.mp4"
+        disguised.symlink_to(secret)
+
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock) as mock_llm:
+            result = self._run(video_analyze_tool(str(disguised), "What is this?"))
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "secret-bearing environment file" in data["error"]
+        mock_llm.assert_not_awaited()
+
     def test_local_file_not_found(self, tmp_path):
         """Non-existent file raises appropriate error."""
         result = self._run(video_analyze_tool("/nonexistent/video.mp4", "What?"))

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -504,6 +504,38 @@ class TestVisionSafetyGuards:
         mock_llm.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_local_env_file_blocked_via_read_guard(self, tmp_path):
+        """A .env file must be blocked even if given an image-like path.
+
+        Mirrors the video_analyze_tool regression: the local-file branch
+        must route through agent.file_safety.raise_if_read_blocked before
+        vision_analyze_tool ever opens the file, not rely solely on the
+        magic-byte mime check as an accidental side effect.
+        """
+        secret = tmp_path / ".env"
+        secret.write_text("OPENAI_API_KEY=sk-super-secret\n", encoding="utf-8")
+
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock) as mock_llm:
+            result = json.loads(await vision_analyze_tool(str(secret), "extract text"))
+
+        assert result["success"] is False
+        assert "secret-bearing environment file" in result["error"]
+        mock_llm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_native_fast_path_local_env_file_blocked_via_read_guard(self, tmp_path):
+        """Same read guard must apply to the native vision fast path."""
+        from tools.vision_tools import _vision_analyze_native
+
+        secret = tmp_path / ".env"
+        secret.write_text("OPENAI_API_KEY=sk-super-secret\n", encoding="utf-8")
+
+        result = json.loads(await _vision_analyze_native(str(secret), "extract text"))
+
+        assert result["success"] is False
+        assert "secret-bearing environment file" in result["error"]
+
+    @pytest.mark.asyncio
     async def test_blocked_remote_url_short_circuits_before_download(self):
         blocked = {
             "host": "blocked.test",

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -848,6 +848,8 @@ async def _vision_analyze_native(
         local_path = Path(os.path.expanduser(resolved_url))
 
         if local_path.is_file():
+            from agent.file_safety import raise_if_read_blocked
+            raise_if_read_blocked(str(local_path))
             temp_image_path = local_path
             should_cleanup = False
         elif await _validate_image_url_async(image_url):
@@ -1005,6 +1007,8 @@ async def vision_analyze_tool(
         local_path = Path(os.path.expanduser(resolved_url))
         if local_path.is_file():
             # Local file path (e.g. from platform image cache) -- skip download
+            from agent.file_safety import raise_if_read_blocked
+            raise_if_read_blocked(str(local_path))
             logger.info("Using local image file: %s", image_url)
             temp_image_path = local_path
             should_cleanup = False  # Don't delete cached/local files
@@ -1527,6 +1531,8 @@ async def video_analyze_tool(
         local_path = Path(os.path.expanduser(resolved_url))
 
         if local_path.is_file():
+            from agent.file_safety import raise_if_read_blocked
+            raise_if_read_blocked(str(local_path))
             logger.info("Using local video file: %s", video_url)
             temp_video_path = local_path
             should_cleanup = False


### PR DESCRIPTION
## Summary
- `video_analyze_tool`'s local-path branch read raw file bytes via `_detect_video_mime_type`, which validates by **file extension only** (no magic-byte check), with no call to `agent.file_safety.raise_if_read_blocked`. A model could point `video_url` at a credential store (e.g. `.env`, `auth.json`) renamed or symlinked to a video-like extension (`.mp4`, `.webm`, `.mov`, ...) and have the raw bytes base64-encoded and sent to the vision provider.
- `vision_analyze_tool` and its native fast path (`_vision_analyze_native`) have the identical local-path branch shape and were only *incidentally* protected by the image magic-byte sniff rejecting non-image content — not by an intentional read guard.
- This is the same credential-read boundary the image-gen/video-gen provider plugins already enforce via a shared chokepoint (`plugins/image_gen/openai/__init__.py`, `plugins/video_gen/xai/__init__.py`, introduced in #57698) — vision's local-file branches never got the equivalent guard.

## Fix
Add `agent.file_safety.raise_if_read_blocked()` to all three local-file branches in `tools/vision_tools.py`, mirroring the existing plugin call sites exactly. This is defense-in-depth (documented as such in `file_safety.py`'s own docstring — the terminal tool can still `cat` these files), consistent with the framing of the existing guard.

## Related
[#35362](https://github.com/NousResearch/hermes-agent/pull/35362) is a larger in-flight refactor of `vision_analyze`'s image-source resolution (unifying byte delivery across data:/http/file/container sources). It explicitly scopes credential-read hardening as out-of-scope ("Security hardening (a readable-root allowlist) is intentionally out of scope here and left as a no-op seam for a possible follow-up"), so this PR is complementary, not a duplicate. It does not touch `video_analyze_tool` at all.

## Test plan
- [x] Added regression tests: `video_analyze_tool` (symlinked `.env` disguised as `.mp4`), `vision_analyze_tool`, and `_vision_analyze_native` (plain `.env` path) all assert the request is rejected before any LLM call.
- [x] `tests/tools/test_video_analyze.py`, `tests/tools/test_vision_tools.py`, `tests/tools/test_vision_native_fast_path.py` — 140 passed.
- [x] Wider vision-related suite (`tests/agent/test_vision_routing_31179.py`, `test_custom_providers_vision.py`, `test_vision_resolved_args.py`, `tests/run_agent/test_vision_aware_preprocessing.py`, `test_copilot_native_vision_headers.py`, `test_vision_tool_messages.py`, `tests/gateway/test_vision_memory_leak.py`, `test_computer_use_vision_routing.py`) — 95 passed.
- [x] `ty check tools/vision_tools.py` — diagnostic count/categories unchanged before vs. after (68/68, verified via `git stash` diff).