### PR TITLE
fix(dashboard): scrub gateway marker from actions

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2835,7 +2835,10 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         "stdin": subprocess.DEVNULL,
         "stdout": log_file,
         "stderr": subprocess.STDOUT,
-        "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
+        "env": {
+            k: v for k, v in os.environ.items()
+            if k != "_HERMES_GATEWAY"
+        } | {"HERMES_NONINTERACTIVE": "1"},
     }
     if sys.platform == "win32":
         popen_kwargs["creationflags"] = windows_detach_flags()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -233,6 +233,49 @@ class TestSessionTokenInjection:
         assert ws._SESSION_TOKEN and len(ws._SESSION_TOKEN) >= 32
 
 
+def test_spawn_hermes_action_strips_gateway_sentinel(monkeypatch, tmp_path):
+    import hermes_cli.web_server as web_server
+
+    captured = {}
+
+    class Proc:
+        pid = 12345
+
+        def poll(self):
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return Proc()
+
+    class _LogDir:
+        def mkdir(self, *args, **kwargs):
+            return None
+
+        def __truediv__(self, name):
+            return tmp_path / name
+
+    monkeypatch.setattr(web_server, "_ACTION_LOG_DIR", _LogDir())
+    monkeypatch.setattr(web_server.subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-1")
+    web_server._ACTION_PROCS.pop("gateway-restart", None)
+    web_server._ACTION_COMMANDS.pop("gateway-restart", None)
+
+    try:
+        proc = web_server._spawn_hermes_action(["gateway", "restart"], "gateway-restart")
+    finally:
+        web_server._ACTION_PROCS.pop("gateway-restart", None)
+        web_server._ACTION_COMMANDS.pop("gateway-restart", None)
+
+    assert proc.pid == 12345
+    env = captured["kwargs"]["env"]
+    assert env["HERMES_NONINTERACTIVE"] == "1"
+    assert env["HERMES_SESSION_KEY"] == "session-1"
+    assert "_HERMES_GATEWAY" not in env
+
+
 # ---------------------------------------------------------------------------
 # web_server tests (FastAPI endpoints)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
- Strip the gateway-only `_HERMES_GATEWAY` sentinel from dashboard/API action subprocesses.
- Preserve the rest of the inherited environment and force non-interactive mode for spawned actions.

Root Cause
- `_spawn_hermes_action()` inherited `_HERMES_GATEWAY=1` from the running gateway process, so `hermes gateway restart` spawned by the dashboard hit the self-restart guard and exited immediately.

Tests
- `python -m pytest tests/hermes_cli/test_web_server.py::test_spawn_hermes_action_strips_gateway_sentinel -q`
- `python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

Fixes #57512