### PR TITLE
fix(browser): guard Camofox back and scroll on private pages

### DIFF
--- a/tests/tools/test_browser_camofox_private_page_guard.py
+++ b/tests/tools/test_browser_camofox_private_page_guard.py
@@ -111,6 +111,48 @@ def test_private_page_blocks_camofox_input_actions(monkeypatch, _session, tool_c
     assert "do-not-send-this" not in json.dumps(out)
 
 
+def test_private_page_blocks_camofox_scroll_before_action(monkeypatch, _session):
+    _block_active(monkeypatch)
+
+    def fail_post(*_args, **_kwargs):
+        raise AssertionError("Camofox scroll HTTP call should not run on a private page")
+
+    monkeypatch.setattr(browser_camofox, "_post", fail_post)
+
+    out = json.loads(browser_camofox.camofox_scroll("down", task_id="t1"))
+
+    assert out["success"] is False
+    assert PRIVATE_URL in out["error"]
+    assert "private or internal address" in out["error"]
+    assert "scroll" in out["error"]
+
+
+def test_camofox_back_blocks_after_landing_on_private_page(monkeypatch, _session):
+    _block_active(monkeypatch)
+    calls = []
+
+    def fake_post(path, body=None, timeout=None):
+        calls.append((path, body, timeout))
+        return {"url": PRIVATE_URL}
+
+    monkeypatch.setattr(browser_camofox, "_post", fake_post)
+
+    out = json.loads(browser_camofox.camofox_back(task_id="t1"))
+
+    assert calls == [
+        (
+            "/tabs/tab-1/back",
+            {"userId": "user-1"},
+            None,
+        )
+    ]
+    assert out["success"] is False
+    assert PRIVATE_URL in out["error"]
+    assert "private or internal address" in out["error"]
+    assert "navigate back" in out["error"]
+    assert "url" not in out
+
+
 def test_snapshot_still_runs_when_page_is_public(monkeypatch, _session):
     _public_page(monkeypatch)
 
@@ -144,6 +186,50 @@ def test_camofox_click_still_runs_when_page_is_public(monkeypatch, _session):
         (
             "/tabs/tab-1/click",
             {"userId": "user-1", "ref": "e1"},
+            None,
+        )
+    ]
+
+
+def test_camofox_scroll_still_runs_when_page_is_public(monkeypatch, _session):
+    _public_page(monkeypatch)
+    calls = []
+
+    def fake_post(path, body=None, timeout=None):
+        calls.append((path, body, timeout))
+        return {}
+
+    monkeypatch.setattr(browser_camofox, "_post", fake_post)
+
+    out = json.loads(browser_camofox.camofox_scroll("down", task_id="t1"))
+
+    assert out == {"success": True, "scrolled": "down"}
+    assert calls == [
+        (
+            "/tabs/tab-1/scroll",
+            {"userId": "user-1", "direction": "down"},
+            None,
+        )
+    ]
+
+
+def test_camofox_back_still_runs_when_landed_page_is_public(monkeypatch, _session):
+    _public_page(monkeypatch)
+    calls = []
+
+    def fake_post(path, body=None, timeout=None):
+        calls.append((path, body, timeout))
+        return {"url": "https://example.test/previous"}
+
+    monkeypatch.setattr(browser_camofox, "_post", fake_post)
+
+    out = json.loads(browser_camofox.camofox_back(task_id="t1"))
+
+    assert out == {"success": True, "url": "https://example.test/previous"}
+    assert calls == [
+        (
+            "/tabs/tab-1/back",
+            {"userId": "user-1"},
             None,
         )
     ]

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -721,6 +721,10 @@ def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
+        blocked = _camofox_private_page_block(session, task_id, "scroll")
+        if blocked:
+            return blocked
+
         _post(
             f"/tabs/{session['tab_id']}/scroll",
             {"userId": session["user_id"], "direction": direction},
@@ -741,6 +745,11 @@ def camofox_back(task_id: Optional[str] = None) -> str:
             f"/tabs/{session['tab_id']}/back",
             {"userId": session["user_id"]},
         )
+
+        blocked = _camofox_private_page_block(session, task_id, "navigate back")
+        if blocked:
+            return blocked
+
         return json.dumps({"success": True, "url": data.get("url", "")})
     except Exception as e:
         return tool_error(str(e), success=False)


### PR DESCRIPTION
## Summary

This extends the Camofox private-page guard to the remaining navigation/action paths that could still operate after the browser is on a private/internal URL.

The existing Camofox guard already blocks snapshot, vision, image extraction, click, type, and key press on private pages. However:

- `camofox_scroll()` sent a scroll action without checking whether the current page was private.
- `camofox_back()` navigated browser history and returned the landed URL without a post-navigation private-page check.

This is the Camofox sibling of the `browser_back` post-navigation guard: browser history can land on an internal/cloud-metadata/private URL that the initial navigate preflight did not see.

## Changes

- Block `camofox_scroll()` before sending the scroll action when the current Camofox page is private/internal.
- Re-check after `camofox_back()` lands, before returning the URL to the model.
- Add regression coverage for blocked private-page scroll/back.
- Add positive coverage showing public-page scroll/back still work.

## Tests

```text
python -m pytest tests/tools/test_browser_camofox_private_page_guard.py -q --timeout-method=thread
13 passed

python -m pytest tests/tools/test_browser_camofox.py -k "back or scroll or private" -q --timeout-method=thread
7 passed, 23 deselected