### PR TITLE
fix(state): increase SQLite busy timeout from 1s to 30s (#57921)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -912,7 +912,7 @@ class SessionDB:
                     f"file:{self.db_path}?mode=ro",
                     uri=True,
                     check_same_thread=False,
-                    timeout=1.0,
+                    timeout=30.0,
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
@@ -924,10 +924,10 @@ class SessionDB:
                 self._conn = sqlite3.connect(
                     str(self.db_path),
                     check_same_thread=False,
-                    # Short timeout — application-level retry with random
-                    # jitter handles contention instead of sitting in
-                    # SQLite's internal busy handler for up to 30s.
-                    timeout=1.0,
+                    # Enough headroom for another process (e.g. the dashboard)
+                    # to release its lock under GIL pressure.  Application-level
+                    # retry with random jitter handles shorter contention.
+                    timeout=30.0,
                     # auto-starts transactions on DML, which conflicts with
                     # our explicit BEGIN IMMEDIATE.  None = we manage
                     # transactions ourselves.


### PR DESCRIPTION
## Problem

The gateway intermittently fails with `sqlite3.OperationalError: database is locked` when `state.db` is shared between the gateway and the dashboard. The dashboard event loop can stall for 16+ seconds under GIL pressure (plugin mounting, console UI initialization), and during that stall its SQLite connection remains open. The gateway's 1-second timeout is too short to wait out these stalls.

## Evidence

Dashboard logs show:
```
18:56:54  event loop stalled 8.5s (GIL pressure suspected)
18:57:19  event loop stalled 16.1s
18:57:51  event loop stalled 16.0s
```

`kanban_db.py` already solved this same class of problem with `PRAGMA busy_timeout=120000` (120 seconds).

## Fix

Increase `sqlite3.connect(timeout=...)` from `1.0` to `30.0` seconds for both read-only and write connections in `SessionDB.__init__()`. This gives enough headroom for another process to release its lock under GIL pressure, while application-level retry with jitter still handles shorter contention.

Fixes #57921
