### PR TITLE
feat: improve kanban autonomy and reviewer notifications

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1089,9 +1089,17 @@ def init_agent(
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
+    from agent.prompt_builder import KANBAN_FEEDBACK_INTAKE_GUIDANCE, KANBAN_GUIDANCE
     agent._kanban_worker_guidance = (
         KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+    )
+    agent._kanban_feedback_intake_guidance = (
+        KANBAN_FEEDBACK_INTAKE_GUIDANCE
+        if (
+            "kanban_create" in agent.valid_tool_names
+            and not os.environ.get("HERMES_KANBAN_TASK")
+        )
+        else ""
     )
 
     # Check tool requirements

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -278,6 +278,27 @@ KANBAN_GUIDANCE = (
     "cross-agent handoffs that outlive one API loop."
 )
 
+KANBAN_FEEDBACK_INTAKE_GUIDANCE = (
+    "# Kanban feedback intake\n"
+    "When the user explicitly complains about, corrects, or asks you to fix an "
+    "assistant/Hermes behavior, do not treat it as style alone. First handle any "
+    "immediate user request, then decide whether the remark names a concrete "
+    "product defect or recurring behavior that should be corrected. If it does "
+    "and the `kanban_create` tool is available, create a focused follow-up card "
+    "instead of only apologizing.\n"
+    "Create a card only for actionable product feedback: a reproducible failure, "
+    "unsafe/noisy behavior, missing notification, wrong default, confusing UX, or "
+    "a repeated correction. Do NOT create a card for vague mood, one-off phrasing "
+    "preferences, dangerous requests, secrets/log dumps, or anything already "
+    "covered by an existing visible card.\n"
+    "Use anti-spam defaults: make the title specific, include the user's complaint "
+    "and relevant task/session ids in the body, redact secrets and raw PII, assign "
+    "the best-fit existing profile, set an `idempotency_key` derived from the "
+    "normalized defect, and use triage when the fix path is unclear. After creating "
+    "(or deciding not to create) a card, tell the user what action you took in one "
+    "short sentence."
+)
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -202,6 +202,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
+    _kanban_feedback_guidance = getattr(agent, "_kanban_feedback_intake_guidance", "")
+    if _kanban_feedback_guidance:
+        tool_guidance.append(_kanban_feedback_guidance)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,125 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+_INTERNAL_KANBAN_TITLE_MARKERS = (
+    "policy autonomie",
+    "autonomous evidence package",
+    "evidence package",
+    "package de preuve",
+    "preuves internes",
+)
+_INTERNAL_KANBAN_TITLE_PREFIXES = (
+    "review:",
+    "review —",
+    "review -",
+    "revue:",
+)
+
+
+def _first_line(text: str, limit: int) -> str:
+    lines = str(text or "").strip().splitlines()
+    value = lines[0] if lines else str(text or "")
+    return value[:limit]
+
+
+def _is_internal_kanban_task(title: str, reason: str = "") -> bool:
+    """Return True for internal policy/review/evidence cards that should not ping users."""
+    haystack = f"{title}\n{reason}".casefold()
+    title_cf = str(title or "").strip().casefold()
+    if any(marker in haystack for marker in _INTERNAL_KANBAN_TITLE_MARKERS):
+        return True
+    if any(title_cf.startswith(prefix) for prefix in _INTERNAL_KANBAN_TITLE_PREFIXES):
+        return True
+    if str(reason or "").strip().casefold().startswith("review-required"):
+        return True
+    return False
+
+
+def _kanban_notification_message(
+    *,
+    kind: str,
+    task,
+    sub: dict,
+    event_payload: Optional[dict],
+    board_tag: str,
+    tag: str,
+) -> Optional[str]:
+    """Build the short user-facing Kanban notification, or None to stay silent.
+
+    The notifier is subscribed to internal workflow cards too; those should
+    advance cursors without sending raw titles/summaries into a human chat.
+    Events that do matter use an explicit action line so the recipient can tell
+    whether Loïc needs to do anything.
+    """
+    title = (task.title if task else sub["task_id"])[:120]
+    reason = ""
+    if event_payload and event_payload.get("reason"):
+        reason = str(event_payload["reason"])
+    block_kind = ""
+    if event_payload and event_payload.get("kind"):
+        block_kind = str(event_payload["kind"])
+
+    internal = _is_internal_kanban_task(title, reason)
+    if internal and kind in {"completed", "status"}:
+        return None
+    if internal and kind == "blocked" and block_kind not in {"needs_input", "capability"}:
+        return None
+
+    prefix = f"{board_tag}{tag}Kanban {sub['task_id']}"
+    if kind == "completed":
+        handoff = ""
+        payload_summary = None
+        if event_payload and event_payload.get("summary"):
+            payload_summary = str(event_payload["summary"])
+        if payload_summary:
+            handoff = f"\nRésumé : {_first_line(payload_summary, 200)}"
+        elif task and task.result:
+            handoff = f"\nRésumé : {_first_line(str(task.result), 160)}"
+        return f"✔ {prefix} terminé.\nAction Loïc : aucune{handoff}"
+    if kind == "blocked":
+        if block_kind == "dependency":
+            return None
+        cause = _first_line(reason, 160) if reason else "intervention humaine requise"
+        if block_kind == "capability":
+            action = "lever la capacité manquante, puis débloquer la carte"
+        elif block_kind == "transient":
+            action = "attendre ou relancer seulement si le problème persiste"
+        else:
+            action = "répondre dans ce thread, puis débloquer la carte"
+        return (
+            f"⏸ {prefix} blocked.\n"
+            f"Cause : {cause}\n"
+            f"Prochaine action sûre : {action}"
+        )
+    if kind == "gave_up":
+        err = ""
+        if event_payload and event_payload.get("error"):
+            err = f"\nDétail : {_first_line(str(event_payload['error']), 200)}"
+        return (
+            f"✖ {prefix} gave up après échecs répétés.\n"
+            f"Action Loïc : aucune{err}"
+        )
+    if kind == "crashed":
+        return (
+            f"✖ {prefix} : worker crashed; le dispatcher va réessayer.\n"
+            f"Action Loïc : aucune"
+        )
+    if kind == "timed_out":
+        limit = 0
+        if event_payload and event_payload.get("limit_seconds"):
+            limit = int(event_payload["limit_seconds"])
+        return (
+            f"⏱ {prefix} timed out (max_runtime={limit}s); relance prévue.\n"
+            f"Action Loïc : aucune"
+        )
+    if kind == "status":
+        new_status = ""
+        if event_payload and event_payload.get("status"):
+            new_status = str(event_payload["status"])
+        return f"🔄 {prefix} → {new_status}.\nAction Loïc : aucune"
+    return None
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -334,8 +453,8 @@ class GatewayKanbanWatchersMixin:
                             board_slug,
                         )
                         continue
