### PR TITLE
fix(desktop): avoid leaking Python path to backend

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -50,10 +50,9 @@ test('desktop backend PATH preserves first occurrence and avoids duplicates', ()
   )
 })
 
-test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () => {
+test('buildDesktopBackendEnv leaves PYTHONPATH unset and builds backend PATH', () => {
   const env = buildDesktopBackendEnv({
     hermesHome: '/Users/test/.hermes',
-    pythonPathEntries: ['/repo/hermes-agent'],
     venvRoot: '/Users/test/.hermes/hermes-agent/venv',
     currentEnv: {
       PATH: '/usr/bin:/bin',
@@ -63,7 +62,7 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
     pathModule: path.posix
   })
 
-  assert.equal(env.PYTHONPATH, '/repo/hermes-agent:/existing/pythonpath')
+  assert.equal(env.PYTHONPATH, undefined)
   assert.ok(env.PATH.startsWith('/Users/test/.hermes/node/bin:/Users/test/.hermes/hermes-agent/venv/bin:'))
   assert.ok(env.PATH.includes('/opt/homebrew/bin'))
 })
@@ -83,7 +82,6 @@ test('normalizeHermesHomeRoot maps profile homes back to the global Hermes root'
 test('Windows PATH casing and delimiter are preserved without POSIX sane entries', () => {
   const env = buildDesktopBackendEnv({
     hermesHome: 'C:\\Users\\test\\AppData\\Local\\hermes',
-    pythonPathEntries: ['C:\\repo\\hermes-agent'],
     venvRoot: 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv',
     currentEnv: {
       Path: 'C:\\Windows\\System32;C:\\Windows',
@@ -99,6 +97,7 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
   assert.ok(env.Path.includes('\\venv\\Scripts;'))
   assert.ok(env.Path.includes(';C:\\Windows\\System32;C:\\Windows'))
   assert.equal(env.Path.includes('/opt/homebrew/bin'), false)
+  assert.equal(env.PYTHONPATH, undefined)
 })
 
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -92,18 +92,14 @@ function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatfor
 
 function buildDesktopBackendEnv({
   hermesHome,
-  pythonPathEntries = [],
   venvRoot,
   currentEnv = process.env,
   platform = process.platform,
   pathModule = pathModuleForPlatform(platform)
 }: any = {}) {
-  const delimiter = delimiterForPlatform(platform)
-  const currentPythonPath = currentEnv?.PYTHONPATH || ''
   const key = pathEnvKey(currentEnv, platform)
 
   return {
-    PYTHONPATH: appendUniquePathEntries([...pythonPathEntries, currentPythonPath], { delimiter }),
     [key]: buildDesktopBackendPath({
       hermesHome,
       venvRoot,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -127,7 +127,7 @@ import {
   MIN_WIDTH as WINDOW_MIN_WIDTH
 } from './window-state'
 import { hiddenWindowsChildOptions } from './windows-child-options'
-import { buildPathExtCandidates, chooseUpdaterArgs, getVenvSitePackagesEntries, resolveVenvHermesCommand } from './windows-hermes-path'
+import { buildPathExtCandidates, chooseUpdaterArgs, resolveVenvHermesCommand } from './windows-hermes-path'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
@@ -1452,7 +1452,6 @@ function unwrapWindowsVenvHermesCommand(command, backendArgs) {
     directoryExists,
     canImportHermesCli,
     getVenvPython,
-    getVenvSitePackagesEntries,
     buildDesktopBackendEnv,
     hermesHome: HERMES_HOME,
     resolvePath: (...segments) => path.resolve(...segments),
@@ -3244,7 +3243,6 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
     args: ['-m', 'hermes_cli.main', ...backendArgs],
     env: buildDesktopBackendEnv({
       hermesHome: HERMES_HOME,
-      pythonPathEntries: [root, ...getVenvSitePackagesEntries(venvRoot)],
       venvRoot
     }),
     root,
@@ -3268,7 +3266,6 @@ function createActiveBackend(backendArgs) {
     args: ['-m', 'hermes_cli.main', ...backendArgs],
     env: buildDesktopBackendEnv({
       hermesHome: HERMES_HOME,
-      pythonPathEntries: [ACTIVE_HERMES_ROOT, ...getVenvSitePackagesEntries(VENV_ROOT)],
       venvRoot: VENV_ROOT
     }),
     root: ACTIVE_HERMES_ROOT,

--- a/apps/desktop/electron/windows-hermes-path.test.ts
+++ b/apps/desktop/electron/windows-hermes-path.test.ts
@@ -61,7 +61,6 @@ function makeDeps(overrides: Partial<Parameters<typeof resolveVenvHermesCommand>
     directoryExists: () => false,
     canImportHermesCli: () => true,
     getVenvPython: (venvRoot: string) => `${venvRoot}/Scripts/python.exe`,
-    getVenvSitePackagesEntries: () => [],
     buildDesktopBackendEnv: () => ({ FAKE_ENV: '1' }),
     hermesHome: '/fake/hermes-home',
     resolvePath: (...segments: string[]) => segments.join('/').replace(/\/+/g, '/'),

--- a/apps/desktop/electron/windows-hermes-path.ts
+++ b/apps/desktop/electron/windows-hermes-path.ts
@@ -167,10 +167,8 @@ export interface ResolveVenvHermesCommandDeps {
   directoryExists: (filePath: string) => boolean
   canImportHermesCli: (python: string, opts?: { env?: Record<string, string> }) => boolean
   getVenvPython: (venvRoot: string) => string
-  getVenvSitePackagesEntries: (venvRoot: string) => string[]
   buildDesktopBackendEnv: (opts: {
     hermesHome: string
-    pythonPathEntries: string[]
     venvRoot: string
   }) => Record<string, string>
   hermesHome: string
@@ -220,7 +218,6 @@ export function resolveVenvHermesCommand(
     directoryExists,
     canImportHermesCli,
     getVenvPython,
-    getVenvSitePackagesEntries,
     buildDesktopBackendEnv,
     hermesHome,
     resolvePath,
@@ -277,7 +274,6 @@ export function resolveVenvHermesCommand(
     bootstrap: false,
     env: buildDesktopBackendEnv({
       hermesHome,
-      pythonPathEntries: [...(directoryExists(root) ? [root] : []), ...getVenvSitePackagesEntries(venvRoot)],
       venvRoot
     }),
     kind: 'python',

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -204,10 +204,6 @@ def _ensure_windows_gateway_venv_imports() -> None:
         sys.path.insert(insert_at, site_entry)
 
         os.environ["VIRTUAL_ENV"] = str(resolved_venv)
-        pythonpath = [project_entry, site_entry]
-        if os.environ.get("PYTHONPATH"):
-            pythonpath.append(os.environ["PYTHONPATH"])
-        os.environ["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath))
         return
 
 

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -309,8 +309,7 @@ def test_windows_gateway_venv_imports_add_site_packages(monkeypatch, tmp_path):
     assert gateway_run.sys.path[:2] == [project_root, str(site_packages)]
     assert str(pth_extra) in gateway_run.sys.path
     assert gateway_run.os.environ["VIRTUAL_ENV"] == str(venv_dir.resolve())
-    pythonpath = gateway_run.os.environ["PYTHONPATH"].split(gateway_run.os.pathsep)
-    assert pythonpath[:3] == [project_root, str(site_packages), "already-there"]
+    assert gateway_run.os.environ["PYTHONPATH"] == "already-there"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
- Stop the Windows gateway import bootstrap from mutating process-global `PYTHONPATH`.
- Stop the desktop backend env helper from exporting Hermes source/site-packages through `PYTHONPATH`, while preserving managed PATH setup.

Root Cause
- Windows gateway startup and desktop backend spawn paths added Hermes source and venv site-packages to environment `PYTHONPATH`, so unrelated Python tools launched from Hermes could inherit Hermes packages ahead of their own environments.

Tests
- `python -m pytest tests/gateway/test_restart_drain.py::test_windows_gateway_venv_imports_add_site_packages tests/gateway/test_restart_drain.py::test_windows_detached_restart_scrubs_gateway_marker -q`
- `node --test apps/desktop/electron/backend-env.test.cjs`
- `python -m py_compile gateway/run.py tests/gateway/test_restart_drain.py`
- `git diff --check`

Fixes #57467