### PR TITLE
fix(dashboard): block managed credential directories

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1194,6 +1194,20 @@ _FS_READDIR_HIDDEN = {
 # managed-files API.  These typically contain credentials (API keys, tokens)
 # and exposing them through the dashboard file browser is a security leak —
 # see issue #57505.
+_SENSITIVE_MANAGED_DIRNAMES = frozenset({
+    "mcp-tokens",
+    "pairing",
+})
+
+
+def _is_sensitive_managed_path(path: str | Path) -> bool:
+    """Return True for dashboard-managed paths that contain credentials."""
+    candidate = Path(path)
+    if _is_sensitive_filename(candidate.name):
+        return True
+    return any(part.lower() in _SENSITIVE_MANAGED_DIRNAMES for part in candidate.parts)
+
+
 def _is_sensitive_filename(name: str) -> bool:
     """Return True for ``.env`` and any ``.env.<suffix>`` variant.
 
@@ -1635,7 +1649,7 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
         entries = [
             _managed_file_entry(policy, child)
             for child in target.iterdir()
-            if not _is_sensitive_filename(child.name)
+            if not _is_sensitive_managed_path(child)
         ]
     except PermissionError:
         raise HTTPException(status_code=403, detail="Directory is not readable")
@@ -1662,7 +1676,7 @@ async def read_managed_file(request: Request, path: str):
         raise HTTPException(status_code=404, detail="File not found")
     if not target.is_file():
         raise HTTPException(status_code=400, detail="Path is not a file")
-    if _is_sensitive_filename(target.name):
+    if _is_sensitive_managed_path(target):
         raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
 
     try:
@@ -1706,7 +1720,7 @@ async def download_managed_file(request: Request, path: str):
         raise HTTPException(status_code=404, detail="File not found")
     if not target.is_file():
         raise HTTPException(status_code=400, detail="Path is not a file")
-    if _is_sensitive_filename(target.name):
+    if _is_sensitive_managed_path(target):
         raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
 
     try:

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -565,11 +565,11 @@ def test_sensitive_env_case_insensitive_blocked(forced_files_client):
 def test_sensitive_credential_directories_blocked(forced_files_client):
     client, root = forced_files_client
 
-    token_dir = root / "mcp-tokens"
+    token_dir = root / "MCP-Tokens"
     token_dir.mkdir(parents=True, exist_ok=True)
     token = token_dir / "server.json"
     token.write_text('{"access_token":"mcp-secret"}')
-    pairing_dir = root / "pairing"
+    pairing_dir = root / "Pairing"
     pairing_dir.mkdir(parents=True, exist_ok=True)
     pairing = pairing_dir / "device.json"
     pairing.write_text('{"pairing_secret":"pair-secret"}')
@@ -577,8 +577,8 @@ def test_sensitive_credential_directories_blocked(forced_files_client):
     listing = client.get("/api/files", params={"path": str(root)})
     assert listing.status_code == 200
     names = {entry["name"] for entry in listing.json()["entries"]}
-    assert "mcp-tokens" not in names
-    assert "pairing" not in names
+    assert "MCP-Tokens" not in names
+    assert "Pairing" not in names
 
     for p in (token, pairing):
         assert client.get("/api/files/read", params={"path": str(p)}).status_code == 403

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -560,3 +560,26 @@ def test_sensitive_env_case_insensitive_blocked(forced_files_client):
         p.write_text("SECRET=abc123")
         assert client.get("/api/files/read", params={"path": str(p)}).status_code == 403
         assert client.get("/api/files/download", params={"path": str(p)}).status_code == 403
+
+
+def test_sensitive_credential_directories_blocked(forced_files_client):
+    client, root = forced_files_client
+
+    token_dir = root / "mcp-tokens"
+    token_dir.mkdir(parents=True, exist_ok=True)
+    token = token_dir / "server.json"
+    token.write_text('{"access_token":"mcp-secret"}')
+    pairing_dir = root / "pairing"
+    pairing_dir.mkdir(parents=True, exist_ok=True)
+    pairing = pairing_dir / "device.json"
+    pairing.write_text('{"pairing_secret":"pair-secret"}')
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+    names = {entry["name"] for entry in listing.json()["entries"]}
+    assert "mcp-tokens" not in names
+    assert "pairing" not in names
+
+    for p in (token, pairing):
+        assert client.get("/api/files/read", params={"path": str(p)}).status_code == 403
+        assert client.get("/api/files/download", params={"path": str(p)}).status_code == 403


### PR DESCRIPTION
## Summary

The dashboard managed-files API only filtered sensitive files by basename. That blocked `.env` and `.env.*`, but directory-scoped credential stores still remained browsable when the managed files root pointed at `HERMES_HOME` or a hosted `/opt/data` layout.

Affected examples:

- `mcp-tokens/<server>.json`
- `mcp-tokens/<server>.client.json`
- `pairing/*`

Those directories can contain live OAuth/MCP bearer tokens or pairing secrets. If the dashboard file browser is configured with a managed root that includes Hermes state, `/api/files`, `/api/files/read`, and `/api/files/download` could still list/read/download files under those sensitive directories.

## Changes

- Add a path-aware managed-files sensitivity check.
- Keep the existing `.env` basename behavior unchanged.
- Hide sensitive credential directories from `/api/files` listings.
- Block direct `/api/files/read` and `/api/files/download` access to files under those directories.
- Add regression coverage for `mcp-tokens/` and `pairing/`.

## Related

This is complementary to #57833. That PR widens the basename denylist for files like `auth.json`, `config.yaml`, and `.envrc`. This PR covers the directory-scoped credential stores that cannot be represented by basename-only filtering.

## Tests

```text
python -m pytest tests/hermes_cli/test_web_server_files.py -k "sensitive" -q --timeout-method=thread
6 passed, 16 deselected