### PR TITLE
fix(mcp): fail fast at OAuth redirect/callback boundary when non-interactive (#57836)

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -262,6 +262,7 @@ class TestRedirectHandlerSshHint:
     def test_ssh_hint_shown_on_ssh_session(self, monkeypatch, capsys):
         import tools.mcp_oauth as mco
         monkeypatch.setattr(mco, "_oauth_port", 49200)
+        monkeypatch.setattr(mco, "_is_interactive", lambda: True)
         monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
@@ -276,6 +277,7 @@ class TestRedirectHandlerSshHint:
     def test_ssh_hint_shown_via_ssh_tty(self, monkeypatch, capsys):
         import tools.mcp_oauth as mco
         monkeypatch.setattr(mco, "_oauth_port", 49201)
+        monkeypatch.setattr(mco, "_is_interactive", lambda: True)
         monkeypatch.delenv("SSH_CLIENT", raising=False)
         monkeypatch.setenv("SSH_TTY", "/dev/pts/1")
         monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
@@ -289,6 +291,7 @@ class TestRedirectHandlerSshHint:
     def test_no_ssh_hint_on_local_session(self, monkeypatch, capsys):
         import tools.mcp_oauth as mco
         monkeypatch.setattr(mco, "_oauth_port", 49202)
+        monkeypatch.setattr(mco, "_is_interactive", lambda: True)
         monkeypatch.delenv("SSH_CLIENT", raising=False)
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.setattr(mco, "_can_open_browser", lambda: True)
@@ -302,6 +305,7 @@ class TestRedirectHandlerSshHint:
     def test_no_ssh_hint_when_port_not_set(self, monkeypatch, capsys):
         import tools.mcp_oauth as mco
         monkeypatch.setattr(mco, "_oauth_port", None)
+        monkeypatch.setattr(mco, "_is_interactive", lambda: True)
         monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
         monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
 
@@ -527,12 +531,19 @@ class TestIsInteractive:
 class TestWaitForCallbackNoBlocking:
     """_wait_for_callback() must never call input() — it raises instead."""
 
-    def test_raises_on_timeout_instead_of_input(self):
-        """When no auth code arrives, raises OAuthNonInteractiveError."""
+    def test_raises_on_timeout_instead_of_input(self, monkeypatch):
+        """Interactive session: when no auth code arrives, raises on timeout.
+
+        Marked interactive so the fail-fast non-interactive guard (#57836)
+        does not short-circuit — this test exercises the timeout path.
+        """
         import tools.mcp_oauth as mod
         import asyncio
 
         mod._oauth_port = _find_free_port()
+        monkeypatch.setattr(mod, "_is_interactive", lambda: True)
+        # EOF on the paste reader so only the HTTP-listener timeout drives it.
+        monkeypatch.setattr("sys.stdin", MagicMock(readline=lambda: ""))
 
         async def instant_sleep(_seconds):
             pass
@@ -581,6 +592,92 @@ class TestBuildOAuthAuthNonInteractive:
 
         assert auth is not None
         assert "no cached tokens found" not in caplog.text.lower()
+
+
+class TestNonInteractiveFailFastAtCallbackBoundary:
+    """#57836: a cached-but-unusable token (expired/revoked, refresh rejected)
+    makes the MCP SDK fall through to the authorization-code flow even though
+    build_oauth_auth's token-file guard passed. In a non-interactive context
+    (systemd gateway, cron, background discovery) that flow must fail fast at
+    the redirect/callback boundary — never launch a browser flow or bind a
+    callback listener, and never block for the full timeout — so gateway
+    startup is not gated on an unusable optional MCP server, and retries do not
+    collide on the callback port ('Address already in use').
+    """
+
+    def test_wait_for_callback_rejects_before_binding_when_noninteractive(self, monkeypatch):
+        """No listener bound and no poll loop entered when non-interactive."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+
+        # Binding the callback listener or entering the poll loop is the bug.
+        fake_server = MagicMock(side_effect=AssertionError("must not bind callback listener"))
+        monkeypatch.setattr(mod, "HTTPServer", fake_server)
+
+        async def no_sleep(_seconds):
+            raise AssertionError("must not wait for the callback timeout")
+        monkeypatch.setattr(mod.asyncio, "sleep", no_sleep)
+
+        with pytest.raises(OAuthNonInteractiveError, match="interactive session"):
+            asyncio.run(mod._wait_for_callback())
+        fake_server.assert_not_called()
+
+    def test_wait_for_callback_fail_fast_holds_even_with_cached_token_file(self, tmp_path, monkeypatch):
+        """Guard does not depend on token-file existence.
+
+        A stale token file on disk passes build_oauth_auth's guard, so the
+        callback boundary is the only place that can reject the flow.
+        """
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        (d / "example.json").write_text(
+            json.dumps({"access_token": "stale", "token_type": "Bearer"})
+        )
+
+        mod._oauth_port = _find_free_port()
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        monkeypatch.setattr(
+            mod, "HTTPServer", MagicMock(side_effect=AssertionError("must not bind"))
+        )
+
+        with pytest.raises(OAuthNonInteractiveError):
+            asyncio.run(mod._wait_for_callback())
+
+    def test_redirect_handler_rejects_and_does_not_open_browser(self, monkeypatch, capsys):
+        """Non-interactive redirect must not print an auth URL or open a browser."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        monkeypatch.setattr(
+            "webbrowser.open", MagicMock(side_effect=AssertionError("must not open browser"))
+        )
+
+        with pytest.raises(OAuthNonInteractiveError, match="browser authorization"):
+            asyncio.run(mod._redirect_handler("https://idp.example.com/authorize?x=1"))
+
+        err = capsys.readouterr().err
+        assert "https://idp.example.com/authorize" not in err
+
+    def test_boundary_errors_point_at_hermes_mcp_login(self, monkeypatch):
+        """Both boundaries emit an actionable next step."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        with pytest.raises(OAuthNonInteractiveError, match="hermes mcp login"):
+            asyncio.run(mod._redirect_handler("https://idp.example.com/authorize"))
+
+        mod._oauth_port = _find_free_port()
+        with pytest.raises(OAuthNonInteractiveError, match="hermes mcp login"):
+            asyncio.run(mod._wait_for_callback())
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -529,6 +529,24 @@ async def _redirect_handler(authorization_url: str) -> None:
     Opens the browser automatically when possible; always prints the URL
     as a fallback for headless/SSH/gateway environments.
     """
