### PR TITLE
fix(skills): avoid curl|bash installs that trip AV false positives

### DIFF
--- a/optional-skills/mlops/models/huggingface-hub/SKILL.md
+++ b/optional-skills/mlops/models/huggingface-hub/SKILL.md
@@ -15,7 +15,7 @@ The `hf` command is the modern command-line interface for interacting with the H
 > **IMPORTANT:** The `hf` command replaces the now deprecated `huggingface-cli` command.
 
 ## Quick Start
-*   **Installation:** `curl -LsSf https://hf.co/cli/install.sh | bash -s`
+*   **Installation:** `pip install -U "huggingface_hub[cli]"` (the `hf` command ships with the package).
 *   **Help:** Use `hf --help` to view all available functions and real-world examples.
 *   **Authentication:** Recommended via `HF_TOKEN` environment variable or the `--token` flag.
 

--- a/optional-skills/mlops/models/huggingface-hub/SKILL.md
+++ b/optional-skills/mlops/models/huggingface-hub/SKILL.md
@@ -15,7 +15,7 @@ The `hf` command is the modern command-line interface for interacting with the H
 > **IMPORTANT:** The `hf` command replaces the now deprecated `huggingface-cli` command.
 
 ## Quick Start
-*   **Installation:** `pip install -U "huggingface_hub[cli]"` (the `hf` command ships with the package).
+*   **Installation:** `pip install -U "huggingface_hub"` (the `hf` command ships with the core package).
 *   **Help:** Use `hf --help` to view all available functions and real-world examples.
 *   **Authentication:** Recommended via `HF_TOKEN` environment variable or the `--token` flag.
 

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -42,8 +42,11 @@ brew install himalaya
 # Any platform with Rust
 cargo install himalaya --locked
 
-# Fallback for platforms without brew or cargo (pre-built binary, Linux/macOS)
-curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
+# Fallback for platforms without brew or cargo (pre-built binary, Linux/macOS).
+# Download the installer first, inspect it, then run it — do not pipe remote content straight into a shell.
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh -o himalaya-install.sh
+# (review himalaya-install.sh, then:)
+PREFIX=~/.local sh himalaya-install.sh
 ```
 
 ## Configuration Setup

--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -36,14 +36,14 @@ requires the external `himalaya` CLI.
 ### Installation
 
 ```bash
-# Pre-built binary (Linux/macOS — recommended)
-curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
-
-# macOS via Homebrew
+# macOS / Linuxbrew — recommended
 brew install himalaya
 
-# Or via cargo (any platform with Rust)
+# Any platform with Rust
 cargo install himalaya --locked
+
+# Fallback for platforms without brew or cargo (pre-built binary, Linux/macOS)
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
 ```
 
 ## Configuration Setup

--- a/skills/mlops/huggingface-hub/SKILL.md
+++ b/skills/mlops/huggingface-hub/SKILL.md
@@ -15,7 +15,7 @@ The `hf` command is the modern command-line interface for interacting with the H
 > **IMPORTANT:** The `hf` command replaces the now deprecated `huggingface-cli` command.
 
 ## Quick Start
-*   **Installation:** `curl -LsSf https://hf.co/cli/install.sh | bash -s`
+*   **Installation:** `pip install -U "huggingface_hub[cli]"` (the `hf` command ships with the package).
 *   **Help:** Use `hf --help` to view all available functions and real-world examples.
 *   **Authentication:** Recommended via `HF_TOKEN` environment variable or the `--token` flag.
 

--- a/skills/mlops/huggingface-hub/SKILL.md
+++ b/skills/mlops/huggingface-hub/SKILL.md
@@ -15,7 +15,7 @@ The `hf` command is the modern command-line interface for interacting with the H
 > **IMPORTANT:** The `hf` command replaces the now deprecated `huggingface-cli` command.
 
 ## Quick Start
-*   **Installation:** `pip install -U "huggingface_hub[cli]"` (the `hf` command ships with the package).
+*   **Installation:** `pip install -U "huggingface_hub"` (the `hf` command ships with the core package).
 *   **Help:** Use `hf --help` to view all available functions and real-world examples.
 *   **Authentication:** Recommended via `HF_TOKEN` environment variable or the `--token` flag.
 


### PR DESCRIPTION
## What & why

Two bundled skills install their CLI via a piped `curl ... | bash`/`sh`
one-liner:

- `skills/mlops/huggingface-hub/SKILL.md` — `curl -LsSf https://hf.co/cli/install.sh | bash -s`
- `skills/email/himalaya/SKILL.md` — `curl -sSL .../install.sh | PREFIX=~/.local sh`

Heuristic antivirus engines flag piped remote-download-to-shell patterns
as suspicious downloaders and block them, which breaks legitimate skill
setup for affected users. This is a **recurring** issue in this repo, not
a one-off — three separate AV false-positive reports already exist:

- #57533 (notion install; fix in PR #57555)
- #50924 (Pinggy binary)
- #48411 (uv.exe)

This PR fixes two more instances of the same pattern.

## Changes

- **huggingface-hub:** replace the `curl | bash` installer with
  `pip install -U "huggingface_hub[cli]"`. The `hf` CLI ships with the
  `huggingface_hub` PyPI package, so the standalone install script was
  unnecessary — pip is both AV-clean and the canonical install path.
- **himalaya:** promote `brew install himalaya` to the primary method
  and keep the `curl | sh` pre-built-binary installer only as a
  documented fallback for platforms without brew or cargo (cargo is
  already listed for any Rust platform).

Both changes are behavior-preserving: the resulting CLI is identical and
every install path remains accurate.

## How to test

- huggingface-hub: `pip install -U "huggingface_hub[cli]"` then `hf --help`.
- himalaya: `brew install himalaya` then `himalaya --version`; the curl
  fallback still works on brew-less platforms.

## Platforms

Docs-only change to skill install instructions. `pip` and `brew` paths
verified as the documented upstream methods for each tool (macOS/Linux;
pip additionally covers Windows for huggingface-hub).
