### PR TITLE
fix(agent): stop dropping image-only user messages in Anthropic conversion

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2128,13 +2128,26 @@ def _convert_user_message(content: Any) -> Dict[str, Any]:
     """Validate and convert a user message to anthropic format."""
     if isinstance(content, list):
         converted_blocks = _convert_content_to_anthropic(content)
-        if not converted_blocks or all(
-            (b.get("text") or "").strip() == ""
+        # Drop blank text blocks (Anthropic rejects whitespace-only text
+        # blocks with HTTP 400). Fall back to the placeholder ONLY when nothing
+        # else survives. The previous guard replaced the WHOLE list with the
+        # placeholder whenever no non-blank text block existed, so an
+        # image-only user turn (a valid OpenAI request shape the API server
+        # accepts, see _content_has_visible_payload) had its image silently
+        # dropped: `all(... for b in blocks if b is a text block)` is vacuously
+        # True when the only blocks are images.
+        kept_blocks = [
+            b
             for b in converted_blocks
-            if isinstance(b, dict) and b.get("type") == "text"
-        ):
-            converted_blocks = [{"type": "text", "text": "(empty message)"}]
-        return {"role": "user", "content": converted_blocks}
+            if not (
+                isinstance(b, dict)
+                and b.get("type") == "text"
+                and (b.get("text") or "").strip() == ""
+            )
+        ]
+        if not kept_blocks:
+            kept_blocks = [{"type": "text", "text": "(empty message)"}]
+        return {"role": "user", "content": kept_blocks}
     else:
         if not content or (isinstance(content, str) and not content.strip()):
             content = "(empty message)"

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1466,6 +1466,53 @@ class TestConvertMessages:
             for b in nxt["content"]
         )
 
+    def test_image_only_user_message_preserves_image(self):
+        """An image-only user turn (no text part) must keep its image block.
+
+        A user message whose content is just an image — the standard OpenAI
+        multimodal shape for "sent an image with no caption", which the API
+        server accepts (``_content_has_visible_payload`` treats an image as a
+        visible payload) — used to be replaced wholesale with the
+        ``(empty message)`` placeholder, silently dropping the image before it
+        reached Claude. Regression for that data loss.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,ZmFrZQ=="}},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        blocks = result[0]["content"]
+        assert isinstance(blocks, list)
+        image_blocks = [b for b in blocks if b.get("type") == "image"]
+        assert len(image_blocks) == 1, f"image block was dropped: {blocks}"
+        assert not any(
+            b.get("type") == "text" and b.get("text") == "(empty message)"
+            for b in blocks
+        )
+
+    def test_blank_text_plus_image_keeps_image_drops_blank_text(self):
+        """A blank caption alongside an image keeps the image and drops the
+        empty text block (Anthropic rejects whitespace-only text blocks)."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "   "},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,ZmFrZQ=="}},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        blocks = result[0]["content"]
+        assert [b for b in blocks if b.get("type") == "image"], f"image dropped: {blocks}"
+        assert not any(
+            b.get("type") == "text" and b.get("text", "").strip() == ""
+            for b in blocks
+        ), f"empty text block leaked (Anthropic rejects it): {blocks}"
 
 # ---------------------------------------------------------------------------
 # Build kwargs


### PR DESCRIPTION
## What does this PR do?

Fixes an image-only user message being silently dropped during Anthropic conversion.

`agent/anthropic_adapter.py::_convert_user_message` replaced a user message's entire content list with the `(empty message)` placeholder whenever no non-blank **text** block existed:

```python
all(b.get("text", "").strip() == ""
    for b in converted_blocks
    if isinstance(b, dict) and b.get("type") == "text")
```

When the only blocks are images, the filtered generator is empty and `all([])` is vacuously `True`, so the guard fires and discards the image. An image-only user turn is the standard OpenAI multimodal shape (image sent with no caption), and the OpenAI-compatible API server **accepts** it — `gateway/platforms/api_server.py::_content_has_visible_payload` treats an image as a visible payload — so the image passes ingress only to be dropped at the conversion boundary (`agent/transports/anthropic.py` → `convert_messages_to_anthropic`). The server accepts the image; the converter throws it away and sends Claude `(empty message)`.

**Fix:** filter out blank text blocks (Anthropic rejects whitespace-only text blocks with HTTP 400) and fall back to the placeholder only when nothing survives. This preserves image-only and blank-caption+image turns while keeping the existing placeholder behavior for genuinely empty messages.

## Related Issue

Fixes #57906

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` — `_convert_user_message`: replace the vacuous-`all()` guard with a blank-text-block filter; placeholder is used only when no block survives.
- `tests/agent/test_anthropic_adapter.py` — add `test_image_only_user_message_preserves_image` and `test_blank_text_plus_image_keeps_image_drops_blank_text`. Both fail on `main`, pass with the fix. Existing `test_empty_user_message_list_gets_placeholder` and `test_user_message_with_empty_text_blocks_gets_placeholder` remain green.

## How to Test

1. Reproduce on `main`:
   ```python
   from agent.anthropic_adapter import convert_messages_to_anthropic
   msgs = [{"role": "user", "content": [
       {"type": "image_url", "image_url": {"url": "data:image/png;base64,ZmFrZQ=="}}]}]
   _, result = convert_messages_to_anthropic(msgs)
   print(result[0]["content"])   # -> [{'type': 'text', 'text': '(empty message)'}]  (image gone)
   ```
2. On this branch the image block is preserved.
3. `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py -q -k "image or placeholder or convert_user or empty_user"` → all pass.
4. Regression proof: revert only `agent/anthropic_adapter.py`, keep the tests → the two new tests fail.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (searched `_convert_user_message`, `convert_table`-adjacent terms, "image dropped anthropic", "empty message image" — no PR/issue touches this guard)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the tests (targeted file passes apart from pre-existing, unrelated `TestRunOauthSetupToken` env-var failures present on clean `main`)
- [x] I've added tests for my changes (two, both fail without the fix)
- [x] I've tested on my platform: macOS (Darwin 25.5.0), Python 3.12

### Documentation & Housekeeping

- [x] Docstrings/comments updated to explain the guard's invariant
- [x] `cli-config.yaml.example` / `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — pure Python data transformation, no OS-specific code; `scripts/check-windows-footguns.py` clean
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
# regression proof — fix reverted, tests kept:
$ scripts/run_tests.sh tests/agent/test_anthropic_adapter.py -q -k "image_only or blank_text_plus_image"
FAILED ...::test_image_only_user_message_preserves_image
FAILED ...::test_blank_text_plus_image_keeps_image_drops_blank_text
2 failed, 173 deselected

# with the fix:
$ scripts/run_tests.sh tests/agent/test_anthropic_adapter.py -q -k "image or placeholder or convert_user or empty_user"
=== Summary: 11 tests passed, 0 failed ===
```
