### PR TITLE
Feat/webhook session key

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -665,7 +665,13 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).
-        session_chat_id = f"webhook:{route_name}:{delivery_id}"
+        session_key = "";
+        session_key_tpl = route_config.get("session_key", "");
+        if session_key_tpl:
+            session_key = self._render_prompt(session_key_tpl, payload, event_type, route_name).strip();
+            if "{" in session_key:
+                session_key = "";
+        session_chat_id = f"webhook:{route_name}:{session_key or delivery_id}";
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
@@ -749,6 +755,9 @@ class WebhookAdapter(BasePlatformAdapter):
         ``end_session()`` is first-reason-wins and no-ops on an already-ended
         row, so this never clobbers a ``compression``/``agent_close`` reason.
         """
+        route_name = (event.source.user_id or "").removeprefix("webhook:");
+        if self._routes.get(route_name, {}).get("session_key"):
+            return;
         await self._end_webhook_session(event, event.source.chat_id)
 
     async def _end_webhook_session(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -665,13 +665,13 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Use delivery_id in session key so concurrent webhooks on the
         # same route get independent agent runs (not queued/interrupted).
-        session_key = "";
-        session_key_tpl = route_config.get("session_key", "");
+        session_key = ""
+        session_key_tpl = route_config.get("session_key", "")
         if session_key_tpl:
-            session_key = self._render_prompt(session_key_tpl, payload, event_type, route_name).strip();
+            session_key = self._render_prompt(session_key_tpl, payload, event_type, route_name).strip()
             if "{" in session_key:
-                session_key = "";
-        session_chat_id = f"webhook:{route_name}:{session_key or delivery_id}";
+                session_key = ""
+        session_chat_id = f"webhook:{route_name}:{session_key or delivery_id}"
 
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
@@ -755,9 +755,9 @@ class WebhookAdapter(BasePlatformAdapter):
         ``end_session()`` is first-reason-wins and no-ops on an already-ended
         row, so this never clobbers a ``compression``/``agent_close`` reason.
         """
-        route_name = (event.source.user_id or "").removeprefix("webhook:");
+        route_name = (event.source.user_id or "").removeprefix("webhook:")
         if self._routes.get(route_name, {}).get("session_key"):
