### PR TITLE
fix(dashboard): basic-auth password-only provider 500s on first load (auto-SSO assumes OAuth)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,11 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password providers have no OAuth redirect flow; auto-SSO would 500 on
+    # /auth/login (start_login raises NotImplementedError). Fall through to the
+    # /login credential form instead.
+    if getattr(provider, "supports_password", False):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -117,6 +117,71 @@ def test_gated_html_redirects_to_login(gated_app):
     assert r.headers["location"].startswith("/auth/login?provider=stub")
 
 
+class _PasswordOnlyProvider(StubAuthProvider):
+    """A password provider whose OAuth ``start_login`` raises, exactly like
+    the shipped ``BasicAuthProvider``.
+
+    ``supports_password = True`` marks it as a credential-form provider with
+    no redirect flow; ``start_login`` raising ``NotImplementedError`` models
+    the shipped basic provider (``plugins/dashboard_auth/basic``), so if
+    ``_auto_sso_response`` ever redirected here it would 500.
+    """
+
+    name = "pwonly"
+    display_name = "Password Only (test only)"
+    supports_password = True
+
+    def start_login(self, *, redirect_uri: str):
+        raise NotImplementedError(
+            "password-only provider has no OAuth redirect flow"
+        )
+
+
+def test_single_password_provider_does_not_auto_sso_and_500s():
+    """Regression: a lone password provider must fall through to ``/login``.
+
+    ``_auto_sso_response`` auto-redirects an unauthenticated first HTML load
+    to ``/auth/login?provider=<name>`` when exactly ONE session provider is
+    registered. For a password-only provider (``supports_password = True``,
+    e.g. the shipped ``BasicAuthProvider``) that route runs ``start_login``,
+    which raises ``NotImplementedError`` → HTTP 500 on the very first visit,
+    locking the operator out. The guard makes auto-SSO skip password
+    providers so the ``/login`` credential form renders instead.
+
+    Contrast with ``test_gated_html_redirects_to_login`` (single OAuth
+    provider → auto-SSO to ``/auth/login`` is correct). Set up bare state
+    here so only the password provider is registered.
+    """
+    clear_providers()
+    register_provider(_PasswordOnlyProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.auth_required = True
+    try:
+        client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+        r = client.get("/", follow_redirects=False)
+        # Must be a 302 to the credential form, NOT a 500 from start_login
+        # and NOT an auto-SSO bounce to /auth/login.
+        assert r.status_code == 302, (
+            f"first HTML load with a lone password provider returned "
+            f"{r.status_code} (auto-SSO tried /auth/login → start_login "
+            f"NotImplementedError → 500): {r.text[:200]}"
+        )
+        location = r.headers["location"]
+        assert "/auth/login" not in location, (
+            f"auto-SSO redirected a password provider to {location}; it must "
+            "fall through to the /login credential form instead"
+        )
+        assert location in ("/login", "/login?next=%2F"), (
+            f"expected a redirect to /login, got {location}"
+        )
+    finally:
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.auth_required = prev_required
+
+
 def test_gated_auth_providers_is_public(gated_app):
     r = gated_app.get("/api/auth/providers")
     assert r.status_code == 200


### PR DESCRIPTION
## Symptom

With a single **password-only** session provider registered — e.g. the shipped `BasicAuthProvider` (`plugins/dashboard_auth/basic`) — the **very first unauthenticated navigation** to the dashboard returns **HTTP 500** instead of the login form. The operator is locked out on first load; the `/login` credential form is never reached.

## Root cause

`_auto_sso_response()` in `hermes_cli/dashboard_auth/middleware.py` auto-initiates the OAuth redirect to `/auth/login?provider=<name>` whenever **exactly one** session provider is registered — *without checking whether that provider supports the OAuth redirect flow*:

```python
providers = list_session_providers()
if len(providers) != 1:
    return None
...
provider = providers[0]
...
auth_login = f"{prefix}/auth/login?provider={quote(provider.name, safe='')}"
resp = RedirectResponse(url=auth_login, status_code=302)
```

For a password provider there is no redirect flow: `/auth/login` → `start_login()` raises `NotImplementedError`, which surfaces as a 500 on the first load.

`start_login` in the shipped basic provider (`plugins/dashboard_auth/basic/__init__.py`):

```python
def start_login(self, *, redirect_uri: str) -> LoginStart:
    raise NotImplementedError(
        "BasicAuthProvider is password-only; there is no OAuth redirect "
        "flow. The login page POSTs to /auth/password-login instead."
    )
```

The `/login` password form and the `/auth/password-login` endpoint work correctly — the auto-SSO gate just never routes there. `supports_password` is never referenced in the middleware.

This directly contradicts the documented provider contract in `base.py`, which states that password providers set `supports_password = True` and may leave `start_login` / `complete_login` as stubs that raise `NotImplementedError`.

### Traceback (first `GET /` with a lone `BasicAuthProvider`)

```
GET /  ->  gated_auth_middleware  ->  _auto_sso_response()
  302 Location: /auth/login?provider=basic
GET /auth/login?provider=basic  ->  start_login(redirect_uri=...)
  File ".../plugins/dashboard_auth/basic/__init__.py", line 230, in start_login
    raise NotImplementedError(
NotImplementedError: BasicAuthProvider is password-only; there is no OAuth
redirect flow. The login page POSTs to /auth/password-login instead.
  ->  HTTP 500 Internal Server Error
```

## Fix

In `_auto_sso_response`, after selecting the sole provider, skip auto-SSO for password providers and return `None` so the caller falls through to the `/login` credential form:

```python
    provider = providers[0]
    # Password providers have no OAuth redirect flow; auto-SSO would 500 on
    # /auth/login (start_login raises NotImplementedError). Fall through to the
    # /login credential form instead.
    if getattr(provider, "supports_password", False):
        return None
```

Five-line change; OAuth-only providers (the common case, `supports_password = False`) are completely unaffected.

## Test

Added `test_single_password_provider_does_not_auto_sso_and_500s` to `tests/hermes_cli/test_dashboard_auth_middleware.py`. It registers a lone password provider whose `start_login` raises (mirroring `BasicAuthProvider`) and asserts `GET /` returns `302 -> /login`, never `/auth/login`, never 500. It is the password counterpart to the existing `test_gated_html_redirects_to_login` (single OAuth provider → auto-SSO is correct).

Verified **RED** before the guard (redirect to `/auth/login?provider=pwonly&next=%2F`) and **GREEN** after. Full `tests/hermes_cli/test_dashboard_auth_middleware.py` suite: **34 passed**.

## Notes

Draft PR — opened for review of the approach. The same one-line guard has been applied to the reporter's local deployment to unblock their dashboard immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)