### PR TITLE
fix: drop duplicate tool results during message repair

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -465,6 +465,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # assistant tool_call_id. Uses a rolling set of known ids refreshed
     # on each assistant message.
     known_tool_ids: set = set()
+    seen_tool_ids: set = set()
     filtered: List[Dict] = []
     for msg in collapsed:
         if not isinstance(msg, dict):
@@ -473,6 +474,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         role = msg.get("role")
         if role == "assistant":
             known_tool_ids = set()
+            seen_tool_ids = set()
             for tc in (msg.get("tool_calls") or []):
                 tc_id = tc.get("id") if isinstance(tc, dict) else None
                 if tc_id:
@@ -480,8 +482,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             filtered.append(msg)
         elif role == "tool":
             tc_id = msg.get("tool_call_id")
-            if tc_id and tc_id in known_tool_ids:
+            if tc_id and tc_id in known_tool_ids and tc_id not in seen_tool_ids:
                 filtered.append(msg)
+                seen_tool_ids.add(tc_id)
             else:
                 repairs += 1
         else:
@@ -490,6 +493,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 # tool messages without a fresh assistant tool_call
                 # are orphans.
                 known_tool_ids = set()
+                seen_tool_ids = set()
             filtered.append(msg)
 
     # Pass 2: merge consecutive user messages. Preserves all user input

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -162,6 +162,31 @@ def test_repair_leaves_valid_conversation_unchanged():
     assert messages == original
 
 
+def test_repair_drops_duplicate_tool_result_for_same_call_id():
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "read_file", "arguments": '{"path":"a"}'}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "A"},
+        {"role": "tool", "tool_call_id": "t1", "content": "A retry duplicate"},
+        {"role": "assistant", "content": "A"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    assert messages == [
+        {"role": "user", "content": "inspect"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "t1", "type": "function",
+                         "function": {"name": "read_file", "arguments": '{"path":"a"}'}}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "A"},
+        {"role": "assistant", "content": "A"},
+    ]
+
+
 def test_repair_preserves_multimodal_user_content():
     """Multimodal (list) content must NOT be merged — risks mangling attachments."""
     agent = _bare_agent()


### PR DESCRIPTION
## Summary
- drop repeated `tool` messages for the same live `tool_call_id` during message-sequence repair
- preserve distinct tool results from parallel tool calls
- add a focused regression test for duplicate tool results

## Tests
- `scripts/run_tests.sh tests/run_agent/test_message_sequence_repair.py`

## Notes
This is intentionally narrower than the earlier local branch: upstream already covers the parallel-tool-result preservation path, so this PR only keeps the remaining duplicate-result guard.