-                    title = (task.title if task else sub["task_id"])[:120]
                     board_tag = f"[{board_slug}] " if board_slug else ""
+                    notified_kinds: set[str] = set()
                     for ev in d["events"]:
                         kind = ev.kind
                         # Identity prefix: attribute terminal pings to the
@@ -343,67 +462,18 @@ class GatewayKanbanWatchersMixin:
                         # chat subscribes to many tasks) legible at a glance.
                         who = (task.assignee if task and task.assignee else None)
                         tag = f"@{who} " if who else ""
-                        if kind == "completed":
-                            # Prefer the run's summary (the worker's
-                            # intentional human-facing handoff, carried
-                            # in the event payload), then fall back to
-                            # task.result for legacy rows written before
-                            # runs shipped.
-                            handoff = ""
-                            payload_summary = None
-                            if ev.payload and ev.payload.get("summary"):
-                                payload_summary = str(ev.payload["summary"])
-                            if payload_summary:
-                                lines = payload_summary.strip().splitlines()
-                                h = lines[0][:200] if lines else payload_summary[:200]
-                                handoff = f"\n{h}"
-                            elif task and task.result:
-                                lines = task.result.strip().splitlines()
-                                r = lines[0][:160] if lines else task.result[:160]
-                                handoff = f"\n{r}"
-                            msg = (
-                                f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
-                            )
-                        elif kind == "blocked":
-                            reason = ""
-                            if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
-                        elif kind == "gave_up":
-                            err = ""
-                            if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
-                            msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
-                            )
-                        elif kind == "crashed":
-                            msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} worker crashed "
-                                f"(pid gone); dispatcher will retry"
-                            )
-                        elif kind == "timed_out":
-                            limit = 0
-                            if ev.payload and ev.payload.get("limit_seconds"):
-                                limit = int(ev.payload["limit_seconds"])
-                            msg = (
-                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
-                            )
-                        elif kind == "status":
-                            new_status = ""
-                            if ev.payload and ev.payload.get("status"):
-                                new_status = str(ev.payload["status"])
-                            msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
-                        else:
-                            # archived / unblocked are claimed by TERMINAL_KINDS
-                            # (so the cursor advances past them and they can't
-                            # wedge a later completed/blocked event behind an
-                            # unclaimed row) but are intentionally SILENT: an
-                            # archive needs no user ping, and unblocked is an
-                            # internal transition. They are also excluded from
-                            # _WAKE_KINDS below, so they never wake the creator.
+                        msg = _kanban_notification_message(
+                            kind=kind,
+                            task=task,
+                            sub=sub,
+                            event_payload=ev.payload,
+                            board_tag=board_tag,
+                            tag=tag,
+                        )
+                        if msg is None:
+                            # archived / unblocked and internal workflow cards
+                            # are claimed so they cannot wedge later events, but
+                            # they do not send user-visible chat noise.
                             continue
                         metadata: dict[str, Any] = {}
                         if sub.get("thread_id"):
