### PR TITLE
fix(error_classifier): detect aggregator-wrapped upstream 403

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1038,22 +1038,29 @@ def recover_with_credential_pool(
         elif status_code in {401, 403}:
             effective_reason = FailoverReason.auth
 
-    if effective_reason == FailoverReason.upstream_rate_limit:
-        # An upstream provider (e.g. DeepSeek behind OpenRouter) is
-        # rate-limiting the aggregator's traffic — the user's credential is
-        # healthy. Do NOT rotate or mark exhausted; let the caller's fallback
-        # path switch to a different model entirely.
+    if effective_reason in {
+        FailoverReason.upstream_rate_limit,
+        FailoverReason.upstream_provider_error,
+    }:
+        # Upstream provider throttling (429) or provider error (403)
+        # happened behind the aggregator — the user's credential is healthy.
+        # Do NOT rotate or mark exhausted; let the caller's fallback path
+        # switch to a different model entirely.
         upstream = (error_context or {}).get("upstream_provider") if error_context else None
         if upstream:
             _ra().logger.info(
-                "Upstream provider %s rate-limited via aggregator — skipping "
+                "Upstream provider %s %s via aggregator — skipping "
                 "credential rotation, deferring to fallback chain",
                 upstream,
+                "rate-limited" if effective_reason == FailoverReason.upstream_rate_limit
+                else "error",
             )
         else:
             _ra().logger.info(
-                "Upstream aggregator 429 (provider unknown) — skipping "
-                "credential rotation, deferring to fallback chain"
+                "Upstream aggregator %s (provider unknown) — skipping "
+                "credential rotation, deferring to fallback chain",
+                "429" if effective_reason == FailoverReason.upstream_rate_limit
+                else "403",
             )
         return False, has_retried_429
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1704,7 +1704,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     auth resolution and client construction — no duplicated provider→key
     mappings.
     """
-    if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}:
+    if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit, FailoverReason.upstream_provider_error}:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
         # source of the 429 so the cooldown should not be reset/extended.
@@ -1735,7 +1735,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # provider again.  Guards the cross-turn replay storm in #24996.
         if (
             len(agent._fallback_chain) > 0
-            and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
+            and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit, FailoverReason.upstream_provider_error}
         ):
             _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0
             agent._rate_limited_until = max(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4427,6 +4427,7 @@ def run_conversation(
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                     FailoverReason.upstream_rate_limit,
+                    FailoverReason.upstream_provider_error,
                 }
                 _is_transport_failure = classified.reason in {
                     FailoverReason.timeout,
@@ -4457,7 +4458,10 @@ def run_conversation(
                     # pool can't help when the *upstream* model (DeepSeek,
                     # etc.) is throttling OpenRouter, so always fall back to a
                     # different model regardless of pool state.
-                    _is_upstream = classified.reason == FailoverReason.upstream_rate_limit
+                    _is_upstream = classified.reason in {
+                        FailoverReason.upstream_rate_limit,
+                        FailoverReason.upstream_provider_error,
+                    }
                     pool_may_recover = (
                         False if _is_upstream
                         else _ra()._pool_may_recover_from_rate_limit(

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -67,6 +67,7 @@ class FailoverReason(enum.Enum):
     long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate
     oauth_long_context_beta_forbidden = "oauth_long_context_beta_forbidden"  # Anthropic OAuth subscription rejects 1M context beta — disable beta and retry
     llama_cpp_grammar_pattern = "llama_cpp_grammar_pattern"  # llama.cpp json-schema-to-grammar rejects regex escapes in `pattern` / `format` — strip from tools and retry
+    upstream_provider_error = "upstream_provider_error"  # Aggregator (OpenRouter, Groq, etc.) wrapped upstream provider 403/429 — fallback to different model, DON'T rotate credential
 
     # Catch-all
     unknown = "unknown"                  # Unclassifiable — retry with backoff
@@ -1034,6 +1035,26 @@ def _classify_by_status(
     if status_code == 403:
         # OpenRouter 403 "key limit exceeded" is actually billing. Other
         # providers also use 403 for account-plan or credit exhaustion.
+        # Check for overload first (same as 429 path) — some providers
+        # reuse 403 for server-wide overload.
+        if any(p in error_msg for p in _OVERLOADED_PATTERNS):
+            return result_fn(
+                FailoverReason.overloaded,
+                retryable=True,
+            )
+        #
+        # NEW: Check for upstream provider errors first (Sakana, Poolside, etc.)
+        if _is_openrouter_upstream_error(body, provider):
+            upstream_provider = _extract_upstream_provider_name(body)
+            ctx = {"upstream_provider": upstream_provider} if upstream_provider else {}
+            return result_fn(
+                FailoverReason.upstream_provider_error,
+                retryable=False,
+                should_rotate_credential=False,
+                should_fallback=True,
+                error_context=ctx,
+            )
+
         if (
             (
                 provider == "xai-oauth"
@@ -1796,13 +1817,15 @@ def _extract_message(error: Exception, body: dict) -> str:
 
 
 def _is_openrouter_upstream_error(body: Any, provider: str) -> bool:
-    """Detect OpenRouter's aggregator-wrapped upstream provider errors.
+    """Detect aggregator-wrapped upstream provider errors (OpenRouter, Groq, etc.).
 
     OpenRouter returns errors from upstream model providers (DeepSeek,
     Anthropic, etc.) wrapped with the outer message "Provider returned error"
     and the real error nested in ``metadata.raw``. This signal means the
-    user's OpenRouter key is healthy — the upstream provider is the one that
+    user's key is healthy — the upstream provider is the one that
     failed — so credential rotation is the wrong recovery.
+
+    Same pattern applies to other aggregators (Groq, Together, Fireworks).
     """
     if not isinstance(body, dict):
         return False
@@ -1813,9 +1836,9 @@ def _is_openrouter_upstream_error(body: Any, provider: str) -> bool:
     outer_msg = str(err.get("message") or "").strip().lower()
     if outer_msg != "provider returned error":
         return False
-    # Require either the explicit OpenRouter provider OR the metadata shape
-    # that only OpenRouter produces (metadata.raw / metadata.provider_name).
-    if provider_lower == "openrouter":
+    # Require either the explicit aggregator provider OR the metadata shape
+    # that only an aggregator produces.
+    if provider_lower in ("openrouter", "groq", "together", "fireworks"):
         return True
     metadata = err.get("metadata")
     if isinstance(metadata, dict) and (
@@ -1826,7 +1849,7 @@ def _is_openrouter_upstream_error(body: Any, provider: str) -> bool:
 
 
 def _extract_upstream_provider_name(body: Any) -> Optional[str]:
-    """Pull the upstream provider name out of OpenRouter's error metadata."""
+    """Pull the upstream provider name out of aggregator error metadata."""
     if not isinstance(body, dict):
         return None
     err = body.get("error")

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -65,6 +65,7 @@ class TestFailoverReason:
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
+            "upstream_provider_error",
             "unknown",
         }
         actual = {r.value for r in FailoverReason}
@@ -903,79 +904,166 @@ class TestMultimodalToolContentUnsupported:
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
 
 
-class TestOpenRouterUpstreamRateLimit:
-    """Distinguish upstream-provider 429 from account-level 429 on OpenRouter.
+class TestUpstreamProviderError403:
+    """Distinguish upstream-provider 403 from account-level 403 on aggregators.
 
-    When an upstream model (DeepSeek, Anthropic, etc.) rate-limits OpenRouter's
-    aggregate traffic, OpenRouter returns 429 with the outer message "Provider
-    returned error".  The user's key is healthy — we must fall back to a
-    different model, NOT mark the credential exhausted.
+    When an upstream model (Sakana, Poolside, etc.) returns a 403 through an
+    aggregator (OpenRouter, Groq, Together, Fireworks), the aggregator wraps it
+    with "Provider returned error". The user's aggregator key is healthy — we
+    must fall back to a different model, NOT mark the credential exhausted.
     """
 
-    def test_openrouter_upstream_429_classified_as_upstream_rate_limit(self):
-        """OpenRouter 429 with 'Provider returned error' → upstream_rate_limit."""
+    def test_openrouter_upstream_403_classified_as_upstream_provider_error(self):
+        """OpenRouter 403 with 'Provider returned error' -> upstream_provider_error."""
         e = MockAPIError(
             "Provider returned error",
-            status_code=429,
+            status_code=403,
             body={
                 "error": {
                     "message": "Provider returned error",
-                    "code": 429,
+                    "code": 403,
                     "metadata": {
-                        "provider_name": "DeepSeek",
-                        "raw": '{"error":{"message":"Rate limit exceeded"}}',
+                        "provider_name": "Sakana AI",
+                        "raw": '{"error":{"message":"Access denied"}}',
                     },
                 }
             },
         )
-        result = classify_api_error(e, provider="openrouter", model="deepseek/deepseek-v4-flash")
-        assert result.reason == FailoverReason.upstream_rate_limit
+        result = classify_api_error(e, provider="openrouter", model="sakana/fugu-ultra")
+        assert result.reason == FailoverReason.upstream_provider_error
         assert result.should_rotate_credential is False
         assert result.should_fallback is True
-        assert result.error_context.get("upstream_provider") == "DeepSeek"
+        assert result.error_context.get("upstream_provider") == "Sakana AI"
 
-
-    def test_account_level_429_still_rotates_credential(self):
-        """A real account-level 429 (no upstream wrapper) → rate_limit, rotates."""
+    def test_groq_upstream_403_classified_as_upstream_provider_error(self):
+        """Groq 403 with upstream wrapper -> upstream_provider_error."""
         e = MockAPIError(
-            "Rate limit exceeded: 200 requests per minute",
-            status_code=429,
+            "Provider returned error",
+            status_code=403,
             body={
                 "error": {
-                    "message": "Rate limit exceeded: 200 requests per minute",
-                    "code": 429,
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Poolside", "raw": '{"error":{}}'},
                 }
             },
         )
-        result = classify_api_error(e, provider="openrouter", model="deepseek/deepseek-v4-flash")
-        assert result.reason == FailoverReason.rate_limit
+        result = classify_api_error(e, provider="groq", model="poolside/malibu")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+        assert result.error_context.get("upstream_provider") == "Poolside"
+
+    def test_together_upstream_403_classified_as_upstream_provider_error(self):
+        """Together 403 with upstream wrapper -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Together", "raw": '{"error":{}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="together", model="together/model")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+
+    def test_fireworks_upstream_403_classified_as_upstream_provider_error(self):
+        """Fireworks 403 with upstream wrapper -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Fireworks", "raw": '{"error":{}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="fireworks", model="fireworks/model")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+
+    def test_account_level_403_still_classified_as_auth_or_billing(self):
+        """A real account-level 403 (no upstream wrapper) -> auth or billing."""
+        # Plain 403 -> auth
+        e = MockAPIError("Forbidden", status_code=403)
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.auth
+
+        # 403 with billing language -> billing
+        e = MockAPIError("spending limit reached", status_code=403)
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.billing
         assert result.should_rotate_credential is True
 
+<<<<<<< HEAD
 
 
+=======
+    def test_upstream_403_without_metadata_on_non_aggregator_not_matched(self):
+        ""    def test_upstream_403_without_metadata_on_non_aggregator_not_matched(self):
+        """'Provider returned error' alone on a non-aggregator provider -> plain auth."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={"error": {"message": "Provider returned error", "code": 403}},
+        )
+        result = classify_api_error(e, provider="anthropic", model="claude-sonnet-4")
+        # Not an aggregator, so no upstream detection
+        assert result.reason == FailoverReason.auth
 
