### PR TITLE
fix(auth): retry Anthropic OAuth code exchange on HTTP 429 instead of burning the authorization code

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1464,6 +1464,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
         return None
 
     try:
+        import urllib.error
         import urllib.request
 
         exchange_data = json.dumps({
@@ -1492,14 +1493,36 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
                 },
                 method="POST",
             )
-            try:
-                with urllib.request.urlopen(req, timeout=15) as resp:
-                    result = json.loads(resp.read().decode())
+            # Anthropic rate-limits the token endpoint (HTTP 429) when login
+            # is attempted repeatedly from the same IP. Retry with capped
+            # backoff (honoring Retry-After) instead of burning the user's
+            # single-use authorization code — mirrors the Codex login flow.
+            max_attempts = 4
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    with urllib.request.urlopen(req, timeout=15) as resp:
+                        result = json.loads(resp.read().decode())
+                    break
+                except urllib.error.HTTPError as exc:
+                    last_error = exc
+                    if exc.code != 429:
+                        logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
+                        break
+                    retry_after = (exc.headers.get("Retry-After") or "").strip() if exc.headers else ""
+                    try:
+                        delay = int(retry_after) if retry_after else 2 ** attempt
+                    except ValueError:
+                        delay = 2 ** attempt
+                    delay = max(1, min(delay, 60))
+                    if attempt < max_attempts:
+                        print(f"Anthropic is rate-limiting login requests (429); retrying in {delay}s...")
+                        time.sleep(delay)
+                except Exception as exc:
+                    last_error = exc
+                    logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
+                    break
+            if result is not None:
                 break
-            except Exception as exc:
-                last_error = exc
-                logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
-                continue
 
         if result is None:
             raise last_error if last_error is not None else ValueError(

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -279,3 +279,175 @@ def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):
     assert "url" not in captured_token, (
         "token exchange must NOT happen when state mismatches"
     )
+
+
+def _http_error(url: str, code: int, retry_after: str | None = None):
+    """Build a real ``urllib.error.HTTPError`` with optional Retry-After."""
+    import io
+    import urllib.error
+    from email.message import Message
+
+    headers = Message()
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    return urllib.error.HTTPError(url, code, "error", headers, io.BytesIO(b""))
+
+
+def _run_login_with_urlopen(monkeypatch, tmp_path, fake_urlopen):
+    """Drive ``run_hermes_oauth_login_pure()`` end-to-end against the given
+    ``urlopen`` stub, echoing the CSRF state back so the guard passes.
+    Returns ``(result, sleeps)`` where ``sleeps`` records ``time.sleep`` calls.
+    """
+    import builtins
+    import time
+    import urllib.request
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_url: Dict[str, str] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="placeholder",
+        capture_auth_url=captured_url,
+    )
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    sleeps: list = []
+    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url.get("url", "")).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    return run_hermes_oauth_login_pure(), sleeps
+
+
+def test_login_token_exchange_retries_on_429(monkeypatch, tmp_path):
+    """A transient HTTP 429 from the token endpoint must be retried (honoring
+    ``Retry-After``) instead of failing the exchange outright.
+
+    The authorization code the user pasted is single-use: if the exchange
+    gives up on a transient rate limit, the code is burned and the user has
+    to redo the whole browser round-trip. The Codex device-code login already
+    retries 429s with capped backoff; the Anthropic login path must match.
+    """
+    attempts: list = []
+
+    def fake_urlopen(req, *_a, **_kw):
+        attempts.append(req.full_url)
+        if len(attempts) == 1:
+            raise _http_error(req.full_url, 429, retry_after="3")
+        body = json.dumps(
+            {
+                "access_token": "sk-ant-test-access",
+                "refresh_token": "sk-ant-test-refresh",
+                "expires_in": 3600,
+            }
+        ).encode()
+
+        class _FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def read(self):
+                return body
+
+        return _FakeResponse()
+
+    result, sleeps = _run_login_with_urlopen(monkeypatch, tmp_path, fake_urlopen)
+
+    assert result is not None, "a single transient 429 must not fail the login"
+    assert attempts == [
+        "https://platform.claude.com/v1/oauth/token",
+        "https://platform.claude.com/v1/oauth/token",
+    ], "the 429'd endpoint must be retried, not skipped to the fallback host"
+    assert sleeps == [3], "backoff must honor the server's Retry-After header"
+
+
+def test_login_429_exhausts_retries_then_falls_back(monkeypatch, tmp_path):
+    """Persistent 429s at the primary host must exhaust the capped retry
+    budget and then fall through to the legacy console host — preserving the
+    endpoint-fallback semantics the host list was introduced for.
+    """
+    attempts: list = []
+
+    def fake_urlopen(req, *_a, **_kw):
+        attempts.append(req.full_url)
+        if req.full_url.startswith("https://platform.claude.com"):
+            raise _http_error(req.full_url, 429)
+        body = json.dumps(
+            {
+                "access_token": "sk-ant-test-access",
+                "refresh_token": "sk-ant-test-refresh",
+                "expires_in": 3600,
+            }
+        ).encode()
+
+        class _FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def read(self):
+                return body
+
+        return _FakeResponse()
+
+    result, sleeps = _run_login_with_urlopen(monkeypatch, tmp_path, fake_urlopen)
+
+    assert result is not None, "login should still succeed via the console fallback"
+    assert attempts == ["https://platform.claude.com/v1/oauth/token"] * 4 + [
+        "https://console.anthropic.com/v1/oauth/token"
+    ], "4 capped attempts at the primary host, then the fallback host"
+    # Exponential backoff 2^1..2^3; no sleep after the final failed attempt.
+    assert sleeps == [2, 4, 8]
+
+
+def test_login_non_429_http_error_is_not_retried(monkeypatch, tmp_path):
+    """Non-429 HTTP errors (e.g. the 404 from the dead console host) must NOT
+    be retried — they fail fast to the next endpoint exactly as before.
+    """
+    attempts: list = []
+
+    def fake_urlopen(req, *_a, **_kw):
+        attempts.append(req.full_url)
+        if req.full_url.startswith("https://platform.claude.com"):
+            raise _http_error(req.full_url, 404)
+        body = json.dumps(
+            {
+                "access_token": "sk-ant-test-access",
+                "refresh_token": "sk-ant-test-refresh",
+                "expires_in": 3600,
+            }
+        ).encode()
+
+        class _FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def read(self):
+                return body
+
+        return _FakeResponse()
+
+    result, sleeps = _run_login_with_urlopen(monkeypatch, tmp_path, fake_urlopen)
+
+    assert result is not None, "login should succeed via the console fallback"
+    assert attempts == [
+        "https://platform.claude.com/v1/oauth/token",
+        "https://console.anthropic.com/v1/oauth/token",
+    ], "a non-429 HTTP error must move straight to the next host, no retries"
+    assert sleeps == [], "no backoff sleeps for non-429 errors"


