### PR TITLE
[codex] fix(fallback): honor explicit api_mode

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -39,6 +39,12 @@ from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
+_FALLBACK_API_MODES = {
+    "chat_completions",
+    "codex_responses",
+    "anthropic_messages",
+    "bedrock_converse",
+}
 
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
@@ -1300,11 +1306,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
+        # Determine api_mode from explicit fallback config first, then infer
+        # from provider / base URL / model like the primary runtime path.
+        fb_explicit_api_mode = (fb.get("api_mode") or "").strip()
         fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        if fb_explicit_api_mode and fb_explicit_api_mode not in _FALLBACK_API_MODES:
+            logger.warning(
+                "Ignoring unsupported fallback api_mode %r for %s/%s",
+                fb_explicit_api_mode, fb_provider, fb_model,
+            )
+            fb_explicit_api_mode = ""
+        elif fb_explicit_api_mode:
+            fb_api_mode = fb_explicit_api_mode
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif (
             fb_provider == "anthropic"

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -211,6 +211,37 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert agent.api_mode == "anthropic_messages"
 
+    def test_explicit_fallback_api_mode_wins_over_url_heuristics(self):
+        """A custom Anthropic-compatible proxy may not use the anthropic
+        provider name, host, or /anthropic suffix. The fallback entry's
+        api_mode is the only durable signal for that transport."""
+        fbs = [
+            {
+                "provider": "custom",
+                "model": "claude-sonnet-4-6",
+                "base_url": "https://proxy.example/v1",
+                "api_key": "fallback-secret",
+                "api_mode": "anthropic_messages",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(
+                        base_url="https://proxy.example/v1",
+                        api_key="fallback-secret",
+                    ),
+                    "claude-sonnet-4-6",
+                ),
+            ),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "anthropic_messages"
+            assert agent._anthropic_base_url == "https://proxy.example/v1"
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
Fixes #57582.

## Problem
The original fallback-index report was corrected in the issue thread: the live failure was that a `fallback_providers` entry could set `api_mode: anthropic_messages`, but fallback activation ignored that field and inferred transport only from provider name, URL, and model. A custom Anthropic-compatible proxy without an `api.anthropic.com` host or `/anthropic` suffix defaulted to chat completions and posted to the wrong endpoint.

## Root cause
`try_activate_fallback()` read provider/model/base_url/api_key from each fallback entry but never read `fb["api_mode"]`. The primary runtime path supports explicit api_mode; fallback activation did not.

## Fix
- Add an explicit fallback api_mode gate for supported transports before the existing inference chain.
- Leave existing provider/URL/model inference intact when api_mode is absent.
- Warn and fall back to inference for unsupported api_mode values.

## Tests
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_provider_fallback.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check agent/chat_completion_helpers.py tests/run_agent/test_provider_fallback.py`