### PR TITLE
fix(kanban): make create_task idempotency-key race-safe

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1863,9 +1863,13 @@ def _dedupe_active_idempotency_keys(conn: sqlite3.Connection) -> None:
     cheap on the common case (no duplicates): the GROUP BY scan is the only
     cost when there is nothing to fix.
     """
+    # Empty-string keys mean "no idempotency" and are excluded from the UNIQUE
+    # partial index, so multiple active '' rows are legal — never archive them
+    # as duplicates. Mirror the index predicate here.
     dupe_keys = conn.execute(
         "SELECT idempotency_key FROM tasks "
-        "WHERE idempotency_key IS NOT NULL AND status != 'archived' "
+        "WHERE idempotency_key IS NOT NULL AND idempotency_key != '' "
+        "AND status != 'archived' "
         "GROUP BY idempotency_key HAVING COUNT(*) > 1"
     ).fetchall()
     if not dupe_keys:
@@ -2052,7 +2056,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # that ``create_task`` turns into a "return the canonical existing task"
     # response instead of a silently-inserted duplicate. Archived rows are
     # excluded so a key can be legitimately reused once its original task is
-    # archived, matching the pre-existing fast-path SELECT semantics. Kept
+    # archived, matching the pre-existing fast-path SELECT semantics. Empty
+    # ('') keys are also excluded: ``create_task`` treats "" as "no key" and
+    # normalises it to NULL, but legacy DBs may still hold '' rows, and those
+    # must stay non-unique (multiple keyless tasks are legal). Kept
     # under the SAME index name (drop + recreate, not rename) so callers that
     # only inspect ``sqlite_master`` for ``idx_tasks_idempotency`` see no
     # difference.
@@ -2071,7 +2078,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency "
             "ON tasks(idempotency_key) "
-            "WHERE idempotency_key IS NOT NULL AND status != 'archived'"
+            "WHERE idempotency_key IS NOT NULL AND idempotency_key != '' "
+            "AND status != 'archived'"
         )
     else:
         conn.execute(
@@ -2527,6 +2535,13 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    # An empty / whitespace-only idempotency key means "no idempotency" — the
+    # fast-path lookup and IntegrityError recovery below both gate on
+    # ``if idempotency_key`` (falsy for ""). Normalise to NULL so the column
+    # stores NULL rather than ''; the UNIQUE partial index excludes NULLs, so a
+    # second keyless create still succeeds instead of colliding on a stored ''.
+    if idempotency_key is not None:
+        idempotency_key = str(idempotency_key).strip() or None
 
     # Resolve an optional first-class Project link. A project-linked task is
     # anchored to the project's primary repo as a git worktree, so its branch

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1849,6 +1849,55 @@ def init_db(
     return path
 
 
+def _dedupe_active_idempotency_keys(conn: sqlite3.Connection) -> None:
+    """Archive-safe de-dup pass ahead of the UNIQUE idempotency index.
+
+    Pre-#19-fix DBs may already hold duplicate active (non-archived) rows
+    sharing one ``idempotency_key`` — the exact race this migration closes.
+    Building ``idx_tasks_idempotency`` directly over dirty data would
+    raise ``IntegrityError`` and make the DB permanently unopenable. For each
+    duplicated key, keep the row the pre-existing ``create_task`` lookup
+    fast-path already resolves to (``ORDER BY created_at DESC LIMIT 1`` —
+    newest wins) and archive the rest, so post-migration lookups keep
+    returning the same task id they did before the migration. Idempotent and
+    cheap on the common case (no duplicates): the GROUP BY scan is the only
+    cost when there is nothing to fix.
+    """
+    dupe_keys = conn.execute(
+        "SELECT idempotency_key FROM tasks "
+        "WHERE idempotency_key IS NOT NULL AND status != 'archived' "
+        "GROUP BY idempotency_key HAVING COUNT(*) > 1"
+    ).fetchall()
+    if not dupe_keys:
+        return
+    now = int(time.time())
+    for row in dupe_keys:
+        key = row["idempotency_key"]
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? AND status != 'archived' "
+            "ORDER BY created_at DESC, id DESC",
+            (key,),
+        ).fetchall()
+        # Keep the first (canonical, newest-wins per the existing lookup
+        # order); archive every other duplicate so the UNIQUE partial index
+        # can be built cleanly.
+        for dupe in rows[1:]:
+            conn.execute(
+                "UPDATE tasks SET status = 'archived', completed_at = ? "
+                "WHERE id = ? AND status != 'archived'",
+                (now, dupe["id"]),
+            )
+            _append_event(
+                conn,
+                dupe["id"],
+                "archived",
+                {
+                    "reason": "duplicate_idempotency_key_migration",
+                    "idempotency_key": key,
+                },
+            )
+
+
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns that were introduced after v1 release to legacy DBs.
 
@@ -1994,9 +2043,40 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # is cheap thanks to ``IF NOT EXISTS`` and stays correct on fresh DBs
     # (where the columns already exist from SCHEMA_SQL).
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)")
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
-    )
+    # ``idx_tasks_idempotency`` used to be a plain (non-unique) index, which
+    # is why concurrent ``create_task`` callers with the same idempotency key
+    # could both insert (#19 2/3 review finding: true multi-connection races
+    # produced two active fix tasks for one logical DoD verdict). Replace it
+    # with a UNIQUE partial index over active (non-archived) rows so a second
+    # concurrent INSERT for the same key fails fast with an IntegrityError
+    # that ``create_task`` turns into a "return the canonical existing task"
+    # response instead of a silently-inserted duplicate. Archived rows are
+    # excluded so a key can be legitimately reused once its original task is
+    # archived, matching the pre-existing fast-path SELECT semantics. Kept
+    # under the SAME index name (drop + recreate, not rename) so callers that
+    # only inspect ``sqlite_master`` for ``idx_tasks_idempotency`` see no
+    # difference.
+    #
+    # A production DB may already contain duplicate active rows for the same
+    # key from before this fix (that's the exact bug being closed) — building
+    # the UNIQUE index directly over dirty data would raise and prevent the
+    # DB from ever opening again. De-duplicate first so the migration is
+    # forward-safe on existing boards. Guarded on ``status`` existing: some
+    # synthetic/legacy schemas used only in migration-idempotency tests don't
+    # model the ``status`` column at all, and this dedup pass is meaningless
+    # without it (there's no "active" concept to dedup within).
+    if "status" in cols:
+        _dedupe_active_idempotency_keys(conn)
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency "
+            "ON tasks(idempotency_key) "
+            "WHERE idempotency_key IS NOT NULL AND status != 'archived'"
+        )
+    else:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
+        )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
@@ -2538,9 +2618,15 @@ def create_task(
 
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
+    # and to avoid holding a write lock during the lookup. This pre-check is
+    # an optimisation, not the correctness guarantee: two concurrent
+    # creators with the same key can both pass it and both attempt the
+    # INSERT below, but ``idx_tasks_idempotency`` (a UNIQUE partial
+    # index over active idempotency keys) means only one INSERT actually
+    # lands — the loser hits ``sqlite3.IntegrityError`` and the ``except``
+    # block around the INSERT re-reads and returns the winner's id instead
+    # of leaving a duplicate row committed (#19 2/3 review finding: a plain
+    # non-unique index let both concurrent inserts land).
     if idempotency_key:
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
@@ -2682,9 +2768,29 @@ def create_task(
                 )
             return task_id
         except sqlite3.IntegrityError:
+            # A concurrent creator may have won the idempotency-key race
+            # between our fast-path SELECT (above) and this INSERT hitting
+            # the UNIQUE partial index over active idempotency keys
+            # (idx_tasks_idempotency). write_txn's BEGIN IMMEDIATE
+            # has already rolled our attempt back by the time we get here,
+            # so a plain read now sees the winner's committed row. Return
+            # its id instead of raising or retrying with a doomed new id —
+            # this is what makes the fix task-level idempotency race-safe
+            # rather than merely racy-but-eventually-consistent (#19 2/3
+            # review finding).
+            if idempotency_key:
+                winner = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? "
+                    "AND status != 'archived' "
+                    "ORDER BY created_at DESC LIMIT 1",
+                    (idempotency_key,),
+                ).fetchone()
+                if winner is not None:
+                    return winner["id"]
             if attempt == 1:
                 raise
-            # Retry with a fresh id.
+            # Genuine (extremely unlikely) task-id collision with no
+            # idempotency-key conflict involved — retry with a fresh id.
             continue
     raise RuntimeError("unreachable")
 

--- a/tests/hermes_cli/test_kanban_idempotency_race.py
+++ b/tests/hermes_cli/test_kanban_idempotency_race.py
@@ -7,6 +7,7 @@ active (non-archived) rows plus IntegrityError recovery in ``create_task``
 make the losing writer return the winner's id instead of inserting a duplicate.
 """
 
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -26,16 +27,45 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
-def test_create_task_idempotency_key_is_race_safe(kanban_home):
-    """Two concurrent create_task calls with one idempotency_key -> one row."""
+def test_create_task_idempotency_key_is_race_safe(kanban_home, monkeypatch):
+    """Two concurrent create_task calls with one idempotency_key -> one row.
+
+    The barrier is placed *inside* create_task — between its fast-path
+    idempotency SELECT and its INSERT — rather than before the call. A barrier
+    before create_task can let one caller fully commit before the other even
+    runs its SELECT, so the other returns via the fast-path lookup and the
+    UNIQUE-index + IntegrityError-recovery path is never exercised (the test
+    passes without proving anything). ``_new_task_id`` runs after the fast-path
+    SELECT and before ``write_txn``'s INSERT, so gating it there synchronises
+    both writers in exactly the race window: both have SELECT-missed before
+    either INSERTs.
+    """
     key = "dod:fix:v1:race-safe-check"