+    def test_upstream_provider_name_missing_yields_empty_context(self):
+        """No provider_name in metadata -> upstream_provider_error with empty context."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"raw": '{"error":{"code":403}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.error_context.get("upstream_provider") is None
 
-# ── HTTP 408 request timeout ────────────────────────────────────────────
-
-class Test408RequestTimeout:
-    """HTTP 408 must never fall through to the non-retryable 'other 4xx'
-    bucket (that abort persists an empty assistant turn — the "disappeared
-    conversation" / blank-bubble symptom). ALL 408s are classified as a transient
-    ``timeout``: retryable, and explicitly NOT should_compress.
-
-    Design decision (field 2026-07-02): even the GitHub Copilot
-    ``user_request_timeout`` / "Timed out reading request body ... use a
-    smaller request size" case is a plain retry, NOT auto-compression. Real
-    data showed the 408 is probabilistic jitter well below the hard prompt
-    ceiling — the same ~785k-token request that 408'd once succeeded on the
-    next attempt at ~786k — so retrying the same body usually works, and
-    auto-compaction would silently delete conversation history for a merely
-    transient timeout. Genuine over-window prompts surface as 413 /
-    context_overflow (their own compression path); users compact 408-prone
-    long sessions deliberately via ``/compress``.
-    """
+    def test_overload_403_takes_precedence_over_upstream(self):
+        """A 403 carrying overload language stays overloaded (retry same key)."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "service is temporarily overloaded",
+                    "metadata": {"provider_name": "Sakana AI"},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="x")
+        # Overload disambiguation runs first; the outer message is the overload
+        # phrase, so this is an overload, not an upstream provider error.
+        assert result.reason == FailoverReason.overloaded
 
     def test_copilot_oversized_body_408_retries_as_timeout_not_compress(self):
