### PR TITLE
feat: add text-only media replay for background review

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from agent.thread_scoped_output import thread_scoped_silence
@@ -151,6 +152,96 @@ def _digest_history(messages_snapshot: List[Dict], tail: int = 24) -> List[Dict]
         ),
     }
     return [digest] + keep
+
+
+_IMAGE_PART_TYPES = {"image", "image_url", "input_image"}
+_BACKGROUND_REVIEW_IMAGE_OMITTED = (
+    "[Image omitted from background review. Use the surrounding tool text "
+    "and the assistant's vision interpretation already present in the "
+    "conversation instead of re-processing media.]"
+)
+
+
+def _background_review_media_replay_mode() -> str:
+    """Return the configured media replay mode for background review.
+
+    ``full`` preserves the historical behavior: the review fork receives the
+    same multimodal message parts as the foreground transcript. ``text_only``
+    omits media parts from the review snapshot while preserving text that was
+    already present in the transcript. This avoids re-running expensive vision
+    encoders for local multimodal models while keeping the change opt-in.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+        task = aux.get("background_review", {}) if isinstance(aux.get("background_review"), dict) else {}
+        value = str(task.get("media_replay", "full") or "full").strip().lower()
+    except Exception:
+        return "full"
+    aliases = {
+        "full": "full",
+        "text_only": "text_only",
+        "text-only": "text_only",
+    }
+    return aliases.get(value, "full")
+
+
+def _background_review_strip_media_parts(messages_snapshot: List[Dict]) -> List[Dict]:
+    """Return a background-review-safe copy with media parts omitted.
+
+    The foreground conversation keeps the full multimodal transcript. This
+    helper only transforms the review fork's private snapshot, so it does not
+    affect user-visible history. Text that was already in the transcript remains
+    verbatim; image parts are removed and annotated with an explanatory text
+    marker. Existing assistant replies after ``vision_analyze`` /
+    ``computer_use`` captures remain in the transcript, so the review can use
+    that prior visual interpretation without forcing the provider to process the
+    pixels again. This helper does not create new image descriptions or match
+    images to prior captions.
+    """
+    cleaned: List[Dict] = []
+    for msg in messages_snapshot or []:
+        if not isinstance(msg, dict):
+            cleaned.append(msg)
+            continue
+        new_msg = dict(msg)
+        content = msg.get("content")
+        if isinstance(content, list):
+            new_parts: List[Any] = []
+            omitted = 0
+            for part in content:
+                if isinstance(part, dict) and part.get("type") in _IMAGE_PART_TYPES:
+                    omitted += 1
+                    continue
+                new_parts.append(deepcopy(part))
+            if omitted:
+                new_parts.append({"type": "text", "text": _BACKGROUND_REVIEW_IMAGE_OMITTED})
+            new_msg["content"] = new_parts
+        elif isinstance(content, dict) and content.get("_multimodal") is True:
+            parts = content.get("content") or []
+            has_media = any(
+                isinstance(part, dict) and part.get("type") in _IMAGE_PART_TYPES
+                for part in parts
+            )
+            if not has_media:
+                new_msg["content"] = deepcopy(content)
+                cleaned.append(new_msg)
+                continue
+            # Tool-result multimodal envelopes already carry a plain-text view
+            # for providers that cannot accept image parts. Reuse that canonical
+            # existing text for the review fork instead of preserving an
+            # envelope that still contains media.
+            try:
+                from agent.tool_dispatch_helpers import _multimodal_text_summary
+
+                summary = _multimodal_text_summary(content)
+            except Exception:
+                summary = str(content.get("text_summary") or "[multimodal tool result]")
+            new_msg["content"] = f"{summary}\n{_BACKGROUND_REVIEW_IMAGE_OMITTED}"
+        cleaned.append(new_msg)
+    return cleaned
 
 
 # Review-prompt strings — used by ``spawn_background_review_thread`` to build
@@ -777,11 +868,15 @@ def _run_review_in_thread(
             try:
                 # Routed to a different model -> replay a digest (cache is cold
                 # on that model anyway, so minimise cold-written tokens). Same
-                # model -> replay the full snapshot (warm cache reads).
+                # model -> replay the full snapshot (warm cache reads), unless
+                # the user opts into text-only media replay to avoid expensive
+                # vision re-encoding on local multimodal models.
                 _review_history = (
                     _digest_history(messages_snapshot) if _routed
                     else messages_snapshot
                 )
+                if _background_review_media_replay_mode() == "text_only":
+                    _review_history = _background_review_strip_media_parts(_review_history)
                 review_agent.run_conversation(
                     user_message=(
                         prompt
@@ -904,4 +999,6 @@ __all__ = [
     "spawn_background_review_thread",
     "summarize_background_review_actions",
     "build_memory_write_metadata",
+    "_background_review_media_replay_mode",
+    "_background_review_strip_media_parts",
 ]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1632,6 +1632,11 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            # full (default): replay multimodal content unchanged. text_only:
+            # replace image/media parts in the review fork with text markers,
+            # relying on surrounding assistant vision interpretations already
+            # in the conversation. Useful for slow local multimodal models.
+            "media_replay": "full",
             "timeout": 120,
             "extra_body": {},
         },

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -473,3 +473,52 @@ def test_skill_patch_off_silent_verbose_shows_diff():
     )
     assert len(verbose) == 1
     assert "demo" in verbose[0] and "→" in verbose[0]
+
+
+def test_background_review_text_only_media_replay_strips_images_before_run(monkeypatch):
+    """media_replay=text_only transforms only the fork's private history."""
+    captured: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            captured["conversation_history"] = kwargs["conversation_history"]
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    messages_snapshot = [
+        {
+            "role": "tool",
+            "content": [
+                {"type": "text", "text": "Image loaded into your context."},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "tool_call_id": "call_img",
+        },
+        {"role": "assistant", "content": "The image shows Excel with B2 selected."},
+    ]
+    cfg = {"auxiliary": {"background_review": {"media_replay": "text_only"}}}
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+    agent = _bare_agent()
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=messages_snapshot,
+        review_skills=True,
+    )
+
+    history = captured["conversation_history"]
+    assert history is not messages_snapshot
+    assert messages_snapshot[0]["content"][1]["type"] == "image_url"
+    assert all(part.get("type") != "image_url" for part in history[0]["content"])
+    assert "Image omitted from background review" in history[0]["content"][-1]["text"]
+    assert history[1]["content"] == "The image shows Excel with B2 selected."

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -136,3 +136,87 @@ def test_digest_records_tool_names_in_arc():
     digest = out[0]["content"]
     assert "USER: do the thing" in digest
     assert "tools: skill_view, patch" in digest
