### PR TITLE
fix(gateway): keep chunk indicator off fence lines, prefer pre-fence splits

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5584,6 +5584,29 @@ class BasePlatformAdapter(ABC):
                     if safe_split > _cp_limit // 4:
                         split_at = safe_split
 
+            # Prefer splitting BEFORE a code block rather than inside it.
+            # If the split point lands inside a fenced block whose opening
+            # fence is in this same chunk, move the split to just before the
+            # fence so the block travels whole to the next chunk. Blocks
+            # carried in from the previous chunk (no local opener) keep the
+            # close-and-reopen behaviour below. The quarter-limit threshold
+            # mirrors the inline-span guard to avoid degenerate tiny chunks.
+            fence_scan = remaining[:split_at]
+            scan_in_code = carry_lang is not None
+            fence_open_pos = -1
+            pos = 0
+            for line in fence_scan.split("\n"):
+                if line.strip().startswith("```"):
+                    if scan_in_code:
+                        scan_in_code = False
+                        fence_open_pos = -1
+                    else:
+                        scan_in_code = True
+                        fence_open_pos = pos
+                pos += len(line) + 1
+            if scan_in_code and fence_open_pos > _cp_limit // 4:
+                split_at = fence_open_pos
+
             chunk_body = remaining[:split_at]
             remaining = remaining[split_at:].lstrip()
 
@@ -5613,11 +5636,17 @@ class BasePlatformAdapter(ABC):
 
             chunks.append(full_chunk)
 
-        # Append chunk indicators when the response spans multiple messages
+        # Append chunk indicators when the response spans multiple messages.
+        # When a chunk ends with a closing fence, put the indicator on its
+        # own line: "``` (1/2)" is trailing text on the fence line, renders
+        # inconsistently, and gets glued into the code when readers
+        # reassemble the chunks.
         if len(chunks) > 1:
             total = len(chunks)
-            chunks = [
-                f"{chunk} ({i + 1}/{total})" for i, chunk in enumerate(chunks)
-            ]
+            labelled = []
+            for i, chunk in enumerate(chunks):
+                separator = "\n" if chunk.rstrip().endswith("```") else " "
+                labelled.append(f"{chunk}{separator}({i + 1}/{total})")
+            chunks = labelled
 
         return chunks

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,6 +1,7 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
 import os
+import re
 import time
 from unittest.mock import patch
 
@@ -1521,6 +1522,59 @@ class TestTruncateMessage:
             assert len(chunk) <= max_len + 20, (
                 f"Chunk {i} too long: {len(chunk)} > {max_len}"
             )
+
+    def test_indicator_not_glued_to_closing_fence(self):
+        """Regression: '``` (1/2)' puts the indicator on the fence line —
+        it renders as fence trailing text and gets glued into the code
+        when readers reassemble the chunks."""
+        adapter = self._adapter()
+        # A single giant code block forces a split inside the block
+        # (opener at position 0 defeats the fence-boundary preference),
+        # so the first chunk ends with an auto-closed fence.
+        msg = "```python\n" + "x = 1\n" * 120 + "```\n"
+        chunks = adapter.truncate_message(msg, max_length=300)
+        assert len(chunks) > 1
+        for i, chunk in enumerate(chunks):
+            for line in chunk.split("\n"):
+                stripped = line.strip()
+                if stripped.startswith("```"):
+                    assert "(" not in stripped[3:], (
+                        f"Chunk {i}: indicator glued to fence line {line!r}"
+                    )
+        # Indicators are still present, on their own line after the fence
+        last_line = chunks[0].rstrip().rsplit("\n", 1)[-1]
+        assert last_line == f"(1/{len(chunks)})"
+
+    def test_split_prefers_fence_boundary(self):
+        """A code block whose opener sits late in the chunk moves whole to
+        the next chunk instead of being split mid-block."""
+        adapter = self._adapter()
+        prose = "word " * 40
+        code = "```python\n" + "y = 2\n" * 10 + "```"
+        msg = prose + "\n" + code + "\nAfter"
+        chunks = adapter.truncate_message(msg, max_length=260)
+        assert len(chunks) > 1
+        # The block must arrive intact: no chunk needs an auto-close, and
+        # the chunk with the opener also carries every code line.
+        code_chunks = [c for c in chunks if "```python" in c]
+        assert len(code_chunks) == 1
+        assert code_chunks[0].count("y = 2") == 10
+        for i, chunk in enumerate(chunks):
+            assert chunk.count("```") % 2 == 0, (
+                f"Chunk {i} has unbalanced fences"
+            )
+
+    def test_fence_boundary_preference_preserves_content(self):
+        adapter = self._adapter()
+        prose = "word " * 40
+        code = "```python\n" + "y = 2\n" * 10 + "```"
+        msg = prose + "\n" + code + "\nAfter"
+        chunks = adapter.truncate_message(msg, max_length=260)
+        stripped = [re.sub(r"(?:\s|\n)\(\d+/\d+\)$", "", c) for c in chunks]
+        reassembled = "\n".join(stripped)
+        assert "```python" in reassembled
+        assert "After" in reassembled
+        assert reassembled.count("y = 2") == 10
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes two `truncate_message` behaviours that corrupt chunked messages containing fenced code blocks:

