### PR TITLE
fix(dashboard): delete whole compression chain so bulk-deleted sessions stay deleted (#57543)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7871,8 +7871,13 @@ async def bulk_delete_sessions_endpoint(body: BulkDeleteSessions):
       deliberate — UI selection state can race against another tab's
       delete, and we'd rather succeed-on-the-rest than fail-the-whole-
       batch.
-    * Children of every deleted parent are orphaned, not cascade-
-      deleted.
+    * Compression chains are deleted whole: the sessions list shows one
+      row per logical conversation carrying the chain *tip's* id, so
+      deleting only that row would leave the root to resurface as the
+      previous chain link on the next reload (#57543). ``deleted``
+      still counts the selected rows, not the expanded chain links.
+    * Branch children of every deleted parent are orphaned, not
+      cascade-deleted; delegate children are cascade-deleted.
     * Active and archived sessions ARE deleted when explicitly
       selected — unlike ``DELETE /api/sessions/empty``, the user
       hand-picked the rows so we trust the selection.
@@ -7898,7 +7903,7 @@ async def bulk_delete_sessions_endpoint(body: BulkDeleteSessions):
         )
     db = _open_session_db_for_profile(body.profile)
     try:
-        deleted = db.delete_sessions(body.ids)
+        deleted = db.delete_sessions(body.ids, include_compression_chain=True)
         return {"ok": True, "deleted": deleted}
     finally:
         db.close()
@@ -8054,7 +8059,11 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
         sid = db.resolve_session_id(session_id)
         if not sid:
             return {"ok": True, "already_absent": True}
-        db.delete_session(sid)
+        # Chain-aware like bulk-delete: the list row the user clicked
+        # represents the whole compression chain (and carries the tip's
+        # id), so deleting just this physical row would resurface the
+        # conversation as the previous chain link on reload (#57543).
+        db.delete_session(sid, include_compression_chain=True)
         return {"ok": True}
     finally:
         db.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4740,10 +4740,70 @@ class SessionDB:
         except OSError:
             pass
 
+    def _expand_compression_lineage(self, conn, session_ids: List[str]) -> List[str]:
+        """Expand *session_ids* to every member of their compression chains.
+
+        The dashboard sessions list surfaces one row per logical
+        conversation: compression roots are projected forward to their
+        latest continuation, and the surfaced row carries the *tip's* id
+        (see :meth:`list_sessions_rich`). Deleting only that tip row leaves
+        the root behind, and the next list re-projects the root onto the
+        previous link — the "deleted" conversation reappears (#57543).
+
+        Walks compression-continuation edges in BOTH directions from the
+        given ids: backward to the chain root, and forward through every
+        continuation — including stale sibling continuations (e.g.
+        ``ws_orphan_reap`` leftovers), which would otherwise be orphaned
+        into brand-new visible top-level rows by the delete itself. The
+        edge definition matches :meth:`get_compression_tip` and the
+        list-projection CTE: parent ended with ``reason='compression'``,
+        child is not a branch / delegate / tool session. Branch and
+        delegate children are deliberately NOT pulled in — a branch is its
+        own conversation, and delegates are handled by the existing
+        cascade in the delete paths.
+
+        Runs inside the caller's write transaction (*conn*). The walk is
+        defensively bounded like :meth:`get_compression_tip` — chains
+        deeper than that are pathological and shouldn't happen in practice.
+        """
+        child_filter = (
+            "json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL "
+            "AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL "
+            "AND COALESCE(child.source, '') != 'tool'"
+        )
+        seen = set(session_ids)
+        frontier = list(session_ids)
+        for _ in range(100):
+            if not frontier:
+                break
+            placeholders = ",".join("?" * len(frontier))
+            forward = conn.execute(
+                f"SELECT child.id FROM sessions parent "
+                f"JOIN sessions child ON child.parent_session_id = parent.id "
+                f"WHERE parent.id IN ({placeholders}) "
+                f"AND parent.end_reason = 'compression' AND {child_filter}",
+                frontier,
+            ).fetchall()
+            backward = conn.execute(
+                f"SELECT parent.id FROM sessions child "
+                f"JOIN sessions parent ON parent.id = child.parent_session_id "
+                f"WHERE child.id IN ({placeholders}) "
+                f"AND parent.end_reason = 'compression' AND {child_filter}",
+                frontier,
+            ).fetchall()
+            frontier = [
+                row["id"]
+                for row in [*forward, *backward]
+                if row["id"] not in seen
+            ]
+            seen.update(frontier)
+        return list(seen)
+
     def delete_session(
         self,
         session_id: str,
         sessions_dir: Optional[Path] = None,
+        include_compression_chain: bool = False,
     ) -> bool:
         """Delete a session and all its messages.
 
@@ -4754,7 +4814,29 @@ class SessionDB:
         When *sessions_dir* is provided, also removes on-disk transcript
         files (``.json`` / ``.jsonl`` / ``request_dump_*``) for every deleted
         session. Returns True if the session was found and deleted.
+
+        With ``include_compression_chain=True``, the whole compression
+        chain the session belongs to is deleted with it (root and every
+        continuation). This is the variant the dashboard delete endpoints
+        use: the sessions list shows one row per logical conversation
+        (carrying the chain *tip's* id), so deleting only the single row
+        would leave the rest of the chain to resurface on the next list
+        (#57543). Default is False so callers that operate on a single
+        physical session (e.g. CLI ``/exit --delete``) keep the historic
+        contract.
         """
+        if include_compression_chain:
+            # Route through the bulk primitive, which owns the chain
+            # expansion. Its return value counts the *requested* ids that
+            # existed, so `> 0` is exactly "the session was found".
+            return (
+                self.delete_sessions(
+                    [session_id],
+                    sessions_dir=sessions_dir,
+                    include_compression_chain=True,
+                )
+                > 0
+            )
         removed_delegate_ids: List[str] = []
 
         def _do(conn):
@@ -4827,6 +4909,7 @@ class SessionDB:
         self,
         session_ids: List[str],
         sessions_dir: Optional[Path] = None,
+        include_compression_chain: bool = False,
     ) -> int:
         """Delete every session in *session_ids* in a single transaction.
 
@@ -4847,10 +4930,19 @@ class SessionDB:
           outside the DB transaction when *sessions_dir* is provided,
           matching :meth:`prune_sessions` and
           :meth:`delete_empty_sessions`.
+        * With ``include_compression_chain=True``, each selected id is
+          expanded to its full compression chain (root + every
+          continuation) before deleting — see
+          :meth:`_expand_compression_lineage`. The dashboard rows carry
+          chain-tip ids, so without the expansion a "deleted"
+          conversation resurfaces as the previous chain link on the next
+          list reload (#57543).
 
-        Returns the count of sessions that actually existed and were
-        deleted (may be less than ``len(session_ids)`` if some IDs were
-        already gone).
+        Returns the count of *requested* sessions that actually existed
+        and were deleted (may be less than ``len(session_ids)`` if some
+        IDs were already gone). Chain members pulled in by the expansion
+        do NOT inflate the count — the caller's toast should match the
+        rows the user selected, not internal chain bookkeeping.
         """
         if not session_ids:
             return 0
