### PR TITLE
fix(dashboard): guard fs preview credential reads

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1202,6 +1202,65 @@ def _is_sensitive_filename(name: str) -> bool:
     """
     lowered = name.lower()
     return lowered == ".env" or lowered.startswith(".env.")
+
+
+_FS_SENSITIVE_DIRNAMES = frozenset({"mcp-tokens", "pairing"})
+
+
+def _fs_hermes_credential_dirs() -> tuple[Path, ...]:
+    dirs: list[Path] = []
+    try:
+        from hermes_constants import get_default_hermes_root, get_hermes_home
+
+        for base in (get_hermes_home(), get_default_hermes_root()):
+            try:
+                resolved = Path(base).expanduser().resolve()
+            except Exception:
+                continue
+            for name in _FS_SENSITIVE_DIRNAMES:
+                credential_dir = resolved / name
+                if credential_dir not in dirs:
+                    dirs.append(credential_dir)
+    except Exception:
+        return ()
+    return tuple(dirs)
+
+
+def _fs_is_under_hermes_credential_dir(path: Path) -> bool:
+    try:
+        resolved = path.expanduser().resolve(strict=False)
+    except Exception:
+        return False
+    for credential_dir in _fs_hermes_credential_dirs():
+        try:
+            resolved.relative_to(credential_dir)
+        except ValueError:
+            continue
+        return True
+    return False
+
+
+def _fs_sensitive_read_error(path: Path) -> str | None:
+    """Return a credential-read error for dashboard fs preview paths."""
+    try:
+        from agent.file_safety import get_read_block_error
+
+        return get_read_block_error(str(path))
+    except Exception:
+        return None
+
+
+def _fs_path_is_sensitive(path: Path) -> bool:
+    if _fs_is_under_hermes_credential_dir(path):
+        return True
+    return _fs_sensitive_read_error(path) is not None
+
+
+def _fs_raise_if_sensitive(path: Path) -> None:
+    if _fs_path_is_sensitive(path):
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
+
+
 _FS_DATA_URL_MAX_BYTES = 16 * 1024 * 1024
 _FS_TEXT_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 _FS_TEXT_PREVIEW_MAX_BYTES = 512 * 1024
@@ -1878,11 +1937,12 @@ async def fs_list(path: str):
         entries = []
         with os.scandir(target) as scan:
             for entry in scan:
-                if entry.name in _FS_READDIR_HIDDEN:
+                child = target / entry.name
+                if entry.name in _FS_READDIR_HIDDEN or _fs_path_is_sensitive(child):
                     continue
                 entries.append({
                     "name": entry.name,
-                    "path": str(target / entry.name),
+                    "path": str(child),
                     "isDirectory": entry.is_dir(follow_symlinks=False),
                 })
         entries.sort(key=lambda item: (not item["isDirectory"], item["name"].lower(), item["name"]))
@@ -1900,6 +1960,7 @@ async def fs_list(path: str):
 @app.get("/api/fs/read-text")
 async def fs_read_text(path: str):
     target, st = _fs_regular_file(_fs_path(path))
+    _fs_raise_if_sensitive(target)
     if st.st_size > _FS_TEXT_SOURCE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     bytes_to_read = min(st.st_size, _FS_TEXT_PREVIEW_MAX_BYTES)
@@ -1976,6 +2037,7 @@ async def fs_write_text(payload: FsWriteText):
 @app.get("/api/fs/read-data-url")
 async def fs_read_data_url(path: str):
     target, st = _fs_regular_file(_fs_path(path))
+    _fs_raise_if_sensitive(target)
     if st.st_size > _FS_DATA_URL_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     try:

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -45,6 +45,27 @@ def test_fs_list_sorts_and_hides_noise(client, tmp_path):
     assert all(entry["name"] not in {".git", "node_modules"} for entry in entries)
 
 
+def test_fs_list_hides_hermes_credential_dirs(client, tmp_path, monkeypatch):
+    import agent.file_safety as file_safety
+    import hermes_constants
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "mcp-tokens").mkdir()
+    (hermes_home / "pairing").mkdir()
+    (hermes_home / "notes").mkdir()
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root", lambda: hermes_home)
+
+    response = client.get("/api/fs/list", params={"path": str(hermes_home)})
+
+    assert response.status_code == 200
+    names = {entry["name"] for entry in response.json()["entries"]}
+    assert names == {"notes"}
+
+
 def test_fs_list_accepts_relative_paths(client, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "rel").mkdir()
@@ -107,6 +128,22 @@ def test_fs_read_text_flags_binary(client, tmp_path):
     assert body["text"].startswith("hello")
 
 
+def test_fs_read_text_blocks_credential_files(client, tmp_path, monkeypatch):
+    import agent.file_safety as file_safety
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    target = hermes_home / ".env"
+    target.write_text("OPENAI_API_KEY=sk-secret")
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+
+    response = client.get("/api/fs/read-text", params={"path": str(target)})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Access to sensitive files is not allowed"
+
+
 def test_fs_read_data_url_returns_capped_data_url(client, tmp_path, monkeypatch):
     monkeypatch.setattr(web_server, "_FS_DATA_URL_MAX_BYTES", 16)
     target = tmp_path / "image.png"
@@ -116,6 +153,31 @@ def test_fs_read_data_url_returns_capped_data_url(client, tmp_path, monkeypatch)
 
     assert response.status_code == 200
     assert response.json() == {"dataUrl": "data:image/png;base64," + base64.b64encode(b"pngbytes").decode("ascii")}
+
+
+def test_fs_read_data_url_blocks_credential_dirs(client, tmp_path, monkeypatch):
+    import agent.file_safety as file_safety
+    import hermes_constants
+
+    hermes_home = tmp_path / "hermes-home"
+    token_dir = hermes_home / "mcp-tokens"
+    pairing_dir = hermes_home / "pairing"
+    token_dir.mkdir(parents=True)
+    pairing_dir.mkdir()
+    token_file = token_dir / "server.json"
+    pairing_file = pairing_dir / "device.json"
+    token_file.write_text('{"access_token":"secret"}')
+    pairing_file.write_text('{"pairing_secret":"secret"}')
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root", lambda: hermes_home)
+
+    token_response = client.get("/api/fs/read-data-url", params={"path": str(token_file)})
+    pairing_response = client.get("/api/fs/read-data-url", params={"path": str(pairing_file)})
+
+    assert token_response.status_code == 403
+    assert pairing_response.status_code == 403
 
 
 def test_fs_read_data_url_rejects_over_cap(client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The dashboard/desktop filesystem preview API (`/api/fs/*`) could read sensitive Hermes credential files through a separate preview surface from the managed file browser.

`/api/fs/read-text` and `/api/fs/read-data-url` resolved arbitrary authenticated paths through `_fs_regular_file()` and then read the file bytes directly. That meant sensitive files such as `~/.hermes/.env`, `auth.json`, `mcp-tokens/*`, or `pairing/*` could be returned as text or base64 data URLs through the preview API.

## Changes

- Add a path-aware sensitive-read check for `/api/fs/*`.
- Block `/api/fs/read-text` before reading credential files.
- Block `/api/fs/read-data-url` before base64-encoding credential files.
- Hide Hermes credential directories from `/api/fs/list`.
- Reuse the shared `agent.file_safety.get_read_block_error()` policy for file reads.
- Add regression tests for `.env`, `mcp-tokens/`, and `pairing/`.

## Related

Part of the dashboard credential-guard cluster called out in #58222, but this PR covers a distinct route family.

- #58222 salvages/hardens the managed-files read/list/download surface (`/api/files/*`).
- This PR hardens the filesystem preview surface (`/api/fs/read-text`, `/api/fs/read-data-url`, and `/api/fs/list`) used by the dashboard/desktop coding rail.

Those surfaces are complementary rather than duplicates: `/api/files/*` and `/api/fs/*` have separate handlers, tests, and call sites.

## Tests

```text
python -m pytest tests/hermes_cli/test_web_server_fs.py -q --timeout-method=thread
16 passed
```
