### PR TITLE
fix(telegram): deliver standalone sends and cron attachments into private DM topic lanes

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1462,15 +1462,32 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 and _looks_like_int(str(thread_id))
             )
             if is_private_dm_topic:
-                # Routed via direct_messages_topic_id (mode 2), no bare thread_id.
+                # Locally-hosted Bot API servers ignore direct_messages_topic_id
+                # for private DM lanes: verified live 2026-07-03 on
+                # telegram-bot-api 10.1 — sendMessage with
+                # direct_messages_topic_id returns a Message WITHOUT the topic
+                # assigned (it lands in the chat root), while a bare
+                # message_thread_id routes correctly and echoes the thread back.
+                # When extra.base_url points at a local server, pass thread_id
+                # via metadata so DeliveryRouter skips its DM-topic anchor
+                # requirement and the adapter sends message_thread_id. Cloud
+                # Bot API targets keep the #22773 three-mode routing.
+                _local_bot_api = bool((getattr(pconfig, "extra", {}) or {}).get("base_url"))
                 route_thread_id = None
-                route_metadata = {
-                    "direct_messages_topic_id": str(thread_id),
-                    "job_id": job["id"],
-                }
-                # Media metadata mirrors the text routing so attachments land in
-                # the same DM topic instead of the General lane (#22773).
-                media_metadata = {"direct_messages_topic_id": str(thread_id)}
+                if _local_bot_api:
+                    route_metadata = {
+                        "thread_id": str(thread_id),
+                        "job_id": job["id"],
+                    }
+                    media_metadata = {"thread_id": str(thread_id)}
+                else:
+                    route_metadata = {
+                        "direct_messages_topic_id": str(thread_id),
+                        "job_id": job["id"],
+                    }
+                    # Media metadata mirrors the text routing so attachments land in
+                    # the same DM topic instead of the General lane (#22773).
+                    media_metadata = {"direct_messages_topic_id": str(thread_id)}
             else:
                 route_thread_id = str(thread_id) if thread_id is not None else None
                 route_metadata = {"job_id": job["id"]}

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5754,18 +5754,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_mode=self._reply_to_mode
             )
 
+            send_kwargs = {
+                "chat_id": normalize_telegram_chat_id(chat_id),
+                "filename": display_name,
+                "caption": caption[:1024] if caption else None,
+                "reply_to_message_id": reply_to_id,
+                **thread_kwargs,
+                **self._notification_kwargs(metadata),
+            }
             with open(file_path, "rb") as f:
                 msg = await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_document,
-                    {
-                        "chat_id": normalize_telegram_chat_id(chat_id),
-                        "document": f,
-                        "filename": display_name,
-                        "caption": caption[:1024] if caption else None,
-                        "reply_to_message_id": reply_to_id,
-                        **thread_kwargs,
-                        **self._notification_kwargs(metadata),
-                    },
+                    {"document": f, **send_kwargs},
                     metadata,
                     reply_to_id,
                     "document",
