### PR TITLE
feat(moa): persist privacy-safe per-slot usage accounting

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2112,9 +2112,13 @@ def run_conversation(
                     # the bulk of a MoA turn — is invisible in token counts.
                     _moa_ref_cost = None
                     _moa_client = getattr(agent, "client", None)
+                    _ref_details = []
                     if _moa_client is not None and hasattr(_moa_client, "consume_reference_usage"):
                         try:
-                            _ref_usage, _moa_ref_cost = _moa_client.consume_reference_usage()
+                            if hasattr(_moa_client, "consume_reference_details"):
+                                _ref_usage, _moa_ref_cost, _ref_details = _moa_client.consume_reference_details()
+                            else:
+                                _ref_usage, _moa_ref_cost = _moa_client.consume_reference_usage()
                             if _ref_usage is not None:
                                 canonical_usage = canonical_usage + _ref_usage
                         except Exception as _moa_acct_exc:  # pragma: no cover - defensive
@@ -2282,6 +2286,30 @@ def run_conversation(
                                 model=agent.model,
                                 api_call_count=1,
                             )
+                            if _moa_client is not None and hasattr(agent._session_db, "add_session_moa_usage"):
+                                # Add the aggregator and reference models to the MoA detailed tracking
+                                _agg_cost_amount = None
+                                try:
+                                    if cost_result.amount_usd is not None:
+                                        _agg_cost_amount = float(cost_result.amount_usd)
+                                except (TypeError, ValueError):
+                                    pass
+                                
+                                _moa_breakdown = list(_ref_details)
+                                _moa_breakdown.append({
+                                    "role": "aggregator",
+                                    "slot_index": len(_ref_details),
+                                    "provider": _agg_cost_provider,
+                                    "model": _agg_cost_model,
+                                    "usage": aggregator_usage,
+                                    "cost_usd": _agg_cost_amount
+                                })
+                                agent._session_db.add_session_moa_usage(
+                                    agent.session_id,
+                                    _moa_breakdown,
+                                    preset=getattr(_moa_client, "preset_name", "")
+                                )
+
                         except Exception as e:
                             # Log token persistence failures so they're
                             # visible in agent.log — silent loss here is

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2113,10 +2113,17 @@ def run_conversation(
                     _moa_ref_cost = None
                     _moa_client = getattr(agent, "client", None)
                     _ref_details = []
-                    if _moa_client is not None and hasattr(_moa_client, "consume_reference_usage"):
+                    _is_moa_call = _moa_client is not None and hasattr(
+                        _moa_client, "consume_reference_usage"
+                    )
+                    if _is_moa_call:
                         try:
                             if hasattr(_moa_client, "consume_reference_details"):
-                                _ref_usage, _moa_ref_cost, _ref_details = _moa_client.consume_reference_details()
+                                (
+                                    _ref_usage,
+                                    _moa_ref_cost,
+                                    _ref_details,
+                                ) = _moa_client.consume_reference_details()
                             else:
                                 _ref_usage, _moa_ref_cost = _moa_client.consume_reference_usage()
                             if _ref_usage is not None:
@@ -2269,6 +2276,30 @@ def run_conversation(
                                     _cost_delta = (_cost_delta or 0.0) + float(_moa_ref_cost)
                                 except (TypeError, ValueError):  # pragma: no cover
                                     pass
+
+                            _moa_breakdown = None
+                            _moa_preset = ""
+                            if _is_moa_call:
+                                _agg_cost_amount = None
+                                try:
+                                    if cost_result.amount_usd is not None:
+                                        _agg_cost_amount = float(cost_result.amount_usd)
+                                except (TypeError, ValueError):
+                                    pass
+
+                                _moa_breakdown = list(_ref_details)
+                                _moa_breakdown.append(
+                                    {
+                                        "role": "aggregator",
+                                        "slot_index": len(_ref_details),
+                                        "provider": _agg_cost_provider,
+                                        "model": _agg_cost_model,
+                                        "usage": aggregator_usage,
+                                        "cost_usd": _agg_cost_amount,
+                                    }
+                                )
+                                _moa_preset = getattr(_moa_client, "preset_name", "")
+
                             agent._session_db.update_token_counts(
                                 agent.session_id,
                                 input_tokens=canonical_usage.input_tokens,
@@ -2285,31 +2316,9 @@ def run_conversation(
                                 if cost_result.status == "included" else None,
                                 model=agent.model,
                                 api_call_count=1,
+                                moa_breakdown=_moa_breakdown,
+                                moa_preset=_moa_preset,
                             )
-                            if _moa_client is not None and hasattr(agent._session_db, "add_session_moa_usage"):
-                                # Add the aggregator and reference models to the MoA detailed tracking
-                                _agg_cost_amount = None
-                                try:
-                                    if cost_result.amount_usd is not None:
-                                        _agg_cost_amount = float(cost_result.amount_usd)
-                                except (TypeError, ValueError):
-                                    pass
-                                
-                                _moa_breakdown = list(_ref_details)
-                                _moa_breakdown.append({
-                                    "role": "aggregator",
-                                    "slot_index": len(_ref_details),
-                                    "provider": _agg_cost_provider,
-                                    "model": _agg_cost_model,
-                                    "usage": aggregator_usage,
-                                    "cost_usd": _agg_cost_amount
-                                })
-                                agent._session_db.add_session_moa_usage(
-                                    agent.session_id,
-                                    _moa_breakdown,
-                                    preset=getattr(_moa_client, "preset_name", "")
-                                )
-
                         except Exception as e:
                             # Log token persistence failures so they're
                             # visible in agent.log — silent loss here is

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -817,6 +817,7 @@ class MoAChatCompletions:
 
         self._pending_reference_usage: Any = CanonicalUsage()
         self._pending_reference_cost: Any = None
+        self._pending_reference_details: list[dict] = []
         # Resolved aggregator slot ({provider, model, ...}) from the most recent
         # create(); read by session cost accounting to price the aggregator's
         # acting turn at its real model instead of the virtual preset name.
@@ -842,6 +843,16 @@ class MoAChatCompletions:
         self._pending_reference_usage = CanonicalUsage()
         self._pending_reference_cost = None
         return usage, cost
+
+    def consume_reference_details(self) -> tuple[Any, Any, list[dict]]:
+        from agent.usage_pricing import CanonicalUsage
+        usage = self._pending_reference_usage or CanonicalUsage()
+        cost = self._pending_reference_cost
+        details = list(self._pending_reference_details)
+        self._pending_reference_usage = CanonicalUsage()
+        self._pending_reference_cost = None
+        self._pending_reference_details = []
+        return usage, cost, details
 
     def consume_and_save_trace(
         self, session_id: Any = None, aggregator_output_fallback: Any = None
@@ -994,6 +1005,7 @@ class MoAChatCompletions:
             # advisor spend by the tool-iteration count, so pending is zero.
             self._pending_reference_usage = CanonicalUsage()
             self._pending_reference_cost = None
+            self._pending_reference_details = []
             # Likewise no trace on a cache HIT — the full turn was already
             # traced on the MISS that ran the references. A repeat iteration is
             # not a new MoA turn.
@@ -1017,14 +1029,24 @@ class MoAChatCompletions:
             # NOT be repriced at the aggregator's rate.
             _ref_usage = CanonicalUsage()
             _ref_cost: Any = None
-            for _lbl, _txt, _acct in reference_outputs:
+            _ref_details: list[dict] = []
+            for _idx, (_lbl, _txt, _acct) in enumerate(reference_outputs):
                 if isinstance(_acct, _RefAccounting):
                     if isinstance(_acct.usage, CanonicalUsage):
                         _ref_usage = _ref_usage + _acct.usage
                     if _acct.cost_usd is not None:
                         _ref_cost = (_ref_cost or 0) + _acct.cost_usd
+                    _ref_details.append({
+                        "role": "reference",
+                        "slot_index": _idx,
+                        "provider": _acct.provider,
+                        "model": _acct.model,
+                        "usage": _acct.usage,
+                        "cost_usd": _acct.cost_usd
+                    })
             self._pending_reference_usage = _ref_usage
             self._pending_reference_cost = _ref_cost
+            self._pending_reference_details = _ref_details
             # Stash the full reference fan-out for trace persistence. The
             # aggregator input/label are filled in below once agg_messages is
             # built; the aggregator OUTPUT is stitched in by the caller
@@ -1143,6 +1165,7 @@ class MoAChatCompletions:
 
 class MoAClient:
     def __init__(self, preset_name: str, reference_callback: Any = None):
+        self.preset_name = preset_name
         self.chat = type("_MoAChat", (), {})()
         self.chat.completions = MoAChatCompletions(preset_name, reference_callback=reference_callback)
 
@@ -1153,6 +1176,10 @@ class MoAClient:
         usage without reaching into ``.chat.completions`` internals.
         """
         return self.chat.completions.consume_reference_usage()
+
+    def consume_reference_details(self) -> Any:
+        """Pop pending reference usage, cost, and per-slot details."""
+        return self.chat.completions.consume_reference_details()
 
     @property
     def last_aggregator_slot(self) -> Any:

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -812,7 +812,7 @@ class MoAChatCompletions:
         # recent cache-MISS create() call, awaiting consumption by session
         # accounting. Set on every create() (zeroed on a cache HIT so per-turn
         # advisor spend is counted exactly once). Consumed via
-        # ``consume_reference_usage``.
+        # ``consume_reference_usage`` / ``consume_reference_details``.
         from agent.usage_pricing import CanonicalUsage
 
         self._pending_reference_usage: Any = CanonicalUsage()
@@ -836,16 +836,17 @@ class MoAChatCompletions:
         always a ``CanonicalUsage`` (zeroed if none); cost is a summed-dollars
         float or ``None`` when no advisor could be priced.
         """
-        from agent.usage_pricing import CanonicalUsage
-
-        usage = self._pending_reference_usage or CanonicalUsage()
-        cost = self._pending_reference_cost
-        self._pending_reference_usage = CanonicalUsage()
-        self._pending_reference_cost = None
+        usage, cost, _details = self._consume_reference_accounting()
         return usage, cost
 
     def consume_reference_details(self) -> tuple[Any, Any, list[dict]]:
+        """Pop usage, cost, and privacy-safe per-reference metadata rows."""
+        return self._consume_reference_accounting()
+
+    def _consume_reference_accounting(self) -> tuple[Any, Any, list[dict]]:
+        """Pop and clear all pending reference accounting representations."""
         from agent.usage_pricing import CanonicalUsage
+
         usage = self._pending_reference_usage or CanonicalUsage()
         cost = self._pending_reference_cost
         details = list(self._pending_reference_details)
@@ -1036,14 +1037,16 @@ class MoAChatCompletions:
                         _ref_usage = _ref_usage + _acct.usage
                     if _acct.cost_usd is not None:
                         _ref_cost = (_ref_cost or 0) + _acct.cost_usd
-                    _ref_details.append({
-                        "role": "reference",
-                        "slot_index": _idx,
-                        "provider": _acct.provider,
-                        "model": _acct.model,
-                        "usage": _acct.usage,
-                        "cost_usd": _acct.cost_usd
-                    })
+                    _ref_details.append(
+                        {
+                            "role": "reference",
+                            "slot_index": _idx,
+                            "provider": _acct.provider,
+                            "model": _acct.model,
+                            "usage": _acct.usage,
+                            "cost_usd": _acct.cost_usd,
+                        }
+                    )
             self._pending_reference_usage = _ref_usage
             self._pending_reference_cost = _ref_cost
             self._pending_reference_details = _ref_details
@@ -1165,9 +1168,12 @@ class MoAChatCompletions:
 
 class MoAClient:
     def __init__(self, preset_name: str, reference_callback: Any = None):
-        self.preset_name = preset_name
         self.chat = type("_MoAChat", (), {})()
-        self.chat.completions = MoAChatCompletions(preset_name, reference_callback=reference_callback)
+        self.chat.completions = MoAChatCompletions(
+            preset_name,
+            reference_callback=reference_callback,
+        )
+        self.preset_name = self.chat.completions.preset_name
 
     def consume_reference_usage(self) -> Any:
         """Pop the pending reference-fan-out usage from the completions facade.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -140,7 +140,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 21
+SCHEMA_VERSION = 22
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -841,6 +841,22 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode)
 );
 
+CREATE TABLE IF NOT EXISTS session_moa_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    preset TEXT,
+    role TEXT NOT NULL,
+    slot_index INTEGER,
+    provider TEXT,
+    model TEXT NOT NULL,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    cost_usd REAL
+);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -909,6 +925,8 @@ CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer
     ON sessions(source, user_id, chat_id, chat_type, thread_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
     ON sessions(handoff_state, started_at);
+CREATE INDEX IF NOT EXISTS idx_session_moa_usage_session
+    ON session_moa_usage(session_id, role, model);
 """
 
 FTS_SQL = """
@@ -2851,6 +2869,35 @@ class SessionDB:
                 now,
             ),
         )
+
+    def add_session_moa_usage(self, session_id: str, moa_breakdown: List[Dict[str, Any]], preset: str = "") -> None:
+        """Add MoA reference and aggregator usage to the detailed breakdown table."""
+        if not moa_breakdown:
+            return
+
+        sql = """INSERT INTO session_moa_usage
+                 (session_id, preset, role, slot_index, provider, model, input_tokens, output_tokens,
+                  cache_read_tokens, cache_write_tokens, reasoning_tokens, cost_usd)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+
+        def _do(conn):
+            for entry in moa_breakdown:
+                usage = entry.get("usage")
+                conn.execute(sql, (
+                    session_id,
+                    preset,
+                    entry.get("role", "reference"),
+                    entry.get("slot_index"),
+                    entry.get("provider") or "",
+                    entry.get("model") or "",
+                    getattr(usage, "input_tokens", 0) if usage else 0,
+                    getattr(usage, "output_tokens", 0) if usage else 0,
+                    getattr(usage, "cache_read_tokens", 0) if usage else 0,
+                    getattr(usage, "cache_write_tokens", 0) if usage else 0,
+                    getattr(usage, "reasoning_tokens", 0) if usage else 0,
+                    entry.get("cost_usd")
+                ))
+        self._execute_write(_do)
 
     def ensure_session(
         self,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -843,7 +843,7 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
 
 CREATE TABLE IF NOT EXISTS session_moa_usage (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_id TEXT NOT NULL REFERENCES sessions(id),
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
     preset TEXT,
     role TEXT NOT NULL,
     slot_index INTEGER,
@@ -2635,8 +2635,10 @@ class SessionDB:
         billing_mode: Optional[str] = None,
         api_call_count: int = 0,
         absolute: bool = False,
+        moa_breakdown: Optional[List[Dict[str, Any]]] = None,
+        moa_preset: str = "",
     ) -> None:
-        """Update token counters and backfill model if not already set.
+        """Update token counters and optional MoA detail rows atomically.
 
         When *absolute* is False (default), values are **incremented** — use
         this for per-API-call deltas (CLI path).
@@ -2644,6 +2646,10 @@ class SessionDB:
         When *absolute* is True, values are **set directly** — use this when
         the caller already holds cumulative totals (gateway path, where the
         cached agent accumulates across messages).
+
+        When *moa_breakdown* is provided, its per-slot rows are inserted in
+        the same transaction as the aggregate counter update. A failure in
+        either representation therefore rolls back both.
         """
         # Ensure the session row exists so the UPDATE doesn't silently affect
         # 0 rows.  Under concurrent load (cron + kanban + delegate_task) the
@@ -2783,6 +2789,13 @@ class SessionDB:
                     cost_source=cost_source,
                     api_call_count=api_call_count,
                 )
+            if moa_breakdown:
+                self._insert_session_moa_usage(
+                    conn,
+                    session_id,
+                    moa_breakdown,
+                    preset=moa_preset,
+                )
         self._execute_write(_do)
 
     def _record_model_usage(
@@ -2870,20 +2883,31 @@ class SessionDB:
             ),
         )
 
-    def add_session_moa_usage(self, session_id: str, moa_breakdown: List[Dict[str, Any]], preset: str = "") -> None:
-        """Add MoA reference and aggregator usage to the detailed breakdown table."""
-        if not moa_breakdown:
-            return
-
+    @staticmethod
+    def _insert_session_moa_usage(
+        conn: sqlite3.Connection,
+        session_id: str,
+        moa_breakdown: List[Dict[str, Any]],
+        *,
+        preset: str = "",
+    ) -> None:
+        """Insert detailed MoA rows using the caller's active transaction."""
         sql = """INSERT INTO session_moa_usage
                  (session_id, preset, role, slot_index, provider, model, input_tokens, output_tokens,
                   cache_read_tokens, cache_write_tokens, reasoning_tokens, cost_usd)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 
-        def _do(conn):
-            for entry in moa_breakdown:
-                usage = entry.get("usage")
-                conn.execute(sql, (
+        for entry in moa_breakdown:
+            usage = entry.get("usage")
+            cost_usd = entry.get("cost_usd")
+            if cost_usd is not None:
+                try:
+                    cost_usd = float(cost_usd)
+                except (TypeError, ValueError):
+                    cost_usd = None
+            conn.execute(
+                sql,
+                (
                     session_id,
                     preset,
                     entry.get("role", "reference"),
@@ -2895,8 +2919,33 @@ class SessionDB:
                     getattr(usage, "cache_read_tokens", 0) if usage else 0,
                     getattr(usage, "cache_write_tokens", 0) if usage else 0,
                     getattr(usage, "reasoning_tokens", 0) if usage else 0,
-                    entry.get("cost_usd")
-                ))
+                    cost_usd,
+                ),
+            )
+
+    def add_session_moa_usage(
+        self,
+        session_id: str,
+        moa_breakdown: List[Dict[str, Any]],
+        preset: str = "",
+    ) -> None:
+        """Add standalone MoA detail rows in one transaction.
+
+        Callers that also update aggregate counters should instead pass the
+        rows to :meth:`update_token_counts` so both representations commit or
+        roll back together.
+        """
+        if not moa_breakdown:
+            return
+
+        def _do(conn):
+            self._insert_session_moa_usage(
+                conn,
+                session_id,
+                moa_breakdown,
+                preset=preset,
+            )
+
         self._execute_write(_do)
 
     def ensure_session(

--- a/tests/agent/test_moa_reference_details.py
+++ b/tests/agent/test_moa_reference_details.py
@@ -1,0 +1,56 @@
+from agent.usage_pricing import CanonicalUsage
+
+
+def test_consume_reference_details():
+    from agent.moa_loop import MoAChatCompletions
+    from agent.moa_loop import _RefAccounting
+    
+    facade = MoAChatCompletions("closed")
+    
+    acct1 = _RefAccounting(provider="p1", model="m1", usage=CanonicalUsage(input_tokens=10), cost_usd=0.1)
+    acct2 = _RefAccounting(provider="p2", model="m2", usage=CanonicalUsage(input_tokens=20), cost_usd=0.2)
+    
+    # Simulate a run
+    facade._pending_reference_usage = CanonicalUsage(input_tokens=30)
+    facade._pending_reference_cost = 0.3
+    facade._pending_reference_details = [
+        {"role": "reference", "slot_index": 0, "provider": "p1", "model": "m1", "usage": acct1.usage, "cost_usd": 0.1},
+        {"role": "reference", "slot_index": 1, "provider": "p2", "model": "m2", "usage": acct2.usage, "cost_usd": 0.2},
+    ]
+    
+    usage, cost, details = facade.consume_reference_details()
+    assert usage.input_tokens == 30
+    assert cost == 0.3
+    assert len(details) == 2
+    assert details[0]["provider"] == "p1"
+    assert details[0]["slot_index"] == 0
+    
+    # State should be cleared
+    assert facade._pending_reference_usage.input_tokens == 0
+    assert facade._pending_reference_cost is None
+    assert facade._pending_reference_details == []
+
+
+def test_moaclient_consume_reference_details_delegates_and_preserves_preset():
+    from agent.moa_loop import MoAClient
+
+    client = MoAClient("code-hard")
+    client.chat.completions._pending_reference_usage = CanonicalUsage(input_tokens=12)
+    client.chat.completions._pending_reference_cost = 0.04
+    client.chat.completions._pending_reference_details = [
+        {
+            "role": "reference",
+            "slot_index": 0,
+            "provider": "openrouter",
+            "model": "anthropic/claude-opus",
+            "usage": CanonicalUsage(input_tokens=12),
+            "cost_usd": 0.04,
+        }
+    ]
+
+    usage, cost, details = client.consume_reference_details()
+
+    assert client.preset_name == "code-hard"
+    assert usage.input_tokens == 12
+    assert cost == 0.04
+    assert details[0]["slot_index"] == 0

--- a/tests/agent/test_moa_reference_details.py
+++ b/tests/agent/test_moa_reference_details.py
@@ -4,27 +4,45 @@ from agent.usage_pricing import CanonicalUsage
 def test_consume_reference_details():
     from agent.moa_loop import MoAChatCompletions
     from agent.moa_loop import _RefAccounting
-    
+
     facade = MoAChatCompletions("closed")
-    
-    acct1 = _RefAccounting(provider="p1", model="m1", usage=CanonicalUsage(input_tokens=10), cost_usd=0.1)
-    acct2 = _RefAccounting(provider="p2", model="m2", usage=CanonicalUsage(input_tokens=20), cost_usd=0.2)
-    
+
+    acct1 = _RefAccounting(
+        provider="p1", model="m1", usage=CanonicalUsage(input_tokens=10), cost_usd=0.1
+    )
+    acct2 = _RefAccounting(
+        provider="p2", model="m2", usage=CanonicalUsage(input_tokens=20), cost_usd=0.2
+    )
+
     # Simulate a run
     facade._pending_reference_usage = CanonicalUsage(input_tokens=30)
     facade._pending_reference_cost = 0.3
     facade._pending_reference_details = [
-        {"role": "reference", "slot_index": 0, "provider": "p1", "model": "m1", "usage": acct1.usage, "cost_usd": 0.1},
-        {"role": "reference", "slot_index": 1, "provider": "p2", "model": "m2", "usage": acct2.usage, "cost_usd": 0.2},
+        {
+            "role": "reference",
+            "slot_index": 0,
+            "provider": "p1",
+            "model": "m1",
+            "usage": acct1.usage,
+            "cost_usd": 0.1,
+        },
+        {
+            "role": "reference",
+            "slot_index": 1,
+            "provider": "p2",
+            "model": "m2",
+            "usage": acct2.usage,
+            "cost_usd": 0.2,
+        },
     ]
-    
+
     usage, cost, details = facade.consume_reference_details()
     assert usage.input_tokens == 30
     assert cost == 0.3
     assert len(details) == 2
     assert details[0]["provider"] == "p1"
     assert details[0]["slot_index"] == 0
-    
+
     # State should be cleared
     assert facade._pending_reference_usage.input_tokens == 0
     assert facade._pending_reference_cost is None
@@ -54,3 +72,14 @@ def test_moaclient_consume_reference_details_delegates_and_preserves_preset():
     assert usage.input_tokens == 12
     assert cost == 0.04
     assert details[0]["slot_index"] == 0
+
+
+def test_legacy_usage_consumer_also_clears_pending_details():
+    from agent.moa_loop import MoAChatCompletions
+
+    facade = MoAChatCompletions("closed")
+    facade._pending_reference_details = [{"slot_index": 0}]
+
+    facade.consume_reference_usage()
+
+    assert facade._pending_reference_details == []

--- a/tests/agent/test_moa_slot_accounting.py
+++ b/tests/agent/test_moa_slot_accounting.py
@@ -1,0 +1,109 @@
+import sqlite3
+
+from hermes_state import SessionDB
+from agent.usage_pricing import CanonicalUsage
+
+
+def test_session_moa_usage_persistence(tmp_path):
+    """Test that MoA per-slot accounting records are persisted correctly."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    
+    # Create a session first so foreign key constraint passes
+    session_id = "test-moa-sess"
+    db.ensure_session(session_id, "test session", model="code-hard")
+    
+    usage1 = CanonicalUsage(input_tokens=10, output_tokens=20, cache_read_tokens=5, cache_write_tokens=0, reasoning_tokens=0)
+    usage2 = CanonicalUsage(input_tokens=100, output_tokens=200, cache_read_tokens=50, cache_write_tokens=0, reasoning_tokens=0)
+    
+    breakdown = [
+        {
+            "role": "reference",
+            "slot_index": 0,
+            "provider": "openrouter",
+            "model": "anthropic/claude-opus",
+            "usage": usage1,
+            "cost_usd": 0.05
+        },
+        {
+            "role": "aggregator",
+            "slot_index": 1,
+            "provider": "openai",
+            "model": "gpt-5.5",
+            "usage": usage2,
+            "cost_usd": 0.15
+        },
+        {
+            "role": "reference",
+            "slot_index": 2,
+            "provider": None,
+            "model": None,
+            "usage": None,
+            "cost_usd": None
+        }
+    ]
+    
+    db.add_session_moa_usage(session_id, breakdown, preset="code-hard")
+    
+    # Verify the records were written correctly
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM session_moa_usage ORDER BY id").fetchall()
+    assert len(rows) == 3
+    
+    # Reference
+    assert rows[0]["session_id"] == session_id
+    assert rows[0]["preset"] == "code-hard"
+    assert rows[0]["role"] == "reference"
+    assert rows[0]["slot_index"] == 0
+    assert rows[0]["provider"] == "openrouter"
+    assert rows[0]["model"] == "anthropic/claude-opus"
+    assert rows[0]["input_tokens"] == 10
+    assert rows[0]["output_tokens"] == 20
+    assert rows[0]["cache_read_tokens"] == 5
+    assert rows[0]["cost_usd"] == 0.05
+    
+    # Aggregator
+    assert rows[1]["session_id"] == session_id
+    assert rows[1]["preset"] == "code-hard"
+    assert rows[1]["role"] == "aggregator"
+    assert rows[1]["slot_index"] == 1
+    assert rows[1]["provider"] == "openai"
+    assert rows[1]["model"] == "gpt-5.5"
+    assert rows[1]["input_tokens"] == 100
+    assert rows[1]["output_tokens"] == 200
+    assert rows[1]["cost_usd"] == 0.15
+
+    # Defensive fallback for sparse/malformed entries: metadata stays safe and insertable.
+    assert rows[2]["session_id"] == session_id
+    assert rows[2]["preset"] == "code-hard"
+    assert rows[2]["role"] == "reference"
+    assert rows[2]["slot_index"] == 2
+    assert rows[2]["provider"] == ""
+    assert rows[2]["model"] == ""
+    assert rows[2]["input_tokens"] == 0
+    assert rows[2]["output_tokens"] == 0
+    assert rows[2]["cache_read_tokens"] == 0
+    assert rows[2]["cache_write_tokens"] == 0
+    assert rows[2]["reasoning_tokens"] == 0
+    assert rows[2]["cost_usd"] is None
+    
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.execute("PRAGMA table_info(session_moa_usage)")
+        columns = [col[1] for col in cursor.fetchall()]
+        assert "slot_index" in columns
+        assert "prompt" not in columns
+        assert "output" not in columns
+        assert "content" not in columns
+
+def test_add_session_moa_usage_empty(tmp_path):
+    """Test that empty breakdown does not crash."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    session_id = "test-moa-sess"
+    db.ensure_session(session_id, "test session", model="code-hard")
+    
+    db.add_session_moa_usage(session_id, [], preset="code-hard")
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT * FROM session_moa_usage").fetchall()
+    assert len(rows) == 0

--- a/tests/agent/test_moa_slot_accounting.py
+++ b/tests/agent/test_moa_slot_accounting.py
@@ -1,4 +1,6 @@
 import sqlite3
+from decimal import Decimal
+from types import SimpleNamespace
 
 from hermes_state import SessionDB
 from agent.usage_pricing import CanonicalUsage
@@ -8,14 +10,26 @@ def test_session_moa_usage_persistence(tmp_path):
     """Test that MoA per-slot accounting records are persisted correctly."""
     db_path = tmp_path / "state.db"
     db = SessionDB(db_path)
-    
+
     # Create a session first so foreign key constraint passes
     session_id = "test-moa-sess"
     db.ensure_session(session_id, "test session", model="code-hard")
-    
-    usage1 = CanonicalUsage(input_tokens=10, output_tokens=20, cache_read_tokens=5, cache_write_tokens=0, reasoning_tokens=0)
-    usage2 = CanonicalUsage(input_tokens=100, output_tokens=200, cache_read_tokens=50, cache_write_tokens=0, reasoning_tokens=0)
-    
+
+    usage1 = CanonicalUsage(
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_tokens=5,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+    )
+    usage2 = CanonicalUsage(
+        input_tokens=100,
+        output_tokens=200,
+        cache_read_tokens=50,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+    )
+
     breakdown = [
         {
             "role": "reference",
@@ -23,7 +37,7 @@ def test_session_moa_usage_persistence(tmp_path):
             "provider": "openrouter",
             "model": "anthropic/claude-opus",
             "usage": usage1,
-            "cost_usd": 0.05
+            "cost_usd": Decimal("0.05"),
         },
         {
             "role": "aggregator",
@@ -31,7 +45,7 @@ def test_session_moa_usage_persistence(tmp_path):
             "provider": "openai",
             "model": "gpt-5.5",
             "usage": usage2,
-            "cost_usd": 0.15
+            "cost_usd": 0.15,
         },
         {
             "role": "reference",
@@ -39,18 +53,18 @@ def test_session_moa_usage_persistence(tmp_path):
             "provider": None,
             "model": None,
             "usage": None,
-            "cost_usd": None
-        }
+            "cost_usd": None,
+        },
     ]
-    
+
     db.add_session_moa_usage(session_id, breakdown, preset="code-hard")
-    
+
     # Verify the records were written correctly
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute("SELECT * FROM session_moa_usage ORDER BY id").fetchall()
     assert len(rows) == 3
-    
+
     # Reference
     assert rows[0]["session_id"] == session_id
     assert rows[0]["preset"] == "code-hard"
@@ -62,7 +76,7 @@ def test_session_moa_usage_persistence(tmp_path):
     assert rows[0]["output_tokens"] == 20
     assert rows[0]["cache_read_tokens"] == 5
     assert rows[0]["cost_usd"] == 0.05
-    
+
     # Aggregator
     assert rows[1]["session_id"] == session_id
     assert rows[1]["preset"] == "code-hard"
@@ -87,7 +101,7 @@ def test_session_moa_usage_persistence(tmp_path):
     assert rows[2]["cache_write_tokens"] == 0
     assert rows[2]["reasoning_tokens"] == 0
     assert rows[2]["cost_usd"] is None
-    
+
     with sqlite3.connect(db_path) as conn:
         cursor = conn.execute("PRAGMA table_info(session_moa_usage)")
         columns = [col[1] for col in cursor.fetchall()]
@@ -96,14 +110,202 @@ def test_session_moa_usage_persistence(tmp_path):
         assert "output" not in columns
         assert "content" not in columns
 
+
 def test_add_session_moa_usage_empty(tmp_path):
     """Test that empty breakdown does not crash."""
     db_path = tmp_path / "state.db"
     db = SessionDB(db_path)
     session_id = "test-moa-sess"
     db.ensure_session(session_id, "test session", model="code-hard")
-    
+
     db.add_session_moa_usage(session_id, [], preset="code-hard")
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute("SELECT * FROM session_moa_usage").fetchall()
     assert len(rows) == 0
+
+
+def test_deleting_session_cascades_moa_usage(tmp_path):
+    """Deleting a session must also delete its detailed MoA accounting rows."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    session_id = "test-moa-delete"
+    db.ensure_session(session_id, "test session", model="review")
+    db.add_session_moa_usage(
+        session_id,
+        [
+            {
+                "role": "reference",
+                "slot_index": 0,
+                "provider": "openrouter",
+                "model": "anthropic/claude-opus",
+                "usage": CanonicalUsage(input_tokens=10, output_tokens=2),
+                "cost_usd": 0.05,
+            }
+        ],
+        preset="review",
+    )
+
+    assert db.delete_session(session_id) is True
+
+    with sqlite3.connect(db_path) as conn:
+        session_count = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()[0]
+        usage_count = conn.execute(
+            "SELECT COUNT(*) FROM session_moa_usage WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()[0]
+    assert session_count == 0
+    assert usage_count == 0
+
+
+def _moa_response(*, content, input_tokens, output_tokens, model):
+    message = SimpleNamespace(content=content, tool_calls=[])
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    usage = SimpleNamespace(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+    )
+    return SimpleNamespace(choices=[choice], usage=usage, model=model)
+
+
+def _make_moa_agent(tmp_path, monkeypatch, db, session_id):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openrouter
+          model: anthropic/claude-sonnet-4.6
+      aggregator:
+        provider: openrouter
+        model: openai/gpt-5.5
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    def fake_call_llm(**kwargs):
+        if kwargs["task"] == "moa_reference":
+            return _moa_response(
+                content="reference advice",
+                input_tokens=11,
+                output_tokens=3,
+                model="anthropic/claude-sonnet-4.6",
+            )
+        return _moa_response(
+            content="aggregator answer",
+            input_tokens=29,
+            output_tokens=7,
+            model="openai/gpt-5.5",
+        )
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    from run_agent import AIAgent
+
+    return AIAgent(
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        model="review",
+        provider="moa",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=["file"],
+        max_iterations=1,
+        session_db=db,
+        session_id=session_id,
+    )
+
+
+def test_real_moa_conversation_persists_matching_aggregate_and_slot_usage(
+    tmp_path, monkeypatch
+):
+    """The real MoA conversation path writes matching aggregate/detail usage."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    session_id = "moa-integration-success"
+    agent = _make_moa_agent(tmp_path, monkeypatch, db, session_id)
+
+    result = agent.run_conversation("solve this")
+
+    assert result["final_response"] == "aggregator answer"
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        session = conn.execute(
+            "SELECT input_tokens, output_tokens FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        rows = conn.execute(
+            "SELECT role, input_tokens, output_tokens "
+            "FROM session_moa_usage WHERE session_id = ? ORDER BY slot_index",
+            (session_id,),
+        ).fetchall()
+        model_usage = conn.execute(
+            "SELECT input_tokens, output_tokens FROM session_model_usage "
+            "WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+
+    assert session is not None
+    assert model_usage is not None
+    assert [
+        (row["role"], row["input_tokens"], row["output_tokens"]) for row in rows
+    ] == [
+        ("reference", 11, 3),
+        ("aggregator", 29, 7),
+    ]
+    assert session["input_tokens"] == sum(row["input_tokens"] for row in rows)
+    assert session["output_tokens"] == sum(row["output_tokens"] for row in rows)
+    assert model_usage["input_tokens"] == session["input_tokens"]
+    assert model_usage["output_tokens"] == session["output_tokens"]
+
+
+def test_real_moa_conversation_rolls_back_aggregate_when_slot_insert_fails(
+    tmp_path, monkeypatch
+):
+    """A detailed-write failure cannot leave aggregate usage committed alone."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    session_id = "moa-integration-rollback"
+    agent = _make_moa_agent(tmp_path, monkeypatch, db, session_id)
+
+    db.ensure_session(session_id, "test session", model="review")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TRIGGER reject_moa_usage
+            BEFORE INSERT ON session_moa_usage
+            BEGIN
+                SELECT RAISE(ABORT, 'forced detailed usage failure');
+            END
+            """
+        )
+
+    result = agent.run_conversation("solve this")
+
+    assert result["final_response"] == "aggregator answer"
+    with sqlite3.connect(db_path) as conn:
+        session = conn.execute(
+            "SELECT input_tokens, output_tokens, api_call_count "
+            "FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        usage_count = conn.execute(
+            "SELECT COUNT(*) FROM session_moa_usage WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()[0]
+        model_usage_count = conn.execute(
+            "SELECT COUNT(*) FROM session_model_usage WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()[0]
+
+    assert session == (0, 0, 0)
+    assert usage_count == 0
+    assert model_usage_count == 0


### PR DESCRIPTION
## Summary

Closes #57973.

Adds granular, privacy-safe token/cost accounting for MoA (Mixture of Agents) calls. Each reference model and the aggregator now get their own row in a new `session_moa_usage` table, enabling downstream tools to display a hierarchical per-preset/per-model breakdown without relying on trace files.

Privacy note: this persists metadata only. No prompt text, model output, message content, or trace payload is stored in the new accounting table.

## Changes

- Add `session_moa_usage` schema v18 table with `preset`, `role`, `slot_index`, `provider`, `model`, token counters, and `cost_usd`
- Add `SessionDB.add_session_moa_usage()` for metadata-only MoA breakdown persistence
- Capture `slot_index` for reference model details and add a `MoAClient.consume_reference_details()` wrapper
- Preserve `MoAClient.preset_name` so conversation accounting can label rows with the active MoA preset
- Initialize `_ref_details` before the MoA call path and persist aggregator usage separately from reference usage to avoid double counting
- Extend tests for persistence, privacy, `slot_index`, `preset_name`, delegation, and defensive `None` metadata handling

## Verification

Passed:

- `./scripts/run_tests.sh tests/agent/test_moa_slot_accounting.py tests/agent/test_moa_reference_details.py`
  - 2 files, 4 tests passed
- Broader MoA/usage regression sweep:
  - `tests/agent/test_moa_slot_accounting.py`
  - `tests/agent/test_moa_reference_details.py`
  - `tests/agent/test_moa_trace_streamed_capture.py`
  - `tests/agent/test_moa_switch_api_mode.py`
  - `tests/agent/test_moa_slot_api_mode.py`
  - `tests/agent/test_moa_aggregator_cost_slot.py`
  - `tests/agent/test_usage_pricing.py`
  - `tests/run_agent/test_moa_loop_mode.py`
  - `tests/run_agent/test_moa_streaming.py`
  - `tests/hermes_cli/test_moa_config.py`
  - `tests/cli/test_moa_command.py`
  - `tests/gateway/test_moa_one_shot_restore.py`
  - `tests/gateway/test_usage_command.py`
  - `tests/tui_gateway/test_moa_reference_emit.py`
  - 14 files, 110 tests passed
- `git diff --check`
- `python -m py_compile agent/moa_loop.py agent/conversation_loop.py hermes_state.py`

Additional broad DB/session-related sweep was attempted. The MoA/accounting-related coverage passed, but this local environment still reports unrelated failures from optional/machine-specific dependencies, including missing `acp`, missing `mcp`, and a Chromium browser launch hint assertion. These are outside the MoA accounting path and were not changed by this PR.

## Migration

`SCHEMA_VERSION` is bumped to 18. The new table is created from `SCHEMA_SQL`; `slot_index` is included in the table definition and the deferred index is created after column reconciliation, matching the existing schema-management pattern.
