### PR TITLE
fix(cli): respect display.compact config + improve TUI loading UX

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6117,7 +6117,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         ctx_len = None
         if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
             ctx_len = self.agent.context_compressor.context_length
-        
+
         # Auto-compact for narrow terminals — the full banner with caduceus
         # + tool list needs ~80 columns minimum to render without wrapping.
         term_width = shutil.get_terminal_size().columns
@@ -11961,7 +11961,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Initialize agent if needed
         if self.agent is None:
-            _cprint(f"{_DIM}Initializing agent...{_RST}")
+            self._spinner_text = "⚡ Initializing agent..."
+            self._invalidate()
         if not self._init_agent(
             model_override=turn_route["model"],
             runtime_override=turn_route["runtime"],
@@ -15090,6 +15091,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     self._agent_running = True
                     self._pet_turn_error = False
                     self._pet_reasoning = False
+                    self._spinner_text = self._spinner_text or "⚡ Thinking..."
                     app.invalidate()  # Refresh status line
 
                     try:
@@ -15591,7 +15593,7 @@ def main(
     max_turns: int = None,
     verbose: Optional[bool] = None,
     quiet: bool = False,
-    compact: bool = False,
+    compact: bool = None,
     list_tools: bool = False,
     list_toolsets: bool = False,
     gateway: bool = False,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2397,7 +2397,7 @@ def cmd_chat(args):
         "max_turns": getattr(args, "max_turns", None),
         "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False) or getattr(args, "safe_mode", False),
-        "compact": getattr(args, "compact", False),
+        "compact": getattr(args, "compact", None),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}


### PR DESCRIPTION
## Problem

The interactive CLI had three UX issues during startup and loading:

1. **`display.compact: true` in config.yaml was silently ignored.** `main.py:cmd_chat` passed `compact=False` (the `getattr` default for non-Termux where `args.compact` is never set). This False value propagated through to `HermesCLI.__init__`, where `self.compact = compact if compact is not None else ...` kept it as False — the config fallback never fired. Users always got the full 35-line banner regardless of config.

2. **"Initializing agent..." was printed as static text** (`_cprint`) that stuck in scrollback. It looked like init never finished, and remained visible even after the agent was ready.

3. **Spinner disappeared for 4+ seconds** between agent init completing and the first API response chunk. During this gap the screen was blank with no feedback — the spinner text was empty (`""`) until `_on_thinking` or a tool event set it.

## Fix

| File | Change |
|------|--------|
| `hermes_cli/main.py:2399` | `getattr(args, "compact", False)` → `getattr(args, "compact", None)` so the None gets filtered by the kwargs dict comprehension and `HermesCLI.__init__` falls back to `CLI_CONFIG["display"]["compact"]` |
| `cli.py:15593` | `compact: bool = False` → `compact: bool = None` (function signature default, same reasoning) |
| `cli.py:11961` | `_cprint("Initializing agent...")` → `self._spinner_text = "⚡ Initializing agent..."; self._invalidate()` — live spinner that clears automatically |
| `cli.py:15091` | Add `self._spinner_text = self._spinner_text or "⚡ Thinking..."` before `self.chat()` so the spinner stays visible during the API gap |

## Test plan

- [x] 227 CLI tests pass (`tests/cli/` — init, status bar, loading indicator, skin integration, background indicator, force redraw, provider resolution, fast command, new session, preloaded skills, single query, config save)
- [x] Live TUI test: compact banner renders (4-line box instead of 35-line ASCII art)
- [x] Live TUI test: spinner shows "⚡ Initializing agent..." → "(≈) tracking undertow..." → response — no blank gap
- [x] `hermes chat -q "hi"` still works (8.5s total)