### PR TITLE
fix(dashboard): guard managed file mutations

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1596,6 +1596,21 @@ def _reject_managed_protected_write(target: Path) -> None:
         raise HTTPException(status_code=403, detail="Access to protected files is not allowed")
 
 
+def _reject_managed_protected_tree(target: Path) -> None:
+    """Block recursive mutations when any descendant is protected."""
+    _reject_managed_protected_write(target)
+    if not target.is_dir():
+        return
+
+    try:
+        for child in target.rglob("*"):
+            _reject_managed_protected_write(child)
+    except HTTPException:
+        raise
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Could not inspect path: {exc}")
+
+
 def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, Any]:
     try:
         resolved = target.resolve()
@@ -1878,6 +1893,7 @@ async def delete_managed_file(payload: ManagedFileDelete, request: Request):
     try:
         if target.is_dir():
             if payload.recursive:
+                _reject_managed_protected_tree(target)
                 shutil.rmtree(target)
             else:
                 target.rmdir()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1582,6 +1582,20 @@ def _managed_response_meta(policy: ManagedFilesPolicy) -> Dict[str, Any]:
     }
 
 
+def _reject_managed_protected_write(target: Path) -> None:
+    """Block dashboard managed-file mutations of credential/protected paths."""
+    if _is_sensitive_filename(target.name):
+        raise HTTPException(status_code=403, detail="Access to protected files is not allowed")
+
+    try:
+        from agent.file_safety import is_write_denied
+    except Exception:
+        is_write_denied = None
+
+    if is_write_denied is not None and is_write_denied(str(target)):
+        raise HTTPException(status_code=403, detail="Access to protected files is not allowed")
+
+
 def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, Any]:
     try:
         resolved = target.resolve()
@@ -1730,6 +1744,7 @@ async def download_managed_file(request: Request, path: str):
 @app.post("/api/files/upload")
 async def upload_managed_file(payload: ManagedFileUpload, request: Request):
     policy, target, display_path = _resolve_managed_path(payload.path, request, for_write=True)
+    _reject_managed_protected_write(target)
     if target.exists() and target.is_dir():
         raise HTTPException(status_code=409, detail="A directory already exists at that path")
     if target.exists() and not payload.overwrite:
@@ -1770,6 +1785,7 @@ async def upload_managed_file_stream(
     overwrite: bool = Form(True),
 ):
     policy, target, display_path = _resolve_managed_path(path, request, for_write=True)
+    _reject_managed_protected_write(target)
     if target.exists() and target.is_dir():
         raise HTTPException(status_code=409, detail="A directory already exists at that path")
     if target.exists() and not overwrite:
