### PR TITLE
fix(environments): portable per-writer PID for atomic snapshot writes on bash 3.2

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -115,25 +115,36 @@ class TestAtomicSnapshotWrite:
         assert f"> '{snap}'" not in wrapped
         assert f"> {snap}\n" not in wrapped
 
-    def test_temp_path_uses_bashpid_not_dollardollar(self):
-        """The temp name MUST use ``$BASHPID`` (the real subshell PID), not
-        ``$$``.  In ``&``-launched concurrent subshells ``$$`` stays the parent
-        shell's PID, so two writers would pick the same temp name, clobber each
+    def test_temp_path_uses_portable_writer_pid_not_dollardollar(self):
+        """The temp name MUST use the real subshell PID, not ``$$``.  In
+        ``&``-launched concurrent subshells ``$$`` stays the parent shell's
+        PID, so two writers would pick the same temp name, clobber each
         other mid-write, and mv would publish a torn file — the corruption is
         only narrowed, not closed.  This is the bug shared by every prior PR in
-        the #38249 cluster."""
+        the #38249 cluster.
+
+        Crucially the PID token must be PORTABLE: ``$BASHPID`` only exists in
+        bash >= 4.0, and macOS ``/bin/bash`` is 3.2.57 where it expands to the
+        EMPTY string — every writer then shares the literal temp name
+        ``snap.tmp.`` and the tear comes back (worse than ``$$``).  The script
+        must therefore compute ``__hermes_pid`` with a bash-3.2 fallback
+        (``sh -c 'echo $PPID'`` = the calling subshell's PID) and use that."""
         env = _TestableEnv()
         env._snapshot_ready = True
         wrapped = env._wrap_command("echo hi", "/tmp")
-        assert "$BASHPID" in wrapped
+        # Portable per-writer PID variable, with the bash-3.2 fallback chain.
+        assert "__hermes_pid=${BASHPID:-" in wrapped
+        assert "echo $PPID" in wrapped
+        assert ".tmp.'$__hermes_pid" in wrapped or ".tmp.$__hermes_pid" in wrapped
         # The bare $$ temp form must be gone.
         assert ".tmp.$$" not in wrapped
+        # The raw $BASHPID temp form must be gone too (empty on macOS bash 3.2).
+        assert ".tmp.'$BASHPID" not in wrapped and ".tmp.$BASHPID" not in wrapped
 
-
-    def test_init_session_bootstrap_also_atomic_and_bashpid(self):
+    def test_init_session_bootstrap_also_atomic_and_portable_pid(self):
         """The init_session bootstrap (first snapshot write) is the same shared
-        file a concurrent command could source — it must be atomic and use
-        ``$BASHPID`` too."""
+        file a concurrent command could source — it must be atomic and use the
+        portable ``__hermes_pid`` token too."""
         env = _TestableEnv()
         captured = {}
 
@@ -148,8 +159,9 @@ class TestAtomicSnapshotWrite:
             pass
         boot = captured.get("cmd", "")
         assert ".tmp." in boot and "mv -f " in boot, boot
-        assert "$BASHPID" in boot
+        assert "__hermes_pid=${BASHPID:-" in boot
         assert ".tmp.$$" not in boot
+        assert ".tmp.'$BASHPID" not in boot and ".tmp.$BASHPID" not in boot
 
 
     def test_init_session_bootstrap_uses_private_umask(self):
@@ -178,13 +190,34 @@ class TestAtomicSnapshotConcurrencyBehavioral:
     the emitted script's guarantee holds under real concurrency: N concurrent
     writers + readers, and the snapshot is ALWAYS a complete, parseable env
     dump — never truncated mid-line with a ``declare -x`` / ``export`` fragment
-    that would corrupt PATH.  Crucially it uses ``$BASHPID`` (per-subshell
-    unique), which is what closes the race; ``$$`` would still tear here.
+    that would corrupt PATH.  The writer's atomic sequence is EXTRACTED from
+    ``_wrap_command`` output (not hand-copied) so this test exercises exactly
+    what production emits and cannot drift from it.
+
+    Runs under ``/bin/bash`` deliberately: on macOS that is bash 3.2.57, where
+    ``$BASHPID`` does not exist (added in bash 4.0) and expands empty — the
+    exact environment where a non-portable PID token degrades every writer to
+    the SAME temp file and the snapshot genuinely tears (caught 2026-07-03).
     """
 
     def _run(self, script):
         import subprocess
         return subprocess.run(["/bin/bash", "-c", script], capture_output=True, text=True)
+
+    @staticmethod
+    def _atomic_seq_from_wrap_command(snap, cwd):
+        """Extract the snapshot-write sequence (PID-token assignment + atomic
+        export/mv line) verbatim from the script _wrap_command emits."""
+        env = _TestableEnv()
+        env._snapshot_ready = True
+        env._snapshot_path = snap
+        wrapped = env._wrap_command("true", cwd)
+        lines = [
+            ln for ln in wrapped.splitlines()
+            if ".tmp." in ln or ln.startswith("__hermes_pid=")
+        ]
+        assert lines, f"no atomic snapshot-write lines found in:\n{wrapped}"
+        return "\n".join(lines)
 
     def test_concurrent_writes_never_tear_the_snapshot(self, tmp_path):
         import shutil
@@ -194,13 +227,12 @@ class TestAtomicSnapshotConcurrencyBehavioral:
         import shlex
         snap = str(tmp_path / "hermes-snap-x.sh")
         _q = shlex.quote
-        _snap_tmp = _q(snap + ".tmp.") + "$BASHPID"
+        atomic_seq = self._atomic_seq_from_wrap_command(snap, str(tmp_path))
         # One writer iteration = the exact atomic sequence _wrap_command emits.
         writer = (
             "for i in $(seq 1 80); do "
             "export BIG_$i=$(head -c 600 /dev/zero | tr '\\0' x); "
-            f"{{ export -p > {_snap_tmp} && mv -f {_snap_tmp} {_q(snap)}; }} "
-            f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true; "
+            f"{atomic_seq}\n"
             "done"
         )
         # Reader: repeatedly source the snapshot and check PATH never absorbs

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -603,12 +603,28 @@ class BaseEnvironment(ABC):
         # writers would pick the SAME temp name, clobber each other's temp
         # mid-write, and mv would then publish a torn file (the corruption is
         # only narrowed, not closed).  ``$BASHPID`` is the actual subshell PID
-        # and is genuinely unique per writer, which closes the race.  The
-        # static path is shell-quoted (Windows/Git-Bash drive letters, spaces)
-        # with ``$BASHPID`` left outside the quotes so it still expands.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # and is genuinely unique per writer — BUT ``$BASHPID`` only exists in
+        # bash >= 4.0.  macOS ``/bin/bash`` is 3.2.57 (GPLv3 freeze), where
+        # ``$BASHPID`` expands to the EMPTY string and every writer degrades to
+        # the same literal ``snap.tmp.`` — the tear comes back, worse than
+        # ``$$``.  So compute ``__hermes_pid`` with a portable fallback:
+        # ``sh -c 'echo $PPID'`` reports the calling (sub)shell's PID
+        # (``command -p`` so a clobbered PATH can't hide sh), and ``$$`` as a
+        # last resort if even that fails.  The static path is shell-quoted via
+        # ``_quote_shell_path`` (LocalEnvironment rewrites ``C:/...`` to
+        # ``/c/...`` for MSYS) with the PID variable left outside the quotes so
+        # it still expands.
+        _pid_assign = (
+            "__hermes_pid=${BASHPID:-$(command -p sh -c 'echo $PPID' 2>/dev/null)}; "
+            "__hermes_pid=${__hermes_pid:-$$}"
+        )
+        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$__hermes_pid"
         snapshot_excluded = self._snapshot_excluded_passthrough_names()
         bootstrap = (
+            f"{_pid_assign}\n"
+            # umask 077 so the snapshot/cwd files land owner-only — they can
+            # carry env-borne secrets (upstream a1e6ea7d7).  Set after the PID
+            # assignment, before the first file write.
             f"umask 077\n"
             f"{_export_dump_excluding_session_vars(_snap_tmp, snapshot_excluded)}\n"
             # Dump function definitions, filtering out private (``_``-prefixed)
@@ -718,11 +734,19 @@ class BaseEnvironment(ABC):
         # Use atomic file replacement for env snapshot updates (issue #38249).
         # Assemble into a per-writer-unique temp file, then mv to atomically
         # replace the snapshot so concurrent source() calls never read a
-        # truncated/half-written file.  ``$BASHPID`` (not ``$$``) is the actual
-        # subshell PID — unique per concurrent ``&``-launched writer — so two
-        # writers never share a temp name and clobber each other before the mv.
-        # Static path shell-quoted (Windows/spaces); ``$BASHPID`` left to expand.
-        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$BASHPID"
+        # truncated/half-written file.  The PID token must be the actual
+        # subshell PID (``$$`` stays the parent's PID in ``&``-launched
+        # writers) AND portable: ``$BASHPID`` needs bash >= 4.0, and on macOS
+        # ``/bin/bash`` 3.2.57 it expands EMPTY — all writers would share the
+        # literal ``snap.tmp.`` name and tear the snapshot again.  See
+        # init_session for the full rationale of the fallback chain.
+        # Static path shell-quoted via ``_quote_shell_path`` (Windows/spaces);
+        # PID var left to expand.
+        _pid_assign = (
+            "__hermes_pid=${BASHPID:-$(command -p sh -c 'echo $PPID' 2>/dev/null)}; "
+            "__hermes_pid=${__hermes_pid:-$$}"
+        )
+        _snap_tmp = self._quote_shell_path(self._snapshot_path + ".tmp.") + "$__hermes_pid"
 
         parts = []
         passthrough_names = self._snapshot_excluded_passthrough_names()
@@ -782,6 +806,7 @@ class BaseEnvironment(ABC):
         # expands the ``mv`` operand), silently orphaning the dump. See
         # _export_dump_excluding_session_vars.
         if self._snapshot_ready:
+            parts.append(_pid_assign)
             parts.append(
                 f"{{ {_export_dump_excluding_session_vars(_snap_tmp, passthrough_names)} "
                 f"&& mv -f {_snap_tmp} {_quoted_snap}; }} "


### PR DESCRIPTION
## Summary

`$BASHPID` only exists in bash >= 4.0. macOS ships `/bin/bash` 3.2.57, where it expands to the empty string, so the #38249 atomic snapshot pattern (`export -p > snap.tmp.$BASHPID && mv -f`) degrades to a single shared temp file `snap.tmp.` for every concurrent writer. Concurrent `export -p` dumps interleave and `mv -f` publishes a torn snapshot; a concurrent `source` then absorbs `declare -x` fragments into `PATH`. `_find_bash()` resolves bash via `shutil.which("bash")`, so any Mac without Homebrew/MacPorts bash is affected in production. Full analysis, reproduction, and control experiments in the companion issue.

Fixes #57866

## Fix

Compute a portable writer-unique token once per emitted script and use it at both write sites (`init_session` bootstrap and `_wrap_command` re-dump):

```bash
__hermes_pid=${BASHPID:-$(command -p sh -c 'echo $PPID' 2>/dev/null)}; __hermes_pid=${__hermes_pid:-$$}
```

- bash >= 4: identical to `$BASHPID`, no extra fork.
- bash 3.2: `sh -c 'echo $PPID'` yields the calling subshell's real PID (`command -p` so a clobbered PATH cannot hide `sh`).
- `$$` as a last resort (the old narrowed-race behavior, never the always-colliding empty suffix).

`$RANDOM` was rejected: before bash 5.1, subshells inherit the RNG state, so concurrent `&`-launched writers draw identical values.

## Tests

- `test_concurrent_writes_never_tear_the_snapshot` now extracts the writer's atomic sequence verbatim from `_wrap_command` output instead of hand-copying it, so the behavioral test can never drift from what production emits. It runs under hardcoded `/bin/bash`, which on macOS is exactly the bash 3.2.57 environment that tears.
- String-inspection tests updated to assert the portable `__hermes_pid` token and reject both `.tmp.$$` and raw `.tmp.$BASHPID`.

## Verification

- Before: behavioral test failed 10/10 on a loaded Apple Silicon Mac (torn `PATH` detected).
- After: 10/10 pass quiet and 10/10 pass under 8-way CPU load; full `tests/tools/test_base_environment.py` 26/26.
- Control experiment: unique temp suffixes under the same shell/load produced 0 corruptions in 8 trials; the shared-name form corrupted 6 of 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
