### PR TITLE
fix(transcription): guard local inputs against credential reads

### DIFF
--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -224,6 +224,24 @@ class TestTranscribeAudio:
         assert result["success"] is True
         mock_openai.assert_called_once()
 
+    def test_blocks_credential_store_before_provider_dispatch(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        token_dir = hermes_home / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        audio_file = token_dir / "github.wav"
+        audio_file.write_bytes(b"fake credential bytes")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "openai"}), \
+             patch("tools.transcription_tools._get_provider", return_value="openai"), \
+             patch("tools.transcription_tools._transcribe_openai") as mock_openai:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(audio_file))
+
+        assert result["success"] is False
+        assert "credential" in result["error"].lower()
+        mock_openai.assert_not_called()
+
     def test_no_provider_returns_error(self, tmp_path):
         audio_file = tmp_path / "test.ogg"
         audio_file.write_bytes(b"fake audio")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1036,6 +1036,14 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
             "error": f"Unsupported format: {audio_path.suffix}. Supported: {', '.join(sorted(SUPPORTED_FORMATS))}",
         }
     try:
+        from agent.file_safety import get_read_block_error
+
+        blocked_error = get_read_block_error(str(audio_path))
+    except Exception:
+        blocked_error = None
+    if blocked_error:
+        return {"success": False, "transcript": "", "error": blocked_error}
+    try:
         file_size = audio_path.stat().st_size
         if file_size > MAX_FILE_SIZE:
             return {


### PR DESCRIPTION
## Summary

Route local STT/transcription input paths through the shared credential-read guard before dispatching to any transcription provider.

## Why

`transcribe_audio()` validated existence, file type, symlinks, and size, but it did not call the shared credential-read guard before provider dispatch. Cloud STT providers such as OpenAI, Groq, Mistral, xAI, and ElevenLabs then open the supplied local path and upload it as multipart audio.

That left a gap next to the recent local media input hardening work: a path with a valid audio extension under a sensitive Hermes credential location, such as `~/.hermes/mcp-tokens/*.wav`, could reach the provider upload path before being denied.

## Changes

- Apply `agent.file_safety.get_read_block_error()` inside `_validate_audio_file()`.
- Return a normal transcription error before provider selection/dispatch when the path targets a blocked credential store.
- Add regression coverage proving a blocked `mcp-tokens/*.wav` input does not call the OpenAI transcription dispatch path.

## Tests

```text
python -m pytest tests/tools/test_transcription.py -q --timeout-method=thread
27 passed