### PR TITLE
fix: add missing _subprocess_compat import in _cmd_update_impl

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9015,6 +9015,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # On Windows, git can fail with "unable to write loose object file: Invalid argument"
     # due to filesystem atomicity issues. Set the recommended workaround.
     if sys.platform == "win32" and git_dir.exists():
+        from hermes_cli import _subprocess_compat
         _subprocess_compat.run(
             [
                 "git",


### PR DESCRIPTION
## Problem

`hermes update` fails with NameError on Windows:

```
NameError: name '_subprocess_compat' is not defined
```

## Root Cause

`_cmd_update_impl` calls `_subprocess_compat.run()` for git config, but the module-level import only pulls selective symbols (windows_detach_popen_kwargs, windows_hide_flags).

## Fix

Add inline `from hermes_cli import _subprocess_compat` inside the function, matching the pattern used elsewhere in the file.