### PR TITLE
perf(state): external-content FTS5 — stop storing message text three times

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -122,7 +122,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 17
+SCHEMA_VERSION = 18
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -799,9 +799,31 @@ CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
     ON sessions(handoff_state, started_at);
 """
 
-FTS_SQL = """
+# External-content FTS5 (v18): both FTS tables read their text through the
+# messages_fts_source view instead of storing a private copy of every
+# message, which removes the two redundant *_content shadow tables (the
+# same text used to be stored three times: messages + base FTS + trigram
+# FTS). The view is the single source of truth for the indexed text — FTS5
+# queries it for the 'rebuild' command and for snippet()/highlight() — so
+# the trigger expressions below MUST stay byte-identical to the view's
+# SELECT. The AFTER DELETE / AFTER UPDATE triggers use the FTS5 'delete'
+# command built from OLD values (the row is already gone/changed when an
+# AFTER trigger fires, so the view cannot be consulted); insert, delete,
+# and rebuild all derive the text from the same expression, so the
+# value-mismatch corruption of #16751 (delete passing different text than
+# insert indexed) cannot recur.
+FTS_SOURCE_VIEW_SQL = """
+CREATE VIEW IF NOT EXISTS messages_fts_source (id, content) AS
+    SELECT id,
+           COALESCE(content, '') || ' ' || COALESCE(tool_name, '') || ' ' || COALESCE(tool_calls, '')
+    FROM messages;
+"""
+
+FTS_SQL = FTS_SOURCE_VIEW_SQL + """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-    content
+    content,
+    content='messages_fts_source',
+    content_rowid='id'
 );
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_insert AFTER INSERT ON messages BEGIN
@@ -812,11 +834,19 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_insert AFTER INSERT ON messages BEGIN
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_delete AFTER DELETE ON messages BEGIN
-    DELETE FROM messages_fts WHERE rowid = old.id;
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES (
+        'delete',
+        old.id,
+        COALESCE(old.content, '') || ' ' || COALESCE(old.tool_name, '') || ' ' || COALESCE(old.tool_calls, '')
+    );
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
-    DELETE FROM messages_fts WHERE rowid = old.id;
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES (
+        'delete',
+        old.id,
+        COALESCE(old.content, '') || ' ' || COALESCE(old.tool_name, '') || ' ' || COALESCE(old.tool_calls, '')
+    );
     INSERT INTO messages_fts(rowid, content) VALUES (
         new.id,
         COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
@@ -828,9 +858,14 @@ END;
 # tokenizer splits CJK characters into individual tokens, breaking phrase
 # matching.  The trigram tokenizer creates overlapping 3-byte sequences so
 # substring queries work natively for any script (CJK, Thai, etc.).
-FTS_TRIGRAM_SQL = """
+# External content like the base table above; the view DDL is repeated here
+# (IF NOT EXISTS makes it idempotent) because the trigram table can be
+# created independently of FTS_SQL, e.g. on the v10 migration path.
+FTS_TRIGRAM_SQL = FTS_SOURCE_VIEW_SQL + """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
     content,
+    content='messages_fts_source',
+    content_rowid='id',
     tokenize='trigram'
 );
 
@@ -842,11 +877,19 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_insert AFTER INSERT ON message
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages BEGIN
-    DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES (
+        'delete',
+        old.id,
+        COALESCE(old.content, '') || ' ' || COALESCE(old.tool_name, '') || ' ' || COALESCE(old.tool_calls, '')
+    );
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages BEGIN
-    DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES (
+        'delete',
+        old.id,
+        COALESCE(old.content, '') || ' ' || COALESCE(old.tool_name, '') || ' ' || COALESCE(old.tool_calls, '')
+    );
     INSERT INTO messages_fts_trigram(rowid, content) VALUES (
         new.id,
         COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
@@ -1061,25 +1104,14 @@ class SessionDB:
         *,
         include_trigram: bool = True,
     ) -> None:
-        cursor.execute("DELETE FROM messages_fts")
-        cursor.execute(
-            "INSERT INTO messages_fts(rowid, content) "
-            "SELECT id, "
-            "COALESCE(content, '') || ' ' || "
-            "COALESCE(tool_name, '') || ' ' || "
-            "COALESCE(tool_calls, '') "
-            "FROM messages"
-        )
+        # External-content tables reject plain DELETE FROM; the FTS5
+        # 'rebuild' command drops the whole index and re-reads every row
+        # from the messages_fts_source view in one statement.
+        cursor.execute("INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
         if not include_trigram:
             return
-        cursor.execute("DELETE FROM messages_fts_trigram")
         cursor.execute(
-            "INSERT INTO messages_fts_trigram(rowid, content) "
-            "SELECT id, "
-            "COALESCE(content, '') || ' ' || "
-            "COALESCE(tool_name, '') || ' ' || "
-            "COALESCE(tool_calls, '') "
-            "FROM messages"
+            "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('rebuild')"
         )
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
@@ -1522,6 +1554,62 @@ class SessionDB:
                     )
                 except sqlite3.OperationalError:
                     pass
+            if current_version < 18:
+                # v18: switch both FTS tables from inline to external-content
+                # mode backed by the messages_fts_source view. Inline mode
+                # stored a full private copy of every message's text in each
+                # FTS *_content shadow table (the same bytes three times:
+                # messages + base FTS + trigram FTS). Dropping and recreating
+                # from FTS_SQL / FTS_TRIGRAM_SQL then running 'rebuild' keeps
+                # search results and snippet() output identical while the
+                # shadow tables stay empty. Skip when the tables are already
+                # external-content (e.g. the v11 block above just created
+                # them from the current DDL on a very old DB).
+                if fts5_available:
+                    _fts_master_sql_row = cursor.execute(
+                        "SELECT sql FROM sqlite_master "
+                        "WHERE type = 'table' AND name = 'messages_fts'"
+                    ).fetchone()
+                    _fts_master_sql = (
+                        _fts_master_sql_row[0] if _fts_master_sql_row else ""
+                    ) or ""
+                    if "messages_fts_source" not in _fts_master_sql:
+                        self._drop_fts_triggers(cursor)
+                        for _tbl in ("messages_fts", "messages_fts_trigram"):
+                            try:
+                                cursor.execute(f"DROP TABLE IF EXISTS {_tbl}")
+                            except sqlite3.OperationalError as exc:
+                                if not self._is_fts5_unavailable_error(exc):
+                                    raise
+                                if self._is_trigram_unavailable_error(exc):
+                                    self._warn_trigram_unavailable(exc)
+                                else:
+                                    self._warn_fts5_unavailable(exc)
+                                    fts5_available = False
+                                    fts_migrations_complete = False
+                                break
+                        if fts5_available:
+                            base_fts_ok = self._ensure_fts_schema(
+                                cursor, "messages_fts", FTS_SQL
+                            )
+                            if base_fts_ok:
+                                cursor.execute(
+                                    "INSERT INTO messages_fts(messages_fts) "
+                                    "VALUES('rebuild')"
+                                )
+                            trigram_ok = self._ensure_fts_schema(
+                                cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                            )
+                            if trigram_ok:
+                                cursor.execute(
+                                    "INSERT INTO messages_fts_trigram("
+                                    "messages_fts_trigram) VALUES('rebuild')"
+                                )
+                            if not base_fts_ok:
+                                fts_migrations_complete = False
+                            self._trigram_available = trigram_ok
+                else:
+                    fts_migrations_complete = False
             if current_version < SCHEMA_VERSION and fts_migrations_complete:
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4258,6 +4258,163 @@ class TestFTS5ToolCallMigration:
             session_db.close()
 
 
+class TestFTS5ExternalContentMigration:
+    """v17 → v18: inline-mode FTS tables become external-content backed by
+    the messages_fts_source view, emptying both *_content shadow tables."""
+
+    def _build_v17_db(self, db_path):
+        """Hand-build a v17-shaped DB: inline FTS tables + the v17 triggers."""
+        import sqlite3
+
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (17);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                started_at REAL,
+                ended_at REAL,
+                title TEXT,
+                parent_session_id TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                api_call_count INTEGER DEFAULT 0
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                timestamp REAL NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_name TEXT,
+                tool_calls TEXT,
+                tool_call_id TEXT,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_content TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT,
+                codex_message_items TEXT
+            );
+
+            CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+            CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content) VALUES (
+                    new.id,
+                    COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
+                );
+            END;
+            CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+                DELETE FROM messages_fts WHERE rowid = old.id;
+            END;
+
+            CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(
+                content, tokenize='trigram'
+            );
+            CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts_trigram(rowid, content) VALUES (
+                    new.id,
+                    COALESCE(new.content, '') || ' ' || COALESCE(new.tool_name, '') || ' ' || COALESCE(new.tool_calls, '')
+                );
+            END;
+            CREATE TRIGGER messages_fts_trigram_delete AFTER DELETE ON messages BEGIN
+                DELETE FROM messages_fts_trigram WHERE rowid = old.id;
+            END;
+        """)
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("s1", "cli", time.time()),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, timestamp, role, content, tool_name) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("s1", time.time(), "assistant", "INLINEMODEMSG hello", "INLINETOOL"),
+        )
+        conn.commit()
+        # Sanity: inline mode stores a private copy in the shadow table.
+        stored = conn.execute(
+            "SELECT COUNT(*) FROM messages_fts_content WHERE c0 IS NOT NULL"
+        ).fetchone()[0]
+        assert stored == 1, "sanity: v17 inline FTS must store content"
+        conn.close()
+
+    def test_v17_to_v18_migration_empties_content_shadow_tables(self, tmp_path):
+        db_path = tmp_path / "legacy_v17.db"
+        self._build_v17_db(db_path)
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            # Search still works, including tool_name tokens and snippets.
+            hits = session_db.search_messages("INLINEMODEMSG")
+            assert len(hits) == 1
+            assert len(session_db.search_messages("INLINETOOL")) == 1
+
+            # The FTS tables are now external-content: SQLite does not even
+            # create the *_content shadow tables that inline mode used to
+            # fill with a private copy of every message.
+            for shadow in ("messages_fts_content", "messages_fts_trigram_content"):
+                remaining = session_db._conn.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE name = ?",
+                    (shadow,),
+                ).fetchone()[0]
+                assert remaining == 0, f"{shadow} must not exist after v18"
+
+            # The virtual tables reference the source view.
+            fts_sql = session_db._conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'messages_fts'"
+            ).fetchone()[0]
+            assert "messages_fts_source" in fts_sql
+
+            from hermes_state import SCHEMA_VERSION
+            row = session_db._conn.execute(
+                "SELECT version FROM schema_version LIMIT 1"
+            ).fetchone()
+            version = row["version"] if hasattr(row, "keys") else row[0]
+            assert version == SCHEMA_VERSION
+        finally:
+            session_db.close()
+
+    def test_external_content_delete_and_update_keep_index_consistent(
+        self, tmp_path
+    ):
+        """The 'delete' command triggers must remove index entries using the
+        exact expression the insert trigger indexed (regression guard for the
+        #16751 class of value-mismatch corruption)."""
+        db_path = tmp_path / "fresh_v18.db"
+        session_db = SessionDB(db_path=db_path)
+        try:
+            session_db.create_session("s1", source="cli")
+            mid = session_db.append_message(
+                "s1", role="user", content="EPHEMERALTOKEN in flight"
+            )
+            assert len(session_db.search_messages("EPHEMERALTOKEN")) == 1
+
+            # UPDATE path: old tokens leave the index, new ones enter it.
+            session_db._conn.execute(
+                "UPDATE messages SET content = 'REPLACEDTOKEN landed' WHERE id = ?",
+                (mid,),
+            )
+            session_db._conn.commit()
+            assert session_db.search_messages("EPHEMERALTOKEN") == []
+            assert len(session_db.search_messages("REPLACEDTOKEN")) == 1
+
+            # DELETE path: the row vanishes from the index without error.
+            session_db._conn.execute("DELETE FROM messages WHERE id = ?", (mid,))
+            session_db._conn.commit()
+            assert session_db.search_messages("REPLACEDTOKEN") == []
+
+            # Index integrity: FTS5 self-check passes after delete+update.
+            session_db._conn.execute(
+                "INSERT INTO messages_fts(messages_fts, rank) "
+                "VALUES('integrity-check', 1)"
+            )
+        finally:
+            session_db.close()
+
+
 # ---------------------------------------------------------------------------
 # apply_wal_with_fallback — read-only probe tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Switches both session-store FTS5 tables (`messages_fts`, `messages_fts_trigram`) from inline-content mode to **external content** backed by a new `messages_fts_source` view over `messages`.