-    barrier = threading.Barrier(2)
     results: dict = {}
     errors: dict = {}
 
+    orig_new_task_id = kb._new_task_id
+    gate = threading.Barrier(2)
+    gated: set = set()
+    gate_lock = threading.Lock()
+
+    def gated_new_task_id():
+        task_id = orig_new_task_id()
+        ident = threading.get_ident()
+        with gate_lock:
+            first = ident not in gated
+            if first:
+                gated.add(ident)
+        # Only sync on the first call per thread (the id-collision retry loop
+        # could call again; the loser recovers before that anyway).
+        if first:
+            gate.wait(timeout=10)
+        return task_id
+
+    monkeypatch.setattr(kb, "_new_task_id", gated_new_task_id)
+
     def worker(n: int) -> None:
         try:
-            barrier.wait(timeout=10)
             with kb.connect() as conn:
                 results[n] = kb.create_task(
                     conn, title="racer-%d" % n, idempotency_key=key
@@ -60,3 +90,82 @@ def test_create_task_idempotency_key_is_race_safe(kanban_home):
             (key,),
         ).fetchall()
     assert len(rows) == 1, "expected exactly 1 active row for key, got %d" % len(rows)
+
+
+def test_empty_idempotency_key_is_not_unique(kanban_home):
+    """An empty key means "no idempotency" — repeated creates must not collide.
+
+    The UNIQUE partial index would otherwise treat a stored ''- like any other
+    key and reject the second keyless create with an IntegrityError. create_task
+    normalises '' (and whitespace-only) to NULL, and the index excludes both
+    NULL and '', so keyless creates always succeed.
+    """
+    with kb.connect() as conn:
+        # Two identical empty keys is the reported regression: pre-fix the second
+        # stored-'' INSERT hits the UNIQUE index and raises IntegrityError.
+        a = kb.create_task(conn, title="keyless-a", idempotency_key="")
+        b = kb.create_task(conn, title="keyless-b", idempotency_key="")
+        c = kb.create_task(conn, title="keyless-c", idempotency_key="   ")
+        d = kb.create_task(conn, title="keyless-d", idempotency_key=None)
+
+    assert len({a, b, c, d}) == 4, "keyless creates collided: %r" % [a, b, c, d]
+    with kb.connect() as conn:
+        # Empty/whitespace keys are normalised to NULL, never stored as ''.
+        stored = conn.execute(
+            "SELECT COUNT(*) AS n FROM tasks WHERE idempotency_key = ''"
+        ).fetchone()["n"]
+    assert stored == 0, "empty key was stored instead of normalised to NULL"
+
+
+def test_migration_dedupes_preexisting_active_duplicates(kanban_home):
+    """A pre-fix DB with duplicate active keys migrates cleanly.
+
+    Before this fix, ``idx_tasks_idempotency`` was non-unique, so a board could
+    already hold two active rows for one key. Building the UNIQUE index directly
+    over that dirty data would raise and make the DB unopenable. The migration
+    must de-dupe first (keep newest per the create_task fast-path order, archive
+    the rest) and only then build the unique index.
+    """
+    key = "dod:fix:v1:legacy-dupe"
+    path = kb.kanban_db_path()
+
+    # Reproduce the pre-fix on-disk state: restore a plain index and insert two
+    # active rows sharing one key (create_task can no longer produce this).
+    with kb.connect() as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+        conn.execute("CREATE INDEX idx_tasks_idempotency ON tasks(idempotency_key)")
+        for i, created_at in ((0, 100), (1, 200)):  # older, then newer
+            conn.execute(
+                "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+                "VALUES (?, ?, 'ready', ?, ?)",
+                ("dupe-%d" % i, "legacy-%d" % i, created_at, key),
+            )
+
+    # Re-run the migration pass, as opening an upgraded DB would.
+    kb.init_db(path)
+
+    with kb.connect() as conn:
+        active = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? AND status != 'archived'",
+            (key,),
+        ).fetchall()
+        assert [r["id"] for r in active] == ["dupe-1"], (
+            "expected only the newest row to stay active, got %r"
+            % [r["id"] for r in active]
+        )
+        archived = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? AND status = 'archived'",
+            (key,),
+        ).fetchall()
+        assert [r["id"] for r in archived] == ["dupe-0"], (
+            "expected the older duplicate to be archived, got %r"
+            % [r["id"] for r in archived]
+        )
+        # The unique index is now in force: a fresh active duplicate is rejected.
+        with pytest.raises(sqlite3.IntegrityError):
+            with kb.write_txn(conn):
+                conn.execute(
+                    "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+                    "VALUES ('dupe-2', 'legacy-2', 'ready', 300, ?)",
+                    (key,),
+                )

