### PR TITLE
fix(mcp): delete git-cloned MCP dirs on Windows despite read-only .git files

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -23,8 +23,10 @@ See references/mcp-catalog.md (this repo's skill) for the manifest schema.
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
+import stat
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -356,6 +358,40 @@ def _install_root() -> Path:
     return root
 
 
+def _rmtree_windows_safe(path: Path) -> None:
+    """``shutil.rmtree`` that tolerates read-only entries.
+
+    Catalog MCPs are ``git clone``\\ d, so the tree contains a ``.git`` with
+    read-only pack files. On Windows ``shutil.rmtree`` raises ``PermissionError``
+    on read-only entries instead of deleting them, so ``mcp uninstall`` (and the
+    pre-clone wipe on re-install) fails with WinError 5. Clear the read-only bit
+    on the failing entry and its parent, then retry — mirroring
+    ``hermes_cli.profiles._rmtree_with_retry``.
+    """
+    def _onexc(func, p, exc):
+        # onexc(func, path, exc) on 3.12+, onerror(func, path, exc_info) on 3.11.
+        if isinstance(exc, tuple):
+            exc = exc[1]
+        if not isinstance(exc, PermissionError):
+            raise exc
+        try:
+            os.chmod(p, os.stat(p).st_mode | stat.S_IWUSR)
+        except OSError:
+            pass
+        parent = os.path.dirname(p)
+        if parent:
+            try:
+                os.chmod(parent, os.stat(parent).st_mode | stat.S_IWUSR)
+            except OSError:
+                pass
+        func(p)
+
+    try:
+        shutil.rmtree(path, onexc=_onexc)
+    except TypeError:  # Python 3.11 uses the older onerror= kwarg
+        shutil.rmtree(path, onerror=_onexc)
+
+
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
 
@@ -386,7 +422,7 @@ def _do_git_install(entry: CatalogEntry) -> Path:
         # Fresh checkout each install — manifest version is the source of truth,
         # so wipe + re-clone for determinism.
         print(color(f"  Removing existing install at {dest}", Colors.DIM))
-        shutil.rmtree(dest)
+        _rmtree_windows_safe(dest)
 
     print(color(f"  Cloning {install.url} ({install.ref}) → {dest}", Colors.CYAN))
 
@@ -406,7 +442,7 @@ def _do_git_install(entry: CatalogEntry) -> Path:
             # Branch/tag form failed (unlikely for valid manifests; possible if
             # the ref was deleted upstream). Fall through to the full-clone path.
             if dest.exists():
-                shutil.rmtree(dest)
+                _rmtree_windows_safe(dest)
             is_sha_ref = True  # treat the same as a SHA ref from here
 
     if is_sha_ref:
@@ -772,7 +808,7 @@ def uninstall_entry(name: str, *, purge_install_dir: bool = True) -> bool:
     if purge_install_dir:
         clone = _install_root() / name
         if clone.exists():
-            shutil.rmtree(clone)
+            _rmtree_windows_safe(clone)
             removed = True
 
     return removed

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -348,6 +348,43 @@ class TestUninstall:
 
         assert uninstall_entry("nonexistent") is False
 
+    def test_uninstall_removes_clone_with_readonly_git_files(self):
+        """A catalog MCP is ``git clone``\\ d, so its ``.git`` holds read-only
+        pack files. Uninstall must still wipe the clone — bare
+        ``shutil.rmtree`` raises PermissionError on read-only entries on Windows.
+        """
+        import os
+        import stat
+
+        from hermes_cli.mcp_catalog import _install_root, uninstall_entry
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg.setdefault("mcp_servers", {})["demo"] = {"command": "demo"}
+        save_config(cfg)
+
+        clone = _install_root() / "demo"
+        git_dir = clone / ".git"
+        git_dir.mkdir(parents=True)
+        pack = git_dir / "pack-readonly.idx"
+        pack.write_text("x")
+        os.chmod(pack, stat.S_IREAD)  # git marks pack files read-only
+
+        try:
+            assert uninstall_entry("demo") is True
+            assert not clone.exists()
+            assert "demo" not in load_config().get("mcp_servers", {})
+        finally:
+            # If the delete failed (e.g. the mutation run), restore write bits
+            # so pytest's tmp_path teardown can still clean up on Windows.
+            if clone.exists():
+                for root, _dirs, files in os.walk(clone):
+                    for fn in files:
+                        try:
+                            os.chmod(os.path.join(root, fn), stat.S_IWRITE)
+                        except OSError:
+                            pass
+
 
 # ---------------------------------------------------------------------------
 # Picker (non-TTY paths only — interactive curses is integration-tested)


### PR DESCRIPTION
## What does this PR do?

Catalog MCPs are installed with `git clone`, so the tree contains a `.git` with
read-only pack files. `uninstall_entry` (and the pre-clone wipe on re-install)
called bare `shutil.rmtree`, which on Windows raises `PermissionError`
(WinError 5) on read-only entries instead of deleting them. So
`hermes mcp uninstall` of a git-installed server fails and leaves the install in
a half-removed state (config entry gone, clone dir still on disk).

Add `_rmtree_windows_safe`: on a `PermissionError`, clear the read-only bit on
the failing entry and its parent, then retry — the onexc/onerror pattern already
used by `hermes_cli.profiles._rmtree_with_retry`. Route the three MCP-clone
deletions (uninstall + the two pre-clone wipes) through it.

## Changes

- `hermes_cli/mcp_catalog.py` — add `_rmtree_windows_safe`; use it for the MCP
  clone deletions.
- `tests/hermes_cli/test_mcp_catalog.py` — regression test.

## Tests

```
pytest tests/hermes_cli/test_mcp_catalog.py -q
→ 36 passed
```

The new test wipes a clone whose `.git` holds a read-only file
(mutation-verified: bare `shutil.rmtree` raises WinError 5 on Windows; the fix
deletes it cleanly).