### PR TITLE
fix(tests): skip/adapt 6 environment-dependent tests on native Windows

### DIFF
--- a/tests/hermes_cli/test_web_server_oauth_write.py
+++ b/tests/hermes_cli/test_web_server_oauth_write.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -32,8 +33,15 @@ def test_dashboard_oauth_write_uses_owner_only_permissions(oauth_file):
         os.umask(old_umask)
 
     assert oauth_file.exists()
-    mode = oauth_file.stat().st_mode & 0o777
-    assert mode == 0o600
+    if os.name == 'posix':
+        mode = oauth_file.stat().st_mode & 0o777
+        assert mode == 0o600
+    else:
+        # Windows os.chmod only toggles the read-only bit, so owner-only
+        # POSIX modes are not representable; verify the write itself landed.
+        payload = json.loads(oauth_file.read_text(encoding='utf-8'))
+        assert payload['accessToken'] == 'access-token'
+        assert payload['refreshToken'] == 'refresh-token'
 
 
 def test_dashboard_oauth_write_uses_atomic_replace_and_cleans_temp_files(oauth_file, monkeypatch):

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -34,6 +34,31 @@ from utils import (
 )
 
 
+@pytest.fixture
+def symlink_privilege(tmp_path: Path) -> None:
+    """Skip when the environment cannot create symlinks.
+
+    On Windows, ``os.symlink`` requires Developer Mode or elevation
+    (``SeCreateSymbolicLinkPrivilege``); without either it raises
+    ``OSError`` WinError 1314 — the default for unelevated contributor
+    runs.  Probe with a throwaway link and skip only on that error, so
+    the symlink coverage still runs where privileges exist (POSIX, or
+    Windows with Developer Mode on) and any other ``OSError`` still
+    fails loudly.
+    """
+    probe_target = tmp_path / ".symlink-probe-target"
+    probe_target.write_text("probe", encoding="utf-8")
+    probe_link = tmp_path / ".symlink-probe-link"
+    try:
+        probe_link.symlink_to(probe_target)
+    except OSError as exc:
+        if getattr(exc, "winerror", None) == 1314:
+            pytest.skip("symlink privilege not held")
+        raise
+    probe_link.unlink()
+    probe_target.unlink()
+
+
 # ─── Direct helper ────────────────────────────────────────────────────────────
 
 
@@ -43,7 +68,7 @@ def _write_tmp(dir_: Path, content: str) -> Path:
     return tmp
 
 
-def test_atomic_replace_preserves_symlink(tmp_path: Path) -> None:
+def test_atomic_replace_preserves_symlink(tmp_path: Path, symlink_privilege: None) -> None:
     real = tmp_path / "real.yaml"
     link = tmp_path / "link.yaml"
     real.write_text("original\n", encoding="utf-8")
@@ -100,7 +125,7 @@ def test_atomic_replace_accepts_pathlike_and_str(tmp_path: Path) -> None:
 # ─── atomic_json_write / atomic_yaml_write wiring ──────────────────────────
 
 
-def test_atomic_json_write_preserves_symlink(tmp_path: Path) -> None:
+def test_atomic_json_write_preserves_symlink(tmp_path: Path, symlink_privilege: None) -> None:
     real = tmp_path / "real.json"
     link = tmp_path / "link.json"
     real.write_text("{}", encoding="utf-8")
@@ -113,7 +138,7 @@ def test_atomic_json_write_preserves_symlink(tmp_path: Path) -> None:
     assert loaded == {"hello": "world"}
 
 
-def test_atomic_yaml_write_preserves_symlink(tmp_path: Path) -> None:
+def test_atomic_yaml_write_preserves_symlink(tmp_path: Path, symlink_privilege: None) -> None:
     real = tmp_path / "real.yaml"
     link = tmp_path / "link.yaml"
     real.write_text("placeholder: true\n", encoding="utf-8")
