### PR TITLE
fix(api_server): close 3 divergence gaps from gateway/run.py (empty-model recovery, session model override, provider-auth error surfacing)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4176,6 +4176,37 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(_eff_sid, str) and _eff_sid:
                     result["session_id"] = _eff_sid
                 return result, usage
+            except RuntimeError as exc:
+                # Codex finding #5, MEDIUM: _resolve_runtime_agent_kwargs()
+                # (called inside _create_agent()) raises RuntimeError(
+                # format_runtime_provider_error(...)) on provider auth/
+                # credential failure -- that's the ONLY thing in this
+                # function that raises RuntimeError specifically (other bugs
+                # in _create_agent()'s other logic would surface as
+                # TypeError/AttributeError/etc., not RuntimeError, so this
+                # catch is deliberately narrower than run.py's own `except
+                # Exception` around the equivalent call in
+                # _resolve_session_agent_runtime — precise enough to avoid
+                # mislabeling an unrelated bug as an auth failure, matching
+                # run.py's exact response shape (final_response text, no
+                # HTTP error) for the case it IS a real one. Previously this
+                # propagated unhandled: /v1/chat/completions caught it as a
+                # bare, undifferentiated "Internal server error: {e}" 500,
+                # and /api/sessions/{id}/chat[/stream] didn't catch it at
+                # all -- aiohttp's raw unhandled-exception 500 with no JSON
+                # body. Handling it here, once, covers every _run_agent()
+                # caller identically.
+                logger.warning("Provider authentication failed for session=%s: %s",
+                                session_id or "", exc)
+                return (
+                    {
+                        "final_response": f"⚠️ Provider authentication failed: {exc}",
+                        "messages": [],
+                        "api_calls": 0,
+                        "tools": [],
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
             finally:
                 clear_session_vars(tokens)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1239,6 +1239,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        session_model: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1258,7 +1259,18 @@ class APIServerAdapter(BasePlatformAdapter):
         ``route`` is an optional ``model_routes`` entry (per-client model
         routing).  When set — and no session ``/model`` override exists for
         this session — its model/provider/api_key/base_url override the
-        global defaults for this agent instance only.
+        global defaults for this agent instance only. Used only by the
+        OpenAI-compatible endpoints (chat completions, responses, runs).
+
+        ``session_model`` is the model persisted on the session row at
+        creation time (POST /api/sessions {"model": ...}). Precedence
+        matches run.py's GatewayRunner._resolve_session_agent_runtime:
+        session model > runtime fallback model > gateway default (Codex
+        finding #1, CRITICAL — this was previously stored but never read
+        on the chat path, so a session's chosen model silently had no
+        effect). Used only by the /api/sessions/{id}/chat[/stream]
+        endpoints — mutually exclusive with ``route`` in practice, since
+        no caller passes both.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -1290,7 +1302,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolved from the request's ``model`` field by the HTTP handler.
         # Precedence (highest first): session ``/model`` override → model_routes
         # route → global config — an explicit user-issued ``/model`` on the
-        # session always beats static per-client route config.
+        # session always beats static per-client route config. Only the
+        # OpenAI-compatible endpoints pass ``route``; session-chat endpoints
+        # never do (see ``session_model`` below instead).
         session_override = self._session_model_override_for(
             gateway_session_key or session_id
         )
@@ -1330,6 +1344,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "api_server model route skipped: session /model override wins for %s",
                 gateway_session_key or session_id,
             )
+
+        # Session-persisted model wins over both of the above (Codex finding
+        # #1, CRITICAL). Matches run.py's precedence: session model > runtime
+        # fallback model > gateway default. Only session-chat endpoints pass
+        # ``session_model``, and they never pass ``route`` (see above), so
+        # this never fights the model_routes block for the same call.
+        if session_model:
+            model = session_model
 
         # When the config has no model.default but a provider was resolved
         # (e.g. user ran `hermes auth add openai-codex` without `hermes model`),
@@ -1933,7 +1955,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
         session_id = request.match_info["session_id"]
-        _, err = self._get_existing_session_or_404(session_id)
+        session, err = self._get_existing_session_or_404(session_id)
         if err:
             return err
         body, err = await self._read_json_body(request)
@@ -1946,12 +1968,17 @@ class APIServerAdapter(BasePlatformAdapter):
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
         history = self._conversation_history_for_session(session_id)
+        # Session's persisted model (Codex finding #1, CRITICAL) — previously
+        # fetched and discarded here, so a session's chosen model at creation
+        # time silently had no effect on any chat turn.
+        session_model = session.get("model") if isinstance(session, dict) else None
         result, usage = await self._run_agent(
             user_message=user_message,
             conversation_history=history,
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            session_model=session_model,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
@@ -1977,7 +2004,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
         session_id = request.match_info["session_id"]
-        _, err = self._get_existing_session_or_404(session_id)
+        session, err = self._get_existing_session_or_404(session_id)
         if err:
             return err
         body, err = await self._read_json_body(request)
@@ -1989,6 +2016,9 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        # Session's persisted model (Codex finding #1, CRITICAL) — see
+        # _handle_session_chat for the non-streaming twin of this fix.
+        session_model = session.get("model") if isinstance(session, dict) else None
 
         loop = asyncio.get_running_loop()
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
@@ -2043,6 +2073,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    session_model=session_model,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -4082,6 +4113,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        session_model: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4097,6 +4129,10 @@ class APIServerAdapter(BasePlatformAdapter):
         at ``agent_ref[0]`` before ``run_conversation`` begins.  This allows
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
+
+        ``session_model`` threads the session's persisted model (Codex
+        finding #1) through to ``_create_agent()`` — see its docstring for
+        precedence.
         """
         loop = asyncio.get_running_loop()
 
@@ -4118,6 +4154,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_complete_callback=tool_complete_callback,
                     gateway_session_key=gateway_session_key,
                     route=route,
+                    session_model=session_model,
                 )
                 if agent_ref is not None:
                     agent_ref[0] = agent

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -815,6 +815,23 @@ except Exception:  # pragma: no cover - scanner is optional hardening
     _scan_cron_prompt = None
 
 
+class _ProviderAuthResolutionError(RuntimeError):
+    """Raised only when gateway.run._resolve_runtime_agent_kwargs() fails
+    to resolve provider credentials (Codex finding #5, MEDIUM).
+
+    That function is the sole raiser of RuntimeError(format_runtime_
+    provider_error(...)) anywhere in _create_agent()'s call graph.
+    Re-raising it as this dedicated subclass -- instead of catching bare
+    RuntimeError around the much wider _create_agent()+run_conversation()
+    span -- lets callers distinguish "provider auth/credential failure"
+    from any other RuntimeError a provider adapter or run_conversation()
+    might legitimately raise (e.g. run_agent.py's "Failed to recreate
+    closed OpenAI client"), which a bare `except RuntimeError` there would
+    otherwise mislabel as an auth failure (Codex round-2 re-review of the
+    original fix).
+    """
+
+
 class APIServerAdapter(BasePlatformAdapter):
     """
     OpenAI-compatible HTTP API server adapter.
@@ -1282,7 +1299,19 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         from hermes_cli.tools_config import _get_platform_tools
 
-        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        # Codex finding #5 (MEDIUM), round-2 correction: catch RuntimeError
+        # ONLY around this call, not the wider _create_agent()+
+        # run_conversation() span -- _resolve_runtime_agent_kwargs() is the
+        # sole raiser of RuntimeError(format_runtime_provider_error(...))
+        # (gateway/run.py:1738/1740) for provider auth/credential failure.
+        # Re-raising as _ProviderAuthResolutionError lets _run_agent() (and
+        # _handle_runs()) distinguish this from an unrelated RuntimeError
+        # elsewhere in the call graph (e.g. run_agent.py's "Failed to
+        # recreate closed OpenAI client").
+        try:
+            runtime_kwargs = _resolve_runtime_agent_kwargs()
+        except RuntimeError as exc:
+            raise _ProviderAuthResolutionError(str(exc)) from exc
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 
@@ -4176,26 +4205,28 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(_eff_sid, str) and _eff_sid:
                     result["session_id"] = _eff_sid
                 return result, usage
-            except RuntimeError as exc:
-                # Codex finding #5, MEDIUM: _resolve_runtime_agent_kwargs()
-                # (called inside _create_agent()) raises RuntimeError(
-                # format_runtime_provider_error(...)) on provider auth/
-                # credential failure -- that's the ONLY thing in this
-                # function that raises RuntimeError specifically (other bugs
-                # in _create_agent()'s other logic would surface as
-                # TypeError/AttributeError/etc., not RuntimeError, so this
-                # catch is deliberately narrower than run.py's own `except
-                # Exception` around the equivalent call in
-                # _resolve_session_agent_runtime — precise enough to avoid
-                # mislabeling an unrelated bug as an auth failure, matching
-                # run.py's exact response shape (final_response text, no
-                # HTTP error) for the case it IS a real one. Previously this
-                # propagated unhandled: /v1/chat/completions caught it as a
-                # bare, undifferentiated "Internal server error: {e}" 500,
-                # and /api/sessions/{id}/chat[/stream] didn't catch it at
-                # all -- aiohttp's raw unhandled-exception 500 with no JSON
-                # body. Handling it here, once, covers every _run_agent()
-                # caller identically.
+            except _ProviderAuthResolutionError as exc:
+                # Codex finding #5, MEDIUM, round-2 correction: catching bare
+                # RuntimeError here (as the first version of this fix did)
+                # is unsafe -- agent.run_conversation() can legitimately
+                # raise unrelated RuntimeErrors (e.g. run_agent.py's "Failed
+                # to recreate closed OpenAI client", or a provider/Responses
+                # adapter's runtime error for a malformed response), which
+                # would get mislabeled as a provider auth failure. Only
+                # _ProviderAuthResolutionError -- raised exclusively where
+                # _resolve_runtime_agent_kwargs() is called inside
+                # _create_agent() -- means this specific failure. Matches
+                # run.py's response shape (final_response text, no HTTP
+                # error) for the case it IS a real auth failure. Previously
+                # this propagated unhandled: /v1/chat/completions caught it
+                # as a bare, undifferentiated "Internal server error: {e}"
+                # 500, and /api/sessions/{id}/chat[/stream] didn't catch it
+                # at all -- aiohttp's raw unhandled-exception 500 with no
+                # JSON body. Handling it here, once, covers every
+                # _run_agent() caller identically (chat_completions,
+                # session_chat, session_chat_stream, responses). /v1/runs
+                # does not call _run_agent() -- see _handle_runs()'s own
+                # _ProviderAuthResolutionError branch for that path.
                 logger.warning("Provider authentication failed for session=%s: %s",
                                 session_id or "", exc)
                 return (
@@ -4539,6 +4570,34 @@ class APIServerAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
                 raise
+            except _ProviderAuthResolutionError as exc:
+                # Codex finding #5, MEDIUM: /v1/runs builds its own agent
+                # via _create_agent() and does not route through
+                # _run_agent() (see that method's own
+                # _ProviderAuthResolutionError branch), so it needs its own
+                # handling to surface the same distinguished, controlled
+                # message the other three endpoints (chat_completions,
+                # session_chat, session_chat_stream) give a provider auth/
+                # credential failure, instead of falling through to the
+                # generic except-Exception branch below and getting an
+                # undistinguished "agent run failed"-style message.
+                logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
+                error_msg = f"⚠️ Provider authentication failed: {exc}"
+                self._set_run_status(
+                    run_id,
+                    "failed",
+                    error=error_msg,
+                    last_event="run.failed",
+                )
+                try:
+                    q.put_nowait({
+                        "event": "run.failed",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "error": error_msg,
+                    })
+                except Exception:
+                    pass
             except Exception as exc:
                 logger.exception("[api_server] run %s failed", run_id)
                 self._set_run_status(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -882,6 +882,13 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        # Last-known-good resolved model per session (keyed by gateway_session_key
+        # ONLY — never session_id, which rotates/is ephemeral for one-off API
+        # server requests; "*" is the process-wide fallback), mirroring
+        # GatewayRunner._last_resolved_model in run.py — recovers from a
+        # transient empty model resolution (#35314) instead of building an
+        # agent with model="" that 400s every call until manual retry.
+        self._last_resolved_model: Dict[str, str] = {}
         # Concurrency cap shared across all agent-serving endpoints
         # (/v1/chat/completions, /v1/responses, /v1/runs). Read from
         # config.yaml gateway.api_server.max_concurrent_runs; 0 disables
@@ -1323,6 +1330,59 @@ class APIServerAdapter(BasePlatformAdapter):
                 "api_server model route skipped: session /model override wins for %s",
                 gateway_session_key or session_id,
             )
+
+        # When the config has no model.default but a provider was resolved
+        # (e.g. user ran `hermes auth add openai-codex` without `hermes model`),
+        # fall back to the provider's first catalog model so the API call
+        # doesn't fail with "model must be a non-empty string". Mirrors
+        # run.py::_resolve_session_agent_runtime (~3537). Runs after the
+        # model_routes block above so a route/session override that already
+        # resolved a model is never treated as "empty" here.
+        if not model and runtime_kwargs.get("provider"):
+            try:
+                from hermes_cli.models import get_default_model_for_provider
+                model = get_default_model_for_provider(runtime_kwargs["provider"])
+                if model:
+                    logger.info(
+                        "No model configured — defaulting to %s for provider %s",
+                        model, runtime_kwargs["provider"],
+                    )
+            except Exception:
+                pass
+
+        # Final safety net (#35314): if resolution still produced an empty
+        # model — e.g. a transient config-cache miss — reuse the last model
+        # successfully resolved for this session (or, failing that, the most
+        # recent one resolved process-wide). Building an agent with model=""
+        # makes every API call fail HTTP 400 "No models provided" until a
+        # manual retry. Mirrors run.py::_resolve_session_agent_runtime (~3549).
+        #
+        # Cache key is gateway_session_key ONLY, never session_id — unlike
+        # run.py's native gateway (stable, long-lived chat scopes), the API
+        # server hands out a fresh UUID session_id per one-off request
+        # (/v1/responses ~3128, /v1/runs ~4059 when no explicit session is
+        # supplied). Keying on session_id would leave one permanent dict
+        # entry per stateless request, growing unbounded for the life of the
+        # process (Codex adversarial re-review, commit 0440094e1). This
+        # docstring's own distinction already says session_id "rotates" —
+        # only gateway_session_key is the deliberately-stable, caller-chosen
+        # identifier worth remembering across calls.
+        _resolved_key = gateway_session_key or ""
+        if not model:
+            _recovered = (self._last_resolved_model.get(_resolved_key)
+                          or self._last_resolved_model.get("*"))
+            if _recovered:
+                logger.warning(
+                    "Empty model resolved for session=%s — recovering "
+                    "last-known-good model %s (config read likely returned "
+                    "empty; see #35314)",
+                    _resolved_key, _recovered,
+                )
+                model = _recovered
+        elif model:
+            if _resolved_key:
+                self._last_resolved_model[_resolved_key] = model
+            self._last_resolved_model["*"] = model
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,7 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _IdempotencyCache,
     _derive_chat_session_id,
+    _ProviderAuthResolutionError,
     _redact_api_error_text,
     check_api_server_requirements,
     cors_middleware,
@@ -625,6 +626,29 @@ class TestAdapterInit:
         )
         adapter._create_agent(session_id="a-totally-different-session-id", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
+
+    def test_create_agent_wraps_runtime_credential_failure_as_provider_auth_error(self, monkeypatch):
+        """Codex finding #5 (MEDIUM), round-2 re-review: the first version of
+        this fix caught bare RuntimeError around the whole _create_agent()+
+        run_conversation() span in _run_agent(), which would mislabel an
+        unrelated RuntimeError (e.g. from run_conversation() itself) as a
+        provider auth failure. The fix instead converts a RuntimeError from
+        gateway.run._resolve_runtime_agent_kwargs() specifically -- the sole
+        raiser of RuntimeError(format_runtime_provider_error(...)) anywhere
+        in this call graph -- into _ProviderAuthResolutionError right where
+        it's called, inside _create_agent(). This is the boundary test:
+        confirms _create_agent() itself does this conversion, independent
+        of any caller's exception handling."""
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: (_ for _ in ()).throw(RuntimeError("No credentials found for provider 'nous'")),
+        )
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        with pytest.raises(_ProviderAuthResolutionError, match="No credentials found for provider 'nous'"):
+            adapter._create_agent(session_id="api-session")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -478,6 +478,154 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["model"] == "primary/model"
 
+    def test_create_agent_defaults_to_provider_catalog_model_when_empty(self, monkeypatch):
+        """Codex finding #2 (CRITICAL): api_server.py had no equivalent of
+        run.py's provider-catalog default when model resolves empty but a
+        provider did resolve (e.g. `hermes auth add openai-codex` without
+        `hermes model`) — AIAgent(model="") 400s every call."""
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": "openai-codex", "base_url": "https://example.test/v1",
+                     "api_mode": "codex_responses"},
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda: {}))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+        monkeypatch.setattr(
+            "hermes_cli.models.get_default_model_for_provider",
+            lambda provider: "gpt-5.5-codex" if provider == "openai-codex" else None,
+        )
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(session_id="api-session")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["model"] == "gpt-5.5-codex"
+
+    def test_create_agent_recovers_last_known_good_model_when_empty(self, monkeypatch):
+        """Codex finding #2 (CRITICAL): api_server.py had no last-known-good
+        recovery (#35314) — a transient config-cache miss producing an empty
+        model would build AIAgent(model="") and fail every call in the
+        session until manual retry, instead of reusing the model that just
+        worked."""
+        captured = []
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.append(dict(kwargs))
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": "nous", "base_url": "https://example.test/v1", "api_mode": "chat_completions"},
+        )
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda: {}))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        # Turn 1: model resolves fine — populates the last-known-good cache.
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "minimax/minimax-m3")
+        adapter._create_agent(session_id="api-session")
+        assert captured[0]["model"] == "minimax/minimax-m3"
+
+        # Turn 2: transient empty resolution, no provider catalog default
+        # available — must recover the model from turn 1, not build model="".
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": None, "base_url": None, "api_mode": None},
+        )
+        adapter._create_agent(session_id="api-session")
+        assert captured[1]["model"] == "minimax/minimax-m3"
+
+    def test_last_resolved_model_cache_does_not_grow_per_ephemeral_session_id(self, monkeypatch):
+        """Codex adversarial re-review of commit 0440094e1: /v1/responses and
+        /v1/runs hand out a fresh UUID session_id per one-off request (no
+        gateway_session_key), unlike run.py's stable, long-lived native
+        gateway chat scopes. Keying the last-known-good cache on session_id
+        would leave one permanent dict entry per stateless request, growing
+        unbounded for the life of the process. Only gateway_session_key
+        (the deliberately-stable, caller-chosen identifier) may be used as
+        a cache key; a bare session_id must never create an entry."""
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                pass
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": "nous", "base_url": "https://example.test/v1", "api_mode": "chat_completions"},
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "minimax/minimax-m3")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda: {}))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        # 50 one-off requests, each a fresh UUID session_id, no gateway_session_key
+        # -- mirrors /v1/responses (~3128) and /v1/runs (~4059) with no explicit
+        # session supplied.
+        import uuid
+        for _ in range(50):
+            adapter._create_agent(session_id=str(uuid.uuid4()))
+
+        # Only the "*" process-wide fallback may exist -- never one entry per
+        # ephemeral session_id.
+        assert list(adapter._last_resolved_model.keys()) == ["*"]
+
+    def test_last_resolved_model_cache_uses_gateway_session_key_when_present(self, monkeypatch):
+        """Counterpart to the ephemeral-session test above: a caller-supplied,
+        stable gateway_session_key IS worth remembering (that's the whole
+        point of the recovery cache), so it must still be keyed correctly."""
+        captured = []
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.append(dict(kwargs))
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": "nous", "base_url": "https://example.test/v1", "api_mode": "chat_completions"},
+        )
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda: {}))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "minimax/minimax-m3")
+        adapter._create_agent(session_id="api-session", gateway_session_key="stable-chan-1")
+        assert adapter._last_resolved_model["stable-chan-1"] == "minimax/minimax-m3"
+
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": None, "base_url": None, "api_mode": None},
+        )
+        adapter._create_agent(session_id="a-totally-different-session-id", gateway_session_key="stable-chan-1")
+        assert captured[1]["model"] == "minimax/minimax-m3"
+
 
 # ---------------------------------------------------------------------------
 # Auth checking

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -270,6 +270,41 @@ class TestRunStatus:
             resp = await cli.get("/v1/runs/run_any")
         assert resp.status == 401
 
