### PR TITLE
fix: preserve a user anchor in api histories

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -906,6 +906,7 @@ def run_conversation(
             api_messages,
             drop_codex_reasoning_items=agent.api_mode != "codex_responses",
         )
+        agent._ensure_user_anchor(api_messages)
 
         # Normalize message whitespace and tool-call JSON for consistent
         # prefix matching.  Ensures bit-perfect prefixes across turns,

--- a/run_agent.py
+++ b/run_agent.py
@@ -5200,10 +5200,43 @@ class AIAgent:
         """Return True when the base URL targets Qwen Portal."""
         return base_url_host_matches(self._base_url_lower, "portal.qwen.ai")
 
+    @staticmethod
+    def _ensure_user_anchor(messages: list) -> None:
+        """Ensure API payloads still contain at least one user-role message.
+
+        Long-context truncation or host-fed histories can leave an API copy
+        with only system, assistant, and tool messages. Some chat-template
+        backends reject that shape because there is no user query left. Add a
+        minimal user anchor to the API copy only; normal histories are a no-op.
+        """
+        if not messages:
+            return
+        if any(isinstance(m, dict) and m.get("role") == "user" for m in messages):
+            return
+        anchor = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "(Earlier user message was truncated from long context. "
+                        "Continue the current task.)"
+                    ),
+                }
+            ],
+        }
+        insert_at = 0
+        for i, message in enumerate(messages):
+            if isinstance(message, dict) and message.get("role") == "system":
+                insert_at = i + 1
+                break
+        messages.insert(insert_at, anchor)
+
     def _qwen_prepare_chat_messages(self, api_messages: list) -> list:
         prepared = copy.deepcopy(api_messages)
         if not prepared:
             return prepared
+        self._ensure_user_anchor(prepared)
 
         for msg in prepared:
             if not isinstance(msg, dict):
@@ -5237,6 +5270,7 @@ class AIAgent:
         """In-place variant — mutates an already-copied message list."""
         if not messages:
             return
+        self._ensure_user_anchor(messages)
 
         for msg in messages:
             if not isinstance(msg, dict):

--- a/tests/agent/test_user_anchor_guard.py
+++ b/tests/agent/test_user_anchor_guard.py
@@ -1,0 +1,59 @@
+from run_agent import AIAgent
+
+
+def _roles(messages):
+    return [message["role"] for message in messages]
+
+
+def test_injects_user_after_system_when_absent():
+    messages = [
+        {"role": "system", "content": "S"},
+        {"role": "assistant", "content": "A"},
+        {"role": "tool", "content": "T"},
+    ]
+
+    AIAgent._ensure_user_anchor(messages)
+
+    assert _roles(messages)[:2] == ["system", "user"]
+
+
+def test_noop_when_user_already_present():
+    messages = [
+        {"role": "system", "content": "S"},
+        {"role": "user", "content": "U"},
+        {"role": "assistant", "content": "A"},
+    ]
+    before = [dict(message) for message in messages]
+
+    AIAgent._ensure_user_anchor(messages)
+
+    assert messages == before
+
+
+def test_injects_at_head_when_no_system():
+    messages = [
+        {"role": "assistant", "content": "A"},
+        {"role": "tool", "content": "T"},
+    ]
+
+    AIAgent._ensure_user_anchor(messages)
+
+    assert _roles(messages)[0] == "user"
+
+
+def test_empty_list_is_noop():
+    messages = []
+
+    AIAgent._ensure_user_anchor(messages)
+
+    assert messages == []
+
+
+def test_anchor_content_is_normalized_parts():
+    messages = [{"role": "tool", "content": "T"}]
+
+    AIAgent._ensure_user_anchor(messages)
+
+    user = next(message for message in messages if message["role"] == "user")
+    assert isinstance(user["content"], list)
+    assert user["content"][0]["type"] == "text"


### PR DESCRIPTION
## Summary
- ensure API payload copies still contain a `user` role after long-context truncation or host-fed history shaping
- insert the anchor after the system message when possible
- cover the helper with focused unit tests

## Tests
- `scripts/run_tests.sh tests/agent/test_user_anchor_guard.py`
- `scripts/run_tests.sh tests/run_agent/test_1630_context_overflow_loop.py tests/run_agent/test_infinite_compaction_loop.py`
- `uv run --extra dev python -m py_compile run_agent.py agent/conversation_loop.py`

## Notes
The anchor is added to the per-call API copy only. Histories that already contain a user message are unchanged.