### PR TITLE
fix(dashboard): don't auto-SSO password-only providers into the OAuth route

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,12 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers (e.g. BasicAuth) have no OAuth redirect flow —
+    # their start_login raises NotImplementedError. Auto-SSO is an OAuth-only
+    # optimization; for a password provider we must fall through to /login so
+    # the password form renders instead of 500ing on /auth/login.
+    if getattr(provider, "supports_password", False):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -406,6 +406,31 @@ class TestAutoSsoRedirect:
         assert r.headers["location"].startswith("/login")
         assert "/auth/login" not in r.headers["location"]
 
+    def test_single_password_provider_renders_login_not_oauth(self, gated_app):
+        """Regression: a single PASSWORD-only provider (e.g. BasicAuth) has no
+        OAuth redirect flow — its start_login raises NotImplementedError. The
+        auto-SSO shortcut must NOT bounce it to /auth/login (which would 500);
+        it must fall through to the /login password form instead."""
+        from hermes_cli.dashboard_auth import clear_providers, register_provider
+
+        class _PasswordStub(StubAuthProvider):
+            name = "basic"
+            display_name = "Username & Password"
+            supports_password = True
+
+            def start_login(self, *, redirect_uri: str):
+                raise NotImplementedError(
+                    "password-only provider has no OAuth redirect flow"
+                )
+
+        clear_providers()
+        register_provider(_PasswordStub())
+        r = gated_app.get("/sessions", follow_redirects=False)
+        assert r.status_code == 302
+        # Falls through to the password form, NOT the OAuth-initiation route.
+        assert r.headers["location"].startswith("/login")
+        assert "/auth/login" not in r.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Gate middleware: same-origin next= validation


### PR DESCRIPTION
## Summary

A dashboard configured with **only** basic (username/password) auth returns **HTTP 500 on every unauthenticated page load** instead of showing the login form.

### Root cause

`_auto_sso_response` in `hermes_cli/dashboard_auth/middleware.py` is an OAuth-only optimization: when exactly one interactive provider is registered, it skips the `/login` chooser and 302-redirects the browser straight to `/auth/login?provider=…`. That route runs the OAuth authorization-code flow via `provider.start_login()`.

A password-only provider (`BasicAuthProvider`, `supports_password = True`) has **no OAuth redirect flow** — its `start_login` raises:

```
NotImplementedError: BasicAuthProvider is password-only; there is no OAuth redirect flow.
The login page POSTs to /auth/password-login instead.
```

So a single-provider BasicAuth dashboard 500s on every unauthenticated document load. It's masked on loopback (already-authenticated sessions), but surfaces immediately when the dashboard is exposed and hit fresh (e.g. bound to a LAN address).

### Fix

Guard the auto-SSO shortcut on the sole provider actually supporting the OAuth redirect. When it's password-based, return `None` so the gate falls through to the `/login` password form. OAuth providers are unaffected.

```python
provider = providers[0]
if getattr(provider, "supports_password", False):
    return None   # password form, not OAuth redirect
```

## Test Plan

- Added `test_single_password_provider_renders_login_not_oauth` to `TestAutoSsoRedirect`: a single password-only provider must 302 to `/login`, never `/auth/login`.
- Verified via `fastapi.testclient.TestClient` against the real app:
  - password-only provider → `302 /login?next=%2Fsessions` ✅ (was 500)
  - OAuth provider (control) → `302 /auth/login?provider=stub&next=%2Fsessions` ✅ (unchanged)
- Existing `TestAutoSsoRedirect` cases (OAuth auto-redirect, loop guard, multi-provider chooser, API-path 401) preserved.

## Notes

Minimal footprint: one guard line in the middleware + one regression test. No new config, no schema change, no impact on the OAuth path.