### PR TITLE
fix(state): strip punctuation symmetrically in /sessions search compact match

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3146,6 +3146,39 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except Exception:
             logger.debug("Could not close a SessionDB connection", exc_info=True)
 
+    @staticmethod
+    def _register_sql_functions(conn: sqlite3.Connection) -> None:
+        """Register custom scalar functions used by SQL queries on ``conn``.
+
+        ``compact_punct`` lowercases its argument and strips every non-word
+        character plus underscore — the exact ``re.sub(r"[\\W_]+", "", …)``
+        alphabet the ``list_sessions_rich`` search needle is normalized with.
+        Registering it on the connection (rather than open-coding a partial
+        REPLACE chain in SQL) keeps the column side and the needle side in the
+        identical alphabet, so the punctuation-insensitive match promised by
+        ``/sessions search`` works for apostrophes/ampersands/slashes/commas —
+        not just ``- _ . space``. Custom functions are per-connection, so this
+        is applied to every connection the search can run on: the read-write
+        connection, the cross-profile ``read_only=True`` connection, and the
+        per-thread read-path connection ``_get_read_conn`` hands to
+        ``_read_ctx``.
+        """
+        def _compact_punct(value):
+            return re.sub(r"[\W_]+", "", (value or "").lower())
+
+        try:
+            conn.create_function(
+                "compact_punct", 1, _compact_punct, deterministic=True
+            )
+        except (TypeError, sqlite3.NotSupportedError):
+            # ``deterministic`` requires Python 3.8+ compiled against
+            # SQLite 3.8.3+. On Python < 3.8 the kwarg itself is unknown
+            # (``TypeError``); on a new-enough Python linked against an
+            # older SQLite, sqlite3 raises ``NotSupportedError`` instead.
+            # Either way, register without it — the function still works in
+            # WHERE/LIKE, just isn't query-optimized.
+            conn.create_function("compact_punct", 1, _compact_punct)
+
     def __init__(self, db_path: Path = None, read_only: bool = False):
         self.db_path = db_path or _default_db_path()
         # Fail hard (before any connection/pragma/mkdir) if a pytest-context
@@ -3263,6 +3296,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                self._register_sql_functions(self._conn)
                 # FTS capability flags normally come from writable schema
                 # initialisation. Probe existing virtual tables with SELECTs
                 # only so read-only search keeps its FTS and trigram paths.
@@ -3349,6 +3383,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                self._register_sql_functions(self._conn)
                 self._wal_active = (
                     apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
                 )
@@ -3513,6 +3548,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             conn.row_factory = sqlite3.Row
             apply_database_pragmas(conn, db_label="state.db")
+            # Custom scalar functions are per-connection, so the read-path
+            # connection needs them too — `list_sessions_rich` runs its
+            # `compact_punct(...)` search clause through `_read_ctx()`.
+            self._register_sql_functions(conn)
             # Load the CJK tokenizer extension on this connection so
             # messages_fts_cjk queries work on the read path. The .so
             # registers the tokenizer in the connection's in-memory
@@ -8580,11 +8619,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # Same chain-membership trick as id_query, but matching either
                 # the title or the id of any session in the chain. The compact
                 # (punctuation-stripped) variant lets `an94` match `AN-94`.
+                # ``compact_punct`` strips the SAME character class as the
+                # needle below (all non-word chars + underscore), so titles
+                # with apostrophes/ampersands/slashes (e.g. ``Bob's Chat``,
+                # ``R&D Notes``) are reachable via the compact path — not just
+                # ``- _ . space`` separators.
                 compact_needle = re.sub(r"[\W_]+", "", search_needle)
