### PR TITLE
fix(auth): skip auto-SSO redirect for password-only providers (#57868)

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -185,6 +185,13 @@ def _auto_sso_response(request: Request) -> Response | None:
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+
+    # Password-only providers (e.g. basic auth) have no OAuth redirect flow;
+    # /auth/login would call start_login() → NotImplementedError (#57868).
+    # Fall through to /login which renders the username/password form directly.
+    if getattr(provider, "supports_password", False):
+        return None
+
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote


### PR DESCRIPTION
## Problem

When the dashboard is bound to a non-loopback host and the only enabled interactive auth provider is a password-only provider (e.g. the bundled `dashboard_auth/basic` plugin), unauthenticated users are redirected to `/auth/login?provider=basic`, which crashes with a 500 Internal Server Error.

```
File "hermes_cli/dashboard_auth/routes.py", line 197, in auth_login
    ls = p.start_login(redirect_uri=_redirect_uri(request))
File "plugins/dashboard_auth/basic/__init__.py", line 230, in start_login
    raise NotImplementedError("BasicAuthProvider is password-only; there is no OAuth redirect flow.")
```

## Root cause

`_auto_sso_response()` in `middleware.py` auto-redirects to `/auth/login` when exactly one interactive provider is registered. This works for OAuth providers, but password-only providers (`supports_password=True`) have no redirect flow. The `/auth/login` route unconditionally calls `provider.start_login()`, which raises `NotImplementedError`.

## Fix

Skip the auto-SSO redirect when the single provider has `supports_password=True`, falling through to `/login` which renders the username/password form directly.

Fixes #57868
