### PR TITLE
feat(telegram): add external callback handlers

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4892,6 +4892,120 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             pass
 
+    def _external_callback_handler_for(self, data: str) -> Optional[Dict[str, Any]]:
+        handlers = self.config.extra.get("callback_handlers", [])
+        if not isinstance(handlers, list):
+            return None
+        for handler in handlers:
+            if not isinstance(handler, dict):
+                continue
+            prefix = str(handler.get("prefix") or "")
+            if prefix and data.startswith(prefix) and handler.get("script"):
+                return handler
+        return None
+
+    @staticmethod
+    def _format_callback_template(template: str, values: Dict[str, Any]) -> str:
+        class _Missing(dict):
+            def __missing__(self, key: str) -> str:
+                return ""
+
+        return template.format_map(_Missing({k: "" if v is None else v for k, v in values.items()}))
+
+    async def _handle_external_callback_query(
+        self,
+        query: Any,
+        data: str,
+        *,
+        query_chat_id: Any,
+        query_chat_type: Any,
+        query_thread_id: Any,
+        query_user_name: Any,
+    ) -> bool:
+        handler = self._external_callback_handler_for(data)
+        if not handler:
+            return False
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text=str(handler.get("unauthorized_text") or "⛔ You are not authorized to use this button."))
+            return True
+
+        await query.answer(text=str(handler.get("answer_text") or "Working…"))
+        script_path = _Path(str(handler["script"])).expanduser()
+        if not script_path.is_absolute():
+            script_path = _Path.home() / ".hermes" / "scripts" / script_path
+        if not script_path.exists():
+            await query.answer(text="Callback handler is not installed.")
+            return True
+
+        chat_id_text = str(query_chat_id or "")
+        user_name_text = str(query_user_name or "")
+        timeout = int(handler.get("timeout_seconds") or 60)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                str(script_path),
+                data,
+                caller_id,
+                chat_id_text,
+                user_name_text,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            stdout_text = stdout.decode("utf-8", errors="replace").strip()
+            stderr_text = stderr.decode("utf-8", errors="replace").strip()
+            try:
+                payload = json.loads(stdout_text or "{}")
+            except Exception:
+                payload = {"ok": False, "detail": stdout_text or stderr_text or "Callback handler returned invalid output."}
+
+            values: Dict[str, Any] = dict(payload) if isinstance(payload, dict) else {}
+            values.update(
+                callback_data=data,
+                user_id=caller_id,
+                user_name=user_name_text or "authorized user",
+                chat_id=chat_id_text,
+                detail=values.get("detail") or stderr_text or "Callback failed",
+            )
+
+            if proc.returncode == 0 and values.get("ok") is True:
+                success_text = str(handler.get("success_text") or "✅ Callback handled.")
+                text = self._format_callback_template(success_text, values)
+                try:
+                    await query.edit_message_text(
+                        text=text[:4096],
+                        reply_markup=None,
+                        **self._link_preview_kwargs(),
+                    )
+                except Exception:
+                    pass
+                return True
+
+            failure_text = str(handler.get("failure_text") or "❌ Callback failed.\n\n{detail}")
+            try:
+                await query.edit_message_text(
+                    text=self._format_callback_template(failure_text, values)[:4096],
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+            return True
+        except asyncio.TimeoutError:
+            await query.answer(text=str(handler.get("timeout_text") or "Callback timed out."))
+            return True
+        except Exception as exc:
+            logger.error("[%s] external Telegram callback failed: %s", self.name, exc, exc_info=True)
+            await query.answer(text=str(handler.get("error_text") or "Callback failed."))
+            return True
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -4924,6 +5038,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 query_thread_id=query_thread_id,
                 query_user_name=query_user_name,
             )
