### PR TITLE
fix(compression): preserve gateway origin on child sessions

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -699,8 +699,18 @@ def compress_context(
                         agent._flush_messages_to_session_db(messages)
                     except Exception:
                         pass  # best-effort — don't block compression on a flush error
-                    # Propagate title to the new session with auto-numbering
+                    # Propagate title to the new session with auto-numbering.
+                    # Snapshot the parent row BEFORE end_session()/id rotation so
+                    # the child can inherit the same gateway-origin metadata
+                    # (source, user_id, session_key, chat_id/chat_type/thread_id).
+                    # Without that carry-forward, compression-created child
+                    # sessions lose the origin identity needed for gateway
+                    # resume/session scoping across compression boundaries.
                     old_title = agent._session_db.get_session_title(agent.session_id)
+                    try:
+                        _parent_session_row = agent._session_db.get_session(agent.session_id)
+                    except Exception:
+                        _parent_session_row = None
                     agent._session_db.end_session(agent.session_id, "compression")
                     old_session_id = agent.session_id
                     agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
@@ -729,12 +739,22 @@ def compress_context(
                         pass
                     agent._session_db_created = False
                     try:
+                        _parent_source = (
+                            (_parent_session_row or {}).get("source")
+                            or agent.platform
+                            or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+                        )
                         agent._session_db.create_session(
                             session_id=agent.session_id,
-                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            source=_parent_source,
                             model=agent.model,
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,
+                            user_id=(_parent_session_row or {}).get("user_id"),
+                            session_key=(_parent_session_row or {}).get("session_key"),
+                            chat_id=(_parent_session_row or {}).get("chat_id"),
+                            chat_type=(_parent_session_row or {}).get("chat_type"),
+                            thread_id=(_parent_session_row or {}).get("thread_id"),
                         )
                     except Exception as _cs_err:
                         # The child row could not be created (e.g. FK constraint,

--- a/tests/gateway/test_session_scope_persistence.py
+++ b/tests/gateway/test_session_scope_persistence.py
@@ -1,0 +1,96 @@
+"""Regression tests for gateway-origin metadata across compression session rotation.
+
+Room-scoped recall depends on compression-created child sessions preserving the
+parent gateway origin metadata (chat/thread identity). When rotation creates a
+new child row without `chat_id` / `chat_type` / `thread_id`, scoped recall can
+silently lose access to the room's older lineage after a compression boundary.
+
+This test intentionally exercises the real rotation path with
+`compression_in_place = False` to pin the fallback behavior even though
+in-place compaction is now the default.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _make_agent(session_db, session_id: str):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.compression_in_place = False
+    return agent
+
+
+def _seed_gateway_parent(db, session_id: str) -> None:
+    db.create_session(
+        session_id=session_id,
+        source="telegram",
+        user_id="user-1",
+        session_key="telegram:chat-123:user-1:thread-456",
+        chat_id="chat-123",
+        chat_type="group",
+        thread_id="thread-456",
+        model="test/model",
+    )
+
+
+class TestCompressionRotationPreservesGatewayOrigin:
+    def test_compression_child_inherits_gateway_chat_thread_identity(self):
+        """A compression-created child row must preserve the parent's gateway
+        origin metadata.
+
+        Current room-scoped recall designs need every session in the lineage to
+        carry the same chat/thread identity. If the rotation child loses these
+        columns, default room-scoped `session_search` can no longer see the
+        pre-compression history after the boundary.
+        """
+        from agent.conversation_compression import compress_context
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            parent_sid = "20260704_000000_parent"
+            _seed_gateway_parent(db, parent_sid)
+
+            agent = _make_agent(db, parent_sid)
+            agent._ensure_db_session()
+
+            messages = [
+                {"role": "user" if i % 2 == 0 else "assistant", "content": f"message {i}"}
+                for i in range(12)
+            ]
+
+            with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+                compress_context(
+                    agent, messages, approx_tokens=100_000, system_message="sys"
+                )
+
+            assert agent.session_id != parent_sid
+            child = db.get_session(agent.session_id)
+            assert child is not None
+            assert child["parent_session_id"] == parent_sid
+
+            # Room-scoped recall specifically depends on the gateway-origin
+            # columns below. Keep these assertions first so RED points at the
+            # real isolation break, not just the generic source label.
+            assert child["chat_id"] == "chat-123"
+            assert child["chat_type"] == "group"
+            assert child["thread_id"] == "thread-456"
+            assert child["user_id"] == "user-1"
+            assert child["session_key"] == "telegram:chat-123:user-1:thread-456"
+            assert child["source"] == "telegram"


### PR DESCRIPTION
## Summary

Preserve gateway-origin metadata when context compression rotates a conversation into a child session.

Before this change, the legacy rotation fallback (`compression_in_place = False`) created the child row with only:
- `session_id`
- `source`
- `model`
- `model_config`
- `parent_session_id`

That dropped the gateway identity columns carried by the parent session:
- `user_id`
- `session_key`
- `chat_id`
- `chat_type`
- `thread_id`

This patch snapshots the parent session row before rotation and carries those fields forward into the child `create_session(...)` call.

## Why this matters

Compression-created child sessions should preserve the same origin identity as the parent session.
Without that carry-forward, a rotation boundary can leave the child row with missing chat/thread metadata even though the parent had it.

That breaks the expectation that all sessions in the same gateway lineage continue to identify the same messaging origin across compression boundaries.

## Changes

- snapshot the parent session row before `end_session(...)` / session-id rotation
- use the parent row as the first source for child-session `source`
- pass through `user_id`, `session_key`, `chat_id`, `chat_type`, and `thread_id` when creating the child row
- add a regression test that exercises the real rotation path and asserts the child session inherits the parent gateway-origin metadata

## Test plan

Ran targeted regression tests:

```bash
pytest \
  tests/gateway/test_session_scope_persistence.py \
  tests/gateway/test_compression_session_id_persistence.py \
  tests/run_agent/test_compression_persistence.py \
  -q -o addopts=''
```

Result:
- `13 passed in 7.32s`

## Scope

This is a small preparatory correctness fix for the rotation fallback path only.
It does not change the in-place compaction path.

## Relationship to PR #50030

`#57981` and `#50030` touch different production-code paths:
- `#57981` fixes the compression rotation fallback (`compression_in_place = False`) to carry gateway-origin columns into child session rows.
- `#50030` adds room-scoped `session_search` / recall-scope plumbing.

Both PRs add `tests/gateway/test_session_scope_persistence.py`. Whichever lands second will need a manual merge of that test file.