### PR TITLE
fix(file-tools): resolve SSH remote paths as POSIX on a Windows host

### DIFF
--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -167,6 +167,37 @@ def test_container_path_detection_uses_live_docker_environment(monkeypatch):
     assert ft._uses_container_paths("default") is True
 
 
+def test_ssh_environment_uses_container_path_resolution(monkeypatch):
+    """An SSH remote is a POSIX host, so file ops must skip host-side path
+    resolution — even though ssh is NOT a container sandbox.
+
+    Regression: ssh is detected by ``_terminal_env_type_for_task`` but was
+    omitted from the path-backends set, so on a Windows gateway an SSH remote
+    path like ``/home/user`` was host-resolved to ``\\home\\user`` and
+    corrupted.
+    """
+    class _DummySshEnvironment:
+        cwd = "/home/ubuntu/.hermes"
+        cwd_owner = "default"
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_active_environments",
+        {"default": _DummySshEnvironment()},
+    )
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: (_ for _ in ()).throw(AssertionError("should not read config")),
+    )
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    assert ft._uses_container_paths("default") is True
+    # ssh must stay OUT of _CONTAINER_BACKENDS so an SSH remote /home/<user> cwd
+    # is not discarded by the unusable-container-cwd guards.
+    assert "ssh" not in terminal_tool._CONTAINER_BACKENDS
+
+
 def test_resolution_base_always_absolute_no_terminal_cwd(_isolated_cwd, monkeypatch):
     """With TERMINAL_CWD unset, the base falls back to an ABSOLUTE process cwd."""
     workspace, decoy = _isolated_cwd

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -118,7 +118,7 @@ def _resolve_path(filepath: str, task_id: str = "default") -> Path | PurePosixPa
 # (gateway/run.py); the file/terminal-tool layer must do likewise so CLI
 # sessions get the same protection. See references/worktree-cwd-discipline.md.
 _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
-_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona"})
+_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "ssh"})
 
 
 def _terminal_env_type_for_task(task_id: str = "default") -> str:
@@ -159,8 +159,12 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
 
 def _uses_container_paths(task_id: str = "default") -> bool:
     try:
-        from tools.terminal_tool import _CONTAINER_BACKENDS
-        container_backends = _CONTAINER_BACKENDS
+        # Use the POSIX-path set (includes ssh), NOT _CONTAINER_BACKENDS: an SSH
+        # remote is a POSIX host, so its paths must skip host-side resolution on
+        # a Windows gateway. ssh stays out of _CONTAINER_BACKENDS so the
+        # unusable-container-cwd guards keep accepting remote /home paths.
+        from tools.terminal_tool import _POSIX_PATH_BACKENDS
+        container_backends = _POSIX_PATH_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
     return _terminal_env_type_for_task(task_id) in container_backends

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1215,6 +1215,15 @@ _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona"})
 
+# Backends whose file paths are POSIX/remote — resolved inside the sandbox or on
+# the remote host, never against the local (possibly Windows) filesystem — so
+# file_tools must skip host-side ``Path.resolve()`` for them. SSH is included
+# here (an SSH remote is POSIX) but is deliberately NOT added to
+# ``_CONTAINER_BACKENDS``: unlike a container sandbox, an SSH remote's
+# ``/home/<user>`` working directory is valid and must not be discarded by the
+# unusable-container-cwd guards that key off ``_CONTAINER_BACKENDS``.
+_POSIX_PATH_BACKENDS = _CONTAINER_BACKENDS | frozenset({"ssh"})
+
 
 def _is_unusable_container_cwd(cwd: str) -> bool:
     """Return True if *cwd* is a host/relative path that won't work as the


### PR DESCRIPTION
## What does this PR do?

`_uses_container_paths` decides whether file_tools skips host-side
`Path.resolve()` so container/remote POSIX paths survive on a Windows gateway.
`_terminal_env_type_for_task` already detects the SSH backend and returns
`"ssh"` (added in #56637), but `"ssh"` was never added to the backend set, so
`_uses_container_paths` returned `False` for SSH sessions. On a Windows host an
SSH remote path like `/home/user` was then host-resolved to `\home\user` and
corrupted, breaking remote file reads/writes. This completes the Docker path
preservation from #56637.

A dedicated set is used instead of just adding `"ssh"` to `_CONTAINER_BACKENDS`,
because that constant also drives the *unusable-container-cwd* guards
(`_HOST_CWD_PREFIXES` includes `/home/`). A container's `/home/user` cwd is a
host path invalid inside the sandbox, but an SSH remote's `/home/<user>` cwd is
valid — so ssh must stay out of `_CONTAINER_BACKENDS` to avoid discarding
legitimate remote working directories.

## Changes

- `tools/terminal_tool.py` — add `_POSIX_PATH_BACKENDS = _CONTAINER_BACKENDS | {"ssh"}`.
- `tools/file_tools.py` — `_uses_container_paths` uses `_POSIX_PATH_BACKENDS`;
  the fallback set includes `"ssh"`.
- `tests/tools/test_file_tools_cwd_resolution.py` — regression test.

## Tests

```
pytest tests/tools/test_file_tools_cwd_resolution.py::test_ssh_environment_uses_container_path_resolution -q
→ 1 passed
```

Asserts an SSH environment resolves via container/POSIX paths, and that ssh
stays out of `_CONTAINER_BACKENDS` (mutation-verified: dropping ssh from the
path set makes `_uses_container_paths` return False again).