### PR TITLE
feat: add system prompt part provider seam

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -401,8 +401,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if _effective_hint:
         stable_parts.append(_effective_hint)
 
+    try:
+        from agent.system_prompt_part_providers import collect_system_prompt_parts
+
+        provider_parts = collect_system_prompt_parts(agent, system_message=system_message)
+    except Exception:
+        provider_parts = {"stable": [], "context": [], "volatile": []}
+    stable_parts.extend(provider_parts.get("stable", []))
+
     # ── Context tier (cwd-dependent, may change between sessions) ─
     context_parts: List[str] = []
+    context_parts.extend(provider_parts.get("context", []))
 
     # Note: ephemeral_system_prompt is NOT included here. It's injected at
     # API-call time only so it stays out of the cached/stored system prompt.
@@ -422,6 +431,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # ── Volatile tier (changes per session/turn — never cached) ───
     volatile_parts: List[str] = []
+    volatile_parts.extend(provider_parts.get("volatile", []))
 
     if agent._memory_store:
         if agent._memory_enabled:

--- a/agent/system_prompt_part_providers.py
+++ b/agent/system_prompt_part_providers.py
@@ -1,0 +1,95 @@
+"""Generic system-prompt part provider registry.
+
+Plugins and edge integrations can register additive prompt parts without adding
+product-specific behavior to ``agent.system_prompt``. Providers are process-local
+and deterministic for a prompt build; callers cache the final assembled prompt
+for the conversation lifetime.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PromptPartProvider = Callable[..., Mapping[str, str | Iterable[str] | None] | None]
+_VALID_TIERS = frozenset({"stable", "context", "volatile"})
+_lock = threading.RLock()
+_providers: dict[str, PromptPartProvider] = {}
+
+
+def register_system_prompt_part_provider(name: str, provider: PromptPartProvider) -> None:
+    """Register an additive prompt-part provider by stable name."""
+    provider_name = str(name or "").strip()
+    if not provider_name:
+        raise ValueError("provider name must be non-empty")
+    if not callable(provider):
+        raise TypeError("provider must be callable")
+    with _lock:
+        _providers[provider_name] = provider
+    logger.info("Registered system prompt part provider: %s", provider_name)
+
+
+def list_system_prompt_part_providers() -> list[str]:
+    """Return registered provider names in registration order."""
+    with _lock:
+        return list(_providers.keys())
+
+
+def collect_system_prompt_parts(
+    agent: Any, *, system_message: str | None = None
+) -> dict[str, list[str]]:
+    """Collect additive prompt parts from all registered providers."""
+    collected: dict[str, list[str]] = {"stable": [], "context": [], "volatile": []}
+    with _lock:
+        providers = list(_providers.items())
+    for name, provider in providers:
+        try:
+            provided = provider(agent, system_message=system_message)
+        except TypeError:
+            try:
+                provided = provider(agent)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.debug("System prompt part provider %s failed: %s", name, exc)
+                continue
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.debug("System prompt part provider %s failed: %s", name, exc)
+            continue
+        if not isinstance(provided, Mapping):
+            continue
+        for tier, value in provided.items():
+            if tier not in _VALID_TIERS:
+                logger.debug(
+                    "System prompt part provider %s returned unknown tier %r",
+                    name,
+                    tier,
+                )
+                continue
+            collected[tier].extend(_coerce_parts(value))
+    return collected
+
+
+def clear_system_prompt_part_providers_for_tests() -> None:
+    """Clear process-local providers for isolated tests."""
+    with _lock:
+        _providers.clear()
+
+
+def _coerce_parts(value: str | Iterable[str] | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+    try:
+        iterator = iter(value)
+    except TypeError:
+        return []
+    parts: list[str] = []
+    for item in iterator:
+        if isinstance(item, str) and item.strip():
+            parts.append(item.strip())
+    return parts

--- a/tests/agent/test_agent_runtime_provider_seams.py
+++ b/tests/agent/test_agent_runtime_provider_seams.py
@@ -1,0 +1,68 @@
+"""Generic agent-runtime provider seam tests."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _make_agent(**overrides):
+    base = dict(
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=[],
+        _task_completion_guidance=False,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance="",
+        _memory_store=None,
+        _memory_manager=None,
+        _memory_enabled=False,
+        model="",
+        provider="",
+        platform="",
+        pass_session_id=False,
+        session_id="",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_system_prompt_part_provider_contributes_ordered_tiers():
+    from agent.system_prompt import build_system_prompt_parts
+    from agent.system_prompt_part_providers import (
+        clear_system_prompt_part_providers_for_tests,
+        register_system_prompt_part_provider,
+    )
+
+    clear_system_prompt_part_providers_for_tests()
+
+    def provider(agent, *, system_message=None):
+        assert agent.platform == "cli"
+        assert system_message == "caller context"
+        return {
+            "stable": ["provider stable A", "provider stable B"],
+            "context": "provider context",
+            "volatile": ["provider volatile"],
+        }
+
+    register_system_prompt_part_provider("test-provider", provider)
+    try:
+        fake_run_agent = SimpleNamespace(
+            load_soul_md=lambda _ctx_len=None: "",
+            build_nous_subscription_prompt=lambda _tools: "",
+            build_environment_hints=lambda: "",
+            build_context_files_prompt=lambda **_kwargs: "",
+        )
+        with patch.dict(sys.modules, {"run_agent": fake_run_agent}):
+            parts = build_system_prompt_parts(
+                _make_agent(platform="cli"), system_message="caller context"
+            )
+    finally:
+        clear_system_prompt_part_providers_for_tests()
+
+    assert "provider stable A\n\nprovider stable B" in parts["stable"]
+    assert "caller context" in parts["context"]
+    assert "provider context" in parts["context"]
+    assert "provider volatile" in parts["volatile"]


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

