### PR TITLE
fix(gateway): mark auth failures as failed runs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4123,11 +4123,16 @@ class TurnRunner:
                 model, runtime_kwargs.get("provider"), ctx.session_key or "",
             )
         except Exception as exc:
+            error = f"Provider authentication failed: {str(exc)[:300]}"
             return {
-                "final_response": f"⚠️ Provider authentication failed: {exc}",
+                "final_response": f"⚠️ {error}",
                 "messages": [],
                 "api_calls": 0,
                 "tools": [],
+                "failed": True,
+                "completed": False,
+                "error": error,
+                "agent_persisted": False,
             }
 
         pr = self._runner._provider_routing
@@ -22763,6 +22768,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "messages": [],
                 "api_calls": 0,
                 "tools": [],
+                "failed": True,
+                "completed": False,
+                "agent_persisted": False,
             }
 
         proxy_url = self._get_proxy_url()
@@ -22772,6 +22780,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "messages": [],
                 "api_calls": 0,
                 "tools": [],
+                "failed": True,
+                "completed": False,
+                "agent_persisted": False,
             }
 
         proxy_key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
@@ -22898,6 +22909,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "messages": [],
                             "api_calls": 0,
                             "tools": [],
+                            "failed": True,
+                            "completed": False,
+                            "agent_persisted": False,
                         }
 
                     # Parse SSE stream
@@ -22958,6 +22972,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "messages": [],
                     "api_calls": 0,
                     "tools": [],
+                    "failed": True,
+                    "completed": False,
+                    "agent_persisted": False,
                 }
             # Partial response — return what we got
         finally:

--- a/tests/gateway/test_run_error_result_contract.py
+++ b/tests/gateway/test_run_error_result_contract.py
@@ -1,0 +1,66 @@
+"""Gateway error returns must be marked failed, not delivered as answers (#57899).
+
+Consumers gate on ``result.get("failed")`` — see ``cli.py`` and
+``run_agent.py`` — so an error dict without the flag is treated as a
+successful turn whose answer happens to be an error message. That makes
+provider/proxy failures non-retryable and persists them as real replies.
+"""
+
+from __future__ import annotations
+
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.gateway.test_run_cleanup_progress import CleanupCaptureAdapter, _make_runner
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+async def _call_proxy(runner):
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    return await runner._run_agent_via_proxy(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:telegram:group:-1001",
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_proxy_url_is_a_failed_result(monkeypatch):
+    runner = _make_runner(CleanupCaptureAdapter())
+    monkeypatch.setattr(runner, "_get_proxy_url", lambda: "", raising=False)
+
+    result = await _call_proxy(runner)
+
+    assert "Proxy URL not configured" in result["final_response"]
+    assert result.get("failed") is True, (
+        "error return lacks failed=True; consumers would treat it as a real answer"
+    )
+    assert result.get("completed") is False
+    assert result.get("agent_persisted") is False
+
+
+@pytest.mark.asyncio
+async def test_missing_aiohttp_is_a_failed_result(monkeypatch):
+    import builtins
+
+    runner = _make_runner(CleanupCaptureAdapter())
+    real_import = builtins.__import__
+
+    def _no_aiohttp(name, *args, **kwargs):
+        if name == "aiohttp":
+            raise ImportError("no aiohttp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_aiohttp)
+
+    result = await _call_proxy(runner)
+
+    assert "aiohttp" in result["final_response"]
+    assert result.get("failed") is True
+    assert result.get("completed") is False


### PR DESCRIPTION
## What does this PR do?

**Re-ported onto current `main`.** The original branch predated a large refactor of `gateway/run.py` (the agent-run path moved behind a `TurnRunner` / `self._runner` boundary), so a plain rebase would have applied the change into unrelated code. This version applies the same fix at the five error sites where they now live.

Five error paths in `gateway/run.py` return a result dict containing only `final_response`, `messages`, `api_calls`, and `tools`. Consumers gate on `result.get("failed")` — `cli.py:13890`, `cli.py:13931`, `run_agent.py:7119`, and `batch_runner.py:758` all do — so an error dict without the flag reads as a **successful turn whose answer happens to be an error string**. The failure is delivered to the user and persisted as a real reply, instead of being treated as a retryable failed run.

`"failed": True` appears exactly once in `gateway/run.py` on current `main`, so these paths are genuinely uncovered.

The five sites:

- provider auth resolution failure (`TurnRunner`)
- proxy mode requires aiohttp
- proxy URL not configured
- proxy error response (`resp.status`)
- proxy connection error

## Related Issue

Fixes #57899

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/run.py` — add the `failed` / `completed` / `agent_persisted` result contract to the five error returns. The auth site additionally carries a bounded `error` string, because its exception detail is otherwise truncated into the user-facing message; the proxy sites already carry their full text in `final_response`.
- `tests/gateway/test_run_error_result_contract.py` — regression tests driving the real `_run_agent_via_proxy` path.

Production diff is +18/−1.

## How to Test

On unmodified `main` both tests fail for the right reason — the key is simply absent:

```
>       assert result.get("failed") is True
E       AssertionError: assert None is True
E        +  where None = <built-in method get of dict object at 0x10ae55380>('failed')
FAILED tests/gateway/test_run_error_result_contract.py::test_missing_proxy_url_is_a_failed_result
FAILED tests/gateway/test_run_error_result_contract.py::test_missing_aiohttp_is_a_failed_result
============================== 2 failed in 0.27s ===============================
```

With the fix:

```
scripts/run_tests.sh tests/gateway/test_run_error_result_contract.py
=== Summary: 1 files, 2 tests passed, 0 failed (100% complete) in 0.6s (16 workers) ===
```

Full gateway suite:

```
scripts/run_tests.sh tests/gateway/
=== Summary: 571 files, 4447 tests passed, 9 failed (100% complete) in 124.2s (16 workers) ===
```

Those 9 failures are **identical on unmodified `main`** — same nine tests, exact set match (SSRF/DNS-rebind connect-time guards, systemd abstract sockets, wecom callbacks, shutdown-forensics subprocess). None are introduced here. ruff is clean.

Honest limits: the tests cover two of the five sites — the two reachable without standing up a live proxy. The other three return the identical dict shape at the same boundary; they are covered by inspection, not execution.

## Note on the overlapping #57975

#57975 adds `"failed": True` to the provider-auth response only, as a one-line change. This PR covers that site plus the four proxy returns and adds the `completed` / `agent_persisted` keys the same consumers read. Both target #57899 — a maintainer should pick whichever scope fits; I have no objection to the minimal one landing first, in which case this can be cut down to the remaining sites plus tests on top.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — see the note on #57975 above
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass (pre-existing environment failures documented above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, internal result contract
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — dict keys only, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Included inline under **How to Test** above.
