### PR TITLE
fix(agent): shorten interruptible_*_api_call poll window 0.3s → 0.05s

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -429,6 +429,26 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # if the join returned early because the thread finished.
         time.sleep(0)
         _poll_count += 1
+        # Diagnostic for issue #57903 — measure the maximum wall-clock
+        # gap between consecutive polls. If the gap is much larger than
+        # ``_POLL_INTERVAL`` (default 50ms), the main thread was blocked
+        # somewhere *outside* this loop (e.g. CPU-bound JSON parsing on
+        # a streaming chunk, retry backoff sleep, or another sync call).
+        # Logged via agent._buffer_status so it shows up in the gateway
+        # status stream and the desktop UI.
+        _now = time.monotonic()
+        if "_last_poll_at" in dir():
+            _gap = _now - _last_poll_at
+            if _gap > _POLL_INTERVAL * 10:  # > 500ms gap is suspicious
+                try:
+                    agent._buffer_status(
+                        f"⚠️ interruptible_api_call poll gap: "
+                        f"{_gap * 1000:.0f}ms (expected <{_POLL_INTERVAL * 1000:.0f}ms) "
+                        f"after {_poll_count} polls; main thread was blocked outside the poll loop"
+                    )
+                except Exception:
+                    pass
+        _last_poll_at = _now
 
         # Touch activity every ~30s so the gateway's inactivity
         # monitor knows we're alive while waiting for the response.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1893,8 +1893,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
         t = threading.Thread(target=_bedrock_call, daemon=True)
         t.start()
+        # Same poll-interval reduction as the non-streaming
+        # ``interruptible_api_call`` in this file: 50ms keeps the
+        # worst-case event-loop stall under the 5s-stall watchdog
+        # threshold. See issue #57903 for the diagnosis.
+        _POLL_INTERVAL = _env_float("HERMES_INTERRUPTIBLE_API_POLL_SECONDS", 0.05)
+        if _POLL_INTERVAL <= 0:
+            _POLL_INTERVAL = 0.05
         while t.is_alive():
-            t.join(timeout=0.3)
+            t.join(timeout=_POLL_INTERVAL)
+            time.sleep(0)  # explicit GIL yield
             if agent._interrupt_requested:
                 raise InterruptedError("Agent interrupted during Bedrock API call")
         if result["error"] is not None:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2838,8 +2838,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     t.start()
     _last_heartbeat = time.time()
     _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
+    # Same poll-interval reduction as the non-streaming and Bedrock
+    # interruptible_*_api_call paths in this file. The 50ms window keeps
+    # the worst-case event-loop stall under the 5s-stall watchdog
+    # threshold. The streaming path is the one most often exercised by
+    # long-running LLM calls (large context prefill, reasoning models),
+    # so this is the most impactful of the three siblings. See
+    # issue #57903.
+    _POLL_INTERVAL = _env_float("HERMES_INTERRUPTIBLE_API_POLL_SECONDS", 0.05)
+    if _POLL_INTERVAL <= 0:
+        _POLL_INTERVAL = 0.05
     while t.is_alive():
-        t.join(timeout=0.3)
+        t.join(timeout=_POLL_INTERVAL)
+        time.sleep(0)  # explicit GIL yield
 
         # Periodic heartbeat: touch the agent's activity tracker so the
         # gateway's inactivity monitor knows we're alive while waiting

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -409,13 +409,31 @@ def interruptible_api_call(agent, api_kwargs: dict):
     t = threading.Thread(target=_call, daemon=True)
     t.start()
     _poll_count = 0
+    # The 0.3s poll window is the worst-case stall length on the main
+    # thread.  When ``interruptible_api_call`` runs on the asyncio event
+    # loop thread (the common case — ``run_conversation`` is sync but
+    # is invoked from the loop thread), each 0.3s ``t.join`` blocks the
+    # event loop from advancing, so the 2s heartbeat callback in
+    # ``hermes_cli/web_server.py`` and the desktop WebSocket heartbeats
+    # don't fire on time, tripping the 5s-stall watchdog.  Halving the
+    # window to 0.05s keeps the worst-case stall well under the 5s
+    # threshold and matches the cadence other tools in the agent use.
+    # See issue #57903.
+    _POLL_INTERVAL = _env_float("HERMES_INTERRUPTIBLE_API_POLL_SECONDS", 0.05)
+    if _POLL_INTERVAL <= 0:
+        _POLL_INTERVAL = 0.05
     while t.is_alive():
-        t.join(timeout=0.3)
+        t.join(timeout=_POLL_INTERVAL)
+        # Explicit GIL yield so other Python threads (web_server event
+        # loop in this process, future pool workers) get scheduled even
+        # if the join returned early because the thread finished.
+        time.sleep(0)
         _poll_count += 1
 
         # Touch activity every ~30s so the gateway's inactivity
         # monitor knows we're alive while waiting for the response.
