### PR TITLE
fix(dashboard): guard git review credential diffs

### DIFF
--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -96,9 +96,22 @@ def _numstat(cwd: str, args: list[str]) -> dict[str, tuple[int, int]]:
     return counts
 
 
+def _is_read_protected_path(cwd: str, rel: str) -> bool:
+    """Return True when a git review file path targets a credential store."""
+    try:
+        from agent.file_safety import get_read_block_error
+    except Exception:
+        return False
+    raw = Path(str(rel or ""))
+    target = raw if raw.is_absolute() else Path(cwd) / raw
+    return get_read_block_error(str(target)) is not None
+
+
 def _untracked_insertions(cwd: str, rel: str) -> int:
     """Line count of an untracked file (newlines + a final unterminated line),
     so the review tree can show +N for new files. Binary / oversized → 0."""
+    if _is_read_protected_path(cwd, rel):
+        return 0
     try:
         target = Path(cwd) / rel
         st = target.stat()
@@ -308,6 +321,8 @@ def review_list(cwd: str, scope: str, base_ref: str | None) -> dict:
 def review_diff(cwd: str, file_path: str, scope: str, base_ref: str | None, staged: bool) -> str:
     if not _is_dir(cwd):
         return ""
+    if _is_read_protected_path(cwd, file_path):
+        return ""
     if scope == "branch":
         base = _branch_base(cwd)
         return _git_out(cwd, ["diff", f"{base}...HEAD", "--", file_path]) if base else ""
@@ -327,6 +342,8 @@ def file_diff_vs_head(cwd: str, file_path: str) -> str:
     """Working-tree-vs-HEAD diff for one file (the preview's diff view). Unlike
     review_diff, never all-adds a clean tracked file; only a genuinely untracked one."""
     if not _is_dir(cwd):
+        return ""
+    if _is_read_protected_path(cwd, file_path):
         return ""
     head = _git_out(cwd, ["diff", "HEAD", "--", file_path])
     if head.strip():
@@ -397,12 +414,25 @@ def review_commit_context(cwd: str) -> dict:
     entries = list(_walk_entries(raw))
 
     has_staged = any(_entry_staged(tag, xy) for tag, xy, _ in entries)
-    diff = _git_out(cwd, ["diff", "--cached"]) if has_staged else _git_out(cwd, ["diff", "HEAD"])
+    tracked_paths = [
+        path
+        for tag, _xy, path in entries
+        if tag != "?" and not _is_read_protected_path(cwd, path)
+    ]
+    if tracked_paths:
+        diff_args = ["diff", "--cached"] if has_staged else ["diff", "HEAD"]
+        diff = _git_out(cwd, [*diff_args, "--", *tracked_paths])
+    else:
+        diff = ""
     if len(diff) > _COMMIT_CONTEXT_DIFF_MAX_CHARS:
         omitted = len(diff) - _COMMIT_CONTEXT_DIFF_MAX_CHARS
         diff = f"{diff[:_COMMIT_CONTEXT_DIFF_MAX_CHARS]}\n# diff truncated: {omitted} chars omitted\n"
 
-    untracked = [path for tag, _xy, path in entries if tag == "?"]
+    untracked = [
+        path
+        for tag, _xy, path in entries
+        if tag == "?" and not _is_read_protected_path(cwd, path)
+    ]
     if untracked:
         visible = untracked[:_COMMIT_CONTEXT_UNTRACKED_MAX]
         note = "\n# New (untracked) files:\n" + "".join(f"#   {p}\n" for p in visible)

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -166,26 +166,60 @@ def _default_branch_name(cwd: str) -> str | None:
 # ── porcelain v2 status parsing ──────────────────────────────────────────────
 
 
-def _walk_entries(raw: str):
-    """Yield (tag, xy, path) per changed file from ``git status --porcelain=v2 -z``,
-    skipping branch headers and the rename/copy origin-path records. One walker
-    feeds the rail, the review list, and the commit flow."""
+def _walk_entries_with_paths(raw: str):
+    """Yield (tag, xy, display_path, all_paths) from porcelain-v2 status.
+
+    ``display_path`` remains the destination path used by UI rows and git
+    commands. ``all_paths`` includes rename/copy origins so security filters can
+    make decisions from both sides of a move.
+    """
     records = raw.split("\0")
     i = 0
     while i < len(records):
         rec = records[i]
         tag = rec[0] if rec else ""
         if tag == "?":
