### PR TITLE
fix(browser): block private CDP createTarget URLs

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -526,6 +526,38 @@ def test_page_navigate_to_private_url_blocked_before_cdp(monkeypatch):
     assert calls == []
 
 
+def test_target_create_target_to_private_url_blocked_before_cdp(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        browser_cdp_tool,
+        "_resolve_cdp_endpoint",
+        lambda: "ws://127.0.0.1:9222/devtools/browser/mock",
+    )
+
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_eval_ssrf_guard_active", lambda task_id: True)
+
+    async def fake_call(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"targetId": "private-tab"}
+
+    monkeypatch.setattr(browser_cdp_tool, "_cdp_call", fake_call)
+
+    result = json.loads(
+        browser_cdp_tool.browser_cdp(
+            method="Target.createTarget",
+            params={"url": PRIVATE_URL},
+            task_id="task-1",
+        )
+    )
+
+    assert "error" in result
+    assert PRIVATE_URL in result["error"]
+    assert calls == []
+
+
 def test_private_guard_inactive_does_not_probe(monkeypatch, cdp_server):
     cdp_server.on("Runtime.evaluate", lambda params, sid: {"result": {"value": "ok"}})
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -145,14 +145,14 @@ def _browser_cdp_private_guard(
         if not bt._eval_ssrf_guard_active(task_id):  # type: ignore[attr-defined]
             return None
 
-        if method == "Page.navigate":
+        if method in {"Page.navigate", "Target.createTarget"}:
             target_url = str((params or {}).get("url") or "").strip()
             if target_url and (
                 bt._is_always_blocked_url(target_url)  # type: ignore[attr-defined]
                 or not bt._is_safe_url(target_url)  # type: ignore[attr-defined]
             ):
                 return tool_error(
-                    "Blocked: CDP Page.navigate target is a private or "
+                    f"Blocked: CDP {method} target is a private or "
                     f"internal address ({target_url}).",
                     method=method,
                     cdp_docs=CDP_DOCS_URL,


### PR DESCRIPTION
## Summary

Extend the raw `browser_cdp` private-network guard to block `Target.createTarget` calls whose `url` points at a private/internal address.

## Why

`browser_cdp` already applies the browser SSRF/private-page boundary to raw CDP calls. It blocks private `Page.navigate` targets before dispatch, but `Target.createTarget` also accepts a `url` and can create a new tab directly at that address.

That left a sibling bypass for the same invariant: model-controlled raw CDP should not be able to navigate a cloud/remote browser to private/internal URLs through an alternate CDP navigation primitive.

## Changes

- Treat `Target.createTarget` like `Page.navigate` in `_browser_cdp_private_guard()`.
- Reuse the existing `_is_always_blocked_url()` / `_is_safe_url()` checks.
- Add a regression test proving `Target.createTarget` to `169.254.169.254` is blocked before `_cdp_call()` runs.

## Tests

```text
python -m pytest tests/tools/test_browser_cdp_tool.py -q --timeout-method=thread
26 passed