-        if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
+        # Cadence preserved: 600 × 0.05s = 30s (was 100 × 0.3s).
+        if _poll_count % 600 == 0:
             _elapsed = time.time() - _call_start
             agent._touch_activity(
                 f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"

--- a/scripts/bench_interruptible_api_call.py
+++ b/scripts/bench_interruptible_api_call.py
@@ -1,0 +1,198 @@
+"""Benchmark + diagnostic for the interruptible_api_call main-thread busy-poll.
+
+Issue: https://github.com/NousResearch/hermes-agent/issues/57903
+
+The non-streaming ``interruptible_api_call`` in
+``agent/chat_completion_helpers.py`` blocks the main thread in a busy-poll
+loop (``t.join(timeout=0.3)``) while waiting for the LLM API call to
+return. Between joins the asyncio event loop in the same process (uvicorn
++ tui_gateway WebSocket server) cannot service its 2s heartbeat, the
+5s-stall watchdog in ``hermes_cli/web_server.py`` fires, and the desktop
+WebSocket trips its 10s timeout — manifesting as "Gateway offline" /
+"не отвечает" flashes during long-running LLM calls.
+
+This script reproduces the symptom locally and quantifies the
+regression by running a simulated ``_call`` that sleeps for N seconds and
+measuring how many times a parallel "heartbeat" thread gets to tick
+while the busy-poll is in progress.
+
+Usage::
+
+    # Run with the current (broken) code:
+    python scripts/bench_interruptible_api_call.py --seconds 30
+    # → expect ~100 heartbeat ticks (GIL is held for the full 300ms poll)
+
+    # After a fix that replaces t.join(timeout=0.3) with
+    # future.result(timeout=0.05) (or equivalent):
+    # → expect ~600 heartbeat ticks (GIL released every 50ms)
+
+A 5x increase in heartbeat ticks per 30s window is the success criterion.
+If your machine shows less than 3x, the fix is not aggressive enough;
+if it shows ~100 ticks, the busy-poll is still starving the event loop.
+
+The benchmark only uses sync primitives available in the stdlib — no
+asyncio, no fixtures, no model provider, no API keys.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Bootstrap: when invoked directly (not via pytest), add repo root to path.
+import pathlib
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from agent import chat_completion_helpers as cch  # noqa: E402
+
+
+def _make_agent(duration_seconds: float) -> MagicMock:
+    """An agent mock whose SDK call sleeps for ``duration_seconds``.
+
+    The agent's surface is the minimum needed to drive
+    ``interruptible_api_call`` through the non-streaming
+    ``chat_completions`` path. All Codex / Anthropic / Bedrock /
+    MoA branches short-circuit to the default chat_completions path
+    so we can use the simplest mock.
+    """
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    agent._compute_non_stream_stale_timeout.return_value = max(60.0, duration_seconds * 3)
+
+    fake_client = MagicMock()
+
+    def _slow_create(**_kwargs):
+        # Simulate a long-running LLM call that returns a minimal
+        # chat.completions response.
+        time.sleep(duration_seconds)
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message = MagicMock()
+        response.choices[0].message.content = "ok"
+        response.choices[0].message.tool_calls = None
+        response.choices[0].finish_reason = "stop"
+        return response
+
+    fake_client.chat.completions.create.side_effect = _slow_create
+    agent._create_request_openai_client.return_value = fake_client
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
+    return agent
+
+
+def _heartbeat_worker(counter: list, interval: float = 0.1, stop: threading.Event | None = None) -> None:
+    """Tick ``counter[0] += 1`` every ``interval`` seconds.
+
+    Stops when ``stop`` is set, or runs forever if ``stop`` is None.
+    Uses ``time.sleep(interval)`` which releases the GIL on every
+    iteration — this is a *contender* for the GIL, not a privileged
+    scheduler. The number of ticks we accumulate while
+    ``interruptible_api_call`` runs is the proxy for "how much does the
+    main thread's busy-poll block other threads from doing work".
+    """
+    deadline = time.monotonic() + 60 * 60  # upper bound, safety
+    while True:
+        if stop is not None and stop.is_set():
+            return
+        if time.monotonic() > deadline:
+            return
+        counter[0] += 1
+        time.sleep(interval)
+
+
+def run_benchmark(duration_seconds: float) -> dict:
+    """Run the benchmark and return a dict of measurements."""
+    agent = _make_agent(duration_seconds)
+    ticks: list = [0]
+    stop = threading.Event()
+    heartbeat = threading.Thread(
+        target=_heartbeat_worker,
+        args=(ticks, 0.1, stop),
+        daemon=True,
+        name="bench-heartbeat",
+    )
+
+    # Warm up the heartbeat thread so the very first tick doesn't
+    # under-count the contention window.
+    heartbeat.start()
+    time.sleep(0.2)
+
+    # Reset the counter and start the timed window.
+    ticks[0] = 0
+    t0 = time.monotonic()
+    response = cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+    elapsed = time.monotonic() - t0
+    stop.set()
+    heartbeat.join(timeout=2.0)
+
+    # ``response`` is a MagicMock from _slow_create; just check it has
+    # the expected attribute, the value is not interesting.
+    assert getattr(response, "choices", None) is not None, (
+        "interruptible_api_call returned no response after sleeping "
+        f"{duration_seconds:.1f}s; the helper is broken or the mock is wrong"
+    )
+
+    expected_ticks_at_50ms = duration_seconds * 20  # 1000 / 50
+    expected_ticks_at_100ms = duration_seconds * 10  # 1000 / 100
+    expected_ticks_at_300ms = duration_seconds / 0.3  # current code baseline
+
+    return {
+        "duration_seconds": round(duration_seconds, 2),
+        "elapsed_seconds": round(elapsed, 3),
+        "heartbeat_ticks": ticks[0],
+        "expected_baseline_300ms_poll": round(expected_ticks_at_300ms, 1),
+        "expected_fixed_50ms_poll": round(expected_ticks_at_50ms, 1),
+        "ratio_to_baseline": round(ticks[0] / expected_ticks_at_300ms, 2)
+            if expected_ticks_at_300ms > 0 else 0.0,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--seconds",
+        type=float,
+        default=30.0,
+        help="How long the simulated LLM call should sleep (default: 30s).",
+    )
+    parser.add_argument(
+        "--output",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    args = parser.parse_args()
+
+    if args.seconds < 0.5:
+        parser.error("--seconds must be at least 0.5 (need a long-enough call to measure)")
+
+    result = run_benchmark(args.seconds)
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Simulated LLM call duration:  {result['duration_seconds']}s")
+        print(f"Wall-clock duration:           {result['elapsed_seconds']}s")
+        print(f"Heartbeat ticks during call:   {result['heartbeat_ticks']}")
+        print(f"  Baseline (300ms poll, current code): {result['expected_baseline_300ms_poll']}")
+        print(f"  Target   (50ms poll, fixed code):     {result['expected_fixed_50ms_poll']}")
+        ratio = result["ratio_to_baseline"]
+        if ratio >= 4.0:
+            print(f"Ratio to baseline: {ratio}x  → FIXED (>= 4x is the success criterion)")
+            return 0
+        if ratio >= 2.0:
+            print(f"Ratio to baseline: {ratio}x  → PARTIAL (better but not the target)")
+            return 1
+        print(f"Ratio to baseline: {ratio}x  → BROKEN (< 2x means the busy-poll still wins)")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_interruptible_api_call.py
+++ b/scripts/bench_interruptible_api_call.py
@@ -1,50 +1,52 @@
-"""Benchmark + diagnostic for the interruptible_api_call main-thread busy-poll.
-
-Issue: https://github.com/NousResearch/hermes-agent/issues/57903
+"""Diagnostic for issue #57903: interruptible_api_call main-thread blocking.
 
 The non-streaming ``interruptible_api_call`` in
-``agent/chat_completion_helpers.py`` blocks the main thread in a busy-poll
-loop (``t.join(timeout=0.3)``) while waiting for the LLM API call to
-return. Between joins the asyncio event loop in the same process (uvicorn
-+ tui_gateway WebSocket server) cannot service its 2s heartbeat, the
-5s-stall watchdog in ``hermes_cli/web_server.py`` fires, and the desktop
-WebSocket trips its 10s timeout — manifesting as "Gateway offline" /
-"не отвечает" flashes during long-running LLM calls.
+``agent/chat_completion_helpers.py`` runs the SDK call in a worker
+thread and busy-polls ``t.join(timeout=0.3)`` on the main thread. The
+busy-poll does release the GIL while the join is blocked (Python's
+``_Condition.wait`` releases the GIL on Windows), so other Python
+threads continue to make progress. The actual harm is to the asyncio
+event loop running on the same thread (uvicorn + tui_gateway): the
+sync ``t.join(timeout=0.3)`` blocks the event loop from servicing
+its 2s heartbeat and the desktop's WebSocket heartbeats, which trips
+the 5s-stall watchdog and the desktop's 10s WS timeout.
 
-This script reproduces the symptom locally and quantifies the
-regression by running a simulated ``_call`` that sleeps for N seconds and
-measuring how many times a parallel "heartbeat" thread gets to tick
-while the busy-poll is in progress.
+This script measures two things:
+  1. **GIL yield**: how many times a parallel heartbeat thread gets to
+     tick while ``interruptible_api_call`` is blocked. Confirms the
+     current code is GIL-friendly (Python releases the GIL inside
+     ``t.join``).
+  2. **Interrupt latency**: how quickly ``interruptible_api_call``
+     returns after ``_interrupt_requested`` is set during a long SDK
+     call. The current 300ms poll caps this at ~300ms plus socket
+     teardown time.
+
+Together these two measurements characterize the *real* symptom
+(event-loop starvation) by ruling out the *plausible* symptoms
+(GIL starvation, slow interrupt detection). The fix — replacing
+the sync ``t.join`` busy-poll with an async-aware bridge that lets the
+event loop run between waits — needs a different kind of measurement
+(see the tests in ``tests/agent/test_interruptible_api_call_yields_gil.py``
+for an end-to-end regression guard).
 
 Usage::
 
-    # Run with the current (broken) code:
-    python scripts/bench_interruptible_api_call.py --seconds 30
-    # → expect ~100 heartbeat ticks (GIL is held for the full 300ms poll)
+    python scripts/bench_interruptible_api_call.py --seconds 10
 
-    # After a fix that replaces t.join(timeout=0.3) with
-    # future.result(timeout=0.05) (or equivalent):
-    # → expect ~600 heartbeat ticks (GIL released every 50ms)
-
-A 5x increase in heartbeat ticks per 30s window is the success criterion.
-If your machine shows less than 3x, the fix is not aggressive enough;
-if it shows ~100 ticks, the busy-poll is still starving the event loop.
-
-The benchmark only uses sync primitives available in the stdlib — no
-asyncio, no fixtures, no model provider, no API keys.
+Exit code 0 = healthy on both metrics; 1 = interrupt latency > 500ms
+(probably the 300ms poll is the bottleneck); 2 = GIL yield below
+floor (probably a GIL regression introduced by future changes).
 """
 from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import sys
 import threading
 import time
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-# Bootstrap: when invoked directly (not via pytest), add repo root to path.
-import pathlib
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
@@ -52,25 +54,26 @@ if str(_REPO_ROOT) not in sys.path:
 from agent import chat_completion_helpers as cch  # noqa: E402
 
 
-def _make_agent(duration_seconds: float) -> MagicMock:
-    """An agent mock whose SDK call sleeps for ``duration_seconds``.
+HEARTBEAT_INTERVAL_SECONDS = 0.1
+INTERRUPT_LATENCY_BUDGET_SECONDS = 0.5  # 300ms poll + ~100ms socket teardown + CI headroom
+GIL_YIELD_FLOOR_TICKS_PER_SECOND = 8.0  # current code yields ~10/s; threshold = 8/s
 
-    The agent's surface is the minimum needed to drive
-    ``interruptible_api_call`` through the non-streaming
-    ``chat_completions`` path. All Codex / Anthropic / Bedrock /
-    MoA branches short-circuit to the default chat_completions path
-    so we can use the simplest mock.
+
+def _make_slow_agent(duration_seconds: float) -> tuple[MagicMock, list]:
+    """Agent whose SDK call sleeps for ``duration_seconds`` and returns a
+    minimal chat-completions response. The second list element is a
+    1-element scratchpad the caller can use to record timestamps.
     """
     agent = MagicMock()
     agent.api_mode = "chat_completions"
     agent._interrupt_requested = False
-    agent._compute_non_stream_stale_timeout.return_value = max(60.0, duration_seconds * 3)
+    agent._compute_non_stream_stale_timeout.return_value = max(
+        60.0, duration_seconds * 3
+    )
 
     fake_client = MagicMock()
 
     def _slow_create(**_kwargs):
-        # Simulate a long-running LLM call that returns a minimal
-        # chat.completions response.
         time.sleep(duration_seconds)
         response = MagicMock()
         response.choices = [MagicMock()]
@@ -84,114 +87,141 @@ def _make_agent(duration_seconds: float) -> MagicMock:
     agent._create_request_openai_client.return_value = fake_client
     agent._close_request_openai_client = MagicMock()
     agent._abort_request_openai_client = MagicMock()
+    return agent, [None]
+
+
+def _make_interrupting_agent(duration_seconds: float) -> MagicMock:
+    """Agent whose SDK call flips ``_interrupt_requested`` mid-flight and
+    raises a transport error to simulate the force-close.
+    """
+    import httpx
+
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    agent._compute_non_stream_stale_timeout.return_value = 60.0
+
+    fake_client = MagicMock()
+
+    def _slow_create(**_kwargs):
+        time.sleep(duration_seconds)
+        agent._interrupt_requested = True
+        time.sleep(0.05)
+        raise httpx.RemoteProtocolError("forced close (bench)")
+
+    fake_client.chat.completions.create.side_effect = _slow_create
+    agent._create_request_openai_client.return_value = fake_client
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
     return agent
 
 
-def _heartbeat_worker(counter: list, interval: float = 0.1, stop: threading.Event | None = None) -> None:
-    """Tick ``counter[0] += 1`` every ``interval`` seconds.
-
-    Stops when ``stop`` is set, or runs forever if ``stop`` is None.
-    Uses ``time.sleep(interval)`` which releases the GIL on every
-    iteration — this is a *contender* for the GIL, not a privileged
-    scheduler. The number of ticks we accumulate while
-    ``interruptible_api_call`` runs is the proxy for "how much does the
-    main thread's busy-poll block other threads from doing work".
-    """
-    deadline = time.monotonic() + 60 * 60  # upper bound, safety
-    while True:
-        if stop is not None and stop.is_set():
-            return
-        if time.monotonic() > deadline:
-            return
+def _heartbeat_worker(counter: list, interval: float, stop: threading.Event) -> None:
+    deadline = time.monotonic() + 60.0
+    while not stop.is_set() and time.monotonic() < deadline:
         counter[0] += 1
         time.sleep(interval)
 
 
-def run_benchmark(duration_seconds: float) -> dict:
-    """Run the benchmark and return a dict of measurements."""
-    agent = _make_agent(duration_seconds)
+def measure_gil_yield(duration_seconds: float) -> dict:
+    """Run a long SDK call and count parallel heartbeat ticks."""
+    agent, _ = _make_slow_agent(duration_seconds)
     ticks: list = [0]
     stop = threading.Event()
     heartbeat = threading.Thread(
         target=_heartbeat_worker,
-        args=(ticks, 0.1, stop),
+        args=(ticks, HEARTBEAT_INTERVAL_SECONDS, stop),
         daemon=True,
         name="bench-heartbeat",
     )
-
-    # Warm up the heartbeat thread so the very first tick doesn't
-    # under-count the contention window.
     heartbeat.start()
     time.sleep(0.2)
-
-    # Reset the counter and start the timed window.
     ticks[0] = 0
     t0 = time.monotonic()
     response = cch.interruptible_api_call(agent, {"model": "x", "messages": []})
     elapsed = time.monotonic() - t0
     stop.set()
     heartbeat.join(timeout=2.0)
-
-    # ``response`` is a MagicMock from _slow_create; just check it has
-    # the expected attribute, the value is not interesting.
-    assert getattr(response, "choices", None) is not None, (
-        "interruptible_api_call returned no response after sleeping "
-        f"{duration_seconds:.1f}s; the helper is broken or the mock is wrong"
-    )
-
-    expected_ticks_at_50ms = duration_seconds * 20  # 1000 / 50
-    expected_ticks_at_100ms = duration_seconds * 10  # 1000 / 100
-    expected_ticks_at_300ms = duration_seconds / 0.3  # current code baseline
-
+    assert getattr(response, "choices", None) is not None
     return {
-        "duration_seconds": round(duration_seconds, 2),
-        "elapsed_seconds": round(elapsed, 3),
+        "call_duration_seconds": round(duration_seconds, 2),
+        "wall_clock_seconds": round(elapsed, 3),
         "heartbeat_ticks": ticks[0],
-        "expected_baseline_300ms_poll": round(expected_ticks_at_300ms, 1),
-        "expected_fixed_50ms_poll": round(expected_ticks_at_50ms, 1),
-        "ratio_to_baseline": round(ticks[0] / expected_ticks_at_300ms, 2)
-            if expected_ticks_at_300ms > 0 else 0.0,
+        "ticks_per_second": round(ticks[0] / elapsed, 2) if elapsed > 0 else 0.0,
+        "expected_perfect_ticks": round(duration_seconds / HEARTBEAT_INTERVAL_SECONDS, 1),
+    }
+
+
+def measure_interrupt_latency(call_setup_seconds: float) -> dict:
+    """Run an SDK call that flips ``_interrupt_requested`` mid-flight and
+    measure wall-clock time from flip to ``interruptible_api_call``
+    return.
+    """
+    agent = _make_interrupting_agent(call_setup_seconds)
+    flag_holder: list = [None]
+
+    real_slow_create = agent._create_request_openai_client.return_value.chat.completions.create.side_effect
+
+    def _timed_create(**kwargs):
+        time.sleep(call_setup_seconds)
+        flag_holder[0] = time.monotonic()
+        agent._interrupt_requested = True
+        time.sleep(0.05)
+        import httpx
+        raise httpx.RemoteProtocolError("forced close (bench)")
+
+    agent._create_request_openai_client.return_value.chat.completions.create.side_effect = _timed_create
+
+    t0 = time.monotonic()
+    try:
+        cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+    except Exception:
+        pass
+    elapsed = time.monotonic() - t0
+
+    assert flag_holder[0] is not None, "interrupt flag was never set"
+    interrupt_to_return = (t0 + elapsed) - flag_holder[0]
+    return {
+        "call_setup_seconds": round(call_setup_seconds, 2),
+        "wall_clock_seconds": round(elapsed, 3),
+        "interrupt_to_return_seconds": round(interrupt_to_return, 3),
+        "budget_seconds": INTERRUPT_LATENCY_BUDGET_SECONDS,
     }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument(
-        "--seconds",
-        type=float,
-        default=30.0,
-        help="How long the simulated LLM call should sleep (default: 30s).",
-    )
-    parser.add_argument(
-        "--output",
-        choices=("text", "json"),
-        default="text",
-        help="Output format (default: text).",
-    )
+    parser.add_argument("--seconds", type=float, default=8.0,
+                        help="Duration of the simulated LLM call (default: 8s).")
+    parser.add_argument("--output", choices=("text", "json"), default="text")
     args = parser.parse_args()
-
     if args.seconds < 0.5:
-        parser.error("--seconds must be at least 0.5 (need a long-enough call to measure)")
+        parser.error("--seconds must be >= 0.5")
 
-    result = run_benchmark(args.seconds)
+    gil = measure_gil_yield(args.seconds)
+    intr = measure_interrupt_latency(args.seconds)
+
+    result = {"gil_yield": gil, "interrupt_latency": intr}
 
     if args.output == "json":
         print(json.dumps(result, indent=2))
     else:
-        print(f"Simulated LLM call duration:  {result['duration_seconds']}s")
-        print(f"Wall-clock duration:           {result['elapsed_seconds']}s")
-        print(f"Heartbeat ticks during call:   {result['heartbeat_ticks']}")
-        print(f"  Baseline (300ms poll, current code): {result['expected_baseline_300ms_poll']}")
-        print(f"  Target   (50ms poll, fixed code):     {result['expected_fixed_50ms_poll']}")
-        ratio = result["ratio_to_baseline"]
-        if ratio >= 4.0:
-            print(f"Ratio to baseline: {ratio}x  → FIXED (>= 4x is the success criterion)")
-            return 0
-        if ratio >= 2.0:
-            print(f"Ratio to baseline: {ratio}x  → PARTIAL (better but not the target)")
-            return 1
-        print(f"Ratio to baseline: {ratio}x  → BROKEN (< 2x means the busy-poll still wins)")
-        return 2
+        print(f"=== GIL yield during {args.seconds}s simulated call ===")
+        print(f"  Heartbeat ticks: {gil['heartbeat_ticks']} "
+              f"({gil['ticks_per_second']}/s, theoretical max {gil['expected_perfect_ticks']})")
+        print(f"=== Interrupt latency ===")
+        print(f"  Wall-clock from flag flip to return: {intr['interrupt_to_return_seconds']}s "
+              f"(budget {intr['budget_seconds']}s)")
+        print()
+
+    # Pass/fail: interrupt latency is the actionable metric.
+    intr_ok = intr["interrupt_to_return_seconds"] <= INTERRUPT_LATENCY_BUDGET_SECONDS
+    gil_ok = gil["ticks_per_second"] >= GIL_YIELD_FLOOR_TICKS_PER_SECOND
+    if intr_ok and gil_ok:
+        return 0
+    if not intr_ok:
+        return 1
+    return 2
 
 
 if __name__ == "__main__":

--- a/scripts/load_interruptible_api_call.py
+++ b/scripts/load_interruptible_api_call.py
@@ -1,0 +1,174 @@
+"""Load test for interruptible_api_call under concurrent LLM-call pressure.
+
+Issue: https://github.com/NousResearch/hermes-agent/issues/57903
+
+The companion ``bench_interruptible_api_call.py`` runs a *single*
+simulated LLM call and measures GIL yield + interrupt latency. This
+script runs **N concurrent simulated calls** to exercise the
+busy-poll under contention — the same shape as a desktop session
+with multiple open tabs each driving their own conversation turn.
+
+What it measures:
+  1. **Wall-clock duration per call** — should be close to the
+     simulated duration, with no extra latency from contention.
+  2. **Heartbeat tick count** in a parallel sentinel thread that
+     mimics the web_server event loop's 2s heartbeat. With the
+     50ms poll interval (post-fix) the heartbeat should keep
+     ticking; with the 300ms poll (pre-fix) it would also tick
+     (Python's GIL switch handles it), but the *event loop in
+     the same thread* would not get to advance.
+
+This script does **not** measure event-loop starvation directly —
+that requires running the real Hermes serve and inspecting gui.log.
+What it does measure is whether concurrent ``interruptible_api_call``
+calls on the same Python process starve the GIL or the event loop.
+
+Usage::
+
+    # Single call, 8 seconds — sanity check
+    python scripts/load_interruptible_api_call.py --seconds 8 --concurrency 1
+
+    # 4 concurrent calls, 8 seconds each
+    python scripts/load_interruptible_api_call.py --seconds 8 --concurrency 4
+
+    # Default: 3 concurrent calls, 8 seconds each
+    python scripts/load_interruptible_api_call.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import threading
+import time
+from unittest.mock import MagicMock
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from agent import chat_completion_helpers as cch  # noqa: E402
+
+
+HEARTBEAT_INTERVAL_SECONDS = 0.1  # mimic web_server's 2s heartbeat at 20x rate for finer resolution
+
+
+def _make_agent(duration_seconds: float) -> MagicMock:
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    agent._compute_non_stream_stale_timeout.return_value = max(
+        60.0, duration_seconds * 3
+    )
+    fake_client = MagicMock()
+
+    def _slow_create(**_kwargs):
+        time.sleep(duration_seconds)
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message = MagicMock()
+        response.choices[0].message.content = "ok"
+        response.choices[0].message.tool_calls = None
+        response.choices[0].finish_reason = "stop"
+        return response
+
+    fake_client.chat.completions.create.side_effect = _slow_create
+    agent._create_request_openai_client.return_value = fake_client
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
+    return agent
+
+
+def _heartbeat_worker(tick_holder: list, stop: threading.Event) -> None:
+    """Tick every HEARTBEAT_INTERVAL_SECONDS. Counts voluntary context
+    switches the OS observes on this thread — the same kind of signal
+    the web_server watchdog looks for."""
+    deadline = time.monotonic() + 600.0
+    while not stop.is_set() and time.monotonic() < deadline:
+        tick_holder[0] += 1
+        time.sleep(HEARTBEAT_INTERVAL_SECONDS)
+
+
+def run_load(duration_seconds: float, concurrency: int) -> dict:
+    """Launch ``concurrency`` parallel ``interruptible_api_call`` instances
+    against simulated agents. Measure heartbeat ticks and per-call latency."""
+    agents = [_make_agent(duration_seconds) for _ in range(concurrency)]
+    ticks: list = [0]
+    stop = threading.Event()
+    heartbeat = threading.Thread(
+        target=_heartbeat_worker, args=(ticks, stop), daemon=True, name="load-heartbeat"
+    )
+    heartbeat.start()
+    time.sleep(0.2)
+
+    ticks[0] = 0
+    t0 = time.monotonic()
+    results: list = []
+
+    def _worker(idx: int, agent: MagicMock) -> None:
+        ct0 = time.monotonic()
+        response = cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+        ct1 = time.monotonic()
+        results.append({
+            "call_index": idx,
+            "duration_seconds": round(ct1 - ct0, 3),
+            "expected_seconds": duration_seconds,
+            "overhead_seconds": round((ct1 - ct0) - duration_seconds, 3),
+        })
+
+    threads = [
+        threading.Thread(target=_worker, args=(i, a), daemon=True, name=f"load-call-{i}")
+        for i, a in enumerate(agents)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    elapsed = time.monotonic() - t0
+    stop.set()
+    heartbeat.join(timeout=2.0)
+
+    expected_total_ticks = elapsed / HEARTBEAT_INTERVAL_SECONDS
+    return {
+        "concurrency": concurrency,
+        "call_duration_seconds": duration_seconds,
+        "total_wall_clock_seconds": round(elapsed, 3),
+        "heartbeat_ticks": ticks[0],
+        "heartbeat_expected_max": round(expected_total_ticks, 1),
+        "heartbeat_ratio": round(ticks[0] / expected_total_ticks, 3) if expected_total_ticks > 0 else 0.0,
+        "per_call_results": results,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=8.0)
+    parser.add_argument("--concurrency", type=int, default=3)
+    parser.add_argument("--output", choices=("text", "json"), default="text")
+    args = parser.parse_args()
+
+    if args.seconds < 0.5:
+        parser.error("--seconds must be >= 0.5")
+    if args.concurrency < 1:
+        parser.error("--concurrency must be >= 1")
+
+    result = run_load(args.seconds, args.concurrency)
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"=== Concurrent load: {args.concurrency} calls × {args.seconds}s ===")
+        print(f"  Wall-clock total: {result['total_wall_clock_seconds']}s")
+        print(f"  Heartbeat ticks:  {result['heartbeat_ticks']} "
+              f"(max expected {result['heartbeat_expected_max']}, "
+              f"ratio {result['heartbeat_ratio']})")
+        for r in result["per_call_results"]:
+            print(f"  Call {r['call_index']}: {r['duration_seconds']}s "
+                  f"(expected {r['expected_seconds']}s, "
+                  f"overhead {r['overhead_seconds']}s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent/test_interruptible_api_call_load.py
+++ b/tests/agent/test_interruptible_api_call_load.py
@@ -1,0 +1,163 @@
+"""Regression load test: does interruptible_api_call starve the asyncio
+event loop under realistic streaming-shape load?
+
+Issue: https://github.com/NousResearch/hermes-agent/issues/57903
+
+The companion ``test_interruptible_api_call_poll_window_is_short``
+test only checks the poll timeout literal. This test exercises the
+*realistic* failure mode observed in production: a long LLM streaming
+call where the worker thread spends most of its time on CPU work
+(JSON parsing each streaming chunk, prompt-cache reconstruction,
+tool-call argument assembly) and releases the GIL only briefly
+between bursts. The pre-fix 300ms ``t.join`` busy-poll let the main
+thread block for up to 300ms between checks; even the 50ms post-fix
+poll can be starved if the worker's CPU burst exceeds 50ms.
+
+The test launches an ``interruptible_api_call`` against a stub agent
+whose SDK call mimics this streaming behavior — periodic CPU bursts
+holding the GIL for 80-150ms separated by short GIL-yield sleeps.
+While that runs, a parallel thread drives a mock asyncio event-loop
+heartbeat every 50ms and records the largest gap between
+consecutive heartbeats. If the gap exceeds 500ms, the heartbeat
+service would have stalled long enough to trip the web_server's 5s
+watchdog in production.
+
+Why this matters: the production stalls are 15-25 seconds. The
+worker-thread CPU-burst pattern is the most plausible mechanism we
+haven't ruled out yet. This test gives us a deterministic
+reproduction we can iterate on without burning tokens on a real LLM.
+
+Pre-fix (300ms poll, no ``time.sleep(0)``): max gap ~ 300ms or more
+when worker holds GIL, accumulating to several seconds over a 30s
+call. Likely FAIL with budget 500ms.
+
+Post-fix (50ms poll + ``time.sleep(0)``): max gap should be ~80-150ms
+(worker CPU burst size). Should PASS with budget 500ms.
+
+Sub-event-loop bridge (follow-up): worker thread owns its own event
+loop and yields GIL naturally on each chunk await. Max gap should
+drop to <50ms. Should PASS with a tighter 100ms budget.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent import chat_completion_helpers as cch
+
+
+# Test parameters chosen to fit in a CI budget (~5s) while still
+# exercising the stall mechanism (a single 100ms CPU burst inside
+# a 2s call is enough to expose 50ms-poll starvation).
+TOTAL_CALL_SECONDS = 2.0
+CPU_BURST_INTERVAL_SECONDS = 0.05  # 20Hz bursts (mimics stream chunks)
+CPU_BURST_DURATION_SECONDS = 0.08  # 80ms CPU = exceeds the 50ms poll window
+MAX_HEARTBEAT_GAP_BUDGET_SECONDS = 0.5
+
+
+def _make_streaming_shape_agent() -> MagicMock:
+    """Build an agent whose SDK call mimics real LLM streaming:
+    periodic CPU bursts separated by short GIL-yield sleeps. The
+    bursts hold the GIL for longer than the main thread's poll
+    window so the busy-poll can be starved. The yield-sleeps
+    release the GIL between bursts so the event loop *can*
+    progress — the question is whether it has enough wall-clock
+    between bursts to do so.
+    """
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    # 60s stale timeout — well above the 2s test call so it never fires.
+    agent._compute_non_stream_stale_timeout.return_value = 60.0
+
+    fake_client = MagicMock()
+
+    def _streaming_shape_create(**_kwargs):
+        t_end = time.monotonic() + TOTAL_CALL_SECONDS
+        while time.monotonic() < t_end and not agent._interrupt_requested:
+            # CPU burst: busy work holding the GIL.
+            burst_end = time.monotonic() + CPU_BURST_DURATION_SECONDS
+            while time.monotonic() < burst_end:
+                _ = sum(range(1000))
+            # Brief GIL yield between bursts.
+            time.sleep(CPU_BURST_INTERVAL_SECONDS - CPU_BURST_DURATION_SECONDS
+                       if CPU_BURST_INTERVAL_SECONDS > CPU_BURST_DURATION_SECONDS
+                       else 0.0)
+        # Return a minimal valid chat-completions response.
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message = MagicMock()
+        response.choices[0].message.content = "ok"
+        response.choices[0].message.tool_calls = None
+        response.choices[0].finish_reason = "stop"
+        return response
+
+    fake_client.chat.completions.create.side_effect = _streaming_shape_create
+    agent._create_request_openai_client.return_value = fake_client
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
+    return agent
+
+
+def _heartbeat_worker(gaps: list, stop: threading.Event) -> None:
+    """Record wall-clock gaps between consecutive heartbeat ticks.
+
+    The mock event loop "heartbeats" every 20ms. If ``interruptible_api_call``
+    blocks the main thread (or any thread the heartbeat is running on)
+    past 500ms, the next tick is delayed by the block time. Recording the
+    max gap captures "how long was the main thread unresponsive" — exactly
+    the symptom the web_server watchdog measures.
+    """
+    HEARTBEAT_INTERVAL = 0.02  # 20ms — 25x finer than the watchdog's 500ms threshold
+    deadline = time.monotonic() + 30.0
+    last = time.monotonic()
+    while not stop.is_set() and time.monotonic() < deadline:
+        time.sleep(HEARTBEAT_INTERVAL)
+        now = time.monotonic()
+        gaps.append(now - last)
+        last = now
+
+
+def test_interruptible_api_call_does_not_starve_event_loop_under_cpu_load():
+    """The fix from commit 29f55d4 keeps the busy-poll window at 50ms;
+    that should be short enough that the main thread stays responsive
+    even when the worker thread is doing CPU work between stream chunks.
+    If this test fails, the 50ms window is still too long for the
+    realistic streaming-shape load, and we need the sub-event-loop
+    bridge (issue #57903 follow-up).
+    """
+    gaps: list = []
+    stop = threading.Event()
+    heartbeat = threading.Thread(
+        target=_heartbeat_worker, args=(gaps, stop), daemon=True, name="load-heartbeat"
+    )
+    heartbeat.start()
+    # Let the heartbeat establish a stable baseline.
+    time.sleep(0.1)
+
+    agent = _make_streaming_shape_agent()
+    t0 = time.monotonic()
+    response = cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+    elapsed = time.monotonic() - t0
+    stop.set()
+    heartbeat.join(timeout=2.0)
+
+    assert getattr(response, "choices", None) is not None
+
+    # Filter the gaps: the first ~5 are warmup, and the last few may
+    # be the heartbeat thread's own wakeup delay at shutdown. Look at
+    # the body of the run only.
+    body = gaps[3:-3] if len(gaps) > 8 else gaps
+    max_gap = max(body) if body else 0.0
+
+    assert max_gap < MAX_HEARTBEAT_GAP_BUDGET_SECONDS, (
+        f"interruptible_api_call starved the GIL: heartbeat gap {max_gap * 1000:.0f}ms "
+        f"during a {TOTAL_CALL_SECONDS}s streaming-shape call (budget "
+        f"{MAX_HEARTBEAT_GAP_BUDGET_SECONDS * 1000:.0f}ms). The 50ms poll window "
+        f"is not short enough for this CPU-burst pattern — see issue "
+        f"#57903 and the sub-event-loop bridge design."
+    )

--- a/tests/agent/test_interruptible_api_call_repro_stall.py
+++ b/tests/agent/test_interruptible_api_call_repro_stall.py
@@ -1,0 +1,196 @@
+"""Reproduction test for production stalls under realistic streaming load.
+
+Issue: https://github.com/NousResearch/hermes-agent/issues/57903
+
+Goal: deterministically reproduce the 15-25 second ``event loop stalled``
+warnings observed during long LLM streaming sessions with 300K+ tokens of
+context (the ``1811fc`` session profile). The reproduction must run in CI
+without burning real API tokens — so we synthesize the streaming-shape
+load that *causes* the stalls.
+
+Mechanism (matches production observations in gui.log):
+
+  - A 30-second simulated streaming call emits chunks every 50ms.
+  - Each chunk is a JSON document of ~5-10KB that the worker thread
+    parses with ``json.loads()`` (mimics the Anthropic SDK's
+    MessageStream event parsing, which on Python 3.11 holds the GIL
+    during JSON deserialization of each event).
+  - A parallel "heartbeat" thread tries to tick every 50ms — this stands
+    in for the web_server 2s heartbeat callback.
+  - If the gap between two consecutive heartbeat ticks exceeds 500ms
+    (the web_server stall watchdog threshold), the test fails.
+
+Production correlates: in gui.log during 1811fc's heavy use, every
+15-25s the watchdog logs ``event loop stalled Ns (GIL pressure
+suspected)`` and the desktop WS times out. The pattern is the GIL
+contention between the worker's stream JSON parsing and the main
+thread's busy-poll.
+
+Test budget: 1s max gap (the 500ms threshold plus slack). On the
+current code with a 50ms busy-poll this *should* pass because the
+poll interval is shorter than the worker's average CPU burst. If
+this test fails, the sub-event-loop bridge from issue #57903 is
+needed to yield the GIL from the worker's JSON parsing path.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent import chat_completion_helpers as cch
+
+
+# Test parameters chosen to match production observations.
+TEST_CALL_SECONDS = 6.0  # long enough to expose stall pattern, short enough for CI
+CHUNK_INTERVAL_SECONDS = 0.05  # 20Hz chunk arrival (mimics Anthropic streaming)
+# Average Anthropic streaming chunk ~5KB; bigger chunks = longer JSON parse
+# = longer GIL hold. We use realistic-sized JSON.
+CHUNK_TEMPLATE_SIZE_BYTES = 6000
+HEARTBEAT_INTERVAL_SECONDS = 0.05  # same as web_server watchdog cadence
+MAX_HEARTBEAT_GAP_BUDGET_SECONDS = 1.0  # 2x the watchdog's 500ms threshold
+
+
+def _make_realistic_streaming_agent() -> MagicMock:
+    """Build an agent whose SDK call simulates the Anthropic streaming
+    response shape: a stream object with __iter__ that yields JSON
+    chunk dicts. The main loop in ``create_anthropic_message`` would
+    parse each chunk with ``json.loads()``-equivalent work.
+
+    We replicate that work here by calling ``json.loads()`` on a
+    realistic-sized JSON payload every CHUNK_INTERVAL_SECONDS for the
+    duration of the call. JSON parsing on a 6KB Python string takes
+    ~5-15ms on a modern CPU, which is enough to expose a 50ms-poll
+    busy-poll starvation when the worker's parse exceeds the poll
+    interval.
+    """
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    agent._compute_non_stream_stale_timeout.return_value = max(60.0, TEST_CALL_SECONDS * 3)
+
+    # Build a realistic chunk payload: a JSON object with text content,
+    # usage metadata, and a stop_reason — close to what Anthropic actually
+    # sends in a MessageStream event.
+    chunk_payload = {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {
+            "type": "text_delta",
+            "text": "x" * (CHUNK_TEMPLATE_SIZE_BYTES // 2),
+        },
+    }
+    chunk_str = json.dumps(chunk_payload)
+
+    fake_client = MagicMock()
+
+    def _streaming_create(**_kwargs):
+        t_end = time.monotonic() + TEST_CALL_SECONDS
+        # Simulate a TCP receive: select() on Windows blocks for tens of
+        # milliseconds waiting for the next chunk. We use socket.select()
+        # on a non-blocking socket pair to model that I/O wait without
+        # spending tokens on a real LLM.
+        import socket
+        sock_a, sock_b = socket.socketpair()
+        sock_a.setblocking(False)
+        sock_b.setblocking(False)
+        try:
+            chunk_str = json.dumps(chunk_payload)
+            iteration = 0
+            while time.monotonic() < t_end and not agent._interrupt_requested:
+                # CPU work that simulates the SDK's chunk JSON parsing.
+                # json.loads on a 6KB string takes ~5-15ms.
+                for _ in range(10):
+                    _ = json.loads(chunk_str)
+                # I/O wait: simulate waiting for the next chunk to arrive.
+                # select() returns immediately (no data ready), but on
+                # Windows the syscall still takes a few ms and any actual
+                # GIL contention shows up here too.
+                try:
+                    sock_a.recv(1)
+                except BlockingIOError:
+                    pass
+                # 10% of chunks trigger a heavier parse (tool-call chunk
+                # with arguments that the SDK has to JSON-validate).
+                if iteration % 10 == 0:
+                    _ = json.loads(json.dumps({"args": list(range(200))}))
+                iteration += 1
+                time.sleep(CHUNK_INTERVAL_SECONDS)
+        finally:
+            sock_a.close()
+            sock_b.close()
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message = MagicMock()
+        response.choices[0].message.content = "ok"
+        response.choices[0].message.tool_calls = None
+        response.choices[0].finish_reason = "stop"
+        return response
+
+    fake_client.chat.completions.create.side_effect = _streaming_create
+    agent._create_request_openai_client.return_value = fake_client
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
+    return agent
+
+
+def _heartbeat_worker(gaps: list, stop: threading.Event) -> None:
+    """Record wall-clock gaps between consecutive heartbeat ticks.
+
+    Mimics what the web_server watchdog measures: a callback that
+    should fire every HEARTBEAT_INTERVAL_SECONDS. A gap > the watchdog
+    threshold would trip the production ``event loop stalled`` warning.
+    """
+    deadline = time.monotonic() + 30.0
+    last = time.monotonic()
+    while not stop.is_set() and time.monotonic() < deadline:
+        time.sleep(HEARTBEAT_INTERVAL_SECONDS)
+        now = time.monotonic()
+        gaps.append(now - last)
+        last = now
+
+
+def test_interruptible_api_call_reproduces_production_stalls():
+    """Reproduce the 15-25s event-loop stall pattern observed in
+    production. If this test fails, the 50ms poll interval is not
+    short enough for the realistic streaming-shape load and we need
+    the sub-event-loop bridge from issue #57903.
+    """
+    gaps: list = []
+    stop = threading.Event()
+    heartbeat = threading.Thread(
+        target=_heartbeat_worker, args=(gaps, stop), daemon=True, name="repro-heartbeat"
+    )
+    heartbeat.start()
+    time.sleep(0.1)  # let heartbeat establish baseline
+
+    agent = _make_realistic_streaming_agent()
+    t0 = time.monotonic()
+    response = cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+    elapsed = time.monotonic() - t0
+    stop.set()
+    heartbeat.join(timeout=2.0)
+
+    assert getattr(response, "choices", None) is not None
+    # Sanity: total wall-clock should match the simulated call duration.
+    assert elapsed >= TEST_CALL_SECONDS * 0.95, (
+        f"interruptible_api_call returned in {elapsed:.1f}s, expected "
+        f"~{TEST_CALL_SECONDS}s. The test setup may be broken."
+    )
+
+    # Look at the body of the run only — first few and last few gaps
+    # are warmup/teardown.
+    body = gaps[3:-3] if len(gaps) > 8 else gaps
+    max_gap = max(body) if body else 0.0
+
+    assert max_gap < MAX_HEARTBEAT_GAP_BUDGET_SECONDS, (
+        f"interruptible_api_call reproduced the production stall pattern: "
+        f"heartbeat gap {max_gap * 1000:.0f}ms during a {TEST_CALL_SECONDS}s "
+        f"streaming-shape call (budget {MAX_HEARTBEAT_GAP_BUDGET_SECONDS * 1000:.0f}ms). "
+        f"This is the symptom users see as 'event loop stalled Ns' warnings "
+        f"and 'Gateway offline' flashes during long LLM calls. See "
+        f"issue #57903 for the diagnosis and the proposed fix."
+    )

--- a/tests/agent/test_interruptible_api_call_yields_gil.py
+++ b/tests/agent/test_interruptible_api_call_yields_gil.py
@@ -111,3 +111,76 @@ def test_interruptible_api_call_returns_quickly_after_interrupt():
         f"means the main-thread poll window is too long — see issue "
         f"#57903."
     )
+
+
+def test_interruptible_api_call_poll_window_is_short(monkeypatch):
+    """Pin the main-thread poll window to <= 0.2s. The original busy-poll
+    used ``t.join(timeout=0.3)``; issue #57903 reduces it to 0.05s
+    (configurable via HERMES_INTERRUPTIBLE_API_POLL_SECONDS). This test
+    captures every ``t.join(timeout=...)`` argument the production
+    function uses and asserts none exceed 0.2s — a generous budget
+    that still flags a regression like ``t.join(timeout=0.3)`` coming
+    back or someone introducing ``t.join(timeout=1.0)``.
+
+    Implementation: we don't reach into the production source text;
+    instead we instrument ``threading.Thread.join`` on the worker
+    thread the test creates. The mock's SDK call runs forever (until
+    interrupt), so the main thread enters its poll loop and calls
+    ``t.join(timeout=X)`` repeatedly. We record every X and assert the
+    maximum is <= 0.2s.
+    """
+    # Build an agent whose SDK call hangs forever (until the main
+    # thread force-closes on interrupt).
+    import httpx
+
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    agent._compute_non_stream_stale_timeout.return_value = 60.0
+
+    join_timeouts: list = []
+    real_join = threading.Thread.join
+
+    def _instrumented_join(self, timeout=None):
+        # Record the timeout this specific join call uses.
+        join_timeouts.append(timeout)
+        # Trigger interrupt on the first join so the call returns
+        # promptly. Without this the test would block for the full
+        # 60s stale timeout.
+        if agent._interrupt_requested is False and len(join_timeouts) > 5:
+            agent._interrupt_requested = True
+        return real_join(self, timeout=timeout)
+
+    monkeypatch.setattr(threading.Thread, "join", _instrumented_join)
+
+    fake_client = MagicMock()
+
+    def _hang(**_kwargs):
+        # Sleep longer than the test budget but short enough to keep CI fast.
+        time.sleep(3.0)
+        raise httpx.RemoteProtocolError("forced close")
+
+    fake_client.chat.completions.create.side_effect = _hang
+    agent._create_request_openai_client.return_value = fake_client
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
+
+    with pytest.raises(Exception):
+        cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+
+    # Filter out the long waits for stale-timeout joins (the
+    # interrupt path uses 2.0s joins to give the worker time to
+    # observe the close). We're only pinning the **poll** window.
+    poll_timeouts = [t for t in join_timeouts if t is not None and t <= 1.0]
+    assert poll_timeouts, (
+        f"interruptible_api_call never entered the poll loop on this code path; "
+        f"recorded joins = {join_timeouts!r}"
+    )
+    max_poll_timeout = max(poll_timeouts)
+    assert max_poll_timeout <= 0.2, (
+        f"interruptible_api_call poll window is {max_poll_timeout}s; "
+        f"the fix in commit 29f55d4 sets it to 0.05s (env-configurable via "
+        f"HERMES_INTERRUPTIBLE_API_POLL_SECONDS). If this test fails, "
+        f"someone has likely reverted or bumped the poll window — "
+        f"see issue #57903. Recorded poll joins: {poll_timeouts!r}"
+    )

--- a/tests/agent/test_interruptible_api_call_yields_gil.py
+++ b/tests/agent/test_interruptible_api_call_yields_gil.py
@@ -1,0 +1,113 @@
+"""Regression test: interruptible_api_call interrupt detection latency.
+
+Issue: https://github.com/NousResearch/hermes-agent/issues/57903
+
+The non-streaming ``interruptible_api_call`` in
+``agent/chat_completion_helpers.py`` polls a worker thread from the
+main thread via ``t.join(timeout=0.3)``. The 300ms poll window is the
+worst-case latency for interrupt detection — when a user hits Ctrl+C
+or the agent flips ``_interrupt_requested``, the busy-poll can spend
+up to 300ms before noticing and force-closing the in-flight HTTP
+request. The same window also gates the stale-call detector, the
+TTFB watchdog, and the Codex stream-idle watchdog.
+
+This test pins the *worst-case* poll window: it sets the agent's
+``_interrupt_requested`` flag from inside the simulated SDK call and
+asserts that ``interruptible_api_call`` returns within
+``MAX_INTERRUPT_LATENCY_SECONDS`` after the flag flip. The current
+300ms busy-poll gives up to ~300ms latency plus the work the worker
+must do to observe the close (~100-300ms of socket teardown); the
+test budget is set to 1.0s to leave room for slow CI while still
+flagging the regression.
+
+A future fix that replaces the busy-poll with a 50ms ``future.result``
+poll would reduce interrupt latency to ~50-100ms; the same test
+would still pass with the same 1.0s budget, so this test is a
+regression guard rather than a forward-looking perf assertion.
+
+The companion diagnostic is ``scripts/bench_interruptible_api_call.py``
+which quantifies GIL yield in the same window.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent import chat_completion_helpers as cch
+
+
+MAX_INTERRUPT_LATENCY_SECONDS = 1.0  # 300ms poll + ~300ms socket teardown + CI headroom
+SDK_SLEEP_BEFORE_INTERRUPT_SECONDS = 1.0  # long enough for the poll to cycle several times
+SDK_SETTLE_AFTER_INTERRUPT_SECONDS = 0.05  # let the worker observe the close
+
+
+def _make_agent(interrupt_after_seconds: float) -> MagicMock:
+    """An agent mock whose SDK call flips ``_interrupt_requested`` after
+    ``interrupt_after_seconds`` and then settles long enough for the
+    worker to observe the close. Returns the agent and a
+    ``flag_flipped_at`` placeholder so the test can measure latency.
+    """
+    agent = MagicMock()
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    agent._compute_non_stream_stale_timeout.return_value = 60.0
+
+    fake_client = MagicMock()
+    flag_flipped_at: list = [None]
+    interrupted_at: list = [None]
+
+    def _slow_create(**_kwargs):
+        time.sleep(interrupt_after_seconds)
+        flag_flipped_at[0] = time.monotonic()
+        # Force-close the worker-local client, then settle so the worker
+        # observes the transport error and exits cleanly.
+        agent._interrupt_requested = True
+        time.sleep(SDK_SETTLE_AFTER_INTERRUPT_SECONDS)
+        # Match the production shape: raise a transport error so the
+        # worker's _call except branch sees it and the
+        # ``_request_cancelled`` token swallows it.
+        import httpx
+        raise httpx.RemoteProtocolError("forced close")
+
+    fake_client.chat.completions.create.side_effect = _slow_create
+    agent._create_request_openai_client.return_value = fake_client
+    agent._close_request_openai_client = MagicMock()
+    agent._abort_request_openai_client = MagicMock()
+
+    return agent, flag_flipped_at, interrupted_at
+
+
+def test_interruptible_api_call_returns_quickly_after_interrupt():
+    """``interruptible_api_call`` must return within
+    ``MAX_INTERRUPT_LATENCY_SECONDS`` after ``_interrupt_requested`` flips
+    to True during a long SDK call. The current 300ms busy-poll
+    baseline gives ~400-700ms wall-clock; the test budget (1.0s) leaves
+    headroom for slow CI while still flagging a regression if the
+    poll window grows (e.g. a regression that bumps it back to 1s).
+    """
+    agent, flag_flipped_at, _ = _make_agent(SDK_SLEEP_BEFORE_INTERRUPT_SECONDS)
+
+    t0 = time.monotonic()
+    with pytest.raises(Exception):
+        # InterruptedError is the expected raise; we accept any
+        # exception to avoid coupling the test to PR #6600's exact
+        # raise type if upstream refactors that path.
+        cch.interruptible_api_call(agent, {"model": "x", "messages": []})
+    elapsed = time.monotonic() - t0
+
+    assert flag_flipped_at[0] is not None, (
+        "SDK call never reached the interrupt-flag-flip point; the test "
+        "setup is broken or ``interruptible_api_call`` returned before "
+        "the worker could run"
+    )
+    interrupt_to_return_latency = (t0 + elapsed) - flag_flipped_at[0]
+    assert interrupt_to_return_latency <= MAX_INTERRUPT_LATENCY_SECONDS, (
+        f"interruptible_api_call took {interrupt_to_return_latency:.3f}s "
+        f"to return after the interrupt flag flipped "
+        f"(budget {MAX_INTERRUPT_LATENCY_SECONDS:.1f}s). This usually "
+        f"means the main-thread poll window is too long — see issue "
+        f"#57903."
+    )


### PR DESCRIPTION
Closing this PR — diagnostic instrumentation (commit 6be7934) showed that the busy-poll is **not** the bottleneck. The poll gap > 500ms warning never fired during production stalls, proving the main thread is NOT in our poll loop during stalls. Standalone reproduction tests pass because they mock the SDK with time.sleep-based workloads that release the GIL; the real Anthropic SDK holds the GIL differently during real HTTP/JSON parsing on 300K+ token contexts.

The PR remains valid as a tiny, harmless improvement (50ms poll instead of 300ms; explicit time.sleep(0) after each poll; new regression-guard tests). It just does not solve the symptom the issue tracks. Maintaining it would be misleading, so closing.

A follow-up issue would be needed for the real fix, which requires one of:
- Async Anthropic SDK migration (~1-2 weeks, requires migrating run_conversation to async def and propagating through acp_adapter)
- Subprocess isolation for LLM calls (significant complexity)
- Python 3.13+ free-threaded GIL (PEP 703) — no application changes needed, but a major version migration

Will not reopen unless a maintainer requests the poll-window reduction as a standalone change.
