### PR TITLE
docs(migrate): point memory-backend recreation at hermes memory setup honcho

### DIFF
--- a/website/docs/guides/migrate-from-openclaw.md
+++ b/website/docs/guides/migrate-from-openclaw.md
@@ -175,7 +175,7 @@ These are saved to `~/.hermes/migration/openclaw/<timestamp>/archive/` for manua
 | Cron jobs | `archive/cron-config.json` | Recreate with `hermes cron create` |
 | Plugins | `archive/plugins-config.json` | See [plugins guide](/user-guide/features/hooks) |
 | Hooks/webhooks | `archive/hooks-config.json` | Use `hermes webhook` or gateway hooks |
-| Memory backend | `archive/memory-backend-config.json` | Configure via `hermes honcho` |
+| Memory backend | `archive/memory-backend-config.json` | Configure via `hermes memory setup honcho` |
 | Skills registry | `archive/skills-registry-config.json` | Use `hermes skills config` |
 | UI/identity | `archive/ui-identity-config.json` | Use `/skin` command |
 | Logging | `archive/logging-diagnostics-config.json` | Set in `config.yaml` logging section |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/migrate-from-openclaw.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/migrate-from-openclaw.md
@@ -171,7 +171,7 @@ TTS 设置从 OpenClaw 配置的**两个**位置读取，优先级如下：
 | Cron 作业 | `archive/cron-config.json` | 通过 `hermes cron create` 重建 |
 | 插件 | `archive/plugins-config.json` | 参见 [插件指南](/user-guide/features/hooks) |
 | Hooks/webhooks | `archive/hooks-config.json` | 使用 `hermes webhook` 或 gateway hooks |
-| 记忆后端 | `archive/memory-backend-config.json` | 通过 `hermes honcho` 配置 |
+| 记忆后端 | `archive/memory-backend-config.json` | 通过 `hermes memory setup honcho` 配置 |
 | Skills 注册表 | `archive/skills-registry-config.json` | 使用 `hermes skills config` |
 | UI/身份 | `archive/ui-identity-config.json` | 使用 `/skin` 命令 |
 | 日志 | `archive/logging-diagnostics-config.json` | 在 `config.yaml` 日志部分设置 |


### PR DESCRIPTION
﻿## What does this PR do?

Fixes a misleading command hint in the OpenClaw migration guide. In the **Archived (no direct Hermes equivalent)** table, the memory-backend row tells migrating users to recreate their setup with `hermes honcho`:

> | Memory backend | `archive/memory-backend-config.json` | Configure via `hermes honcho` |

But the `hermes honcho` subcommand is **only registered when Honcho is already the active memory provider** — which a freshly-migrated user does not have yet. The canonical fresh-install command is `hermes memory setup honcho`.

Source of truth:
- `website/docs/user-guide/features/honcho.md`: *"The `hermes honcho` subcommand is **only registered when Honcho is the active memory provider**... On a fresh install, configure Honcho directly with `hermes memory setup honcho`... the `hermes honcho` subcommand then appears on the next invocation."*
- `hermes_cli/subcommands/memory.py`: the `setup` subcommand takes a positional `provider` argument documented as *"Provider to configure directly (e.g. honcho)"* — so `hermes memory setup honcho` is valid.

Since migration targets fresh installs by definition, the guide was pointing at a command that is not available to its audience.

## The fix

```diff
-| Memory backend | `archive/memory-backend-config.json` | Configure via `hermes honcho` |
+| Memory backend | `archive/memory-backend-config.json` | Configure via `hermes memory setup honcho` |
```

## Type of Change

- [x] Documentation update

## Notes

- Docs-only. Zero runtime/behavior change. 1 file, 1 line.
- Provable by direct comparison against `honcho.md` and `hermes_cli/subcommands/memory.py`.
