### PR TITLE
fix(gateway): route queued follow-ups to compression children (#57895)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24510,6 +24510,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # new message).
 
                 updated_history = result.get("messages", history)
+                followup_session_id = session_id
+                if isinstance(response, dict):
+                    followup_session_id = response.get("session_id") or followup_session_id
                 next_source = source
                 next_message = pending
                 next_message_id = None
@@ -24521,7 +24524,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_message_type = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
-                    if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
+                    if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(followup_session_id):
                         logger.info(
                             "Discarding stale goal continuation for session %s — goal is no longer active",
                             session_key or "?",
@@ -24589,17 +24592,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # prefix #46237 was merged to preserve.  The existing
                 # re-baseline in _handle_message_with_agent only runs after the
                 # whole _run_agent chain unwinds — too late for the in-band
-                # follow-up.  Use the same (session_key, session_id) the
-                # recursive call runs under so the snapshot matches exactly
+                # follow-up.  Use the same (next_session_key, followup_session_id)
+                # the recursive call runs under so the snapshot matches exactly
                 # what the follow-up's guard will consult.  Fail-safe in helper.
-                await self._refresh_agent_cache_message_count(session_key, session_id)
+                await self._refresh_agent_cache_message_count(next_session_key, followup_session_id)
 
                 followup_result = await self._run_agent(
                     message=next_message,
                     context_prompt=context_prompt,
                     history=updated_history,
                     source=next_source,
-                    session_id=session_id,
+                    session_id=followup_session_id,
                     session_key=next_session_key,
                     run_generation=run_generation,
                     _interrupt_depth=_interrupt_depth + 1,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3431,13 +3431,16 @@ class GatewayTurnMixin:
             await self._run_agent_deliver_first_response(turn_ctx, adapter, response, result, stream_task)
 
         updated_history = result.get("messages", history)
+        followup_session_id = session_id
+        if isinstance(response, dict):
+            followup_session_id = response.get("session_id") or followup_session_id
         next_source, next_message, next_session_key = source, pending, session_key
         # message_type is carried into the recursive call so queued voice turns can stream TTS.
         next_message_id = next_channel_prompt = next_message_type = None
         # See #60671.
         if pending_event is not None:
             next_source = getattr(pending_event, "source", None) or source
-            if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
+            if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(followup_session_id):
                 logger.info(
                     "Discarding stale goal continuation for session %s — goal is no longer active",
                     session_key or "?",
@@ -3484,14 +3487,14 @@ class GatewayTurnMixin:
         # call re-enters — would otherwise see the grown on-disk count against the stale build-time snapshot
         # and rebuild the agent on THIS process's OWN writes, destroying the prompt-cache prefix #46237 was
         # merged to preserve. The existing re-baseline in _handle_message_with_agent only runs after the
-        # whole _run_agent chain unwinds — too late for the in-band follow-up. Use the same (session_key,
-        # session_id) the recursive call runs under so the snapshot matches exactly what the follow-up's
-        # guard will consult. Fail-safe in helper.
-        await self._refresh_agent_cache_message_count(session_key, session_id)
+        # whole _run_agent chain unwinds — too late for the in-band follow-up. Use the same
+        # (next_session_key, followup_session_id) as the recursive call so its guard sees the
+        # completed turn's compression child. Fail-safe in helper.
+        await self._refresh_agent_cache_message_count(next_session_key, followup_session_id)
 
         followup_result = await self._run_agent(
             message=next_message, context_prompt=turn_ctx.context_prompt, history=updated_history,
-            source=next_source, session_id=session_id, session_key=next_session_key,
+            source=next_source, session_id=followup_session_id, session_key=next_session_key,
             run_generation=run_generation, _interrupt_depth=_interrupt_depth + 1,
             event_message_id=next_message_id, channel_prompt=next_channel_prompt,
             message_type=next_message_type,

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -494,7 +494,9 @@ def test_queued_followup_after_compression_uses_rotated_session(monkeypatch):
         message_id="queued-1",
     )
     runner.adapters[Platform.TELEGRAM]._pending_messages[SESSION_KEY] = queued
-    runner._prepare_inbound_message_text = AsyncMock(return_value="queued follow-up")
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(
+        return_value="queued follow-up"
+    )
 
     original_run_agent = runner._run_agent
     followup_session_ids = []
@@ -529,3 +531,4 @@ def test_queued_followup_after_compression_uses_rotated_session(monkeypatch):
 
     assert result["final_response"] == "follow-up done"
     assert followup_session_ids == ["session-after-compression"]
+    runner._prepare_profile_scoped_inbound_message_text.assert_awaited_once()

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import gateway.run as gateway_run
 from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
@@ -62,6 +63,22 @@ class _CompressionThenFailureAgent:
         pass
 
 
+class _CompressionThenInterruptedAgent(_CompressionThenFailureAgent):
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, **_kwargs):
+        self.session_id = "session-after-compression"
+        return {
+            "final_response": "",
+            "interrupted": True,
+            "interrupt_message": "queued follow-up",
+            "session_id": self.session_id,
+            "messages": [
+                {"role": "user", "content": "[compressed summary]"},
+                {"role": "user", "content": user_message},
+            ],
+            "api_calls": 1,
+        }
+
+
 class _StreamConsumer:
     final_response_sent = False
 
@@ -77,9 +94,14 @@ class _StreamConsumer:
 
 class _Adapter:
     SUPPORTS_MESSAGE_EDITING = True
-    _pending_messages = {}
 
-    def get_pending_message(self, _session_key):
+    def __init__(self):
+        self._pending_messages = {}
+
+    def get_pending_message(self, session_key):
+        return self._pending_messages.pop(session_key, None)
+
+    async def send(self, *_args, **_kwargs):
         return None
 
     async def send_typing(self, *_args, **_kwargs):
@@ -181,6 +203,58 @@ def test_failed_turn_still_syncs_compression_session_split(monkeypatch):
     )
 
 
+def test_stale_run_does_not_overwrite_new_session_after_compression(monkeypatch):
+    """A /stop + /new can invalidate a run while its compression is still unwinding.
+
+    The stale run may still return with a rotated agent.session_id, but it must
+    not publish that old compressed child back into the channel's active session
+    binding. The outer gateway stale-result check will discard the response too;
+    this regression covers the earlier side effect inside _run_agent().
+    """
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    runner._session_run_generation[SESSION_KEY] = 2
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+
+    result = _run_compression_failure_turn(runner, source, run_generation=1)
+
+    assert result["failed"] is True
+    assert result["session_id"] == "session-after-compression"
+    assert result["history_offset"] == 0
+    assert session_store.entry.session_id == "session-before-compression"
+    assert session_store.save_calls == 0
+    assert session_store.peer_records == []
+    assert getattr(runner._sync_telegram_topic_binding, "call_count") == 0
+
+
+def test_session_split_sync_skips_when_binding_already_moved(monkeypatch):
+    """A live session binding is identity-guarded, not blindly overwritten.
+
+    This catches the exact race where an old run starts with session A, /new
+    moves the binding to fresh session B, and the old run finishes compression
+    into child C. C must not replace B.
+    """
+    _install_compression_failure_agent(monkeypatch)
+
+    session_store = _SessionStore()
+    session_store.entry.session_id = "fresh-session-after-new"
+    runner = _runner(session_store)
+    runner._session_run_generation[SESSION_KEY] = 1
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+
+    result = _run_compression_failure_turn(runner, source, run_generation=1)
+
+    assert result["failed"] is True
+    assert result["session_id"] == "session-after-compression"
+    assert result["history_offset"] == 0
+    assert session_store.entry.session_id == "fresh-session-after-new"
+    assert session_store.save_calls == 0
+    assert session_store.peer_records == []
+    assert getattr(runner._sync_telegram_topic_binding, "call_count") == 0
+
+
 class _RateLimitFailureAgent(_CompressionThenFailureAgent):
     def run_conversation(self, user_message, conversation_history=None, task_id=None, **_kwargs):
         return {
@@ -195,6 +269,26 @@ class _RateLimitFailureAgent(_CompressionThenFailureAgent):
             ],
             "api_calls": 3,
         }
+
+
+def test_nonempty_rate_limit_response_preserves_failure_metadata(monkeypatch):
+    _install_compression_failure_agent(monkeypatch, _RateLimitFailureAgent)
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+    result = _run_compression_failure_turn(runner, source)
+
+    assert result["final_response"].startswith("API call failed after 3 retries")
+    assert result["failed"] is True
+    assert result["failure_reason"] == "rate_limit"
+    assert result["completed"] is False
 
 
 class _EmptyRateLimitFailureAgent(_CompressionThenFailureAgent):
@@ -283,3 +377,155 @@ class _ProviderSwitchAgent(_CompressionThenFailureAgent):
         }
 
 
