### PR TITLE
fix(model-switch): handle list-of-dicts models in providers config (500 on /api/model/options)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1965,8 +1965,9 @@ def list_authenticated_providers(
                         models_list.append(m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    mid = (m.get("id") if isinstance(m, dict) else m) if m else ""
+                    if mid and mid not in models_list:
+                        models_list.append(mid)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.


### PR DESCRIPTION
# Bug: `providers.<name>.models` list-of-dicts format crashes `/api/model/options` with 500

## Summary

When `config.yaml` has any `providers.<name>` entry whose `models:` is a **list of dicts** (e.g. `[{id: foo, context_length: 128000}, ...]` — a Hermes-supported format), and that provider falls through to Section 3 of `list_authenticated_providers()` without a live-probe, the Desktop GUI's model picker fails to open with:

```
Error invoking remote method 'hermes:api': Error: 500: {"detail":"Failed to list model options"}
```

Because `/api/model/options` is all-or-nothing, a single misbehaving provider row poisons the entire response — even providers the user actively uses can't be listed.

## Environment

- Hermes Agent commit: `528159f7a` (main, PR #57438 merged)
- Platform: macOS 15.7.5 (Intel), Hermes Desktop GUI
- Python 3.11 venv at `~/.hermes/hermes-agent/venv`

## Reproduce

Minimal `~/.hermes/config.yaml`:

```yaml
model:
  default: some-model
  provider: some-provider

providers:
  # Any provider that:
  # 1. Falls through to Section 3 (not matched by Section 1/2 credentials), AND
  # 2. Has no api_key set (so should_probe stays False), AND
  # 3. Uses list-of-dicts models format
  github-copilot:
    name: Claude Code
    models:
      - context_length: 200000
        id: claude-opus-4.7
      - context_length: 200000
        id: claude-sonnet-4.7
```

Then either:
- Open Hermes Desktop → click model picker → 500 error banner
- Or via curl: `curl http://127.0.0.1:<port>/api/model/options` → HTTP 500

## Root Cause

`hermes_cli/model_switch.py`, `list_authenticated_providers()` Section 3, lines **1966–1969**:

```python
elif isinstance(cfg_models, list):
    for m in cfg_models:
        if m and m not in models_list:
            models_list.append(m)         # ← appends the whole dict verbatim
```

When `cfg_models` is `[{"id": "claude-opus-4.7", "context_length": 200000}, ...]`, the loop appends the **dict** to `models_list`. That poisoned list is returned as the row's `"models"` field and propagates to `hermes_cli/inventory.py:188`:

```python
user_models.update(m.lower() for m in (row.get("models") or []))
#                  ^^^^^^^^^
# AttributeError: 'dict' object has no attribute 'lower'
```

Which bubbles out of `build_models_payload()` → `web_server.py:4232` → the 500 response.

### Full stack trace (from `~/.hermes/logs/errors.log`)

```
ERROR hermes_cli.web_server: GET /api/model/options failed
Traceback (most recent call last):
  File "hermes_cli/web_server.py", line 4219, in get_model_options
    return build_models_payload(
  File "hermes_cli/inventory.py", line 188, in build_models_payload
    user_models.update(m.lower() for m in (row.get("models") or []))
  File "hermes_cli/inventory.py", line 188, in <genexpr>
    user_models.update(m.lower() for m in (row.get("models") or []))
                       ^^^^^^^
AttributeError: 'dict' object has no attribute 'lower'
```

## Why This Only Bites Sometimes

Section 3 has an escape hatch that masks the bug for providers with credentials:

```python
should_probe = bool(api_url) and discover and (
    bool(api_key) or not has_explicit_models
)
if should_probe:
    live_models = fetch_api_models(api_key, api_url)
    if live_models:
        models_list = live_models      # ← overwrites the poisoned list with strings
```

So a **volcengine-agent-plan** with an api_key hits `/v1/models`, gets a clean string list, and the dict-poisoning is invisible. But a **credential-less provider with an explicit `models:` list** (e.g. a `providers.github-copilot` entry configured for Claude Code but lacking `GH_TOKEN`/`COPILOT_GITHUB_TOKEN`) skips the probe and ships the poisoned row downstream — 500-ing the whole endpoint.

Related: Section 4 (`custom_providers`) handles the same shape **correctly**:

```python
# model_switch.py, section 4 — CORRECT
elif isinstance(cfg_models, list):
    for m in cfg_models:
        if m and m not in groups[group_key]["models"]:
            groups[group_key]["models"].append(m)     # <-- but cfg_models here is already normalized to dict-of-strings
```

And `_normalize_custom_provider_entry()` in `hermes_cli/config.py:4582-4589` already knows list-of-dicts is a valid input… but silently drops them:

```python
elif isinstance(models, list) and models:
    normalized["models"] = {
        str(m): {} for m in models if isinstance(m, str) and m.strip()
        #                             ^^^^^^^^^^^^^^^^^^^ dicts fail this and get dropped
    }
```

## Fix

Apply the same dict-flattening pattern already used elsewhere in the codebase (e.g. `hermes_cli/config.py` similar sites):

```diff
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1963,10 +1963,11 @@
             cfg_models = ep_cfg.get("models", [])
             if isinstance(cfg_models, dict):
                 for m in cfg_models:
                     if m and m not in models_list:
                         models_list.append(m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    mid = (m.get("id") if isinstance(m, dict) else m) if m else ""
+                    if mid and mid not in models_list:
+                        models_list.append(mid)
```

### Verification

Before fix:
```
$ curl http://127.0.0.1:<port>/api/model/options
{"detail":"Failed to list model options"}
```

After fix:
```
$ curl http://127.0.0.1:<port>/api/model/options | jq '.providers | length'
42
```

All configured providers (`volcengine-agent-plan`: 12 models, `openai-codex`: 4 models, `github-copilot`/Claude Code: 4 models) now appear in the GUI picker.

### Suggested Additional Improvements (out of scope for this PR)

1. **`_normalize_custom_provider_entry()`** in `hermes_cli/config.py:4579-4589` should also accept list-of-dicts (extract `id` field) instead of silently dropping them.
2. **`/api/model/options`** should degrade gracefully — one malformed provider shouldn't 500 the whole endpoint. Consider per-row try/except so bad rows are skipped with a warning rather than killing the entire response.
3. **Config validation** (`hermes config check` / doctor) should warn when it sees list-of-dicts models with no `id` field, or when a `providers.<name>` shape doesn't match any documented schema.
