### PR TITLE
fix(anthropic): clear env-derived api_key on OAuth/Bearer clients

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -826,7 +826,15 @@ def build_anthropic_client(
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
 
-    return _anthropic_sdk.Anthropic(**kwargs)
+    client = _anthropic_sdk.Anthropic(**kwargs)
+    if "auth_token" in kwargs and "api_key" not in kwargs:
+        # OAuth/Bearer path: the SDK constructor auto-reads ANTHROPIC_API_KEY
+        # from the environment when api_key isn't passed, which makes it send
+        # BOTH X-Api-Key and Authorization headers. Anthropic then bills the
+        # API key instead of the subscription. Clear it so OAuth requests go
+        # out Bearer-only.
+        client.api_key = None
+    return client
 
 
 def build_anthropic_bedrock_client(region: str):

--- a/tests/agent/test_anthropic_oauth_env_api_key.py
+++ b/tests/agent/test_anthropic_oauth_env_api_key.py
@@ -1,0 +1,33 @@
+"""Regression test: OAuth/Bearer clients must not pick up ANTHROPIC_API_KEY.
+
+When build_anthropic_client() authenticates via ``auth_token`` and omits
+``api_key``, the Anthropic SDK constructor falls back to reading
+ANTHROPIC_API_KEY from the environment. The client then sends BOTH
+X-Api-Key and Authorization headers, and Anthropic bills the API key
+instead of the OAuth subscription. The adapter must null out
+``client.api_key`` on that path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from agent.anthropic_adapter import build_anthropic_client
+
+OAUTH_TOKEN = "sk-ant-oat01-test-token"
+API_KEY = "sk-ant-api03-env-key"
+
+
+def test_oauth_client_does_not_inherit_env_api_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", API_KEY)
+    client = build_anthropic_client(OAUTH_TOKEN)
+    assert client.auth_token == OAUTH_TOKEN
+    assert client.api_key is None
+
+
+def test_regular_api_key_client_unaffected(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-other")
+    client = build_anthropic_client(API_KEY)
+    assert client.api_key == API_KEY

--- a/tests/agent/test_anthropic_oauth_env_api_key.py
+++ b/tests/agent/test_anthropic_oauth_env_api_key.py
@@ -20,11 +20,28 @@ OAUTH_TOKEN = "sk-ant-oat01-test-token"
 API_KEY = "sk-ant-api03-env-key"
 
 
-def test_oauth_client_does_not_inherit_env_api_key(monkeypatch):
+@pytest.mark.parametrize(
+    "token, base_url",
+    [
+        pytest.param(OAUTH_TOKEN, None, id="native-oauth"),
+        pytest.param(
+            "minimax-secret-123", "https://api.minimax.io/anthropic", id="minimax"
+        ),
+        pytest.param(
+            "azure-foundry-secret-123",
+            "https://my-resource.openai.azure.com/anthropic",
+            id="azure",
+        ),
+    ],
+)
+def test_bearer_client_does_not_inherit_env_api_key(monkeypatch, token, base_url):
     monkeypatch.setenv("ANTHROPIC_API_KEY", API_KEY)
-    client = build_anthropic_client(OAUTH_TOKEN)
-    assert client.auth_token == OAUTH_TOKEN
-    assert client.api_key is None
+    with build_anthropic_client(token, base_url=base_url) as client:
+        assert client.auth_token == token
+        assert client.api_key is None
+        headers = {key.lower(): value for key, value in client.default_headers.items()}
+        assert headers["authorization"] == f"Bearer {token}"
+        assert "x-api-key" not in headers
 
 
 def test_regular_api_key_client_unaffected(monkeypatch):


### PR DESCRIPTION
## Problem

On the OAuth path (line 817) and Bearer-auth path (line 801), `build_anthropic_client()` (agent/anthropic_adapter.py) intentionally authenticates via `auth_token` and does not pass `api_key`. But the Anthropic SDK constructor treats a missing `api_key` as "read `ANTHROPIC_API_KEY` from the environment" — so the env key is silently attached to a client that was deliberately built without one.

With both an OAuth subscription and `ANTHROPIC_API_KEY` set, every OAuth request carries two headers:

- `Authorization: Bearer ***
- `X-Api-Key: *** api key>`

Anthropic bills the API key, not the subscription.

## Relation to credential-pool fallback

API-key fallback is meant to be handled by the credential pool: when the subscription is exhausted, the pool marks the OAuth entry cooled-down (429 → 1h TTL, `agent/credential_pool.py`) and rotates to the API key. This bug made that fallback happen accidentally on every request — the API key was always billed and the subscription never used. With the fix, the subscription is billed until genuinely exhausted; the pool then rotates as designed.

## Reproduction

1. Set `ANTHROPIC_API_KEY`
2. `build_anthropic_client("sk-ant-oat-...")`
3. `client.api_key` is the env key; requests carry both headers

## Fix

Null `client.api_key` after construction when `auth_token` is the credential, so requests go out Bearer-only.

## Validation

- Confirmed against live billing: without the guard, OAuth traffic bills the API key; with it, the subscription.
- Regression test `tests/agent/test_anthropic_oauth_env_api_key.py`: fails on main (`client.api_key == env key`), passes with the fix. Also asserts the regular API-key path keeps `api_key` set.

Sibling paths checked:

- Entra ID hook (line 700): unaffected — httpx hook rewrites Authorization per request
- Kimi / third-party / regular-key branches: set `api_key` explicitly
- No async client path exists in the adapter
