### PR TITLE
fix(webhook): support Linear-Signature HMAC verification

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -822,7 +822,7 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Linear, Svix, generic HMAC-SHA256)."""
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
@@ -860,6 +860,14 @@ class WebhookAdapter(BasePlatformAdapter):
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
+
+        # Linear: Linear-Signature = <hex HMAC-SHA256 of raw body>
+        ln_sig = _header("Linear-Signature")
+        if ln_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(ln_sig, expected)
 
         # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
         generic_sig = request.headers.get("X-Webhook-Signature", "")


### PR DESCRIPTION
## Summary

`WebhookAdapter._validate_signature` recognises GitHub, GitLab, Svix, and the generic `X-Webhook-Signature` header — but not Linear. Linear signs each webhook delivery with a hex HMAC-SHA256 of the raw request body in the `Linear-Signature` header (see [Linear's webhook docs](https://linear.app/developers/webhooks#securing-webhooks)), so with a webhook secret configured, every Linear delivery is rejected with "Secret configured but no signature header found".

This adds `Linear-Signature` to the recognised formats, verified the same way as the generic HMAC path (constant-time compare via `hmac.compare_digest`), and mentions Linear in the method docstring.

## Testing

- Running in production on a Linear → hermes webhook-platform integration since 2026-07-02: signature-checked deliveries verified end-to-end; tampered/unsigned payloads rejected.
- File compiles clean (`compile()` syntax check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
