### PR TITLE
fix: strip empty text blocks from assistant content before Bedrock/Anthropic send

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2015,8 +2015,22 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     )
     if isinstance(reasoning_content, str) and not _already_has_thinking:
         blocks.insert(0, {"type": "thinking", "thinking": reasoning_content})
-    # Anthropic rejects empty assistant content
+    # Anthropic rejects empty assistant content. A merely non-empty *list*
+    # isn't sufficient — a list containing only empty-string text blocks
+    # (e.g. [{"type": "text", "text": ""}]) passes `blocks or content` but
+    # still trips Bedrock/Anthropic's "text content blocks must be
+    # non-empty" validation. Strip empty text blocks and only then fall
+    # back to the placeholder if nothing usable remains.
     effective = blocks or content
+    if isinstance(effective, list):
+        effective = [
+            b for b in effective
+            if not (
+                isinstance(b, dict)
+                and b.get("type") == "text"
+                and not str(b.get("text", "")).strip()
+            )
+        ]
     if not effective or effective == "":
         effective = [{"type": "text", "text": "(empty)"}]
     return {"role": "assistant", "content": effective}


### PR DESCRIPTION
## Summary

Fixes a crash where a turn dies with a non-retryable `HTTP 400: messages: text content blocks must be non-empty` error from Bedrock/Anthropic.

## Root cause

`_convert_assistant_message()` in `agent/anthropic_adapter.py` guards against sending empty assistant content with:

```python
effective = blocks or content
if not effective or effective == "":
    effective = [{"type": "text", "text": "(empty)"}]
```

This checks whether `effective` (a list) is *truthy*, not whether the text *inside* its blocks is non-empty. When the model returns assistant content shaped like `[{"type": "text", "text": ""}]` — e.g. right after a tool call errors out (observed after a failed `clarify` call with no question text) — that list is non-empty, so the guard passes it through untouched. Bedrock/Anthropic then reject the empty text block outright, and Hermes treats the resulting 400 as non-retryable, killing the turn.

## Fix

Filter out text blocks whose `text` is empty/whitespace-only before the emptiness check, so a genuinely-empty result still falls through to the existing `"(empty)"` placeholder — otherwise the real content is preserved unchanged.

## Repro

```python
from agent.anthropic_adapter import _convert_assistant_message

_convert_assistant_message({"role": "assistant", "content": [{"type": "text", "text": ""}]})
# before: {"role": "assistant", "content": [{"type": "text", "text": ""}]}   -> 400 from API
# after:  {"role": "assistant", "content": [{"type": "text", "text": "(empty)"}]}
```

## Test plan

- Ran `tests/agent/test_anthropic_adapter.py` (173 tests) before and after the change: 170 passed / 3 failed both times (the 3 failures are pre-existing and unrelated — `TestRunOauthSetupToken`, a `MagicMock`/`json.loads` issue, confirmed present on unmodified `main` too).
- Manually verified the repro above, plus sanity-checked normal text content and fully-empty content still behave as before.