@@ -1829,6 +1845,7 @@ async def upload_managed_file_stream(
 @app.post("/api/files/mkdir")
 async def create_managed_directory(payload: ManagedDirectoryCreate, request: Request):
     policy, target, display_path = _resolve_managed_path(payload.path, request, for_write=True)
+    _reject_managed_protected_write(target)
     if target.exists() and not target.is_dir():
         raise HTTPException(status_code=409, detail="A file already exists at that path")
 
@@ -1854,6 +1871,7 @@ async def delete_managed_file(payload: ManagedFileDelete, request: Request):
         raise HTTPException(status_code=400, detail="Cannot delete the managed files root")
     if target.parent == target:
         raise HTTPException(status_code=400, detail="Cannot delete the filesystem root")
+    _reject_managed_protected_write(target)
     if not target.exists():
         raise HTTPException(status_code=404, detail="Path not found")
 

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -312,6 +312,26 @@ def test_delete_blocks_protected_env_file(forced_files_client):
     assert env_file.read_text() == "SECRET=1"
 
 
+def test_recursive_delete_blocks_directory_containing_protected_env_file(forced_files_client):
+    client, root = forced_files_client
+    project = root / "project"
+    env_file = project / ".env"
+    safe_file = project / "notes.txt"
+    project.mkdir(parents=True)
+    env_file.write_text("SECRET=1")
+    safe_file.write_text("safe")
+
+    blocked = client.request(
+        "DELETE",
+        "/api/files",
+        json={"path": str(project), "recursive": True},
+    )
+
+    assert blocked.status_code == 403
+    assert env_file.read_text() == "SECRET=1"
+    assert safe_file.read_text() == "safe"
+
+
 def _seed_file(client, root, name="out/hello.txt"):
     file_path = root / name
     created = client.post(

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -254,6 +254,64 @@ def test_local_mode_upload_read_mkdir_delete_roundtrip(local_files_client):
     assert not folder.exists()
 
 
+def test_upload_blocks_protected_env_file(forced_files_client):
+    client, root = forced_files_client
+    env_file = root / ".env"
+
+    blocked = client.post(
+        "/api/files/upload",
+        json={
+            "path": str(env_file),
+            "data_url": "data:text/plain;base64,U0VDUkVUPTE=",
+        },
+    )
+
+    assert blocked.status_code == 403
+    assert not env_file.exists()
+
+
+def test_stream_upload_blocks_protected_env_file(forced_files_client):
+    client, root = forced_files_client
+    env_file = root / ".env.local"
+
+    blocked = client.post(
+        "/api/files/upload-stream",
+        data={"path": str(env_file), "overwrite": "true"},
+        files={"file": (".env.local", b"SECRET=1", "text/plain")},
+    )
+
+    assert blocked.status_code == 403
+    assert not env_file.exists()
+
+
+def test_mkdir_blocks_protected_mcp_tokens_directory(local_files_client, monkeypatch):
+    client, home = local_files_client
+    hermes_home = home / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    token_dir = hermes_home / "mcp-tokens"
+
+    blocked = client.post("/api/files/mkdir", json={"path": str(token_dir)})
+
+    assert blocked.status_code == 403
+    assert not token_dir.exists()
+
+
+def test_delete_blocks_protected_env_file(forced_files_client):
+    client, root = forced_files_client
+    env_file = root / ".env"
+    root.mkdir(parents=True, exist_ok=True)
+    env_file.write_text("SECRET=1")
+
+    blocked = client.request(
+        "DELETE",
+        "/api/files",
+        json={"path": str(env_file)},
+    )
+
+    assert blocked.status_code == 403
+    assert env_file.read_text() == "SECRET=1"
+
+
 def _seed_file(client, root, name="out/hello.txt"):
     file_path = root / name
     created = client.post(


### PR DESCRIPTION
## Summary

The dashboard managed-files API blocked sensitive files from read/download paths, but the matching mutation endpoints did not apply the same protection.

Affected routes:

- `POST /api/files/upload`
- `POST /api/files/upload-stream`
- `POST /api/files/mkdir`
- `DELETE /api/files`

That allowed an authenticated dashboard client to create, overwrite, or delete protected files such as `.env`, `.env.local`, or Hermes credential directories through the managed file browser surface, even though read/download access to those paths is treated as sensitive.

## Why

The managed-files read/download routes already reject sensitive filenames. Separately, the file tools have a shared write denylist for protected Hermes paths such as `mcp-tokens/`.

The mutation routes resolved the path and then wrote/deleted directly without checking either protection layer. This left a credential-destruction/poisoning path in the dashboard file manager.

## Changes

- Add a shared `_reject_managed_protected_write()` helper.
- Reject managed-file writes when the target basename is sensitive.
- Reject managed-file writes when `agent.file_safety.is_write_denied()` blocks the resolved path.
- Apply the helper to upload, streaming upload, mkdir, and delete.
- Add regression tests for:
  - JSON upload to `.env`
  - streaming upload to `.env.local`
  - mkdir under `HERMES_HOME/mcp-tokens`
  - delete of `.env`

## Related

This is a sibling to the existing dashboard credential-boundary fixes:

- Managed-files read/list/download hardening covers disclosure paths.
- `/api/fs/write-text` hardening covers the spot editor path.
- This PR covers the separate `/api/files/*` managed-file mutation surface.

## Tests

```text
python -m pytest tests/hermes_cli/test_web_server_files.py -k "protected_env_file or protected_mcp_tokens_directory or local_mode_upload" -q --timeout-method=thread
5 passed, 20 deselected