In inline mode, each FTS table keeps a full private copy of every message's indexed text in its `*_content` shadow table — so the same bytes live **three times** on disk: once in `messages`, once per FTS table. On a real-world 752 MB `state.db` (540 sessions / 49k messages), those two redundant copies alone accounted for **256 MB**:

| table | size |
|---|---|
| `messages` (canonical) | 185 MB |
| `messages_fts_trigram_data` (index) | 254 MB |
| `messages_fts_trigram_content` (**redundant copy**) | 128 MB |
| `messages_fts_content` (**redundant copy**) | 128 MB |
| `messages_fts_data` (index) | 33 MB |

After migration + `hermes sessions optimize`: **752.5 MB → 496.4 MB (−34%)**, with search results and `snippet()` output byte-identical.

### Why external content is safe now (the #16751 history)

The v11 migration deliberately moved *away* from external content ("Fixes #16751"), but the underlying bug wasn't external content itself — it was the delete trigger passing `old.content` while the insert trigger indexed `content || tool_name || tool_calls`, so the FTS5 `'delete'` command received text that never matched what was indexed.

This PR eliminates that failure class structurally: the view is the single source of truth for the indexed expression. `'rebuild'` and `snippet()`/`highlight()` read the view, and the insert/delete/update triggers inline the *same* expression over NEW/OLD values (AFTER triggers can't consult the view because the row is already gone/changed). Insert, delete, and rebuild can no longer disagree about what text a rowid maps to.

## Related Issue

Related to #43690 (FTS5 trigram bloat on tool_calls JSON — this removes the duplicated *content* half of that cost; the trigram index expansion itself remains) and #53415 (state.db size contributing to resident memory).

## Type of Change

- [x] ♻️ Refactor (no behavior change) — storage-layout/perf change with an automatic schema migration; search behavior is unchanged

## Changes Made

- `hermes_state.py`
  - New `messages_fts_source` view; `FTS_SQL` / `FTS_TRIGRAM_SQL` now create external-content tables (`content='messages_fts_source'`, `content_rowid='id'`)
  - Delete/update triggers use the FTS5 `'delete'` command built from OLD values with the same concat expression the insert trigger uses
  - `_rebuild_fts_indexes()` uses the FTS5 `'rebuild'` command (external-content tables reject plain `DELETE FROM`)
  - `SCHEMA_VERSION` 17 → 18 with a v18 migration: drops inline-mode FTS tables, recreates from the new DDL, and rebuilds from the view. Skips when tables are already external-content (fresh DBs, or ancient DBs the v11 block just rebuilt with current DDL). Mirrors the v11 block's FTS5-unavailable error handling.
- `tests/test_hermes_state.py`
  - `TestFTS5ExternalContentMigration`: hand-built v17 inline DB migrates with search/tool-token parity, `*_content` shadow tables gone, version bumped
  - delete/update consistency test: old tokens leave the index, new ones enter, FTS5 `integrity-check` passes (regression guard for the #16751 value-mismatch class)

## How to Test

1. `pytest tests/test_hermes_state.py tests/test_state_db_malformed_repair.py -q` — includes the new v17→v18 migration tests and the existing v10→v11 upgrade path
2. On a real pre-v18 `state.db`: open it once (migration runs automatically, ~35 s for 49k messages), then `hermes sessions optimize` to reclaim the freed pages
3. Verify parity: `hermes sessions stats` (same session/message counts), any `search_messages()` query returns identical hits and snippets

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs — no duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the state-store test suites (`tests/test_hermes_state.py`, `tests/test_state_db_malformed_repair.py`, `tests/hermes_state/`, WAL fallback, compression locks): 384 passed. Full `pytest tests/ -q` on this machine has pre-existing Windows-only failures (file-locking in `TemporaryDirectory` teardown) that are identical on a clean `main` checkout
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.13.12 (also exercised against a production 752 MB DB)

### Documentation & Housekeeping

- [x] Docstrings/comments updated in `hermes_state.py` — schema comments document the view contract
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure SQLite DDL/DML, no platform-specific code; FTS5 `'delete'`/`'rebuild'` commands and external-content views are long-standing FTS5 features
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ hermes sessions optimize   # after the v18 migration, real 540-session DB
Optimizing session store (FTS merge + VACUUM)…
Optimized 2 FTS index(es).
Database size: 752.5 MB -> 496.4 MB (reclaimed 256.1 MB)

$ hermes sessions stats
Total sessions: 540
Total messages: 49062
```