### PR DESCRIPTION
## What does this PR do?

Retries the Anthropic OAuth login token exchange on transient HTTP 429 with capped backoff (honoring `Retry-After`, max 4 attempts per endpoint), instead of failing the flow and burning the user's **single-use** authorization code.

Today, `run_hermes_oauth_login_pure()` treats a 429 from the token endpoint like any other error: it falls through to the legacy `console.anthropic.com` host (which 404s) and gives up with `Token exchange failed: HTTP Error 429: Too Many Requests`. Since the pasted authorization code is single-use, the user must redo the whole browser round-trip — from the same IP that was just rate-limited, so the retry usually 429s again. This can lock users out of Anthropic subscription login for an extended period.

The fix mirrors the 429 handling that already exists in the Codex device-code login (`_codex_device_code_login()` in `hermes_cli/auth.py`): retry in place with exponential backoff (`2^attempt`, honoring `Retry-After` when present, delay clamped to [1, 60]s, 4 attempts), then fall through to the next host in `_OAUTH_TOKEN_URLS`. Non-429 errors keep the exact existing fail-fast-to-next-endpoint semantics — verified by a dedicated test.

## Related Issue

Fixes #58013

Related: #12905 / #6475 (broader Anthropic OAuth/subscription pain), PR #46535 (same class of fix on the token **refresh** path in cron; this PR covers the login **exchange** path).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` — wrap the per-endpoint `urlopen` in a bounded retry loop: 429 → backoff and retry (honoring `Retry-After`); any other `HTTPError`/exception → log and move to the next endpoint exactly as before; success → break out of both loops.
- `tests/agent/test_anthropic_oauth_pkce.py` — three regression tests:
  - `test_login_token_exchange_retries_on_429` — a single 429 with `Retry-After: 3` is retried at the same endpoint (not skipped to the fallback host) and sleeps exactly 3s.
  - `test_login_429_exhausts_retries_then_falls_back` — persistent 429s exhaust 4 attempts (backoff 2s/4s/8s, no sleep after the final attempt) and then fall through to the console host, preserving endpoint-fallback semantics.
  - `test_login_non_429_http_error_is_not_retried` — a 404 still fails fast to the next host with no retries and no sleeps.

## How to Test

1. `pytest tests/agent/test_anthropic_oauth_pkce.py -v` — 7 passed (4 pre-existing + 3 new).
2. Proof the new tests guard the fix: with `agent/anthropic_adapter.py` reverted to `main`, `test_login_token_exchange_retries_on_429` and `test_login_429_exhausts_retries_then_falls_back` fail; `test_login_non_429_http_error_is_not_retried` passes on both (it pins the preserved behavior).
3. Real-world check: this patch has been running on my local v0.18.0 install; a login that previously died on the first 429 completes after the backoff retry.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (closest is #46535, which covers the refresh path, not the login exchange)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the touched area instead: `tests/agent/test_anthropic_oauth_pkce.py`, `tests/agent/test_anthropic_oauth_ua_prefix.py`, `tests/agent/test_anthropic_adapter.py`, `tests/hermes_cli/test_auth_commands.py` (233 passed; 3 pre-existing environment-dependent failures in `TestRunOauthSetupToken` that reproduce identically on pristine `main` — real local credentials leak into the mocks; they pass under the hermetic runner's blanked env). Full suite left to CI.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple Silicon), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavioral fix, comments inline)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib `urllib`/`time` only, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Retry in action (previously an immediate `Token exchange failed`):

```
Anthropic is rate-limiting login requests (429); retrying in 3s...
```

```
$ pytest tests/agent/test_anthropic_oauth_pkce.py -v
...
tests/agent/test_anthropic_oauth_pkce.py::test_authorization_url_state_is_not_pkce_verifier PASSED
tests/agent/test_anthropic_oauth_pkce.py::test_login_token_exchange_uses_platform_claude_host PASSED
tests/agent/test_anthropic_oauth_pkce.py::test_login_token_exchange_falls_back_to_console_host PASSED
tests/agent/test_anthropic_oauth_pkce.py::test_callback_state_mismatch_aborts PASSED
tests/agent/test_anthropic_oauth_pkce.py::test_login_token_exchange_retries_on_429 PASSED
tests/agent/test_anthropic_oauth_pkce.py::test_login_429_exhausts_retries_then_falls_back PASSED
tests/agent/test_anthropic_oauth_pkce.py::test_login_non_429_http_error_is_not_retried PASSED

============================== 7 passed in 2.24s ===============================
```
