### PR TITLE
security(dashboard): widen managed-files sensitive-filename guard past .env

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1193,15 +1193,41 @@ _FS_READDIR_HIDDEN = {
 # Filenames that must never be listed, read, or downloaded through the
 # managed-files API.  These typically contain credentials (API keys, tokens)
 # and exposing them through the dashboard file browser is a security leak —
-# see issue #57505.
-def _is_sensitive_filename(name: str) -> bool:
-    """Return True for ``.env`` and any ``.env.<suffix>`` variant.
+# see issue #57505. The set mirrors the two canonical credential guards
+# elsewhere in the codebase (agent.file_safety.get_read_block_error and
+# gateway.platforms.base._ROOT_CREDENTIAL_FILES) so the dashboard Files tab
+# doesn't lag behind them — an operator can point the managed root at
+# HERMES_HOME itself, at which point every one of these basenames is a live
+# secret store sitting in the browsable tree.
+_SENSITIVE_MANAGED_FILE_BASENAMES = frozenset({
+    "auth.json",
+    "auth.lock",
+    "credentials",
+    "config.yaml",
+    ".anthropic_oauth.json",
+    "google_token.json",
+    "google_oauth_pending.json",
+    "google_oauth.json",
+    "webhook_subscriptions.json",
+    "bws_cache.json",
+})
 
-    Case-insensitive so ``.ENV`` / ``.Env.local`` on case-insensitive
-    filesystems (macOS/Windows mounts) can't slip past the guard.
+
+def _is_sensitive_filename(name: str) -> bool:
+    """Return True for a filename the managed-files API must never expose.
+
+    Covers ``.env`` / ``.env.<suffix>`` / ``.envrc`` variants plus the
+    canonical Hermes credential-store basenames (see
+    ``_SENSITIVE_MANAGED_FILE_BASENAMES`` above).
+
+    Case-insensitive so ``.ENV`` / ``.Env.local`` / ``Auth.JSON`` on
+    case-insensitive filesystems (macOS/Windows mounts) can't slip past
+    the guard.
     """
     lowered = name.lower()
-    return lowered == ".env" or lowered.startswith(".env.")
+    if lowered == ".env" or lowered.startswith(".env.") or lowered == ".envrc":
+        return True
+    return lowered in _SENSITIVE_MANAGED_FILE_BASENAMES
 _FS_DATA_URL_MAX_BYTES = 16 * 1024 * 1024
 _FS_TEXT_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 _FS_TEXT_PREVIEW_MAX_BYTES = 512 * 1024

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -560,3 +560,49 @@ def test_sensitive_env_case_insensitive_blocked(forced_files_client):
         p.write_text("SECRET=abc123")
         assert client.get("/api/files/read", params={"path": str(p)}).status_code == 403
         assert client.get("/api/files/download", params={"path": str(p)}).status_code == 403
+
+
+def test_envrc_blocked(forced_files_client):
+    """Regression: .envrc (direnv) is a distinct basename from .env.<suffix> and
+    was not caught by the old ``== ".env" or startswith(".env.")`` check."""
+    client, root = forced_files_client
+
+    root.mkdir(parents=True, exist_ok=True)
+    p = root / ".envrc"
+    p.write_text("export SECRET_KEY=abc123")
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert ".envrc" not in [e["name"] for e in listing.json()["entries"]]
+    assert client.get("/api/files/read", params={"path": str(p)}).status_code == 403
+    assert client.get("/api/files/download", params={"path": str(p)}).status_code == 403
+
+
+def test_other_credential_store_basenames_blocked(forced_files_client):
+    """Regression: the managed-files guard must cover the same credential
+    basenames as gateway.platforms.base._ROOT_CREDENTIAL_FILES and
+    agent.file_safety.get_read_block_error, not just .env — an operator can
+    point the managed root at HERMES_HOME itself (#57505), which contains
+    all of these live secret stores."""
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+
+    for name in (
+        "auth.json",
+        "auth.lock",
+        "credentials",
+        "config.yaml",
+        ".anthropic_oauth.json",
+        "google_token.json",
+        "google_oauth_pending.json",
+        "google_oauth.json",
+        "webhook_subscriptions.json",
+        "bws_cache.json",
+    ):
+        p = root / name
+        p.write_text("SECRET=abc123")
+        assert client.get("/api/files/read", params={"path": str(p)}).status_code == 403, name
+        assert client.get("/api/files/download", params={"path": str(p)}).status_code == 403, name
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    names = [e["name"] for e in listing.json()["entries"]]
+    assert names == []


### PR DESCRIPTION
## Summary
- `_is_sensitive_filename()` (added by the #57505 fix) only blocks `.env` and `.env.<suffix>` variants from the dashboard Files tab (list/read/download).
- The managed-files root is operator-configurable, and per the exact scenario #57505 was filed against (`docker run -v ~/.hermes:/opt/data ... dashboard`), it can point directly at `HERMES_HOME`. That directory holds every credential store this codebase already treats as sensitive elsewhere — `auth.json`, `.anthropic_oauth.json`, `google_token.json`, `webhook_subscriptions.json`, the Bitwarden disk cache, etc. — none of which were in the dashboard's denylist.
- `.envrc` (direnv) also slipped past the old check: it doesn't equal `".env"` and doesn't start with `".env."`, so the case-insensitivity/pattern-match hardening from the same series didn't cover it.
- Live-verified before this fix: `auth.json`, `credentials`, `config.yaml`, `.anthropic_oauth.json`, `google_token.json`, `webhook_subscriptions.json`, and `.envrc` all returned `blocked=False`.

## Fix
Widen `_is_sensitive_filename()`'s basename set to mirror the two canonical credential guards already established elsewhere in the codebase:
- `gateway/platforms/base.py::_ROOT_CREDENTIAL_FILES` (the media-delivery/exfil guard)
- `agent/file_safety.py::get_read_block_error` (the terminal/tool read guard)

Scope is intentionally limited to basename matching (the existing contract of this function — callers only pass a bare filename, not a resolved path), consistent with how the original `.env` guard works. Directory-scoped entries from those two guards (`mcp-tokens/`, `pairing/`) aren't representable in a basename-only check and are out of scope here — call sites would need to pass full paths to cover those, a larger change.

## Test plan
- [x] New regression tests: `.envrc` blocked (list/read/download), and each of the newly-added credential basenames (`auth.json`, `auth.lock`, `credentials`, `config.yaml`, `.anthropic_oauth.json`, `google_token.json`, `google_oauth_pending.json`, `google_oauth.json`, `webhook_subscriptions.json`, `bws_cache.json`) blocked from listing/read/download.
- [x] `tests/hermes_cli/test_web_server_files.py` — 23 passed.
- [x] Wider web_server suite (`test_web_server_fs.py`, `test_web_server.py` root + `hermes_cli/`) — 358 passed.
- [x] `ty check hermes_cli/web_server.py` — identical diagnostic set before/after (25/25, verified via `git stash` diff).