### PR TITLE
fix(gateway): omit --replace from launchd service

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3843,7 +3843,6 @@ def generate_launchd_plist() -> str:
         [
             "<string>gateway</string>",
             "<string>run</string>",
-            "<string>--replace</string>",
         ]
     )
     prog_args_xml = "\n        ".join(prog_args)


### PR DESCRIPTION
## Summary

- Remove `--replace` from the generated launchd gateway service command.
- Prevent launchd-managed gateway starts/restarts from replacing the existing gateway process.
- Preserve explicit manual `hermes gateway run --replace` behavior.

## Why

The live gateway was entering a planned shutdown/replacement loop when launchd launched the service with `gateway run --replace`. For a launchd-managed service, auto-restart should be owned by launchd and the service command should not intentionally replace an existing gateway process during normal supervision.

## Validation

- `python -m py_compile hermes_cli/gateway.py`
- `hermes gateway status`
  - service definition matches the current Hermes install
  - gateway is supervised by launchd
- `hermes update --check`
  - already up to date
- `curl -fsS http://127.0.0.1:8642/health`
  - `{"status": "ok", "platform": "hermes-agent", "version": "0.18.0"}`
- Local survivability guard:
  - `PASS_GATEWAY_UPDATE_GUARD`

## Scope

- One source file changed: `hermes_cli/gateway.py`
- One-line launchd generation change only.
- No auth, secrets, runtime state, gateway registry, provider routing, or update logic changed.