### PR TITLE
fix(tools): refresh delegation config from disk

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,6 +11,7 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import tempfile
 import threading
 import time
 import unittest
@@ -2385,6 +2386,88 @@ class TestDelegateEventEnum(unittest.TestCase):
         parent.tool_progress_callback.assert_called_once()
         # No '⚡' tool-start emoji should appear — that's the pre-fix bug.
         self.assertFalse(any("⚡" in str(c) for c in calls))
+
+
+class TestDelegateLoadConfig(unittest.TestCase):
+    def test_persistent_config_overrides_stale_cli_snapshot(self):
+        """A running gateway should see delegation config written to disk."""
+        from tools.delegate_tool import _load_config
+
+        mock_cli = MagicMock()
+        mock_cli.CLI_CONFIG = {
+            "delegation": {
+                "child_timeout_seconds": 600,
+                "max_concurrent_children": 4,
+            }
+        }
+
+        with patch.dict("sys.modules", {"cli": mock_cli}), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"delegation": {"child_timeout_seconds": 900}},
+        ), patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"delegation": {"child_timeout_seconds": 900}},
+        ):
+            result = _load_config()
+
+        self.assertEqual(result["child_timeout_seconds"], 900)
+        self.assertEqual(result["max_concurrent_children"], 4)
+
+    def test_cli_snapshot_used_when_key_missing_from_persistent_config(self):
+        """Runtime-only delegation values still work when absent from config.yaml."""
+        from tools.delegate_tool import _load_config
+
+        mock_cli = MagicMock()
+        mock_cli.CLI_CONFIG = {"delegation": {"max_concurrent_children": 7}}
+
+        with patch.dict("sys.modules", {"cli": mock_cli}), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"delegation": {}},
+        ), patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"delegation": {"max_concurrent_children": 3}},
+        ):
+            result = _load_config()
+
+        self.assertEqual(result["max_concurrent_children"], 7)
+
+    def test_disk_config_keeps_expansion_empty_override_and_cli_fallback(self):
+        """Fresh disk config keeps load_config semantics without stale CLI keys."""
+        from pathlib import Path
+
+        from hermes_cli import config as config_mod
+        from tools.delegate_tool import _load_config
+
+        mock_cli = MagicMock()
+        mock_cli.CLI_CONFIG = {
+            "delegation": {
+                "base_url": "https://stale.example/v1",
+                "provider": "openrouter",
+                "max_concurrent_children": 7,
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "config.yaml").write_text(
+                "delegation:\n"
+                "  base_url: ${DELEGATION_BASE_URL}\n"
+                "  provider: ''\n",
+                encoding="utf-8",
+            )
+            config_mod._LOAD_CONFIG_CACHE.clear()
+            config_mod._RAW_CONFIG_CACHE.clear()
+            with patch.dict(
+                os.environ,
+                {
+                    "HERMES_HOME": tmp,
+                    "DELEGATION_BASE_URL": "https://fresh.example/v1",
+                },
+            ), patch.dict("sys.modules", {"cli": mock_cli}):
+                result = _load_config()
+
+        self.assertEqual(result["base_url"], "https://fresh.example/v1")
+        self.assertEqual(result["provider"], "")
+        self.assertEqual(result["max_concurrent_children"], 7)
 
 
 class TestConcurrencyDefaults(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3098,28 +3098,46 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config from persistent config or CLI_CONFIG.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    User-authored persistent config is authoritative so ``hermes config set
+    delegation.*`` changes take effect in long-lived processes. ``CLI_CONFIG``
+    is still used as a fallback for default-only keys and entry points with
+    runtime-only overrides.
     """
+    delegation_config = {}
+    persistent_keys = set()
+    try:
+        from hermes_cli.config import load_config_readonly, read_raw_config
+
+        raw_delegation = read_raw_config().get("delegation") or {}
+        if isinstance(raw_delegation, dict):
+            persistent_keys.update(raw_delegation)
+        loaded_delegation = load_config_readonly().get("delegation") or {}
+        if isinstance(loaded_delegation, dict):
+            delegation_config.update(loaded_delegation)
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.managed_scope import managed_config_keys
+
+        for dotted_key in managed_config_keys():
+            if dotted_key.startswith("delegation."):
+                persistent_keys.add(dotted_key.split(".", 1)[1])
+    except Exception:
+        pass
+
     try:
         from cli import CLI_CONFIG
 
         cfg = CLI_CONFIG.get("delegation") or {}
-        if cfg:
-            return cfg
+        for key, value in cfg.items():
+            if key not in persistent_keys:
+                delegation_config[key] = value
     except Exception:
         pass
-    try:
-        from hermes_cli.config import load_config
-
-        full = load_config()
-        return full.get("delegation") or {}
-    except Exception:
-        return {}
+    return delegation_config
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes delegation config refresh for long-lived processes by making `tools.delegate_tool._load_config()` prefer the current persistent `delegation.*` config instead of returning the stale `cli.CLI_CONFIG` startup snapshot.

The merge keeps the important existing semantics:

- values written by `hermes config set delegation.*` win on the next `delegate_task`
- `${VAR}` expansion and managed-scope overlays still come from the normal config loader
- `CLI_CONFIG` still fills runtime-only/default-only keys when the persistent config has no explicit value
- explicit empty persistent values, such as `provider: ""`, clear stale runtime snapshot values

## Related Issue

Fixes #57930

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`: load fresh config via `load_config_readonly()` and use raw config/managed keys only to decide which keys are persistent and should not be overwritten by stale `CLI_CONFIG`.
- `tests/tools/test_delegate.py`: add regression coverage for stale `CLI_CONFIG`, CLI fallback keys, real `HERMES_HOME/config.yaml` disk reads, env expansion, and explicit empty values.

## How to Test

1. Fails-on-main regression:

   ```bash
   scripts/run_tests.sh tests/tools/test_delegate.py -- -k persistent_config_overrides_stale_cli_snapshot -q
   ```

   Before the fix, this failed with `AssertionError: 600 != 900`.

2. Focused config proof:

   ```bash
   scripts/run_tests.sh tests/tools/test_delegate.py -- -k DelegateLoadConfig -q
   ```

   Result: 3 passed.

3. Broader delegate proof:

   ```bash
   scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/run_agent/test_agent_guardrails.py -- -q
   ```

   Result: 211 passed.

4. Static/lightweight checks:

   ```bash
   .venv/bin/ruff check tools/delegate_tool.py tests/tools/test_delegate.py
   .venv/bin/python scripts/check-windows-footguns.py tools/delegate_tool.py tests/tools/test_delegate.py
   git diff --check
   ```

5. Duplicate-work checks:

   ```bash
   gh pr list --repo NousResearch/hermes-agent --state all --search "57930" --json number,title,state,isDraft,author,url,updatedAt --limit 20
   gh pr list --repo NousResearch/hermes-agent --state all --search "delegate_tool _load_config cli.CLI_CONFIG stale delegation config set" --json number,title,state,isDraft,author,url,updatedAt --limit 20
   ```

   Both returned `[]` before opening this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (local delegate-focused suite)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is delegation config-loading behavior.
