### PR TITLE
fix(dashboard-auth): don't auto-redirect to OAuth when sole provider is password-only

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -179,12 +179,15 @@ def _auto_sso_response(request: Request) -> Response | None:
     # token-only credentials (drain/service providers) are never candidates.
     providers = list_session_providers()
     if len(providers) != 1:
-        # Zero → nothing to redirect to. Two+ → user must choose at /login.
+        # Zero -> nothing to redirect to. Two+ -> user must choose at /login.
         return None
 
     from hermes_cli.dashboard_auth.prefix import prefix_from_request
 
     provider = providers[0]
+    # Password-only providers have no OAuth redirect flow; skip auto-redirect.
+    if getattr(provider, "supports_password", False):
+        return None
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -195,6 +195,11 @@ async def auth_login(request: Request, provider: str, next: str = ""):
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
+    except NotImplementedError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=str(e),
+        )
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -325,6 +325,59 @@ def test_login_non_interactive_provider_returns_404_not_500(gated_app):
     assert "stub" in names
 
 
+def test_password_only_provider_prevents_auto_oauth_redirect_and_gates_login(gated_app):
+    """Regression: when the only session provider is password-only,
+    the auto-SSO redirect must NOT 500 on start_login().
+
+    Previously _auto_sso_response() picked the sole provider and called
+    start_login(), which raised NotImplementedError, surfacing as 500.
+    After the fix the middleware skips auto-redirect and falls through
+    to the /login interstitial, and /auth/login returns 400 instead of 500.
+    """
+    clear_providers()
+    from hermes_cli.dashboard_auth.base import DashboardAuthProvider
+    class PasswordOnlyProvider(DashboardAuthProvider):
+        name = "basic-like"
+        display_name = "Password Only"
+        supports_password = True
+        # supports_session defaults to True, so list_session_providers includes us
+        def start_login(self, *, redirect_uri):
+            raise NotImplementedError("password-only")
+        def complete_login(self, *, code, state, code_verifier, redirect_uri):
+            raise NotImplementedError
+        def verify_session(self, *, access_token):
+            return None
+        def refresh_session(self, *, refresh_token):
+            raise NotImplementedError
+        def revoke_session(self, *, refresh_token):
+            pass
+
+    register_provider(PasswordOnlyProvider())
+
+    try:
+        r = gated_app.get("/", follow_redirects=False)
+        assert r.status_code == 302, f"Expected 302, got {r.status_code}: {r.text}"
+        # Must land on /login, NOT /auth/login?provider=basic-like (which would 500)
+        assert "/login" in r.headers["location"], r.headers["location"]
+        assert "auth/login" not in r.headers["location"], r.headers["location"]
+
+        login = gated_app.get(r.headers["location"], follow_redirects=False)
+        assert login.status_code == 200, login.text
+        # The login interstitial should contain the password form, not an error page
+        assert "Sign in" in login.text or "password" in login.text.lower(), login.text[:200]
+
+        # Direct access to /auth/login?provider=basic-like should 400, not 500
+        auth_login = gated_app.get(
+            "/auth/login?provider=basic-like", follow_redirects=False
+        )
+        assert auth_login.status_code == 400, (
+            f"Expected 400 on start_login for password-only provider, got {auth_login.status_code}: {auth_login.text}"
+        )
+    finally:
+        clear_providers()
+        register_provider(StubAuthProvider())
+
+
 def test_callback_without_pkce_cookie_returns_400(gated_app):
     # No prior /auth/login → no PKCE cookie.
     r = gated_app.get(


### PR DESCRIPTION
# Bug Report: Dashboard 500 crash when only password-based auth provider is configured

## Summary
When a self-hosted Hermes dashboard is configured with only a password-based authentication provider (e.g. `BasicAuthProvider`) and bound to a non-loopback host, every unauthenticated request produces a `500 Internal Server Error`. The dashboard becomes completely unusable because the auth gate's auto-SSO redirect unconditionally calls `start_login()` on a provider that does not implement OAuth redirect flow.

## Environment
- **Hermes version:** 0.18.0 (2026.7.1)
- **Config version:** 32
- **Provider:** BasicAuthProvider (password-only, no external IDP)
- **Dashboard bind:** `--host 0.0.0.0 --port 9119` (non-loopback, auth gate engaged)
- **Auth providers:** `["basic"]` (only one, password-only)

## Steps to Reproduce
1. Configure the dashboard with only `BasicAuthProvider`:
   ```yaml
   dashboard:
     basic_auth:
       username: admin
       password: yourpassword
   ```
2. Start the dashboard on a non-loopback host:
   ```bash
   hermes dashboard --host 0.0.0.0 --port 9119
   ```
3. Open an incognito/private window and navigate to `http://your-host:9119/`

## Expected Behavior
- The unauthenticated visitor is redirected to `/login`
- The login interstitial renders with a username+password form
- No errors in the service logs

## Actual Behavior
- **500 Internal Server Error** on every unauthenticated request
- Service logs show unhandled `NotImplementedError`:
  ```
  Jul 04 02:55:27 hermes1 hermes[247]:
    NotImplementedError: BasicAuthProvider is password-only;
    there is no OAuth redirect flow. The login page POSTs to
    /auth/password-login instead.
  ```
- The dashboard SPA never loads; the login page is inaccessible

## Root Cause
Two places in the auth gate call `provider.start_login()` without checking if the provider actually supports OAuth redirect:

1. **`hermes_cli/dashboard_auth/middleware.py:_auto_sso_response()`**
   - When exactly one `supports_session=True` provider is registered, the middleware auto-redirects to `/auth/login?provider=<name>` to silently initiate OAuth.
   - If that sole provider is password-only (`supports_password=True`, no `start_login()` implementation), the redirect hits `/auth/login`, which calls `start_login()` → `NotImplementedError`.

2. **`hermes_cli/dashboard_auth/routes.py:auth_login()`**
   - The `auth_login` route calls `provider.start_login()` inside a `try/except ProviderError` block.
   - `NotImplementedError` is not caught, so it bubbles up as an unhandled exception → HTTP 500.

## Fix

### Patch 1: Skip auto-redirect for password-only providers
**File:** `hermes_cli/dashboard_auth/middleware.py`
```python
    provider = providers[0]
+   # Password-only providers have no OAuth redirect flow; skip auto-redirect.
+   if getattr(provider, "supports_password", False):
+       return None
    prefix = prefix_from_request(request)
```

### Patch 2: Defensive catch in auth_login route
**File:** `hermes_cli/dashboard_auth/routes.py`
```python
    try:
        ls = p.start_login(redirect_uri=_redirect_uri(request))
+   except NotImplementedError as e:
+       raise HTTPException(
+           status_code=400,
+           detail=str(e),
+       )
    except ProviderError as e:
```

## Regression Test
Added new test: `test_password_only_provider_prevents_auto_oauth_redirect_and_gates_login`

- Verifies that `/` 302-redirects to `/login` (not `/auth/login?provider=...`)
- Verifies that the `/login` interstitial renders correctly (200 + password form)
- Verifies that `/auth/login?provider=basic-like` returns 400 (not 500)

**Test result:** 34/34 tests in `test_dashboard_auth_middleware.py` pass, including the new regression test.

## Full Branch with Fix + Test
```
fix/basic-auth-auto-redirect-crash
```
Branch contains 3 files changed, 62 insertions(+), 1 deletion(-):
- `hermes_cli/dashboard_auth/middleware.py`
- `hermes_cli/dashboard_auth/routes.py`
- `tests/hermes_cli/test_dashboard_auth_middleware.py`

## Suggested Commit Message
```
fix(dashboard-auth): don't auto-redirect to OAuth when sole provider is password-only

When a dashboard is configured with only a password-based auth provider
(e.g., BasicAuthProvider) and binds to a non-loopback host, the
gated-auth middleware's auto-SSO redirect would unconditionally call
provider.start_login(), which raises NotImplementedError.

This produced an unhandled 500 Internal Server Error on every
unauthenticated request, making the dashboard completely unusable in
basic-auth-only self-hosted mode.

The fix has two parts:
1. In _auto_sso_response(): skip auto-redirect when the sole session
   provider has supports_password=True (no OAuth redirect flow).
2. In auth_login(): catch NotImplementedError from start_login() and
   return 400 with the provider's message instead of crashing.

Added regression test.
```
