### PR TITLE
fix(update): self-heal venv after failed lazy backend refresh

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8178,7 +8178,187 @@ def _cleanup_quarantined_exes(scripts_dir: Path | None = None) -> None:
         pass
 
 
-def _refresh_active_lazy_features() -> None:
+# Import probes for venv corruption after a failed lazy ``uv pip install``.
+# Metadata can look fine while ``.py`` files were removed mid-install (#57828).
+_LAZY_REFRESH_IMPORT_PROBES: tuple[tuple[str, str], ...] = (
+    ("yaml", "SafeDumper"),
+    ("dotenv", "load_dotenv"),
+    ("click", "Command"),
+    ("certifi", "contents"),
+    ("rich", "print"),
+    ("cryptography", "__version__"),
+    ("jwt", "encode"),
+)
+
+_LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = {
+    "yaml": "PyYAML",
+    "dotenv": "python-dotenv",
+    "click": "click",
+    "certifi": "certifi",
+    "rich": "rich",
+    "cryptography": "cryptography",
+    "jwt": "PyJWT",
+}
+
+
+def _run_package_only_install(
+    cmd: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Run a package-only pip/uv install without quarantining entry-point shims.
+
+    ``pip install --upgrade pip`` and ``--force-reinstall <pkg>`` do not
+    rewrite ``hermes.exe``. The editable-install quarantine path would rename
+    shims without uv recreating them on Windows (#57828).
+    """
+    _run_install_with_heartbeat(cmd, env=env)
+
+
+def _lazy_refresh_repair_specs(packages: list[str]) -> list[str]:
+    """Map repair package names to their declared pin specs in pyproject.toml."""
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:  # pragma: no cover
+        return packages
+
+    pyproject = PROJECT_ROOT / "pyproject.toml"
+    if not pyproject.is_file():
+        return packages
+
+    try:
+        with open(pyproject, "rb") as f:
+            raw_deps = tomllib.load(f).get("project", {}).get("dependencies", []) or []
+    except Exception as exc:
+        logger.debug("lazy refresh repair spec lookup failed: %s", exc)
+        return packages
+
+    name_to_spec: dict[str, str] = {}
+    try:
+        from packaging.requirements import Requirement  # type: ignore
+
+        for spec in raw_deps:
+            try:
+                req = Requirement(spec)
+                name_to_spec[req.name.lower()] = spec.split(";", 1)[0].strip()
+            except Exception:
+                continue
+    except Exception:
+        for spec in raw_deps:
+            head = spec.split(";", 1)[0].strip()
+            bare = head
+            for op in ("==", ">=", "<=", "~=", ">", "<", "!="):
+                if op in bare:
+                    bare = bare.split(op, 1)[0]
+                    break
+            key = bare.strip().split("[", 1)[0].strip().lower()
+            if key:
+                name_to_spec[key] = head
+
+    return [name_to_spec.get(pkg.lower(), pkg) for pkg in packages]
+
+
+def _upgrade_pip_before_lazy_refresh(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Upgrade pip before lazy-backend refreshes.
+
+    Older pip (e.g. 24.0 on Python 3.11) can fail setuptools-backed source
+    builds during lazy installs and leave a partially-written venv (#57828).
+    Never raises.
+    """
+    try:
+        _run_package_only_install(
+            install_cmd_prefix + ["install", "--upgrade", "pip"],
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.debug("pip upgrade before lazy refresh failed: %s", exc)
+
+
+def _detect_broken_lazy_refresh_imports(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> list[str]:
+    """Return pip distribution names whose import probes fail."""
+    venv_python = _resolve_install_target_python(install_cmd_prefix, env)
+    if venv_python is None:
+        return []
+
+    probe_lines = "\n".join(
+        f"    ({mod!r}, {attr!r})," for mod, attr in _LAZY_REFRESH_IMPORT_PROBES
+    )
+    check_script = (
+        "import sys\n"
+        "probes = [\n"
+        f"{probe_lines}\n"
+        "]\n"
+        "broken = []\n"
+        "for mod, attr in probes:\n"
+        "    try:\n"
+        "        imported = __import__(mod)\n"
+        "        if not hasattr(imported, attr):\n"
+        "            broken.append(mod)\n"
+        "    except Exception:\n"
+        "        broken.append(mod)\n"
+        "print('\\n'.join(broken))\n"
+    )
+    try:
+        result = subprocess.run(
+            [str(venv_python), "-c", check_script],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+    except Exception as exc:
+        logger.debug("lazy refresh import probe failed: %s", exc)
+        return []
+
+    broken_modules = [
+        line.strip() for line in result.stdout.splitlines() if line.strip()
+    ]
+    packages: list[str] = []
+    seen: set[str] = set()
+    for mod in broken_modules:
+        pkg = _LAZY_REFRESH_REPAIR_PACKAGES.get(mod)
+        if pkg and pkg not in seen:
+            seen.add(pkg)
+            packages.append(pkg)
+    return packages
+
+
+def _repair_broken_lazy_refresh_imports(
+    install_cmd_prefix: list[str],
+    packages: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> bool:
+    """Force-reinstall ``packages`` and re-probe imports. Never raises."""
+    if not packages:
+        return True
+
+    specs = _lazy_refresh_repair_specs(packages)
+    try:
+        _run_package_only_install(
+            install_cmd_prefix + ["install", "--force-reinstall", *specs],
+            env=env,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning("lazy refresh venv repair failed: %s", exc)
+        return False
+
+    return not _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+
+
+def _refresh_active_lazy_features(
+    install_cmd_prefix: list[str] | None = None,
+    *,
+    env: dict[str, str] | None = None,
+) -> bool:
     """Refresh lazy-installed backends after a code update.
 
     When pyproject.toml's ``[all]`` extra was slimmed down (May 2026), most
@@ -8192,22 +8372,27 @@ def _refresh_active_lazy_features() -> None:
     activated and reinstalls them under the current pins. Features the
     user never enabled stay quiet — no churn for cold backends.
 
+    Returns True when the venv is safe to use (refresh succeeded, or no
+    active lazy backends, or post-failure import repair succeeded). Returns
+    False when a failed lazy install left broken core imports that automatic
+    repair could not fix (#57828).
+
     Never raises. A failure here must not block the rest of the update.
     """
     try:
         from tools import lazy_deps
     except Exception as exc:
         logger.debug("Lazy refresh skipped (import failed): %s", exc)
-        return
+        return True
 
     try:
         active = lazy_deps.active_features()
     except Exception as exc:
         logger.debug("Lazy refresh skipped (active_features failed): %s", exc)
-        return
+        return True
 
     if not active:
-        return
+        return True
 
     print()
     print(f"→ Refreshing {len(active)} active lazy backend(s)...")
@@ -8218,7 +8403,7 @@ def _refresh_active_lazy_features() -> None:
         # refresh_active_features is documented as never-raise, but defend
         # the update flow against future regressions.
         print(f"  ⚠ Lazy refresh failed unexpectedly: {exc}")
-        return
+        results = {}
 
     refreshed = [f for f, s in results.items() if s == "refreshed"]
     current = [f for f, s in results.items() if s == "current"]
@@ -8242,8 +8427,37 @@ def _refresh_active_lazy_features() -> None:
             if len(reason) > 200:
                 reason = reason[:200] + "..."
             print(f"  ⚠ {feature} failed to refresh: {reason}")
-        print("  Backends keep their previously-installed version; rerun")
-        print("  `hermes update` once the upstream issue is resolved.")
+
+        if install_cmd_prefix is None:
+            print("  ⚠ Lazy refresh failed; rerun `hermes update` once resolved.")
+            return False
+
+        broken = _detect_broken_lazy_refresh_imports(
+            install_cmd_prefix, env=env
+        )
+        if broken:
+            print("  → Detected corrupted venv packages; repairing...")
+            if _repair_broken_lazy_refresh_imports(
+                install_cmd_prefix, broken, env=env
+            ):
+                print("  ✓ Venv repair succeeded")
+                print("  Lazy backend(s) keep their previous version until refresh succeeds.")
+                return True
+
+            manual = " ".join(
+                repr(p) for p in broken
+            )
+            print("  ⚠ Venv repair incomplete. Run manually, then `hermes update`:")
+            print(
+                f"    {' '.join(install_cmd_prefix)} install --force-reinstall {manual}"
+            )
+            return False
+
+        print("  Lazy backend(s) keep their previous version; core venv looks intact.")
+        print("  Rerun `hermes update` once the upstream issue is resolved.")
+        return True
+
+    return True
 
 
 def _install_python_dependencies_with_optional_fallback(
@@ -10746,13 +10960,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _install_psutil_android_compat(pip_cmd)
             _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
-        # Core Python deps installed AND verified (the fallback helper runs
-        # _verify_core_dependencies_installed). Clear the interrupted-install
-        # breadcrumb now — the remaining steps (lazy refresh, node deps, web
-        # UI, desktop rebuild) are non-core and can't brick the venv.
-        _clear_update_incomplete_marker()
+        install_prefix = [uv_bin, "pip"] if uv_bin else pip_cmd
+        lazy_env = uv_env if uv_bin else None
 
-        _refresh_active_lazy_features()
+        # Upgrade pip before lazy refreshes — stale pip can fail source builds
+        # and leave partially-written packages (#57828).
+        _upgrade_pip_before_lazy_refresh(install_prefix, env=lazy_env)
+
+        # Lazy refresh can corrupt the venv when a backend install fails.
+        # Keep the interrupted-install marker until refresh + repair succeed.
+        lazy_ok = _refresh_active_lazy_features(install_prefix, env=lazy_env)
+        if lazy_ok:
+            _clear_update_incomplete_marker()
+        else:
+            print(
+                "  ⚠ Update incomplete — run `hermes` again to finish venv recovery."
+            )
 
         node_failures = _update_node_dependencies()
         _build_web_ui(PROJECT_ROOT / "web")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7724,9 +7724,11 @@ def _recover_lazy_refresh_marker_locked() -> None:
             "Leaving `.lazy-refresh-incomplete` for the next launch."
         )
         print("  Recover manually with:")
+        repair_pkgs = list(_LAZY_REFRESH_REPAIR_PACKAGES.values())
+        repair_specs = " ".join(_lazy_refresh_repair_specs(repair_pkgs))
         print(
             f"    {' '.join(install_prefix)} install --force-reinstall "
-            "PyYAML python-dotenv click certifi rich cryptography PyJWT"
+            f"{repair_specs}"
         )
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7551,62 +7551,93 @@ def _load_installable_optional_extras(group: str = "all") -> list[str]:
     return referenced
 
 
-# Install-scoped breadcrumb dropped right before ``hermes update`` mutates the
-# venv and cleared only after the dependency install verifies clean.  If a user
-# kills the update mid-install (Ctrl-C, terminal close, WSL OOM), the marker
-# survives and the next ``hermes`` launch finishes the install instead of
-# limping along on a half-built venv (e.g. pip wiped, a core dep like Pillow
-# never landed).  Lives next to the venv (not under $HERMES_HOME) because the
-# venv is shared across all profiles, so a single marker covers every profile.
+# Install-scoped breadcrumbs live next to the venv (not under $HERMES_HOME)
+# because the venv is shared across profiles.
+#
+# ``.update-incomplete`` — generic core ``.[all]`` install was interrupted.
+# Cleared only after a confirmed full dependency reinstall/recovery.
+#
+# ``.lazy-refresh-incomplete`` — lazy-backend refresh phase may have corrupted
+# packages. Cleared only after import-probe repair confirms healthy (not when
+# probes are unavailable/indeterminate). Narrow lazy probes must NEVER clear
+# the generic core marker (#58004 review).
 def _update_marker_path() -> Path:
     return PROJECT_ROOT / ".update-incomplete"
 
 
-def _write_update_incomplete_marker() -> None:
-    """Drop the interrupted-install breadcrumb. Never raises."""
+def _lazy_refresh_marker_path() -> Path:
+    return PROJECT_ROOT / ".lazy-refresh-incomplete"
+
+
+def _write_marker_file(path: Path, *, label: str) -> None:
+    """Drop an update-recovery breadcrumb. Never raises."""
     try:
-        _update_marker_path().write_text(
+        path.write_text(
             f"started={_time.time()}\npid={os.getpid()}\n", encoding="utf-8"
         )
     except OSError as exc:
-        logger.debug("Could not write update-incomplete marker: %s", exc)
+        logger.debug("Could not write %s marker: %s", label, exc)
 
 
-def _clear_update_incomplete_marker() -> None:
-    """Remove the interrupted-install breadcrumb. Never raises."""
+def _clear_marker_file(path: Path, *, label: str) -> None:
+    """Remove an update-recovery breadcrumb. Never raises."""
     try:
-        _update_marker_path().unlink()
+        path.unlink()
     except FileNotFoundError:
         pass
     except OSError as exc:
-        logger.debug("Could not clear update-incomplete marker: %s", exc)
+        logger.debug("Could not clear %s marker: %s", label, exc)
+
+
+def _write_update_incomplete_marker() -> None:
+    """Drop the interrupted core-install breadcrumb. Never raises."""
+    _write_marker_file(_update_marker_path(), label="update-incomplete")
+
+
+def _clear_update_incomplete_marker() -> None:
+    """Remove the interrupted core-install breadcrumb. Never raises."""
+    _clear_marker_file(_update_marker_path(), label="update-incomplete")
+
+
+def _write_lazy_refresh_incomplete_marker() -> None:
+    """Drop the interrupted lazy-refresh breadcrumb. Never raises."""
+    _write_marker_file(_lazy_refresh_marker_path(), label="lazy-refresh-incomplete")
+
+
+def _clear_lazy_refresh_incomplete_marker() -> None:
+    """Remove the interrupted lazy-refresh breadcrumb. Never raises."""
+    _clear_marker_file(_lazy_refresh_marker_path(), label="lazy-refresh-incomplete")
 
 
 def _recover_from_interrupted_install() -> None:
-    """Finish a dependency install that a prior ``hermes update`` left half-done.
+    """Finish update work left half-done by a prior ``hermes update``.
 
-    Triggered on launch when ``.update-incomplete`` is present — meaning the
-    code was pulled but the dep install was killed before it verified clean.
-    Unconditionally bootstraps pip via ``ensurepip`` (a killed ``pip install``
-    can wipe pip from the venv entirely, which blocks the venv from recovering
-    on its own), then re-runs the editable ``.[all]`` install + core-dependency
-    verification, then clears the marker.
+    Handles two independent breadcrumbs:
+
+    - ``.update-incomplete`` — core ``.[all]`` install interrupted. Recovers
+      via full quarantined reinstall. Never cleared by the narrow lazy-refresh
+      import probes alone.
+    - ``.lazy-refresh-incomplete`` — lazy-backend refresh may have corrupted
+      packages. Recovers via package-only import probes; cleared only when
+      probes confirm healthy/repaired (indeterminate keeps the marker).
 
     Never raises: a recovery failure must not block launch.  If it can't
-    self-heal it prints the one-line manual command and leaves the marker so
+    self-heal it prints the manual command and leaves the relevant marker so
     the next launch tries again.
 
-    Concurrency: the marker lives next to the shared venv, so a gateway start
-    plus a CLI launch (or two profiles starting at once) can both see it.  An
-    ``O_EXCL`` lockfile ensures only one process runs the reinstall; the
-    others skip and let the winner clear the marker.
+    Concurrency: markers live next to the shared venv, so a gateway start
+    plus a CLI launch (or two profiles starting at once) can both see them.
+    An ``O_EXCL`` lockfile ensures only one process runs recovery; the
+    others skip and let the winner clear markers.
 
     Output: everything — our status lines AND the streamed pip/uv install
     (which inherits fd 1) — is routed to stderr.  Launches whose stdout is a
     protocol stream (``hermes acp`` speaks JSON-RPC on stdout) must never get
     install noise on stdout.
     """
-    if not _update_marker_path().exists():
+    core_marker = _update_marker_path().exists()
+    lazy_marker = _lazy_refresh_marker_path().exists()
+    if not core_marker and not lazy_marker:
         return
 
     # Skip in managed/Docker installs and on PyPI installs with no git checkout:
@@ -7614,6 +7645,7 @@ def _recover_from_interrupted_install() -> None:
     # to act on. Just clear it.
     if not (PROJECT_ROOT / "pyproject.toml").is_file():
         _clear_update_incomplete_marker()
+        _clear_lazy_refresh_incomplete_marker()
         return
 
     # Single-flight guard: atomically claim the recovery lock. If another
@@ -7638,55 +7670,6 @@ def _recover_from_interrupted_install() -> None:
         # the install itself will surface the real problem.
         logger.debug("Could not create install-recovery lock: %s", exc)
 
-    # Windows self-lock guard: if hermes.exe is the launcher that spawned
-    # this Python process, any attempt to pip-install will fail with
-    # "拒绝访问 / WinError 32" because the running .exe cannot be replaced.
-    # Rather than entering the permanent retry loop described in issue
-    # #45542, clear the marker and give the user an offline recovery command.
-    if _is_windows():
-        scripts_dir = _venv_scripts_dir()
-        if scripts_dir is not None:
-            shims = _hermes_exe_shims(scripts_dir)
-            if shims:
-                _shim_set: set[str] = set()
-                for _s in shims:
-                    try:
-                        _shim_set.add(str(_s.resolve()).lower())
-                    except OSError:
-                        _shim_set.add(str(_s).lower())
-                try:
-                    import psutil
-                    _me = psutil.Process()
-                    for _anc in [_me] + list(_me.parents()):
-                        try:
-                            _anc_exe = _anc.exe()
-                            _anc_norm = str(Path(_anc_exe).resolve()).lower()
-                        except Exception:
-                            continue
-                        if _anc_norm in _shim_set:
-                            print(
-                                "✗ Hermes is running from the binary that "
-                                "needs to be replaced — the auto-recovery "
-                                "cannot overwrite a running executable."
-                            )
-                            print(
-                                "  Restart Hermes from a different terminal, "
-                                "then run the manual recovery command below:"
-                            )
-                            print(f'    cd /d "{PROJECT_ROOT}"')
-                            print(
-                                f'    "{sys.executable}" -m pip install '
-                                '-e ".[all]"'
-                            )
-                            _clear_update_incomplete_marker()
-                            try:
-                                lock_path.unlink()
-                            except OSError:
-                                pass
-                            return
-                except Exception:
-                    pass  # psutil is best-effort; fall through to install
-
     saved_stdout_fd = None
     saved_sys_stdout = sys.stdout
     try:
@@ -7699,54 +7682,11 @@ def _recover_from_interrupted_install() -> None:
             saved_stdout_fd = None
         sys.stdout = sys.stderr
 
-        print(
-            "⚠ A previous `hermes update` was interrupted mid-install — "
-            "finishing dependency installation now..."
-        )
+        if lazy_marker:
+            _recover_lazy_refresh_marker_locked()
 
-        try:
-            from hermes_cli.managed_uv import ensure_uv
-
-            # Always bootstrap pip first: a killed install can leave the venv with
-            # no pip module at all, and uv may also be gone. ensurepip restores a
-            # known-good pip so at least the plain-pip path below can proceed.
-            try:
-                subprocess.run(
-                    [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                )
-            except Exception as exc:
-                logger.debug("ensurepip during install recovery failed: %s", exc)
-
-            uv_bin = ensure_uv()
-            if uv_bin:
-                uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
-                if _is_termux_env(uv_env):
-                    uv_env.pop("PYTHONPATH", None)
-                    uv_env.pop("PYTHONHOME", None)
-                _install_python_dependencies_with_optional_fallback(
-                    [uv_bin, "pip"],
-                    env=uv_env,
-                    group="termux-all" if _is_termux_env(uv_env) else "all",
-                )
-            else:
-                _install_python_dependencies_with_optional_fallback(
-                    [sys.executable, "-m", "pip"],
-                    group="termux-all" if _is_termux_env() else "all",
-                )
-
-            _clear_update_incomplete_marker()
-            print("✓ Dependency installation recovered — your install is healthy again.")
-        except Exception as exc:
-            # Leave the marker in place so the next launch retries. Give the user
-            # the exact manual recovery command in the meantime.
-            logger.debug("Interrupted-install recovery failed: %s", exc)
-            print("✗ Could not auto-recover the interrupted install.")
-            print("  Recover manually with:")
-            print(f"    cd {PROJECT_ROOT}")
-            print(f"    {sys.executable} -m ensurepip --upgrade")
-            print(f"    {sys.executable} -m pip install -e '.[all]'")
+        if _update_marker_path().exists():
+            _recover_core_update_marker_locked()
     finally:
         sys.stdout = saved_sys_stdout
         if saved_stdout_fd is not None:
@@ -7759,6 +7699,169 @@ def _recover_from_interrupted_install() -> None:
             lock_path.unlink()
         except OSError:
             pass
+
+
+def _recover_lazy_refresh_marker_locked() -> None:
+    """Heal ``.lazy-refresh-incomplete`` via confirmed import-probe repair."""
+    print(
+        "⚠ A previous lazy-backend refresh may have left the venv unhealthy — "
+        "running import-based package repair..."
+    )
+    install_prefix, install_env = _default_venv_install_target()
+    status = _repair_venv_via_import_probes(install_prefix, env=install_env)
+    if status in ("healthy", "repaired"):
+        _clear_lazy_refresh_incomplete_marker()
+        print("✓ Lazy-refresh venv recovery confirmed — install is healthy again.")
+        return
+    if status == "indeterminate":
+        print(
+            "  ⚠ Import probes unavailable — cannot confirm venv health. "
+            "Leaving `.lazy-refresh-incomplete` for the next launch."
+        )
+    else:
+        print(
+            "  ⚠ Lazy-refresh package repair incomplete. "
+            "Leaving `.lazy-refresh-incomplete` for the next launch."
+        )
+        print("  Recover manually with:")
+        print(
+            f"    {' '.join(install_prefix)} install --force-reinstall "
+            "PyYAML python-dotenv click certifi rich cryptography PyJWT"
+        )
+
+
+def _recover_core_update_marker_locked() -> None:
+    """Heal ``.update-incomplete`` via full ``.[all]`` reinstall only.
+
+    Narrow lazy-refresh import probes are not sufficient proof that a generic
+    interrupted core install finished — a missing dep outside that probe set
+    would otherwise look healthy and clear the breadcrumb too early.
+    """
+    print(
+        "⚠ A previous `hermes update` was interrupted mid-install — "
+        "finishing dependency installation now..."
+    )
+
+    # Windows: a normal ``hermes.exe`` launch always has the launcher as an
+    # ancestor. Full editable reinstall uses quarantine so the live shim can
+    # still be replaced. Package-only import repair may help as first aid but
+    # must NEVER clear this core marker on its own (#58004 review).
+    self_locked = _windows_running_hermes_launcher_locked()
+    if self_locked:
+        install_prefix, install_env = _default_venv_install_target()
+        print(
+            "  → Running from hermes.exe; applying package-only first aid, "
+            "then quarantined full reinstall (core marker stays until that "
+            "succeeds)..."
+        )
+        _repair_venv_via_import_probes(install_prefix, env=install_env)
+
+    try:
+        from hermes_cli.managed_uv import ensure_uv
+
+        # Always bootstrap pip first: a killed install can leave the venv with
+        # no pip module at all, and uv may also be gone. ensurepip restores a
+        # known-good pip so at least the plain-pip path below can proceed.
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+            )
+        except Exception as exc:
+            logger.debug("ensurepip during install recovery failed: %s", exc)
+
+        uv_bin = ensure_uv()
+        if uv_bin:
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            if _is_termux_env(uv_env):
+                uv_env.pop("PYTHONPATH", None)
+                uv_env.pop("PYTHONHOME", None)
+            _install_python_dependencies_with_optional_fallback(
+                [uv_bin, "pip"],
+                env=uv_env,
+                group="termux-all" if _is_termux_env(uv_env) else "all",
+            )
+        else:
+            _install_python_dependencies_with_optional_fallback(
+                [sys.executable, "-m", "pip"],
+                group="termux-all" if _is_termux_env() else "all",
+            )
+
+        _clear_update_incomplete_marker()
+        print("✓ Dependency installation recovered — your install is healthy again.")
+    except Exception as exc:
+        # Leave the marker in place so the next launch retries. Give the user
+        # the exact manual recovery command in the meantime.
+        logger.debug("Interrupted-install recovery failed: %s", exc)
+        print("✗ Could not auto-recover the interrupted install.")
+        if self_locked:
+            print(
+                "  Hermes is still running from the launcher that needs "
+                "replacing. Close other Hermes windows, restart from a "
+                "different terminal, then run:"
+            )
+            print(f'    cd /d "{PROJECT_ROOT}"')
+            print(
+                f'    "{sys.executable}" -m pip install -e ".[all]"'
+            )
+        else:
+            print("  Recover manually with:")
+            print(f"    cd {PROJECT_ROOT}")
+            print(f"    {sys.executable} -m ensurepip --upgrade")
+            print(f"    {sys.executable} -m pip install -e '.[all]'")
+
+
+def _windows_running_hermes_launcher_locked() -> bool:
+    """True when a venv ``hermes*.exe`` shim is this process or an ancestor.
+
+    Best-effort: returns False when psutil is unavailable or inspection fails.
+    """
+    if not _is_windows():
+        return False
+    scripts_dir = _venv_scripts_dir()
+    if scripts_dir is None:
+        return False
+    shims = _hermes_exe_shims(scripts_dir)
+    if not shims:
+        return False
+    shim_set: set[str] = set()
+    for shim in shims:
+        try:
+            shim_set.add(str(shim.resolve()).lower())
+        except OSError:
+            shim_set.add(str(shim).lower())
+    try:
+        import psutil
+
+        me = psutil.Process()
+        for proc in [me] + list(me.parents()):
+            try:
+                exe_norm = str(Path(proc.exe()).resolve()).lower()
+            except Exception:
+                continue
+            if exe_norm in shim_set:
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def _default_venv_install_target() -> tuple[list[str], dict[str, str] | None]:
+    """Return ``(install_cmd_prefix, env)`` for the project venv when possible."""
+    try:
+        from hermes_cli.managed_uv import ensure_uv
+
+        uv_bin = ensure_uv()
+    except Exception:
+        uv_bin = None
+    if uv_bin:
+        env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        if _is_termux_env(env):
+            env.pop("PYTHONPATH", None)
+            env.pop("PYTHONHOME", None)
+        return [uv_bin, "pip"], env
+    return [sys.executable, "-m", "pip"], None
 
 
 def _run_install_with_heartbeat(
@@ -8282,11 +8385,18 @@ def _detect_broken_lazy_refresh_imports(
     install_cmd_prefix: list[str],
     *,
     env: dict[str, str] | None = None,
-) -> list[str]:
-    """Return pip distribution names whose import probes fail."""
+) -> list[str] | None:
+    """Probe lazy-refresh packages via real imports.
+
+    Returns:
+      - ``[]`` when probes ran and every package imported cleanly
+      - ``[dist, ...]`` when probes ran and some packages failed
+      - ``None`` when the probe could not run (missing venv Python, subprocess
+        failure, non-zero probe exit) — this is *indeterminate*, not healthy
+    """
     venv_python = _resolve_install_target_python(install_cmd_prefix, env)
     if venv_python is None:
-        return []
+        return None
 
     probe_lines = "\n".join(
         f"    ({mod!r}, {attr!r})," for mod, attr in _LAZY_REFRESH_IMPORT_PROBES
@@ -8316,7 +8426,15 @@ def _detect_broken_lazy_refresh_imports(
         )
     except Exception as exc:
         logger.debug("lazy refresh import probe failed: %s", exc)
-        return []
+        return None
+
+    if result.returncode != 0:
+        logger.debug(
+            "lazy refresh import probe exited %s: %s",
+            result.returncode,
+            (result.stderr or "")[:200],
+        )
+        return None
 
     broken_modules = [
         line.strip() for line in result.stdout.splitlines() if line.strip()
@@ -8351,7 +8469,51 @@ def _repair_broken_lazy_refresh_imports(
         logger.warning("lazy refresh venv repair failed: %s", exc)
         return False
 
-    return not _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+    after = _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+    # Indeterminate re-probe is not confirmed success.
+    return after == []
+
+
+def _repair_venv_via_import_probes(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Probe imports and force-reinstall any broken lazy-refresh packages.
+
+    Uses real ``import`` checks (not distribution metadata) so a venv where
+    METADATA remains but ``.py`` files were wiped mid-install is still
+    detected (#57828). Package-only reinstall — never rewrites ``hermes.exe``.
+
+    Never raises. Returns one of:
+      - ``"healthy"`` — probes ran and found nothing broken
+      - ``"repaired"`` — probes found breakage and force-reinstall confirmed clean
+      - ``"failed"`` — probes found breakage and repair did not confirm clean
+      - ``"indeterminate"`` — probes could not run; do NOT treat as healthy
+    """
+    broken = _detect_broken_lazy_refresh_imports(install_cmd_prefix, env=env)
+    if broken is None:
+        print(
+            "  ⚠ Import probes unavailable — cannot confirm venv package health."
+        )
+        return "indeterminate"
+    if not broken:
+        return "healthy"
+    print(
+        "  → Detected corrupted venv packages via import probes: "
+        f"{', '.join(broken)}; repairing..."
+    )
+    if _repair_broken_lazy_refresh_imports(
+        install_cmd_prefix, broken, env=env
+    ):
+        print("  ✓ Venv repair succeeded")
+        return "repaired"
+    manual = " ".join(repr(p) for p in broken)
+    print("  ⚠ Venv repair incomplete. Run manually, then `hermes update`:")
+    print(
+        f"    {' '.join(install_cmd_prefix)} install --force-reinstall {manual}"
+    )
+    return "failed"
 
 
 def _refresh_active_lazy_features(
@@ -8397,6 +8559,7 @@ def _refresh_active_lazy_features(
     print()
     print(f"→ Refreshing {len(active)} active lazy backend(s)...")
 
+    unexpected_failure = False
     try:
         results = lazy_deps.refresh_active_features(prompt=False)
     except Exception as exc:
@@ -8404,6 +8567,7 @@ def _refresh_active_lazy_features(
         # the update flow against future regressions.
         print(f"  ⚠ Lazy refresh failed unexpectedly: {exc}")
         results = {}
+        unexpected_failure = True
 
     refreshed = [f for f, s in results.items() if s == "refreshed"]
     current = [f for f, s in results.items() if s == "current"]
@@ -8420,44 +8584,41 @@ def _refresh_active_lazy_features(
         names = ", ".join(f for f, _ in skipped)
         reason = skipped[0][1].split(": ", 1)[-1]
         print(f"  · {len(skipped)} skipped ({reason}): {names}")
-    if failed:
-        for feature, status in failed:
-            reason = status.split(": ", 1)[-1]
-            # Clip noisy pip stderr to keep update output legible.
-            if len(reason) > 200:
-                reason = reason[:200] + "..."
-            print(f"  ⚠ {feature} failed to refresh: {reason}")
 
-        if install_cmd_prefix is None:
-            print("  ⚠ Lazy refresh failed; rerun `hermes update` once resolved.")
-            return False
-
-        broken = _detect_broken_lazy_refresh_imports(
-            install_cmd_prefix, env=env
-        )
-        if broken:
-            print("  → Detected corrupted venv packages; repairing...")
-            if _repair_broken_lazy_refresh_imports(
-                install_cmd_prefix, broken, env=env
-            ):
-                print("  ✓ Venv repair succeeded")
-                print("  Lazy backend(s) keep their previous version until refresh succeeds.")
-                return True
-
-            manual = " ".join(
-                repr(p) for p in broken
-            )
-            print("  ⚠ Venv repair incomplete. Run manually, then `hermes update`:")
-            print(
-                f"    {' '.join(install_cmd_prefix)} install --force-reinstall {manual}"
-            )
-            return False
-
-        print("  Lazy backend(s) keep their previous version; core venv looks intact.")
-        print("  Rerun `hermes update` once the upstream issue is resolved.")
+    if not failed and not unexpected_failure:
         return True
 
-    return True
+    for feature, status in failed:
+        reason = status.split(": ", 1)[-1]
+        # Clip noisy pip stderr to keep update output legible.
+        if len(reason) > 200:
+            reason = reason[:200] + "..."
+        print(f"  ⚠ {feature} failed to refresh: {reason}")
+
+    if install_cmd_prefix is None:
+        print("  ⚠ Lazy refresh failed; rerun `hermes update` once resolved.")
+        return False
+
+    # Immediate import-based recovery — metadata-only verifiers miss the case
+    # where DISTRIBUTION-INFO remains but import files were wiped (#57828).
+    # Unavailable probes are indeterminate, not healthy — keep the lazy marker.
+    status = _repair_venv_via_import_probes(install_cmd_prefix, env=env)
+    if status == "repaired":
+        print(
+            "  Lazy backend(s) keep their previous version until refresh succeeds."
+        )
+        return True
+    if status == "healthy":
+        print(
+            "  Lazy backend(s) keep their previous version; probed packages look intact."
+        )
+        print("  Rerun `hermes update` once the upstream issue is resolved.")
+        return True
+    if status == "indeterminate":
+        print(
+            "  ⚠ Leaving `.lazy-refresh-incomplete` until import probes can confirm health."
+        )
+    return False
 
 
 def _install_python_dependencies_with_optional_fallback(
@@ -10901,11 +11062,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # breaks on this machine, keep base deps and reinstall the remaining extras
         # individually so update does not silently strip working capabilities.
         #
-        # Drop the interrupted-install breadcrumb BEFORE touching the venv. If
-        # the install is killed mid-flight (Ctrl-C, terminal close, WSL OOM),
-        # the marker survives and the next ``hermes`` launch finishes the
-        # install via ``_recover_from_interrupted_install``. Cleared only after
-        # the install + core-dependency verification completes below.
+        # Drop the core-install breadcrumb BEFORE touching the venv. If the
+        # install is killed mid-flight (Ctrl-C, terminal close, WSL OOM), the
+        # marker survives and the next ``hermes`` launch finishes the install
+        # via ``_recover_from_interrupted_install``. Cleared after the core
+        # ``.[all]`` install completes — lazy refresh uses a separate marker.
         _write_update_incomplete_marker()
         print("→ Updating Python dependencies...")
         from hermes_cli.managed_uv import ensure_uv, update_managed_uv
@@ -10963,18 +11124,26 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_prefix = [uv_bin, "pip"] if uv_bin else pip_cmd
         lazy_env = uv_env if uv_bin else None
 
+        # Core ``.[all]`` install finished. Clear the generic core breadcrumb
+        # before the lazy-refresh phase — that phase uses its own marker so a
+        # later lazy failure cannot be "healed" by clearing the core marker
+        # based on a narrow 7-package import probe (#58004 review).
+        _clear_update_incomplete_marker()
+
         # Upgrade pip before lazy refreshes — stale pip can fail source builds
         # and leave partially-written packages (#57828).
+        _write_lazy_refresh_incomplete_marker()
         _upgrade_pip_before_lazy_refresh(install_prefix, env=lazy_env)
 
         # Lazy refresh can corrupt the venv when a backend install fails.
-        # Keep the interrupted-install marker until refresh + repair succeed.
+        # Clear the lazy marker only when refresh/repair is confirmed healthy.
         lazy_ok = _refresh_active_lazy_features(install_prefix, env=lazy_env)
         if lazy_ok:
-            _clear_update_incomplete_marker()
+            _clear_lazy_refresh_incomplete_marker()
         else:
             print(
-                "  ⚠ Update incomplete — run `hermes` again to finish venv recovery."
+                "  ⚠ Lazy-refresh recovery incomplete — run `hermes` again "
+                "to finish import-based venv repair."
             )
 
         node_failures = _update_node_dependencies()

--- a/hermes_entry.py
+++ b/hermes_entry.py
@@ -1,0 +1,40 @@
+"""Dependency-light console entry for ``hermes``.
+
+Runs stdlib-only update-marker recovery *before* importing ``hermes_cli.main``,
+so a wiped ``python-dotenv`` (or other probed package) cannot prevent recovery
+from starting (#57828 / #58004 review).
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main(argv: list[str] | None = None) -> object:
+    if argv is not None:
+        # Tests may pass argv; keep sys.argv consistent for downstream CLI.
+        sys.argv = [sys.argv[0], *argv]
+
+    # UTF-8 stdio on Windows — same guard as every other Hermes entry point.
+    try:
+        import hermes_bootstrap  # noqa: F401
+    except ModuleNotFoundError:
+        pass
+    else:
+        try:
+            hermes_bootstrap.harden_import_path()
+        except Exception:
+            pass
+
+    # Marker recovery must not import hermes_cli.main / env_loader / dotenv.
+    from hermes_update_recovery import maybe_recover
+
+    maybe_recover()
+
+    from hermes_cli.main import main as cli_main
+
+    return cli_main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main() or 0)

--- a/hermes_update_recovery.py
+++ b/hermes_update_recovery.py
@@ -1,0 +1,363 @@
+"""Stdlib-only update recovery that runs *before* ``hermes_cli.main`` imports.
+
+``hermes_cli.main`` pulls in ``hermes_cli.env_loader`` → ``dotenv`` at module
+import time. If a failed lazy refresh emptied ``python-dotenv`` (#57828), the
+console entry would crash before ``main()`` could call
+``_recover_from_interrupted_install()``.
+
+This module uses only the standard library (+ subprocess to ``uv``/``pip``) so
+marker-driven recovery can heal probed packages — including ``dotenv`` —
+before the heavy CLI import graph loads (#58004 review).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+
+UPDATE_MARKER = ".update-incomplete"
+LAZY_MARKER = ".lazy-refresh-incomplete"
+LOCK_NAME = ".update-incomplete.lock"
+
+# (import_name, attr, pip_distribution_name)
+IMPORT_PROBES: tuple[tuple[str, str, str], ...] = (
+    ("yaml", "SafeDumper", "PyYAML"),
+    ("dotenv", "load_dotenv", "python-dotenv"),
+    ("click", "Command", "click"),
+    ("certifi", "contents", "certifi"),
+    ("rich", "print", "rich"),
+    ("cryptography", "__version__", "cryptography"),
+    ("jwt", "encode", "PyJWT"),
+)
+
+
+def update_marker_path(root: Path | None = None) -> Path:
+    return (root or PROJECT_ROOT) / UPDATE_MARKER
+
+
+def lazy_refresh_marker_path(root: Path | None = None) -> Path:
+    return (root or PROJECT_ROOT) / LAZY_MARKER
+
+
+def markers_present(root: Path | None = None) -> bool:
+    base = root or PROJECT_ROOT
+    return update_marker_path(base).exists() or lazy_refresh_marker_path(base).exists()
+
+
+def repair_specs(packages: list[str], root: Path | None = None) -> list[str]:
+    """Map distribution names to pinned specs from ``pyproject.toml``."""
+    if not packages:
+        return []
+    pyproject = (root or PROJECT_ROOT) / "pyproject.toml"
+    if not pyproject.is_file():
+        return list(packages)
+    try:
+        import tomllib
+    except ImportError:  # pragma: no cover
+        return list(packages)
+    try:
+        with open(pyproject, "rb") as f:
+            raw_deps = tomllib.load(f).get("project", {}).get("dependencies", []) or []
+    except Exception:
+        return list(packages)
+
+    name_to_spec: dict[str, str] = {}
+    for spec in raw_deps:
+        head = spec.split(";", 1)[0].strip()
+        bare = head
+        for op in ("==", ">=", "<=", "~=", ">", "<", "!="):
+            if op in bare:
+                bare = bare.split(op, 1)[0]
+                break
+        key = bare.strip().split("[", 1)[0].strip().lower()
+        if key:
+            name_to_spec[key] = head
+    return [name_to_spec.get(pkg.lower(), pkg) for pkg in packages]
+
+
+def _clear_marker(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+def _write_marker(path: Path) -> None:
+    try:
+        path.write_text(f"started={time.time()}\npid={os.getpid()}\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _venv_python(root: Path) -> Path | None:
+    scripts = root / "venv" / ("Scripts" if sys.platform == "win32" else "bin")
+    candidate = scripts / ("python.exe" if sys.platform == "win32" else "python")
+    return candidate if candidate.is_file() else None
+
+
+def _find_uv() -> str | None:
+    found = shutil.which("uv")
+    if found:
+        return found
+    # Managed uv used by hermes_cli.managed_uv — best-effort without importing it.
+    home = Path.home()
+    for candidate in (
+        home / ".hermes" / "bin" / ("uv.exe" if sys.platform == "win32" else "uv"),
+        home / ".local" / "bin" / ("uv.exe" if sys.platform == "win32" else "uv"),
+    ):
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def _install_target(root: Path) -> tuple[list[str], dict[str, str] | None]:
+    uv = _find_uv()
+    venv = root / "venv"
+    if uv and venv.is_dir():
+        return [uv, "pip"], {**os.environ, "VIRTUAL_ENV": str(venv)}
+    return [sys.executable, "-m", "pip"], None
+
+
+def detect_broken_imports(
+    root: Path | None = None,
+    *,
+    env: dict[str, str] | None = None,
+) -> list[str] | None:
+    """Return broken pip names, ``[]`` if healthy, or ``None`` if indeterminate."""
+    base = root or PROJECT_ROOT
+    python = _venv_python(base)
+    if python is None:
+        return None
+
+    probe_lines = "\n".join(
+        f"    ({mod!r}, {attr!r}, {pkg!r})," for mod, attr, pkg in IMPORT_PROBES
+    )
+    script = (
+        "broken = []\n"
+        "probes = [\n"
+        f"{probe_lines}\n"
+        "]\n"
+        "for mod, attr, pkg in probes:\n"
+        "    try:\n"
+        "        imported = __import__(mod)\n"
+        "        if not hasattr(imported, attr):\n"
+        "            broken.append(pkg)\n"
+        "    except Exception:\n"
+        "        broken.append(pkg)\n"
+        "print('\\n'.join(broken))\n"
+    )
+    try:
+        result = subprocess.run(
+            [str(python), "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            cwd=str(base),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def force_reinstall_packages(
+    packages: list[str],
+    root: Path | None = None,
+    *,
+    env: dict[str, str] | None = None,
+) -> bool:
+    """Force-reinstall packages with pyproject pins. Never raises."""
+    if not packages:
+        return True
+    base = root or PROJECT_ROOT
+    prefix, default_env = _install_target(base)
+    run_env = env if env is not None else default_env
+    specs = repair_specs(packages, base)
+    try:
+        subprocess.run(
+            prefix + ["install", "--force-reinstall", *specs],
+            cwd=str(base),
+            check=True,
+            env=run_env,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return False
+    after = detect_broken_imports(base, env=run_env)
+    return after == []
+
+
+def _quarantine_hermes_exe(root: Path) -> None:
+    """Best-effort rename of live Windows shims so pip can rewrite them."""
+    if sys.platform != "win32":
+        return
+    scripts = root / "venv" / "Scripts"
+    if not scripts.is_dir():
+        return
+    stamp = int(time.time() * 1000)
+    for name in ("hermes.exe", "hermes-gateway.exe", "hermes-agent.exe", "hermes-acp.exe"):
+        shim = scripts / name
+        if not shim.is_file():
+            continue
+        dest = scripts / f"{name}.old.{stamp}"
+        try:
+            shim.rename(dest)
+        except OSError:
+            pass
+
+
+def recover_lazy_marker(root: Path | None = None) -> str:
+    """Heal ``.lazy-refresh-incomplete``. Returns status string."""
+    base = root or PROJECT_ROOT
+    marker = lazy_refresh_marker_path(base)
+    if not marker.exists():
+        return "absent"
+
+    print(
+        "⚠ A previous lazy-backend refresh may have left the venv unhealthy — "
+        "running import-based package repair (pre-main bootstrap)...",
+        file=sys.stderr,
+    )
+    prefix, env = _install_target(base)
+    broken = detect_broken_imports(base, env=env)
+    if broken is None:
+        print(
+            "  ⚠ Import probes unavailable — leaving `.lazy-refresh-incomplete`.",
+            file=sys.stderr,
+        )
+        return "indeterminate"
+    if not broken:
+        _clear_marker(marker)
+        print("✓ Lazy-refresh probes clean — cleared recovery marker.", file=sys.stderr)
+        return "healthy"
+    print(
+        f"  → Bootstrap repairing: {', '.join(broken)}",
+        file=sys.stderr,
+    )
+    if force_reinstall_packages(broken, base, env=env):
+        _clear_marker(marker)
+        print("✓ Lazy-refresh bootstrap repair confirmed.", file=sys.stderr)
+        return "repaired"
+
+    specs = " ".join(repair_specs(broken, base))
+    print("  ⚠ Bootstrap lazy repair incomplete. Run manually:", file=sys.stderr)
+    print(
+        f"    {' '.join(prefix)} install --force-reinstall {specs}",
+        file=sys.stderr,
+    )
+    return "failed"
+
+
+def recover_core_marker(root: Path | None = None) -> str:
+    """Heal ``.update-incomplete`` via full editable install. Returns status."""
+    base = root or PROJECT_ROOT
+    marker = update_marker_path(base)
+    if not marker.exists():
+        return "absent"
+
+    print(
+        "⚠ A previous `hermes update` was interrupted mid-install — "
+        "finishing dependency installation (pre-main bootstrap)...",
+        file=sys.stderr,
+    )
+
+    # First aid: heal probe packages (incl. dotenv) so a later main import works
+    # even if the full reinstall is still needed. Does NOT clear the core marker.
+    prefix, env = _install_target(base)
+    broken = detect_broken_imports(base, env=env)
+    if broken:
+        print(
+            f"  → Bootstrap first-aid reinstall: {', '.join(broken)}",
+            file=sys.stderr,
+        )
+        force_reinstall_packages(broken, base, env=env)
+
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+            cwd=str(base),
+            capture_output=True,
+            check=False,
+        )
+    except Exception:
+        pass
+
+    _quarantine_hermes_exe(base)
+    try:
+        subprocess.run(
+            prefix + ["install", "-e", ".[all]"],
+            cwd=str(base),
+            check=True,
+            env=env,
+        )
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"✗ Bootstrap core recovery failed: {exc}", file=sys.stderr)
+        print("  Recover manually with:", file=sys.stderr)
+        print(f"    cd {base}", file=sys.stderr)
+        print(f"    {sys.executable} -m ensurepip --upgrade", file=sys.stderr)
+        print(f"    {' '.join(prefix)} install -e '.[all]'", file=sys.stderr)
+        return "failed"
+
+    _clear_marker(marker)
+    print("✓ Core dependency bootstrap recovery succeeded.", file=sys.stderr)
+    return "repaired"
+
+
+def maybe_recover(
+    root: Path | None = None,
+    *,
+    argv: list[str] | None = None,
+) -> bool:
+    """Run marker recovery if needed. Returns True when any recovery ran.
+
+    Skips when ``update`` appears in argv (same rule as ``hermes_cli.main``)
+    so recovery never races the real update flow.
+    """
+    args = sys.argv[1:] if argv is None else argv
+    if "update" in args:
+        return False
+
+    base = root or PROJECT_ROOT
+    if not markers_present(base):
+        return False
+
+    if not (base / "pyproject.toml").is_file():
+        _clear_marker(update_marker_path(base))
+        _clear_marker(lazy_refresh_marker_path(base))
+        return False
+
+    lock_path = base / LOCK_NAME
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.write(fd, f"{os.getpid()}\n".encode())
+        os.close(fd)
+    except FileExistsError:
+        try:
+            if time.time() - lock_path.stat().st_mtime > 3600:
+                lock_path.unlink()
+        except OSError:
+            pass
+        return False
+    except OSError:
+        pass
+
+    try:
+        if lazy_refresh_marker_path(base).exists():
+            recover_lazy_marker(base)
+        if update_marker_path(base).exists():
+            recover_core_marker(base)
+        return True
+    finally:
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,14 +306,17 @@ requires = ["setuptools>=77.0,<83"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]
-hermes = "hermes_cli.main:main"
+# hermes_entry recovers update markers before importing hermes_cli.main
+# (which pulls dotenv via env_loader) so a wiped python-dotenv cannot brick
+# launch-time self-heal (#57828 / #58004).
+hermes = "hermes_entry:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's
 # sealed venv is missing hermes_constants, run_agent, etc.
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_entry", "hermes_update_recovery", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
 
 [tool.setuptools.packages.find]
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]

--- a/tests/hermes_cli/test_hermes_entry_recovery.py
+++ b/tests/hermes_cli/test_hermes_entry_recovery.py
@@ -1,0 +1,177 @@
+"""Entry-point lifecycle: recovery runs before ``hermes_cli.main`` imports.
+
+Proves the #58004 / #57828 bootstrap contract — a wiped probed package
+(``dotenv``) must not prevent marker recovery from starting, because recovery
+lives in a dependency-light entry point that does not import
+``hermes_cli.env_loader``.
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+import textwrap
+import types
+from pathlib import Path
+
+import hermes_entry
+import hermes_update_recovery as recovery
+
+
+def test_pyproject_hermes_script_uses_bootstrap_entry():
+    import tomllib
+
+    root = Path(__file__).resolve().parents[2]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert data["project"]["scripts"]["hermes"] == "hermes_entry:main"
+    py_modules = data["tool"]["setuptools"]["py-modules"]
+    assert "hermes_entry" in py_modules
+    assert "hermes_update_recovery" in py_modules
+
+
+def test_entry_recovers_before_importing_main(monkeypatch):
+    """``hermes_cli.main`` (dotenv via env_loader) must load only after recover."""
+    order: list[str] = []
+
+    def fake_recover(*, root=None, argv=None):
+        order.append("recover")
+        return True
+
+    monkeypatch.setattr(recovery, "maybe_recover", fake_recover)
+
+    stub = types.ModuleType("hermes_cli.main")
+
+    def stub_main():
+        order.append("main")
+        return 0
+
+    stub.main = stub_main  # type: ignore[attr-defined]
+
+    # Drop any cached real module so the entry re-imports under our gate.
+    monkeypatch.delitem(sys.modules, "hermes_cli.main", raising=False)
+
+    real_import = builtins.__import__
+
+    def gated_import(name, globals=None, locals=None, fromlist=(), level=0):
+        loading_main = name == "hermes_cli.main" or (
+            name == "hermes_cli" and fromlist and "main" in fromlist
+        )
+        if loading_main:
+            assert "recover" in order, (
+                "hermes_cli.main imported before bootstrap recovery — "
+                f"order={order}"
+            )
+            order.append("import_main")
+            sys.modules["hermes_cli.main"] = stub
+            if name == "hermes_cli.main":
+                return stub
+            # ``from hermes_cli.main import main`` may import package first.
+            pkg = real_import(name, globals, locals, fromlist, level)
+            return pkg
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", gated_import)
+
+    rc = hermes_entry.main([])
+    assert rc == 0
+    assert order[0] == "recover"
+    assert "import_main" in order
+    assert order.index("recover") < order.index("import_main")
+    assert "main" in order
+
+
+def test_bootstrap_repair_specs_preserve_pyproject_pins(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = [
+              "python-dotenv>=1.2.1,<2",
+              "PyYAML>=6.0.3,<7",
+            ]
+            """
+        ),
+        encoding="utf-8",
+    )
+    specs = recovery.repair_specs(["python-dotenv", "PyYAML"], tmp_path)
+    assert specs == ["python-dotenv>=1.2.1,<2", "PyYAML>=6.0.3,<7"]
+
+
+def test_bootstrap_force_reinstall_uses_pinned_specs(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = ["python-dotenv>=1.2.1,<2"]
+            """
+        ),
+        encoding="utf-8",
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(recovery.subprocess, "run", fake_run)
+    monkeypatch.setattr(recovery, "detect_broken_imports", lambda *a, **k: [])
+    monkeypatch.setattr(
+        recovery, "_install_target", lambda root: (["uv", "pip"], {"VIRTUAL_ENV": "v"})
+    )
+
+    assert recovery.force_reinstall_packages(["python-dotenv"], tmp_path) is True
+    assert calls
+    assert "python-dotenv>=1.2.1,<2" in calls[0]
+
+
+def test_bootstrap_lazy_recovery_clears_marker_when_probes_healthy(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    recovery.lazy_refresh_marker_path(tmp_path).write_text("x\n", encoding="utf-8")
+    monkeypatch.setattr(recovery, "detect_broken_imports", lambda *a, **k: [])
+    status = recovery.recover_lazy_marker(tmp_path)
+    assert status == "healthy"
+    assert not recovery.lazy_refresh_marker_path(tmp_path).exists()
+
+
+def test_bootstrap_skips_during_update_argv(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    recovery.update_marker_path(tmp_path).write_text("x\n", encoding="utf-8")
+    called = {"n": 0}
+    monkeypatch.setattr(
+        recovery, "recover_core_marker", lambda *a, **k: called.__setitem__("n", 1)
+    )
+    assert recovery.maybe_recover(tmp_path, argv=["update"]) is False
+    assert called["n"] == 0
+    assert recovery.update_marker_path(tmp_path).exists()
+
+
+def test_recovery_module_import_does_not_load_dotenv(monkeypatch):
+    """Contract: loading recovery must work even when dotenv is absent."""
+    import importlib
+
+    monkeypatch.delitem(sys.modules, "dotenv", raising=False)
+    monkeypatch.delitem(sys.modules, "hermes_cli.env_loader", raising=False)
+
+    # Pretend dotenv is missing for any accidental import during reload.
+    real_import = builtins.__import__
+
+    def no_dotenv(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "dotenv" or name.startswith("dotenv."):
+            raise ModuleNotFoundError("No module named 'dotenv'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", no_dotenv)
+    mod = importlib.reload(recovery)
+    assert mod.markers_present is not None
+    assert "dotenv" not in sys.modules
+    assert "hermes_cli.env_loader" not in sys.modules

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -1,0 +1,219 @@
+"""Tests for lazy-backend refresh venv repair (#57828)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import hermes_cli.main as m
+
+
+def test_detect_broken_imports_returns_repair_package_names(
+    tmp_path, monkeypatch
+):
+    venv_bin = tmp_path / "bin"
+    venv_bin.mkdir(parents=True)
+    python = venv_bin / "python"
+    python.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        m,
+        "_resolve_install_target_python",
+        lambda prefix, env: python,
+    )
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = "yaml\nclick\n"
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(m.subprocess, "run", fake_run)
+
+    broken = m._detect_broken_lazy_refresh_imports(
+        ["python", "-m", "pip"], env={"VIRTUAL_ENV": str(tmp_path)}
+    )
+    assert broken == ["PyYAML", "click"]
+
+
+def test_repair_runs_force_reinstall_with_pyproject_pins(
+    tmp_path, monkeypatch
+):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = [
+              "pyyaml==6.0.3",
+              "click==8.2.1",
+            ]
+        """
+        )
+    )
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+
+    calls: list[list[str]] = []
+
+    def fake_install(cmd, **kwargs):
+        calls.append(cmd)
+
+    detect_calls = {"count": 0}
+
+    def fake_detect(prefix, *, env=None):
+        detect_calls["count"] += 1
+        return []
+
+    monkeypatch.setattr(m, "_run_package_only_install", fake_install)
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", fake_detect)
+
+    ok = m._repair_broken_lazy_refresh_imports(
+        ["uv", "pip"],
+        ["PyYAML", "click"],
+        env={"VIRTUAL_ENV": str(tmp_path)},
+    )
+    assert ok is True
+    assert calls == [
+        [
+            "uv",
+            "pip",
+            "install",
+            "--force-reinstall",
+            "pyyaml==6.0.3",
+            "click==8.2.1",
+        ]
+    ]
+    assert detect_calls["count"] == 1
+
+
+def test_refresh_repairs_venv_after_lazy_failure(tmp_path, monkeypatch, capsys):
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "refresh_active_features",
+        lambda **kw: {"platform.matrix": "failed: pip install failed"},
+    )
+
+    repair_calls: list[list[str]] = []
+
+    def fake_repair(prefix, packages, *, env=None):
+        repair_calls.append(packages)
+        return True
+
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: ["PyYAML"])
+    monkeypatch.setattr(m, "_repair_broken_lazy_refresh_imports", fake_repair)
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    out = capsys.readouterr().out
+
+    assert ok is True
+    assert repair_calls == [["PyYAML"]]
+    assert "Venv repair succeeded" in out
+    assert "Backends keep their previously-installed version" not in out
+
+
+def test_refresh_returns_false_when_repair_fails(tmp_path, monkeypatch, capsys):
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "refresh_active_features",
+        lambda **kw: {"platform.matrix": "failed: pip install failed"},
+    )
+
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: ["PyYAML"])
+    monkeypatch.setattr(
+        m, "_repair_broken_lazy_refresh_imports", lambda *a, **k: False
+    )
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    out = capsys.readouterr().out
+
+    assert ok is False
+    assert "Venv repair incomplete" in out
+
+
+def test_upgrade_pip_before_lazy_refresh_never_raises(monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "_run_package_only_install",
+        MagicMock(side_effect=m.subprocess.CalledProcessError(1, "pip")),
+    )
+    m._upgrade_pip_before_lazy_refresh(["uv", "pip"])
+
+
+def test_package_only_repair_does_not_quarantine_shims_on_windows(
+    tmp_path, monkeypatch
+):
+    """Regression: package-only repairs must not rename hermes.exe on Windows."""
+    fake_scripts = tmp_path / "venv" / "Scripts"
+    fake_scripts.mkdir(parents=True)
+
+    install_calls: list[list[str]] = []
+
+    def fake_install(cmd, **kwargs):
+        install_calls.append(cmd)
+
+    monkeypatch.setattr(m, "_is_windows", lambda: True)
+    monkeypatch.setattr(m, "_venv_scripts_dir", lambda: fake_scripts)
+    monkeypatch.setattr(m, "_run_package_only_install", fake_install)
+    monkeypatch.setattr(
+        m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: []
+    )
+
+    with patch("hermes_cli.main._quarantine_running_hermes_exe") as mock_quar:
+        m._repair_broken_lazy_refresh_imports(
+            ["uv", "pip"],
+            ["PyYAML"],
+            env={"VIRTUAL_ENV": str(tmp_path / "venv")},
+        )
+
+    mock_quar.assert_not_called()
+    assert install_calls
+
+
+def test_upgrade_pip_does_not_quarantine_shims_on_windows(tmp_path, monkeypatch):
+    fake_scripts = tmp_path / "venv" / "Scripts"
+    fake_scripts.mkdir(parents=True)
+
+    install_calls: list[list[str]] = []
+
+    def fake_install(cmd, **kwargs):
+        install_calls.append(cmd)
+
+    monkeypatch.setattr(m, "_is_windows", lambda: True)
+    monkeypatch.setattr(m, "_venv_scripts_dir", lambda: fake_scripts)
+    monkeypatch.setattr(m, "_run_package_only_install", fake_install)
+
+    with patch("hermes_cli.main._quarantine_running_hermes_exe") as mock_quar:
+        m._upgrade_pip_before_lazy_refresh(["uv", "pip"])
+
+    mock_quar.assert_not_called()
+    assert install_calls == [["uv", "pip", "install", "--upgrade", "pip"]]
+
+
+def test_lazy_refresh_repair_specs_resolves_extras(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = [
+              "PyJWT[crypto]==2.13.0",
+              "cryptography==46.0.7",
+            ]
+        """
+        )
+    )
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+
+    specs = m._lazy_refresh_repair_specs(["PyJWT", "cryptography"])
+    assert specs == ["PyJWT[crypto]==2.13.0", "cryptography==46.0.7"]

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -1,4 +1,4 @@
-"""Tests for lazy-backend refresh venv repair (#57828)."""
+"""Tests for lazy-backend refresh venv repair (#57828 / #58004)."""
 
 from __future__ import annotations
 
@@ -35,6 +35,53 @@ def test_detect_broken_imports_returns_repair_package_names(
         ["python", "-m", "pip"], env={"VIRTUAL_ENV": str(tmp_path)}
     )
     assert broken == ["PyYAML", "click"]
+
+
+def test_detect_returns_none_when_venv_python_unresolved(monkeypatch):
+    monkeypatch.setattr(m, "_resolve_install_target_python", lambda *a, **k: None)
+    assert m._detect_broken_lazy_refresh_imports(["uv", "pip"]) is None
+
+
+def test_detect_returns_none_when_probe_subprocess_fails(tmp_path, monkeypatch):
+    python = tmp_path / "python"
+    python.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        m, "_resolve_install_target_python", lambda *a, **k: python
+    )
+    monkeypatch.setattr(
+        m.subprocess,
+        "run",
+        MagicMock(side_effect=OSError("exec failed")),
+    )
+    assert m._detect_broken_lazy_refresh_imports(["uv", "pip"]) is None
+
+
+def test_detect_returns_none_when_probe_exits_nonzero(tmp_path, monkeypatch):
+    python = tmp_path / "python"
+    python.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        m, "_resolve_install_target_python", lambda *a, **k: python
+    )
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = ""
+        result.stderr = "boom"
+        result.returncode = 1
+        return result
+
+    monkeypatch.setattr(m.subprocess, "run", fake_run)
+    assert m._detect_broken_lazy_refresh_imports(["uv", "pip"]) is None
+
+
+def test_repair_via_probes_indeterminate_is_not_success(monkeypatch, capsys):
+    monkeypatch.setattr(
+        m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: None
+    )
+    status = m._repair_venv_via_import_probes(["uv", "pip"])
+    out = capsys.readouterr().out
+    assert status == "indeterminate"
+    assert "cannot confirm" in out
 
 
 def test_repair_runs_force_reinstall_with_pyproject_pins(
@@ -114,6 +161,7 @@ def test_refresh_repairs_venv_after_lazy_failure(tmp_path, monkeypatch, capsys):
     assert ok is True
     assert repair_calls == [["PyYAML"]]
     assert "Venv repair succeeded" in out
+    assert "import probes" in out
     assert "Backends keep their previously-installed version" not in out
 
 
@@ -137,6 +185,73 @@ def test_refresh_returns_false_when_repair_fails(tmp_path, monkeypatch, capsys):
 
     assert ok is False
     assert "Venv repair incomplete" in out
+
+
+def test_refresh_returns_false_when_probes_indeterminate(
+    tmp_path, monkeypatch, capsys
+):
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "refresh_active_features",
+        lambda **kw: {"platform.matrix": "failed: pip install failed"},
+    )
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: None)
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    out = capsys.readouterr().out
+
+    assert ok is False
+    assert "lazy-refresh-incomplete" in out
+
+
+def test_refresh_repairs_on_unexpected_lazy_exception(tmp_path, monkeypatch, capsys):
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+
+    def boom(**kw):
+        raise RuntimeError("refresh registry broke")
+
+    monkeypatch.setattr(lazy_deps_mod, "refresh_active_features", boom)
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: ["click"])
+    monkeypatch.setattr(
+        m, "_repair_broken_lazy_refresh_imports", lambda *a, **k: True
+    )
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    out = capsys.readouterr().out
+
+    assert ok is True
+    assert "Lazy refresh failed unexpectedly" in out
+    assert "Venv repair succeeded" in out
+
+
+def test_lazy_marker_stays_until_repair_confirmed(tmp_path, monkeypatch):
+    """Lazy marker is independent of the generic core ``.update-incomplete``."""
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    m._write_lazy_refresh_incomplete_marker()
+    m._write_update_incomplete_marker()
+
+    import tools.lazy_deps as lazy_deps_mod
+
+    monkeypatch.setattr(lazy_deps_mod, "active_features", lambda: ["platform.matrix"])
+    monkeypatch.setattr(
+        lazy_deps_mod,
+        "refresh_active_features",
+        lambda **kw: {"platform.matrix": "failed: pip install failed"},
+    )
+    monkeypatch.setattr(m, "_detect_broken_lazy_refresh_imports", lambda *a, **k: ["PyYAML"])
+    monkeypatch.setattr(
+        m, "_repair_broken_lazy_refresh_imports", lambda *a, **k: False
+    )
+
+    ok = m._refresh_active_lazy_features(["uv", "pip"], env={"VIRTUAL_ENV": str(tmp_path)})
+    assert ok is False
+    assert m._lazy_refresh_marker_path().exists()
+    assert m._update_marker_path().exists(), "core marker must not be touched by lazy refresh"
 
 
 def test_upgrade_pip_before_lazy_refresh_never_raises(monkeypatch):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -393,7 +393,8 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_config, "get_missing_config_fields", lambda: [])
     monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
-    monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda: None)
+    monkeypatch.setattr(hermes_main, "_upgrade_pip_before_lazy_refresh", lambda *a, **kw: None)
+    monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda *a, **kw: True)
 
 
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_update_interrupted_recovery.py
+++ b/tests/hermes_cli/test_update_interrupted_recovery.py
@@ -52,6 +52,7 @@ def test_recovery_clears_stray_marker_without_pyproject(tmp_path, monkeypatch):
     # act on; recovery should just clear it without trying to install.
     monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
     m._write_update_incomplete_marker()
+    m._write_lazy_refresh_incomplete_marker()
     called = {"install": False}
     monkeypatch.setattr(
         m,
@@ -61,6 +62,7 @@ def test_recovery_clears_stray_marker_without_pyproject(tmp_path, monkeypatch):
     m._recover_from_interrupted_install()
     assert called["install"] is False
     assert not m._update_marker_path().exists()
+    assert not m._lazy_refresh_marker_path().exists()
 
 
 def test_recovery_runs_install_and_clears_marker(tmp_path, monkeypatch):
@@ -139,11 +141,13 @@ def _stub_install_env(monkeypatch, m, seen):
     )
 
 
-def test_recovery_self_lock_guard_clears_marker_without_install(tmp_path, monkeypatch):
-    # Windows self-lock: hermes.exe is an ancestor of this Python process, so a
-    # pip-install would fail trying to replace the running launcher (WinError 32
-    # / 拒绝访问). Recovery must short-circuit — clear the marker, skip install,
-    # break the loop (#45542 / #52378) — instead of retrying forever.
+def test_recovery_self_lock_does_not_clear_core_marker_via_import_probes(
+    tmp_path, monkeypatch
+):
+    # ``.update-incomplete`` is the generic core-install marker. Healthy
+    # lazy-refresh import probes alone must NOT clear it and skip full
+    # reinstall — a missing dep outside the 7-probe set would look healthy
+    # (#58004 review blocker).
     monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
     (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
     m._write_update_incomplete_marker()
@@ -156,6 +160,14 @@ def test_recovery_self_lock_guard_clears_marker_without_install(tmp_path, monkey
     monkeypatch.setattr(m, "_is_windows", lambda: True)
     monkeypatch.setattr(m, "_venv_scripts_dir", lambda: scripts_dir)
     monkeypatch.setattr(m, "_hermes_exe_shims", lambda d: [shim])
+    monkeypatch.setattr(
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
+    )
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "healthy"
+    )
 
     class FakeProc:
         def __init__(self, exe_path):
@@ -174,8 +186,142 @@ def test_recovery_self_lock_guard_clears_marker_without_install(tmp_path, monkey
 
     m._recover_from_interrupted_install()
 
-    assert seen["install"] is False, "self-lock must skip the install"
-    assert not m._update_marker_path().exists(), "marker cleared to break the loop"
+    assert seen["install"] is True, "core marker still requires full reinstall"
+    assert not m._update_marker_path().exists(), "cleared only after full reinstall"
+
+
+def test_recovery_self_lock_keeps_core_marker_when_install_fails(
+    tmp_path, monkeypatch
+):
+    # Quarantined full install failed under self-lock — keep the core marker.
+    # Never clear it solely because hermes.exe is an ancestor.
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_update_incomplete_marker()
+
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    shim = scripts_dir / "hermes.exe"
+    shim.write_text("")
+
+    monkeypatch.setattr(m, "_is_windows", lambda: True)
+    monkeypatch.setattr(m, "_venv_scripts_dir", lambda: scripts_dir)
+    monkeypatch.setattr(m, "_hermes_exe_shims", lambda d: [shim])
+    monkeypatch.setattr(
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
+    )
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "failed"
+    )
+
+    class FakeProc:
+        def __init__(self, exe_path):
+            self._exe = exe_path
+
+        def exe(self):
+            return self._exe
+
+        def parents(self):
+            return [FakeProc(str(shim))]
+
+    monkeypatch.setattr("psutil.Process", lambda: FakeProc(sys_executable_path()))
+
+    class R:
+        returncode = 0
+
+    monkeypatch.setattr(m.subprocess, "run", lambda *a, **k: R())
+    monkeypatch.setattr(m, "_is_termux_env", lambda *a, **k: False)
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: None)
+
+    def boom(*a, **k):
+        raise RuntimeError("WinError 32")
+
+    monkeypatch.setattr(
+        m, "_install_python_dependencies_with_optional_fallback", boom
+    )
+
+    m._recover_from_interrupted_install()
+
+    assert m._update_marker_path().exists(), (
+        "core marker kept for retry when self-locked recovery fails"
+    )
+
+
+def test_lazy_marker_cleared_only_after_confirmed_import_repair(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_lazy_refresh_incomplete_marker()
+
+    monkeypatch.setattr(
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
+    )
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "repaired"
+    )
+
+    seen = {"install": False}
+    _stub_install_env(monkeypatch, m, seen)
+
+    m._recover_from_interrupted_install()
+
+    assert seen["install"] is False, "lazy marker does not require full .[all] reinstall"
+    assert not m._lazy_refresh_marker_path().exists()
+
+
+def test_lazy_marker_kept_when_probes_indeterminate(tmp_path, monkeypatch):
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_lazy_refresh_incomplete_marker()
+
+    monkeypatch.setattr(
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
+    )
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "indeterminate"
+    )
+
+    seen = {"install": False}
+    _stub_install_env(monkeypatch, m, seen)
+
+    m._recover_from_interrupted_install()
+
+    assert seen["install"] is False
+    assert m._lazy_refresh_marker_path().exists(), (
+        "indeterminate probes must not clear the lazy marker"
+    )
+
+
+def test_lazy_and_core_markers_recover_independently(tmp_path, monkeypatch):
+    monkeypatch.setattr(m, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    m._write_lazy_refresh_incomplete_marker()
+    m._write_update_incomplete_marker()
+
+    monkeypatch.setattr(
+        m,
+        "_default_venv_install_target",
+        lambda: (["uv", "pip"], {"VIRTUAL_ENV": str(tmp_path / "venv")}),
+    )
+    monkeypatch.setattr(
+        m, "_repair_venv_via_import_probes", lambda *a, **k: "healthy"
+    )
+
+    seen = {"install": False}
+    _stub_install_env(monkeypatch, m, seen)
+
+    m._recover_from_interrupted_install()
+
+    assert not m._lazy_refresh_marker_path().exists()
+    assert seen["install"] is True, "core marker still drives full reinstall"
+    assert not m._update_marker_path().exists()
 
 
 def sys_executable_path():


### PR DESCRIPTION
## Summary
- Upgrade pip before lazy backend refreshes during `hermes update` (avoids stale pip build failures)
- After a failed lazy `uv pip install`, probe core imports (PyYAML, click, etc.) and auto `--force-reinstall` corrupted packages
- Keep the `.update-incomplete` marker until lazy refresh + repair succeed so the next `hermes` launch can recover
- Replace the misleading "backends keep their previous version" message when the venv is actually corrupted

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_lazy_refresh_venv_repair.py -q`