### PR TITLE
fix(dashboard): apply write guard to fs editor saves

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -72,14 +72,6 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Top-level Anthropic PKCE credential store remains sensitive even
             # when a profile is active; default/non-profile sessions still read it.
             str(hermes_root / ".anthropic_oauth.json"),
-            # Keep the write side aligned with the read-side Hermes credential
-            # store list so dashboard/file writes cannot poison stores that
-            # read_file already refuses to expose.
-            *(
-                str(base / rel_path)
-                for base in (hermes_home, hermes_root)
-                for rel_path in _HERMES_CREDENTIAL_STORE_REL_PATHS
-            ),
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),
@@ -133,9 +125,6 @@ def is_write_denied(path: str) -> bool:
     """Return True if path is blocked by the write denylist or safe root."""
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
-
-    if Path(resolved).name.lower() in _BLOCKED_PROJECT_ENV_BASENAMES:
-        return True
 
     if resolved in build_write_denied_paths(home):
         return True

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -37,6 +37,20 @@ _HERMES_CREDENTIAL_STORE_REL_PATHS = (
 )
 
 
+# Common secret-bearing project-local environment file basenames.
+# These are blocked because .env files routinely contain API keys,
+# database passwords, and other credentials.
+_BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
+    ".env",
+    ".env.local",
+    ".env.development",
+    ".env.production",
+    ".env.test",
+    ".env.staging",
+    ".envrc",
+}
+
+
 def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
     hermes_home = _hermes_home_path()
@@ -120,6 +134,9 @@ def is_write_denied(path: str) -> bool:
     home = os.path.realpath(os.path.expanduser("~"))
     resolved = os.path.realpath(os.path.expanduser(str(path)))
 
+    if Path(resolved).name.lower() in _BLOCKED_PROJECT_ENV_BASENAMES:
+        return True
+
     if resolved in build_write_denied_paths(home):
         return True
     for prefix in build_write_denied_prefixes(home):
@@ -162,20 +179,6 @@ def is_write_denied(path: str) -> bool:
             return True
 
     return False
-
-
-# Common secret-bearing project-local environment file basenames.
-# These are blocked because .env files routinely contain API keys,
-# database passwords, and other credentials.
-_BLOCKED_PROJECT_ENV_BASENAMES: set[str] = {
-    ".env",
-    ".env.local",
-    ".env.development",
-    ".env.production",
-    ".env.test",
-    ".env.staging",
-    ".envrc",
-}
 
 
 def get_read_block_error(path: str) -> Optional[str]:

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -25,6 +25,18 @@ def _hermes_root_path() -> Path:
         return Path(os.path.expanduser("~/.hermes"))
 
 
+_HERMES_CREDENTIAL_STORE_REL_PATHS = (
+    "auth.json",
+    "auth.lock",
+    ".anthropic_oauth.json",
+    ".env",
+    "webhook_subscriptions.json",
+    os.path.join("auth", "google_oauth.json"),
+    # Bitwarden Secrets Manager disk cache stores plaintext secret values.
+    os.path.join("cache", "bws_cache.json"),
+)
+
+
 def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
     hermes_home = _hermes_home_path()
@@ -46,6 +58,14 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Top-level Anthropic PKCE credential store remains sensitive even
             # when a profile is active; default/non-profile sessions still read it.
             str(hermes_root / ".anthropic_oauth.json"),
+            # Keep the write side aligned with the read-side Hermes credential
+            # store list so dashboard/file writes cannot poison stores that
+            # read_file already refuses to expose.
+            *(
+                str(base / rel_path)
+                for base in (hermes_home, hermes_root)
+                for rel_path in _HERMES_CREDENTIAL_STORE_REL_PATHS
+            ),
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),
@@ -238,18 +258,7 @@ def get_read_block_error(path: str) -> Optional[str]:
 
     # Credential / secret stores. Exact-file matches under either
     # HERMES_HOME or <root>.
-    credential_file_names = (
-        "auth.json",
-        "auth.lock",
-        ".anthropic_oauth.json",
-        ".env",
-        "webhook_subscriptions.json",
-        os.path.join("auth", "google_oauth.json"),
-        # Bitwarden Secrets Manager disk cache: stores plaintext secret values
-        # to avoid re-fetching across back-to-back CLI invocations. The file
-        # was introduced by #31968 but not added to this guard.
-        os.path.join("cache", "bws_cache.json"),
-    )
+    credential_file_names = _HERMES_CREDENTIAL_STORE_REL_PATHS
     for hd in hermes_dirs:
         for name in credential_file_names:
             try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1939,6 +1939,16 @@ async def fs_write_text(payload: FsWriteText):
     so both transports behave identically.
     """
     target = _fs_path(payload.path)
+    try:
+        from agent.file_safety import is_write_denied
+    except Exception:  # noqa: BLE001 - safety helper is in-tree; surface as a server error if unavailable
+        logger.exception("Dashboard fs write guard unavailable")
+        raise HTTPException(status_code=500, detail="File write guard unavailable")
+    if is_write_denied(str(target)):
+        raise HTTPException(
+            status_code=403,
+            detail="Writing protected credential or system paths is not allowed",
+        )
     text = payload.content or ""
     if len(text.encode("utf-8")) > _FS_TEXT_WRITE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="Content too large")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1940,11 +1940,11 @@ async def fs_write_text(payload: FsWriteText):
     """
     target = _fs_path(payload.path)
     try:
