### PR TITLE
fix(line): route audio/video/file payloads to cache_audio_from_bytes

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -92,6 +92,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_audio_from_bytes,
     cache_image_from_bytes,
 )
 from gateway.config import Platform
@@ -1067,6 +1068,11 @@ class LineAdapter(BasePlatformAdapter):
             "file": ".bin",
         }.get(msg_type, ".bin")
         try:
+            # Audio/video/file payloads must not go through the image cache —
+            # cache_image_from_bytes validates magic bytes and refuses
+            # non-image data (e.g. LINE voice notes arrive as .m4a).
+            if msg_type in ("audio", "video", "file"):
+                return cache_audio_from_bytes(data, ext=ext)
             return cache_image_from_bytes(data, ext=ext)
         except Exception as exc:
             logger.warning("LINE: failed to cache %s payload: %s", msg_type, exc)


### PR DESCRIPTION
Fixes #57882.

`cache_image_from_bytes` validates image magic bytes and refuses non-image data, so inbound LINE voice notes (`.m4a`), videos and file attachments failed to cache and were dropped before the agent ever saw them (`LINE: failed to cache audio payload: ... Refusing to cache non-image data`).

Route `audio` / `video` / `file` message types through `cache_audio_from_bytes`, matching what every other media-capable platform adapter (discord, telegram, slack, matrix, mattermost, feishu, google_chat, photon) already does. Images keep going through the image cache, unchanged.

**Tested:** running in production on a live LINE bot — voice notes now cache correctly and flow into the STT pipeline (faster-whisper), the agent replies to the transcribed content; image messages unaffected.
