### PR TITLE
fix(cli): keep torn paste tails from interrupting turns

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3029,22 +3029,55 @@ def _apply_bracketed_paste_timeout_patch() -> None:
         _BP_TIMEOUT_S = 2.0  # max time to wait for ESC[201~ before flushing
 
         def _patched_vt100_feed(self_parser, data: str) -> None:
+            end_mark = "\x1b[201~"
+
+            def _emit_bracketed_paste(text: str) -> None:
+                if text:
+                    self_parser.feed_key_callback(
+                        _PtKeyPress(_PtKeys.BracketedPaste, text)
+                    )
+
+            def _arm_timeout_recovery(now: float) -> None:
+                """Keep late bytes from a torn paste grouped briefly.
+
+                The timeout path fires while the terminal is still streaming a
+                bracketed paste but the ESC[201~ terminator has not arrived.
+                If we immediately return to normal parsing, any remaining
+                pasted newlines become real Enter keys. In Hermes' busy input
+                mode those Enters are treated as interrupts, which can flood a
+                running agent with dozens of fake user turns.
+
+                Arm a short idle-based recovery window so subsequent bytes are
+                still surfaced as BracketedPaste events. The cap prevents a
+                genuinely missing terminator from capturing normal typing
+                indefinitely.
+                """
+
+                idle_s = 1.0
+                max_s = 15.0
+                self_parser._hermes_bp_recovery_idle = idle_s
+                self_parser._hermes_bp_recovery_until = now + idle_s
+                self_parser._hermes_bp_recovery_max = now + max_s
+
+            def _clear_timeout_recovery() -> None:
+                self_parser._hermes_bp_recovery_idle = None
+                self_parser._hermes_bp_recovery_until = None
+                self_parser._hermes_bp_recovery_max = None
+
             if self_parser._in_bracketed_paste:
                 self_parser._paste_buffer += data
-                end_mark = "\x1b[201~"
 
                 if end_mark in self_parser._paste_buffer:
                     end_index = self_parser._paste_buffer.index(end_mark)
                     paste_content = self_parser._paste_buffer[:end_index]
-                    self_parser.feed_key_callback(
-                        _PtKeyPress(_PtKeys.BracketedPaste, paste_content)
-                    )
+                    _emit_bracketed_paste(paste_content)
                     self_parser._in_bracketed_paste = False
                     remaining = self_parser._paste_buffer[
                         end_index + len(end_mark):
                     ]
                     self_parser._paste_buffer = ""
                     self_parser._hermes_bp_start = None
+                    _clear_timeout_recovery()
                     if remaining:
                         _patched_vt100_feed(self_parser, remaining)
                 else:
@@ -3058,9 +3091,8 @@ def _apply_bracketed_paste_timeout_patch() -> None:
                         self_parser._paste_buffer = ""
                         self_parser._hermes_bp_start = None
                         if paste_content:
-                            self_parser.feed_key_callback(
-                                _PtKeyPress(_PtKeys.BracketedPaste, paste_content)
-                            )
+                            _emit_bracketed_paste(paste_content)
+                            _arm_timeout_recovery(now)
                             logger.warning(
                                 "Bracketed-paste timeout (%.1fs) — flushed %d bytes "
                                 "without end mark. Terminal may have dropped ESC[201~ "
@@ -3069,6 +3101,46 @@ def _apply_bracketed_paste_timeout_patch() -> None:
                                 len(paste_content),
                             )
             else:
+                recovery_until = getattr(self_parser, "_hermes_bp_recovery_until", None)
+                recovery_max = getattr(self_parser, "_hermes_bp_recovery_max", None)
+                if recovery_until is not None:
+                    now = time.monotonic()
+                    if now <= recovery_until and (recovery_max is None or now <= recovery_max):
+                        if end_mark in data:
+                            end_index = data.index(end_mark)
+                            _emit_bracketed_paste(data[:end_index])
+                            remaining = data[end_index + len(end_mark):]
+                            # If the user pressed Enter immediately after the
+                            # torn paste, drop that one submit. Otherwise the
+                            # recovered tail can still interrupt the in-flight
+                            # agent once. The next explicit Enter still works.
+                            if remaining.startswith("\r\n"):
+                                remaining = remaining[2:]
+                            elif remaining.startswith("\r") or remaining.startswith("\n"):
+                                remaining = remaining[1:]
+                            _clear_timeout_recovery()
+                            if remaining:
+                                _patched_vt100_feed(self_parser, remaining)
+                        else:
+                            _emit_bracketed_paste(data)
+                            recovery_idle = getattr(self_parser, "_hermes_bp_recovery_idle", None)
+                            if recovery_idle is None:
+                                recovery_idle = 1.0
+                            else:
+                                try:
+                                    recovery_idle = float(recovery_idle)
+                                except (TypeError, ValueError):
+                                    recovery_idle = 1.0
+                            if recovery_max is not None:
+                                self_parser._hermes_bp_recovery_until = min(
+                                    now + max(0.0, recovery_idle),
+                                    recovery_max,
+                                )
+                            else:
+                                self_parser._hermes_bp_recovery_until = now + max(0.0, recovery_idle)
+                        return
+                    _clear_timeout_recovery()
+
                 # Normal mode — re-inline prompt_toolkit's normal feed path.
                 # Calling the original feed here would double-buffer after the
                 # bracketed-paste entry transition.

--- a/tests/cli/test_bracketed_paste_timeout.py
+++ b/tests/cli/test_bracketed_paste_timeout.py
@@ -135,6 +135,49 @@ class TestBracketedPasteTimeout:
         assert not parser._in_bracketed_paste
         assert callback.call_count >= 1
 
+    def test_late_bytes_after_timeout_stay_paste_events(self, monkeypatch):
+        """Late bytes from a torn paste must not become Enter submits.
+
+        Regression for the interrupt storm seen when Hermes timed out a large
+        bracketed paste, returned to normal key parsing, then treated each
+        remaining pasted newline as a real Enter while the agent was running.
+        """
+        now = [0.0]
+        monkeypatch.setattr(time, "monotonic", lambda: now[0])
+        parser, callback = self._make_parser()
+
+        parser.feed("\x1b[200~first line\n")
+        assert parser._in_bracketed_paste
+        assert not callback.called
+
+        now[0] = 3.0
+        parser.feed("second line\n")
+
+        assert not parser._in_bracketed_paste
+        paste_events = [
+            c[0][0]
+            for c in callback.call_args_list
+            if hasattr(c[0][0], "key") and c[0][0].key == Keys.BracketedPaste
+        ]
+        assert len(paste_events) == 1
+        assert paste_events[0].data == "first line\nsecond line\n"
+
+        callback.reset_mock()
+        now[0] = 3.2
+        parser.feed("late line\n")
+        now[0] = 3.4
+        parser.feed("late line 2\n")
+
+        late_events = [
+            c[0][0]
+            for c in callback.call_args_list
+            if hasattr(c[0][0], "key") and c[0][0].key == Keys.BracketedPaste
+        ]
+        assert [event.data for event in late_events] == [
+            "late line\n",
+            "late line 2\n",
+        ]
+
     def test_torn_end_mark_recovers(self):
         """If end mark arrives split across feeds within timeout, it still works."""
         parser, callback = self._make_parser()


### PR DESCRIPTION
## Summary

- keep bytes arriving after a bracketed-paste timeout grouped as `Keys.BracketedPaste` events instead of normal keypresses
- add an idle/max recovery window for torn paste tails so pasted newlines cannot become busy-input Enter submits / interrupts
- add regression coverage for late bytes after timeout continuing as paste events

## Root cause / comparison

The recurrence matched the existing bracketed-paste timeout failure mode, not a separate tool execution bug. The running CLI build did not contain this repo fix yet, so a torn paste could still time out, flush the first chunk, then parse the remaining terminal bytes as normal keys. While an agent is running, those newlines route through the busy-input interrupt path, producing the observed MallocStackLogging / status-line interrupt storm.

## Tests

- `python -m pytest tests/cli/test_bracketed_paste_timeout.py tests/cli/test_cli_bracketed_paste_sanitizer.py tests/cli/test_cli_shift_enter_newline.py -q` — 26 passed
- `python -m py_compile cli.py tests/cli/test_bracketed_paste_timeout.py` — passed
- `python -m pytest tests/cli -q` — 813 passed, 1 pre-existing unrelated failure in `tests/cli/test_resume_quiet_stderr.py::TestResumeQuietStderr::test_session_not_found_goes_to_stdout_in_full_mode`