@@ -4876,8 +4968,12 @@ class SessionDB:
             if not existing:
                 return 0
 
-            existing_placeholders = ",".join("?" * len(existing))
-            removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
+            targets = existing
+            if include_compression_chain:
+                targets = self._expand_compression_lineage(conn, existing)
+
+            target_placeholders = ",".join("?" * len(targets))
+            removed_delegate_ids.extend(_delete_delegate_children(conn, targets))
             # Orphan remaining children whose parent is in the kill list so the
             # FK constraint stays satisfied. Pin children whose parent
             # is itself in the kill list rather than NULL-ing parents
@@ -4885,18 +4981,21 @@ class SessionDB:
             # exactly this.
             conn.execute(
                 f"UPDATE sessions SET parent_session_id = NULL "
-                f"WHERE parent_session_id IN ({existing_placeholders})",
-                existing,
+                f"WHERE parent_session_id IN ({target_placeholders})",
+                targets,
             )
             conn.execute(
-                f"DELETE FROM messages WHERE session_id IN ({existing_placeholders})",
-                existing,
+                f"DELETE FROM messages WHERE session_id IN ({target_placeholders})",
+                targets,
             )
             conn.execute(
-                f"DELETE FROM sessions WHERE id IN ({existing_placeholders})",
-                existing,
+                f"DELETE FROM sessions WHERE id IN ({target_placeholders})",
+                targets,
             )