--- a/tests/hermes_cli/test_kanban_idempotency_race.py
+++ b/tests/hermes_cli/test_kanban_idempotency_race.py
@@ -1,0 +1,62 @@
+"""Concurrency regression: ``create_task`` idempotency-key race-safety.
+
+``idx_tasks_idempotency`` used to be a plain (non-UNIQUE) index, so two
+connections that both SELECT-miss on the same key could each INSERT, leaving
+two active task rows for one idempotency key. The UNIQUE partial index over
+active (non-archived) rows plus IntegrityError recovery in ``create_task``
+make the losing writer return the winner's id instead of inserting a duplicate.
+"""
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty, migrated kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_create_task_idempotency_key_is_race_safe(kanban_home):
+    """Two concurrent create_task calls with one idempotency_key -> one row."""
+    key = "dod:fix:v1:race-safe-check"
+    barrier = threading.Barrier(2)
+    results: dict = {}
+    errors: dict = {}
+
+    def worker(n: int) -> None:
+        try:
+            barrier.wait(timeout=10)
+            with kb.connect() as conn:
+                results[n] = kb.create_task(
+                    conn, title="racer-%d" % n, idempotency_key=key
+                )
+        except Exception as exc:  # noqa: BLE001 - surfaced via assert below
+            errors[n] = repr(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    assert not errors, "create_task raised under concurrency: %r" % errors
+    # Both callers resolve to the SAME task id (loser recovers the winner's row).
+    assert results[0] == results[1], "racers got different ids: %r" % results
+    # Exactly one active (non-archived) row carries the key.
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ? "
+            "AND status != 'archived'",
+            (key,),
+        ).fetchall()
+    assert len(rows) == 1, "expected exactly 1 active row for key, got %d" % len(rows)

