### PR TITLE
fix(tts): block output to protected paths

### DIFF
--- a/tests/tools/test_tts_path_traversal.py
+++ b/tests/tools/test_tts_path_traversal.py
@@ -58,3 +58,44 @@ def test_output_path_relative_no_dotdot_passes_guard(tmp_path, monkeypatch):
     ))
     error = result.get("error", "")
     assert "traversal" not in error.lower()
+
+
+def test_output_path_rejects_hermes_oauth_store(tmp_path, monkeypatch):
+    """TTS output_path must not bypass the shared protected-file write guard."""
+    import agent.file_safety as file_safety
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+
+    target = hermes_home / ".anthropic_oauth.json"
+    result = json.loads(text_to_speech_tool(
+        text="hello",
+        output_path=str(target),
+    ))
+
+    assert result["success"] is False
+    assert "protected credential" in result["error"]
+    assert not target.exists()
+
+
+def test_output_path_rejects_mcp_token_directory(tmp_path, monkeypatch):
+    """TTS output_path must not write synthesized audio over MCP token files."""
+    import agent.file_safety as file_safety
+
+    hermes_home = tmp_path / "hermes-home"
+    token_dir = hermes_home / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    monkeypatch.setattr(file_safety, "_hermes_root_path", lambda: hermes_home)
+
+    target = token_dir / "server.mp3"
+    result = json.loads(text_to_speech_tool(
+        text="hello",
+        output_path=str(target),
+    ))
+
+    assert result["success"] is False
+    assert "protected credential" in result["error"]
+    assert not target.exists()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2229,6 +2229,16 @@ def text_to_speech_tool(
             file_path = _configured_command_tts_output_path(
                 file_path, command_provider_config
             )
+        from agent.file_safety import is_write_denied
+
+        if is_write_denied(str(file_path)):
+            return json.dumps({
+                "success": False,
+                "error": (
+                    f"output_path targets a protected credential or system path: "
+                    f"{file_path}. Choose a normal audio output location."
+                ),
+            }, ensure_ascii=False)
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = Path(DEFAULT_OUTPUT_DIR)


### PR DESCRIPTION
## Summary

`text_to_speech` accepts an optional `output_path` and only rejected `..` traversal before handing the resolved path to the selected TTS backend. Absolute paths were allowed, but protected credential/system paths were not checked against the same write denylist used by the file tools.

That means a tool call could write synthesized audio bytes over protected paths such as `~/.hermes/.anthropic_oauth.json`, `~/.hermes/mcp-tokens/*`, `~/.hermes/pairing/*`, SSH credential files, or other write-denied locations. `write_file` already blocks these paths; TTS should not bypass that write boundary through an output-path parameter.

## Changes

- Check explicit `output_path` values with `agent.file_safety.is_write_denied()` after path normalization and command-provider extension normalization.
- Return a structured failure before any provider work when the target is protected.
- Add regression tests for Hermes OAuth storage and `mcp-tokens/`.
- Preserve existing behavior for safe absolute paths and relative paths without traversal.

## Tests

```text
python -m pytest tests/tools/test_tts_path_traversal.py -q --timeout-method=thread
6 passed