### PR TITLE
fix: dashboard basic auth (password-only provider) no longer crashes on first page load (#57868)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -182,9 +182,13 @@ def _auto_sso_response(request: Request) -> Response | None:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None
 
-    from hermes_cli.dashboard_auth.prefix import prefix_from_request
-
     provider = providers[0]
+    # If the sole provider is password-only, don't auto-redirect to /auth/login
+    # as it has no OAuth redirect flow. Fall through to /login interstitial.
+    if getattr(provider, "supports_password", False):
+        return None
+
+    from hermes_cli.dashboard_auth.prefix import prefix_from_request
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
Fixes #57868

## Description
When the dashboard is bound to a non-loopback host and the only enabled interactive auth provider is a password-only provider (e.g. the bundled  plugin), unauthenticated users are redirected to , which then crashes with a 500 Internal Server Error because the basic-auth provider has no OAuth redirect flow.

The fix adds a guard in  to avoid auto-redirecting to  when the sole provider is password-only, falling through to render the  interstitial instead.

## Verification
- Applied the fix locally and verified:
  -  redirects to 
  -  renders the password form for "Username & Password"
  -  with configured credentials succeeds and sets the session cookie
  -  returns the authenticated user
- All relevant tests pass (see test run in the CI)
- Quality gates passed: no secrets, no personal refs, conventional commit, focused diff, and local compilation.
