### PR TITLE
Fix systemd timeout check for missing user unit

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -367,15 +367,29 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl", *flag, "show", unit_name,
+                    "--property=LoadState",
+                    "--property=TimeoutStopUSec",
+                ],
                 capture_output=True, text=True, timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
             continue
+
+        lines = result.stdout.splitlines()
+        load_state = None
+        for line in lines:
+            if line.startswith("LoadState="):
+                load_state = line.split("=", 1)[1].strip()
+                break
+        if load_state in {"not-found", "masked", "error"}:
+            continue
+
         # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
-        for line in result.stdout.splitlines():
+        for line in lines:
             if line.startswith("TimeoutStopUSec="):
                 value = line.split("=", 1)[1].strip()
                 # Try numeric microseconds first

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import builtins
+import io
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -248,3 +251,30 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_skips_missing_user_unit_before_system_unit(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/self/cgroup":
+                return io.StringIO("0::/system.slice/hermes-gateway.service\n")
+            return real_open(path, *args, **kwargs)
+
+        def fake_run(args, **kwargs):
+            if "--user" in args:
+                stdout = "LoadState=not-found\nTimeoutStopUSec=1min 30s\n"
+            else:
+                stdout = "LoadState=loaded\nTimeoutStopUSec=4min\n"
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["unit"] == "hermes-gateway.service"
+        assert result["timeout_stop_sec"] == 240.0
+        assert result["mismatch"] is False


### PR DESCRIPTION
## Summary
- query `LoadState` together with `TimeoutStopUSec` in `check_systemd_timing_alignment()`
- skip user-scope systemd results whose unit is `not-found`, `masked`, or `error` before falling back to the system unit
- add regression coverage for a system service where `systemctl --user show hermes-gateway` returns `LoadState=not-found` plus the user-manager default timeout

## Why
On a system-level Hermes gateway deployment, the current check tries `systemctl --user show hermes-gateway --property=TimeoutStopUSec` first. On Ubuntu/systemd, that can return success for a missing user-scope unit with `LoadState=not-found` and the manager default `TimeoutStopUSec=1min 30s`. Hermes then logs a false stale-unit warning even when the real system service has an aligned timeout.

Observed on a live `v0.18.0` system-service gateway:
- user-scope query: `LoadState=not-found`, `TimeoutStopUSec=1min 30s`
- system query: effective timeout >= drain timeout + headroom
- warning before this patch: `Stale systemd unit detected: hermes-gateway.service has TimeoutStopSec=90s...`

Fixes #36755.

## Test
- `pytest tests/gateway/test_shutdown_forensics.py -q`
