### PR TITLE
fix: add same-call-repeat guardrail for idempotent tools with varying results

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -77,6 +77,8 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    same_call_repeat_warn_after: int = 3
+    same_call_repeat_block_after: int = 6
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
     loop_caps: "LoopCapConfig" = field(default_factory=lambda: LoopCapConfig())
@@ -110,6 +112,10 @@ class ToolCallGuardrailConfig:
                 warn_after.get("idempotent_no_progress", data.get("no_progress_warn_after")),
                 defaults.no_progress_warn_after,
             ),
+            same_call_repeat_warn_after=_positive_int(
+                warn_after.get("same_call_repeat", data.get("same_call_repeat_warn_after")),
+                defaults.same_call_repeat_warn_after,
+            ),
             exact_failure_block_after=_positive_int(
                 hard_stop_after.get("exact_failure", data.get("exact_failure_block_after")),
                 defaults.exact_failure_block_after,
@@ -121,6 +127,10 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            same_call_repeat_block_after=_positive_int(
+                hard_stop_after.get("same_call_repeat", data.get("same_call_repeat_block_after")),
+                defaults.same_call_repeat_block_after,
             ),
             loop_caps=LoopCapConfig.from_mapping(data.get("loop_caps")),
         )
@@ -281,6 +291,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._same_call_repeat_counts: dict[ToolCallSignature, int] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
         # Per-turn runaway-loop cap counters. Reset every turn (this method
         # runs at the start of each run_conversation), so the caps bound a
@@ -344,6 +355,24 @@ class ToolCallGuardrailController:
                     )
                     self._halt_decision = decision
                     return decision
+
+            same_call_count = self._same_call_repeat_counts.get(signature, 0)
+            if same_call_count >= self.config.same_call_repeat_block_after:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="same_call_repeat_block",
+                    message=(
+                        f"Blocked {tool_name}: the same read-only call was made "
+                        f"{same_call_count} times this turn with varying results. "
+                        "Stop repeating it; use the results already provided or "
+                        "try a different query."
+                    ),
+                    tool_name=tool_name,
+                    count=same_call_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
 
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -423,6 +452,9 @@ class ToolCallGuardrailController:
             repeat_count = previous[1] + 1
         self._no_progress[signature] = (result_hash, repeat_count)
 
+        same_call_count = self._same_call_repeat_counts.get(signature, 0) + 1
+        self._same_call_repeat_counts[signature] = same_call_count
+
         if self.config.warnings_enabled and repeat_count >= self.config.no_progress_warn_after:
             return ToolGuardrailDecision(
                 action="warn",
@@ -434,6 +466,20 @@ class ToolCallGuardrailController:
                 ),
                 tool_name=tool_name,
                 count=repeat_count,
+                signature=signature,
+            )
+
+        if self.config.warnings_enabled and same_call_count >= self.config.same_call_repeat_warn_after:
+            return ToolGuardrailDecision(
+                action="warn",
+                code="same_call_repeat_warning",
+                message=(
+                    f"{tool_name} was called with the same arguments {same_call_count} "
+                    "times this turn. This looks like a loop; use the results already "
+                    "provided or try a different query instead of repeating it."
+                ),
+                tool_name=tool_name,
+                count=same_call_count,
                 signature=signature,
             )
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -399,10 +399,12 @@ tool_loop_guardrails:
     exact_failure: 2
     same_tool_failure: 3
     idempotent_no_progress: 2
+    same_call_repeat: 3
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    same_call_repeat: 6
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -538,11 +538,13 @@ DEFAULT_CONFIG = {
             "exact_failure": 2,
             "same_tool_failure": 3,
             "idempotent_no_progress": 2,
+            "same_call_repeat": 3,
         },
         "hard_stop_after": {
             "exact_failure": 5,
             "same_tool_failure": 8,
             "idempotent_no_progress": 5,
+            "same_call_repeat": 6,
         },
         # Per-turn runaway-loop caps (inspired by Claude Code v2.1.212,
         # Week 29, July 2026). Hard ceilings on how many times a runaway-prone

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -33,8 +33,6 @@ def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposi
     assert "☤" not in json.dumps(metadata)
 
 
-
-
 def test_config_parses_nested_warn_and_hard_stop_thresholds():
     cfg = ToolCallGuardrailConfig.from_mapping(
         {
@@ -44,11 +42,13 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
                 "exact_failure": 3,
                 "same_tool_failure": 4,
                 "idempotent_no_progress": 5,
+                "same_call_repeat": 5,
             },
             "hard_stop_after": {
                 "exact_failure": 6,
                 "same_tool_failure": 7,
                 "idempotent_no_progress": 8,
+                "same_call_repeat": 8,
             },
         }
     )
@@ -58,9 +58,11 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
     assert cfg.exact_failure_warn_after == 3
     assert cfg.same_tool_failure_warn_after == 4
     assert cfg.no_progress_warn_after == 5
+    assert cfg.same_call_repeat_warn_after == 5
     assert cfg.exact_failure_block_after == 6
     assert cfg.same_tool_failure_halt_after == 7
     assert cfg.no_progress_block_after == 8
+    assert cfg.same_call_repeat_block_after == 8
 
 
 def test_default_repeated_identical_failed_call_warns_without_blocking():
