### PR TITLE
feat(desktop): Add repeat count and enabled toggle to cron job editor dialog

### DIFF
--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -714,6 +714,8 @@ function CronEditorDialog({
   const [schedule, setSchedule] = useState('')
   const [schedulePreset, setSchedulePreset] = useState('daily')
   const [deliver, setDeliver] = useState(DEFAULT_DELIVER)
+  const [enabled, setEnabled] = useState(true)
+  const [repeat, setRepeat] = useState<number | undefined>()
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
 
@@ -727,6 +729,8 @@ function CronEditorDialog({
     setSchedule(initial ? jobScheduleExpr(initial) : (SCHEDULE_OPTIONS[0].expr ?? ''))
     setSchedulePreset(initial ? scheduleOptionForExpr(jobScheduleExpr(initial)).value : 'daily')
     setDeliver(initial ? jobDeliver(initial) : DEFAULT_DELIVER)
+    setEnabled(initial ? (initial.enabled ?? true) : true)
+    setRepeat(initial.repeat)
     setError(null)
     setSaving(false)
   }, [initial, open])
@@ -766,9 +770,11 @@ function CronEditorDialog({
     try {
       await onSave({
         deliver,
+        enabled,
         name: name.trim(),
         prompt: trimmedPrompt,
-        schedule: trimmedSchedule
+        schedule: trimmedSchedule,
+        repeat: repeat || undefined
       })
     } catch (err) {
       setError(err instanceof Error ? err.message : c.failedSave)
@@ -858,6 +864,35 @@ function CronEditorDialog({
             </div>
           )}
 
+          <div className="grid items-start gap-4 sm:grid-cols-2">
+            <Field htmlFor="cron-repeat" label={c.repeatLabel} optional optionalLabel={c.optional}>
+              <Input
+                id="cron-repeat"
+                min={1}
+                onChange={event => {
+                  const val = event.target.value
+                  setRepeat(val ? parseInt(val, 10) : undefined)
+                }}
+                placeholder={c.repeatPlaceholder}
+                type="number"
+                value={repeat ?? ''}
+              />
+            </Field>
+
+            <div className="flex items-center gap-2 pt-6">
+              <input
+                checked={enabled}
+                className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+                id="cron-enabled"
+                onChange={event => setEnabled(event.target.checked)}
+                type="checkbox"
+              />
+              <label className="text-xs font-medium text-foreground" htmlFor="cron-enabled">
+                {c.enabledLabel}
+              </label>
+            </div>
+          </div>
+
           {error && (
             <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
               <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
@@ -911,9 +946,11 @@ type EditorState = { mode: 'closed' } | { mode: 'create' } | { job: CronJob; mod
 
 interface EditorValues {
   deliver: string
+  enabled: boolean
   name: string
   prompt: string
   schedule: string
+  repeat?: number
 }
 
 interface ScheduleOption {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -573,6 +573,12 @@ export interface CronJobUpdates {
   name?: string
   prompt?: string
   schedule?: string
+  repeat?: number
+  skills?: string[]
+  model?: string
+  provider?: string
+  script?: string
+  context_from?: string[]
 }
 
 export interface ProfileCreatePayload {


### PR DESCRIPTION
## What's Changed

This PR adds the missing `repeat` and `enabled` fields to the Hermes Desktop app's cron job editor dialog, bringing the UI parity with the CLI (`hermes cron edit`) which already supports these fields.

### Changes

#### 1. `apps/desktop/src/types/hermes.ts`
Extended `CronJobUpdates` interface to include:
- `repeat?: number` — max execution count
- `skills?: string[]` — attached skills
- `model?: string` — per-job model override
- `provider?: string` — per-job provider override
- `script?: string` — script path for no_agent jobs
- `context_from?: string[]` — chaining upstream job outputs

#### 2. `apps/desktop/src/app/cron/index.tsx`
- Added `repeat` (number input) and `enabled` (checkbox) state variables to `CronEditorDialog`
- Added corresponding UI fields in the editor form
- Updated `EditorValues` interface to include `enabled` and `repeat`
- Initialized state from existing job data when editing
- Included new fields in the submit payload sent to `updateCronJob`

### Problem Solved

Previously, when a cron job reached its `repeat` limit (e.g. `1/10` completed), users had no way to renew it through the desktop UI. They had to either use the CLI or ask an agent to update it. This created a poor UX where the desktop UI felt incomplete compared to the CLI.

### Screenshots

N/A — adds two new form fields to the existing cron editor dialog.

## Related Issue

Fixes the limitation described in the feature request for desktop cron editor parity with CLI.