+    @pytest.mark.asyncio
+    async def test_status_reports_provider_auth_failure_distinctly(self, adapter):
+        """Codex finding #5 (MEDIUM): /v1/runs builds its own agent via
+        _create_agent() and does not route through _run_agent() at all, so
+        the controlled "Provider authentication failed" message added there
+        does not automatically cover this endpoint (Codex round-2
+        re-review). _handle_runs()'s own _ProviderAuthResolutionError
+        branch must give the same distinguished message here instead of
+        falling through to the generic except-Exception branch's
+        undistinguished "agent run failed" text."""
+        from gateway.platforms.api_server import _ProviderAuthResolutionError
+
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _ProviderAuthResolutionError(
+                    "No credentials found for provider 'nous'"
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "failed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert status["status"] == "failed"
+                assert status["error"] == "⚠️ Provider authentication failed: No credentials found for provider 'nous'"
+                assert status["last_event"] == "run.failed"
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id}/events — SSE event stream

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -124,6 +124,82 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_run_agent_returns_controlled_response_on_provider_auth_failure(adapter, monkeypatch):
+    """Codex finding #5 (MEDIUM): _resolve_runtime_agent_kwargs() (inside
+    _create_agent()) raises RuntimeError on provider auth/credential
+    failure. Previously this propagated unhandled out of _run_agent():
+    /v1/chat/completions caught it as a generic, undifferentiated
+    "Internal server error: {e}" 500, and /api/sessions/{id}/chat didn't
+    catch it at all (raw aiohttp 500, no JSON body). Must now return
+    run.py's exact controlled response shape instead of raising."""
+    def fake_create_agent(**kwargs):
+        raise RuntimeError("No credentials found for provider 'nous' — run `hermes auth add nous`")
+
+    monkeypatch.setattr(adapter, "_create_agent", fake_create_agent)
+
+    result, usage = await adapter._run_agent(
+        user_message="hello",
+        conversation_history=[],
+        session_id="request-session",
+    )
+
+    assert result == {
+        "final_response": "⚠️ Provider authentication failed: No credentials found for provider 'nous' — run `hermes auth add nous`",
+        "messages": [],
+        "api_calls": 0,
+        "tools": [],
+    }
+    assert usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_does_not_swallow_unrelated_exceptions(adapter, monkeypatch):
+    """The RuntimeError catch must stay narrow -- a TypeError (or any other
+    non-RuntimeError bug elsewhere in _create_agent()/run_conversation())
+    must still propagate normally, not get mislabeled as a provider auth
+    failure."""
+    def fake_create_agent(**kwargs):
+        raise TypeError("unrelated bug: unexpected keyword argument")
+
+    monkeypatch.setattr(adapter, "_create_agent", fake_create_agent)
+
+    with pytest.raises(TypeError, match="unrelated bug"):
+        await adapter._run_agent(
+            user_message="hello",
+            conversation_history=[],
+            session_id="request-session",
+        )
+
+
+@pytest.mark.asyncio
+async def test_session_chat_surfaces_controlled_response_on_provider_auth_failure(auth_adapter, session_db):
+    """End-to-end: POST /api/sessions/{id}/chat previously had zero wrapping
+    around _run_agent() -- an unhandled RuntimeError would have produced a
+    raw aiohttp 500 with no JSON body. Must now return 200 with the
+    controlled error message as the assistant content, matching what
+    /v1/chat/completions' existing (separate) generic-500 fallback would
+    have produced for other errors, but distinguishing this specific case
+    the way run.py does."""
+    session_id = session_db.create_session("auth-fail-session", "api_server")
+
+    def fake_create_agent(**kwargs):
+        raise RuntimeError("Auth failed: token expired")
+
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_create_agent", fake_create_agent):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi"},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status == 200
+            payload = await resp.json()
+
+    assert payload["message"]["content"] == "⚠️ Provider authentication failed: Auth failed: token expired"
+
+
+@pytest.mark.asyncio
 async def test_session_crud_and_message_history(adapter, session_db):
     app = _create_session_app(adapter)
     async with TestClient(TestServer(app)) as cli:

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -252,6 +252,51 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
 
 
 @pytest.mark.asyncio