-            return;
+            return
         await self._end_webhook_session(event, event.source.chat_id)
 
     async def _end_webhook_session(

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -81,6 +81,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `events` | No | List of event types to accept (e.g. `["pull_request"]`). If empty, all events are accepted. Event type is read from `X-GitHub-Event`, `X-GitLab-Event`, or `event_type` in the payload. |
 | `secret` | **Yes** | HMAC secret for signature validation. Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for testing only (skips validation). |
 | `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. Payload fields are untrusted — see [Authenticated does not mean trusted](#authenticated-does-not-mean-trusted). |
+| `session_key` | No | Template string (same `{dot.notation}` syntax as `prompt`) that pins all deliveries with the same rendered value to one **persistent session**, instead of the default new-session-per-delivery. E.g. `"{satellite}"` gives each satellite its own ongoing conversation. If unset, or if the template doesn't resolve for a given payload, that delivery falls back to per-delivery behavior. See [Persistent Sessions](#persistent-sessions). |
 | `skills` | No | List of skill names to load for the agent run. |
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
@@ -156,6 +157,33 @@ webhooks:
 ```
 
 If `chat_id` is not provided in `deliver_extra`, the delivery falls back to the home channel configured for the target platform.
+
+---
+
+## Persistent Sessions {#persistent-sessions}
+
+By default, every webhook delivery runs in a fresh session — delivery identity *is* conversation identity. That's correct for event streams (each PR event is independent), but wrong for conversational sources like voice satellites or chat bridges, where each POST is one turn in an ongoing dialogue and the agent needs memory of previous turns.
+
+Setting `session_key` on a route separates the two: the rendered template becomes the conversation identity, so repeat events from the same source share one session — like a Telegram or WhatsApp thread.
+
+```yaml
+routes:
+  voice-assistant:
+    secret: "voice-webhook-secret"
+    session_key: "{satellite}"
+    prompt: "[voice from {satellite}] {message}"
+    deliver: homeassistant
+```
+
+Two POSTs with `"satellite": "assist_satellite.pod1"` land in the same session; a POST from `pod2` gets its own. Session count is bounded by distinct rendered values, not by delivery count.
+
+Behavior notes:
+
+- **Idempotency is unchanged** — duplicate deliveries are still deduplicated by delivery ID, regardless of `session_key`.
+- **Fallback** — if the template doesn't resolve against a payload (e.g. the field is missing), that delivery gets a per-delivery session, same as an unconfigured route.
+- **Lifecycle** — persistent sessions are not auto-closed after each event (they expect follow-up turns). Manage them with `hermes sessions prune` or your idle-timeout policy.
+- **Ordering vs. concurrency** — deliveries sharing a `session_key` are processed sequentially on that session. For conversational sources this is what you want (turns stay ordered); routes that need concurrent processing should leave `session_key` unset.
+- **Sender-controlled** — the key is rendered from the payload, so a sender chooses which of the route's sessions their event joins. This is scoped to the route (the route name is part of the session identity) and gated by the route's HMAC secret; the [untrusted-content warning](#authenticated-does-not-mean-trusted) applies to session_key values as it does to every payload field.
 
 ---
 


### PR DESCRIPTION
…conversations

## What does this PR do?

Adds an opt-in `session_key` field to webhook route configuration, allowing a route to maintain a persistent conversation across deliveries.

**Problem:** The webhook platform derives the session chat key from the delivery ID (`webhook:{route_name}:{delivery_id}`), so every POST creates a brand-new session, and TTL prevents reuse. This is correct for fire-and-forget event routes, but makes multi-turn use cases impossible — each utterance from a voice satellite (my use case) arrives with total amnesia, and sessions multiply per event (the "ghost session" accumulation that v0.18.0's auto-close addressed).

**Approach:** Delivery and conversation identity are separated. A route may set `session_key`, a template rendered from the payload (e.g. `"{satellite}"`), which pins the chat key to a stable value: `webhook:{route_name}:{rendered_key}`. Repeat events from the same source then share one session, like a WhatsApp or Telegram thread. Idempotency still keys on `delivery_id`, and routes without `session_key` are completely unaffected — per-delivery remains the default. If the template doesn't resolve against a payload, the route falls back to per-delivery behavior for that event.

Because persistent routes expect follow-up turns, they are exempted from the `on_processing_complete` → `_end_webhook_session` auto-close introduced in v0.18.0; their lifecycle is managed by idle timeout / `hermes sessions prune` instead. This does not reintroduce the ghost-session problem the auto-close fixed — session count is bounded by distinct rendered keys (one per satellite per route in my deployment), not by delivery count.

**Security note:** the `session_key` template is rendered from the request payload, so a sender controls which session their events land in. This is inherent to the feature and scoped to the route: a sender must already hold the route's HMAC secret, and cross-route access is not possible since the route name is part of the chat key. Signature validation and idempotency are unchanged.

**Trade-off worth flagging:** the original per-delivery key also served to keep concurrent POSTs on one route from serializing on a single session. With a shared `session_key`, rapid successive events from the same source will queue on one session. For conversational sources this is desirable (turns should be ordered); routes that need concurrency simply don't set `session_key`.


## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/webhook.py` — render optional `session_key` route config (template over payload) into the session chat key, falling back to `delivery_id` when unset or unresolved
- `gateway/platforms/webhook.py` — exempt `session_key` routes from `_end_webhook_session` auto-close in `on_processing_complete`
- <tests/docs/config-example paths — list what you actually added>

## How to Test

1. Add a route with a session key to `~/.hermes/config.yaml` under `platforms: webhook: extra:`:
```yaml
   routes:
     voice-test:
       secret: ""
       session_key: "{satellite}"
       prompt: "[voice from {satellite}] {message}"
       deliver: log
```
2. Restart the gateway and POST two signed events with the same `satellite` value:
```bash
   SECRET=""
   BODY='{"satellite":"assist_satellite.pod1","message":"My favorite color is teal. Remember it."}'
   SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
   curl -si -X POST http://127.0.0.1:8644/webhooks/voice-test \
     -H "Content-Type: application/json" -H "X-Webhook-Signature: $SIG" -d "$BODY"
   # then a second POST asking "What is my favorite color?"
```
3. Verify: both turns log the **same** session ID, the second shows non-empty history and the response recalls "teal", and `hermes sessions list` shows **one** new session, not two. A route without `session_key` still produces one session per delivery (unchanged default).

Tested end-to-end in a live deployment: voice satellites (Home Assistant → webhook) with per-satellite persistent sessions.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux spark-240 6.17.0-1008-nvidia #8-Ubuntu SMP PREEMPT_DYNAMIC Wed Jan 21 17:56:56 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Contents of ~/.hermes/voice-test.sh:
    SECRET="same key as in config.yaml. ex: openssl rand -hex 24"
    hermes-agent$ BODY='{"satellite":"assist_satellite.pod1","message":"My favorite color is teal. Remember it."}'
    SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
    curl -si -X POST http://127.0.0.1:8644/webhooks/voice-test -H "Content-Type: application/json" -H "X-Webhook-Signature: $SIG" -d "$BODY"
    sleep 35
    BODY='{"satellite":"assist_satellite.pod1","message":"What is my favorite color?"}'
    SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
    curl -si -X POST http://127.0.0.1:8644/webhooks/voice-test -H "Content-Type: application/json" -H "X-Webhook-Signature: $SIG" -d "$BODY"
    sleep 35
    hermes logs | grep -E "turn_context|Response for" | tail -4
    hermes sessions list | head -4

gilles@spark-240:~/.hermes$ ./voice-test.sh
HTTP/1.1 202 Accepted
Content-Type: application/json; charset=utf-8
Content-Length: 97
Date: Fri, 03 Jul 2026 22:11:26 GMT
Server: Python/3.11 aiohttp/3.14.1

{"status": "accepted", "route": "voice-test", "event": "unknown", "delivery_id": "1783116686765"}HTTP/1.1 202 Accepted
Content-Type: application/json; charset=utf-8
Content-Length: 97
Date: Fri, 03 Jul 2026 22:12:01 GMT
Server: Python/3.11 aiohttp/3.14.1

{"status": "accepted", "route": "voice-test", "event": "unknown", "delivery_id": "1783116721786"}2026-07-03 12:10:31,853 INFO gateway.platforms.webhook: [webhook] Response for webhook:voice-test:assist_satellite.pod1: Oh, you're testing me?
2026-07-03 15:11:27,214 INFO [20260703_120854_0b7ee4f8] agent.turn_context: conversation turn: session=20260703_120854_0b7ee4f8 model=qwen3.6:27b provider=custom platform=webhook history=0 msg='[voice from assist_satellite.pod1] My favorite color is teal. Remember it.'
2026-07-03 15:11:54,685 INFO gateway.platforms.webhook: [webhook] Response for webhook:voice-test:assist_satellite.pod1: Teal. Consider it etched into my heart.
2026-07-03 15:12:01,847 INFO [20260703_120854_0b7ee4f8] agent.turn_context: conversation turn: session=20260703_120854_0b7ee4f8 model=qwen3.6:27b provider=custom platform=webhook history=2 msg='[voice from assist_satellite.pod1] What is my favorite color?'
Title                            Preview                                  Last Active   ID
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
—                                [voice from assist_satellite.pod1] My    just now      20260703_120854_0b7ee4f8
—                                What is my favorite color?               16h ago       20260702_225954_64eb4c4e