+
+
+# ---------------------------------------------------------------------------
+# media_replay=text_only — strip media from background-review private snapshot
+# ---------------------------------------------------------------------------
+
+def test_background_review_media_replay_defaults_to_full():
+    with patch("hermes_cli.config.load_config", return_value={}):
+        assert br._background_review_media_replay_mode() == "full"
+
+
+def test_background_review_media_replay_accepts_documented_text_only_alias():
+    cfg = {"auxiliary": {"background_review": {"media_replay": "text-only"}}}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        assert br._background_review_media_replay_mode() == "text_only"
+
+
+def test_background_review_media_replay_unknown_values_fall_back_to_full():
+    cfg = {"auxiliary": {"background_review": {"media_replay": "strip-images"}}}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        assert br._background_review_media_replay_mode() == "full"
+
+
+def test_strip_media_parts_preserves_text_and_omits_images_without_mutating_input():
+    original = [
+        {
+            "role": "tool",
+            "content": [
+                {"type": "text", "text": "Image loaded. Question: what is visible?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+        },
+        {"role": "assistant", "content": "The screenshot shows Excel with B2 selected."},
+    ]
+
+    out = br._background_review_strip_media_parts(original)
+
+    assert out is not original
+    assert original[0]["content"][1]["type"] == "image_url"  # input untouched
+    assert out[0]["content"][0] == {"type": "text", "text": "Image loaded. Question: what is visible?"}
+    assert all(part.get("type") != "image_url" for part in out[0]["content"])
+    assert "Image omitted from background review" in out[0]["content"][-1]["text"]
+    assert out[1] == original[1]
+
+
+def test_strip_media_parts_handles_multimodal_envelopes():
+    original = [{
+        "role": "tool",
+        "content": {
+            "_multimodal": True,
+            "text_summary": "capture mode=vision 100x100",
+            "content": [
+                {"type": "text", "text": "capture mode=vision 100x100"},
+                {"type": "input_image", "image_url": {"url": "data:image/png;base64,BBBB"}},
+            ],
+        },
+    }]
+
+    out = br._background_review_strip_media_parts(original)
+    content = out[0]["content"]
+
+    assert isinstance(content, str)
+    assert "capture mode=vision" in content
+    assert "data:image" not in content
+    assert "input_image" not in content
+    assert "Image omitted from background review" in content
+
+
+def test_strip_media_parts_leaves_text_only_multimodal_envelopes_unchanged():
+    original = [{
+        "role": "tool",
+        "content": {
+            "_multimodal": True,
+            "text_summary": "plain text capture metadata",
+            "content": [{"type": "text", "text": "plain text capture metadata"}],
+        },
+    }]
+
+    out = br._background_review_strip_media_parts(original)
+
+    assert out == original
+    assert out is not original
+    assert out[0]["content"] is not original[0]["content"]
+    assert "Image omitted" not in str(out[0]["content"])

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1072,6 +1072,15 @@ auxiliary:
     api_key: ""
     timeout: 30
 
+  # Background memory/skill self-improvement review
+  background_review:
+    provider: "auto"           # "auto" = main chat model; set provider+model to route elsewhere
+    model: ""
+    base_url: ""
+    api_key: ""
+    media_replay: "full"       # "full" | "text_only"; text_only omits image parts in the review fork
+    timeout: 120
+
   # Kanban triage specifier — `hermes kanban specify <id>` (or the
   # dashboard's ✨ Specify button on Triage-column cards) uses this
   # slot to expand a one-liner into a concrete spec and promote the

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -295,6 +295,26 @@ identical and skill capture near-identical to the main-model review.
 Leave it at `auto` (or set it to your main model) and nothing changes — the
 review keeps running on the main model with the full warm-cache replay.
 
+### Avoiding repeated image processing in background review
+
+If your main model is a slow local multimodal model, a full-cache replay can
+still be expensive when the conversation contains screenshots or attached
+images. Keep the review on the main model but ask the review fork to omit media
+parts and rely only on text that is already present in the transcript:
+
+```yaml
+auxiliary:
+  background_review:
+    media_replay: text_only   # full (default) | text_only
+```
+
+`text_only` only changes the private background-review snapshot. The foreground
+conversation and persisted session keep their original multimodal content. The
+review snapshot keeps text that was already in the conversation, including tool
+text, multimodal `text_summary` fields, and prior assistant interpretations, but
+removes direct image/media parts and adds an explicit omitted-media marker. It
+does not create new image descriptions or match images to prior captions.
+
 ## Controlling skill writes (`skills.write_approval`)
 
 Skills use the same on/off gate, but the review UX differs because a


### PR DESCRIPTION
## Summary

Adds an opt-in `auxiliary.background_review.media_replay` setting for background memory/skill self-improvement review.

The default remains `full`, preserving existing behavior. A new `text_only` mode prepares only the private background-review conversation snapshot by omitting image/media parts while keeping text that is already present in the transcript.

## Motivation

Background review normally replays the conversation on the main model to benefit from prompt-cache locality. This is cheap for text, but can still be expensive for local multimodal models when the session contains screenshots or attached images: the review fork may trigger repeated image encoding/decoding even though the foreground turn already produced text around the visual content.

This is especially noticeable in computer-use workflows where several screenshots are captured in one session.

## Behavior

```yaml
auxiliary:
  background_review:
    media_replay: full      # default, existing behavior
    # or:
    media_replay: text_only
```

`text_only` mode:

- only transforms the private background-review snapshot;
- does not mutate the foreground conversation;
- does not mutate persisted session history;
- preserves text parts already present in the transcript;
- for multimodal tool-result envelopes that contain media, uses their existing plain-text view instead of passing the media envelope through;
- removes direct image/media parts and adds an explicit omitted-media marker.

It does not create new image descriptions, run another vision pass, or match images to prior captions. If the review needs full visual context, keep the default `media_replay: full` behavior.

## Tests

```bash
python -m pytest \
  tests/run_agent/test_background_review.py \
  tests/run_agent/test_background_review_cache_parity.py \
  tests/run_agent/test_background_review_cost_controls.py \
  tests/run_agent/test_vision_tool_messages.py \
  -q -o 'addopts='
```

Result: `46 passed`

Additional checks:

```bash
git diff --check
python -m py_compile agent/background_review.py hermes_cli/config.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cost_controls.py
python -m ruff check agent/background_review.py hermes_cli/config.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cost_controls.py
```

Result: all passed.
