### PR TITLE
fix: scope kanban auto-subscriptions to active profile

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -2070,6 +2070,7 @@ def _sub_index(subs):
                 "chat_id": getattr(s, "chat_id", None),
                 "thread_id": getattr(s, "thread_id", None),
                 "user_id": getattr(s, "user_id", None),
+                "notifier_profile": getattr(s, "notifier_profile", None),
             })
     return out
 
@@ -2100,6 +2101,31 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     assert s["chat_id"] == "chat-42"
     assert s["thread_id"] == "thread-7"
     assert s["user_id"] == "user-9"
+    assert s["notifier_profile"] == "test-worker"
+
+
+def test_create_subscribes_gateway_session_with_active_profile_when_env_missing(monkeypatch, worker_env):
+    """Gateway auto-subscribe rows must be owned by the active profile even
+    when session/env profile markers are missing. Otherwise every Telegram
+    gateway with the same chat_id can deliver another bot's Kanban event."""
+    from tools import kanban_tools as kt
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
+    monkeypatch.delenv("HERMES_SESSION_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", lambda: "spanorama")
+
+    out = kt._handle_create({
+        "title": "auto-sub active profile",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["subscribed"] is True, d
+
+    subs = _sub_index(_list_subs_for_task(d["task_id"]))
+    assert len(subs) == 1
+    assert subs[0]["notifier_profile"] == "spanorama"
 
 
 def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1031,6 +1031,12 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
         )
+        if not notifier_profile:
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+                notifier_profile = get_active_profile_name() or "default"
+            except Exception:
+                notifier_profile = "default"
 
         # Lazy-import to keep the module-level dependency light
         from hermes_cli import kanban_db as _kb


### PR DESCRIPTION
## Summary

- stamp Kanban auto-subscribe rows with the active profile when session/env profile markers are absent
- preserve existing `HERMES_SESSION_PROFILE` / `HERMES_PROFILE` behavior when present
- add regression coverage for gateway sessions that have a shared Telegram chat ID but no exported profile marker

Fixes #57993.

## Why

In multi-bot installs, `telegram:<chat_id>` is not a complete delivery identity. If a Kanban notification subscription is written with `notifier_profile=None`, another profile's Telegram gateway that shares the same human chat can claim and deliver the task's terminal event.

The notifier already respects `notifier_profile`; this patch makes the auto-subscribe path reliably populate it from `get_active_profile_name()` as a fallback.

## Tests

- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/gateway/test_kanban_notifier.py` — 105 passed
- `python -m pytest tests/tools/test_kanban_tools.py -q` — 98 passed (Codex review lane)
- `python -m pytest tests/hermes_cli/test_kanban_notify.py tests/gateway/test_kanban_notifier.py -q` — 19 passed (Codex review lane)
- `git diff --check`

## Review

Codex reviewed the uncommitted diff and reported no blocking correctness issues.
