### PR TITLE
fix(web-server): close OAuth token TOCTOU by writing 0o600 atomically

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6951,26 +6951,15 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
         "refreshToken": refresh_token,
         "expiresAt": expires_at_ms,
     }
-    _HERMES_OAUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = _HERMES_OAUTH_FILE.with_name(
-        f"{_HERMES_OAUTH_FILE.name}.tmp.{os.getpid()}.{secrets.token_hex(8)}"
-    )
-    try:
-        with tmp_path.open("w", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, indent=2))
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(tmp_path, _HERMES_OAUTH_FILE)
-        try:
-            _HERMES_OAUTH_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
-    finally:
-        try:
-            if tmp_path.exists():
-                tmp_path.unlink()
-        except OSError:
-            pass
+    # atomic_json_write creates the temp with mode 0o600 (via mkstemp) *before*
+    # any content is written, then fsyncs and atomically replaces the target.
+    # The previous os.replace + post-hoc chmod left a TOCTOU window in which the
+    # OAuth token file was world-readable at the default umask (0o644 on most
+    # hosts) between the rename and the chmod. atomic_json_write also preserves
+    # the existing file's owner and cleans up its temp on failure.
+    from utils import atomic_json_write
+
+    atomic_json_write(_HERMES_OAUTH_FILE, payload, indent=2, mode=0o600)
     # Best-effort credential-pool insert. Failure here doesn't invalidate
     # the file write — pool registration only matters for the rotation
     # strategy, not for runtime credential resolution.

--- a/tests/hermes_cli/test_web_server_oauth_write.py
+++ b/tests/hermes_cli/test_web_server_oauth_write.py
@@ -36,18 +36,40 @@ def test_dashboard_oauth_write_uses_owner_only_permissions(oauth_file):
     assert mode == 0o600
 
 
-def test_dashboard_oauth_write_uses_atomic_replace_and_cleans_temp_files(oauth_file, monkeypatch):
-    replace_calls = []
+def test_dashboard_oauth_write_is_atomic_and_cleans_temp_on_failure(oauth_file, monkeypatch):
+    """If the atomic replace fails, no partial file or temp file is left."""
+    import utils
 
     def flaky_replace(src, dst):
-        replace_calls.append((src, dst))
         raise OSError('simulated replace failure')
 
-    monkeypatch.setattr('hermes_cli.web_server.os.replace', flaky_replace)
+    monkeypatch.setattr(utils, 'atomic_replace', flaky_replace)
 
     with pytest.raises(OSError, match='simulated replace failure'):
         _save_anthropic_oauth_creds('access-token', 'refresh-token', 123456)
 
-    assert replace_calls, 'helper should attempt atomic os.replace()'
     assert not oauth_file.exists()
-    assert not list(oauth_file.parent.glob(f'{oauth_file.name}.tmp*'))
+    # atomic_json_write stages to ``.<stem>_*.tmp`` and unlinks it on failure.
+    assert not list(oauth_file.parent.glob('*.tmp'))
+
+
+def test_dashboard_oauth_write_uses_atomic_json_write_with_owner_only_mode(oauth_file, monkeypatch):
+    """The OAuth token file must be written 0o600 from creation via
+    ``atomic_json_write(mode=0o600)``, so it is never briefly world-readable
+    (the old ``os.replace`` + post-hoc ``chmod`` TOCTOU)."""
+    import utils
+
+    calls = {}
+    real = utils.atomic_json_write
+
+    def spy(path, data, **kwargs):
+        calls['mode'] = kwargs.get('mode')
+        return real(path, data, **kwargs)
+
+    monkeypatch.setattr(utils, 'atomic_json_write', spy)
+
+    _save_anthropic_oauth_creds('access-token', 'refresh-token', 123456)
+
+    assert calls.get('mode') == 0o600, \
+        'OAuth creds must be written 0o600 atomically (no chmod-after-replace window)'
+    assert oauth_file.exists()


### PR DESCRIPTION
## What does this PR do?

`_save_anthropic_oauth_creds` persists the Anthropic OAuth token file with
`os.replace(tmp, path)` followed by a **post-hoc** `chmod(0o600)`:

```python
os.replace(tmp_path, _HERMES_OAUTH_FILE)
_HERMES_OAUTH_FILE.chmod(stat.S_IRUSR | stat.S_IWUSR)
```

Between the rename and the chmod the token file exists at the default umask
(0o644 on most hosts), so for that window another local user can read the
access/refresh tokens.

Write via `utils.atomic_json_write(_HERMES_OAUTH_FILE, payload, indent=2,
mode=0o600)`, which creates the temp with mode 0o600 **before** any content is
written (`mkstemp` + `fchmod`), fsyncs, atomically replaces, preserves the
existing file's owner, and cleans up its temp on failure. This is the same
`atomic_json_write(mode=0o600)` pattern already used elsewhere in this module
for the credential-pool write, and mirrors the owner preservation from #56644.

## Changes

- `hermes_cli/web_server.py` — persist OAuth creds via
  `atomic_json_write(mode=0o600)`.
- `tests/hermes_cli/test_web_server_oauth_write.py` — update the atomicity test
  to the new mechanism and assert the write uses `mode=0o600`.

## Tests

```
pytest tests/hermes_cli/test_web_server_oauth_write.py -q
```

The write now goes through `atomic_json_write(mode=0o600)` (mutation-verified —
reverting drops the call and the assertion fails), and a simulated replace
failure leaves no partial or temp file behind.