### PR TITLE
feat(gateway): accept rar and 7z document uploads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1344,6 +1344,8 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ini": "text/plain",
     ".cfg": "text/plain",
     ".zip": "application/zip",
+    ".rar": "application/vnd.rar",
+    ".7z": "application/x-7z-compressed",
     ".doc": "application/msword",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xls": "application/vnd.ms-excel",

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -156,6 +156,8 @@ class TestSupportedDocumentTypes:
             ".md",
             ".txt",
             ".zip",
+            ".rar",
+            ".7z",
             ".doc",
             ".docx",
             ".xls",

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -261,6 +261,35 @@ class TestDocumentDownloadBlock:
         assert event.media_urls and event.media_urls[0].endswith("archive.zip")
         assert event.media_types == ["application/zip"]
 
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("filename", "mime_type", "expected_mime"),
+        [
+            ("assets.rar", "application/vnd.rar", "application/vnd.rar"),
+            ("assets.7z", "application/x-7z-compressed", "application/x-7z-compressed"),
+        ],
+    )
+    async def test_archive_document_cached(self, adapter, filename, mime_type, expected_mime):
+        """RAR/7z uploads should be cached like zip archives for CLI inspection."""
+        archive_bytes = b"archive-bytes"
+        file_obj = _make_file_obj(archive_bytes)
+        doc = _make_document(
+            file_name=filename,
+            mime_type=mime_type,
+            file_size=len(archive_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls and event.media_urls[0].endswith(filename)
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == [expected_mime]
+        assert event.text == ""
+
     @pytest.mark.asyncio
     async def test_png_document_is_routed_as_image(self, adapter):
         """Telegram documents that are really PNGs should use the image path."""


### PR DESCRIPTION
## Summary
- accept `.rar` and `.7z` uploads as supported gateway documents
- preserve archive MIME types so Telegram users can hand archives to the agent for terminal/file inspection
- add document cache and Telegram document routing regressions

Closes #28791.

## Test Plan
- [x] `python -m pytest -q -o 'addopts=' tests/gateway/test_document_cache.py::TestSupportedDocumentTypes tests/gateway/test_telegram_documents.py::TestDocumentDownloadBlock::test_zip_document_cached tests/gateway/test_telegram_documents.py::TestDocumentDownloadBlock::test_archive_document_cached`
- [x] `git diff --check`