+    # Fail fast at the authorization boundary in non-interactive contexts
+    # (systemd gateway, cron, background MCP discovery). A cached-but-unusable
+    # token (expired/revoked, refresh rejected) makes the SDK fall through to
+    # the authorization-code flow even though build_oauth_auth's token-file
+    # guard passed. Without this check we would print a URL and launch a
+    # browser flow no operator can complete, then block in _wait_for_callback
+    # for the full timeout. Raise before launching so gateway adapters start
+    # promptly and the caller can skip this server with an actionable warning.
+    # This intentionally re-checks interactivity here rather than trusting the
+    # token-file existence guard alone. See #57836.
+    if not _is_interactive():
+        raise OAuthNonInteractiveError(
+            "MCP OAuth requires browser authorization but no interactive "
+            "session is available (non-interactive/background context). "
+            "Run `hermes mcp login <server>` interactively to (re)authorize, "
+            "then restart or reload the gateway."
+        )
+
     msg = (
         f"\n  MCP OAuth: authorization required.\n"
         f"  Open this URL in your browser:\n\n"
@@ -598,6 +616,25 @@ async def _wait_for_callback() -> tuple[str, str | None]:
         raise RuntimeError(
             "OAuth callback port not set — build_oauth_auth must be called "
             "before _wait_for_oauth_callback"
+        )
+
+    # Reject before binding the callback listener in non-interactive contexts.
+    # Reaching here means the SDK entered the authorization-code flow (a valid
+    # or refreshable token would never call the callback handler), so a cached
+    # token file is present but unusable. Binding the listener here would block
+    # for the full 300s timeout and — on the next connection retry — collide
+    # with the still-bound/TIME_WAIT port, surfacing as
+    # ``OSError: [Errno 98] Address already in use``. Failing fast keeps
+    # gateway startup independent of an unusable optional MCP server. This
+    # guard holds "regardless of whether a token file exists" — the point the
+    # build_oauth_auth token-file guard cannot cover. See #57836.
+    if not _is_interactive():
+        raise OAuthNonInteractiveError(
+            "OAuth callback requires an interactive session but none is "
+            "available (non-interactive/background context); skipping browser "
+            "authorization without binding a callback listener. "
+            "Run `hermes mcp login <server>` interactively to (re)authorize, "
+            "then restart or reload the gateway."
         )
 
     # The callback server is already running (started in build_oauth_auth).


### PR DESCRIPTION
## Summary

A non-interactive `hermes gateway run` (systemd/cron/background MCP discovery) could hang in MCP OAuth for the full 300s callback timeout before messaging adapters started, then collide on the callback port on retry (`OSError: [Errno 98] Address already in use`).

Root cause: `build_oauth_auth`'s non-interactive guard only rejects when **no token file exists**. A cached-but-unusable token (expired/revoked, or a refresh the IdP rejects) passes that guard, so the MCP SDK falls through to the authorization-code flow. `_redirect_handler` then prints an auth URL / launches a browser flow no operator can complete, and `_wait_for_callback` binds a localhost listener and blocks for the full timeout.

This PR re-checks interactivity **at the redirect/callback boundary** and raises an actionable `OAuthNonInteractiveError` *before* printing a URL, opening a browser, or binding a listener:

- Holds **regardless of whether a token file exists** — the point the token-file guard cannot cover.
- Only triggers on the authorization-code path, so **valid/refreshable tokens keep working non-interactively** (they never call the callback handler).
- Reuses the existing `_is_interactive()` context, so `suppress_interactive_oauth()` (background discovery) and `force_interactive_oauth()` (dashboard/desktop GUI) both behave correctly.
- Both `build_oauth_auth` and `MCPOAuthManager` share these handlers, so the sibling construction path is covered too.

Scope note: the async gateway-discovery startup budget and the module-level `_oauth_port` per-flow state are tracked separately (#16856, #5344, #44590). This PR is the focused fix for the cached-but-unusable-token path called out in #57836.

## Test plan

- [x] `scripts/run_tests.sh tests/tools/test_mcp_oauth.py -q` (76 passed)
- [x] `scripts/run_tests.sh tests/tools/test_mcp_oauth_manager.py tests/hermes_cli/test_mcp_startup.py tests/tools/test_mcp_tool_401_handling.py -q`
- [x] New `TestNonInteractiveFailFastAtCallbackBoundary`: rejects before binding a listener, no poll-loop wait, holds with a stale token file present, no URL print / browser open, actionable `hermes mcp login` guidance.