### PR TITLE
feat: first-class Cloudflare Workers AI provider integration

### DIFF
--- a/agent/cloudflare_workers_ai.py
+++ b/agent/cloudflare_workers_ai.py
@@ -1,0 +1,220 @@
+"""Cloudflare Workers AI catalog helpers.
+
+Shared by the custom-provider discovery path, the first-class Cloudflare
+provider profile, and capability fallbacks when models.dev has no entry for a
+Cloudflare-served model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+import time
+import urllib.parse
+import urllib.request
+from typing import Any, Optional
+
+from hermes_cli import __version__ as _HERMES_VERSION
+
+logger = logging.getLogger(__name__)
+
+_HERMES_USER_AGENT = f"hermes-cli/{_HERMES_VERSION}"
+_CATALOG_TTL_SECONDS = 300.0
+_catalog_cache_lock = threading.Lock()
+_catalog_cache: dict[tuple[str, str], tuple[float, list[dict[str, Any]]]] = {}
+
+
+def is_cloudflare_workers_ai_base_url(base_url: str) -> bool:
+    """Return True when *base_url* is a Cloudflare Workers AI OpenAI endpoint."""
+    normalized = (base_url or "").strip().rstrip("/")
+    if not normalized:
+        return False
+    parsed = urllib.parse.urlparse(normalized)
+    path = parsed.path.rstrip("/")
+    return (
+        "api.cloudflare.com" in (parsed.netloc or "").lower()
+        and path.endswith("/ai/v1")
+    )
+
+
+def cloudflare_ai_models_search_url(base_url: str) -> Optional[str]:
+    """Map a Workers AI inference base URL to Cloudflare's native catalog URL."""
+    normalized = (base_url or "").strip().rstrip("/")
+    if not is_cloudflare_workers_ai_base_url(normalized):
+        return None
+    parsed = urllib.parse.urlparse(normalized)
+    path = parsed.path.rstrip("/")
+    search_path = path[: -len("/ai/v1")] + "/ai/models/search"
+    return urllib.parse.urlunparse(
+        parsed._replace(path=search_path, params="", query="", fragment="")
+    )
+
+
+def parse_cloudflare_model_search_response(payload: Any) -> list[dict[str, Any]]:
+    """Return the raw Cloudflare catalog entries from ``result[]``."""
+    if not isinstance(payload, dict):
+        return []
+    result = payload.get("result")
+    if not isinstance(result, list):
+        return []
+    return [item for item in result if isinstance(item, dict)]
+
+
+def _cloudflare_task_name(entry: dict[str, Any]) -> str:
+    raw_task = entry.get("task")
+    if not isinstance(raw_task, dict):
+        return ""
+    return str(raw_task.get("name") or "").strip()
+
+
+def cloudflare_model_names(payload: Any, *, text_generation_only: bool = True) -> list[str]:
+    """Extract unique model IDs from a Cloudflare model-catalog payload.
+
+    By default Hermes only surfaces ``Text Generation`` models from Workers AI.
+    The catalog includes embeddings, TTS, ASR, text-to-image, classifiers, and
+    other non-agentic tasks that do not belong in the main model picker.
+    """
+    models: list[str] = []
+    seen: set[str] = set()
+    for item in parse_cloudflare_model_search_response(payload):
+        if text_generation_only and _cloudflare_task_name(item) != "Text Generation":
+            continue
+        name = str(item.get("name") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        models.append(name)
+    return models
+
+
+def _catalog_cache_key(search_url: str, api_key: str) -> tuple[str, str]:
+    digest = hashlib.blake2b(api_key.encode("utf-8", errors="replace"), digest_size=8)
+    return search_url, digest.hexdigest()
+
+
+def fetch_cloudflare_model_catalog(
+    api_key: str,
+    base_url: str,
+    *,
+    timeout: float = 8.0,
+    force_refresh: bool = False,
+) -> Optional[list[dict[str, Any]]]:
+    """Fetch Cloudflare's native Workers AI catalog for a given account."""
+    search_url = cloudflare_ai_models_search_url(base_url)
+    if not search_url or not api_key:
+        return None
+
+    cache_key = _catalog_cache_key(search_url, api_key)
+    now = time.monotonic()
+    if not force_refresh:
+        with _catalog_cache_lock:
+            cached = _catalog_cache.get(cache_key)
+            if cached is not None:
+                ts, entries = cached
+                if now - ts < _CATALOG_TTL_SECONDS:
+                    return [dict(item) for item in entries]
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "User-Agent": _HERMES_USER_AGENT,
+    }
+    req = urllib.request.Request(search_url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except Exception as exc:
+        logger.debug("Cloudflare catalog fetch failed for %s: %s", search_url, exc)
+        return None
+
+    entries = parse_cloudflare_model_search_response(payload)
+    with _catalog_cache_lock:
+        _catalog_cache[cache_key] = (now, [dict(item) for item in entries])
+    return entries
+
+
+def _properties_map(entry: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for prop in entry.get("properties") or []:
+        if not isinstance(prop, dict):
+            continue
+        property_id = str(prop.get("property_id") or "").strip()
+        if not property_id:
+            continue
+        out[property_id] = prop.get("value")
+    return out
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return False
+
+
+def _as_positive_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value) if value > 0 else None
+    if isinstance(value, str):
+        try:
+            parsed = int(value.strip())
+        except Exception:
+            return None
+        return parsed if parsed > 0 else None
+    return None
+
+
+def model_capabilities_from_cloudflare_catalog_entry(
+    entry: dict[str, Any], *, model: Optional[str] = None
+):
+    """Convert a Cloudflare catalog entry into ``agent.models_dev.ModelCapabilities``."""
+    from agent.models_dev import ModelCapabilities
+
+    props = _properties_map(entry)
+    raw_task = entry.get("task")
+    task: dict[str, Any] = raw_task if isinstance(raw_task, dict) else {}
+    task_name = str(task.get("name") or "").strip().lower()
+    model_name = str(model or entry.get("name") or "").strip()
+    model_family = model_name.removeprefix("@cf/")
+
+    supports_reasoning = _as_bool(props.get("reasoning"))
+    supports_tools = _as_bool(props.get("function_calling"))
+    supports_vision = _as_bool(props.get("vision"))
+    if not supports_vision and task_name == "text generation":
+        supports_vision = _as_bool(props.get("vision"))
+
+    context_window = _as_positive_int(props.get("context_window")) or 200000
+    max_output_tokens = _as_positive_int(props.get("max_output_tokens")) or 8192
+
+    return ModelCapabilities(
+        supports_tools=supports_tools,
+        supports_vision=supports_vision,
+        supports_reasoning=supports_reasoning,
+        context_window=context_window,
+        max_output_tokens=max_output_tokens,
+        model_family=model_family,
+    )
+
+
+def get_cloudflare_model_capabilities(
+    api_key: str,
+    base_url: str,
+    model: str,
+    *,
+    timeout: float = 8.0,
+):
+    """Fetch and return live capability metadata for a Cloudflare model."""
+    entries = fetch_cloudflare_model_catalog(api_key, base_url, timeout=timeout)
+    if not entries:
+        return None
+    for entry in entries:
+        if str(entry.get("name") or "").strip() == str(model or "").strip():
+            return model_capabilities_from_cloudflare_catalog_entry(entry, model=model)
+    return None

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -462,50 +462,59 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
       - family     (str)   → model_family
     """
     models = _get_provider_models(provider)
-    if models is None:
-        return None
+    if models is not None:
+        entry = _find_model_entry(models, model)
+        if entry is not None:
+            # Extract capability flags (default to False if missing)
+            supports_tools = bool(entry.get("tool_call", False))
+            # Vision: prefer explicit `modalities.input` when models.dev provides it.
+            # The older `attachment` flag can be stale or too broad for image routing;
+            # fall back to it only when the input modalities are absent/invalid.
+            input_mods = entry.get("modalities", {})
+            if isinstance(input_mods, dict):
+                input_mods = input_mods.get("input")
+            else:
+                input_mods = None
+            if isinstance(input_mods, list):
+                supports_vision = "image" in input_mods
+            else:
+                supports_vision = bool(entry.get("attachment", False))
+            supports_reasoning = bool(entry.get("reasoning", False))
 
-    entry = _find_model_entry(models, model)
-    if entry is None:
-        return None
+            # Extract limits
+            limit = entry.get("limit", {})
+            if not isinstance(limit, dict):
+                limit = {}
 
-    # Extract capability flags (default to False if missing)
-    supports_tools = bool(entry.get("tool_call", False))
-    # Vision: prefer explicit `modalities.input` when models.dev provides it.
-    # The older `attachment` flag can be stale or too broad for image routing;
-    # fall back to it only when the input modalities are absent/invalid.
-    input_mods = entry.get("modalities", {})
-    if isinstance(input_mods, dict):
-        input_mods = input_mods.get("input")
-    else:
-        input_mods = None
-    if isinstance(input_mods, list):
-        supports_vision = "image" in input_mods
-    else:
-        supports_vision = bool(entry.get("attachment", False))
-    supports_reasoning = bool(entry.get("reasoning", False))
+            ctx = limit.get("context")
+            context_window = int(ctx) if isinstance(ctx, (int, float)) and ctx > 0 else 200000
 
-    # Extract limits
-    limit = entry.get("limit", {})
-    if not isinstance(limit, dict):
-        limit = {}
+            out = limit.get("output")
+            max_output_tokens = int(out) if isinstance(out, (int, float)) and out > 0 else 8192
 
-    ctx = limit.get("context")
-    context_window = int(ctx) if isinstance(ctx, (int, float)) and ctx > 0 else 200000
+            model_family = entry.get("family", "") or ""
 
-    out = limit.get("output")
-    max_output_tokens = int(out) if isinstance(out, (int, float)) and out > 0 else 8192
+            return ModelCapabilities(
+                supports_tools=supports_tools,
+                supports_vision=supports_vision,
+                supports_reasoning=supports_reasoning,
+                context_window=context_window,
+                max_output_tokens=max_output_tokens,
+                model_family=model_family,
+            )
 
-    model_family = entry.get("family", "") or ""
+    try:
+        from providers import get_provider_profile
 
-    return ModelCapabilities(
-        supports_tools=supports_tools,
-        supports_vision=supports_vision,
-        supports_reasoning=supports_reasoning,
-        context_window=context_window,
-        max_output_tokens=max_output_tokens,
-        model_family=model_family,
-    )
+        profile = get_provider_profile(provider)
+        if profile is not None:
+            live_caps = profile.get_model_capabilities(model=model, provider_id=provider)
+            if isinstance(live_caps, ModelCapabilities):
+                return live_caps
+    except Exception:
+        pass
+
+    return None
 
 
 def list_provider_models(provider: str) -> List[str]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -43,6 +43,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 
+from hermes_cli.cloudflare import cloudflare_base_url_from_account_id
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
@@ -284,6 +285,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.gmi-serving.com/v1",
         api_key_env_vars=("GMI_API_KEY",),
         base_url_env_var="GMI_BASE_URL",
+    ),
+    "cloudflare": ProviderConfig(
+        id="cloudflare",
+        name="Cloudflare Workers AI",
+        auth_type="api_key",
+        inference_base_url="https://api.cloudflare.com/client/v4/accounts/ACCOUNT_ID/ai/v1",
+        api_key_env_vars=("CLOUDFLARE_API_KEY",),
+        base_url_env_var="CLOUDFLARE_BASE_URL",
     ),
     "minimax": ProviderConfig(
         id="minimax",
@@ -1609,6 +1618,7 @@ def resolve_provider(
         "step": "stepfun", "stepfun-coding-plan": "stepfun",
         "arcee-ai": "arcee", "arceeai": "arcee",
         "gmi-cloud": "gmi", "gmicloud": "gmi",
+        "cloudflare-workers-ai": "cloudflare", "workers-ai": "cloudflare", "workersai": "cloudflare",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
@@ -6246,6 +6256,11 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
                     base_url = resolved
         except Exception as exc:
             logger.debug("Copilot base URL resolution fell back to default: %s", exc)
+    elif provider_id == "cloudflare":
+        if env_url:
+            base_url = env_url.rstrip("/")
+        else:
+            base_url = cloudflare_base_url_from_account_id(os.getenv("CLOUDFLARE_ACCOUNT_ID", ""))
     elif env_url:
         base_url = env_url.rstrip("/")
     else:
@@ -6258,7 +6273,10 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     # base URL (a set-but-empty COPILOT_API_BASE_URL or similar env override
     # otherwise wedges chat inference — #50252).
     if not (isinstance(base_url, str) and base_url.strip()):
-        base_url = pconfig.inference_base_url
+        if provider_id == "cloudflare":
+            base_url = ""
+        else:
+            base_url = pconfig.inference_base_url
 
     return {
         "provider": provider_id,

--- a/hermes_cli/cloudflare.py
+++ b/hermes_cli/cloudflare.py
@@ -1,0 +1,98 @@
+"""Cloudflare Workers AI config/runtime helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+from hermes_cli.config import get_compatible_custom_providers, load_config
+
+
+_DEFAULT_BASE_TEMPLATE = "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"
+_CLOUDFLARE_PROVIDER_ALIASES = frozenset(
+    {
+        "cloudflare",
+        "cloudflare-workers-ai",
+        "workers-ai",
+        "workersai",
+        "custom:cloudflare",
+        "custom:cloudflare-workers-ai",
+        "custom:workers-ai",
+        "custom:workersai",
+    }
+)
+
+
+def is_cloudflare_provider_name(provider_id: str) -> bool:
+    requested = str(provider_id or "").strip().lower()
+    return requested in _CLOUDFLARE_PROVIDER_ALIASES
+
+
+def _entry_looks_like_cloudflare(entry: dict[str, Any]) -> bool:
+    base_url = str(entry.get("base_url") or entry.get("url") or entry.get("api") or "").strip()
+    if "api.cloudflare.com/client/v4/accounts/" in base_url and "/ai/v1" in base_url:
+        return True
+    provider_key = str(entry.get("provider_key") or "").strip().lower()
+    name = str(entry.get("name") or "").strip().lower()
+    return provider_key == "cloudflare" or name == "cloudflare"
+
+
+def _custom_provider_slug(display_name: str) -> str:
+    return "custom:" + display_name.strip().lower().replace(" ", "-")
+
+
+def _entry_matches_provider(entry: dict[str, Any], provider_id: str) -> bool:
+    requested = str(provider_id or "").strip().lower()
+    if not requested:
+        return False
+    display_name = str(entry.get("name") or "").strip()
+    candidates = {
+        requested,
+        str(entry.get("provider_key") or "").strip().lower(),
+        display_name.lower(),
+        _custom_provider_slug(display_name).lower() if display_name else "",
+    }
+    if is_cloudflare_provider_name(requested) and _entry_looks_like_cloudflare(entry):
+        return True
+    return requested in candidates
+
+
+def resolve_cloudflare_runtime_credentials(provider_id: str) -> dict[str, str]:
+    """Resolve Cloudflare Workers AI runtime credentials from config/env."""
+    requested = str(provider_id or "cloudflare").strip().lower() or "cloudflare"
+
+    config = load_config()
+    for entry in get_compatible_custom_providers(config):
+        if not isinstance(entry, dict) or not _entry_matches_provider(entry, requested):
+            continue
+        api_key = str(entry.get("api_key") or "").strip()
+        if not api_key:
+            key_env = str(entry.get("key_env") or "").strip()
+            if key_env:
+                api_key = os.getenv(key_env, "").strip()
+        base_url = str(entry.get("base_url") or entry.get("url") or entry.get("api") or "").strip().rstrip("/")
+        if api_key and base_url:
+            return {
+                "provider": requested,
+                "api_key": api_key,
+                "base_url": base_url,
+                "source": str(entry.get("name") or "custom_providers"),
+            }
+
+    api_key = os.getenv("CLOUDFLARE_API_KEY", "").strip()
+    base_url = os.getenv("CLOUDFLARE_BASE_URL", "").strip().rstrip("/")
+    if not base_url:
+        account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID", "").strip()
+        if account_id:
+            base_url = _DEFAULT_BASE_TEMPLATE.format(account_id=account_id)
+    return {
+        "provider": requested,
+        "api_key": api_key,
+        "base_url": base_url,
+        "source": "environment" if api_key or base_url else "",
+    }
+
+
+def cloudflare_base_url_from_account_id(account_id: Optional[str]) -> str:
+    account_id = str(account_id or "").strip()
+    return _DEFAULT_BASE_TEMPLATE.format(account_id=account_id) if account_id else ""

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -17,6 +17,10 @@ from difflib import get_close_matches
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
+from agent.cloudflare_workers_ai import (
+    cloudflare_ai_models_search_url,
+    cloudflare_model_names,
+)
 from hermes_cli import __version__ as _HERMES_VERSION
 
 # Identify ourselves so endpoints fronted by Cloudflare's Browser Integrity
@@ -1221,6 +1225,9 @@ _PROVIDER_ALIASES = {
     "arceeai": "arcee",
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+    "cloudflare-workers-ai": "cloudflare",
+    "workers-ai": "cloudflare",
+    "workersai": "cloudflare",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
     "minimax-portal": "minimax-oauth",
@@ -2456,8 +2463,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                 api_key, base_url = "", _p.base_url
             if not base_url:
                 base_url = _p.base_url
-            if api_key:
-                live = _p.fetch_models(api_key=api_key, base_url=base_url or None)
+            if api_key or normalized.startswith("custom:"):
+                live = _p.fetch_models(api_key=api_key or None, base_url=base_url or None)
                 if live:
                     # Merge static curated list with live API results so
                     # models that the live endpoint omits (stale cache,
@@ -3510,6 +3517,16 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+def _cloudflare_ai_models_search_url(base_url: str) -> Optional[str]:
+    """Back-compat wrapper for shared Cloudflare catalog URL logic."""
+    return cloudflare_ai_models_search_url(base_url)
+
+
+def _parse_cloudflare_model_search_response(payload: Any) -> list[str]:
+    """Back-compat wrapper for shared Cloudflare catalog parsing."""
+    return cloudflare_model_names(payload)
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
@@ -3568,6 +3585,25 @@ def probe_api_models(
         from hermes_cli.config import normalize_extra_headers
 
         headers.update(normalize_extra_headers(request_headers))
+
+    cloudflare_search_url = _cloudflare_ai_models_search_url(normalized)
+    if cloudflare_search_url:
+        tried.append(cloudflare_search_url)
+        req = urllib.request.Request(cloudflare_search_url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+                models = _parse_cloudflare_model_search_response(data)
+                if models:
+                    return {
+                        "models": models,
+                        "probed_url": cloudflare_search_url,
+                        "resolved_base_url": normalized,
+                        "suggested_base_url": None,
+                        "used_fallback": False,
+                    }
+        except Exception:
+            pass
 
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -196,6 +196,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.gmi-serving.com/v1",
         base_url_env_var="GMI_BASE_URL",
     ),
+    "cloudflare": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("CLOUDFLARE_API_KEY",),
+        base_url_override="https://api.cloudflare.com/client/v4/accounts/ACCOUNT_ID/ai/v1",
+        base_url_env_var="CLOUDFLARE_BASE_URL",
+    ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
         base_url_override="https://ollama.com/v1",
@@ -343,6 +349,11 @@ ALIASES: Dict[str, str] = {
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
 
+    # cloudflare
+    "cloudflare-workers-ai": "cloudflare",
+    "workers-ai": "cloudflare",
+    "workersai": "cloudflare",
+
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",
     "lm-studio": "lmstudio",
@@ -367,6 +378,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
+    "cloudflare": "Cloudflare Workers AI",
     "tencent-tokenhub": "Tencent TokenHub",
     "lmstudio": "LM Studio",
     "local": "Local endpoint",

--- a/plugins/model-providers/cloudflare/__init__.py
+++ b/plugins/model-providers/cloudflare/__init__.py
@@ -1,0 +1,106 @@
+"""Cloudflare Workers AI provider profile."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent import cloudflare_workers_ai as cloudflare_catalog
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+def _needs_runtime_resolution(api_key: str | None, base_url: str | None) -> bool:
+    normalized = str(base_url or "").strip()
+    return (not api_key) or (not normalized) or ("ACCOUNT_ID" in normalized)
+
+
+class CloudflareProfile(ProviderProfile):
+    """Cloudflare Workers AI — native catalog + OpenAI-compatible inference."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        if supports_reasoning:
+            if reasoning_config is not None:
+                extra_body["reasoning"] = dict(reasoning_config)
+                effort = str(reasoning_config.get("effort") or "").strip().lower()
+                if effort == "none" or reasoning_config.get("enabled") is False:
+                    extra_body["think"] = False
+            else:
+                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+        return extra_body, {}
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        if _needs_runtime_resolution(api_key, base_url):
+            from hermes_cli.cloudflare import resolve_cloudflare_runtime_credentials
+
+            creds = resolve_cloudflare_runtime_credentials(self.name)
+            api_key = api_key or str(creds.get("api_key") or "").strip()
+            resolved_base_url = str(creds.get("base_url") or "").strip()
+            if not base_url or "ACCOUNT_ID" in str(base_url):
+                base_url = resolved_base_url
+        if not api_key or not base_url:
+            return None
+        entries = cloudflare_catalog.fetch_cloudflare_model_catalog(api_key, base_url, timeout=timeout)
+        if not entries:
+            return None
+        payload = {"result": entries}
+        return cloudflare_catalog.cloudflare_model_names(payload)
+
+    def get_model_capabilities(
+        self,
+        *,
+        model: str,
+        provider_id: str | None = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+        **context: Any,
+    ):
+        if _needs_runtime_resolution(api_key, base_url):
+            try:
+                from hermes_cli.cloudflare import resolve_cloudflare_runtime_credentials
+
+                creds = resolve_cloudflare_runtime_credentials(provider_id or self.name)
+                api_key = api_key or str(creds.get("api_key") or "").strip()
+                resolved_base_url = str(creds.get("base_url") or "").strip()
+                if not base_url or "ACCOUNT_ID" in str(base_url):
+                    base_url = resolved_base_url
+            except Exception:
+                return None
+        if not api_key or not base_url:
+            return None
+        return cloudflare_catalog.get_cloudflare_model_capabilities(api_key, base_url, model, timeout=timeout)
+
+
+cloudflare = CloudflareProfile(
+    name="cloudflare",
+    aliases=(
+        "cloudflare-workers-ai",
+        "workers-ai",
+        "workersai",
+        "custom:cloudflare",
+        "custom:cloudflare-workers-ai",
+        "custom:workers-ai",
+        "custom:workersai",
+    ),
+    display_name="Cloudflare Workers AI",
+    description="Cloudflare Workers AI (native catalog + OpenAI-compatible inference)",
+    signup_url="https://developers.cloudflare.com/workers-ai/",
+    env_vars=("CLOUDFLARE_API_KEY", "CLOUDFLARE_BASE_URL", "CLOUDFLARE_ACCOUNT_ID"),
+    base_url="https://api.cloudflare.com/client/v4/accounts/ACCOUNT_ID/ai/v1",
+    auth_type="api_key",
+)
+
+register_provider(cloudflare)

--- a/providers/base.py
+++ b/providers/base.py
@@ -215,3 +215,21 @@ class ProviderProfile:
         except Exception as exc:
             logger.debug("fetch_models(%s): %s", self.name, exc)
             return None
+
+    def get_model_capabilities(
+        self,
+        *,
+        model: str,
+        provider_id: str | None = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+        **context: Any,
+    ) -> Any | None:
+        """Return provider-specific live capability metadata for *model*.
+
+        Profiles may override this when they can answer capability questions
+        from a live provider catalog that Hermes' models.dev mirror does not
+        cover (e.g. user-scoped custom catalogs).
+        """
+        return None

--- a/tests/hermes_cli/test_cloudflare_provider.py
+++ b/tests/hermes_cli/test_cloudflare_provider.py
@@ -1,0 +1,206 @@
+"""Focused tests for Cloudflare Workers AI provider wiring."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: None)
+    sys.modules["dotenv"] = fake_dotenv
+
+from agent.cloudflare_workers_ai import (
+    cloudflare_ai_models_search_url,
+    cloudflare_model_names,
+    model_capabilities_from_cloudflare_catalog_entry,
+)
+from agent.models_dev import ModelCapabilities, get_model_capabilities
+from hermes_cli.auth import resolve_api_key_provider_credentials, resolve_provider
+from hermes_cli.models import normalize_provider, provider_model_ids
+from providers import get_provider_profile
+
+
+@pytest.fixture(autouse=True)
+def _clear_cloudflare_env(monkeypatch):
+    for key in (
+        "CLOUDFLARE_API_KEY",
+        "CLOUDFLARE_BASE_URL",
+        "CLOUDFLARE_ACCOUNT_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestCloudflareAliases:
+    @pytest.mark.parametrize("alias", ["cloudflare", "cloudflare-workers-ai", "workers-ai", "workersai"])
+    def test_auth_alias_resolves(self, alias, monkeypatch):
+        monkeypatch.setenv("CLOUDFLARE_API_KEY", "cf-test-key")
+        monkeypatch.setenv(
+            "CLOUDFLARE_BASE_URL",
+            "https://api.cloudflare.com/client/v4/accounts/test-account/ai/v1",
+        )
+        assert resolve_provider(alias) == "cloudflare"
+
+    def test_models_normalize_provider(self):
+        assert normalize_provider("workers-ai") == "cloudflare"
+        assert normalize_provider("workersai") == "cloudflare"
+
+    def test_profile_aliases_resolve(self):
+        profile = get_provider_profile("custom:cloudflare")
+        assert profile is not None
+        assert profile.name == "cloudflare"
+
+        derived = get_provider_profile("custom:cloudflare-workers-ai")
+        assert derived is not None
+        assert derived.name == "cloudflare"
+
+
+class TestCloudflareCatalogHelpers:
+    def test_search_url_translation(self):
+        assert cloudflare_ai_models_search_url(
+            "https://api.cloudflare.com/client/v4/accounts/abc123/ai/v1"
+        ) == "https://api.cloudflare.com/client/v4/accounts/abc123/ai/models/search"
+
+    def test_catalog_parsing_and_capabilities(self):
+        payload = {
+            "result": [
+                {
+                    "name": "@cf/zai-org/glm-5.2",
+                    "task": {"name": "Text Generation"},
+                    "properties": [
+                        {"property_id": "context_window", "value": "262144"},
+                        {"property_id": "function_calling", "value": "true"},
+                        {"property_id": "reasoning", "value": "true"},
+                        {"property_id": "vision", "value": "true"},
+                    ],
+                },
+                {
+                    "name": "@cf/baai/bge-m3",
+                    "task": {"name": "Text Embeddings"},
+                    "properties": [],
+                },
+            ]
+        }
+        assert cloudflare_model_names(payload) == ["@cf/zai-org/glm-5.2"]
+        assert cloudflare_model_names(payload, text_generation_only=False) == [
+            "@cf/zai-org/glm-5.2",
+            "@cf/baai/bge-m3",
+        ]
+        caps = model_capabilities_from_cloudflare_catalog_entry(payload["result"][0])
+        assert caps == ModelCapabilities(
+            supports_tools=True,
+            supports_vision=True,
+            supports_reasoning=True,
+            context_window=262144,
+            max_output_tokens=8192,
+            model_family="zai-org/glm-5.2",
+        )
+
+
+class TestCloudflareCapabilitiesFallback:
+    def test_models_dev_falls_back_to_profile_live_caps(self, monkeypatch, tmp_path):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").write_text(
+            "custom_providers:\n"
+            "  - name: Cloudflare Workers AI\n"
+            "    base_url: https://api.cloudflare.com/client/v4/accounts/test-account/ai/v1\n"
+            "    api_key: test-token\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(
+            "agent.cloudflare_workers_ai.fetch_cloudflare_model_catalog",
+            lambda api_key, base_url, timeout=8.0: [
+                {
+                    "name": "@cf/openai/gpt-oss-120b",
+                    "task": {"name": "Text Generation"},
+                    "properties": [
+                        {"property_id": "context_window", "value": "128000"},
+                        {"property_id": "function_calling", "value": "true"},
+                        {"property_id": "reasoning", "value": "true"},
+                    ],
+                },
+                {
+                    "name": "@cf/baai/bge-m3",
+                    "task": {"name": "Text Embeddings"},
+                    "properties": [
+                        {"property_id": "context_window", "value": "8192"},
+                    ],
+                },
+            ],
+        )
+
+        caps = get_model_capabilities("custom:cloudflare-workers-ai", "@cf/openai/gpt-oss-120b")
+        assert caps is not None
+        assert caps.supports_reasoning is True
+        assert caps.supports_tools is True
+        assert caps.context_window == 128000
+
+        embedding_caps = get_model_capabilities("custom:cloudflare-workers-ai", "@cf/baai/bge-m3")
+        assert embedding_caps is not None
+        assert embedding_caps.supports_reasoning is False
+        assert embedding_caps.supports_tools is False
+        assert embedding_caps.context_window == 8192
+
+
+class TestCloudflareModelCatalog:
+    def test_provider_model_ids_prefers_live_catalog(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            lambda provider_id: {
+                "provider": provider_id,
+                "api_key": "cf-live-key",
+                "base_url": "https://api.cloudflare.com/client/v4/accounts/test-account/ai/v1",
+                "source": "CLOUDFLARE_API_KEY",
+            },
+        )
+        monkeypatch.setattr(
+            "agent.cloudflare_workers_ai.fetch_cloudflare_model_catalog",
+            lambda api_key, base_url, timeout=8.0: [
+                {"name": "@cf/zai-org/glm-5.2", "task": {"name": "Text Generation"}},
+                {"name": "@cf/openai/gpt-oss-120b", "task": {"name": "Text Generation"}},
+                {"name": "@cf/baai/bge-m3", "task": {"name": "Text Embeddings"}},
+            ],
+        )
+
+        assert provider_model_ids("cloudflare") == [
+            "@cf/zai-org/glm-5.2",
+            "@cf/openai/gpt-oss-120b",
+        ]
+
+    def test_custom_provider_model_ids_use_cloudflare_profile_resolution(self, monkeypatch, tmp_path):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").write_text(
+            "custom_providers:\n"
+            "  - name: Cloudflare Workers AI\n"
+            "    base_url: https://api.cloudflare.com/client/v4/accounts/test-account/ai/v1\n"
+            "    api_key: test-token\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "agent.cloudflare_workers_ai.fetch_cloudflare_model_catalog",
+            lambda api_key, base_url, timeout=8.0: [
+                {"name": "@cf/zai-org/glm-5.2", "task": {"name": "Text Generation"}},
+                {"name": "@cf/openai/gpt-oss-120b", "task": {"name": "Text Generation"}},
+                {"name": "@cf/baai/bge-m3", "task": {"name": "Text Embeddings"}},
+            ],
+        )
+
+        assert provider_model_ids("custom:cloudflare-workers-ai") == [
+            "@cf/zai-org/glm-5.2",
+            "@cf/openai/gpt-oss-120b",
+        ]
+
+
+class TestCloudflareCredentials:
+    def test_missing_account_id_does_not_return_placeholder_base_url(self, monkeypatch):
+        monkeypatch.setenv("CLOUDFLARE_API_KEY", "cf-test-key")
+        creds = resolve_api_key_provider_credentials("cloudflare")
+        assert creds["api_key"] == "cf-test-key"
+        assert creds["base_url"] == ""

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -4,9 +4,16 @@ from unittest.mock import patch, MagicMock
 
 from hermes_cli.nous_account import NousPortalAccountInfo
 from hermes_cli.models import (
-    OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
-    is_nous_free_tier, partition_nous_models_by_tier,
-    check_nous_free_tier, _FREE_TIER_CACHE_TTL,
+    OPENROUTER_MODELS,
+    _FREE_TIER_CACHE_TTL,
+    check_nous_free_tier,
+    detect_provider_for_model,
+    fetch_api_models,
+    fetch_openrouter_models,
+    is_nous_free_tier,
+    model_ids,
+    partition_nous_models_by_tier,
+    probe_api_models,
     union_with_portal_free_recommendations,
     union_with_portal_paid_recommendations,
 )
@@ -210,6 +217,76 @@ class TestOpenRouterToolSupportHelper:
         assert _openrouter_model_supports_tools(
             {"id": "x", "supported_parameters": []}
         ) is False
+
+
+class TestCloudflareModelDiscovery:
+    def test_probe_api_models_uses_cloudflare_native_search_endpoint(self):
+        class _Resp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"success":true,"result":['
+                    b'{"id":"uuid-1","name":"@cf/zai-org/glm-5.2","task":{"name":"Text Generation"}},'
+                    b'{"id":"uuid-2","name":"@cf/meta/llama-3.2-3b-instruct","task":{"name":"Text Generation"}},'
+                    b'{"id":"uuid-3","name":"@cf/baai/bge-m3","task":{"name":"Text Embeddings"}},'
+                    b'{"id":"uuid-4","name":"@cf/zai-org/glm-5.2","task":{"name":"Text Generation"}}'
+                    b']}'
+                )
+
+        requests = []
+
+        def fake_urlopen(req, timeout=5.0):
+            requests.append(req.full_url)
+            return _Resp()
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=fake_urlopen):
+            result = probe_api_models(
+                "cf-token",
+                "https://api.cloudflare.com/client/v4/accounts/test-account/ai/v1",
+            )
+
+        assert requests == [
+            "https://api.cloudflare.com/client/v4/accounts/test-account/ai/models/search"
+        ]
+        assert result["probed_url"] == requests[0]
+        assert result["resolved_base_url"] == "https://api.cloudflare.com/client/v4/accounts/test-account/ai/v1"
+        assert result["models"] == [
+            "@cf/zai-org/glm-5.2",
+            "@cf/meta/llama-3.2-3b-instruct",
+        ]
+
+    def test_fetch_api_models_returns_cloudflare_model_names(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"success":true,"result":['
+                    b'{"id":"uuid-1","name":"@cf/openai/gpt-oss-120b","task":{"name":"Text Generation"}},'
+                    b'{"id":"uuid-2","name":"@cf/qwen/qwen3-embedding-0.6b","task":{"name":"Text Embeddings"}}'
+                    b']}'
+                )
+
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+            models = fetch_api_models(
+                "cf-token",
+                "https://api.cloudflare.com/client/v4/accounts/test-account/ai/v1",
+            )
+
+        assert models == [
+            "@cf/openai/gpt-oss-120b",
+        ]
 
 
 class TestFindOpenrouterSlug:


### PR DESCRIPTION
## Summary

Replaces the generic `custom` provider path for Cloudflare Workers AI with a dedicated, provider-aware integration that uses Cloudflare's native catalog endpoint for model discovery and capability metadata.

### Changes

- **Dedicated Cloudflare provider** — native catalog discovery via `/accounts/<id>/ai/models/search` instead of relying on OpenAI-compatible `/models`
- **Shared catalog helper** (`agent/cloudflare_workers_ai.py`) — URL detection, catalog fetch/cache, capability metadata parsing (context window, function calling, reasoning, vision)
- **Capability fallback** — uses live Cloudflare metadata when `models.dev` lacks data for Cloudflare-served models
- **Custom-provider slug fix** — `custom:cloudflare` and display-name-derived slugs resolve end-to-end
- **Picker filtering** — defaults to Text Generation models only, reducing the picker from ~60 to ~26 models (excludes embeddings, TTS, ASR, image gen, classification, translation)
- **Model-provider plugin scaffolding** under `plugins/model-providers/cloudflare/`
- **Regression tests** for catalog parsing, filtering, slug resolution, and capability lookup

### Design notes

- DRY, shared-logic-first — no one-off special cases
- Provider-aware: leverages Cloudflare's task metadata for better-than-generic integration
- Core footprint is minimal — catalog logic lives in a dedicated module, not scattered across existing files

## Test plan

- [x] Focused regression tests pass (`tests/hermes_cli/test_cloudflare_provider.py`, `tests/hermes_cli/test_models.py`)
- [x] Live validation against configured Cloudflare account
- [ ] CI green on push