+def test_rate_limit_then_provider_switch_continues_without_replaying_error(
+    monkeypatch
+):
+    _ProviderSwitchAgent.created_providers = []
+    _ProviderSwitchAgent.second_turn_history = None
+    _install_compression_failure_agent(monkeypatch, _ProviderSwitchAgent)
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_gateway_model",
+        lambda _config=None: "model-a",
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "provider-a",
+            "model": "model-a",
+            "api_key": "key-a",
+            "base_url": "https://provider-a.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    runner._resolve_session_agent_runtime = (
+        gateway_run.GatewayRunner._resolve_session_agent_runtime.__get__(
+            runner, gateway_run.GatewayRunner
+        )
+    )
+    runner._agent_config_signature = (
+        gateway_run.GatewayRunner._agent_config_signature
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+    )
+    initial_history = [
+        {"role": "user", "content": "Earlier question"},
+        {"role": "assistant", "content": "Earlier answer"},
+    ]
+
+    first_result = asyncio.run(
+        runner._run_agent(
+            message="First request",
+            context_prompt="",
+            history=initial_history,
+            source=source,
+            session_id="session-before-compression",
+            session_key=SESSION_KEY,
+        )
+    )
+
+    assert first_result["failed"] is True
+    assert first_result["failure_reason"] == "rate_limit"
+
+    runner._session_model_overrides[SESSION_KEY] = {
+        "model": "model-b",
+        "provider": "provider-b",
+        "api_key": "key-b",
+        "base_url": "https://provider-b.example/v1",
+        "api_mode": "chat_completions",
+    }
+
+    second_result = asyncio.run(
+        runner._run_agent(
+            message="Second request",
+            context_prompt="",
+            history=first_result["messages"],
+            source=source,
+            session_id="session-before-compression",
+            session_key=SESSION_KEY,
+        )
+    )
+
+    assert _ProviderSwitchAgent.created_providers == [
+        "provider-a",
+        "provider-b",
+    ]
+    assert second_result["failed"] is False
+    assert second_result["completed"] is True
+    assert second_result["final_response"] == (
+        "Provider B completed the next turn"
+    )
+    assert not any(
+        "429 Too Many Requests" in str(message.get("content", ""))
+        for message in (_ProviderSwitchAgent.second_turn_history or [])
+    )
+
+
+def test_queued_followup_after_compression_uses_rotated_session(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CompressionThenInterruptedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr("gateway.stream_consumer.GatewayStreamConsumer", _StreamConsumer)
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda *_args, **_kwargs: {"core"})
+
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+    queued = MessageEvent(
+        text="queued follow-up",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="queued-1",
+    )
+    runner.adapters[Platform.TELEGRAM]._pending_messages[SESSION_KEY] = queued
+    runner._prepare_inbound_message_text = AsyncMock(return_value="queued follow-up")
+
+    original_run_agent = runner._run_agent
+    followup_session_ids = []
+
+    async def spy_run_agent(*args, **kwargs):
+        if kwargs.get("_interrupt_depth", 0) > 0:
+            followup_session_ids.append(kwargs.get("session_id"))
+            return {
+                "final_response": "follow-up done",
+                "messages": [],
+                "api_calls": 1,
+                "history_offset": 0,
+                "session_id": kwargs.get("session_id"),
+            }
+        return await original_run_agent(*args, **kwargs)
+
+    runner._run_agent = spy_run_agent
+
+    result = asyncio.run(
+        asyncio.wait_for(
+            runner._run_agent(
+                message="continue",
+                context_prompt="",
+                history=[{"role": "user", "content": "old question"}],
+                source=source,
+                session_id="session-before-compression",
+                session_key=SESSION_KEY,
+            ),
+            timeout=2,
+        )
+    )
+
+    assert result["final_response"] == "follow-up done"
+    assert followup_session_ids == ["session-after-compression"]