1. **Chunk indicator glued to the closing fence.** The `(i/N)` indicator is appended with a space, so a chunk that ends with an auto-closed code fence becomes ` ``` (1/2)` — trailing text on the fence line. It renders inconsistently across clients, and when a reader (human copy-pasting, or another bot reassembling the chunks) joins the parts, the indicator lands **inside the code**. Observed in production in a two-agent Telegram group: a chunked bash script arrived with a literal `(1/2)` spliced into a command line, and the peer agent flagged the script as syntactically broken.

2. **Splits landing mid-code-block when they don't have to.** When the natural split point falls inside a fenced block whose opening fence is in the same chunk, the block gets split and the fence closed/reopened even when the whole block would comfortably fit in the next chunk.

Approach:

- When a chunk ends with a closing fence, the indicator goes on its own line (other chunks keep the legacy same-line suffix, so plain-text rendering is unchanged). `INDICATOR_RESERVE` already covers the newline variant.
- When the split point falls inside a fenced block whose opener is in the same chunk, move the split to just before the fence so the block travels whole to the next chunk. The quarter-limit threshold mirrors the existing inline-span guard to avoid degenerate tiny chunks; blocks carried in from a previous chunk (no local opener) keep the close-and-reopen behaviour, so giant blocks still split as before.

## Related Issue

No issue filed; defect is fully described above (happy to open one if preferred).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — `truncate_message`: fence-boundary split preference + indicator placement for fence-terminated chunks.
- `tests/gateway/test_platform_base.py` — three new tests: `test_indicator_not_glued_to_closing_fence`, `test_split_prefers_fence_boundary`, `test_fence_boundary_preference_preserves_content`.

## How to Test

1. `pytest tests/gateway/test_platform_base.py -q` — 178 passed, 2 skipped.
2. Repro of the original defect (fails before this patch, passes after):
   ```python
   chunks = BasePlatformAdapter.truncate_message("```python\n" + "x = 1\n" * 120 + "```\n", max_length=300)
   assert not any(line.strip().startswith("```") and "(" in line.strip()[3:] for c in chunks for line in c.split("\n"))
   ```
3. Fence-boundary preference: prose + a late ~70-char code block at `max_length=260` now yields the block intact in a single chunk (previously auto-closed/reopened across two).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (closest are #48500 — Discord edit fence balance, #52096 — inline-entity guard, #45020 — Markdown tables; none touches indicator placement or pre-fence split preference)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `tests/gateway/test_platform_base.py` in full (178 passed, 2 skipped), which covers `truncate_message`; full-suite run left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.5.0), Python 3.12
- [x] `ruff check` clean on both changed files

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behaviour documented in `truncate_message` docstring comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure string manipulation, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Production repro (Telegram, two-agent group): chunk 1 tail before the fix —

```
  if docker exec \
``` (1/2)
```

— reassembled by the peer agent into `if docker exec \ (1/2) -e PGPASSWORD=...`, which it then flagged as a syntax error ("посторонний символ `(1/2)` в строке 170").
