### PR TITLE
Fix Desktop remote artifact previews

### DIFF
--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -23,8 +23,10 @@ import { getSessionMessages, listAllProfileSessions } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { ExternalLink, ExternalLinkIcon, hostPathLabel, urlSlugTitleLabel, useLinkTitle } from '@/lib/external-link'
 import { FileImage, FileText, FolderOpen, Link2 } from '@/lib/icons'
+import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
+import { setSessionPreviewTarget } from '@/store/preview'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -90,7 +92,7 @@ function paginationItems(page: number, pageCount: number): Array<number | 'ellip
 }
 
 type CellCtx = {
-  onOpen: (href: string) => void | Promise<void>
+  onOpen: (artifact: ArtifactRecord) => void | Promise<void>
   onOpenChat: (sessionId: string) => void
 }
 
@@ -221,18 +223,29 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   }, [artifacts])
 
   const openArtifact = useCallback(
-    async (href: string) => {
+    async (artifact: ArtifactRecord) => {
       try {
+        if (artifact.kind === 'file') {
+          const preview = await normalizeOrLocalPreviewTarget(artifact.value)
+
+          if (preview) {
+            setSessionPreviewTarget(artifact.sessionId, preview, 'file-browser', artifact.value)
+            navigate(sessionRoute(artifact.sessionId))
+
+            return
+          }
+        }
+
         if (window.hermesDesktop?.openExternal) {
-          await window.hermesDesktop.openExternal(href)
+          await window.hermesDesktop.openExternal(artifact.href)
         } else {
-          window.open(href, '_blank', 'noopener,noreferrer')
+          window.open(artifact.href, '_blank', 'noopener,noreferrer')
         }
       } catch (err) {
         notifyError(err, a.openFailed)
       }
     },
-    [a]
+    [a, navigate]
   )
 
   const markImageFailed = useCallback((id: string) => {
@@ -544,7 +557,7 @@ function PrimaryCell({ artifact, ctx }: { artifact: ArtifactRecord; ctx: CellCtx
   return (
     <ArtifactCellAction
       href={isLink ? artifact.href : undefined}
-      onClick={isLink ? undefined : () => void ctx.onOpen(artifact.href)}
+      onClick={isLink ? undefined : () => void ctx.onOpen(artifact)}
       title={label}
     >
       <span className="mt-0.5 grid size-6 shrink-0 place-items-center self-start rounded-md bg-(--ui-bg-tertiary) text-(--ui-text-tertiary)">

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.test.tsx
@@ -139,6 +139,6 @@ describe('usePreviewRouting', () => {
     act(() => handleEvent({ payload: { path: './dist/index.html' }, session_id: 'session-1', type: 'tool.complete' }))
 
     expect($previewTarget.get()).toBeNull()
-    expect(window.localStorage.getItem('hermes.desktop.sessionPreviews.v1')).toBeNull()
+    expect(JSON.parse(window.localStorage.getItem('hermes.desktop.sessionPreviews.v1') || '{}')).toEqual({})
   })
 })

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -92,6 +92,20 @@ describe('desktop filesystem facade', () => {
     expect(api).not.toHaveBeenCalled()
   })
 
+  it('falls back to active gateway filesystem when local IPC cannot see a backend path', async () => {
+    $connection.set({ mode: 'local' } as never)
+    readFileText.mockRejectedValueOnce(new Error('Text preview failed: file does not exist.'))
+    readFileDataUrl.mockRejectedValueOnce(new Error('File preview failed: ENOENT'))
+
+    await expect(readDesktopFileText('/home/chris/artifact.md')).resolves.toMatchObject({ text: 'remote' })
+    await expect(readDesktopFileDataUrl('/home/chris/artifact.png')).resolves.toBe('data:text/plain;base64,cmVtb3Rl')
+
+    expect(readFileText).toHaveBeenCalledWith('/home/chris/artifact.md')
+    expect(readFileDataUrl).toHaveBeenCalledWith('/home/chris/artifact.png')
+    expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-text?path=%2Fhome%2Fchris%2Fartifact.md' })
+    expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-data-url?path=%2Fhome%2Fchris%2Fartifact.png' })
+  })
+
   it('routes filesystem reads through authenticated backend REST in remote mode', async () => {
     $connection.set({ mode: 'remote' } as never)
 

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -58,6 +58,12 @@ function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T
   )
 }
 
+function shouldTryGatewayFsFallback(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /file does not exist|ENOENT|no such file/i.test(message)
+}
+
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {
   if (!isDesktopFsRemoteMode()) {
     return bridge().readDir(path)
@@ -68,7 +74,15 @@ export async function readDesktopDir(path: string): Promise<HermesReadDirResult>
 
 export async function readDesktopFileText(path: string): Promise<HermesReadFileTextResult> {
   if (!isDesktopFsRemoteMode()) {
-    return bridge().readFileText(path)
+    try {
+      return await bridge().readFileText(path)
+    } catch (error) {
+      if (!shouldTryGatewayFsFallback(error)) {
+        throw error
+      }
+
+      return remoteFsApi<HermesReadFileTextResult>(fsPath('read-text', path))
+    }
   }
 
   return remoteFsApi<HermesReadFileTextResult>(fsPath('read-text', path))
@@ -96,7 +110,17 @@ export async function writeDesktopFileText(path: string, content: string): Promi
 
 export async function readDesktopFileDataUrl(path: string): Promise<string> {
   if (!isDesktopFsRemoteMode()) {
-    return bridge().readFileDataUrl(path)
+    try {
+      return await bridge().readFileDataUrl(path)
+    } catch (error) {
+      if (!shouldTryGatewayFsFallback(error)) {
+        throw error
+      }
+
+      const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path))
+
+      return typeof result === 'string' ? result : result.dataUrl || ''
+    }
   }
 
   const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path))


### PR DESCRIPTION
## Summary

Fix remote-backend Desktop file artifacts so clicking a file in the Artifacts view opens an in-app preview instead of routing through a local `file://` path on the desktop client.

## Root Cause

When Hermes Desktop is connected to a remote backend, artifact values such as `/home/chris/.../desktop-artifact.md` refer to files on the backend host. The Artifacts view treated file artifacts as external hrefs, so the desktop shell could try to resolve the backend path through the local Electron/macOS filesystem path.

In some preview paths the renderer can also reach the local Electron IPC read branch even though the file lives behind the active gateway. That produces `file does not exist`/`ENOENT` failures for valid backend paths.

## Changes

- Open file artifacts by creating a normalized preview target and selecting the source session, allowing the existing preview rail to render the file.
- Keep external-link behavior unchanged for link artifacts.
- Add a conservative filesystem fallback: if local IPC cannot find a file, retry through the authenticated gateway `/api/fs/read-text` or `/api/fs/read-data-url` API.
- Add regression coverage for the gateway filesystem fallback.
- Update a preview-routing test assertion to allow the persisted preview registry to exist as an empty object.

## Validation

- `npx eslint src/app/artifacts/index.tsx src/lib/desktop-fs.ts src/lib/desktop-fs.test.ts src/app/session/hooks/use-preview-routing.test.tsx`
- `npm run typecheck`
- `npm run test:ui -- src/lib/desktop-fs.test.ts src/app/artifacts/index.test.ts src/lib/media.remote.test.ts src/app/session/hooks/use-preview-routing.test.tsx`
- `npm run build`

Manual verification:

- macOS Hermes Desktop connected to a remote GX10 Hermes backend via OAuth.
- The remote backend created `/home/chris/hermes-desktop-smoke/desktop-artifact.md`.
- The Artifacts view listed `desktop-artifact.md`.
- Clicking the artifact opened the source session and rendered the markdown preview from the backend filesystem in Hermes Desktop.

Related issue: #44523