--- a/tests/gateway/test_compression_failure_session_sync.py
+++ b/tests/gateway/test_compression_failure_session_sync.py
@@ -5,9 +5,13 @@ import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 import gateway.run as gateway_run
 from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
+from gateway.turn_context import TurnContext
 
 
 SESSION_KEY = "agent:main:telegram:dm:12345"
@@ -77,9 +81,14 @@ class _StreamConsumer:
 
 class _Adapter:
     SUPPORTS_MESSAGE_EDITING = True
-    _pending_messages = {}
 
-    def get_pending_message(self, _session_key):
+    def __init__(self):
+        self._pending_messages = {}
+
+    def get_pending_message(self, session_key):
+        return self._pending_messages.pop(session_key, None)
+
+    async def send(self, *_args, **_kwargs):
         return None
 
     async def send_typing(self, *_args, **_kwargs):
@@ -96,7 +105,7 @@ def _runner(session_store):
     runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
     runner.session_store = session_store
     runner._session_db = MagicMock()
-    runner._session_db.get_telegram_topic_binding_by_session.return_value = None
+    runner._session_db._db.get_telegram_topic_binding_by_session.return_value = None
     runner._agent_cache = {}
     runner._agent_cache_lock = threading.Lock()
     runner._running_agents = {}
@@ -235,6 +244,7 @@ def test_empty_rate_limit_response_preserves_failure_metadata(monkeypatch):
     assert result["failure_reason"] == "rate_limit"
     assert result["completed"] is False
 