@@ -420,6 +490,7 @@ class GatewayKanbanWatchersMixin:
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
                             )
+                            notified_kinds.add(kind)
                             # After delivering the text notification, surface
                             # any artifact paths the worker referenced in
                             # ``kanban_complete(summary=..., artifacts=[...])``
@@ -490,7 +561,7 @@ class GatewayKanbanWatchersMixin:
                         # above for the failure mode this prevents.
                         task_terminal = task and task.status in {"done", "archived"}
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
-                        _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                        _wake_kinds = {kind for kind in notified_kinds if kind in _WAKE_KINDS}
                         if _wake_kinds:
                             try:
                                 _session_key = getattr(task, "session_id", None) or ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5452,6 +5452,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else "Your current task will be interrupted."
         )
         msg = f"⚠️ Gateway {action} — {hint}"
+        discord_restart_msg = (
+            "♻️ Hermes reload in progress — I'll resume my threads once back."
+        )
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
@@ -5484,6 +5487,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 platform_str = _parsed["platform"]
                 chat_id = _parsed["chat_id"]
                 thread_id = _parsed.get("thread_id")
+
+            if self._restart_requested and platform_str == Platform.DISCORD.value:
+                # Discord servers may have many active session threads. Avoid
+                # broadcasting routine reload lifecycle pings into every thread;
+                # keep in-chat /restart notices scoped to the originator, while
+                # planned/service reloads use only the configured home channel.
+                if restart_source is None:
+                    continue
+                try:
+                    restart_thread_id = (
+                        str(restart_source.thread_id) if restart_source.thread_id else None
+                    )
+                    if (
+                        restart_source.platform.value,
+                        str(restart_source.chat_id),
+                        restart_thread_id,
+                    ) != (
+                        platform_str,
+                        chat_id,
+                        str(thread_id) if thread_id else None,
+                    ):
+                        continue
+                except Exception:
+                    continue
 
             # Deduplicate only identical delivery targets. Thread/topic-aware
             # platforms can share a parent chat while still routing to distinct
@@ -5526,7 +5553,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter=adapter,
                 )
 
-                result = await adapter.send(chat_id, msg, metadata=metadata)
+                message = (
+                    discord_restart_msg
+                    if platform == Platform.DISCORD and self._restart_requested
+                    else msg
+                )
+                result = await adapter.send(
+                    chat_id,
+                    message,
+                    metadata=_non_conversational_metadata(metadata, platform=platform),
+                )
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
@@ -5606,10 +5642,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     home.thread_id,
                     adapter=adapter,
                 )
+                metadata = _non_conversational_metadata(metadata, platform=platform)
+                message = (
+                    discord_restart_msg
+                    if platform == Platform.DISCORD and self._restart_requested
+                    else msg
+                )
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    result = await adapter.send(str(home.chat_id), message, metadata=metadata)
                 else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                    result = await adapter.send(str(home.chat_id), message)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
@@ -14184,9 +14226,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 reply_to_message_id=message_id,
                 adapter=adapter,
             )
