### PR TITLE
docs(memory-providers): add Brain Memory

### DIFF
--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -587,6 +587,46 @@ hermes config set memory.provider memori
 hermes memory setup
 ```
 
+### Brain Memory
+
+Local-first, human-readable Markdown memory in `~/.brain/` — the same store shared by Claude Code, Codex, OpenCode, and OpenClaw, so Hermes remembers what your other agents learned (and vice versa). Memories decay over time, strengthen with use (spaced reinforcement), and connect through an associative network with spreading activation. The model decides *what* to remember via explicit tools; the `brain` CLI scores recall deterministically.
+
+| | |
+|---|---|
+| **Best for** | One memory shared across all your AI agents; plain Markdown you can read, grep, and edit |
+| **Requires** | `pip install hermes-brain-memory` + `hermes-brain-memory install` + the [`brain` CLI](https://brainmemory.ai) (`npm install -g brain-memory`) — no pip runtime dependencies (stdlib only) |
+| **Data storage** | Local (`~/.brain/`), optional Brain Cloud / Git-remote sync |
+| **Cost** | Free (local) |
+
+**Tools (3):** `brain_recall` (deterministic recall — TF-IDF relevance, decayed strength, spreading activation, context match, salience — with full memory bodies and auto-reinforcement), `brain_memorize` (validated store: title, type, life-domain path, markdown content), `brain_reinforce` (spaced reinforcement + Hebbian co-retrieval strengthening by ID)
+
+**Setup:**
+```bash
+npm install -g brain-memory        # the brain CLI (once)
+pip install hermes-brain-memory
+hermes-brain-memory install
+hermes config set memory.provider brain
+hermes memory setup
+```
+
+**Config:** `$HERMES_HOME/brain.json`; environment variables override.
+
+| Key | Default | Env var | Description |
+|-----|---------|---------|-------------|
+| `project` | `hermes` | `BRAIN_PROJECT` | Project label for context-dependent recall |
+| `top_recall` | `6` | `BRAIN_TOP_RECALL` | Max memories per recall (1–25) |
+| `auto_reinforce` | `true` | `BRAIN_AUTO_REINFORCE` | Reinforce memories surfaced by `brain_recall` |
+| `brain_bin` | `brain` | `BRAIN_BIN` | Path to the brain CLI |
+| `sync_on_memorize` | `false` | `BRAIN_SYNC_ON_MEMORIZE` | Push each store to Brain Cloud / Git remote |
+
+**Key features:**
+- **Cross-agent store** — the same `~/.brain/` is read and written by Claude Code, Codex, OpenCode, and OpenClaw
+- Budget-bounded session-start context: status line, pinned facts, procedural-skills index, relevant memory titles
+- Pre-compression reminder so notable un-memorized content is stored before context is discarded
+- Mirrors built-in MEMORY.md writes into `~/.brain` as content-hash-deduplicated observations
+- No transcript dumping — `sync_turn` does lightweight in-memory topic tracking only; nothing leaves the machine unless Brain's own sync is enabled
+- `~/.brain` is declared via `backup_paths()` so `hermes backup` captures it
+
 ---
 
 ## Provider Comparison
@@ -602,6 +642,7 @@ hermes memory setup
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
+| **Brain** | Local (+ optional sync) | Free | 3 | `hermes-brain-memory` + `brain` CLI | Cross-agent shared store + decay/reinforcement |
 
 ## Profile Isolation
 
@@ -611,6 +652,7 @@ Each provider's data is isolated per [profile](/user-guide/profiles):
 - **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
+- **Cross-agent providers** (Brain) keep config per profile in `$HERMES_HOME/brain.json`, but the store itself (`~/.brain/`) is deliberately shared across profiles *and* other AI agents — use the `project` config key to scope recall per profile
 
 ## Building a Memory Provider
 


### PR DESCRIPTION
## What does this PR do?

Adds a docs entry for **Brain Memory** to the memory-providers page — a standalone, pip-installable memory provider ([`hermes-brain-memory`](https://pypi.org/project/hermes-brain-memory/)), following the standalone-provider path from CONTRIBUTING.md and the same shape as the existing Memori entry.

Brain Memory is a local-first, human-readable Markdown memory store in `~/.brain/` that is **shared across AI agents** — the same store is read and written by Claude Code, Codex, OpenCode, and OpenClaw, so Hermes remembers what the user's other agents learned, and vice versa. Memories are plain Markdown files with YAML frontmatter (greppable, diffable, user-editable); they decay over time, strengthen with use (spaced reinforcement), and connect through an associative network with spreading activation. The model decides *what* to remember via explicit tools — no transcript dumping; the `brain` CLI scores recall deterministically.

Install mechanism mirrors `hermes-memori` exactly: `pip install hermes-brain-memory` + a `hermes-brain-memory install` console script that copies the provider into `$HERMES_HOME/plugins/brain/` (idempotent, with `uninstall`/`status` subcommands), then `hermes config set memory.provider brain`. Both the installer package and the provider are Python-stdlib-only — zero pip runtime dependencies.

Per CONTRIBUTING.md ("Memory Providers: Ship as a Standalone Plugin"), the provider itself lives in its own repo ([omelas-tech/brain](https://github.com/omelas-tech/brain), `integrations/hermes/`) with a 74-test hermetic pytest suite — this PR only adds the docs entry, like Memori's.

## Related Issue

No existing issue — this is the docs-entry step of the standalone-provider path described in CONTRIBUTING.md.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/memory-providers.md` — purely additive (+42 lines, 3 hunks):
  - `### Brain Memory` section after `### Memori` (metadata table, tools, setup, config reference, key features — same format as the surrounding entries)
  - Row in the Provider Comparison table
  - Bullet in Profile Isolation documenting the deliberate cross-profile/cross-agent sharing of `~/.brain/` (per-profile scoping via the `project` config key)

Deliberately **not** touched (they enumerate bundled providers, matching the Memori precedent): the page frontmatter/intro count, the `memory.provider` config comment, `cli-commands.md`, and the `hermes memory --help` provider list.

## How to Test

1. Render the page (`cd website && npm start`) and check the new section, table row, and bullet.
2. Live flow the entry documents:
   ```bash
   npm install -g brain-memory
   pip install hermes-brain-memory
   hermes-brain-memory install
   hermes config set memory.provider brain
   hermes memory status     # → Provider: brain — installed ✓ / available ✓
   ```
3. In a session: the system prompt gains a budget-bounded `## Brain Memory` block; `brain_recall` / `brain_memorize` / `brain_reinforce` tools are exposed; `hermes brain status` prints store diagnostics.

**Verification:** verified live end-to-end on Hermes v0.18.0 (2026-07-04): system_prompt_block injection, brain_recall with scored results, brain_memorize capture with agent attribution, running as the active provider. Additionally verified in an isolated `HERMES_HOME`: pip install of the built wheel → `hermes-brain-memory install` → `hermes memory status` discovers the provider as installed/available/active; the provider's 74-test hermetic suite passes against the packaged payload.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only change; no code touched. The provider's own 74-test suite passes in its repo)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A (docs-only)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (docs-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

`hermes memory status` (Hermes v0.18.0) after the documented install flow:

```
Memory status
────────────────────────────────────────
  Built-in:  always active
  Provider:  brain

  Plugin:    installed ✓
  Status:    available ✓

  Installed plugins:
    • byterover  (API key / local)
    • hindsight  (API key / local)
    • holographic  (local)
    • honcho  (API key / local)
    • mem0  (API key / local)
    • openviking  (API key / local)
    • retaindb  (API key / local)
    • supermemory  (requires API key)
    • brain  (local) ← active
```