+
 class _ProviderSwitchAgent(_CompressionThenFailureAgent):
     created_providers = []
     second_turn_history = None
@@ -283,3 +293,88 @@ class _ProviderSwitchAgent(_CompressionThenFailureAgent):
         }
 
 
+@pytest.mark.parametrize("interrupted", [False, True])
+@pytest.mark.parametrize("rotates", [False, True])
+def test_queued_burst_follows_each_compression_child(monkeypatch, interrupted, rotates):
+    session_store = _SessionStore()
+    runner = _runner(session_store)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    next_key = runner._session_key_for_source(source)
+    run_ids, agent_ids = [], []
+
+    class BurstAgent(_CompressionThenFailureAgent):
+        def run_conversation(self, user_message, conversation_history=None, **kwargs):
+            agent_ids.append(self.session_id)
+            turn = len(agent_ids)
+            messages = [{"role": "user", "content": user_message}]
+            if turn < 3:
+                if rotates:
+                    self.session_id = f"compression-child-{turn}"
+                    messages.insert(0, {"role": "user", "content": f"summary-{turn}"})
+                key = SESSION_KEY if turn == 1 else next_key
+                adapter._pending_messages[key] = MessageEvent(
+                    text=f"queued-{turn}", source=source, message_type=MessageType.TEXT,
+                    message_id=f"queued-id-{turn}",
+                )
+            return {
+                "final_response": f"turn-{turn}-done", "session_id": self.session_id,
+                "interrupted": interrupted and turn < 3, "messages": messages, "api_calls": 1,
+            }
+
+    _install_compression_failure_agent(monkeypatch, BurstAgent)
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(
+        side_effect=lambda **kw: kw["event"].text,
+    )
+    runner._refresh_agent_cache_message_count = AsyncMock()
+    runner._deliver_queued_first_response = AsyncMock()
+    original_run_agent = runner._run_agent
+
+    async def record_turn(*args, **kwargs):
+        run_ids.append(kwargs["session_id"])
+        return await original_run_agent(*args, **kwargs)
+
+    runner._run_agent = record_turn
+    result = _run_compression_failure_turn(runner, source)
+    expected = ["session-before-compression", "compression-child-1", "compression-child-2"] if rotates else ["session-before-compression"] * 3
+    assert run_ids == expected
+    assert agent_ids == expected
+    assert result["session_id"] == expected[-1]
+    assert result["final_response"] == "turn-3-done"
+    assert not adapter._pending_messages
+    assert runner._deliver_queued_first_response.await_count == (0 if interrupted else 2)
+    assert [call.args for call in runner._refresh_agent_cache_message_count.await_args_list] == [
+        (next_key, session_id) for session_id in expected[1:]
+    ]
+    assert [call.kwargs["session_key"] for call in runner._prepare_profile_scoped_inbound_message_text.await_args_list] == [next_key, next_key]
+    if rotates:
+        assert runner._prepare_profile_scoped_inbound_message_text.await_args_list[1].kwargs["history"][0]["content"] == "summary-2"
+
+
+@pytest.mark.parametrize("active", [False, True])
+def test_queued_goal_checks_compression_child_before_preprocessing(active):
+    runner = _runner(_SessionStore())
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="user-1")
+    ctx = TurnContext(source=source, session_id="closed-parent", session_key=SESSION_KEY, history=[])
+    pending = MessageEvent(text="continue goal", source=source)
+    response = {"session_id": "compression-child", "messages": [], "interrupted": True}
+    runner._is_goal_continuation_event = lambda event: True
+    runner._goal_still_active_for_session = MagicMock(side_effect=lambda sid: active and sid == response["session_id"])
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(return_value=pending.text)
+    runner._refresh_agent_cache_message_count = AsyncMock()
+    runner._run_agent = AsyncMock(return_value={"final_response": "continued", "session_id": response["session_id"]})
+
+    result = asyncio.run(runner._run_agent_queued_followup(
+        ctx, runner.adapters[Platform.TELEGRAM], pending.text, pending, response, response, None,
+    ))
+
+    runner._goal_still_active_for_session.assert_called_once_with(response["session_id"])
+    if active:
+        assert result["final_response"] == "continued"
+        assert runner._run_agent.await_args.kwargs["session_id"] == response["session_id"]
+        runner._prepare_profile_scoped_inbound_message_text.assert_awaited_once()
+    else:
+        assert result is response
+        runner._prepare_profile_scoped_inbound_message_text.assert_not_awaited()
+        runner._refresh_agent_cache_message_count.assert_not_awaited()
+        runner._run_agent.assert_not_awaited()