-            removed_ids.extend(existing)
+            removed_ids.extend(targets)
+            # Count the ids the caller asked for, not the expanded chain —
+            # the dashboard toast should say "3 deleted" when the user
+            # selected 3 rows, however many physical links those rows had.
             return len(existing)
 
         count = self._execute_write(_do)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5341,6 +5341,30 @@ class TestDeleteSessionEndpoint:
         assert resp.json().get("ok") is True
         assert not self._exists("20260618_abcdef_unique")
 
+    def test_delete_removes_whole_compression_chain(self):
+        """#57543 (single-row flavour): the list row the user clicked
+        carries the compression-chain tip's id; deleting it must take
+        the root with it, or the conversation resurfaces as the
+        previous chain link on the next reload."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="conv_root", source="tui")
+            db.end_session("conv_root", end_reason="compression")
+            db.create_session(
+                session_id="conv_tip", source="tui",
+                parent_session_id="conv_root",
+            )
+        finally:
+            db.close()
+
+        resp = self.auth_client.delete("/api/sessions/conv_tip")
+        assert resp.status_code == 200
+        assert resp.json().get("ok") is True
+        assert not self._exists("conv_tip")
+        assert not self._exists("conv_root")
+
 
 class TestBulkDeleteSessionsEndpoint:
     """Tests for ``POST /api/sessions/bulk-delete`` — backs the
@@ -5445,6 +5469,38 @@ class TestBulkDeleteSessionsEndpoint:
             json={"ids": [f"s{i}" for i in range(500)]},
         )
         assert resp.status_code == 200
+
+    def test_deletes_whole_compression_chain(self):
+        """#57543: the sessions list surfaces a compressed conversation
+        as ONE row carrying the chain tip's id. Bulk-deleting that id
+        must remove the whole chain — otherwise the root resurfaces as
+        the previous link on the next reload and the user sees the
+        delete "not work". ``deleted`` still counts selected rows."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="chain_root", source="tui")
+            db.end_session("chain_root", end_reason="compression")
+            db.create_session(
+                session_id="chain_tip", source="tui",
+                parent_session_id="chain_root",
+            )
+        finally:
+            db.close()
+
+        resp = self.auth_client.post(
+            "/api/sessions/bulk-delete", json={"ids": ["chain_tip"]}
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "deleted": 1}
+
+        db = SessionDB()
+        try:
+            assert db.get_session("chain_tip") is None
+            assert db.get_session("chain_root") is None
+        finally:
+            db.close()
 
     def test_route_order_not_shadowed_by_session_id(self):
         """Pin the route-ordering contract: ``POST /api/sessions/bulk-delete``

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2077,6 +2077,145 @@ class TestBulkDeleteSessions:
         assert not (tmp_path / "s2.json").exists()
 
 