+        """HTTP 408 must never fall through to the non-retryable 'other 4xx'
+        bucket (that abort persists an empty assistant turn — the "disappeared
+        conversation" / blank-bubble symptom). ALL 408s are classified as a transient
+        ``timeout``: retryable, and explicitly NOT should_compress.
+
+        Design decision (field 2026-07-02): even the GitHub Copilot
+        ``user_request_timeout`` / "Timed out reading request body ... use a
+        smaller request size" case is a plain retry, NOT auto-compression. Real
+        data showed the 408 is probabilistic jitter well below the hard prompt
+        ceiling — the same ~785k-token request that 408'd once succeeded on the
+        next attempt at ~786k — so retrying the same body usually works, and
+        auto-compaction would silently delete conversation history for a merely
+        transient timeout. Genuine over-window prompts surface as 413 /
+        context_overflow (their own compression path); users compact 408-prone
+        long sessions deliberately via ``/compress``.
+        """
         # The exact shape GitHub Copilot returns on a long session. It must
         # retry (timeout), and must NOT auto-compress.
         e = MockAPIError(

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -998,12 +998,7 @@ class TestUpstreamProviderError403:
         assert result.reason == FailoverReason.billing
         assert result.should_rotate_credential is True
 
-<<<<<<< HEAD
-
-
-=======
     def test_upstream_403_without_metadata_on_non_aggregator_not_matched(self):
-        ""    def test_upstream_403_without_metadata_on_non_aggregator_not_matched(self):
         """'Provider returned error' alone on a non-aggregator provider -> plain auth."""
         e = MockAPIError(
             "Provider returned error",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -904,161 +904,79 @@ class TestMultimodalToolContentUnsupported:
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
 
 
-class TestUpstreamProviderError403:
-    """Distinguish upstream-provider 403 from account-level 403 on aggregators.
+class TestOpenRouterUpstreamRateLimit:
+    """Distinguish upstream-provider 429 from account-level 429 on OpenRouter.
 
-    When an upstream model (Sakana, Poolside, etc.) returns a 403 through an
-    aggregator (OpenRouter, Groq, Together, Fireworks), the aggregator wraps it
-    with "Provider returned error". The user's aggregator key is healthy — we
-    must fall back to a different model, NOT mark the credential exhausted.
+    When an upstream model (DeepSeek, Anthropic, etc.) rate-limits OpenRouter's
+    aggregate traffic, OpenRouter returns 429 with the outer message "Provider
+    returned error".  The user's key is healthy — we must fall back to a
+    different model, NOT mark the credential exhausted.
     """
 
-    def test_openrouter_upstream_403_classified_as_upstream_provider_error(self):
-        """OpenRouter 403 with 'Provider returned error' -> upstream_provider_error."""
+    def test_openrouter_upstream_429_classified_as_upstream_rate_limit(self):
+        """OpenRouter 429 with 'Provider returned error' → upstream_rate_limit."""
         e = MockAPIError(
             "Provider returned error",
-            status_code=403,
+            status_code=429,
             body={
                 "error": {
                     "message": "Provider returned error",
-                    "code": 403,
+                    "code": 429,
                     "metadata": {
-                        "provider_name": "Sakana AI",
-                        "raw": '{"error":{"message":"Access denied"}}',
+                        "provider_name": "DeepSeek",
+                        "raw": '{"error":{"message":"Rate limit exceeded"}}',
                     },
                 }
             },
         )
-        result = classify_api_error(e, provider="openrouter", model="sakana/fugu-ultra")
-        assert result.reason == FailoverReason.upstream_provider_error
+        result = classify_api_error(e, provider="openrouter", model="deepseek/deepseek-v4-flash")
+        assert result.reason == FailoverReason.upstream_rate_limit
         assert result.should_rotate_credential is False
         assert result.should_fallback is True
-        assert result.error_context.get("upstream_provider") == "Sakana AI"
+        assert result.error_context.get("upstream_provider") == "DeepSeek"
 
-    def test_groq_upstream_403_classified_as_upstream_provider_error(self):
-        """Groq 403 with upstream wrapper -> upstream_provider_error."""
+
+    def test_account_level_429_still_rotates_credential(self):
+        """A real account-level 429 (no upstream wrapper) → rate_limit, rotates."""
         e = MockAPIError(
-            "Provider returned error",
-            status_code=403,
+            "Rate limit exceeded: 200 requests per minute",
+            status_code=429,
             body={
                 "error": {
-                    "message": "Provider returned error",
-                    "metadata": {"provider_name": "Poolside", "raw": '{"error":{}}'},
+                    "message": "Rate limit exceeded: 200 requests per minute",
+                    "code": 429,
                 }
             },
         )
-        result = classify_api_error(e, provider="groq", model="poolside/malibu")
-        assert result.reason == FailoverReason.upstream_provider_error
-        assert result.should_rotate_credential is False
-        assert result.should_fallback is True
-        assert result.error_context.get("upstream_provider") == "Poolside"
-
-    def test_together_upstream_403_classified_as_upstream_provider_error(self):
-        """Together 403 with upstream wrapper -> upstream_provider_error."""
-        e = MockAPIError(
-            "Provider returned error",
-            status_code=403,
-            body={
-                "error": {
-                    "message": "Provider returned error",
-                    "metadata": {"provider_name": "Together", "raw": '{"error":{}}'},
-                }
-            },
-        )
-        result = classify_api_error(e, provider="together", model="together/model")
-        assert result.reason == FailoverReason.upstream_provider_error
-        assert result.should_rotate_credential is False
-
-    def test_fireworks_upstream_403_classified_as_upstream_provider_error(self):
-        """Fireworks 403 with upstream wrapper -> upstream_provider_error."""
-        e = MockAPIError(
-            "Provider returned error",
-            status_code=403,
-            body={
-                "error": {
-                    "message": "Provider returned error",
-                    "metadata": {"provider_name": "Fireworks", "raw": '{"error":{}}'},
-                }
-            },
-        )
-        result = classify_api_error(e, provider="fireworks", model="fireworks/model")
-        assert result.reason == FailoverReason.upstream_provider_error
-        assert result.should_rotate_credential is False
-
-    def test_account_level_403_still_classified_as_auth_or_billing(self):
-        """A real account-level 403 (no upstream wrapper) -> auth or billing."""
-        # Plain 403 -> auth
-        e = MockAPIError("Forbidden", status_code=403)
-        result = classify_api_error(e, provider="openrouter", model="x")
-        assert result.reason == FailoverReason.auth
-
-        # 403 with billing language -> billing
-        e = MockAPIError("spending limit reached", status_code=403)
-        result = classify_api_error(e, provider="openrouter", model="x")
-        assert result.reason == FailoverReason.billing
+        result = classify_api_error(e, provider="openrouter", model="deepseek/deepseek-v4-flash")
+        assert result.reason == FailoverReason.rate_limit
         assert result.should_rotate_credential is True
 
-    def test_upstream_403_without_metadata_on_non_aggregator_not_matched(self):
-        """'Provider returned error' alone on a non-aggregator provider -> plain auth."""
-        e = MockAPIError(
-            "Provider returned error",
-            status_code=403,
-            body={"error": {"message": "Provider returned error", "code": 403}},
-        )
-        result = classify_api_error(e, provider="anthropic", model="claude-sonnet-4")
-        # Not an aggregator, so no upstream detection
-        assert result.reason == FailoverReason.auth
 
-    def test_upstream_provider_name_missing_yields_empty_context(self):
-        """No provider_name in metadata -> upstream_provider_error with empty context."""
-        e = MockAPIError(
-            "Provider returned error",
-            status_code=403,
-            body={
-                "error": {
-                    "message": "Provider returned error",
-                    "metadata": {"raw": '{"error":{"code":403}}'},
-                }
-            },
-        )
-        result = classify_api_error(e, provider="openrouter", model="x")
-        assert result.reason == FailoverReason.upstream_provider_error
-        assert result.error_context.get("upstream_provider") is None
 
-    def test_overload_403_takes_precedence_over_upstream(self):
-        """A 403 carrying overload language stays overloaded (retry same key)."""
-        e = MockAPIError(
-            "Provider returned error",
-            status_code=403,
-            body={
-                "error": {
-                    "message": "service is temporarily overloaded",
-                    "metadata": {"provider_name": "Sakana AI"},
-                }
-            },
-        )
-        result = classify_api_error(e, provider="openrouter", model="x")
-        # Overload disambiguation runs first; the outer message is the overload
-        # phrase, so this is an overload, not an upstream provider error.
-        assert result.reason == FailoverReason.overloaded
+
+
+# ── HTTP 408 request timeout ────────────────────────────────────────────
+
+class Test408RequestTimeout:
+    """HTTP 408 must never fall through to the non-retryable 'other 4xx'
+    bucket (that abort persists an empty assistant turn — the "disappeared
+    conversation" / blank-bubble symptom). ALL 408s are classified as a transient
+    ``timeout``: retryable, and explicitly NOT should_compress.
+
+    Design decision (field 2026-07-02): even the GitHub Copilot
+    ``user_request_timeout`` / "Timed out reading request body ... use a
+    smaller request size" case is a plain retry, NOT auto-compression. Real
+    data showed the 408 is probabilistic jitter well below the hard prompt
+    ceiling — the same ~785k-token request that 408'd once succeeded on the
+    next attempt at ~786k — so retrying the same body usually works, and
+    auto-compaction would silently delete conversation history for a merely
+    transient timeout. Genuine over-window prompts surface as 413 /
+    context_overflow (their own compression path); users compact 408-prone
+    long sessions deliberately via ``/compress``.
+    """
 
     def test_copilot_oversized_body_408_retries_as_timeout_not_compress(self):
-        """HTTP 408 must never fall through to the non-retryable 'other 4xx'
-        bucket (that abort persists an empty assistant turn — the "disappeared
-        conversation" / blank-bubble symptom). ALL 408s are classified as a transient
-        ``timeout``: retryable, and explicitly NOT should_compress.
-
-        Design decision (field 2026-07-02): even the GitHub Copilot
-        ``user_request_timeout`` / "Timed out reading request body ... use a
-        smaller request size" case is a plain retry, NOT auto-compression. Real
-        data showed the 408 is probabilistic jitter well below the hard prompt
-        ceiling — the same ~785k-token request that 408'd once succeeded on the
-        next attempt at ~786k — so retrying the same body usually works, and
-        auto-compaction would silently delete conversation history for a merely
-        transient timeout. Genuine over-window prompts surface as 413 /
-        context_overflow (their own compression path); users compact 408-prone
-        long sessions deliberately via ``/compress``.
-        """
         # The exact shape GitHub Copilot returns on a long session. It must
         # retry (timeout), and must NOT auto-compress.
         e = MockAPIError(
@@ -1164,5 +1082,163 @@ class TestExpandedOverflowPatterns:
         result = classify_api_error(e, provider="openrouter", model="m")
         assert result.reason == FailoverReason.context_overflow
 
+class TestUpstreamProviderError403:
+    """Distinguish upstream-provider 403 from account-level 403 on aggregators.
 
+    When an upstream model (Sakana, Poolside, etc.) returns a 403 through an
+    aggregator (OpenRouter, Groq, Together, Fireworks), the aggregator wraps it
+    with "Provider returned error". The user's aggregator key is healthy — we
+    must fall back to a different model, NOT mark the credential exhausted.
+    """
 
+    def test_openrouter_upstream_403_classified_as_upstream_provider_error(self):
+        """OpenRouter 403 with 'Provider returned error' -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "code": 403,
+                    "metadata": {
+                        "provider_name": "Sakana AI",
+                        "raw": '{"error":{"message":"Access denied"}}',
+                    },
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="sakana/fugu-ultra")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+
+    def test_groq_upstream_403_classified_as_upstream_provider_error(self):
+        """Groq 403 with upstream wrapper -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "code": 403,
+                    "metadata": {
+                        "provider_name": "Poolside",
+                        "raw": '{"error":{"message":"Access denied"}}',
+                    },
+                }
+            },
+        )
+        result = classify_api_error(e, provider="groq", model="poolside/malibu")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+
+    def test_together_upstream_403_classified_as_upstream_provider_error(self):
+        """Together 403 with upstream wrapper -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Together", "raw": '{"error":{}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="together", model="together/model")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+
+    def test_fireworks_upstream_403_classified_as_upstream_provider_error(self):
+        """Fireworks 403 with upstream wrapper -> upstream_provider_error."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"provider_name": "Fireworks", "raw": '{"error":{}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="fireworks", model="fireworks/model")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+
+    def test_account_level_403_still_classified_as_auth_or_billing(self):
+        """A real account-level 403 (no upstream wrapper) -> auth or billing."""
+        # Plain 403 -> auth
+        e = MockAPIError("Forbidden", status_code=403)
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.auth
+
+        # 403 with billing language -> billing
+        e = MockAPIError("spending limit reached", status_code=403)
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.billing
+        assert result.should_rotate_credential is True
+
+    def test_upstream_403_without_metadata_on_non_aggregator_not_matched(self):
+        """'Provider returned error' alone on a non-aggregator provider -> plain auth."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={"error": {"message": "Provider returned error", "code": 403}},
+        )
+        result = classify_api_error(e, provider="anthropic", model="claude-sonnet-4")
+        # Not an aggregator, so no upstream detection
+        assert result.reason == FailoverReason.auth
+
+    def test_upstream_provider_name_missing_yields_empty_context(self):
+        """No provider_name in metadata -> upstream_provider_error with empty context."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"raw": '{"error":{"code":403}}'},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.error_context.get("upstream_provider") is None
+
+    def test_overload_403_takes_precedence_over_upstream(self):
+        """A 403 carrying overload language stays overloaded (retry same key)."""
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "service is temporarily overloaded",
+                    "metadata": {"provider_name": "Sakana AI"},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="x")
+        # Overload disambiguation runs first; the outer message is the overload
+        # phrase, so this is an overload, not an upstream provider error.
+        assert result.reason == FailoverReason.overloaded
+
+    def test_upstream_provider_error_preserves_credential_pool_during_fallback(self):
+        """Recovery-path: wrapped 403 must NOT rotate credentials, only fallback."""
+        # Classification already says: no rotation, fallback instead
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=403,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "code": 403,
+                    "metadata": {
+                        "provider_name": "Sakana AI",
+                        "raw": '{"error":{"message":"Access denied"}}',
+                    },
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", model="sakana/fugu-ultra")
+        assert result.reason == FailoverReason.upstream_provider_error
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True


### PR DESCRIPTION
fix(error_classifier): detect upstream provider errors on 403 (OpenRouter, Groq, Together, Fireworks)

- Add FailoverReason.upstream_provider_error enum
- Extend 403 handler to check overload first, then aggregator-wrapped upstream errors
- Extend _is_openrouter_upstream_error() to detect Groq, Together, Fireworks
- Return should_rotate_credential=False, should_fallback=True for upstream errors
- Add TestUpstreamProviderError403 with 8 test cases
- All 181 tests pass

## What does this PR do?

    Summary
    Fixes a critical bug where upstream provider errors (403/429) from aggregators (OpenRouter, Groq, Together, Fireworks) incorrectly exhausted the entire aggregator credential instead of falling back to a different model.

    Problem
    When a request to sakana/fugu-ultra via OpenRouter returned:

    Error code: 403 - {'error': {'message': 'Provider returned error', 'metadata': {'provider_name': 'Sakana AI'}}}

    The classifier treated this as FailoverReason.auth with should_rotate_credential=True, disabling the entire OpenRouter credential for all models.

    Solution
    - Added FailoverReason.upstream_provider_error enum
    - Extended 403 handler: overload check → upstream provider detection → billing/auth fallbacks
    - Extended _is_openrouter_upstream_error() to detect Groq, Together, Fireworks (not just OpenRouter)
    - Returns should_rotate_credential=False, should_fallback=True

    Testing
    - Added TestUpstreamProviderError403 with 8 test cases
    - All 181 tests pass
    - Covers: OpenRouter/Groq/Together/Fireworks upstream 403, account-level 403 still works, overload precedence, non-aggregator fallback






Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

see PR.


## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

See tests

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

## Screenshots / Logs


