### PR TITLE
fix(telegram): remove early return that blocks direct_messages_topic_id fallback for anchor-less DM topic sends

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3342,12 +3342,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 else:
                     should_thread = self._should_thread_reply(reply_to_source, i)
                 reply_to_id = int(reply_to_source) if should_thread and reply_to_source else None
-                if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
-                    return SendResult(
-                        success=False,
-                        error=self._dm_topic_missing_anchor_error(),
-                        retryable=False,
-                    )
                 thread_kwargs = self._thread_kwargs_for_send(
                     chat_id,
                     thread_id,


### PR DESCRIPTION
## Summary

Fixes #57891.

Removes the early `SendResult` return at `plugins/platforms/telegram/adapter.py:3345` that prevents `_thread_kwargs_for_send` from reaching its `direct_messages_topic_id` fallback (line 835-840) when no reply anchor is available — common after a gateway restart or context compression.

## Changes

6 lines deleted (`-6`):

```diff
-                if private_dm_topic_send and reply_to_id is None and not dm_topic_reply_to_off:
-                    return SendResult(
-                        success=False,
-                        error=self._dm_topic_missing_anchor_error(),
-                        retryable=False,
-                    )
```

## Validation

- `tests/gateway/test_delivery.py`: 28 passed
- `tests/gateway/test_telegram_reply_mode.py`: 40 passed

Closes #57891