### PR DESCRIPTION
## What does this PR do?

Route an immediately queued follow-up through the session returned by the completed turn. After compression rotates `parent → child`, the follow-up currently re-enters the closed parent for execution, goal checks and cache re-baselining. A burst can repeat that stale-parent handoff.

## Related Issue

Related #56391. Supplements merged #56416 and preserves the narrow replacement for closed #56442. The earlier compression-lock demotion remains intact.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- `gateway/run_turn.py`: use the returned compression child for goal checks, cache re-baselining and recursive execution. Keep `next_session_key` for queued media preprocessing and cache lookup.
- `tests/gateway/test_compression_failure_session_sync.py`: exercise real three-turn recursion with normal and interrupted queue drains, successive compression children, unchanged sessions, and active/stale goal continuations. Use the live profile-scoped preprocessing and topic-binding seams.

## How to Test

Integrated on main `6b2d4faf36f107c364048e2fe17eaa02154e9ea9`. The final regressions fail on that unchanged main: **4 failed, 4 passed**, with recursive execution and goal checks receiving the parent. After the fix:

```bash
scripts/run_tests.sh tests/gateway/test_compression_failure_session_sync.py tests/gateway/test_compression_concurrent_sessions.py tests/agent/test_compression_concurrent_fork.py tests/gateway/test_busy_session_ack.py tests/gateway/test_compression_interrupt_demotion_56391.py -j 4 -q
scripts/run_tests.sh tests/gateway/test_queued_native_image_session_key.py tests/gateway/test_session_id_cache_coherence.py -j 2 -q
```

**78 distinct tests passed** across seven files on Linux, using the existing interpreter through `HERMES_PYTHON`. Ruff and `git diff --check` pass.

## Checklist

- [x] Read the contributing guide and checked related open/closed PRs.
- [x] One focused fix with regression tests; tested on Linux.
- [x] Considered cross-platform behavior.
- [x] Documentation, configuration, tool schemas and new skills: N/A.

## Not checked

- Full repository suite, native Windows/macOS, and a live messaging deployment with model compression.
- CodeRabbit: skipped for this self-authored P2 PR.

## Attribution

[Teknium's preprocessing review](https://github.com/NousResearch/hermes-agent/pull/57895#discussion_r3588766384) and [Michael Beetz's normal/interrupted production confirmation](https://github.com/NousResearch/hermes-agent/pull/57895#issuecomment-5200909032) informed the regression coverage. Both are commit co-authors.

## Automation disclosure

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.