-                compact_sql = (
-                    "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(COALESCE({0}, '')),"
-                    " '-', ''), '_', ''), '.', ''), ' ', '')"
-                )
                 search_clause = (
                     "EXISTS (SELECT 1 FROM chain cq"
                     " JOIN sessions cs ON cs.id = cq.cur_id"
@@ -8595,7 +8635,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 id_params.extend([_like_pattern(search_needle)] * 2)
                 if compact_needle:
                     search_clause += (
-                        f" OR {compact_sql.format('cs.title')} LIKE ? ESCAPE '\\'"
+                        " OR compact_punct(cs.title) LIKE ? ESCAPE '\\'"
                     )
                     id_params.append(_like_pattern(compact_needle))
                 filter_clauses.append(search_clause + "))")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1903,6 +1903,39 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 data["system_prompt"] = resolved
         return data
 
+    @staticmethod
+    def _register_sql_functions(conn: sqlite3.Connection) -> None:
+        """Register custom scalar functions used by SQL queries on ``conn``.
+
+        ``compact_punct`` lowercases its argument and strips every non-word
+        character plus underscore — the exact ``re.sub(r"[\\W_]+", "", …)``
+        alphabet the ``list_sessions_rich`` search needle is normalized with.
+        Registering it on the connection (rather than open-coding a partial
+        REPLACE chain in SQL) keeps the column side and the needle side in the
+        identical alphabet, so the punctuation-insensitive match promised by
+        ``/sessions search`` works for apostrophes/ampersands/slashes/commas —
+        not just ``- _ . space``. Custom functions are per-connection, so this
+        is applied to every connection the search can run on: the read-write
+        connection, the cross-profile ``read_only=True`` connection, and the
+        per-thread read-path connection ``_get_read_conn`` hands to
+        ``_read_ctx``.
+        """
+        def _compact_punct(value):
+            return re.sub(r"[\W_]+", "", (value or "").lower())
+
+        try:
+            conn.create_function(
+                "compact_punct", 1, _compact_punct, deterministic=True
+            )
+        except (TypeError, sqlite3.NotSupportedError):
+            # ``deterministic`` requires Python 3.8+ compiled against
+            # SQLite 3.8.3+. On Python < 3.8 the kwarg itself is unknown
+            # (``TypeError``); on a new-enough Python linked against an
+            # older SQLite, sqlite3 raises ``NotSupportedError`` instead.
+            # Either way, register without it — the function still works in
+            # WHERE/LIKE, just isn't query-optimized.
+            conn.create_function("compact_punct", 1, _compact_punct)
+
     def __init__(self, db_path: Path = None, read_only: bool = False):
         self.db_path = db_path or _default_db_path()
         self.read_only = read_only
@@ -1970,6 +2003,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                self._register_sql_functions(self._conn)
                 # FTS capability flags normally come from writable schema
                 # initialisation. Probe existing virtual tables with SELECTs
                 # only so read-only search keeps its FTS and trigram paths.
@@ -2054,6 +2088,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                self._register_sql_functions(self._conn)
                 self._wal_active = (
                     apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
                 )
@@ -2181,6 +2216,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             conn.row_factory = sqlite3.Row
             apply_database_pragmas(conn, db_label="state.db")
+            # Custom scalar functions are per-connection, so the read-path
+            # connection needs them too — `list_sessions_rich` runs its
+            # `compact_punct(...)` search clause through `_read_ctx()`.
+            self._register_sql_functions(conn)
             # Load the CJK tokenizer extension on this connection so
             # messages_fts_cjk queries work on the read path. The .so
             # registers the tokenizer in the connection's in-memory
@@ -5727,11 +5766,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # Same chain-membership trick as id_query, but matching either
                 # the title or the id of any session in the chain. The compact
                 # (punctuation-stripped) variant lets `an94` match `AN-94`.
+                # ``compact_punct`` strips the SAME character class as the
+                # needle below (all non-word chars + underscore), so titles
+                # with apostrophes/ampersands/slashes (e.g. ``Bob's Chat``,
+                # ``R&D Notes``) are reachable via the compact path — not just
+                # ``- _ . space`` separators.
                 compact_needle = re.sub(r"[\W_]+", "", search_needle)
-                compact_sql = (
-                    "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(COALESCE({0}, '')),"
-                    " '-', ''), '_', ''), '.', ''), ' ', '')"
-                )
                 search_clause = (
                     "EXISTS (SELECT 1 FROM chain cq"
                     " JOIN sessions cs ON cs.id = cq.cur_id"
@@ -5742,7 +5782,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 id_params.extend([_like_pattern(search_needle)] * 2)
                 if compact_needle:
                     search_clause += (
-                        f" OR {compact_sql.format('cs.title')} LIKE ? ESCAPE '\\'"
+                        " OR compact_punct(cs.title) LIKE ? ESCAPE '\\'"
                     )
                     id_params.append(_like_pattern(compact_needle))
                 filter_clauses.append(search_clause + "))")

--- a/tests/hermes_cli/test_session_listing.py
+++ b/tests/hermes_cli/test_session_listing.py
@@ -56,6 +56,94 @@ class TestQuerySessionListingSearch:
         finally:
             db.close()
 
+    def test_punctuation_normalized_match_apostrophe(self, tmp_path):
+        # The compact needle strips all punctuation (re.sub(r"[\W_]+", ...)),
+        # so the title side must strip the same alphabet — "bobs" has to match
+        # "Bob's Chat" even though the apostrophe is not a - _ . separator.
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "bob.db")
+        # Id is deliberately chosen NOT to contain "bobs" so the match is
+        # forced through the compact-title path, not the id-substring fallback.
+        db.create_session("sess_x1", "telegram", user_id="1", chat_id="2")
+        db.set_session_title("sess_x1", "Bob's Chat")
+        try:
+            assert self._ids(db, source="telegram", search_query="bobs") == ["sess_x1"]
+            # The literal (non-compacted) fallback still matches the apostrophe.
+            assert self._ids(db, source="telegram", search_query="bob's") == ["sess_x1"]
+        finally:
+            db.close()
+
+    def test_punctuation_normalized_match_ampersand(self, tmp_path):
+        # "rd" must match "R&D Notes" via the compact path (ampersand stripped).
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "rd.db")
+        # Id avoids the "rd" substring so the id-fallback can't mask a broken
+        # compact-title path.
+        db.create_session("sess_x2", "telegram", user_id="1", chat_id="2")
+        db.set_session_title("sess_x2", "R&D Notes")
+        try:
+            assert self._ids(db, source="telegram", search_query="rd") == ["sess_x2"]
+        finally:
+            db.close()
+
+    def test_old_sqlite_deterministic_unsupported_falls_back(self, tmp_path, monkeypatch):
+        # sqlite3.create_function(..., deterministic=True) raises
+        # sqlite3.NotSupportedError (NOT TypeError) when the module knows the
+        # kwarg but the linked SQLite is < 3.8.3. SessionDB.__init__ must
+        # survive that by re-registering compact_punct without deterministic —
+        # never crash the whole DB open on an old-SQLite runtime.
+        import functools
+        import sqlite3
+
+        from hermes_state import SessionDB
+
+        class _OldSqliteConnection(sqlite3.Connection):
+            # Mimic a Python linked against SQLite < 3.8.3: the deterministic
+            # kwarg is recognised by the module but rejected by the engine.
+            def create_function(self, name, narg, func, *args, **kwargs):
+                if kwargs.get("deterministic"):
+                    raise sqlite3.NotSupportedError(
+                        "deterministic=True requires SQLite 3.8.3 or higher"
+                    )
+                return super().create_function(name, narg, func, *args, **kwargs)
+
+        real_connect = sqlite3.connect
+        monkeypatch.setattr(
+            sqlite3,
+            "connect",
+            functools.partial(real_connect, factory=_OldSqliteConnection),
+        )
+
+        db = SessionDB(db_path=tmp_path / "old_sqlite.db")
+        try:
+            # __init__ succeeded; the fallback (non-deterministic) registration
+            # produced a working compact_punct — the compact-title path still
+            # matches, proving we fell back rather than skipping the function.
+            db.create_session("sess_x3", "telegram", user_id="1", chat_id="2")
+            db.set_session_title("sess_x3", "R&D Notes")
+            assert self._ids(db, source="telegram", search_query="rd") == ["sess_x3"]
+        finally:
+            db.close()
+
+    def test_compact_search_works_on_the_wal_read_path(self, tmp_path):
+        # SQLite scalar functions are registered PER CONNECTION. Under WAL the
+        # search runs on the per-thread read-only connection from
+        # `_get_read_conn`, not the writer, so compact_punct has to be
+        # registered there too — otherwise `/sessions search` raises
+        # "no such function: compact_punct" on every WAL install. This test
+        # forces the read path on because runtimes with a WAL-unsafe SQLite
+        # fall back to journal_mode=DELETE and would never exercise it.
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "walread.db")
+        db.create_session("sess_x4", "telegram", user_id="1", chat_id="2")
+        db.set_session_title("sess_x4", "R&D Notes")
+        db._wal_active = True
+        try:
+            assert db._get_read_conn() is not None
+            assert self._ids(db, source="telegram", search_query="rd") == ["sess_x4"]
+        finally:
+            db.close()
+
 
 class TestQuerySessionListingLaneScope:
     @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

