### PR TITLE
fix(cli,tui): inform the model when session is resumed after a process restart

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -15,10 +15,16 @@ loaded) so this module never imports ``cli`` at import time -> no import cycle.
 from __future__ import annotations
 
 import sys
+import time
 
 from rich.markup import escape as _escape
 
 from utils import base_url_host_matches
+
+# Record process start time for session-resume detection.
+# Compared against the last message timestamp in a resumed session
+# to determine whether the conversation history predates this process.
+_PROCESS_START: float = time.time()
 
 
 def _single_query_clarify_callback(question: str, choices=None, multi_select=False) -> str:
@@ -531,7 +537,7 @@ class CLIAgentSetupMixin:
                     break
             if (
                 _last_message_ts is not None
-                and _last_message_ts < self.session_start.timestamp()
+                and _last_message_ts < _PROCESS_START
             ):
                 _resume_note = (
                     "\n\n[Session resumed after a process restart. "

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -516,6 +516,35 @@ class CLIAgentSetupMixin:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+            # Build ephemeral system prompt, appending a resume note when
+            # the conversation history predates the current process — i.e.,
+            # the session was restored from a prior Hermes run.  Compare
+            # the last message's timestamp against process start time to
+            # detect this regardless of how the session was loaded
+            # (--resume flag, TUI auto-resume, or /resume in-session).
+            _ephemeral_sp = self.system_prompt if self.system_prompt else None
+            _last_message_ts = None
+            for msg in reversed(self.conversation_history):
+                ts = msg.get("timestamp")
+                if ts is not None:
+                    _last_message_ts = ts
+                    break
+            if (
+                _last_message_ts is not None
+                and _last_message_ts < self.session_start.timestamp()
+            ):
+                _resume_note = (
+                    "\n\n[Session resumed after a process restart. "
+                    "This conversation history was restored from a prior session. "
+                    "Tool calls shown in the history have already been executed — "
+                    "do NOT re-execute them. "
+                    "The previous session's work was already reported — "
+                    "continue without re-summarizing. "
+                    "Address the user's current message below. "
+                    "Unless the user explicitly asks for a recap, ignore the past work.]"
+                )
+                _ephemeral_sp = (_ephemeral_sp or "") + _resume_note
+
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -534,7 +563,6 @@ class CLIAgentSetupMixin:
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,
                 tool_progress_mode=getattr(self, "tool_progress_mode", "all"),
-                ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
                 prefill_messages=self.prefill_messages or None,
                 reasoning_config=self.reasoning_config,
                 service_tier=self.service_tier,
@@ -548,6 +576,7 @@ class CLIAgentSetupMixin:
                 openrouter_min_coding_score=self._openrouter_min_coding_score,
                 session_id=self.session_id,
                 platform="cli",
+                ephemeral_system_prompt=_ephemeral_sp,
                 session_db=self._session_db,
                 # A -q turn never builds the prompt_toolkit application, so
                 # the interactive modal can never be painted or answered —

--- a/tests/hermes_cli/test_session_resume_note.py
+++ b/tests/hermes_cli/test_session_resume_note.py
@@ -1,0 +1,71 @@
+"""Tests for session-resume note injection in CLI agent construction.
+
+Tests the resume-note logic directly by exercising the timestamp
+comparison that determines whether the note is appended.  The full
+_init_agent() integration is too complex to mock (40+ attributes,
+provider resolution, TIRITH security); this tests the core logic.
+"""
+
+import pytest
+
+
+RESUME_NOTE = (
+    "\n\n[Session resumed after a process restart. "
+    "This conversation history was restored from a prior session. "
+    "Tool calls shown in the history have already been executed — "
+    "do NOT re-execute them. "
+    "The previous session's work was already reported — "
+    "continue without re-summarizing. "
+    "Address the user's current message below. "
+    "Unless the user explicitly asks for a recap, ignore the past work.]"
+)
+
+
+def _should_add_resume_note(conversation_history, session_start_ts):
+    """Replicate the logic from cli_agent_setup_mixin._init_agent()."""
+    last_ts = None
+    for msg in reversed(conversation_history):
+        ts = msg.get("timestamp")
+        if ts is not None:
+            last_ts = ts
+            break
+    return last_ts is not None and last_ts < session_start_ts
+
+
+class TestResumeNoteLogic:
+    def test_added_when_last_message_predates_session(self):
+        assert _should_add_resume_note(
+            conversation_history=[
+                {"role": "user", "content": "hi", "timestamp": 1000.0},
+                {"role": "assistant", "content": "hello", "timestamp": 1001.0},
+            ],
+            session_start_ts=2000.0,
+        ) is True
+
+    def test_not_added_when_last_message_after_session_start(self):
+        assert _should_add_resume_note(
+            conversation_history=[
+                {"role": "user", "content": "hi", "timestamp": 3000.0},
+            ],
+            session_start_ts=2000.0,
+        ) is False
+
+    def test_not_added_when_no_history(self):
+        assert _should_add_resume_note(
+            conversation_history=[], session_start_ts=2000.0,
+        ) is False
+
+    def test_not_added_when_no_timestamp_in_history(self):
+        assert _should_add_resume_note(
+            conversation_history=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+            session_start_ts=2000.0,
+        ) is False
+
+    def test_note_text_contains_key_instructions(self):
+        """The resume note text itself is correct."""
+        assert "do NOT re-execute" in RESUME_NOTE
+        assert "process restart" in RESUME_NOTE
+        assert "was already reported" in RESUME_NOTE

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9047,10 +9047,13 @@ def _make_agent(
 
     # Appends a resume note when the conversation history predates this
     # process start, indicating the session was restored from a prior
-    # Hermes run.
-    if session_db is not None and session_id is not None:
+    # Hermes run.  Resolve the effective DB first — callers that don't
+    # pass a session_db (e.g. the default-profile cold-resume path in
+    # _start_agent_build) pass None, but _get_db() provides the fallback.
+    _db = session_db if session_db is not None else _get_db()
+    if _db is not None and session_id is not None:
         try:
-            row = session_db._conn.execute(
+            row = _db._conn.execute(
                 "SELECT MAX(timestamp) FROM messages "
                 "WHERE session_id = ? AND active = 1",
                 (session_id,),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -132,6 +132,11 @@ def _thread_panic_hook(args):
 
 threading.excepthook = _thread_panic_hook
 
+# Record process start time for session-resume detection.
+# Compared against the last message timestamp in a resumed session to
+# determine whether the conversation history predates this process run.
+_PROCESS_START: float = time.time()
+
 try:
     from hermes_cli.banner import prefetch_update_check
 
@@ -9039,6 +9044,32 @@ def _make_agent(
             system_prompt = "\n\n".join(
                 part for part in (system_prompt, skills_prompt) if part
             ).strip()
+
+    # Appends a resume note when the conversation history predates this
+    # process start, indicating the session was restored from a prior
+    # Hermes run.
+    if session_db is not None and session_id is not None:
+        try:
+            row = session_db._conn.execute(
+                "SELECT MAX(timestamp) FROM messages "
+                "WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+            if row is not None and row[0] is not None and row[0] < _PROCESS_START:
+                _resume_note = (
+                    "\n\n[Session resumed after a process restart. "
+                    "This conversation history was restored from a prior session. "
+                    "Tool calls shown in the history have already been executed — "
+                    "do NOT re-execute them. "
+                    "The previous session's work was already reported — "
+                    "continue without re-summarizing. "
+                    "Address the user's current message below. "
+                    "Unless the user explicitly asks for a recap, ignore the past work.]"
+                )
+                system_prompt = (system_prompt + "\n\n" + _resume_note).strip()
+        except Exception:
+            pass
+
     # Prefer a per-session model override (set by a prior in-session /model
     # switch) over global config/env resolution. Resume-time stored sessions may
     # also pass scalar model/provider/runtime knobs from the persisted DB row.


### PR DESCRIPTION
## What does this PR do?

When a Hermes process exits and restarts with the same session — whether via `--resume` on the CLI, `/resume` in the TUI, or the TUI's auto-resume — the model has no way to know the session was restored from a prior run. It treats an old conversation as fresh, reruns stale tool calls, and crucially **cannot detect that the environment has changed** — newly installed plugins, modified skills, updated config, or restarted services are invisible to it.

This has been a persistent pain point while developing Hermes itself and its plugins: every restart looks like nothing happened to the model.

### The fix

Compare the last message's timestamp in the conversation history against the current process start time. If the history predates the process, inject a system prompt note:

```
[Session resumed after a process restart.
This conversation history was restored from a prior session.
Tool calls shown in the history have already been executed —
do NOT re-execute them.
Address the user's current message below.]
```

The note lives in the **ephemeral system prompt** (not user messages), so it cannot accumulate across repeated restarts — each restart is a new process with a fresh prompt.

### Two paths

1. **CLI path** (`hermes_cli/cli_agent_setup_mixin.py`): iterates `conversation_history` in-memory, compares against `self.session_start.timestamp()`.
2. **TUI path** (`tui_gateway/server.py`): records `_PROCESS_START` at module load, queries `SELECT MAX(timestamp) FROM messages` for the session, compares directly.

Works regardless of how the session was loaded (`--resume`, TUI auto-resume, or `/resume` in-session). Does NOT trigger for `/new` (clears history) or regular fresh sessions.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py`: added timestamp-based resume detection in `_init_agent()`, before passing `ephemeral_system_prompt` to the agent constructor.
- `tui_gateway/server.py`: added `_PROCESS_START` module constant and timestamp query in `_make_agent()`.

## How to Test

1. Start a conversation, send a few messages, then `/new` to switch sessions.
2. Exit Hermes (`Ctrl+C`) and restart with `--resume <session_id>`.
3. The model's first response should acknowledge the restart (check the system prompt or model output).
4. Verify that a fresh session (no `--resume`) shows no such note.
5. Verify that `/resume` to another session in the same process shows the note when that session's history predates the current process start.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [ ] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] N/A — no config changes, no tool changes, no new skills

## Motivation

This came out of a real workflow frustration: when modifying Hermes itself or its plugins/skills, the user restarts the process to pick up changes, but the resumed session looks identical to the model. The model then acts as if nothing changed — it runs stale tool calls, misses newly loaded plugins, and generally behaves as though it's the same uninterrupted session. This PR makes the restart visible to the model so it can adapt accordingly.