### PR TITLE
fix(gemini): never send an empty contents array to generateContent

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -430,6 +430,21 @@ def build_gemini_request(
     thinking_config: Any = None,
 ) -> Dict[str, Any]:
     contents, system_instruction = _build_gemini_contents(messages)
+    if not contents:
+        # generateContent rejects an empty `contents` array with HTTP 400
+        # (INVALID_ARGUMENT: "contents is not specified") — a non-retryable
+        # error that surfaces to the user as an opaque "model provider
+        # failed after retries". `contents` can legitimately end up empty
+        # when every message is system-only or loses all of its parts
+        # (e.g. a platform adapter forwarded an event whose media download
+        # failed, or a background/system-only turn). Inject a minimal user
+        # turn so the request is always valid.
+        logger.warning(
+            "Gemini request had empty contents (messages were system-only "
+            "or produced no parts); injecting a minimal user turn to avoid "
+            "a 400 contents is not specified."
+        )
+        contents = [{"role": "user", "parts": [{"text": "."}]}]
     request: Dict[str, Any] = {"contents": contents}
     if system_instruction:
         request["systemInstruction"] = system_instruction

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -461,3 +461,35 @@ def test_explicit_max_tokens_is_respected():
 
     req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
     assert req["generationConfig"]["maxOutputTokens"] == 4096
+
+
+def test_build_gemini_request_injects_minimal_turn_when_contents_empty():
+    """System-only message lists must not produce an empty `contents` —
+    generateContent rejects that with a non-retryable HTTP 400."""
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{"role": "system", "content": "You are a helpful agent."}]
+    )
+    assert request["contents"], "contents must never be empty"
+    assert request["contents"][0]["role"] == "user"
+
+
+def test_build_gemini_request_injects_minimal_turn_for_empty_messages():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(messages=[])
+    assert request["contents"], "contents must never be empty"
+
+
+def test_build_gemini_request_keeps_normal_conversation_untouched():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ]
+    )
+    parts = request["contents"][0]["parts"]
+    assert any(p.get("text") == "hello" for p in parts)


### PR DESCRIPTION
Fixes #57940

## Problem

The Gemini native API rejects `{"contents": []}` with **HTTP 400 (INVALID_ARGUMENT): `contents is not specified`** — non-retryable, surfaced to the end user as an opaque "model provider failed after retries". `build_gemini_request` produces exactly that when every message is system-only or loses all of its parts. Observed triggers in production: a Telegram media download failure forwarded as an empty event, and a background review turn built only from system prompts.

## Fix

Defense-in-depth at the request builder (the single choke point all callers share): if `contents` comes back empty, log a warning and inject a minimal user turn (`.`) so the request is always valid — whatever upstream path produced the empty conversation.

## Tests

Three regression tests added: system-only messages, empty message list, and a normal conversation left untouched. Full adapter suite passes (one pre-existing failure on `test_async_native_client_streams_without_requiring_async_iterator_from_sync_client` reproduces on pristine `main` in my environment and is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)