### PR TITLE
fix(gemini): do not merge distinct parallel calls to the same tool in streaming

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -693,6 +693,26 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 sort_keys=True,
             )
             slot = tool_call_indices.get(call_key)
+            # Distinct parallel calls to the SAME tool collide on the same
+            # call_key: each arrives in its own SSE event with part_index=0,
+            # the same name, and (usually) no thoughtSignature. Without this
+            # guard the second call's arguments get appended to the first
+            # slot, producing concatenated JSON ('{"a":1}{"b":2}') that fails
+            # to parse downstream — the loop then stamps the turn with
+            # finish_reason='length' and gives up after retries with a
+            # misleading "Response truncated due to output length limit".
+            # If the existing slot already holds complete arguments and the
+            # new args_str is neither identical (re-send dedup) nor an
+            # extension (incremental streaming), treat it as a NEW call:
+            # walk a "#next" key chain until we find a compatible or empty
+            # slot.
+            while slot is not None:
+                prev_args = str(slot.get("last_arguments") or "")
+                if prev_args and args_str != prev_args and not args_str.startswith(prev_args):
+                    call_key += "#next"
+                    slot = tool_call_indices.get(call_key)
+                else:
+                    break
             if slot is None:
                 slot = {
                     "index": len(tool_call_indices),

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -461,3 +461,72 @@ def test_explicit_max_tokens_is_respected():
 
     req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
     assert req["generationConfig"]["maxOutputTokens"] == 4096
+
+
+def test_stream_event_translation_separates_parallel_calls_across_events():
+    """Two distinct parallel calls to the same tool arrive in separate SSE
+    events, each with part_index=0 and the same name — they must become two
+    tool calls, not one slot with concatenated JSON arguments."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    event_a = {
+        "candidates": [
+            {"content": {"parts": [{"functionCall": {"name": "read_file", "args": {"path": "A"}}}]}}
+        ]
+    }
+    event_b = {
+        "candidates": [
+            {"content": {"parts": [{"functionCall": {"name": "read_file", "args": {"path": "B"}}}]}},
+        ]
+    }
+
+    first = translate_stream_event(event_a, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
+    second = translate_stream_event(event_b, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
+
+    call_a = first[0].choices[0].delta.tool_calls[0]
+    call_b = second[0].choices[0].delta.tool_calls[0]
+    assert call_a.index == 0
+    assert call_b.index == 1
+    assert call_a.id != call_b.id
+    assert call_a.function.arguments == '{"path": "A"}'
+    assert call_b.function.arguments == '{"path": "B"}'
+
+
+def test_stream_event_translation_chains_three_parallel_calls_across_events():
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    calls = []
+    for path in ("A", "B", "C"):
+        event = {
+            "candidates": [
+                {"content": {"parts": [{"functionCall": {"name": "read_file", "args": {"path": path}}}]}}
+            ]
+        }
+        chunks = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
+        calls.append(chunks[0].choices[0].delta.tool_calls[0])
+
+    assert [c.index for c in calls] == [0, 1, 2]
+    assert len({c.id for c in calls}) == 3
+    assert [c.function.arguments for c in calls] == ['{"path": "A"}', '{"path": "B"}', '{"path": "C"}']
+
+
+def test_stream_event_translation_still_dedups_resent_identical_call_across_events():
+    """Identical re-sends of the same call across events must still dedup
+    (emit empty arguments the second time) instead of opening a new slot."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    event = {
+        "candidates": [
+            {"content": {"parts": [{"functionCall": {"name": "search", "args": {"q": "abc"}}}]}}
+        ]
+    }
+
+    first = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
+    second = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
+
+    assert first[0].choices[0].delta.tool_calls[0].index == 0
+    assert second[0].choices[0].delta.tool_calls[0].index == 0
+    assert second[0].choices[0].delta.tool_calls[0].function.arguments == ""


### PR DESCRIPTION
Fixes #57939

## Problem

`translate_stream_event` keys streaming tool calls by `{part_index, name, thought_signature}`. Distinct **parallel calls to the same tool** arrive in separate SSE events, each with `part_index=0`, the same name and usually no `thoughtSignature` — they collide on one slot and their JSON arguments get concatenated (`{"path":"A"}{"path":"B"}`), which fails to parse downstream. The conversation loop then stamps `finish_reason='length'`, retries (the model repeats the pattern) and gives up with a misleading **"Response truncated due to output length limit"**, rolling back the turn. Observed 31 times over 4 days in a production Telegram gateway on gemini-3-flash.

## Fix

When the existing slot already holds complete arguments and the incoming `args_str` is **neither identical** (re-send dedup) **nor an extension** (incremental streaming) of them, treat it as a **new call**: walk a `#next` key chain to a fresh slot with its own index/id.

Preserved behaviors, covered by tests:
- identical re-send across events still dedups (empty delta, same index/id);
- incremental argument streaming still emits suffix deltas;
- same-event duplicate parts keep distinct indices (existing test untouched).

## Tests

Three regression tests added to `tests/agent/test_gemini_native_adapter.py`:
- two parallel calls across events → distinct index/id, intact arguments;
- three chained parallel calls → indices 0/1/2, three distinct ids;
- identical re-send across events → still dedups.

Full adapter suite passes (one pre-existing failure on `test_async_native_client_streams_without_requiring_async_iterator_from_sync_client` reproduces on pristine `main` in my environment and is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)