### PR TITLE
fix(state): preserve API counts on absolute sync

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2146,7 +2146,7 @@ class SessionDB:
         billing_provider: Optional[str] = None,
         billing_base_url: Optional[str] = None,
         billing_mode: Optional[str] = None,
-        api_call_count: int = 0,
+        api_call_count: Optional[int] = 0,
         absolute: bool = False,
     ) -> None:
         """Update token counters and backfill model if not already set.
@@ -2182,7 +2182,7 @@ class SessionDB:
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
                    model = COALESCE(model, ?),
-                   api_call_count = ?
+                   api_call_count = COALESCE(?, api_call_count)
                    WHERE id = ?"""
         else:
             sql = """UPDATE sessions SET
@@ -2205,6 +2205,7 @@ class SessionDB:
                    model = COALESCE(model, ?),
                    api_call_count = COALESCE(api_call_count, 0) + ?
                    WHERE id = ?"""
+        api_call_count_param = api_call_count if (absolute or api_call_count is not None) else 0
         params = (
             input_tokens,
             output_tokens,
@@ -2221,7 +2222,7 @@ class SessionDB:
             billing_base_url,
             billing_mode,
             model,
-            api_call_count,
+            api_call_count_param,
             session_id,
         )
         def _do(conn):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -264,6 +264,19 @@ class TestSessionLifecycle:
         assert session["api_call_count"] == 5
         assert session["input_tokens"] == 300
 
+    def test_update_token_counts_absolute_preserves_api_call_count_when_unknown(self, db):
+        """absolute metadata sync must not clobber an existing API-call count."""
+        db.create_session(session_id="s1", source="webui")
+        db.update_token_counts("s1", input_tokens=100, output_tokens=50, api_call_count=3)
+        db.update_token_counts("s1", input_tokens=300, output_tokens=150,
+                               cache_read_tokens=1200, api_call_count=None,
+                               absolute=True)
+
+        session = db.get_session("s1")
+        assert session["api_call_count"] == 3
+        assert session["input_tokens"] == 300
+        assert session["cache_read_tokens"] == 1200
+
     def test_update_token_counts_backfills_model_when_null(self, db):
         db.create_session(session_id="s1", source="telegram")
         db.update_token_counts("s1", input_tokens=10, output_tokens=5, model="openai/gpt-5.4")


### PR DESCRIPTION
## Thinking Path

- Hermes `SessionDB.update_token_counts(..., absolute=True)` is used by state-sync paths that already hold cumulative totals.
- Some callers know token/cache totals but do not know the authoritative cumulative API-call count.
- Before this change, passing no API-call count to an absolute update meant `0`, which could clobber a row that had already accumulated real calls.
- The safer contract is: explicit absolute counts still set the field; unknown absolute counts preserve the current field.

## What Changed

- Changed `api_call_count` in `SessionDB.update_token_counts()` to allow `None`.
- In absolute mode, `api_call_count=None` now preserves the existing DB value with `COALESCE(?, api_call_count)`.
- In incremental mode, omitted/`None` call counts still behave as zero so additive updates do not regress.
- Added regression coverage proving an absolute metadata sync can update token/cache totals without clobbering an existing API-call count.

## Why It Matters

This prevents metadata-sync paths from turning real session activity into `api_call_count=0` just because they only know cumulative token/cache totals. That matters for insights, session accounting, orphan-detection heuristics, and reports that use `state.db` as the durable source.

## Verification

Ran on a clean branch from current `origin/main`:

```bash
python3 -m pytest tests/test_hermes_state.py -q
python3 -m py_compile hermes_state.py tests/test_hermes_state.py
git diff --check origin/main..HEAD
```

Results:

- `304 passed`
- `py_compile` passed
- `git diff --check`: clean

Also verified in a local temp `state.db` smoke with WebUI state-sync code:

- unknown `api_call_count` preserved existing value `4`
- explicit `api_call_count=9` updated the row
- cache counters updated correctly in both cases

## Risks / Follow-ups

- This is intentionally narrow: it only changes absolute-mode handling for an unknown API-call count. Existing explicit absolute updates and incremental updates keep their current semantics.
- A companion WebUI PR forwards cache counters and known streaming API-call counts through its state-sync bridge.

## Contract Routing

Task type: runtime/session metadata durability bug fix

Touched areas:

- `SessionDB.update_token_counts()` absolute counter semantics
- session accounting regression coverage

Relevant public docs:

- `AGENTS.md`

State layer affected: Hermes Agent `state.db` session usage counters.

Evidence: full `tests/test_hermes_state.py`, syntax check, diff check, and local temp-DB smoke.

## Model Used

AI-assisted: OpenAI GPT-5.5 via Hermes, with Codex read-only review.