### PR TITLE
fix(desktop): fix scrollbar overlap and add tooltip on tool output copy button

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -486,10 +486,11 @@ function ToolEntry({ part }: ToolEntryProps) {
           {copyAction.text && (
             <CopyButton
               appearance="inline"
-              className="absolute right-1.5 top-1.5 z-10 h-5 gap-0 rounded-md px-1 opacity-5 transition-opacity group-hover/tool-block:opacity-100 hover:opacity-100 focus-visible:opacity-100"
+              className="absolute right-4 top-1.5 z-10 h-5 gap-0 rounded-md px-1 opacity-5 transition-opacity group-hover/tool-block:opacity-100 hover:opacity-100 focus-visible:opacity-100"
               iconClassName="size-3"
               label={copyAction.label}
               showLabel={false}
+              side="left"
               stopPropagation
               text={copyAction.text}
             />

--- a/apps/desktop/src/components/ui/copy-button.tsx
+++ b/apps/desktop/src/components/ui/copy-button.tsx
@@ -49,6 +49,7 @@ export interface CopyButtonProps {
   onCopyError?: (error: unknown) => void
   preventDefault?: boolean
   showLabel?: boolean
+  side?: React.ComponentProps<typeof Tip>['side']
   stopPropagation?: boolean
   text: CopyPayload
   title?: string
@@ -69,6 +70,7 @@ export function CopyButton({
   onCopyError,
   preventDefault = false,
   showLabel,
+  side,
   stopPropagation = false,
   text,
   title
@@ -180,18 +182,20 @@ export function CopyButton({
 
   if (appearance === 'inline') {
     return (
-      <button
-        aria-label={ariaLabel}
-        className={cn(
-          'inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[0.75rem] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40',
-          className
-        )}
-        disabled={disabled}
-        onClick={event => void copy(event)}
-        type="button"
-      >
-        {content}
-      </button>
+      <Tip label={feedbackLabel} side={side}>
+        <button
+          aria-label={ariaLabel}
+          className={cn(
+            'inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[0.75rem] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40',
+            className
+          )}
+          disabled={disabled}
+          onClick={event => void copy(event)}
+          type="button"
+        >
+          {content}
+        </button>
+      </Tip>
     )
   }
 
@@ -229,5 +233,5 @@ export function CopyButton({
   )
 
   // Only icon-only buttons need a tooltip; the text variant already shows its label.
-  return appearance === 'icon' ? <Tip label={feedbackLabel}>{button}</Tip> : button
+  return appearance === 'icon' ? <Tip label={feedbackLabel} side={side ?? 'bottom'}>{button}</Tip> : button
 }


### PR DESCRIPTION
## What does this PR do?
The Copy button's icon on expanded tool output (e.g. terminal command results) partially overlapped the output panel's scrollbar and had no tooltip. 
Fixed the button's position to clear the scrollbar and gave it a working styled tooltip. 
Also aligned its tooltip side with the existing Refresh/More actions buttons in the message action bar for visual consistency.

## Related Issue
Fixes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `apps/desktop/src/components/assistant-ui/tool/fallback.tsx` — moved the Copy button off the output panel's scrollbar (`right-1.5` → `right-4`) and gave it a `side="left"` tooltip via `CopyButton`'s new `side` prop
- `apps/desktop/src/components/ui/copy-button.tsx` — added an optional `side` prop; wrapped the `inline` appearance in `<Tip>` (it previously had no tooltip); defaulted the `icon` appearance's tooltip to `side="bottom"` to match the existing Refresh/More actions buttons

## How to Test
1. Run a command (e.g. `ls`) so the tool output panel is scrollable
2. Expand the tool row and hover the Copy icon near the scrollbar — verify it no longer overlaps the scrollbar and shows a tooltip to its left
3. Hover the Copy button in the assistant message action bar (next to Refresh and More actions) — verify its tooltip appears below the icon, matching Refresh/More
4. Verify clicking Copy still copies the correct content in both locations — tooltip/positioning-only change, no functional regressions

## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills
N/A

## Screenshots / Logs
<img width="780" height="181" alt="image" src="https://github.com/user-attachments/assets/e61c9331-3967-48a3-bf1a-522ce5c3a81a" />

<img width="786" height="175" alt="image" src="https://github.com/user-attachments/assets/b695d291-71ed-41e6-a1a3-b5158d41b969" />


https://github.com/user-attachments/assets/cd85feef-eee5-4b5c-a772-d9511813e5f4