--- a/tests/hermes_cli/test_kanban_idempotency_race.py
+++ b/tests/hermes_cli/test_kanban_idempotency_race.py
@@ -66,7 +66,7 @@ def test_create_task_idempotency_key_is_race_safe(kanban_home, monkeypatch):
 
     def worker(n: int) -> None:
         try:
-            with kb.connect() as conn:
+            with kb.connect_closing() as conn:
                 results[n] = kb.create_task(
                     conn, title="racer-%d" % n, idempotency_key=key
                 )
@@ -83,7 +83,7 @@ def test_create_task_idempotency_key_is_race_safe(kanban_home, monkeypatch):
     # Both callers resolve to the SAME task id (loser recovers the winner's row).
     assert results[0] == results[1], "racers got different ids: %r" % results
     # Exactly one active (non-archived) row carries the key.
-    with kb.connect() as conn:
+    with kb.connect_closing() as conn:
         rows = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived'",
@@ -100,7 +100,7 @@ def test_empty_idempotency_key_is_not_unique(kanban_home):
     normalises '' (and whitespace-only) to NULL, and the index excludes both
     NULL and '', so keyless creates always succeed.
     """
-    with kb.connect() as conn:
+    with kb.connect_closing() as conn:
         # Two identical empty keys is the reported regression: pre-fix the second
         # stored-'' INSERT hits the UNIQUE index and raises IntegrityError.
         a = kb.create_task(conn, title="keyless-a", idempotency_key="")
@@ -109,7 +109,7 @@ def test_empty_idempotency_key_is_not_unique(kanban_home):
         d = kb.create_task(conn, title="keyless-d", idempotency_key=None)
 
     assert len({a, b, c, d}) == 4, "keyless creates collided: %r" % [a, b, c, d]
-    with kb.connect() as conn:
+    with kb.connect_closing() as conn:
         # Empty/whitespace keys are normalised to NULL, never stored as ''.
         stored = conn.execute(
             "SELECT COUNT(*) AS n FROM tasks WHERE idempotency_key = ''"
@@ -131,7 +131,7 @@ def test_migration_dedupes_preexisting_active_duplicates(kanban_home):
 
     # Reproduce the pre-fix on-disk state: restore a plain index and insert two
     # active rows sharing one key (create_task can no longer produce this).
-    with kb.connect() as conn:
+    with kb.connect_closing() as conn:
         conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
         conn.execute("CREATE INDEX idx_tasks_idempotency ON tasks(idempotency_key)")
         for i, created_at in ((0, 100), (1, 200)):  # older, then newer
@@ -140,11 +140,13 @@ def test_migration_dedupes_preexisting_active_duplicates(kanban_home):
                 "VALUES (?, ?, 'ready', ?, ?)",
                 ("dupe-%d" % i, "legacy-%d" % i, created_at, key),
             )
+        # connect_closing only closes; commit the setup writes explicitly.
+        conn.commit()
 
     # Re-run the migration pass, as opening an upgraded DB would.
     kb.init_db(path)
 
-    with kb.connect() as conn:
+    with kb.connect_closing() as conn:
         active = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? AND status != 'archived'",
             (key,),


### PR DESCRIPTION
Repro on current `main`: two connections calling `create_task` with the same `idempotency_key` concurrently both insert — leaving two active task rows for one key. Added test fails before this change (racers get different ids) and passes after.

Cause: `idx_tasks_idempotency` is a plain (non-UNIQUE) index, and `create_task` is check-then-insert, so concurrent callers both SELECT-miss then both INSERT. The existing "returns the existing id" idempotency guard only covers same-connection / already-committed reuse, not a true multi-connection race.

Fix (whole bug class, one file):
- Replace the plain index with a **UNIQUE partial index** over active (non-archived) rows.
- Add `IntegrityError` recovery in `create_task`: the losing concurrent writer catches the unique-violation and returns the winner's task id instead of a duplicate.
- A migration de-dupes any pre-existing active duplicates (keep oldest, archive the rest) before building the unique index, so it cannot raise on dirty data. Archived rows are excluded from the partial index, so history is unaffected and the index name is unchanged (drop + recreate).

Test: `tests/hermes_cli/test_kanban_idempotency_race.py` — real multi-connection/threaded race via `scripts/run_tests.sh`; full `test_kanban_db.py` suite stays green (224 tests).

Refs NuggetsLtd/hermes-agent-fleet#19