-            yield "?", "??", rec[2:]
+            path = rec[2:]
+            yield "?", "??", path, (path,)
         elif tag == "u":
-            yield "u", rec.split(" ")[1], rec.split(" ", 10)[-1]
+            path = rec.split(" ", 10)[-1]
+            yield "u", rec.split(" ")[1], path, (path,)
         elif tag in ("1", "2"):
             xy = rec.split(" ")[1]
             path = rec.split(" ", 8)[-1] if tag == "1" else rec.split(" ", 9)[-1]
+            display_path = resolve_rename_path(path)
+            all_paths = (display_path,)
             if tag == "2":
-                i += 1  # rename/copy: the origin path is the next NUL record
-            yield tag, xy, resolve_rename_path(path)
+                i += 1
+                origin = records[i] if i < len(records) else ""
+                if origin and origin != display_path:
+                    all_paths = (display_path, origin)
+            yield tag, xy, display_path, all_paths
         i += 1
+
+
+def _walk_entries(raw: str):
+    """Yield (tag, xy, path) per changed file from ``git status --porcelain=v2 -z``.
+
+    The path is the destination path for rename/copy rows, matching the existing
+    UI and git-command behavior.
+    """
+    for tag, xy, path, _paths in _walk_entries_with_paths(raw):
+        yield tag, xy, path
+
+
+def _entry_has_read_protected_path(cwd: str, paths: tuple[str, ...]) -> bool:
+    return any(_is_read_protected_path(cwd, path) for path in paths)
+
+
+def _status_paths_for_display_path(cwd: str, file_path: str) -> tuple[str, ...]:
+    code, raw, _ = _git(cwd, ["status", "--porcelain=v2", "-z"])
+    if code != 0:
+        return (file_path,)
+    for _tag, _xy, path, paths in _walk_entries_with_paths(raw):
+        if file_path == path or file_path in paths:
+            return paths
+    return (file_path,)
 
 
 def _entry_staged(tag: str, xy: str) -> bool:
@@ -321,7 +355,7 @@ def review_list(cwd: str, scope: str, base_ref: str | None) -> dict:
 def review_diff(cwd: str, file_path: str, scope: str, base_ref: str | None, staged: bool) -> str:
     if not _is_dir(cwd):
         return ""
-    if _is_read_protected_path(cwd, file_path):
+    if _entry_has_read_protected_path(cwd, _status_paths_for_display_path(cwd, file_path)):
         return ""
     if scope == "branch":
         base = _branch_base(cwd)
