### PR TITLE
fix(config): respect database.journal_mode from config.yaml

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -23,6 +23,7 @@ import sqlite3
 import sys
 import threading
 import time
+import platform
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -411,6 +412,57 @@ def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
         db_label,
         exc,
     )
+
+
+# ---------------------------------------------------------------------------
+# Config-driven database pragmas
+# ---------------------------------------------------------------------------
+def apply_database_pragmas(
+    conn: sqlite3.Connection,
+    *,
+    db_label: str = "state.db",
+) -> None:
+    """Apply optional database PRAGMAs from ``config.yaml``."""
+    try:
+        # ponytail: local import avoids circular with hermes_cli.config
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+    except Exception:
+        return
+
+    journal_mode = cfg_get(cfg, "database", "journal_mode", default="")
+    if journal_mode:
+        journal_mode = str(journal_mode).strip().upper()
+        if journal_mode:
+            try:
+                current = conn.execute("PRAGMA journal_mode").fetchone()
+                current = current[0].upper() if current and current[0] else ""
+            except sqlite3.OperationalError:
+                current = ""
+
+            if current != journal_mode:
+                if platform.system() == "Windows" and journal_mode != "WAL":
+                    return
+                try:
+                    conn.execute(f"PRAGMA journal_mode={journal_mode}")
+                except sqlite3.OperationalError:
+                    pass
+
+    wal_autocheckpoint = cfg_get(cfg, "database", "wal_autocheckpoint", default="")
+    if wal_autocheckpoint is not None and str(wal_autocheckpoint).strip().isdigit():
+        try:
+            conn.execute(f"PRAGMA wal_autocheckpoint={int(wal_autocheckpoint)}")
+        except sqlite3.OperationalError:
+            pass
+
+    journal_size_limit = cfg_get(cfg, "database", "journal_size_limit", default="")
+    if journal_size_limit is not None and str(journal_size_limit).strip().isdigit():
+        try:
+            conn.execute(f"PRAGMA journal_size_limit={int(journal_size_limit)}")
+        except sqlite3.OperationalError:
+            pass
+
 
 # ---------------------------------------------------------------------------
 # Malformed-schema recovery
@@ -935,6 +987,7 @@ class SessionDB:
                 )
                 self._conn.row_factory = sqlite3.Row
                 apply_wal_with_fallback(self._conn, db_label="state.db")
+                apply_database_pragmas(self._conn, db_label="state.db")
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._init_schema()
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4881,3 +4881,85 @@ def test_refresh_compression_lock_requires_holder_and_preserves_reclaimability(d
 
     monkeypatch.setattr(hermes_state.time, "time", lambda: 1016.0)
     assert db.try_acquire_compression_lock("s1", "holder-b", ttl_seconds=10.0) is True
+
+
+class TestApplyDatabasePragmas:
+    """Config-driven database pragma application."""
+
+    def test_honors_wal_autocheckpoint_from_config(self, tmp_path, monkeypatch):
+        import sqlite3
+        from hermes_state import apply_database_pragmas
+
+        db_path = tmp_path / "pragmas.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            cfg = {
+                "database": {
+                    "journal_mode": "WAL",
+                    "wal_autocheckpoint": 250,
+                }
+            }
+            monkeypatch.setattr(
+                "hermes_cli.config.load_config",
+                lambda: cfg,
+            )
+            monkeypatch.setattr(
+                "hermes_cli.config.cfg_get",
+                lambda c, *keys, default="": (
+                    c.get("database", {}).get(keys[-1], default)
+                ),
+            )
+            apply_database_pragmas(conn, db_label="test.db")
+            val = conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]
+            assert val == 250
+        finally:
+            conn.close()
+
+    def test_honors_journal_size_limit_from_config(self, tmp_path, monkeypatch):
+        import sqlite3
+        from hermes_state import apply_database_pragmas
+
+        db_path = tmp_path / "pragmas.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            cfg = {
+                "database": {
+                    "journal_mode": "WAL",
+                    "journal_size_limit": 10485760,
+                }
+            }
+            monkeypatch.setattr(
+                "hermes_cli.config.load_config",
+                lambda: cfg,
+            )
+            monkeypatch.setattr(
+                "hermes_cli.config.cfg_get",
+                lambda c, *keys, default="": (
+                    c.get("database", {}).get(keys[-1], default)
+                ),
+            )
+            apply_database_pragmas(conn, db_label="test.db")
+            val = conn.execute("PRAGMA journal_size_limit").fetchone()[0]
+            assert val == 10485760
+        finally:
+            conn.close()
+
+    def test_noop_when_database_section_missing(self, tmp_path, monkeypatch):
+        import sqlite3
+        from hermes_state import apply_database_pragmas
+
+        db_path = tmp_path / "pragmas.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("PRAGMA journal_mode=DELETE")
+            monkeypatch.setattr(
+                "hermes_cli.config.load_config",
+                lambda: {},
+            )
+            apply_database_pragmas(conn, db_label="test.db")
+            assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        finally:
+            conn.close()
+


### PR DESCRIPTION
fix(config): respect database.journal_mode from config.yaml

What
- Config-driven database pragmas are now honored in `SessionDB` init
- Users had no working config surface for SQLite tuning on NFS/SMB/custom setups

Fix
- New `apply_database_pragmas()` in `hermes_state.py` reads nested `database:` keys from `config.yaml` via existing `cfg_get`/`load_config`
- Called after `apply_wal_with_fallback()` in `SessionDB._connect_and_init()`
- `journal_mode`, `wal_autocheckpoint`, `journal_size_limit` applied in order
- On non-Windows; Windows keeps DELETE unless config explicitly requests WAL

Runtime Proof
```
$ /opt/homebrew/bin/pytest tests/test_hermes_state.py::TestApplyDatabasePragmas -q
3 passed in 0.72s
```

Regression Checks
- Full `tests/test_hermes_state.py`: 306 passed in 11.32s
- Failed first: SQLite returns `delete` not `DELETE`; updated assertions to use actual probe values

Closes #57820