### PR TITLE
fix(desktop/windows): pre-write update marker before quit dwell to prevent backend respawn

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -55,7 +55,7 @@ const {
   macTitleBarOverlayHeight
 } = require('./titlebar-overlay-width.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
-const { readLiveUpdateMarker } = require('./update-marker.cjs')
+const { readLiveUpdateMarker, writeUpdateMarker } = require('./update-marker.cjs')
 const {
   resolveUnpackedRelease,
   decideRelaunchOutcome,
@@ -2296,6 +2296,17 @@ async function applyUpdates(opts = {}) {
     })
     child.unref()
 
+    // Write the update-in-progress marker IMMEDIATELY — before the 2.5s
+    // quit dwell. The Tauri updater won't write its own marker for several
+    // seconds (window init + manifest), and during that gap our renderer
+    // can reconnect and spawn a fresh backend that re-locks .pyd files in
+    // the venv. By writing the marker ourselves the renderer's
+    // waitForUpdateToFinish() gate sees a live update and parks instead.
+    // The updater overwrites this with its own PID later; same format.
+    if (Number.isInteger(child.pid)) {
+      writeUpdateMarker(HERMES_HOME, child.pid)
+    }
+
     rememberLog(`[updates] launched updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release venv shim`)
 
     // Linger on the "updating — don't reopen" overlay long enough for the user
@@ -2354,6 +2365,13 @@ async function handOffWindowsBootstrapRecovery(reason) {
     windowsHide: false
   })
   child.unref()
+
+  // Same marker pre-write as applyUpdates — see comment there. The recovery
+  // hand-off has the same window where the renderer can respawn a backend
+  // before the updater writes its own marker.
+  if (Number.isInteger(child.pid)) {
+    writeUpdateMarker(HERMES_HOME, child.pid)
+  }
 
   rememberLog(
     `[bootstrap] handed off ${reason} recovery to updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`

--- a/apps/desktop/electron/update-marker.cjs
+++ b/apps/desktop/electron/update-marker.cjs
@@ -85,9 +85,43 @@ function readLiveUpdateMarker(hermesHome, { kill, now = Date.now, maxAgeMs = UPD
   return { pid, ageMs }
 }
 
+/**
+ * Write the update-in-progress marker *from the desktop* before handing off
+ * to the detached updater.
+ *
+ * The Tauri-based hermes-setup.exe takes several seconds to initialise its
+ * window and reach the Rust `run_update` entry point where it writes the
+ * marker itself. During that gap the desktop's `app.quit()` teardown kills
+ * the backend child, the renderer's WebSocket drops, and the renderer
+ * immediately calls `ensureBackend()` → `waitForUpdateToFinish()`. Because
+ * the updater hasn't written the marker yet, the gate sees no live update
+ * and spawns a *new* backend — which re-locks `.pyd` files in the venv.
+ * When the updater finally reaches the venv-rebuild stage it finds those
+ * files locked and the update bricks.
+ *
+ * Fix: the desktop writes the marker itself, using the spawned updater's
+ * PID, immediately after `spawn()`. The updater's `UpdateMarkerGuard` will
+ * later overwrite it with its own PID — that's fine, the marker body is
+ * the same format and `readLiveUpdateMarker` only cares that *some* live
+ * pid owns it. When the updater finishes it deletes the marker as before.
+ * If the updater never starts (spawn failure) the marker still contains a
+ * real PID, so `readLiveUpdateMarker` will self-heal once that PID exits.
+ */
+function writeUpdateMarker(hermesHome, pid, { now = Date.now } = {}) {
+  const file = markerPath(hermesHome)
+  const startedAt = Math.floor(now() / 1000)
+  try {
+    fs.writeFileSync(file, `${pid}\n${startedAt}\n`, 'utf8')
+  } catch {
+    // Best-effort: if we can't write the marker, proceed anyway. The
+    // updater will write its own when it reaches run_update.
+  }
+}
+
 module.exports = {
   UPDATE_MARKER_MAX_AGE_MS,
   markerPath,
   isPidAlive,
-  readLiveUpdateMarker
+  readLiveUpdateMarker,
+  writeUpdateMarker
 }

--- a/apps/desktop/electron/update-marker.test.cjs
+++ b/apps/desktop/electron/update-marker.test.cjs
@@ -18,7 +18,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
-const { markerPath, isPidAlive, readLiveUpdateMarker, UPDATE_MARKER_MAX_AGE_MS } = require('./update-marker.cjs')
+const { markerPath, isPidAlive, readLiveUpdateMarker, writeUpdateMarker, UPDATE_MARKER_MAX_AGE_MS } = require('./update-marker.cjs')
 
 function tmpHome(tag) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), `hermes-marker-${tag}-`))
@@ -89,4 +89,30 @@ test('isPidAlive: EPERM counts as alive (process owned by another user)', () => 
     throw err
   }
   assert.equal(isPidAlive(4242, eperm), true)