+class TestDeleteCompressionChain:
+    """``include_compression_chain=True`` — the chain-aware variant of
+    ``delete_session`` / ``delete_sessions`` used by the dashboard
+    delete endpoints (#57543).
+
+    ``list_sessions_rich`` surfaces one row per logical conversation:
+    compression roots are projected forward and the row carries the
+    chain *tip's* id. Deleting only that physical row leaves the root
+    behind, and the next list re-projects it onto the previous link —
+    the user sees the "deleted" conversation reappear ("deletes some of
+    them, but not all"). Invariants this class locks in:
+
+    1. Deleting a tip removes the whole chain (backward walk to root).
+    2. Deleting a root removes every continuation — including stale
+       sibling continuations, which the delete would otherwise orphan
+       into brand-new visible top-level rows (forward walk collects ALL
+       compression children, not just the preferred tip).
+    3. Branch children of chain members keep the plain contract
+       (orphaned, not deleted); delegate children are cascade-deleted.
+    4. The returned count reflects the *selected* rows, not the
+       expanded chain links, so the dashboard toast matches what the
+       user picked.
+    5. The default stays chain-blind — existing callers (CLI
+       ``/exit --delete``, ACP, gateway API) are behaviour-identical.
+    """
+
+    def _make_chain(self, db):
+        """root --compression--> mid --compression--> tip (live)."""
+        db.create_session(session_id="root", source="tui")
+        db.append_message("root", role="user", content="the start")
+        db.end_session("root", end_reason="compression")
+        db.create_session(session_id="mid", source="tui", parent_session_id="root")
+        db.append_message("mid", role="user", content="continued once")
+        db.end_session("mid", end_reason="compression")
+        db.create_session(session_id="tip", source="tui", parent_session_id="mid")
+        db.append_message("tip", role="user", content="continued twice")
+
+    def test_deleting_tip_removes_whole_chain(self, db):
+        """The exact #57543 repro: the dashboard row carries the tip id;
+        bulk-deleting it must not leave the root to resurface on the
+        next list reload."""
+        self._make_chain(db)
+        rows = db.list_sessions_rich(limit=20)
+        assert [r["id"] for r in rows] == ["tip"]
+
+        deleted = db.delete_sessions(["tip"], include_compression_chain=True)
+        assert deleted == 1
+        assert db.get_session("root") is None
+        assert db.get_session("mid") is None
+        assert db.get_session("tip") is None
+        assert db.list_sessions_rich(limit=20) == []
+
+    def test_deleting_root_removes_continuations_and_stale_siblings(self, db):
+        """Forward direction: every compression child dies with the
+        chain — including a stale sibling continuation, which orphaning
+        would otherwise promote into a visible top-level row."""
+        db.create_session(session_id="root", source="tui")
+        db.end_session("root", end_reason="compression")
+        db.create_session(session_id="tip", source="tui", parent_session_id="root")
+        db.create_session(session_id="stale", source="tui", parent_session_id="root")
+        db.end_session("stale", end_reason="ws_orphan_reap")
+
+        deleted = db.delete_sessions(["root"], include_compression_chain=True)
+        assert deleted == 1
+        assert db.get_session("root") is None
+        assert db.get_session("tip") is None
+        assert db.get_session("stale") is None
+
+    def test_chain_delete_orphans_branches_and_cascades_delegates(self, db):
+        """Branch/delegate children of chain members keep the plain
+        per-row contract: a branch is its own conversation and survives
+        (orphaned); a delegate subagent run is cascade-deleted."""
+        self._make_chain(db)
+        db.create_session(
+            session_id="branch",
+            source="tui",
+            parent_session_id="root",
+            model_config={"_branched_from": "root"},
+        )
+        db.create_session(
+            session_id="delegate",
+            source="tui",
+            parent_session_id="tip",
+            model_config={"_delegate_from": "tip"},
+        )
+
+        deleted = db.delete_sessions(["tip"], include_compression_chain=True)
+        assert deleted == 1
+        branch = db.get_session("branch")
+        assert branch is not None
+        assert branch["parent_session_id"] is None
+        assert db.get_session("delegate") is None
+
+    def test_count_reflects_selected_rows_not_chain_links(self, db):
+        """Selecting 2 rows deletes 5 physical sessions but reports 2 —
+        the toast should match the user's selection."""
+        self._make_chain(db)
+        db.create_session(session_id="plain", source="tui")
+
+        deleted = db.delete_sessions(["tip", "plain"], include_compression_chain=True)
+        assert deleted == 2
+
+    def test_default_remains_chain_blind(self, db):
+        """Without the flag, only the listed row is deleted — pins the
+        historic contract for non-dashboard callers."""
+        self._make_chain(db)
+        deleted = db.delete_sessions(["tip"])
+        assert deleted == 1
+        assert db.get_session("tip") is None
+        assert db.get_session("mid") is not None
+        assert db.get_session("root") is not None
+
+    def test_single_delete_session_chain_variant(self, db):
+        """``delete_session(..., include_compression_chain=True)`` —
+        the single-row dashboard endpoint has the same reappearing-
+        conversation bug, so it routes through the same expansion."""
+        self._make_chain(db)
+        assert db.delete_session("tip", include_compression_chain=True) is True
+        assert db.get_session("root") is None
+        assert db.get_session("mid") is None
+        assert db.get_session("tip") is None
+        # Missing sessions still report False.
+        assert db.delete_session("ghost", include_compression_chain=True) is False
+
+    def test_chain_transcript_files_cleaned(self, db, tmp_path):
+        """On-disk transcripts of every expanded chain member are swept,
+        not just the selected row's."""
+        self._make_chain(db)
+        (tmp_path / "root.jsonl").write_text("")
+        (tmp_path / "tip.json").write_text("{}")
+
+        deleted = db.delete_sessions(
+            ["tip"], sessions_dir=tmp_path, include_compression_chain=True
+        )
+        assert deleted == 1
+        assert not (tmp_path / "root.jsonl").exists()
+        assert not (tmp_path / "tip.json").exists()
+
+
 class TestDeleteEmptySessions:
     """``delete_empty_sessions`` sweeps every ended, non-archived session
     whose ``message_count`` is 0. Backs the dashboard's "Delete empty"


### PR DESCRIPTION
## Problem

Fixes #57543 — deleting multiple sessions at once in the dashboard "usually doesn't work. It seems to delete some of them, but not all", and deleting one by one works.

## Root cause (deterministically reproduced)

The sessions list surfaces **one row per logical conversation**: `list_sessions_rich` (with `project_compression_tips=True`) projects compression roots forward and the surfaced row carries the chain **tip's** id. The delete endpoints then deleted only that physical tip row — the root (`end_reason='compression'`) stayed in the DB, and the next list reload re-projected it onto the previous chain link, so the "deleted" conversation reappeared.

Minimal repro on `main` with `SessionDB` directly:

```python
db.create_session("root", source="tui"); db.append_message("root", role="user", content="hi")
db.end_session("root", end_reason="compression")
db.create_session("tip", source="tui", parent_session_id="root")

[r["id"] for r in db.list_sessions_rich()]   # ['tip']  <- the dashboard row
db.delete_sessions(["tip"])                  # what bulk-delete did
[r["id"] for r in db.list_sessions_rich()]   # ['root'] <- conversation is back
```

This exactly matches the reported symptom: any auto-compressed conversation in the selection "survives" a bulk delete (as its previous chain link), while never-compressed sessions delete fine — so it "deletes some of them, but not all". Deleting one by one only appears to work because each pass peels one link off the chain.

## Fix

An opt-in `include_compression_chain` flag on `SessionDB.delete_session` / `delete_sessions`, backed by a new `_expand_compression_lineage` helper that expands each selected id to its full compression chain inside the same write transaction — backward to the root and forward through every continuation, including stale sibling continuations (e.g. `ws_orphan_reap` leftovers), which the delete would otherwise orphan into brand-new visible top-level rows. The edge definition is byte-equivalent to `get_compression_tip` and the list-projection CTE (parent `end_reason='compression'`; child not branch/delegate/tool), and the walk carries the same 100-iteration defensive bound.

Only the two dashboard endpoints opt in — `POST /api/sessions/bulk-delete` and `DELETE /api/sessions/{session_id}`. All other callers (CLI `/exit --delete`, `hermes sessions delete`, ACP, TUI gateway, gateway API server) keep the historic single-row contract; the new parameter is keyword-appended and no existing caller can hit it positionally.

Contract details preserved:
- Branch children of chain members are **orphaned** (a branch is its own conversation); delegate children are **cascade-deleted** — same per-row contract as before.
- The bulk response's `deleted` still counts the **selected** rows, not expanded chain links, so the dashboard toast and the frontend's `setTotal(prev - resp.deleted)` stay consistent (`session_count(exclude_children=True)` counts one top-level row per chain).
- The desktop's archived-sessions panel hits the same single-row DELETE endpoint; `set_session_archived` is already lineage-wide for the same resurrection reason, so chain-aware delete makes that flow consistent rather than changing it.

## Tests

- `tests/test_hermes_state.py::TestDeleteCompressionChain` (7 tests): tip-delete removes whole chain (the exact repro, asserted through `list_sessions_rich`), root-delete removes continuations + stale siblings, branch/delegate contract, count semantics, transcript-file sweep, and a pin that the **default stays chain-blind** for non-dashboard callers.
- Endpoint-level regression tests for both dashboard endpoints in `tests/hermes_cli/test_web_server.py`.
- Verified the regression tests fail on the parent commit for the reported reason (chain root survives the delete), and mutation-checked the fix (backward-only walk, unfiltered child expansion, wrong count, endpoints without the flag — each caught by at least one test).
- Full suites green: `tests/test_hermes_state.py` (310), `tests/hermes_cli/test_web_server.py` (343), `tests/gateway/test_session_api.py` (12), `ruff check` clean.

## Known edge cases (deliberate, non-blocking — happy to follow up)

- A **live** sibling continuation is deleted with its chain even though it was never its own visible row — consistent with the endpoint's documented "active sessions ARE deleted when explicitly selected" stance, since the user selected the logical conversation it belongs to.
- On SQLite builds with `SQLITE_MAX_VARIABLE_NUMBER=999` (< 3.32), a 500-id selection of long chains could exceed the `IN`-list limit; the codebase already builds unbounded `IN` lists in `delete_empty_sessions` / `prune_sessions`, so chunking those uniformly would make a good separate cleanup.
- Chains deeper than the pre-existing 100-iteration projection bound (200+ compression events in one conversation) are still truncated, matching `get_compression_tip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)