@@ -220,7 +245,9 @@ def test_atomic_roundtrip_yaml_update_restores_owner(
 # ─── Broken-symlink edge case ─────────────────────────────────────────────
 
 
-def test_atomic_replace_broken_symlink_creates_target(tmp_path: Path) -> None:
+def test_atomic_replace_broken_symlink_creates_target(
+    tmp_path: Path, symlink_privilege: None
+) -> None:
     """A symlink pointing at a missing file: the write should create the
     real target (resolving via realpath) rather than leaving the dangling
     link in place as a regular file.
@@ -261,7 +288,7 @@ def test_atomic_replace_copy_fallback(
 
 
 def test_atomic_replace_copy_fallback_preserves_symlink(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, symlink_privilege: None
 ) -> None:
     real = tmp_path / "real.yaml"
     link = tmp_path / "link.yaml"


### PR DESCRIPTION
## What does this PR do?

Makes the native-Windows test run clean for two classes of tests that fail for **environmental** reasons (not product bugs), in the default contributor setup (Developer Mode off, unelevated shell):

1. **`tests/test_atomic_replace_symlinks.py`** — 5 tests create real symlinks via `Path.symlink_to()`, which on Windows requires Developer Mode or `SeCreateSymbolicLinkPrivilege`. Without either, `os.symlink` raises `OSError` WinError 1314 and the tests fail in setup. This PR adds a `symlink_privilege` fixture that attempts a probe symlink in `tmp_path` and `pytest.skip("symlink privilege not held")` **only** when the probe raises WinError 1314 — any other `OSError` still propagates as a real failure. This is deliberately **not** an unconditional Windows skip: symlinks work fine with Developer Mode on, and the symlink-preservation coverage is valuable there. (Same spirit as the existing `_can_symlink()` skipif idiom in `tests/tools/test_skills_guard.py` and `tests/tools/test_symlink_prefix_confusion.py`, but scoped per-test via a fixture and narrowed to the privilege error.)

2. **`tests/hermes_cli/test_web_server_oauth_write.py::test_dashboard_oauth_write_uses_owner_only_permissions`** — asserted `stat().st_mode & 0o777 == 0o600` after the helper's `chmod`. On Windows `os.chmod` only toggles the read-only bit, so the mode reads `0o666` (438) and the assert fails even though the write behaved correctly. The `0o600` assertion now runs only on POSIX; on Windows the test still verifies something meaningful — the file exists and round-trips the exact JSON payload (`accessToken`/`refreshToken`).

## Related Issue

Fixes #57883

Continues the native-Windows test-infra series: #57181 (fixes #57145), #57182 (fixes #57147), batch #57016.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/test_atomic_replace_symlinks.py`: new `symlink_privilege` fixture (probe symlink in `tmp_path`, skip on WinError 1314 only); applied to the 5 symlink-dependent tests: `test_atomic_replace_preserves_symlink`, `test_atomic_json_write_preserves_symlink`, `test_atomic_yaml_write_preserves_symlink`, `test_atomic_replace_broken_symlink_creates_target`, `test_atomic_replace_copy_fallback_preserves_symlink`
- `tests/hermes_cli/test_web_server_oauth_write.py`: gate the `0o600` mode assert to `os.name == 'posix'`; on Windows assert the file exists and the JSON payload round-trips

## How to Test

1. On Windows 11 (Developer Mode **off**, unelevated), before this change: `python -m pytest tests/test_atomic_replace_symlinks.py tests/hermes_cli/test_web_server_oauth_write.py -q` → **6 failed** (5× `OSError: [WinError 1314]`, 1× `assert 438 == 384`)
2. After this change, same command → **8 passed, 11 skipped** (5 skips are `symlink privilege not held`; the rest are the pre-existing POSIX-only skips)
3. On POSIX (or Windows with Developer Mode on), the probe succeeds and all 5 symlink tests run exactly as before — no coverage lost

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (both affected files green natively; see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (native, Python 3.11, Developer Mode off, unelevated)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (fixture docstring documents the rationale)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — that is the point of this PR; POSIX behavior is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (main @ 528159f7a, native Windows):

```
FAILED tests/test_atomic_replace_symlinks.py::test_atomic_replace_preserves_symlink
FAILED tests/test_atomic_replace_symlinks.py::test_atomic_json_write_preserves_symlink
FAILED tests/test_atomic_replace_symlinks.py::test_atomic_yaml_write_preserves_symlink
FAILED tests/test_atomic_replace_symlinks.py::test_atomic_replace_broken_symlink_creates_target
FAILED tests/test_atomic_replace_symlinks.py::test_atomic_replace_copy_fallback_preserves_symlink
FAILED tests/hermes_cli/test_web_server_oauth_write.py::test_dashboard_oauth_write_uses_owner_only_permissions
6 failed, 7 passed, 6 skipped in 5.31s
```

After:

```
SKIPPED [5] tests/test_atomic_replace_symlinks.py: symlink privilege not held
8 passed, 11 skipped in 1.82s
```

Note: #57777 (`fix/atomic-replace-sharing-violation`) also touches `tests/test_atomic_replace_symlinks.py`; this PR is built on current `origin/main` and I'll rebase whichever lands second.