+            return
+
+        # --- Configured external callback handlers ---
+        if await self._handle_external_callback_query(
+            query,
+            data,
+            query_chat_id=query_chat_id,
+            query_chat_type=query_chat_type,
+            query_thread_id=query_thread_id,
+            query_user_name=query_user_name,
+        ):
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -588,3 +588,122 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+# ===========================================================================
+# telegram.extra.callback_handlers — external callback dispatcher
+# ===========================================================================
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout=b'{"ok": true}', stderr=b''):
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+class TestTelegramExternalCallbackHandlers:
+    """Configured callback handlers route callback_data to external scripts."""
+
+    def test_finds_matching_external_callback_handler(self, tmp_path):
+        script = tmp_path / "handler.py"
+        script.write_text("print('ok')\n")
+        adapter = _make_adapter(extra={
+            "callback_handlers": [
+                {"prefix": "other:", "script": str(script)},
+                {"prefix": "cfwpa:", "script": str(script)},
+            ]
+        })
+
+        handler = adapter._external_callback_handler_for("cfwpa:abc123")
+
+        assert handler is not None
+        assert handler["prefix"] == "cfwpa:"
+        assert adapter._external_callback_handler_for("missing:abc123") is None
+
+    @pytest.mark.asyncio
+    async def test_external_callback_invokes_script_and_edits_message(self, tmp_path):
+        script = tmp_path / "handler.py"
+        script.write_text("print('ok')\n")
+        adapter = _make_adapter(extra={
+            "callback_handlers": [{
+                "prefix": "cfwpa:",
+                "script": str(script),
+                "answer_text": "Approving…",
+                "success_text": "Done {commit_short_sha} {job_url} by {user_name}",
+            }]
+        })
+        runner = _AuthRunner(True)
+        adapter._message_handler = runner._handle_message
+
+        query = AsyncMock()
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        async def fake_exec(*args, **kwargs):
+            assert args[:6] == (
+                sys.executable,
+                str(script),
+                "cfwpa:abc123",
+                "12345",
+                "98765",
+                "Norbert",
+            )
+            return _FakeProc(
+                stdout=(
+                    b'{"ok": true, "commit_short_sha": "abc1234", '
+                    b'"job_url": "https://example.test/job"}'
+                )
+            )
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            handled = await adapter._handle_external_callback_query(
+                query,
+                "cfwpa:abc123",
+                query_chat_id=98765,
+                query_chat_type="private",
+                query_thread_id=None,
+                query_user_name="Norbert",
+            )
+
+        assert handled is True
+        query.answer.assert_called_with(text="Approving…")
+        query.edit_message_text.assert_called_once()
+        assert "Done abc1234 https://example.test/job by Norbert" in query.edit_message_text.call_args.kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_external_callback_auth_denied_does_not_invoke_script(self, tmp_path):
+        script = tmp_path / "handler.py"
+        script.write_text("print('ok')\n")
+        adapter = _make_adapter(extra={
+            "callback_handlers": [{
+                "prefix": "cfwpa:",
+                "script": str(script),
+                "unauthorized_text": "Nope.",
+            }]
+        })
+        runner = _AuthRunner(False)
+        adapter._message_handler = runner._handle_message
+
+        query = AsyncMock()
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        with patch("asyncio.create_subprocess_exec") as create_proc:
+            handled = await adapter._handle_external_callback_query(
+                query,
+                "cfwpa:abc123",
+                query_chat_id=98765,
+                query_chat_type="private",
+                query_thread_id=None,
+                query_user_name="Norbert",
+            )
+
+        assert handled is True
+        create_proc.assert_not_called()
+        query.answer.assert_called_with(text="Nope.")
+        query.edit_message_text.assert_not_called()
+


### PR DESCRIPTION
## Summary
- add telegram.extra.callback_handlers for prefix-based callback_data dispatch to local scripts
- keep callback auth fail-closed by reusing the existing Telegram callback authorization path
- support configurable answer/success/failure/timeout text templates for handler output

## Test Plan
- python3 -m py_compile plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_approval_buttons.py
- pytest tests/gateway/test_telegram_callback_auth_fail_closed.py tests/gateway/test_telegram_approval_buttons.py -q