### PR TITLE
fix(computer-use): prefer X11 active window when z_index ties

### DIFF
--- a/tests/tools/test_computer_use_cua_backend_linux.py
+++ b/tests/tools/test_computer_use_cua_backend_linux.py
@@ -1,0 +1,153 @@
+"""Regression tests for Linux/X11 capture target selection (#58026)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+# Tied z_index=0 fixture from #58026 (ding ahead of real terminals).
+ISSUE_58026_WINDOWS = [
+    {
+        "app_name": "ding",
+        "pid": 4294,
+        "window_id": 33554439,
+        "title": "Desktop Icons 1",
+        "is_on_screen": True,
+        "z_index": 0,
+    },
+    {
+        "app_name": "",
+        "pid": 1816017,
+        "window_id": 60817412,
+        "title": "zcode",
+        "is_on_screen": True,
+        "z_index": 0,
+    },
+    {
+        "app_name": "",
+        "pid": 1877178,
+        "window_id": 84043449,
+        "title": "xr@10:~/hermes",
+        "is_on_screen": True,
+        "z_index": 0,
+    },
+    {
+        "app_name": "",
+        "pid": 1877178,
+        "window_id": 84065715,
+        "title": "HERMES-CU",
+        "is_on_screen": True,
+        "z_index": 0,
+    },
+]
+
+
+def _normalized_windows(raw=ISSUE_58026_WINDOWS):
+    from tools.computer_use.cua_backend import _ingest_windows
+
+    return _ingest_windows(raw)
+
+
+def test_parse_xprop_net_active_window_standard_output():
+    from tools.computer_use.cua_backend import _parse_xprop_net_active_window
+
+    raw = "_NET_ACTIVE_WINDOW(WINDOW): window id # 0x503000b\n"
+    assert _parse_xprop_net_active_window(raw) == 0x503000b
+
+
+def test_parse_xprop_net_active_window_bare_hex_fallback():
+    from tools.computer_use.cua_backend import _parse_xprop_net_active_window
+
+    assert _parse_xprop_net_active_window("active=0xABcdef01") == 0xABCDEF01
+
+
+def test_parse_xprop_net_active_window_rejects_unparseable():
+    from tools.computer_use.cua_backend import _parse_xprop_net_active_window
+
+    assert _parse_xprop_net_active_window("") is None
+    assert _parse_xprop_net_active_window("_NET_ACTIVE_WINDOW(WINDOW): none") is None
+    assert _parse_xprop_net_active_window("window id # not-a-hex") is None
+
+
+def test_default_capture_prefers_x11_active_window_when_z_index_tied():
+    from tools.computer_use.cua_backend import _select_capture_target
+
+    windows = _normalized_windows()
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "linux"), patch(
+        "tools.computer_use.cua_backend._linux_x11_active_window_id",
+        return_value=84043449,
+    ):
+        target = _select_capture_target(windows, app_requested=False)
+
+    assert target["title"] == "xr@10:~/hermes"
+    assert target["window_id"] == 84043449
+
+
+def test_default_capture_falls_back_to_list_order_when_active_window_unknown():
+    from tools.computer_use.cua_backend import _select_capture_target
+
+    windows = _normalized_windows()
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "linux"), patch(
+        "tools.computer_use.cua_backend._linux_x11_active_window_id",
+        return_value=None,
+    ):
+        target = _select_capture_target(windows, app_requested=False)
+
+    # Without informative z-order or active-window, keep list order (caller
+    # sorts higher-z frontmost; here all tied so first on-screen wins).
+    assert target["window_id"] == 33554439
+    assert target["title"] == "Desktop Icons 1"
+
+
+def test_default_capture_keeps_higher_z_index_when_ordering_informative():
+    """Active-window fallback must not override a real frontmost z_index."""
+    from tools.computer_use.cua_backend import _select_capture_target
+
+    windows = _normalized_windows(
+        [
+            {
+                "app_name": "",
+                "pid": 1,
+                "window_id": 10,
+                "title": "back",
+                "is_on_screen": True,
+                "z_index": 1,
+            },
+            {
+                "app_name": "",
+                "pid": 2,
+                "window_id": 20,
+                "title": "front",
+                "is_on_screen": True,
+                "z_index": 5,
+            },
+        ]
+    )
+    # Mirror _load_windows: higher z_index is frontmost.
+    windows.sort(key=lambda w: w["z_index"], reverse=True)
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "linux"), patch(
+        "tools.computer_use.cua_backend._linux_x11_active_window_id",
+        return_value=10,
+    ) as active:
+        target = _select_capture_target(windows, app_requested=False)
+
+    assert target["window_id"] == 20
+    assert target["title"] == "front"
+    active.assert_not_called()
+
+
+def test_explicit_app_capture_skips_active_window_fallback():
+    from tools.computer_use.cua_backend import _select_capture_target
+
+    windows = _normalized_windows()
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "linux"), patch(
+        "tools.computer_use.cua_backend._linux_x11_active_window_id",
+        return_value=84043449,
+    ) as active:
+        target = _select_capture_target(windows, app_requested=True)
+
+    assert target["window_id"] == 33554439
+    active.assert_not_called()

--- a/tests/tools/test_computer_use_cua_backend_linux.py
+++ b/tests/tools/test_computer_use_cua_backend_linux.py
@@ -151,3 +151,48 @@ def test_explicit_app_capture_skips_active_window_fallback():
 
     assert target["window_id"] == 33554439
     active.assert_not_called()
+
+
+def test_exact_target_selection_skips_active_window_fallback():
+    from tools.computer_use.cua_backend import _select_capture_target
+
+    windows = _normalized_windows()[:1]
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "linux"), patch(
+        "tools.computer_use.cua_backend._linux_x11_active_window_id",
+        return_value=84043449,
+    ) as active:
+        target = _select_capture_target(
+            windows, app_requested=False, exact_target=True
+        )
+
+    assert target["window_id"] == 33554439
+    active.assert_not_called()
+
+
+def test_exact_pid_window_capture_does_not_probe_x11_active_window():
+    """capture_after / exact pid+window_id must not pay for an xprop probe."""
+    from unittest.mock import MagicMock
+
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend()
+    session = MagicMock()
+    session.call_tool.return_value = {
+        "data": "✅ Chrome — 0 elements",
+        "images": [],
+        "structuredContent": {"elements": []},
+        "isError": False,
+    }
+    backend._session = session
+
+    with patch("tools.computer_use.cua_backend.sys.platform", "linux"), patch(
+        "tools.computer_use.cua_backend._linux_x11_active_window_id",
+        return_value=999,
+    ) as active:
+        backend.capture(mode="ax", pid=1816017, window_id=60817412)
+
+    assert backend._active_pid == 1816017
+    assert backend._active_window_id == 60817412
+    active.assert_not_called()
+    assert all(c.args[0] != "list_windows" for c in session.call_tool.call_args_list)

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -205,6 +205,78 @@ def cua_driver_child_env(base_env: Optional[Dict[str, str]] = None) -> Dict[str,
     return env
 
 
+def _z_index_uninformative(windows: List[Dict[str, Any]]) -> bool:
+    """True when every window shares the same z_index (common on Linux/X11)."""
+    if not windows:
+        return True
+    return len({w.get("z_index", 0) for w in windows}) <= 1
+
+
+def _parse_xprop_net_active_window(stdout: str) -> Optional[int]:
+    """Parse ``xprop -root _NET_ACTIVE_WINDOW`` stdout into a window id.
+
+    Accepts the common ``window id # 0x...`` form and falls back to the first
+    hex token. Returns None for empty/unparseable output.
+    """
+    text = stdout or ""
+    match = re.search(r"window id # (0x[0-9a-fA-F]+)", text)
+    if not match:
+        match = re.search(r"(0x[0-9a-fA-F]+)", text)
+    if not match:
+        return None
+    try:
+        return int(match.group(1), 16)
+    except ValueError:
+        return None
+
+
+def _linux_x11_active_window_id() -> Optional[int]:
+    """Best-effort read of ``_NET_ACTIVE_WINDOW`` via xprop. Never raises."""
+    if sys.platform != "linux" or not os.environ.get("DISPLAY"):
+        return None
+    try:
+        proc = subprocess.run(
+            ["xprop", "-root", "_NET_ACTIVE_WINDOW"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return _parse_xprop_net_active_window(proc.stdout or "")
+
+
+def _select_capture_target(
+    windows: List[Dict[str, Any]], *, app_requested: bool
+) -> Dict[str, Any]:
+    """Select the best window for capture from normalized list_windows output.
+
+    Callers pass windows already sorted by ``z_index`` descending (higher =
+    frontmost). When ordering is informative, keep that frontmost contract.
+    On Linux/X11, when every on-screen candidate shares the same ``z_index``
+    (tied or unknown), prefer ``_NET_ACTIVE_WINDOW`` over list order (#58026).
+    """
+    candidates = [w for w in windows if not w["off_screen"]]
+    pool = candidates
+    if (
+        not app_requested
+        and pool
+        and sys.platform == "linux"
+        and _z_index_uninformative(pool)
+    ):
+        active_id = _linux_x11_active_window_id()
+        if active_id is not None:
+            for w in pool:
+                if w.get("window_id") == active_id:
+                    return w
+    if pool:
+        return pool[0]
+    return windows[0]
+
+
 def _resolve_mcp_invocation(
     driver_cmd: str,
     *,
@@ -1631,7 +1703,9 @@ class CuaDriverBackend(ComputerUseBackend):
             windows = filtered
 
         # Pick first on-screen window (sorted by z_index / z-order above).
-        target = next((w for w in windows if not w["off_screen"]), windows[0])
+        # On Linux/X11, tied/unknown z_index may additionally consult
+        # _NET_ACTIVE_WINDOW (#58026).
+        target = _select_capture_target(windows, app_requested=bool(app))
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
         # Tokens belong to the prior window snapshot. Disarm them before any

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -250,19 +250,25 @@ def _linux_x11_active_window_id() -> Optional[int]:
 
 
 def _select_capture_target(
-    windows: List[Dict[str, Any]], *, app_requested: bool
+    windows: List[Dict[str, Any]],
+    *,
+    app_requested: bool,
+    exact_target: bool = False,
 ) -> Dict[str, Any]:
     """Select the best window for capture from normalized list_windows output.
 
     Callers pass windows already sorted by ``z_index`` descending (higher =
     frontmost). When ordering is informative, keep that frontmost contract.
-    On Linux/X11, when every on-screen candidate shares the same ``z_index``
-    (tied or unknown), prefer ``_NET_ACTIVE_WINDOW`` over list order (#58026).
+    On Linux/X11, for unqualified default captures only (no app filter and no
+    exact pid/window_id), when every on-screen candidate shares the same
+    ``z_index`` (tied or unknown), prefer ``_NET_ACTIVE_WINDOW`` over list
+    order (#58026). Exact-target captures must not pay for an ``xprop`` probe.
     """
     candidates = [w for w in windows if not w["off_screen"]]
     pool = candidates
     if (
-        not app_requested
+        not exact_target
+        and not app_requested
         and pool
         and sys.platform == "linux"
         and _z_index_uninformative(pool)
@@ -1703,9 +1709,13 @@ class CuaDriverBackend(ComputerUseBackend):
             windows = filtered
 
         # Pick first on-screen window (sorted by z_index / z-order above).
-        # On Linux/X11, tied/unknown z_index may additionally consult
-        # _NET_ACTIVE_WINDOW (#58026).
-        target = _select_capture_target(windows, app_requested=bool(app))
+        # On Linux/X11, unqualified default captures with tied/unknown z_index
+        # may additionally consult _NET_ACTIVE_WINDOW (#58026).
+        target = _select_capture_target(
+            windows,
+            app_requested=bool(app),
+            exact_target=pid is not None or window_id is not None,
+        )
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
         # Tokens belong to the prior window snapshot. Disarm them before any


### PR DESCRIPTION
## Summary
- Narrow #58026 salvage: when Linux/X11 `z_index` is tied/unknown, prefer `_NET_ACTIVE_WINDOW` via `xprop`
- Preserve main's higher-`z_index`-is-frontmost contract — active-window fallback does **not** override informative stacking order
- Extract `_parse_xprop_net_active_window` and cover the parse boundary directly

Complementary to #54173 (null `is_on_screen`, nameless title match, GNOME helper skip). This PR is intentionally rebased on current `main` with only the active-window piece so it stays independently mergeable / attribution-clean; after #54173 lands the two `_select_capture_target` helpers should be folded together.

Fixes #58026

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_computer_use_cua_backend_linux.py -q`
- [x] `scripts/run_tests.sh tests/tools/test_computer_use_cua_backend_linux.py tests/tools/test_computer_use.py -q`


## Infographic

![linux-x11-active-window-capture](https://v3b.fal.media/files/b/0aa35bd3/ncO1s_DiigYWkWyr8LhIT_JC8jlEW6.png)
