### PR TITLE
fix: cron sessions now properly inherit MCP tools from platform config (#57861)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -191,7 +191,8 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
-        return sorted(_get_platform_tools(cfg or {}, "cron"))
+        base_toolsets = _get_platform_tools(cfg or {}, "cron")
+        return _merge_mcp_into_per_job_toolsets(list(base_toolsets), cfg or {})
     except Exception as exc:
         logger.warning(
             "Cron toolset resolution failed, falling back to full default toolset: %s",


### PR DESCRIPTION
Fixes #57861

## Description
Cron-triggered sessions were not inheriting MCP server tools from the platform config. The `_resolve_cron_enabled_toolsets` function in `cron/scheduler.py` called `_get_platform_tools` for the `cron` platform but returned the result directly without passing it through `_merge_mcp_into_per_job_toolsets`. This meant MCP tools were only attached when a job had explicit per-job `enabled_toolsets` set, but not when falling through to the platform-level toolset resolution.

## Fix
In `cron/scheduler.py:_resolve_cron_enabled_toolsets`, the platform-level toolset path now passes its result through `_merge_mcp_into_per_job_toolsets` — the same function already used for the per-job path — so MCP tools are layered onto the resolved platform toolset regardless of which precedence path is taken.

## Verification
- Quality gates passed (no secrets, no personal refs, conventional commit, focused diff)
- Only `cron/scheduler.py` changed (2 lines)
- The fix mirrors the exact pattern already used on the per-job path