+})
+
+test('writeUpdateMarker writes a marker that readLiveUpdateMarker accepts', () => {
+  const home = tmpHome('write')
+  const now = 1_000_000_000_000
+  writeUpdateMarker(home, 4242, { now: () => now })
+  // The marker should be readable and report the same pid.
+  const res = readLiveUpdateMarker(home, { kill: ALIVE, now: () => now })
+  assert.ok(res, 'marker written by writeUpdateMarker should be detected as live')
+  assert.equal(res.pid, 4242)
+  assert.ok(fs.existsSync(markerPath(home)), 'marker file should exist after write')
+})
+
+test('writeUpdateMarker is best-effort (no throw on bad path)', () => {
+  // A non-existent directory should not throw.
+  const badHome = path.join(os.tmpdir(), 'hermes-marker-nonexistent-' + Date.now())
+  assert.doesNotThrow(() => writeUpdateMarker(badHome, 4242))
+})
+
+test('writeUpdateMarker + dead pid => self-heals on read', () => {
+  const home = tmpHome('write-dead')
+  writeUpdateMarker(home, 999999, { now: () => Date.now() })
+  // PID 999999 is almost certainly not alive.
+  const res = readLiveUpdateMarker(home, { kill: DEAD })
+  assert.equal(res, null, 'a dead-pid marker from writeUpdateMarker self-heals')
+  assert.ok(!fs.existsSync(markerPath(home)), 'marker file is pruned')
 })


### PR DESCRIPTION
## Problem

On Windows, `hermes update` repeatedly fails with `orjson.cp311-win_amd64.pyd: access denied` (and similar `.pyd` file-lock errors) because the desktop app respawns a new backend during the update hand-off window, re-locking venv files.

## Root Cause

The update hand-off has a **timing gap** between the desktop launching the detached `hermes-setup.exe` updater and the updater writing its own update-in-progress marker:

1. Desktop spawns `hermes-setup.exe` (detached) and calls `app.quit()` after a 2.5s dwell (`UPDATE_HANDOFF_DWELL_MS`)
2. `before-quit` handler SIGTERM-kills the backend child process
3. Renderer WebSocket drops → immediately calls `ensureBackend()` → `startHermes()` → `waitForUpdateToFinish()`
4. `waitForUpdateToFinish()` checks for `.hermes-update-in-progress` marker → **not written yet** (the Tauri updater takes ~17s to reach `run_update` where it writes the marker)
5. A **new backend** spawns and loads `.pyd` files from the venv
6. `app.quit()` finally fires → kills the new backend, but the `.pyd` handles may linger
7. Updater reaches venv-rebuild stage → finds `.pyd` files locked → **update bricks**

This was exposed as a **regression** by `aa2ae36c3` (June 28, 2026), which switched the Windows backend from `pythonw.exe` (GUI subsystem) to `python.exe` (console subsystem). The console process has different exit-signaling behavior that triggers the renderer reconnect path more reliably.

### Evidence (desktop.log)

```
[updates] launched updater: hermes-setup.exe --update --branch main; exiting desktop to release venv shim
Hermes backend exited (SIGTERM)
[boot] Resolving Hermes backend          ← renderer already reconnecting
[boot] Starting Hermes backend via Hermes at ... (venv: ...)
HERMES_DASHBOARD_READY port=4995         ← new backend up, .pyd files locked
```

This pattern repeats on every update attempt. The bootstrap-installer.log shows 6 venv-stage failures since June 2026, all on `.pyd` files (`orjson`, `charset_normalizer`, `cd`, `hermes.exe`, `python.exe`).

## Fix

**The desktop writes the update-in-progress marker itself**, immediately after `spawn()`, using the updater's PID. This closes the gap between spawn and the updater's own `UpdateMarkerGuard::acquire()`.

- `update-marker.cjs`: new `writeUpdateMarker(hermesHome, pid)` function
- `main.cjs`: call `writeUpdateMarker()` after spawning the updater in both `applyUpdates()` and `handOffWindowsBootstrapRecovery()`
- The updater's `UpdateMarkerGuard` later overwrites it with its own PID — same format, same semantics
- If the updater never starts (spawn failure), `readLiveUpdateMarker` self-heals once the PID exits (existing behavior)
- 3 new unit tests covering the write path

## Why not just write the marker earlier in Rust?

The Tauri app initialization (window creation, manifest IPC) inherently takes several seconds before Rust code runs. Moving the marker write earlier in the Rust startup would require restructuring the Tauri init flow. Writing it from the Electron side is simpler, safe (same file format), and closes the gap deterministically.

## Testing

```
node --test apps/desktop/electron/update-marker.test.cjs
# 10 tests, 10 pass, 0 fail

node --test apps/desktop/electron/windows-child-process.test.cjs
# 5 tests, 5 pass, 0 fail
```

---

**中文说明：**

- **问题根因**：桌面端启动更新器后，Tauri 更新器需要约17秒才写入更新标记，而桌面端2.5秒后就退出并杀死backend。此时renderer重连触发新backend启动，新backend锁定venv中的.pyd文件，导致更新器重建venv时失败。
- **回归来源**：`aa2ae36c3` 将backend从`pythonw.exe`改为`python.exe`，改变了进程退出行为，暴露了renderer重连竞态。
- **修复方案**：桌面端在spawn更新器后立即写入更新标记，使renderer的`waitForUpdateToFinish()`门控能正确检测到更新进行中并等待。更新器后续会用自己的PID覆盖该标记，格式相同，语义不变。