`/sessions search <query>` (added in #57685) advertises a **punctuation-stripped** match variant — its docstring promises "e.g. `an94` finds `AN-94`". That variant compares two compacted strings, but the two sides strip **different** character classes:

- **Needle side:** `compact_needle = re.sub(r"[\W_]+", "", search_needle)` — strips *all* non-word chars **and** underscore.
- **Title (column) side:** a fixed `REPLACE(REPLACE(REPLACE(REPLACE(…, '-', ''), '_', ''), '.', ''), ' ', '')` chain — strips **only** `-`, `_`, `.`, and space.

So any title whose relevant punctuation is outside `{- _ . space}` is silently unreachable via the compact path. Searching `bobs` never finds `Bob's Chat`; `rd` never finds `R&D Notes` — the exact capability the feature provides is defeated for apostrophes/ampersands/slashes/commas.

This aligns the title normalization to the **same alphabet** as the needle by registering a deterministic `compact_punct` SQLite scalar function (applying the identical `re.sub(r"[\W_]+", "", …)`), so both compacted sides live in one alphabet. The function is registered on both the read-write and read-only connections so cross-profile (read-only) search behaves identically. The literal (non-compacted) title/id match paths are unchanged.

## Related Issue

No filed issue — code-originated regression in the freshly landed #57685 feature.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: add `SessionDB._register_sql_functions`, registering a deterministic `compact_punct(s)` scalar (`re.sub(r"[\W_]+", "", (s or "").lower())`) on both the read-write and read-only connections; replace the partial 4-separator `REPLACE`-chain in the `list_sessions_rich` search block with `compact_punct(cs.title)` so the title side strips the same alphabet as the needle. Falls back to registering without `deterministic=True` on older SQLite/Python that lacks the kwarg.
- `tests/hermes_cli/test_session_listing.py`: add fail-before/pass-after cases for the apostrophe (`bobs` → `Bob's Chat`, plus literal `bob's` fallback) and ampersand (`rd` → `R&D Notes`) paths.

## How to Test

Before this fix, the compact path returns `[]` for punctuation outside `{- _ . space}`; after, it matches:

| Title | Query | Before | After |
|-------|-------|--------|-------|
| `Bob's Chat` | `bobs` | `[]` | matches |
| `R&D Notes` | `rd` | `[]` | matches |
| `AN-94 Build` | `an94` | matches | matches (control, unchanged) |

Reproduce with the added tests:

1. `uv run --with pytest --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_session_listing.py -v`
2. Regression guard: revert the `compact_punct(cs.title)` hunk to the old REPLACE chain → the new apostrophe/ampersand cases fail (`[]`); the `an94` control still passes. Restore → all green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A