### PR TITLE
fix(kanban): run auto-decompose tick under the profile secret scope

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1149,63 +1149,86 @@ class GatewayKanbanWatchersMixin:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             attempted = 0
             successes = 0
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
-                if attempted >= auto_decompose_per_tick:
-                    break
-                # Pin this board for the duration of the call — same
-                # pattern as the dashboard specify endpoint. The
-                # decomposer module connects with no board kwarg and
-                # relies on the env var.
-                prev_env = os.environ.get("HERMES_KANBAN_BOARD")
-                try:
-                    os.environ["HERMES_KANBAN_BOARD"] = slug
+
+            # Run under the profile's secret scope. get_secret() fails closed
+            # outside an installed scope once profile isolation is in play
+            # (multiple gateway profiles / room->profile multiplexing), and
+            # this tick fires from asyncio.to_thread with no per-turn scope —
+            # so decompose_task()'s auxiliary LLM call died in
+            # resolve_runtime_provider() with UnscopedSecretError before
+            # model selection, silently no-op'ing auto-decompose under
+            # multiplex (swallowed by the broad except below). Mirrors the
+            # cron fix for the identical ticker-thread gap (run_one_job).
+            from hermes_constants import get_hermes_home
+            from agent.secret_scope import (
+                build_profile_secret_scope,
+                reset_secret_scope,
+                set_secret_scope,
+            )
+
+            _scope_token = set_secret_scope(
+                build_profile_secret_scope(get_hermes_home())
+            )
+            try:
+                for b in boards:
+                    slug = b.get("slug") or _kb.DEFAULT_BOARD
+                    if attempted >= auto_decompose_per_tick:
+                        break
+                    # Pin this board for the duration of the call — same
+                    # pattern as the dashboard specify endpoint. The
+                    # decomposer module connects with no board kwarg and
+                    # relies on the env var.
+                    prev_env = os.environ.get("HERMES_KANBAN_BOARD")
                     try:
-                        triage_ids = _decomp.list_triage_ids()
-                    except Exception as exc:
-                        logger.debug(
-                            "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
-                            slug, exc,
-                        )
-                        triage_ids = []
-                    for tid in triage_ids:
-                        if attempted >= auto_decompose_per_tick:
-                            break
-                        attempted += 1
+                        os.environ["HERMES_KANBAN_BOARD"] = slug
                         try:
-                            outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
-                            )
-                        except Exception:
-                            logger.exception(
-                                "kanban auto-decompose: decompose_task crashed on %s",
-                                tid,
-                            )
-                            continue
-                        if outcome.ok:
-                            successes += 1
-                            if outcome.fanout and outcome.child_ids:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → %d children",
-                                    slug, tid, len(outcome.child_ids),
-                                )
-                            else:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → single task (no fanout)",
-                                    slug, tid,
-                                )
-                        else:
-                            # Common no-op reasons (no aux client configured) shouldn't
-                            # spam logs every tick. Log at debug.
+                            triage_ids = _decomp.list_triage_ids()
+                        except Exception as exc:
                             logger.debug(
-                                "kanban auto-decompose [%s]: %s skipped: %s",
-                                slug, tid, outcome.reason,
+                                "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
+                                slug, exc,
                             )