@@ -107,18 +109,6 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
     assert blocked.count == 2
 
 
-
-
-
-
-
-
-
-
-
-
-
-
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
@@ -131,17 +121,98 @@ def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_succes
         assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
 
 
+def test_same_call_varying_result_warns_at_threshold_by_default():
+    """Identical idempotent args with distinct successful results should warn.
+
+    This is the varying-result counterpart to the identical-result hash tests:
+    the same read-only call made repeatedly this turn is a loop even when each
+    invocation happens to return different content.
+    """
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(same_call_repeat_warn_after=3)
+    )
+    args = {"query": "same call"}
+    results = ["result-one", "result-two", "result-three", "result-four"]
+
+    for i in range(2):
+        assert controller.before_call("web_search", args).action == "allow"
+        assert controller.after_call("web_search", args, results[i], failed=False).action == "allow"
+
+    # Third same-args call reaches the warn threshold.
+    assert controller.before_call("web_search", args).action == "allow"
+    warn = controller.after_call("web_search", args, results[2], failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "same_call_repeat_warning"
+    assert warn.count == 3
+
+    # Still not blocked (warnings never prevent execution).
+    assert controller.before_call("web_search", args).action == "allow"
+    assert controller.halt_decision is None
 
 
+def test_same_call_varying_result_blocks_only_next_call_in_hard_stop():
+    """Hard-stop mode should block only the next call after the threshold.
+
+    The distinct results mean the identical-result hash path never fires;
+    only the same-args counter should gate this loop.
+    """
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            same_call_repeat_warn_after=3,
+            same_call_repeat_block_after=3,
+        )
+    )
+    args = {"query": "same call"}
+    results = ["r1", "r2", "r3", "r4"]
+
+    # Calls 1 and 2 are allowed (count 1, 2 < warn threshold 3).
+    for i in range(2):
+        assert controller.before_call("web_search", args).action == "allow"
+        assert controller.after_call("web_search", args, results[i], failed=False).action == "allow"
+
+    # Third successful call reaches the warn threshold (count == 3).
+    assert controller.before_call("web_search", args).action == "allow"
+    warn = controller.after_call("web_search", args, results[2], failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "same_call_repeat_warning"
+
+    # Only the NEXT call blocks (count == 3 >= block_after == 3).
+    blocked = controller.before_call("web_search", args)
+    assert blocked.action == "block"
+    assert blocked.code == "same_call_repeat_block"
+    assert blocked.count == 3
+
+
+def test_same_call_counter_resets_on_turn_change():
+    """The varying-result same-args counter should reset between turns."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            same_call_repeat_warn_after=2,
+            same_call_repeat_block_after=2,
+        )
+    )
+    args = {"query": "same call"}
+
+    # First call allowed; second call reaches warn threshold.
+    assert controller.before_call("web_search", args).action == "allow"
+    assert controller.after_call("web_search", args, "result-0", failed=False).action == "allow"
+    assert controller.before_call("web_search", args).action == "allow"
+    assert controller.after_call("web_search", args, "result-1", failed=False).action == "warn"
+
+    # Next call blocks within the turn (count == 2 >= block_after == 2).
+    assert controller.before_call("web_search", args).action == "block"
+
+    controller.reset_for_turn()
+    # After reset, the same call is allowed again.
+    assert controller.before_call("web_search", args).action == "allow"
+    assert controller.after_call("web_search", args, "fresh-result", failed=False).action == "allow"
 
 
 # ── Per-turn runaway-loop caps (Claude Code v2.1.212, Week 29) ──────────────
 
 from agent.tool_guardrails import LoopCapConfig  # noqa: E402
-
-
-
-
 
 
 def test_loop_cap_zero_disables_and_junk_falls_back():
@@ -167,13 +238,3 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
     assert decision.should_halt is True
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Fixes #57818

## Description
The existing tool-call guardrails only detect loops when idempotent tools return identical results (hash match). However, tools like `web_search` can return slightly varying results on each call even with the same query, allowing the agent to loop indefinitely without any guardrail firing.

This PR adds a `same_call_repeat` counter that tracks how many times the same idempotent tool+args combination is called in a single turn, regardless of whether results vary. After 3 calls (configurable via `same_call_repeat_warn_after`), a warning is appended to the tool result. With `hard_stop_enabled: true`, the call is blocked after 6 repeats (`same_call_repeat_block_after`).

## Changes
- Added `same_call_repeat_warn_after` (default: 3) and `same_call_repeat_block_after` (default: 6) to `ToolCallGuardrailConfig`
- Added `_same_call_repeat_counts` tracking dict to `ToolCallGuardrailController`
- Added warn/block decisions in `after_call` and `before_call` for same-call-repeat detection
- Configurable via `tool_loop_guardrails.warn_after.same_call_repeat` and `tool_loop_guardrails.hard_stop_after.same_call_repeat` in config.yaml

## Verification
- All 13 existing `test_tool_guardrails.py` tests pass
- All 9 existing `test_tool_call_guardrail_runtime.py` tests pass
- Quality gates: S1 (secrets) clean, S2 (personal refs) clean, C1 (conventional commits) clean, F1 (focused diff) clean