### PR TITLE
[codex] fix(shell-hooks): reapprove changed scripts

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -106,6 +106,7 @@ emitted by each built-in hook site.
 from __future__ import annotations
 
 import difflib
+import hashlib
 import json
 import logging
 import os
@@ -662,13 +663,22 @@ def save_allowlist(data: Dict[str, Any]) -> None:
 
 
 def _is_allowlisted(event: str, command: str) -> bool:
+    current_hash = script_sha256(command)
     data = load_allowlist()
-    return any(
-        isinstance(e, dict)
-        and e.get("event") == event
-        and e.get("command") == command
-        for e in data.get("approvals", [])
-    )
+    for e in data.get("approvals", []):
+        if not (
+            isinstance(e, dict)
+            and e.get("event") == event
+            and e.get("command") == command
+        ):
+            continue
+        approved_hash = e.get("script_sha256_at_approval")
+        if approved_hash is not None:
+            return approved_hash == current_hash
+        if current_hash is not None:
+            return False
+        return True
+    return False
 
 
 @contextmanager
@@ -749,6 +759,7 @@ def _record_approval(event: str, command: str) -> None:
         "command": command,
         "approved_at": _utc_now_iso(),
         "script_mtime_at_approval": script_mtime_iso(command),
+        "script_sha256_at_approval": script_sha256(command),
     }
     with _locked_update_approvals() as data:
         data["approvals"] = [
@@ -867,6 +878,21 @@ def script_mtime_iso(command: str) -> Optional[str]:
         return datetime.fromtimestamp(
             os.path.getmtime(expanded), tz=timezone.utc,
         ).isoformat().replace("+00:00", "Z")
+    except OSError:
+        return None
+
+
+def script_sha256(command: str) -> Optional[str]:
+    """SHA-256 digest of the resolved hook script, or ``None`` if absent."""
+    path = _command_script_path(command)
+    if not path:
+        return None
+    try:
+        h = hashlib.sha256()
+        with open(os.path.expanduser(path), "rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
     except OSError:
         return None
 

--- a/tests/agent/test_shell_hooks_consent.py
+++ b/tests/agent/test_shell_hooks_consent.py
@@ -100,6 +100,35 @@ class TestTTYPromptFlow:
             )
         assert len(registered) == 1
 
+    def test_modified_script_requires_reapproval(self, tmp_path):
+        """Allowlisting the command string must not trust changed script bytes."""
+        from hermes_cli import plugins
+
+        script = _write_hook_script(tmp_path)
+        plugins._plugin_manager = plugins.PluginManager()
+
+        with patch("sys.stdin") as mock_stdin, patch("builtins.input", return_value="y"):
+            mock_stdin.isatty.return_value = True
+            shell_hooks.register_from_config(
+                {"hooks": {"on_session_start": [{"command": str(script)}]}},
+                accept_hooks=False,
+            )
+
+        script.write_text("#!/usr/bin/env bash\nprintf '{\"changed\": true}\\n'\n")
+        script.chmod(0o755)
+        shell_hooks.reset_for_tests()
+        plugins._plugin_manager = plugins.PluginManager()
+
+        with patch("sys.stdin") as mock_stdin, patch("builtins.input", return_value="n") as mock_input:
+            mock_stdin.isatty.return_value = True
+            registered = shell_hooks.register_from_config(
+                {"hooks": {"on_session_start": [{"command": str(script)}]}},
+                accept_hooks=False,
+            )
+
+        assert registered == []
+        mock_input.assert_called_once()
+
 
 # ── non-TTY flow ──────────────────────────────────────────────────────────
 
@@ -181,6 +210,7 @@ class TestAllowlistOps:
         assert entry["script_mtime_at_approval"] is not None
         # ISO-8601 Z-suffix
         assert entry["script_mtime_at_approval"].endswith("Z")
+        assert entry["script_sha256_at_approval"] == shell_hooks.script_sha256(str(script))
 
     def test_revoke_removes_entry(self, tmp_path):
         script = _write_hook_script(tmp_path)
@@ -239,6 +269,19 @@ class TestAllowlistOps:
             and e.get("command") == str(script)
         ]
         assert len(matching) == 1
+
+    def test_legacy_script_entry_without_hash_does_not_allow_current_file(self, tmp_path):
+        script = _write_hook_script(tmp_path)
+        shell_hooks.save_allowlist({
+            "approvals": [{
+                "event": "on_session_start",
+                "command": str(script),
+                "approved_at": "2026-01-01T00:00:00Z",
+                "script_mtime_at_approval": shell_hooks.script_mtime_iso(str(script)),
+            }],
+        })
+
+        assert shell_hooks._is_allowlisted("on_session_start", str(script)) is False
 
 
 # ── hooks_auto_accept config parsing ──────────────────────────────────────
@@ -309,4 +352,3 @@ class TestHooksAutoAcceptParsing:
         assert shell_hooks._resolve_effective_accept(
             {"hooks_auto_accept": "false"}, accept_hooks_arg=True,
         ) is True
-


### PR DESCRIPTION
Fixes #57558.

## Problem
Shell-hook consent was keyed only by `(event, command)`, so an approved command pointing at a script stayed trusted after the script bytes changed. The existing mtime drift check was advisory only and did not participate in registration.

## Root cause
`_record_approval()` stored `script_mtime_at_approval`, but `_is_allowlisted()` only compared the saved event and command string. Runtime registration never checked the current script content.

## Fix
- Store `script_sha256_at_approval` with each approval.
- Require the current script digest to match before treating a script command as allowlisted.
- Force legacy script approvals without a hash to re-prompt once a current script file exists, so old command-only trust does not survive the upgrade.

## Tests
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_shell_hooks_consent.py tests/agent/test_shell_hooks.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check agent/shell_hooks.py tests/agent/test_shell_hooks_consent.py`