-                finally:
-                    if prev_env is None:
-                        os.environ.pop("HERMES_KANBAN_BOARD", None)
-                    else:
-                        os.environ["HERMES_KANBAN_BOARD"] = prev_env
+                            triage_ids = []
+                        for tid in triage_ids:
+                            if attempted >= auto_decompose_per_tick:
+                                break
+                            attempted += 1
+                            try:
+                                outcome = _decomp.decompose_task(
+                                    tid, author="auto-decomposer",
+                                )
+                            except Exception:
+                                logger.exception(
+                                    "kanban auto-decompose: decompose_task crashed on %s",
+                                    tid,
+                                )
+                                continue
+                            if outcome.ok:
+                                successes += 1
+                                if outcome.fanout and outcome.child_ids:
+                                    logger.info(
+                                        "kanban auto-decompose [%s]: %s → %d children",
+                                        slug, tid, len(outcome.child_ids),
+                                    )
+                                else:
+                                    logger.info(
+                                        "kanban auto-decompose [%s]: %s → single task (no fanout)",
+                                        slug, tid,
+                                    )
+                            else:
+                                # Common no-op reasons (no aux client configured) shouldn't
+                                # spam logs every tick. Log at debug.
+                                logger.debug(
+                                    "kanban auto-decompose [%s]: %s skipped: %s",
+                                    slug, tid, outcome.reason,
+                                )
+                    finally:
+                        if prev_env is None:
+                            os.environ.pop("HERMES_KANBAN_BOARD", None)
+                        else:
+                            os.environ["HERMES_KANBAN_BOARD"] = prev_env
+            finally:
+                reset_secret_scope(_scope_token)
             return successes
 
         logger.info(

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -8,6 +8,11 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 from __future__ import annotations
 
 import inspect
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 
@@ -67,3 +72,95 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+@pytest.mark.asyncio
+async def test_auto_decompose_tick_installs_secret_scope_under_multiplex(
+    monkeypatch, tmp_path,
+):
+    """Regression: the auto-decompose tick fires from asyncio.to_thread with
+    no per-turn scope installed, same gap as the cron ticker (fdab380a1).
+    Under profile isolation (multiplex active), decompose_task's auxiliary
+    LLM call resolves credentials via resolve_runtime_provider -> get_secret,
+    which fails closed with UnscopedSecretError outside an installed scope.
+
+    Behavior contract: a profile secret scope is present while
+    decompose_task runs and torn down again afterward — mirrors
+    test_run_one_job_installs_secret_scope_under_multiplex (def6d6fe1).
+    """
+    import hermes_cli
+    import gateway.kanban_watchers as kw
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n")
+
+    fake_cfg = {
+        "kanban": {
+            "dispatch_in_gateway": True,
+            "auto_decompose": True,
+            "auto_decompose_per_tick": 1,
+        }
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: fake_cfg)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        kw, "_acquire_singleton_lock", lambda path: (object(), "held"),
+    )
+    monkeypatch.setattr(kw, "_release_singleton_lock", lambda handle: None)
+
+    fake_kb = MagicMock()
+    fake_kb.kanban_home.return_value = tmp_path
+    fake_kb.DEFAULT_BOARD = "default"
+    _board_list_calls = {"n": 0}
+
+    def _list_boards(include_archived=False):
+        # First call is _auto_decompose_tick's own board enumeration; every
+        # later call (from _tick_once / _ready_nonempty in the same
+        # iteration) gets an empty list so only the auto-decompose path
+        # under test actually does anything this tick.
+        _board_list_calls["n"] += 1
+        if _board_list_calls["n"] == 1:
+            return [{"slug": "default"}]
+        return []
+
+    fake_kb.list_boards.side_effect = _list_boards
+    # "from hermes_cli import kanban_db as _kb" resolves the submodule via
+    # the package attribute if already imported, so both the sys.modules
+    # entry and the package attribute must point at the fake.
+    monkeypatch.setattr(hermes_cli, "kanban_db", fake_kb, raising=False)
+    monkeypatch.setitem(sys.modules, "hermes_cli.kanban_db", fake_kb)
+
+    self = SimpleNamespace(_running=True, _kanban_dispatcher_lock_handle=None)
+
+    scope_during_call = {}
+
+    def fake_decompose_task(task_id, author=None):
+        # Flip the stop flag FIRST: on unmodified code (no scope installed)
+        # ss.get_secret raises UnscopedSecretError under multiplex, which the
+        # real _auto_decompose_tick swallows in a bare except — if _running
+        # were set after the read, that exception would leave the watcher
+        # loop spinning forever instead of failing the assertions below.
+        self._running = False
+        scope_during_call["scope"] = ss.current_secret_scope()
+        scope_during_call["base_url"] = ss.get_secret("OPENROUTER_BASE_URL")
+        return SimpleNamespace(ok=True, fanout=False, child_ids=None, reason=None)
+
+    fake_decomp = SimpleNamespace(
+        list_triage_ids=lambda: ["t1"],
+        decompose_task=fake_decompose_task,
+    )
+    monkeypatch.setattr(hermes_cli, "kanban_decompose", fake_decomp, raising=False)
+    monkeypatch.setitem(sys.modules, "hermes_cli.kanban_decompose", fake_decomp)
+
+    ss.set_multiplex_active(True)
+    try:
+        await GatewayKanbanWatchersMixin._kanban_dispatcher_watcher(self)
+    finally:
+        ss.set_multiplex_active(False)
+
+    assert scope_during_call.get("scope") is not None, (
+        "decompose_task ran with no secret scope installed"
+    )
+    assert scope_during_call.get("base_url") == "https://openrouter.ai/api/v1"
+    # Torn down after the tick — no leak into subsequent work.
+    assert ss.current_secret_scope() is None


### PR DESCRIPTION
## Summary
- Once profile isolation is active (multiple gateway profiles / room→profile multiplexing), `get_secret()` fails closed outside an installed scope (`UnscopedSecretError`).
- `_auto_decompose_tick` (the kanban auto-decomposer, enabled by default via `kanban.auto_decompose: true`) fires via `asyncio.to_thread` with no per-turn scope installed. `decompose_task()`'s auxiliary LLM call resolves credentials through `resolve_runtime_provider()` → `get_secret()`, which raises `UnscopedSecretError` before model selection under multiplex.
- The failure is swallowed by a broad `except Exception: logger.exception(...); continue` per-task, so auto-decompose silently no-ops every tick under multiplex with no user-visible error — it just looks like the feature stopped working.
- This is the same gap [fdab380a1](https://github.com/NousResearch/hermes-agent/commit/fdab380a1ada1e1fc127b3a51d5695f538cb774f) fixed for the cron ticker today, hitting the identical `UnscopedSecretError` from the same "background thread with no per-turn scope" shape.

## Fix
Wrap `_auto_decompose_tick`'s work in `set_secret_scope(build_profile_secret_scope(get_hermes_home()))` with a `finally`-reset, mirroring the cron fix exactly. Single-profile installs are unaffected — the installed scope is just the profile's own `.env`, same value `get_secret` would've read from `os.environ` anyway.

## Test plan
- [x] New regression test `test_auto_decompose_tick_installs_secret_scope_under_multiplex`, mirroring the cron regression test ([def6d6fe1](https://github.com/NousResearch/hermes-agent/commit/def6d6fe1b7b1a214bb385500646ffde8fe82019)): drives `_kanban_dispatcher_watcher` through one real tick with mocked `kanban_db`/`kanban_decompose`/config, and asserts a secret scope is installed and a real `.env` secret resolves during `decompose_task`, then is torn down afterward.
- [x] Mutation-verified: reverting just the `gateway/kanban_watchers.py` fix makes the test fail with the exact `UnscopedSecretError` this PR closes; passes with the fix applied.
- [x] `tests/gateway/test_kanban_watchers_mixin.py`, `test_kanban_notifier_watcher_dispatch_gate.py`, `test_kanban_auto_decompose_live.py`, `test_kanban_notifier.py`, `tests/hermes_cli/test_kanban_decompose.py`, `test_kanban_decompose_db.py` — 42 passed.
- [x] `ty check gateway/kanban_watchers.py` — identical diagnostic set before/after (16/16, verified via `git stash` diff).