+async def test_session_chat_threads_session_model_to_run_agent(auth_adapter, session_db):
+    """Codex finding #1 (CRITICAL): POST /api/sessions persists a per-session
+    model, but /api/sessions/{id}/chat fetched the session record and threw
+    it away -- the session's chosen model silently had no effect on any chat
+    turn. Must reach _run_agent as session_model."""
+    session_id = session_db.create_session("model-pinned-session", "api_server", model="claude-sonnet-4-6")
+
+    mock_run = AsyncMock(return_value=({"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}))
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi"},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status == 200
+
+    mock_run.assert_awaited_once()
+    _, kwargs = mock_run.call_args
+    assert kwargs["session_model"] == "claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_threads_session_model_to_run_agent(adapter, session_db):
+    """Streaming twin of the CRITICAL finding #1 regression test above."""
+    session_id = session_db.create_session("model-pinned-stream-session", "api_server", model="gpt-5.5")
+
+    mock_run = AsyncMock(return_value=({"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}))
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "hi"},
+            )
+            assert resp.status == 200
+            await resp.read()
+
+    mock_run.assert_awaited_once()
+    _, kwargs = mock_run.call_args
+    assert kwargs["session_model"] == "gpt-5.5"
+
+
+@pytest.mark.asyncio
 async def test_session_chat_accepts_multimodal_message(auth_adapter, session_db):
     session_id = session_db.create_session("image-session", "api_server")
     image_payload = [

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -131,11 +131,22 @@ async def test_run_agent_returns_controlled_response_on_provider_auth_failure(ad
     /v1/chat/completions caught it as a generic, undifferentiated
     "Internal server error: {e}" 500, and /api/sessions/{id}/chat didn't
     catch it at all (raw aiohttp 500, no JSON body). Must now return
-    run.py's exact controlled response shape instead of raising."""
-    def fake_create_agent(**kwargs):
-        raise RuntimeError("No credentials found for provider 'nous' — run `hermes auth add nous`")
+    run.py's exact controlled response shape instead of raising.
 
-    monkeypatch.setattr(adapter, "_create_agent", fake_create_agent)
+    Exercises the REAL boundary (gateway.run._resolve_runtime_agent_kwargs,
+    the sole raiser of this RuntimeError) rather than mocking away
+    _create_agent() wholesale -- per Codex round-2 re-review, mocking
+    _create_agent() only validates the wrapper shape, not that
+    _create_agent() actually converts the RuntimeError into
+    _ProviderAuthResolutionError at the right call site. This is the
+    first substantive call inside _create_agent(), so no other config
+    loader needs stubbing for this failure path."""
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: (_ for _ in ()).throw(
+            RuntimeError("No credentials found for provider 'nous' — run `hermes auth add nous`")
+        ),
+    )
 
     result, usage = await adapter._run_agent(
         user_message="hello",
@@ -154,10 +165,9 @@ async def test_run_agent_returns_controlled_response_on_provider_auth_failure(ad
 
 @pytest.mark.asyncio
 async def test_run_agent_does_not_swallow_unrelated_exceptions(adapter, monkeypatch):
-    """The RuntimeError catch must stay narrow -- a TypeError (or any other
-    non-RuntimeError bug elsewhere in _create_agent()/run_conversation())
-    must still propagate normally, not get mislabeled as a provider auth
-    failure."""
+    """The _ProviderAuthResolutionError catch must stay narrow -- a
+    TypeError elsewhere in _create_agent()/run_conversation() must still
+    propagate normally, not get mislabeled as a provider auth failure."""
     def fake_create_agent(**kwargs):
         raise TypeError("unrelated bug: unexpected keyword argument")
 
@@ -172,29 +182,58 @@ async def test_run_agent_does_not_swallow_unrelated_exceptions(adapter, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_session_chat_surfaces_controlled_response_on_provider_auth_failure(auth_adapter, session_db):
+async def test_run_agent_does_not_swallow_unrelated_runtime_error_from_run_conversation(adapter, monkeypatch):
+    """Codex round-2 re-review: this was the actual bug in the first version
+    of this fix. agent.run_conversation() can legitimately raise a
+    RuntimeError unrelated to provider auth (e.g. run_agent.py's "Failed to
+    recreate closed OpenAI client"). A bare `except RuntimeError` around the
+    whole _create_agent()+run_conversation() span would mislabel it as
+    "Provider authentication failed". Only _ProviderAuthResolutionError --
+    raised exclusively inside _create_agent() at the
+    _resolve_runtime_agent_kwargs() call site -- may trigger the controlled
+    response; this unrelated RuntimeError from run_conversation() must
+    propagate unhandled."""
+    class _FakeAgent:
+        def run_conversation(self, **kwargs):
+            raise RuntimeError("Failed to recreate closed OpenAI client")
+
+    monkeypatch.setattr(adapter, "_create_agent", lambda **kwargs: _FakeAgent())
+
+    with pytest.raises(RuntimeError, match="Failed to recreate closed OpenAI client"):
+        await adapter._run_agent(
+            user_message="hello",
+            conversation_history=[],
+            session_id="request-session",
+        )
+
+
+@pytest.mark.asyncio
+async def test_session_chat_surfaces_controlled_response_on_provider_auth_failure(auth_adapter, session_db, monkeypatch):
     """End-to-end: POST /api/sessions/{id}/chat previously had zero wrapping
     around _run_agent() -- an unhandled RuntimeError would have produced a
     raw aiohttp 500 with no JSON body. Must now return 200 with the
     controlled error message as the assistant content, matching what
     /v1/chat/completions' existing (separate) generic-500 fallback would
     have produced for other errors, but distinguishing this specific case
-    the way run.py does."""
+    the way run.py does. Exercises the real
+    gateway.run._resolve_runtime_agent_kwargs() boundary, not a mocked
+    _create_agent()."""
     session_id = session_db.create_session("auth-fail-session", "api_server")
 
-    def fake_create_agent(**kwargs):
-        raise RuntimeError("Auth failed: token expired")
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: (_ for _ in ()).throw(RuntimeError("Auth failed: token expired")),
+    )
 
     app = _create_session_app(auth_adapter)
-    with patch.object(auth_adapter, "_create_agent", fake_create_agent):
-        async with TestClient(TestServer(app)) as cli:
-            resp = await cli.post(
-                f"/api/sessions/{session_id}/chat",
-                json={"message": "hi"},
-                headers={"Authorization": "Bearer sk-test"},
-            )
-            assert resp.status == 200
-            payload = await resp.json()
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            f"/api/sessions/{session_id}/chat",
+            json={"message": "hi"},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert resp.status == 200
+        payload = await resp.json()
 
     assert payload["message"]["content"] == "⚠️ Provider authentication failed: Auth failed: token expired"
 


### PR DESCRIPTION
## What this does

`gateway/platforms/api_server.py` (the OpenAI-compatible API surface) has drifted from `gateway/run.py`'s native gateway path on several points since it was added. This closes three of them, each independently verified as not yet addressed on `main`:

1. **Empty-model recovery** — `run.py` gained provider-catalog-default → last-known-good recovery in #35381 (closing #35314), but it was never ported to `api_server.py`. A transient empty model resolution here still builds `AIAgent(model="")` and 400s every call until manual retry.
2. **Session model override ignored** — `POST /api/sessions {"model": ...}` persists a model choice, but `/api/sessions/{id}/chat` never read it back — silent wrong-model execution with no error to notice.
3. **Provider-auth failures leak as undifferentiated/raw 500s** — `run.py` returns a controlled "Provider authentication failed" response on credential resolution failure; `api_server.py` either 500'd generically or (on the session-chat endpoints) didn't catch it at all. Added a narrowly-scoped exception type so this doesn't also swallow unrelated errors from elsewhere in the call path.

Found via adversarial review after a related production crash (`AIAgent() got multiple values for keyword argument 'model'`, already fixed independently in #56170). Each fix has a regression test that fails on the pre-fix code and passes after.

**Out of scope on purpose:** service_tier/request_overrides forwarding overlaps with in-flight work (#34006, #53765) and isn't included here to avoid duplicate effort — happy to coordinate separately if useful.

## Testing

253 passed in the targeted API-server suite (`test_api_server.py`, `test_api_server_runs.py`, `test_session_api.py`, `test_empty_model_recovery.py`, `test_session_model_override_routing.py`).