+            message = (
+                "♻️ Hermes reloaded — resuming my threads."
+                if platform == Platform.DISCORD
+                else "♻ Gateway restarted successfully. Your session continues."
+            )
             result = await adapter.send(
                 str(chat_id),
-                "♻ Gateway restarted successfully. Your session continues.",
+                message,
                 metadata=_non_conversational_metadata(metadata, platform=platform),
             )
             # adapter.send() catches provider errors (e.g. "Chat not found")

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -29,6 +29,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PARALLEL_TOOL_CALL_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
+    KANBAN_FEEDBACK_INTAKE_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
@@ -53,6 +54,13 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_kanban_feedback_guidance_has_intake_guardrails(self):
+        assert "complains" in KANBAN_FEEDBACK_INTAKE_GUIDANCE
+        assert "kanban_create" in KANBAN_FEEDBACK_INTAKE_GUIDANCE
+        assert "idempotency_key" in KANBAN_FEEDBACK_INTAKE_GUIDANCE
+        assert "vague mood" in KANBAN_FEEDBACK_INTAKE_GUIDANCE
+        assert "secrets/log dumps" in KANBAN_FEEDBACK_INTAKE_GUIDANCE
 
 
 # =========================================================================

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -15,6 +15,7 @@ def _make_agent(**overrides):
         _tool_use_enforcement=False,
         _environment_probe=False,
         _kanban_worker_guidance="",
+        _kanban_feedback_intake_guidance="",
         _memory_store=None,
         _memory_manager=None,
         model="",
@@ -99,3 +100,20 @@ class TestCodingContextBlock:
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         agent = _make_agent(valid_tool_names=[], platform="cli")
         assert "coding agent" not in _stable_prompt(agent)
+
+
+class TestKanbanFeedbackIntakeBlock:
+    def test_injected_when_agent_init_enables_it(self):
+        stable = _stable_prompt(
+            _make_agent(
+                valid_tool_names=["kanban_create"],
+                _kanban_feedback_intake_guidance="KANBAN_FEEDBACK_SENTINEL",
+            )
+        )
+
+        assert "KANBAN_FEEDBACK_SENTINEL" in stable
+
+    def test_absent_by_default_without_agent_init_flag(self):
+        stable = _stable_prompt(_make_agent(valid_tool_names=["kanban_create"]))
+
+        assert "Kanban feedback intake" not in stable

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -10,9 +10,13 @@ from hermes_cli import kanban_db as kb
 class RecordingAdapter:
     def __init__(self):
         self.sent = []
+        self.handled = []
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
 
 
 class DisconnectedAdapters(dict):
@@ -135,6 +139,143 @@ def test_kanban_db_path_is_test_isolated_from_real_home():
 
     assert kb.kanban_db_path().resolve().is_relative_to(hermes_home.resolve())
     assert kb.kanban_db_path().resolve() != production_db.resolve()
