### PR TITLE
fix(desktop): sync queued edit save from DOM

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -42,6 +42,7 @@ import { useComposerUrlDialog } from './hooks/use-composer-url-dialog'
 import { useComposerVoice } from './hooks/use-composer-voice'
 import { useSlashCompletions } from './hooks/use-slash-completions'
 import { useSessionStatusPresence } from './hooks/use-status-presence'
+import { saveQueuedEditFromEditor } from './queue-edit-save'
 import { QueuePanel } from './queue-panel'
 import {
   composerPlainText,
@@ -290,6 +291,13 @@ export function ChatBar({
       flushEditorToDraft(editor)
     })
   }
+
+  const handleQueuedEditSave = () =>
+    saveQueuedEditFromEditor({
+      editor: editorRef.current,
+      exitQueuedEdit,
+      flushEditorToDraft
+    })
 
   useEffect(
     () => () => {
@@ -953,7 +961,7 @@ export function ChatBar({
                       </Button>
                       <Button
                         className="h-6 rounded-md px-2 text-[0.68rem]"
-                        onClick={() => exitQueuedEdit('save')}
+                        onClick={handleQueuedEditSave}
                         type="button"
                       >
                         {t.common.save}

--- a/apps/desktop/src/app/chat/composer/queue-edit-save-dom-race.test.tsx
+++ b/apps/desktop/src/app/chat/composer/queue-edit-save-dom-race.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { saveQueuedEditFromEditor } from './queue-edit-save'
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe('queued-edit Save live DOM vs stale draft state (#57945)', () => {
+  it('flushes the visible editor DOM before saving the queued prompt', () => {
+    const editor = document.createElement('div')
+    editor.contentEditable = 'true'
+    editor.textContent = 'visible queued edit'
+    document.body.appendChild(editor)
+
+    let draftRef = 'stale queued edit'
+    const calls: string[] = []
+    const savedTexts: string[] = []
+
+    const flushEditorToDraft = vi.fn((node: HTMLDivElement) => {
+      calls.push('flush')
+      draftRef = node.textContent ?? ''
+    })
+
+    const exitQueuedEdit = vi.fn((action: 'save') => {
+      calls.push(`exit:${action}`)
+      savedTexts.push(draftRef)
+
+      return true
+    })
+
+    const saved = saveQueuedEditFromEditor({ editor, exitQueuedEdit, flushEditorToDraft })
+
+    expect(saved).toBe(true)
+    expect(flushEditorToDraft).toHaveBeenCalledWith(editor)
+    expect(exitQueuedEdit).toHaveBeenCalledWith('save')
+    expect(calls).toEqual(['flush', 'exit:save'])
+    expect(savedTexts).toEqual(['visible queued edit'])
+  })
+
+  it('keeps the existing save fallback when the editor ref is unavailable', () => {
+    let draftRef = 'existing queued edit'
+    const savedTexts: string[] = []
+
+    const flushEditorToDraft = vi.fn((node: HTMLDivElement) => {
+      draftRef = node.textContent ?? ''
+    })
+
+    const exitQueuedEdit = vi.fn((action: 'save') => {
+      savedTexts.push(draftRef)
+
+      return action === 'save'
+    })
+
+    const saved = saveQueuedEditFromEditor({ editor: null, exitQueuedEdit, flushEditorToDraft })
+
+    expect(saved).toBe(true)
+    expect(flushEditorToDraft).not.toHaveBeenCalled()
+    expect(exitQueuedEdit).toHaveBeenCalledWith('save')
+    expect(savedTexts).toEqual(['existing queued edit'])
+  })
+
+  it('uses an empty visible editor to preserve the existing unsaved-empty behavior', () => {
+    const editor = document.createElement('div')
+    editor.contentEditable = 'true'
+    editor.textContent = ''
+    document.body.appendChild(editor)
+
+    let draftRef = 'stale non-empty queued edit'
+
+    const flushEditorToDraft = vi.fn((node: HTMLDivElement) => {
+      draftRef = node.textContent ?? ''
+    })
+
+    const exitQueuedEdit = vi.fn(() => draftRef.trim().length > 0)
+
+    const saved = saveQueuedEditFromEditor({ editor, exitQueuedEdit, flushEditorToDraft })
+
+    expect(saved).toBe(false)
+    expect(flushEditorToDraft).toHaveBeenCalledWith(editor)
+    expect(exitQueuedEdit).toHaveBeenCalledWith('save')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/queue-edit-save.ts
+++ b/apps/desktop/src/app/chat/composer/queue-edit-save.ts
@@ -1,0 +1,17 @@
+interface SaveQueuedEditFromEditorArgs {
+  editor: HTMLDivElement | null
+  exitQueuedEdit: (action: 'save') => boolean
+  flushEditorToDraft: (editor: HTMLDivElement) => void
+}
+
+export function saveQueuedEditFromEditor({
+  editor,
+  exitQueuedEdit,
+  flushEditorToDraft
+}: SaveQueuedEditFromEditorArgs): boolean {
+  if (editor) {
+    flushEditorToDraft(editor)
+  }
+
+  return exitQueuedEdit('save')
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop queued-edit race where clicking the composer Save button could persist stale queued text. The Save button now flushes the live `contentEditable` editor into the existing draft ref before calling `exitQueuedEdit('save')`, matching the already-safe Enter/submit path.

This keeps the change local to queued-edit Save: Cancel remains unchanged, and the existing submit/Enter behavior continues to use its current DOM-sync path.

## Related Issue

Fixes #57945

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`
  - Routes the queued-edit Save button through `handleQueuedEditSave`.
  - The handler calls a small composer helper that flushes `editorRef.current` through the existing `flushEditorToDraft` path before saving.
- `apps/desktop/src/app/chat/composer/queue-edit-save.ts`
  - Adds `saveQueuedEditFromEditor`, a tiny helper shared by production and the focused regression test.
- `apps/desktop/src/app/chat/composer/queue-edit-save-dom-race.test.tsx`
  - Covers the stale DOM-vs-draft Save race, no-editor fallback, and empty visible editor behavior.

## How to Test

1. Queue a prompt in the desktop composer while a turn is running.
2. Edit the queued prompt, type new text, and click Save immediately.
3. Confirm the queued prompt saves the visible editor text instead of an older draft value.

Local verification:

- `npx vitest run --environment jsdom apps/desktop/src/app/chat/composer/queue-edit-save-dom-race.test.tsx` - passed, 1 file / 3 tests.
- `npx vitest run --environment jsdom apps/desktop/src/app/chat/composer/enter-submit-dom-race.test.tsx` - passed, 1 file / 5 tests.
- `npx vitest run --environment jsdom apps/desktop/src/app/chat/composer/queue-edit-save-dom-race.test.tsx apps/desktop/src/app/chat/composer/enter-submit-dom-race.test.tsx` - passed, 2 files / 8 tests.
- `npm run --prefix apps/desktop typecheck` - passed.
- `npm run --prefix apps/desktop lint` - exited 0 with one unrelated existing warning in `apps/desktop/src/app/settings/model-settings.tsx:412`.
- `npm run --prefix apps/desktop build` - passed.
- `npm run --prefix apps/desktop test:ui -- src/app/chat/composer` - 45 passed / 1 unrelated existing failure in `attachments.test.tsx`, which expects `data-testid="composer-attachments"` while the component renders `data-slot="composer-attachments"`.
- `git diff --check` - passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. Not run; this is a desktop frontend-only fix and focused desktop checks were run instead.
- [x] I've added tests for my changes.
- [ ] I've tested on my platform. Not manually smoke-tested in Electron; covered by focused jsdom regression, existing nearby race test, desktop typecheck, and lint.

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A.
- [x] `cli-config.yaml.example` update: N/A.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A.
- [x] Cross-platform impact considered: N/A, this is DOM/ref synchronization in the desktop composer with no platform-specific code.
- [x] Tool descriptions/schemas update: N/A.

## Screenshots / Logs

No screenshot; this is a timing/path fix. The regression is covered by the new jsdom DOM-race test that mutates the visible `contentEditable` editor without an input event and proves Save reads the freshly flushed value.

## Scope / non-goals

- Does not change queued-edit Cancel behavior.
- Does not alter Enter/submit, IME/composition, queue focus, or queue drain behavior beyond preserving the existing proof lane.
- Does not refactor the broader composer or queue store.

## Submission caveats

- Full repository tests were not run.
- Manual Electron smoke testing was not run.
- The broader composer suite currently has one unrelated pre-existing `attachments.test.tsx` selector failure, recorded above.