@@ -5774,6 +5774,42 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning("[%s] Failed to send document: %s", self.name, e, exc_info=True)
+            # Topic-routed sends must NOT fall through to the base sender: it
+            # has no forum/DM-topic routing, so its retry lands in the chat
+            # root («Все»/General) instead of the requested topic. For
+            # transient network errors (slow uploads hitting ReadTimeout —
+            # sendDocument uploads take much longer than text sends) retry
+            # once natively with the SAME routing kwargs; otherwise report
+            # failure rather than misdeliver.
+            _topic_routed = bool(
+                (metadata and metadata.get("telegram_dm_topic_reply_fallback"))
+                or self._metadata_direct_messages_topic_id(metadata) is not None
+                or self._metadata_thread_id(metadata) is not None
+            )
+            _sk = locals().get("send_kwargs")
+            if _topic_routed and isinstance(_sk, dict):
+                err_name = e.__class__.__name__.lower()
+                transient = "timeout" in err_name or "timedout" in err_name or "network" in err_name or "connect" in err_name
+                if transient:
+                    try:
+                        with open(file_path, "rb") as f2:
+                            msg = await self._bot.send_document(
+                                document=f2,
+                                read_timeout=120,
+                                write_timeout=300,
+                                **_sk,
+                            )
+                        return SendResult(success=True, message_id=str(msg.message_id))
+                    except Exception as retry_err:
+                        logger.warning(
+                            "[%s] Topic-routed document retry also failed: %s",
+                            self.name, retry_err,
+                        )
+                        e = retry_err
+                return SendResult(
+                    success=False,
+                    error=f"document send failed; refusing topic-less fallback that would land outside the topic: {e}",
+                )
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
     async def send_video(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -791,7 +791,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # limit (issue #28557). Pass the whole message in one call; media attaches
     # after all text chunks.
     if platform == Platform.TELEGRAM:
-        disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
+        _extra = getattr(pconfig, "extra", {}) or {}
+        disable_link_previews = bool(_extra.get("disable_link_previews"))
         return await _send_telegram(
             pconfig.token,
             chat_id,
@@ -800,6 +801,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            base_url=_extra.get("base_url"),
+            base_file_url=_extra.get("base_file_url"),
+            local_mode=bool(_extra.get("local_mode")),
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1014,7 +1018,7 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, base_url=None, base_file_url=None, local_mode=False):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1054,7 +1058,21 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
         except Exception:
             _tg_proxy = None
-        if _tg_proxy:
+        # A locally-hosted telegram-bot-api server (extra.base_url) is where
+        # Telegram private DM topic lanes live: the cloud Bot API rejects their
+        # thread ids ("message thread not found"), and the retry-without-thread
+        # fallback then lands the message in the chat root instead of the
+        # topic. Mirror the gateway adapter and use the configured
+        # base_url/base_file_url/local_mode. No proxy in this branch — the
+        # local server is on loopback.
+        if base_url:
+            bot = Bot(
+                token=token,
+                base_url=base_url,
+                base_file_url=base_file_url or base_url.replace("/bot", "/file/bot"),
+                local_mode=bool(local_mode),
+            )
+        elif _tg_proxy:
             try:
                 from telegram.request import HTTPXRequest
                 logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)


### PR DESCRIPTION
## Problem

Messages sent to Telegram **private DM topic lanes** land in the chat root (General/«Все») instead of the requested topic. Hit in production by Multica/CI agents using `hermes send --to telegram:<user_id>:<topic_id> --file report.md` and by cron deliveries.

Three related causes:

### 1. Standalone sender bypasses the locally-hosted Bot API server
`tools/send_message_tool.py` always built `Bot(token)` against cloud `api.telegram.org`, even when the deployment runs a local `telegram-bot-api` server (`platforms.telegram.extra.base_url`). Private DM topic lanes only exist on the local server — the cloud API rejects their thread ids ("message thread not found") and the existing retry-without-thread fallback then delivers into the chat root. The gateway adapter already honours `extra.base_url`/`base_file_url`/`local_mode`; the standalone path now does the same.

### 2. `send_document` topic-less fallback misroutes files
`adapter.send_document` fell back to the base sender on **any** exception — including `httpx.ReadTimeout`, which slow document uploads hit far more often than text sends. The base sender has no topic routing, so the file was delivered outside the topic. Topic-routed document sends now retry once natively (same routing kwargs, longer upload timeouts) on transient network errors, and otherwise fail loudly instead of misdelivering.

### 3. Cron deliveries: `direct_messages_topic_id` is a no-op on local Bot API servers
`cron/scheduler.py` routes private DM topics via `direct_messages_topic_id` (#22773 three-mode routing). Verified live on a locally-hosted **telegram-bot-api 10.1**: the local server silently ignores the parameter for private DM lanes, while a bare `message_thread_id` routes correctly. Gated fix: when `extra.base_url` points at a local server, pass `thread_id` via metadata (DeliveryRouter skips its anchor requirement; adapter sends `message_thread_id`). Cloud targets keep the existing #22773 routing unchanged.

## Live verification matrix

Private chat, DM topic lane `921025`, local telegram-bot-api **10.1** (`aiogram/telegram-bot-api:latest`, 2026-06-24 build), PTB 22.8:

| send params | `Message.message_thread_id` in response | lands in |
|---|---|---|
| `message_thread_id=921025` | `921025` | ✅ topic |
| `reply_to_message_id=<real msg in lane>` | `921025` | ✅ topic |
| `direct_messages_topic_id=921025` | `None` | ❌ chat root |

After the fix, `hermes send --to telegram:<uid>:<topic> --file x.md` delivers text **and** the attachment into the topic (confirmed by the receiving user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)