+
+
+def test_internal_policy_card_completion_is_silent_and_does_not_wake_agent(tmp_path, monkeypatch):
+    """Internal policy/evidence/review cards must not surface as raw Discord/chat noise."""
+    db_path = tmp_path / "internal-policy.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="Policy autonomie Luna — finir les processus sans Loïc sauf dossier projects",
+            assignee="worker",
+            session_id="discord:chat-1:thread-1",
+        )
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.complete_task(conn, tid, summary="review-required handoff: preuve interne prête")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.handled == []
+
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_internal_review_and_evidence_completions_are_silent(tmp_path, monkeypatch):
+    db_path = tmp_path / "internal-review-evidence.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        task_ids = []
+        for title in (
+            "Review: policy autonomie sans Loïc sauf projects",
+            "Autonomous evidence package for t_4841d870: Review privacy/security",
+        ):
+            tid = kb.create_task(conn, title=title, assignee="worker")
+            kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+            kb.complete_task(conn, tid, summary="preuve interne prête")
+            task_ids.append(tid)
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    conn = kb.connect()
+    try:
+        for tid in task_ids:
+            assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+
+
+def test_human_blocker_notification_uses_besoin_loic_wording(tmp_path, monkeypatch):
+    db_path = tmp_path / "human-blocker.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="Connect production OAuth credential", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.block_task(conn, tid, kind="needs_input", reason="Choisir le compte OAuth à connecter")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "blocked" in text
+    assert "Cause : Choisir le compte OAuth à connecter" in text
+    assert "Prochaine action sûre : répondre dans ce thread, puis débloquer la carte" in text
+    assert "Action Loïc : aucune" not in text
+    assert "Connect production OAuth credential" not in text
+
+
+def test_push_impossible_capability_block_notifies_origin_with_safe_action(tmp_path, monkeypatch):
+    db_path = tmp_path / "push-impossible.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="Chaîne Discord reload: push final",
+            assignee="coder",
+            session_id="discord:loic-chat:reload-thread",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="loic-chat",
+            thread_id="reload-thread",
+            user_id="loic",
+            notifier_profile="luna",
+        )
+        kb.block_task(conn, tid, kind="capability", reason="push-impossible: remote rejected credentials")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {"luna": {Platform.DISCORD: adapter}}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_notifier_profile = "luna"
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    msg = adapter.sent[0]
+    assert msg["chat_id"] == "loic-chat"
+    assert msg["metadata"] == {"thread_id": "reload-thread"}
+    assert "push-impossible: remote rejected credentials" in msg["text"]
+    assert "Prochaine action sûre : lever la capacité manquante, puis débloquer la carte" in msg["text"]
+    assert "Chaîne Discord reload" not in msg["text"]
+    assert len(adapter.handled) == 1
 
 
 class FailingAdapter:

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -9,7 +9,7 @@ import pytest
 import gateway.run as gateway_run
 from gateway.config import HomeChannel, Platform
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
-from gateway.session import build_session_key
+from gateway.session import SessionSource, build_session_key
 from tests.gateway.restart_test_helpers import (
     make_restart_runner,
     make_restart_source,
@@ -643,6 +643,109 @@ async def test_send_restart_notification_logs_info_on_sendresult_success(
         f"got records: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
     )
     assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_marks_discord_lifecycle_nonconversational(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({"platform": "discord", "chat_id": "42"}))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms = {
+        Platform.DISCORD: runner.config.platforms[Platform.TELEGRAM],
+    }
+    runner.adapters = {Platform.DISCORD: adapter}
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("discord", "42", None)
+    adapter.send.assert_awaited_once_with(
+        "42",
+        "♻️ Hermes reloaded — resuming my threads.",
+        metadata={"non_conversational": True},
+    )
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_discord_planned_restart_shutdown_notifies_home_only():
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.platforms = {
+        Platform.DISCORD: runner.config.platforms[Platform.TELEGRAM],
+    }
+    runner.config.platforms[Platform.DISCORD].home_channel = HomeChannel(
+        platform=Platform.DISCORD,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+
+    for thread_id in ("topic-a", "topic-b"):
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="parent-42",
+            chat_type="group",
+            user_id=f"user-{thread_id}",
+            thread_id=thread_id,
+        )
+        session_key = build_session_key(source)
+        runner._running_agents[session_key] = object()
+        runner.session_store._entries[session_key] = MagicMock(origin=source)
+
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once_with(
+        "home-42",
+        "♻️ Hermes reload in progress — I'll resume my threads once back.",
+        metadata={"non_conversational": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_discord_in_chat_restart_shutdown_notifies_origin_thread_only():
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.platforms = {
+        Platform.DISCORD: runner.config.platforms[Platform.TELEGRAM],
+    }
+    runner.adapters = {Platform.DISCORD: adapter}
+
+    origin = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="parent-42",
+        chat_type="group",
+        user_id="u1",
+        thread_id="topic-a",
+    )
+    other = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="parent-42",
+        chat_type="group",
+        user_id="u2",
+        thread_id="topic-b",
+    )
+    runner._restart_command_source = origin
+    for source in (origin, other):
+        session_key = build_session_key(source)
+        runner._running_agents[session_key] = object()
+        runner.session_store._entries[session_key] = MagicMock(origin=source)
+
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once_with(
+        "parent-42",
+        "♻️ Hermes reload in progress — I'll resume my threads once back.",
+        metadata={"thread_id": "topic-a", "non_conversational": True},
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Improve Kanban guidance so workers ingest reviewer feedback from the comment thread and block explicitly when follow-up review is required.
- Improve notifier behavior around Kanban review requests and evidence hygiene so review-required handoffs surface with the right context.
- Preserve targeted validation coverage for the reviewed changes.

## Tests
- Targeted test command previously validated on `feature/kanban-reviewer-autonomy` for commit `f5d4a72fca14`.
- Result: 180/180 targeted tests passed.

## Reservations / risks
- Local untracked `.install_method` and `kanban-artifacts/` remain outside the commit and were not pushed.
- The silent filter for `Review:` / `review-required` should be watched because it could mask a legitimate card if that card is named poorly.

## Security / hygiene
- No `.env*`, `auth.json`, raw token, cookie, or credential file was read or exposed while preparing this PR.
