### PR TITLE
fix(signal): remove ?account= query param from SSE events URL

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -26,7 +26,7 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 import httpx
 
@@ -419,7 +419,10 @@ class SignalAdapter(BasePlatformAdapter):
 
     async def _sse_listener(self) -> None:
         """Listen for SSE events from signal-cli daemon."""
-        url = f"{self.http_url}/api/v1/events"
+        _account_param = quote(self.account, safe='')
+        if self._recipient_uuid_by_number and self._account_normalized in self._recipient_uuid_by_number:
+            _account_param = self._recipient_uuid_by_number[self._account_normalized]
+        url = f"{self.http_url}/api/v1/events?account={_account_param}"
         backoff = SSE_RETRY_DELAY_INITIAL
 
         while self._running:

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -26,7 +26,7 @@ from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import quote, unquote
+from urllib.parse import unquote
 
 import httpx
 
@@ -419,7 +419,7 @@ class SignalAdapter(BasePlatformAdapter):
 
     async def _sse_listener(self) -> None:
         """Listen for SSE events from signal-cli daemon."""
-        url = f"{self.http_url}/api/v1/events?account={quote(self.account, safe='')}"
+        url = f"{self.http_url}/api/v1/events"
         backoff = SSE_RETRY_DELAY_INITIAL
 
         while self._running:


### PR DESCRIPTION
### Description

Removes the `?account=` query parameter from the SSE events URL in `gateway/platforms/signal.py`. 

### Problem

The `?account=` parameter causes **HTTP 400 Bad Request** when `signal-cli` runs in **multi-account mode** (without `-u` flag). In Docker environments, single-account mode often fails with `User is not registered` because Signal uses self-signed certificates that Java cannot verify. Multi-account mode works perfectly but rejects the `?account=` query param on the SSE endpoint.

The gateway then enters a reconnect loop and never processes events.

### Fix

- Removed `?account={quote(self.account, safe="")}` from the SSE URL (line 422)
- Cleaned up unused `quote` import from the `urllib.parse` import
- The account filtering already happens downstream in `_handle_envelope()` (line 572) — no information is lost

### Related Issues

Fixes #57862

### Checklist

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My code follows the project style
- [x] I have tested that the fix works with signal-cli in multi-account mode