-        from agent.file_safety import is_write_denied
+        from agent.file_safety import get_read_block_error, is_write_denied
     except Exception:  # noqa: BLE001 - safety helper is in-tree; surface as a server error if unavailable
         logger.exception("Dashboard fs write guard unavailable")
         raise HTTPException(status_code=500, detail="File write guard unavailable")
-    if is_write_denied(str(target)):
+    if is_write_denied(str(target)) or get_read_block_error(str(target)):
         raise HTTPException(
             status_code=403,
             detail="Writing protected credential or system paths is not allowed",

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -128,6 +128,52 @@ def test_fs_read_data_url_rejects_over_cap(client, tmp_path, monkeypatch):
     assert response.status_code == 413
 
 
+def test_fs_write_text_writes_safe_file(client, tmp_path):
+    target = tmp_path / "notes.txt"
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(target), "content": "hello"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert target.read_text() == "hello"
+
+
+def test_fs_write_text_rejects_protected_oauth_file(client, tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    target = hermes_home / ".anthropic_oauth.json"
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(target), "content": "not json"},
+    )
+
+    assert response.status_code == 403
+    assert "protected" in response.json()["detail"].lower()
+    assert not target.exists()
+
+
+def test_fs_write_text_rejects_mcp_token_files(client, tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    token_dir = hermes_home / "mcp-tokens"
+    token_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    target = token_dir / "github.json"
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(target), "content": "{}"},
+    )
+
+    assert response.status_code == 403
+    assert "protected" in response.json()["detail"].lower()
+    assert not target.exists()
+
+
 def test_fs_git_root_for_nested_file(client, tmp_path):
     (tmp_path / ".git").mkdir()
     nested = tmp_path / "pkg" / "mod"

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -174,6 +174,33 @@ def test_fs_write_text_rejects_mcp_token_files(client, tmp_path, monkeypatch):
     assert not target.exists()
 
 
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "auth.json",
+        "auth.lock",
+        "webhook_subscriptions.json",
+        "auth/google_oauth.json",
+        "cache/bws_cache.json",
+    ],
+)
+def test_fs_write_text_rejects_hermes_credential_stores(
+    client, tmp_path, monkeypatch, relative_path
+):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    target = hermes_home / relative_path
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(target), "content": "attacker-controlled"},
+    )
+
+    assert response.status_code == 403
+    assert "protected" in response.json()["detail"].lower()
+    assert not target.exists()
+
+
 def test_fs_git_root_for_nested_file(client, tmp_path):
     (tmp_path / ".git").mkdir()
     nested = tmp_path / "pkg" / "mod"

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -201,6 +201,35 @@ def test_fs_write_text_rejects_hermes_credential_stores(
     assert not target.exists()
 
 
+@pytest.mark.parametrize("filename", [".env", ".env.local", ".env.production", ".envrc"])
+def test_fs_write_text_rejects_project_env_files(client, tmp_path, filename):
+    target = tmp_path / "project" / filename
+    target.parent.mkdir()
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(target), "content": "SECRET=attacker-controlled"},
+    )
+
+    assert response.status_code == 403
+    assert "protected" in response.json()["detail"].lower()
+    assert not target.exists()
+
+
+def test_fs_write_text_allows_env_example(client, tmp_path):
+    target = tmp_path / "project" / ".env.example"
+    target.parent.mkdir()
+
+    response = client.post(
+        "/api/fs/write-text",
+        json={"path": str(target), "content": "KEY=example"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert target.read_text() == "KEY=example"
+
+
 def test_fs_git_root_for_nested_file(client, tmp_path):
     (tmp_path / ".git").mkdir()
     nested = tmp_path / "pkg" / "mod"


### PR DESCRIPTION
## Summary

The dashboard/desktop `/api/fs/write-text` endpoint resolved arbitrary filesystem paths and atomically overwrote them for the in-app spot editor, but it did not apply the shared protected-path write guard used by the file tools.

That left the remote dashboard fs editor able to write protected credential/system paths such as Hermes OAuth stores, `mcp-tokens/*`, `pairing/*`, SSH credential files, and other paths covered by `agent.file_safety.is_write_denied()`.

The `/api/fs/read-text` and `/api/fs/read-data-url` surfaces are already hardened against credential reads; the matching write surface should enforce the same protected-path boundary before staging and replacing the target file.

## Changes

- Apply `agent.file_safety.is_write_denied()` in `/api/fs/write-text` immediately after path normalization.
- Return `403` before any temp-file write/replace when the target is protected.
- Add regression coverage for:
  - normal safe spot-editor saves
  - protected Hermes OAuth store writes
  - protected `mcp-tokens/` writes

## Tests

```text
python -m pytest tests/hermes_cli/test_web_server_fs.py -q --timeout-method=thread
16 passed