### PR TITLE
fix(dashboard): bound graceful shutdown

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -331,6 +331,11 @@ _DASHBOARD_EMBEDDED_CHAT_ENABLED = True
 # overhead.
 _DESKTOP_ATTACHMENT_WS_MAX_BYTES = 384 * 1024 * 1024
 
+# Upper bound on uvicorn's graceful shutdown for the dashboard. Long enough for
+# in-flight HTTP requests to drain, short enough that SIGTERM is honoured well
+# inside systemd's default 90s TimeoutStopSec and Docker's 10s SIGKILL window.
+_DASHBOARD_GRACEFUL_SHUTDOWN_SECONDS = 5
+
 # Simple rate limiter for the reveal endpoint
 _reveal_timestamps: List[float] = []
 _REVEAL_MAX_PER_WINDOW = 5
@@ -17212,6 +17217,11 @@ def start_server(
         ws_ping_interval=None if _is_loopback else 20.0,
         ws_ping_timeout=None if _is_loopback else 20.0,
         ws_max_size=_DESKTOP_ATTACHMENT_WS_MAX_BYTES,
+        # uvicorn defaults this to None — an unbounded graceful wait. A single
+        # still-open WebSocket (idle browser tab, half-open tunnel) then holds
+        # the process through SIGTERM until the supervisor's own kill timer
+        # fires, which reads as a hung dashboard to systemd/Docker (#58005).
+        timeout_graceful_shutdown=_DASHBOARD_GRACEFUL_SHUTDOWN_SECONDS,
     )
     server = uvicorn.Server(config)
 

--- a/tests/hermes_cli/test_dashboard_shutdown_bound.py
+++ b/tests/hermes_cli/test_dashboard_shutdown_bound.py
@@ -1,0 +1,43 @@
+"""The dashboard must bound uvicorn's graceful shutdown (#58005).
+
+uvicorn defaults ``timeout_graceful_shutdown`` to ``None``, which waits
+forever. A single still-open WebSocket then holds the process through SIGTERM
+until the supervisor's kill timer fires, which looks like a hung dashboard to
+systemd/Docker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _StopBeforeServing(Exception):
+    """Abort start_server once the uvicorn config has been captured."""
+
+
+def test_start_server_bounds_graceful_shutdown(monkeypatch):
+    import uvicorn
+
+    from hermes_cli import web_server
+
+    captured = {}
+    real_config = uvicorn.Config
+
+    def _capture_config(*args, **kwargs):
+        captured.update(kwargs)
+        # Build the real object so any downstream attribute access stays honest,
+        # then stop before a socket is ever bound.
+        real_config(*args, **kwargs)
+        raise _StopBeforeServing
+
+    monkeypatch.setattr(uvicorn, "Config", _capture_config)
+
+    with pytest.raises(_StopBeforeServing):
+        web_server.start_server(host="127.0.0.1", port=0, open_browser=False, headless=True)
+
+    timeout = captured.get("timeout_graceful_shutdown")
+    assert timeout is not None, (
+        "uvicorn.Config was built without timeout_graceful_shutdown; "
+        "the dashboard would wait forever on SIGTERM"
+    )
+    assert 0 < timeout <= 30, f"graceful shutdown bound is not sane: {timeout!r}"


### PR DESCRIPTION
## What does this PR do?

**Rewritten and rebased on current `main`.** Part of the original patch is now redundant, so this PR is reduced to the defect that is still real.

`hermes dashboard` builds its `uvicorn.Config` without `timeout_graceful_shutdown`, and uvicorn defaults that to `None` — an unbounded graceful wait. A single still-open WebSocket (an idle browser tab, a half-open reverse-proxy or SSH tunnel) holds the process through SIGTERM until the supervisor's own kill timer fires. To systemd or Docker that looks like a hung dashboard.

What changed since this PR was opened:

- `ws_ping_interval` / `ws_ping_timeout` config keys — **no longer needed.** `main` now implements exactly that policy directly (`hermes_cli/web_server.py`): the protocol ping is disabled on loopback, where it kills recoverable stalls without adding liveness value, and set to 20/20 on public binds, where half-open sockets are a real failure mode. Re-exposing it as config would reopen a decision `main` made deliberately, with a documented rationale.
- **The unbounded graceful shutdown is still there** — `timeout_graceful_shutdown` appears nowhere in the tree.

This version drops the four new config keys and the custom SIGTERM/`os._exit` escalation in favour of uvicorn's own supported bound. That keeps the fix inside the machinery uvicorn already provides, adds no config surface, and avoids `os._exit`, which would skip cleanup the graceful path performs.

Five seconds drains in-flight requests while staying well inside systemd's default 90s `TimeoutStopSec` and Docker's 10s SIGKILL window. If maintainers would rather have this operator-tunable, a config key is a small follow-up — I left it as a constant because `main`'s neighbouring ws-ping policy is a constant for the same reasons.

## Related Issue

Fixes #58005

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/web_server.py` — add `_DASHBOARD_GRACEFUL_SHUTDOWN_SECONDS = 5` and pass it as `timeout_graceful_shutdown` on the dashboard's `uvicorn.Config`.
- `tests/hermes_cli/test_dashboard_shutdown_bound.py` — regression test driving the real `start_server()` path.

Production diff is 10 lines.

## How to Test

The test captures the `uvicorn.Config` that `start_server()` actually builds, then aborts before a socket is bound.

1. On unmodified `main` it fails for the right reason:

```
>       assert timeout is not None, (
            "the dashboard would wait forever on SIGTERM"
E       AssertionError: uvicorn.Config was built without timeout_graceful_shutdown; the dashboard would wait forever on SIGTERM
E       assert None is not None
tests/hermes_cli/test_dashboard_shutdown_bound.py:39: AssertionError
============================== 1 failed in 0.51s ===============================
```

2. With the fix:

```
scripts/run_tests.sh tests/hermes_cli/test_dashboard_shutdown_bound.py
=== Summary: 1 files, 1 tests passed, 0 failed (100% complete) in 1.0s (16 workers) ===
```

3. Surrounding dashboard and web-server suites, all green:

```
scripts/run_tests.sh tests/test_web_server.py tests/hermes_cli/test_dashboard_lifecycle_flags.py \
  tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_dashboard_web_dist_validation.py \
  tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_shutdown_bound.py

=== Summary: 6 files, 37 tests passed, 0 failed (100% complete) in 4.6s (16 workers) ===
```

Blast radius: the only production caller of `start_server()` is `hermes_cli/main.py:10360`. The change adds one keyword to a config object and alters no other behaviour. ruff is clean.

Honest limit: the bound is verified at the `uvicorn.Config` boundary, not by sending a real SIGTERM to a live dashboard holding an open WebSocket. uvicorn owns the enforcement of `timeout_graceful_shutdown`; this PR only stops passing `None` into it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.13.13, uvicorn 0.41.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing surface change
- [x] I've updated `cli-config.yaml.example` — N/A, this version adds no config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the change is a uvicorn config value, shared by the POSIX and Windows serve paths
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Included inline under **How to Test** above.