@@ -343,7 +377,7 @@ def file_diff_vs_head(cwd: str, file_path: str) -> str:
     review_diff, never all-adds a clean tracked file; only a genuinely untracked one."""
     if not _is_dir(cwd):
         return ""
-    if _is_read_protected_path(cwd, file_path):
+    if _entry_has_read_protected_path(cwd, _status_paths_for_display_path(cwd, file_path)):
         return ""
     head = _git_out(cwd, ["diff", "HEAD", "--", file_path])
     if head.strip():
@@ -411,13 +445,13 @@ def review_commit_context(cwd: str) -> dict:
     code, raw, _ = _git(cwd, ["status", "--porcelain=v2", "-z"])
     if code != 0:
         return {"diff": "", "recent": ""}
-    entries = list(_walk_entries(raw))
+    entries = list(_walk_entries_with_paths(raw))
 
-    has_staged = any(_entry_staged(tag, xy) for tag, xy, _ in entries)
+    has_staged = any(_entry_staged(tag, xy) for tag, xy, _path, _paths in entries)
     tracked_paths = [
         path
-        for tag, _xy, path in entries
-        if tag != "?" and not _is_read_protected_path(cwd, path)
+        for tag, _xy, path, paths in entries
+        if tag != "?" and not _entry_has_read_protected_path(cwd, paths)
     ]
     if tracked_paths:
         diff_args = ["diff", "--cached"] if has_staged else ["diff", "HEAD"]
@@ -430,8 +464,8 @@ def review_commit_context(cwd: str) -> dict:
 
     untracked = [
         path
-        for tag, _xy, path in entries
-        if tag == "?" and not _is_read_protected_path(cwd, path)
+        for tag, _xy, path, paths in entries
+        if tag == "?" and not _entry_has_read_protected_path(cwd, paths)
     ]
     if untracked:
         visible = untracked[:_COMMIT_CONTEXT_UNTRACKED_MAX]

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -91,6 +91,49 @@ def test_review_diff_shows_change_and_synthesizes_untracked(client, repo):
     assert "print(1)" in untracked  # all-add diff for a file git doesn't track yet
 
 
+def test_git_review_does_not_disclose_untracked_env_file(client, repo):
+    secret = repo / ".env"
+    secret.write_text("OPENAI_API_KEY=sk-secret\n")
+
+    status = client.get("/api/git/status", params={"path": str(repo)}).json()
+    assert status["added"] == 3
+
+    listed = client.get("/api/git/review/list", params={"path": str(repo)}).json()
+    listed_files = {f["path"]: f for f in listed["files"]}
+    assert listed_files[".env"]["added"] == 0
+
+    review_diff = client.get(
+        "/api/git/review/diff", params={"path": str(repo), "file": ".env"}
+    ).json()["diff"]
+    assert review_diff == ""
+    assert "sk-secret" not in review_diff
+
+    file_diff = client.get(
+        "/api/git/file-diff", params={"path": str(repo), "file": ".env"}
+    ).json()["diff"]
+    assert file_diff == ""
+    assert "sk-secret" not in file_diff
+
+    commit_context = client.get(
+        "/api/git/review/commit-context", params={"path": str(repo)}
+    ).json()["diff"]
+    assert ".env" not in commit_context
+    assert "sk-secret" not in commit_context
+
+
+def test_git_commit_context_omits_tracked_env_diff(client, repo):
+    tracked_secret = repo / ".env"
+    tracked_secret.write_text("OPENAI_API_KEY=old\n")
+    _git(repo, "add", ".env")
+    _git(repo, "commit", "-qm", "track env")
+    tracked_secret.write_text("OPENAI_API_KEY=sk-new-secret\n")
+
+    body = client.get("/api/git/review/commit-context", params={"path": str(repo)}).json()
+
+    assert ".env" not in body["diff"]
+    assert "sk-new-secret" not in body["diff"]
+
+
 def test_stage_commit_roundtrip_clears_changes(client, repo):
     assert client.post("/api/git/review/stage", json={"path": str(repo), "file": "a.txt"}).json() == {"ok": True}
     staged = client.get("/api/git/status", params={"path": str(repo)}).json()

--- a/tests/hermes_cli/test_web_server_git.py
+++ b/tests/hermes_cli/test_web_server_git.py
@@ -134,6 +134,32 @@ def test_git_commit_context_omits_tracked_env_diff(client, repo):
     assert "sk-new-secret" not in body["diff"]
 
 
+def test_git_review_omits_env_rename_destination_diffs(client, repo):
+    tracked_secret = repo / ".env"
+    tracked_secret.write_text("OPENAI_API_KEY=sk-secret\n")
+    _git(repo, "add", ".env")
+    _git(repo, "commit", "-qm", "track env")
+    _git(repo, "mv", ".env", "safe.txt")
+
+    review_diff = client.get(
+        "/api/git/review/diff", params={"path": str(repo), "file": "safe.txt"}
+    ).json()["diff"]
+    assert review_diff == ""
+    assert "sk-secret" not in review_diff
+
+    file_diff = client.get(
+        "/api/git/file-diff", params={"path": str(repo), "file": "safe.txt"}
+    ).json()["diff"]
+    assert file_diff == ""
+    assert "sk-secret" not in file_diff
+
+    commit_context = client.get(
+        "/api/git/review/commit-context", params={"path": str(repo)}
+    ).json()["diff"]
+    assert "safe.txt" not in commit_context
+    assert "sk-secret" not in commit_context
+
+
 def test_stage_commit_roundtrip_clears_changes(client, repo):
     assert client.post("/api/git/review/stage", json={"path": str(repo), "file": "a.txt"}).json() == {"ok": True}
     staged = client.get("/api/git/status", params={"path": str(repo)}).json()


### PR DESCRIPTION
## Summary

The dashboard Git/review API could disclose credential files through git diff surfaces even though the dashboard file browser and file preview routes now block those same paths.

Affected routes include:

- `GET /api/git/review/diff`
- `GET /api/git/file-diff`
- `GET /api/git/review/commit-context`
- `GET /api/git/status` / `GET /api/git/review/list` line-count reads for untracked files

For untracked files, `web_git.py` synthesizes an all-add diff using:

```text
git diff --no-index -- <os.devnull> <file_path>