### PR TITLE
feat(achievements): add export endpoint and agent summary (#18472)

### DIFF
--- a/plugins/hermes-achievements/README.md
+++ b/plugins/hermes-achievements/README.md
@@ -128,12 +128,24 @@ Endpoints:
 
 ```text
 GET  /achievements
+GET  /achievements/summary
+GET  /export?format=json|markdown|svg&state=unlocked|discovered|secret
 GET  /scan-status
 GET  /recent-unlocks
 GET  /sessions/{session_id}/badges
 POST /rescan
 POST /reset-state
 ```
+
+`GET /achievements/summary` returns a compact profile (strengths, gaps,
+top tier, unlocked ids) for agent context injection. The same payload is
+written to `agent_summary.json` next to `state.json` after every finished
+scan, so agents and external tools can read it without the dashboard
+running.
+
+`GET /export` renders the current snapshot as machine-readable JSON, a
+Markdown badge table (README-pasteable, unlocked badges by default), or
+an SVG badge sheet.
 
 ## Development
 

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -9,8 +9,10 @@ import math
 import re
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
+from xml.sax.saxutils import escape as xml_escape
 
 try:
     from hermes_constants import get_hermes_home
@@ -22,12 +24,22 @@ except ImportError:
 
 try:
     from fastapi import APIRouter
+    from fastapi.responses import JSONResponse, PlainTextResponse
 except Exception:  # Allows local unit tests without dashboard dependencies.
     class APIRouter:  # type: ignore
         def get(self, *_args, **_kwargs):
             return lambda fn: fn
         def post(self, *_args, **_kwargs):
             return lambda fn: fn
+
+    class JSONResponse:  # type: ignore
+        def __init__(self, content: Any, **_kwargs: Any) -> None:
+            self.content = content
+
+    class PlainTextResponse:  # type: ignore
+        def __init__(self, content: Any, **kwargs: Any) -> None:
+            self.content = content
+            self.media_type = kwargs.get("media_type")
 
 router = APIRouter()
 
@@ -51,6 +63,7 @@ SUCCESS_RE = re.compile(r"\b(success|passed|built|compiled|done|exit_code[\"']?\
 FILE_RE = re.compile(r"(?:/home/|~/?|\./|/mnt/)[\w./-]+\.(?:py|js|ts|tsx|jsx|css|html|md|json|yaml|yml|svg|sql|sh)")
 
 TIER_NAMES = ["Copper", "Silver", "Gold", "Diamond", "Olympian"]
+TIER_ORDER = {name: index for index, name in enumerate(TIER_NAMES, start=1)}
 
 
 def tiers(values: List[int]) -> List[Dict[str, Any]]:
@@ -152,6 +165,10 @@ def snapshot_path() -> Path:
 
 def checkpoint_path() -> Path:
     return get_hermes_home() / "plugins" / "hermes-achievements" / "scan_checkpoint.json"
+
+
+def agent_summary_path() -> Path:
+    return get_hermes_home() / "plugins" / "hermes-achievements" / "agent_summary.json"
 
 
 def load_state() -> Dict[str, Any]:
@@ -856,6 +873,173 @@ def _build_pending_snapshot(now: int) -> Dict[str, Any]:
     }
 
 
+def filter_and_sort_achievements(
+    items: List[Dict[str, Any]],
+    state: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Filter achievements by badge state.
+
+    Minimal seam for the filtering/sorting workstream in #18472: the export
+    formatters below only need state filtering today, and the full
+    category/sort/limit query support can extend this same function.
+    """
+    selected = list(items)
+    if state:
+        wanted = str(state).strip().lower()
+        selected = [item for item in selected if str(item.get("state", "")).lower() == wanted]
+    return selected
+
+
+def export_json(data: Dict[str, Any], state: Optional[str] = None) -> str:
+    """Export achievements as structured JSON."""
+    items = filter_and_sort_achievements(data.get("achievements", []), state=state)
+    export = {
+        "generated_at": data.get("generated_at"),
+        "unlocked_count": data.get("unlocked_count", 0),
+        "total_count": data.get("total_count", 0),
+        "achievements": items,
+    }
+    return json.dumps(export, indent=2, default=str)
+
+
+def _scan_date(generated_at: Any) -> str:
+    try:
+        return datetime.fromtimestamp(int(generated_at), tz=timezone.utc).strftime("%Y-%m-%d")
+    except (TypeError, ValueError, OverflowError, OSError):
+        return "unknown"
+
+
+def export_markdown(data: Dict[str, Any], state: Optional[str] = None) -> str:
+    """Export achievements as markdown with progress bars and shields.io badges."""
+    items = filter_and_sort_achievements(data.get("achievements", []), state=state or "unlocked")
+    unlocked = data.get("unlocked_count", 0)
+    total = data.get("total_count", 0)
+
+    lines = [
+        "# Hermes Achievements",
+        "",
+        f"**{unlocked}/{total} unlocked** | Last scanned: {_scan_date(data.get('generated_at'))}",
+        "",
+    ]
+
+    categories: Dict[str, List[Dict[str, Any]]] = {}
+    for item in items:
+        categories.setdefault(str(item.get("category", "Other")), []).append(item)
+
+    tier_colors = {
+        "Copper": "CD7F32", "Silver": "C0C0C0", "Gold": "FFD700",
+        "Diamond": "B9F2FF", "Olympian": "FF00FF",
+    }
+
+    for cat in sorted(categories):
+        lines.append(f"## {cat}")
+        lines.append("")
+        lines.append("| Achievement | Tier | Progress |")
+        lines.append("|---|---|---|")
+        for item in categories[cat]:
+            name = str(item.get("name", "???")).replace("|", "\\|")
+            tier = str(item.get("tier") or "-")
+            pct = int(item.get("progress_pct", 0) or 0)
+            color = tier_colors.get(tier, "gray")
+            badge = f"![{tier}](https://img.shields.io/badge/{tier}-{pct}%25-{color})"
+            bar_filled = max(0, min(10, pct // 10))
+            bar = "█" * bar_filled + "░" * (10 - bar_filled) + f" {pct}%"
+            lines.append(f"| {name} | {badge} | {bar} |")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def export_svg(data: Dict[str, Any], state: Optional[str] = None) -> str:
+    """Export achievements as an SVG badge sheet (unlocked badges by default)."""
+    items = filter_and_sort_achievements(data.get("achievements", []), state=state or "unlocked")
+
+    tier_colors = {
+        "Copper": "#B87333", "Silver": "#C0C0C0", "Gold": "#FFD700",
+        "Diamond": "#B9F2FF", "Olympian": "#FF00FF",
+    }
+
+    badge_w, badge_h, pad = 280, 28, 8
+    height = len(items) * (badge_h + pad) + pad
+
+    svg_parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{badge_w}" height="{height}" '
+        f'viewBox="0 0 {badge_w} {height}">',
+        '<style>.badge{rx:4;fill:#1a1a2e;stroke:#333;stroke-width:1}'
+        '.name{fill:#e0e0e0;font-family:monospace;font-size:11px}'
+        '.tier{font-family:monospace;font-size:10px;font-weight:bold}</style>',
+    ]
+
+    for i, item in enumerate(items):
+        y = i * (badge_h + pad) + pad
+        name = xml_escape(str(item.get("name", "???"))[:24])
+        tier = str(item.get("tier") or "-")
+        color = tier_colors.get(tier, "#666")
+        svg_parts.append(
+            f'<rect class="badge" x="0" y="{y}" width="{badge_w}" height="{badge_h}"/>'
+            f'<circle cx="14" cy="{y + badge_h // 2}" r="5" fill="{color}"/>'
+            f'<text class="name" x="24" y="{y + 18}">{name}</text>'
+            f'<text class="tier" x="{badge_w - 60}" y="{y + 18}" fill="{color}">{xml_escape(tier)}</text>'
+        )
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts)
+
+
+def _build_agent_summary(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the compact agent-consumable profile from evaluated data.
+
+    Small enough to inject as context without eating token budget:
+    strengths are the categories with the most unlocks, gaps are the
+    locked categories closest to their next unlock.
+    """
+    items = data.get("achievements", [])
+    aggregate = data.get("aggregate", {})
+
+    cat_unlocks: Dict[str, int] = {}
+    for item in items:
+        if item.get("unlocked"):
+            cat = str(item.get("category", "Other"))
+            cat_unlocks[cat] = cat_unlocks.get(cat, 0) + 1
+    strengths = sorted(cat_unlocks, key=lambda cat: (-cat_unlocks[cat], cat))[:5]
+
+    cat_progress: Dict[str, float] = {}
+    for item in items:
+        if not item.get("unlocked"):
+            cat = str(item.get("category", "Other"))
+            cat_progress[cat] = max(cat_progress.get(cat, 0), float(item.get("progress_pct", 0) or 0))
+    gaps = sorted(cat_progress, key=lambda cat: (-cat_progress[cat], cat))[:3]
+
+    top_tier = None
+    for item in items:
+        tier = item.get("tier")
+        if item.get("unlocked") and tier:
+            if not top_tier or TIER_ORDER.get(tier, 0) > TIER_ORDER.get(top_tier, 0):
+                top_tier = tier
+
+    return {
+        "total_sessions": aggregate.get("session_count", 0),
+        "total_tool_calls": aggregate.get("total_tool_calls", 0),
+        "unlocked_count": data.get("unlocked_count", 0),
+        "total_count": data.get("total_count", 0),
+        "top_categories": strengths,
+        "top_tier": top_tier,
+        "strengths": strengths,
+        "gaps": gaps,
+        "unlocked_ids": [a["id"] for a in items if a.get("unlocked")],
+    }
+
+
+def _write_agent_summary(data: Dict[str, Any]) -> None:
+    """Persist agent_summary.json for context injection. Best-effort."""
+    try:
+        path = agent_summary_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(_build_agent_summary(data), indent=2, default=str))
+    except Exception:
+        pass  # Non-critical: the summary is a best-effort context artifact.
+
+
 def _run_scan_and_update_cache(publish_partial_snapshots: bool = True) -> None:
     """Execute a scan + snapshot update. Called synchronously or from a thread.
 
@@ -907,6 +1091,7 @@ def _run_scan_and_update_cache(publish_partial_snapshots: bool = True) -> None:
             _SNAPSHOT_CACHE = _json_safe(computed)
             _SNAPSHOT_CACHE_AT = int(_SNAPSHOT_CACHE.get("generated_at") or int(time.time()))
             save_snapshot(_SNAPSHOT_CACHE)
+            _write_agent_summary(_SNAPSHOT_CACHE)
             _SCAN_STATUS["state"] = "idle"
         except Exception as exc:
             _SCAN_STATUS["state"] = "failed"
@@ -1008,6 +1193,28 @@ async def achievements():
     return payload
 
 
+@router.get("/achievements/summary")
+async def achievements_summary():
+    """Compact achievement profile for agent context injection.
+
+    Mirrors the agent_summary.json artifact written on each finished scan.
+    """
+    return _build_agent_summary(evaluate_all())
+
+
+@router.get("/export")
+async def export_achievements(format: str = "json", state: Optional[str] = None):
+    data = evaluate_all()
+    fmt = (format or "json").strip().lower()
+    if fmt == "markdown":
+        return PlainTextResponse(export_markdown(data, state=state), media_type="text/markdown")
+    if fmt == "svg":
+        return PlainTextResponse(export_svg(data, state=state), media_type="image/svg+xml")
+    if fmt != "json":
+        return JSONResponse({"error": f"unsupported format: {format}", "supported": ["json", "markdown", "svg"]}, status_code=400)
+    return JSONResponse(json.loads(export_json(data, state=state)))
+
+
 @router.get("/scan-status")
 async def scan_status():
     return _scan_status_payload()
@@ -1056,6 +1263,10 @@ async def reset_state():
         pass
     try:
         checkpoint_path().unlink(missing_ok=True)
+    except Exception:
+        pass
+    try:
+        agent_summary_path().unlink(missing_ok=True)
     except Exception:
         pass
     return {"ok": True}

--- a/plugins/hermes-achievements/tests/test_export_and_summary.py
+++ b/plugins/hermes-achievements/tests/test_export_and_summary.py
@@ -1,0 +1,182 @@
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "dashboard" / "plugin_api.py"
+spec = importlib.util.spec_from_file_location("plugin_api", MODULE_PATH)
+plugin_api = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(plugin_api)
+
+
+def sample_data():
+    return {
+        "generated_at": 1751328000,  # 2025-07-01 UTC
+        "unlocked_count": 2,
+        "total_count": 4,
+        "aggregate": {"session_count": 12, "total_tool_calls": 340},
+        "achievements": [
+            {
+                "id": "red_text",
+                "name": "Red Text Connoisseur",
+                "category": "Debugging",
+                "state": "unlocked",
+                "unlocked": True,
+                "tier": "Gold",
+                "progress_pct": 100,
+                "unlocked_at": 1751200000,
+            },
+            {
+                "id": "let_him_cook",
+                "name": "Let Him Cook",
+                "category": "Toolchain",
+                "state": "discovered",
+                "unlocked": False,
+                "tier": None,
+                "progress_pct": 40,
+            },
+            {
+                "id": "night_owl",
+                "name": "Night <Owl> & Friends",
+                "category": "Lifestyle",
+                "state": "unlocked",
+                "unlocked": True,
+                "tier": "Copper",
+                "progress_pct": 100,
+                "unlocked_at": 1751100000,
+            },
+            {
+                "id": "model_hopper",
+                "name": "Model Hopper",
+                "category": "Models",
+                "state": "secret",
+                "unlocked": False,
+                "tier": None,
+                "progress_pct": 0,
+            },
+        ],
+    }
+
+
+class FilterTests(unittest.TestCase):
+    def test_filter_by_state(self):
+        items = sample_data()["achievements"]
+
+        unlocked = plugin_api.filter_and_sort_achievements(items, state="unlocked")
+        self.assertEqual([item["id"] for item in unlocked], ["red_text", "night_owl"])
+
+        self.assertEqual(len(plugin_api.filter_and_sort_achievements(items)), 4)
+        self.assertEqual(plugin_api.filter_and_sort_achievements(items, state="nope"), [])
+
+
+class ExportJsonTests(unittest.TestCase):
+    def test_export_json_structure_and_state_filter(self):
+        payload = json.loads(plugin_api.export_json(sample_data(), state="unlocked"))
+
+        self.assertEqual(payload["unlocked_count"], 2)
+        self.assertEqual(payload["total_count"], 4)
+        self.assertEqual(payload["generated_at"], 1751328000)
+        self.assertEqual([item["id"] for item in payload["achievements"]], ["red_text", "night_owl"])
+
+    def test_export_json_defaults_to_all_states(self):
+        payload = json.loads(plugin_api.export_json(sample_data()))
+
+        self.assertEqual(len(payload["achievements"]), 4)
+
+
+class ExportMarkdownTests(unittest.TestCase):
+    def test_markdown_has_header_categories_and_badges(self):
+        content = plugin_api.export_markdown(sample_data())
+
+        self.assertIn("# Hermes Achievements", content)
+        self.assertIn("**2/4 unlocked** | Last scanned: 2025-07-01", content)
+        # Defaults to unlocked-only.
+        self.assertIn("## Debugging", content)
+        self.assertIn("## Lifestyle", content)
+        self.assertNotIn("## Toolchain", content)
+        self.assertIn("| Achievement | Tier | Progress |", content)
+        self.assertIn("img.shields.io/badge/Gold-100%25-FFD700", content)
+        self.assertIn("██████████ 100%", content)
+
+    def test_markdown_state_override_and_bad_timestamp(self):
+        data = sample_data()
+        data["generated_at"] = "not-a-timestamp"
+
+        content = plugin_api.export_markdown(data, state="discovered")
+
+        self.assertIn("Last scanned: unknown", content)
+        self.assertIn("## Toolchain", content)
+        self.assertIn("████░░░░░░ 40%", content)
+
+
+class ExportSvgTests(unittest.TestCase):
+    def test_svg_renders_one_row_per_unlocked_badge(self):
+        content = plugin_api.export_svg(sample_data())
+
+        self.assertTrue(content.startswith("<svg "))
+        self.assertTrue(content.endswith("</svg>"))
+        self.assertEqual(content.count('<rect class="badge"'), 2)
+        self.assertIn("Red Text Connoisseur", content)
+        self.assertIn("#FFD700", content)
+
+    def test_svg_escapes_markup_in_names(self):
+        content = plugin_api.export_svg(sample_data())
+
+        self.assertNotIn("<Owl>", content)
+        self.assertIn("Night &lt;Owl&gt; &amp; Frie", content)
+
+    def test_svg_with_no_matching_badges_is_valid(self):
+        content = plugin_api.export_svg(sample_data(), state="nope")
+
+        self.assertTrue(content.startswith("<svg "))
+        self.assertEqual(content.count('<rect class="badge"'), 0)
+
+
+class AgentSummaryTests(unittest.TestCase):
+    def test_summary_strengths_gaps_and_top_tier(self):
+        summary = plugin_api._build_agent_summary(sample_data())
+
+        self.assertEqual(summary["unlocked_count"], 2)
+        self.assertEqual(summary["total_count"], 4)
+        self.assertEqual(summary["total_sessions"], 12)
+        self.assertEqual(summary["total_tool_calls"], 340)
+        self.assertEqual(summary["strengths"], ["Debugging", "Lifestyle"])
+        self.assertEqual(summary["gaps"], ["Toolchain", "Models"])
+        self.assertEqual(summary["top_tier"], "Gold")
+        self.assertEqual(summary["unlocked_ids"], ["red_text", "night_owl"])
+
+    def test_summary_handles_empty_data(self):
+        summary = plugin_api._build_agent_summary({})
+
+        self.assertEqual(summary["unlocked_count"], 0)
+        self.assertEqual(summary["strengths"], [])
+        self.assertEqual(summary["gaps"], [])
+        self.assertIsNone(summary["top_tier"])
+
+
+class AgentSummaryFileTests(unittest.TestCase):
+    def test_write_agent_summary_persists_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            previous = os.environ.get("HERMES_HOME")
+            os.environ["HERMES_HOME"] = tmp
+            original_home = plugin_api.get_hermes_home
+            plugin_api.get_hermes_home = lambda: Path(tmp)
+            try:
+                plugin_api._write_agent_summary(sample_data())
+                path = Path(tmp) / "plugins" / "hermes-achievements" / "agent_summary.json"
+                self.assertTrue(path.exists())
+                payload = json.loads(path.read_text())
+                self.assertEqual(payload["top_tier"], "Gold")
+                self.assertEqual(payload["unlocked_ids"], ["red_text", "night_owl"])
+            finally:
+                plugin_api.get_hermes_home = original_home
+                if previous is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = previous
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Implements the **export & agent-communication workstream** from the achievements upgrades tracking issue (#18472, spec in closed PR #18151). Achievements are currently trapped in `state.json` and the dashboard tab; this adds the two surfaces the spec defines for getting them out:

- **`GET /api/plugins/hermes-achievements/export?format=json|markdown|svg&state=...`** — renders the current snapshot as machine-readable JSON, a README-pasteable Markdown badge table (shields.io badges + `██░░` progress bars, unlocked badges by default), or an SVG badge sheet with tier-colored markers. Unknown formats return a 400 JSON error instead of guessing.
- **`GET /api/plugins/hermes-achievements/achievements/summary`** — the compact agent profile from the spec (`strengths`, `gaps`, `top_tier`, `unlocked_ids`, `unlocked_count`, `total_count`, session/tool totals), small enough for context injection.
- **`agent_summary.json`** — the same payload is written next to `state.json` after every finished scan (best-effort, never fails the scan) and removed on `/reset-state`, so agents and external tools can read the profile without the dashboard running.

Scope notes, per the issue's guidance that the four workstreams land as separate PRs:

- `filter_and_sort_achievements()` is added as the minimal state-filter seam the export formatters need; the filtering/sorting workstream can extend the same function with `category`/`sort_by`/`limit` without rework.
- The `hermes achievements` CLI and TUI panel workstream is intentionally not included here; the CLI's export path can delegate to these formatters when it lands.

Two small deviations from the spec's reference snippets, both deliberate:

- The spec's `agent_summary.json` write used a hardcoded `Path.home() / ".hermes"`; this PR uses the existing `get_hermes_home()` helper so `HERMES_HOME` overrides and platform-aware homes keep working (same direction as #57216 / #26508).
- SVG badge names/tiers are XML-escaped so session-derived text can't inject markup into rendered sheets.

FastAPI response classes are stubbed in the existing no-FastAPI fallback so the plugin's dependency-free unit tests keep working.

## Related Issue

Addresses the export/agent-summary section of #18472 (spec: #18151).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/hermes-achievements/dashboard/plugin_api.py`: add `TIER_ORDER`, `agent_summary_path()`, `filter_and_sort_achievements()`, `export_json()`, `export_markdown()`, `export_svg()`, `_build_agent_summary()`, `_write_agent_summary()`; new `/export` and `/achievements/summary` routes; write `agent_summary.json` in `_run_scan_and_update_cache()`; clear it in `/reset-state`; stub `JSONResponse`/`PlainTextResponse` in the FastAPI fallback.
- `plugins/hermes-achievements/tests/test_export_and_summary.py`: 13 new unit tests (state filtering, JSON structure/filter, Markdown header/categories/badges/bad-timestamp handling, SVG rows/escaping/empty sheet, agent summary strengths/gaps/top-tier/empty data, `agent_summary.json` persistence).
- `plugins/hermes-achievements/README.md`: document the new endpoints and the `agent_summary.json` artifact.

## How to Test

1. `cd plugins/hermes-achievements && python3 -m unittest discover -s tests -v` — 21 tests (13 new + 8 existing engine tests) pass without dashboard dependencies.
2. Start the Hermes dashboard, open the Achievements tab once so a scan completes, then:
   - `curl 'localhost:<port>/api/plugins/hermes-achievements/export?format=markdown'` → Markdown badge table
   - `curl 'localhost:<port>/api/plugins/hermes-achievements/export?format=svg' > badges.svg` → renderable badge sheet
   - `curl 'localhost:<port>/api/plugins/hermes-achievements/achievements/summary'` → compact profile
3. Check `$HERMES_HOME/plugins/hermes-achievements/agent_summary.json` exists after the scan and disappears after `POST /reset-state`.
