### PR TITLE
feat(cron): add retention tiers and run audit metadata

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1243,6 +1243,43 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def _normalize_output_retention(value: Any) -> Optional[int]:
+    """Normalize an optional per-job output retention cap."""
+    if value is None or value == "" or value is False:
+        return None
+    try:
+        ivalue = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Cron output_retention must be an integer or null (got {value!r})") from exc
+    return ivalue
+
+
+def _normalize_state_paths(paths: Any) -> Optional[List[str]]:
+    """Normalize a cron job state/audit manifest."""
+    if paths is None or paths == "" or paths is False:
+        return None
+    raw_items = [paths] if isinstance(paths, str) else list(paths) if isinstance(paths, list) else None
+    if raw_items is None:
+        raise ValueError("Cron state_paths must be a path string, a list of path strings, or null")
+    normalized: List[str] = []
+    seen: Set[str] = set()
+    for item in raw_items:
+        raw = str(item).strip()
+        if not raw:
+            continue
+        expanded = Path(raw).expanduser()
+        if not expanded.is_absolute():
+            raise ValueError(
+                f"Cron state_paths entries must be absolute or ~/ paths (got {raw!r})"
+            )
+        canonical = str(expanded.resolve(strict=False))
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        normalized.append(canonical)
+    return normalized or None
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1261,6 +1298,8 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    output_retention: Optional[int] = None,
+    state_paths: Optional[Union[str, List[str]]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1337,6 +1376,8 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_output_retention = _normalize_output_retention(output_retention)
+    normalized_state_paths = _normalize_state_paths(state_paths)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1426,6 +1467,8 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "output_retention": normalized_output_retention,
+        "state_paths": normalized_state_paths,
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -1529,6 +1572,12 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            if "output_retention" in updates:
+                updates["output_retention"] = _normalize_output_retention(updates.get("output_retention"))
+
+            if "state_paths" in updates:
+                updates["state_paths"] = _normalize_state_paths(updates.get("state_paths"))
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
@@ -2527,16 +2576,57 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 # accumulated one file per run forever and could fill the disk (#52383). Keep the
 # most recent N files per job; a non-positive value disables pruning (opt-out).
 _CRON_OUTPUT_DEFAULT_KEEP = 50
+_CRON_SILENT_OUTPUT_DEFAULT_KEEP = 20
 
 
-def _cron_output_keep() -> int:
-    """Resolve the per-job output-file retention cap from config (``cron.output_retention``)."""
+def _cron_output_keep(job: Optional[Dict[str, Any]] = None, *, silent: Optional[bool] = None) -> int:
+    """Resolve the output-file retention cap.
+
+    Priority:
+    1. Per-job ``output_retention`` override (when set)
+    2. Global config ``cron.output_retention_silent`` / ``cron.silent_output_retention``
+       for silent runs, or ``cron.output_retention_substantive`` /
+       ``cron.substantive_output_retention`` for substantive/error runs
+    3. Global config ``cron.output_retention``
+    4. Built-in defaults
+    """
     try:
         from hermes_cli.config import load_config
         cfg = load_config() or {}
         cron_cfg = cfg.get("cron", {}) if isinstance(cfg, dict) else {}
-        return int(cron_cfg.get("output_retention", _CRON_OUTPUT_DEFAULT_KEEP))
+        override = None
+        if isinstance(job, dict):
+            override = _normalize_output_retention(job.get("output_retention"))
+            if override is not None:
+                return override
+        default_keep = int(cron_cfg.get("output_retention", _CRON_OUTPUT_DEFAULT_KEEP))
+        if silent is True:
+            return int(
+                cron_cfg.get(
+                    "output_retention_silent",
+                    cron_cfg.get("silent_output_retention", _CRON_SILENT_OUTPUT_DEFAULT_KEEP),
+                )
+            )
+        if silent is False:
+            return int(
+                cron_cfg.get(
+                    "output_retention_substantive",
+                    cron_cfg.get("substantive_output_retention", default_keep),
+                )
+            )
+        return default_keep
     except Exception:
+        if isinstance(job, dict):
+            try:
+                override = _normalize_output_retention(job.get("output_retention"))
+            except ValueError:
+                override = None
+            if override is not None:
+                return override
+        if silent is True:
+            return _CRON_SILENT_OUTPUT_DEFAULT_KEEP
+        if silent is False:
+            return _CRON_OUTPUT_DEFAULT_KEEP
         return _CRON_OUTPUT_DEFAULT_KEEP
 
 
@@ -2569,7 +2659,7 @@ def _prune_job_output(job_output_dir: Path, keep: int) -> int:
     return deleted
 
 
-def save_job_output(job_id: str, output: str):
+def save_job_output(job_id: str, output: str, *, keep: Optional[int] = None):
     """Save job output to file."""
     ensure_dirs()
     job_output_dir = _job_output_dir(job_id)
@@ -2594,10 +2684,50 @@ def save_job_output(job_id: str, output: str):
             pass
         raise
 
-    # Bound per-job output growth so long-running deploys don't fill the disk (#52383).
-    _prune_job_output(job_output_dir, _cron_output_keep())
+    # Bound per-job history so frequently-running crons don't grow without
+    # limit. The append-only ``runs.jsonl`` index is intentionally retained
+    # separately; this cap applies only to the heavier per-run markdown docs.
+    _prune_job_output(job_output_dir, _cron_output_keep() if keep is None else keep)
 
     return output_file
+
+
+def append_job_output_footer(output_file: Union[str, Path], footer: str) -> None:
+    """Append a footer to an existing run artifact atomically."""
+    path = Path(output_file)
+    existing = path.read_text(encoding="utf-8")
+    updated = existing.rstrip() + "\n\n---\n\n" + footer.strip() + "\n"
+
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix='.tmp', prefix='.output_footer_')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            f.write(updated)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, path)
+        _secure_file(path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def append_job_run_index(job_id: str, record: Dict[str, Any]) -> Path:
+    """Append a compact per-run JSONL index record for ``job_id``."""
+    ensure_dirs()
+    job_output_dir = _job_output_dir(job_id)
+    job_output_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(job_output_dir)
+    index_path = job_output_dir / "runs.jsonl"
+    line = json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+    with open(index_path, "a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.flush()
+        os.fsync(fh.fileno())
+    _secure_file(index_path)
+    return index_path
 
 
 # =============================================================================

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1245,8 +1245,10 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
 
 def _normalize_output_retention(value: Any) -> Optional[int]:
     """Normalize an optional per-job output retention cap."""
-    if value is None or value == "" or value is False:
+    if value is None or value == "":
         return None
+    if isinstance(value, bool):
+        raise ValueError(f"Cron output_retention must be an integer or null (got {value!r})")
     try:
         ivalue = int(value)
     except (TypeError, ValueError) as exc:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -282,7 +282,18 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    get_due_jobs,
+    mark_job_run,
+    save_job_output,
+    advance_next_runs,
+    claim_dispatch,
+    heartbeat_run_claim,
+    append_job_output_footer,
+    append_job_run_index,
+    _cron_output_keep,
+    _normalize_state_paths,
+)
 from cron.executions import create_execution, finish_execution, mark_execution_running
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
@@ -2204,10 +2215,10 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, str]:
     """Execute a cron job's data-collection script and capture its output.
 
-    Scripts must reside within HERMES_HOME/scripts/.  Both relative and
+    Scripts must reside within HERMES_HOME/scripts/. Both relative and
     absolute paths are resolved and validated against this directory to
     prevent arbitrary script execution via path traversal or absolute
     path injection.
@@ -2238,8 +2249,9 @@ def _run_job_script(
             (#69396).
 
     Returns:
-        (success, output) — on failure *output* contains the error message so the
-        LLM can report the problem to the user.
+        ``(success, stdout, stderr)``. On failure, stdout/stderr preserve the
+        redacted subprocess streams so the scheduler can build a useful audit
+        artifact instead of losing quiet-decision context.
     """
     scripts_dir = _get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
@@ -2259,12 +2271,12 @@ def _run_job_script(
         return False, (
             f"Blocked: script path resolves outside the scripts directory "
             f"({scripts_dir_resolved}): {script_path!r}"
-        )
+        ), ""
 
     if not path.exists():
-        return False, f"Script not found: {path}"
+        return False, f"Script not found: {path}", ""
     if not path.is_file():
-        return False, f"Script path is not a file: {path}"
+        return False, f"Script path is not a file: {path}", ""
 
     script_timeout = _get_script_timeout()
 
@@ -2284,10 +2296,10 @@ def _run_job_script(
         )
         if _bash is None:
             return False, (
-                f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "
-                "On Windows, install Git for Windows (which ships Git Bash) "
+                "Shell cron scripts require 'bash' on PATH (or /bin/bash on Unix), "
+                "but none was found. Install Git Bash / WSL bash on Windows, "
                 "or rewrite the script as Python (.py)."
-        )
+            ), ""
         argv = [_bash, str(path)]
         env_overlay: dict[str, str] = {}
     else:
@@ -2334,19 +2346,18 @@ def _run_job_script(
             stderr = "[REDACTED - redaction failed]"
 
         if result.returncode != 0:
-            parts = [f"Script exited with code {result.returncode}"]
             if stderr:
-                parts.append(f"stderr:\n{stderr}")
-            if stdout:
-                parts.append(f"stdout:\n{stdout}")
-            return False, "\n".join(parts)
+                stderr = f"Script exited with code {result.returncode}\n{stderr}"
+            else:
+                stderr = f"Script exited with code {result.returncode}"
+            return False, stdout, stderr
 
-        return True, stdout
+        return True, stdout, stderr
 
     except subprocess.TimeoutExpired:
-        return False, f"Script timed out after {script_timeout}s: {path}"
+        return False, "", f"Script timed out after {script_timeout}s: {path}"
     except Exception as exc:
-        return False, f"Script execution failed: {exc}"
+        return False, "", f"Script execution failed: {exc}"
 
 
 def _run_job_script_with_claim_heartbeat(
@@ -2465,9 +2476,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     script_path = job.get("script")
     if script_path:
         if prerun_script is not None:
-            success, script_output = prerun_script
+            success, script_output, script_stderr = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output, script_stderr = _run_job_script(script_path)
         if success:
             if script_output:
                 prompt = (
@@ -2482,10 +2493,16 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 # Script produced no output — nothing to report, skip AI call.
                 return None
         else:
+            error_parts = []
+            if script_stderr:
+                error_parts.append(f"stderr:\n{script_stderr}")
+            if script_output:
+                error_parts.append(f"stdout:\n{script_output}")
+            error_blob = "\n\n".join(error_parts) or "Script failed with no output."
             prompt = (
                 "## Script Error\n"
                 "The data-collection script failed. Report this to the user.\n\n"
-                f"```\n{script_output}\n```\n\n"
+                f"```\n{error_blob}\n```\n\n"
                 f"{prompt}"
             )
             has_injected_data = True
@@ -2821,24 +2838,30 @@ def run_job(
             _job_workdir = None
 
         try:
-            ok, output = _run_job_script_with_claim_heartbeat(
+            ok, output, script_stderr = _run_job_script_with_claim_heartbeat(
                 job, script_path, workdir=_job_workdir,
             )
         except Exception as exc:
             logger.exception(
                 "Job '%s': script execution raised unexpectedly", job_id,
             )
-            ok, output = False, f"Script execution failed: {exc}"
+            ok, output, script_stderr = False, "", f"Script execution failed: {exc}"
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 
         if not ok:
-            # Script crashed / timed out / exited non-zero.  Deliver the
+            # Script crashed / timed out / exited non-zero. Deliver the
             # error so the user knows the watchdog itself broke — silent
             # failure for an alerting job is the worst-case outcome.
+            error_lines = [f"Script exited with a failure in watchdog '{job_name}'"]
+            if script_stderr:
+                error_lines.append(f"stderr:\n{script_stderr}")
+            if output:
+                error_lines.append(f"stdout:\n{output}")
+            error_blob = "\n\n".join(error_lines)
             alert = (
                 f"⚠ Cron watchdog '{job_name}' script failed\n\n"
-                f"{output}\n\n"
+                f"{error_blob}\n\n"
                 f"Time: {now_iso}"
             )
             doc = (
@@ -2847,9 +2870,10 @@ def run_job(
                 f"**Run Time:** {now_iso}\n"
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** script failed\n\n"
-                f"{output}\n"
+                f"## Script stderr\n\n```\n{script_stderr or '(empty)'}\n```\n\n"
+                f"## Script stdout\n\n```\n{output or '(empty)'}\n```\n"
             )
-            return False, doc, alert, output
+            return False, doc, alert, error_blob
 
         # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
         # means "nothing to report this tick", same as empty stdout.
@@ -2862,7 +2886,9 @@ def run_job(
                 f"**Job ID:** {job_id}\n"
                 f"**Run Time:** {now_iso}\n"
                 f"**Mode:** no_agent (script)\n"
-                f"**Status:** silent (wakeAgent=false)\n"
+                f"**Status:** silent (wakeAgent=false)\n\n"
+                f"## Gate stdout\n\n```\n{output or '(empty)'}\n```\n\n"
+                f"## Gate stderr\n\n```\n{script_stderr or '(empty)'}\n```\n"
             )
             return True, silent_doc, SILENT_MARKER, None
 
@@ -2873,7 +2899,8 @@ def run_job(
                 f"**Job ID:** {job_id}\n"
                 f"**Run Time:** {now_iso}\n"
                 f"**Mode:** no_agent (script)\n"
-                f"**Status:** silent (empty output)\n"
+                f"**Status:** silent (empty output)\n\n"
+                f"## Script stderr\n\n```\n{script_stderr or '(empty)'}\n```\n"
             )
             return True, silent_doc, SILENT_MARKER, None
 
@@ -2882,8 +2909,7 @@ def run_job(
             f"**Job ID:** {job_id}\n"
             f"**Run Time:** {now_iso}\n"
             f"**Mode:** no_agent (script)\n\n"
-            f"---\n\n"
-            f"{output}\n"
+            f"## Script stdout\n\n```\n{output}\n```\n"
         )
         return True, doc, output, None
 
@@ -2969,8 +2995,17 @@ def run_job(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path)
-        _ran_ok, _script_output = prerun_script
+        _job_workdir = (job.get("workdir") or "").strip() or None
+        if _job_workdir and not Path(_job_workdir).is_dir():
+            logger.warning(
+                "Job '%s': configured workdir %r no longer exists — running without it",
+                job_id, _job_workdir,
+            )
+            _job_workdir = None
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job, script_path, workdir=_job_workdir,
+        )
+        _ran_ok, _script_output, _script_stderr = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
@@ -2979,8 +3014,10 @@ def run_job(
             silent_doc = (
                 f"# Cron Job: {job_name}\n\n"
                 f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-                "Script gate returned `wakeAgent=false` — agent skipped.\n"
+                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+                f"**Status:** silent (wakeAgent=false)\n\n"
+                f"## Gate stdout\n\n```\n{_script_output or '(empty)'}\n```\n\n"
+                f"## Gate stderr\n\n```\n{_script_stderr or '(empty)'}\n```\n"
             )
             return True, silent_doc, SILENT_MARKER, None
 
@@ -3011,7 +3048,20 @@ def run_job(
         return False, blocked_doc, "", str(block_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
-        return True, "", SILENT_MARKER, None
+        script_stdout = ""
+        script_stderr = ""
+        if prerun_script is not None:
+            _, script_stdout, script_stderr = prerun_script
+        silent_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"**Status:** silent (empty script output)\n\n"
+            f"## Script stdout\n\n```\n{script_stdout or '(empty)'}\n```\n\n"
+            f"## Script stderr\n\n```\n{script_stderr or '(empty)'}\n```\n"
+        )
+        return True, silent_doc, SILENT_MARKER, None
+    origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
@@ -3719,6 +3769,7 @@ def run_job(
         output = f"""# Cron Job: {job_name}
 
 **Job ID:** {job_id}
+**Session ID:** {_cron_session_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
 
@@ -3741,6 +3792,7 @@ def run_job(
         output = f"""# Cron Job: {job_name} (FAILED)
 
 **Job ID:** {job_id}
+**Session ID:** {_cron_session_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
 
@@ -3889,6 +3941,53 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
+def _cron_state_paths(job: dict) -> list[str]:
+    try:
+        return _normalize_state_paths(job.get("state_paths")) or []
+    except ValueError as exc:
+        logger.warning("Job '%s': invalid state_paths ignored: %s", job.get("id", "?"), exc)
+        return []
+
+
+def _cron_delivery_footer(job: dict, *, should_deliver: bool, delivery_error: Optional[str], delivery_targets: Optional[list[dict]]) -> str:
+    sections: list[str] = []
+    if should_deliver:
+        lines = []
+        if delivery_targets:
+            for target in delivery_targets:
+                platform = str(target.get("platform") or "?")
+                chat_id = str(target.get("chat_id") or "?")
+                thread_id = target.get("thread_id")
+                label = f"{platform}:{chat_id}"
+                if thread_id not in {None, ""}:
+                    label += f" thread={thread_id}"
+                if delivery_error:
+                    lines.append(f"- `{label}`: error — {delivery_error}")
+                else:
+                    lines.append(f"- `{label}`: delivered")
+        else:
+            lines.append("- local-only or no external delivery target")
+        sections.append("## Delivery\n" + "\n".join(lines))
+    elif delivery_error:
+        sections.append(f"## Delivery\n- error while delivery was suppressed: {delivery_error}")
+    else:
+        sections.append("## Delivery\n- not delivered (silent/local-only run)")
+
+    state_paths = _cron_state_paths(job)
+    if state_paths:
+        sections.append("## State Paths\n" + "\n".join(f"- `{path}`" for path in state_paths))
+
+    return "\n\n".join(section for section in sections if section.strip())
+
+
+def _cron_run_status(success: bool, final_response: str, error: Optional[str]) -> str:
+    if not success:
+        return "error"
+    if _is_cron_silence_response(final_response or ""):
+        return "silent"
+    return "ok"
+
+
 def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
     """Run ONE due job end-to-end: execute → save output → deliver → mark.
 
@@ -3930,6 +4029,7 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # The attempt is claimed durably before executor/provider dispatch and
         # becomes running only immediately before the actual run.
         mark_execution_running(execution_id)
+        started_at = time.monotonic()
 
         # Run the job under the profile's secret scope. get_secret() fails
         # closed outside a scope once profile isolation is in play (multiple
@@ -3970,26 +4070,20 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             raise
         finally:
             reset_secret_scope(_scope_token)
+        initial_status = _cron_run_status(success, final_response, error)
 
-        # Everything from here through delivery runs with the agent still live
-        # (deferred teardown). Wrap it ALL in a try/finally so that if any step
-        # between run_job returning and delivery — save_job_output, the [SILENT]
-        # / empty-response computation, or _deliver_result itself — raises, the
-        # deferred agent is still torn down. Otherwise the outer `except` would
-        # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
+        delivery_targets = None
+        unresolved_origin = False
         try:
-            output_file = save_job_output(job["id"], output)
+            output_file = save_job_output(
+                job["id"],
+                output,
+                keep=_cron_output_keep(job, silent=(initial_status == "silent")),
+            )
             if verbose:
                 logger.info("Output saved to: %s", output_file)
 
-            # If the gateway shutdown killed this job's tool subprocess
-            # mid-flight (#60432), the agent may still have produced a
-            # plausible-looking final_response from the truncated output --
-            # force the failure path so the delivered message is an honest
-            # "this run was interrupted" summary instead of that response.
-            # Peek-only: the flag stays set for the authoritative check
-            # right before mark_job_run below.
             if success and _is_interrupted(job["id"]):
                 success = False
                 error = (
@@ -3997,21 +4091,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     "(tool subprocess was killed mid-flight)."
                 )
 
-            # Deliver the final response to the origin/target chat.
-            # If the agent responded with [SILENT], skip delivery (but
-            # output is already saved above).  Failed jobs always deliver.
             deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
-            # Treat whitespace-only final responses the same as empty
-            # responses: do not deliver a blank message, and let the
-            # empty-response guard below mark the run as a soft failure.
             should_deliver = bool(deliver_content.strip())
-            unresolved_origin = False
-            # Cron silence suppression — see _is_cron_silence_response.  Replaces the
-            # old `SILENT_MARKER in ...upper()` substring check, which both leaked
-            # bracketless near-markers ("SILENT" / "NO_REPLY") and wrongly swallowed
-            # a real report that merely quoted "[SILENT]" mid-sentence (#51438,
-            # #46917).  Keeps the intentional bracketed-prefix / trailing-line
-            # tolerance the cron contract relies on.
             if should_deliver and success and _is_cron_silence_response(deliver_content):
                 logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                 should_deliver = False
@@ -4021,24 +4102,56 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     _normalize_deliver_value(job.get("deliver", "local")) == "origin"
                     and not _resolve_delivery_targets(job)
                 )
+                delivery_targets = _resolve_delivery_targets(job)
                 try:
                     delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
         finally:
-            # Tear down the deferred agent(s) now that save + delivery have run
-            # (or raised). Must happen on every path so cron agents never leak
-            # their subprocesses/clients (#10200).
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
 
-        # Treat empty final_response as a soft failure so last_status
-        # is not "ok" — the agent ran but produced nothing useful.
-        # (issue #8585)
-        if success and not final_response.strip():
+        # Treat empty final_response as a soft failure so last_status is not
+        # "ok" — unless it was an intentional cron-silent run.
+        if success and not final_response.strip() and initial_status != "silent":
             success = False
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+        final_status = _cron_run_status(success, final_response, error)
+        footer = _cron_delivery_footer(
+            job,
+            should_deliver=should_deliver,
+            delivery_error=delivery_error,
+            delivery_targets=delivery_targets,
+        )
+        if footer.strip():
+            try:
+                append_job_output_footer(output_file, footer)
+            except OSError:
+                logger.debug("Job '%s': could not append footer to %s", job["id"], output_file, exc_info=True)
+
+        duration_seconds = round(time.monotonic() - started_at, 3)
+        try:
+            output_size = Path(output_file).stat().st_size
+        except OSError:
+            output_size = None
+        try:
+            append_job_run_index(
+                job["id"],
+                {
+                    "delivery_error": delivery_error,
+                    "delivery_targets": delivery_targets,
+                    "duration_seconds": duration_seconds,
+                    "error": error,
+                    "output_bytes": output_size,
+                    "output_file": str(output_file),
+                    "run_at": _hermes_now().isoformat(),
+                    "status": final_status,
+                },
+            )
+        except Exception:
+            logger.warning("Job '%s': could not write run index", job["id"], exc_info=True)
 
         if not _consume_interrupted_flag(job["id"]):
             mark_job_run(job["id"], success, error, delivery_error=delivery_error)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -286,6 +286,7 @@ from cron.jobs import (
     get_due_jobs,
     mark_job_run,
     save_job_output,
+    advance_next_run,
     advance_next_runs,
     claim_dispatch,
     heartbeat_run_claim,
@@ -2297,7 +2298,7 @@ def _run_job_script(
         if _bash is None:
             return False, (
                 "Shell cron scripts require 'bash' on PATH (or /bin/bash on Unix), "
-                "but none was found. Install Git Bash / WSL bash on Windows, "
+                "but bash not found on this system. Install Git Bash / WSL bash on Windows, "
                 "or rewrite the script as Python (.py)."
             ), ""
         argv = [_bash, str(path)]
@@ -2362,7 +2363,7 @@ def _run_job_script(
 
 def _run_job_script_with_claim_heartbeat(
     job: dict, script_path: str, workdir: Optional[str] = None,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
     Script execution is synchronous and may legitimately outlive the stale
@@ -2451,16 +2452,35 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _normalize_script_result(result: Optional[tuple]) -> tuple[bool, str, str]:
+    """Normalize legacy/new script result tuples to ``(success, stdout, stderr)``.
+
+    Older tests and helper call sites may still provide ``(success, stdout)``.
+    Keep accepting that shape so broader scheduler/test compatibility does not
+    depend on every mock being updated in lockstep.
+    """
+    if result is None:
+        return False, "", ""
+    if len(result) == 3:
+        success, stdout, stderr = result
+        return bool(success), str(stdout or ""), str(stderr or "")
+    if len(result) == 2:
+        success, stdout = result
+        return bool(success), str(stdout or ""), ""
+    raise ValueError(f"Expected script result tuple of len 2 or 3, got {len(result)}")
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
     Args:
         job: The cron job dict.
-        prerun_script: Optional ``(success, stdout)`` from a script that has
-            already been executed by the caller (e.g. for a wake-gate check).
-            When provided, the script is not re-executed and the cached
-            result is used for prompt injection. When omitted, the script
-            (if any) runs inline as before.
+        prerun_script: Optional cached script result from a caller-side
+            execution (e.g. for a wake-gate check). Accepts both the legacy
+            ``(success, stdout)`` shape and the richer
+            ``(success, stdout, stderr)`` shape. When provided, the script is
+            not re-executed and the cached result is used for prompt injection.
+            When omitted, the script (if any) runs inline as before.
     """
     user_prompt = str(job.get("prompt") or "")
     prompt = user_prompt
@@ -2476,9 +2496,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     script_path = job.get("script")
     if script_path:
         if prerun_script is not None:
-            success, script_output, script_stderr = prerun_script
+            success, script_output, script_stderr = _normalize_script_result(prerun_script)
         else:
-            success, script_output, script_stderr = _run_job_script(script_path)
+            success, script_output, script_stderr = _normalize_script_result(_run_job_script(script_path))
         if success:
             if script_output:
                 prompt = (
@@ -2838,8 +2858,10 @@ def run_job(
             _job_workdir = None
 
         try:
-            ok, output, script_stderr = _run_job_script_with_claim_heartbeat(
-                job, script_path, workdir=_job_workdir,
+            ok, output, script_stderr = _normalize_script_result(
+                _run_job_script_with_claim_heartbeat(
+                    job, script_path, workdir=_job_workdir,
+                )
             )
         except Exception as exc:
             logger.exception(
@@ -3002,8 +3024,10 @@ def run_job(
                 job_id, _job_workdir,
             )
             _job_workdir = None
-        prerun_script = _run_job_script_with_claim_heartbeat(
-            job, script_path, workdir=_job_workdir,
+        prerun_script = _normalize_script_result(
+            _run_job_script_with_claim_heartbeat(
+                job, script_path, workdir=_job_workdir,
+            )
         )
         _ran_ok, _script_output, _script_stderr = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -82,6 +82,105 @@ def test_cronjob_tool_create_no_agent_without_script_errors(hermes_env):
     assert "no_agent=True requires a script" in result.get("error", "")
 
 
+def test_cronjob_tool_create_no_agent_with_script_succeeds(hermes_env):
+    from tools.cronjob_tools import cronjob
+
+    script_path = hermes_env / "scripts" / "alert.sh"
+    script_path.write_text("#!/bin/bash\necho alert\n")
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            script="alert.sh",
+            no_agent=True,
+            deliver="local",
+        )
+    )
+    assert result.get("success") is True
+    assert result["job"]["no_agent"] is True
+    assert result["job"]["script"] == "alert.sh"
+
+
+def test_cronjob_tool_create_output_retention_zero_roundtrips(hermes_env):
+    from tools.cronjob_tools import cronjob
+
+    script_path = hermes_env / "scripts" / "retain.sh"
+    script_path.write_text("#!/bin/bash\necho retain\n")
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            script="retain.sh",
+            no_agent=True,
+            output_retention=0,
+            deliver="local",
+        )
+    )
+    assert result.get("success") is True
+    assert result["job"]["output_retention"] == 0
+
+
+def test_cronjob_tool_update_toggles_no_agent(hermes_env):
+    from tools.cronjob_tools import cronjob
+
+    script_path = hermes_env / "scripts" / "w.sh"
+    script_path.write_text("echo hi\n")
+
+    created = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            script="w.sh",
+            no_agent=True,
+            deliver="local",
+        )
+    )
+    job_id = created["job_id"]
+
+    off = json.loads(cronjob(action="update", job_id=job_id, no_agent=False, prompt="run"))
+    assert off["success"] is True
+    assert off["job"].get("no_agent") in {False, None}
+
+    on = json.loads(cronjob(action="update", job_id=job_id, no_agent=True))
+    assert on["success"] is True
+    assert on["job"]["no_agent"] is True
+
+
+def test_cronjob_tool_update_no_agent_without_script_errors(hermes_env):
+    """Flipping no_agent=True on a job that has no script must fail."""
+    from tools.cronjob_tools import cronjob
+
+    created = json.loads(
+        cronjob(action="create", schedule="every 5m", prompt="do a thing", deliver="local")
+    )
+    job_id = created["job_id"]
+
+    result = json.loads(cronjob(action="update", job_id=job_id, no_agent=True))
+    assert result.get("success") is False
+    assert "without a script" in result.get("error", "")
+
+
+def test_cronjob_tool_create_does_not_require_prompt_when_no_agent(hermes_env):
+    """The 'prompt or skill required' rule is relaxed for no_agent jobs."""
+    from tools.cronjob_tools import cronjob
+
+    script_path = hermes_env / "scripts" / "w.sh"
+    script_path.write_text("echo hi\n")
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            script="w.sh",
+            no_agent=True,
+            deliver="local",
+        )
+    )
+    assert result.get("success") is True
+
+
 # ---------------------------------------------------------------------------
 # scheduler.run_job: short-circuit behavior
 # ---------------------------------------------------------------------------
@@ -105,9 +204,120 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+def test_run_job_no_agent_empty_output_is_silent(hermes_env):
+    """Empty stdout → SILENT_MARKER, which suppresses delivery downstream."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job, SILENT_MARKER
+
+    script_path = hermes_env / "scripts" / "quiet.sh"
+    script_path.write_text("#!/bin/bash\n# nothing to say\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="quiet.sh", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert error is None
+    assert final_response == SILENT_MARKER
+    assert "silent (empty output)" in doc
+
+
+def test_run_job_no_agent_wake_gate_is_silent(hermes_env):
+    """wakeAgent=false gate in stdout triggers a silent run."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job, SILENT_MARKER
+
+    script_path = hermes_env / "scripts" / "gated.sh"
+    script_path.write_text('#!/bin/bash\necho \'{"wakeAgent": false}\'\n')
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="gated.sh", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is True
+    assert final_response == SILENT_MARKER
+
+
+def test_run_job_no_agent_script_failure_delivers_error(hermes_env):
+    """Non-zero exit → success=False, error alert is the delivered message."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "broken.sh"
+    script_path.write_text("#!/bin/bash\necho oops >&2\nexit 3\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="broken.sh", no_agent=True, deliver="local"
+    )
+    success, doc, final_response, error = run_job(job)
+    assert success is False
+    assert error is not None
+    assert "oops" in final_response
+    assert "exited with code 3" in final_response
+    assert "Cron watchdog" in final_response  # alert header
+
+
+def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
+    """no_agent jobs must NOT import/construct the AIAgent."""
+    from cron.jobs import create_job
+
+    script_path = hermes_env / "scripts" / "alert.sh"
+    script_path.write_text("#!/bin/bash\necho alert\n")
+
+    job = create_job(
+        prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"
+    )
+
+    with patch("run_agent.AIAgent") as ai_mock:
+        from cron.scheduler import run_job
+
+        run_job(job)
+
+    ai_mock.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # _run_job_script: shell-script support
 # ---------------------------------------------------------------------------
+
+
+def test_run_job_script_shell_script_runs_via_bash(hermes_env):
+    """.sh files should execute under /bin/bash even without a shebang line."""
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "shelly.sh"
+    # No shebang — relies on the interpreter-by-extension rule.
+    script_path.write_text('echo "shell: $BASH_VERSION" | head -c 7\n')
+
+    ok, output, stderr = _run_job_script("shelly.sh")
+    assert ok is True
+    assert output.startswith("shell:")
+    assert stderr == ""
+
+
+def test_run_job_script_bash_extension_also_runs_via_bash(hermes_env):
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "thing.bash"
+    script_path.write_text('printf "via bash\\n"\n')
+
+    ok, output, stderr = _run_job_script("thing.bash")
+    assert ok is True
+    assert output == "via bash"
+    assert stderr == ""
+
+
+def test_run_job_script_python_still_runs_via_python(hermes_env):
+    """Regression: .py files must keep running via sys.executable."""
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "py.py"
+    script_path.write_text("import sys\nprint(f'python {sys.version_info.major}')\n")
+
+    ok, output, stderr = _run_job_script("py.py")
+    assert ok is True
+    assert output.startswith("python ")
+    assert stderr == ""
 
 
 def test_run_job_script_path_traversal_still_blocked(hermes_env):
@@ -115,6 +325,7 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     from cron.scheduler import _run_job_script
 
     # Absolute path outside the scripts dir should be rejected.
-    ok, output = _run_job_script("/etc/passwd")
+    ok, output, stderr = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+    assert stderr == ""

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -90,7 +90,7 @@ class TestRunJobScript:
         script = cron_env / "scripts" / "test.py"
         script.write_text('print("hello from script")\n')
 
-        success, output = _run_job_script(str(script))
+        success, output, stderr = _run_job_script(str(script))
         assert success is True
         assert output == "hello from script"
 
@@ -100,10 +100,47 @@ class TestRunJobScript:
         script = cron_env / "scripts" / "relative.py"
         script.write_text('print("relative works")\n')
 
-        success, output = _run_job_script("relative.py")
+        success, output, stderr = _run_job_script("relative.py")
         assert success is True
         assert output == "relative works"
 
+
+
+    def test_script_not_found(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        success, output, stderr = _run_job_script("nonexistent_script.py")
+        assert success is False
+        assert "not found" in output.lower()
+        assert stderr == ""
+
+    def test_script_nonzero_exit_splits_stdout_and_stderr(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "fail.py"
+        script.write_text(textwrap.dedent("""\
+            import sys
+            print("partial output")
+            print("error info", file=sys.stderr)
+            sys.exit(1)
+        """))
+
+        success, output, stderr = _run_job_script(str(script))
+        assert success is False
+        assert output == "partial output"
+        assert "Script exited with code 1" in stderr
+        assert "error info" in stderr
+
+    def test_script_empty_output(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "empty.py"
+        script.write_text("# no output\n")
+
+        success, output, stderr = _run_job_script(str(script))
+        assert success is True
+        assert output == ""
+        assert stderr == ""
 
     def test_script_subprocess_env_sanitized(self, cron_env, monkeypatch):
         """Cron scripts must not inherit Hermes provider env (SECURITY.md §2.3)."""
@@ -126,9 +163,10 @@ class TestRunJobScript:
             )
         )
 
-        success, output = _run_job_script("env_probe.py")
+        success, output, stderr = _run_job_script("env_probe.py")
         assert success is True
         assert output == "ABSENT"
+        assert stderr == ""
 
     def test_windows_uv_venv_python_script_bypasses_launcher(self, cron_env, tmp_path, monkeypatch):
         from cron import scheduler as sched_mod
@@ -162,10 +200,11 @@ class TestRunJobScript:
         monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
         monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
 
-        success, output = _run_job_script("probe.py")
+        success, output, stderr = _run_job_script("probe.py")
 
         assert success is True
         assert output == "ok"
+        assert stderr == ""
         assert captured["argv"] == [str(base_python), str(script.resolve())]
         assert captured["kwargs"]["creationflags"] == 0x08000000
         env = captured["kwargs"]["env"]
@@ -190,10 +229,11 @@ class TestRunJobScript:
         monkeypatch.setattr(sched_mod.sys, "platform", "linux")
         monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
 
-        success, output = _run_job_script("probe.py")
+        success, output, stderr = _run_job_script("probe.py")
 
         assert success is True
         assert output == "ok"
+        assert stderr == ""
         assert captured["argv"] == [sys.executable, str(script.resolve())]
         assert captured["kwargs"]["text"] is True
         assert "creationflags" not in captured["kwargs"]
@@ -297,16 +337,26 @@ class TestScriptPathContainment:
         outside_script = cron_env / "outside.py"
         outside_script.write_text('print("should not run")\n')
 
-        success, output = _run_job_script(str(outside_script))
+        success, output, stderr = _run_job_script(str(outside_script))
         assert success is False
         assert "blocked" in output.lower() or "outside" in output.lower()
 
+
+
+    def test_absolute_path_tmp_blocked(self, cron_env):
+        """Absolute paths to /tmp must be rejected."""
+        from cron.scheduler import _run_job_script
+
+        success, output, stderr = _run_job_script("/tmp/evil.py")
+        assert success is False
+        assert "blocked" in output.lower() or "outside" in output.lower()
+        assert stderr == ""
 
     def test_tilde_path_blocked(self, cron_env):
         """~ prefixed paths must be rejected (expanduser bypasses check)."""
         from cron.scheduler import _run_job_script
 
-        success, output = _run_job_script("~/evil.py")
+        success, output, stderr = _run_job_script("~/evil.py")
         assert success is False
         assert "blocked" in output.lower() or "outside" in output.lower()
 
@@ -314,7 +364,7 @@ class TestScriptPathContainment:
         """~/../../../tmp/evil.py must be rejected."""
         from cron.scheduler import _run_job_script
 
-        success, output = _run_job_script("~/../../../tmp/evil.py")
+        success, output, stderr = _run_job_script("~/../../../tmp/evil.py")
         assert success is False
         assert "blocked" in output.lower() or "outside" in output.lower()
 
@@ -322,7 +372,7 @@ class TestScriptPathContainment:
         """../../etc/passwd style traversal must still be blocked."""
         from cron.scheduler import _run_job_script
 
-        success, output = _run_job_script("../../etc/passwd")
+        success, output, stderr = _run_job_script("../../etc/passwd")
         assert success is False
         assert "blocked" in output.lower() or "outside" in output.lower()
 
@@ -333,7 +383,7 @@ class TestScriptPathContainment:
         script = cron_env / "scripts" / "good.py"
         script.write_text('print("ok")\n')
 
-        success, output = _run_job_script("good.py")
+        success, output, stderr = _run_job_script("good.py")
         assert success is True
         assert output == "ok"
 
@@ -346,10 +396,23 @@ class TestScriptPathContainment:
         script = subdir / "check.py"
         script.write_text('print("sub ok")\n')
 
-        success, output = _run_job_script("monitors/check.py")
+        success, output, stderr = _run_job_script("monitors/check.py")
         assert success is True
         assert output == "sub ok"
 
+
+
+    def test_absolute_path_inside_scripts_dir_allowed(self, cron_env):
+        """Absolute paths that resolve WITHIN scripts/ should work."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "abs_ok.py"
+        script.write_text('print("abs ok")\n')
+
+        success, output, stderr = _run_job_script(str(script))
+        assert success is True
+        assert output == "abs ok"
+        assert stderr == ""
 
     @pytest.mark.skipif(
         sys.platform == "win32",
@@ -367,7 +430,7 @@ class TestScriptPathContainment:
         link = cron_env / "scripts" / "sneaky.py"
         link.symlink_to(outside)
 
-        success, output = _run_job_script("sneaky.py")
+        success, output, stderr = _run_job_script("sneaky.py")
         assert success is False
         assert "blocked" in output.lower() or "outside" in output.lower()
 

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -145,6 +145,53 @@ class TestTickWorkdirPartition:
     pieces tick() calls.
     """
 
+    def test_workdir_jobs_run_sequentially(self, tmp_path, monkeypatch):
+        import cron.scheduler as sched
+
+        # Two workdir jobs (both sequential) + one parallel job.
+        workdir_a = {"id": "a", "name": "A", "workdir": str(tmp_path)}
+        workdir_b = {"id": "b", "name": "B", "workdir": str(tmp_path)}
+        parallel_job = {"id": "c", "name": "C", "workdir": None}
+
+        monkeypatch.setattr(sched, "get_due_jobs", lambda: [workdir_a, workdir_b, parallel_job])
+        monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+
+        # Record call order / thread context.
+        import threading
+        calls: list[tuple[str, str]] = []
+        order_lock = threading.Lock()
+
+        def fake_run_job(job, **_kwargs):
+            # Return a minimal tuple matching run_job's signature.
+            with order_lock:
+                calls.append((job["id"], threading.current_thread().name))
+            return True, "output", "response", None
+
+        monkeypatch.setattr(sched, "run_job", fake_run_job)
+        monkeypatch.setattr(sched, "save_job_output", lambda _jid, _o, **_kw: "/tmp/out.md")
+        monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(
+            sched, "_deliver_result", lambda *_a, **_kw: None
+        )
+
+        n = sched.tick(verbose=False)
+        assert n == 3
+
+        ids = [c[0] for c in calls]
+        # Sequential workdir jobs preserve submission order relative to each
+        # other (single-thread pool).
+        assert ids.index("a") < ids.index("b")
+
+        # Workdir jobs run on the persistent single-thread cron-seq pool —
+        # NOT the main thread — so a long workdir job never blocks the ticker.
+        main_thread_name = threading.current_thread().name
+        for jid in ("a", "b"):
+            workdir_thread_name = next(t for j, t in calls if j == jid)
+            assert workdir_thread_name != main_thread_name
+            assert workdir_thread_name.startswith("cron-seq"), workdir_thread_name
+        par_thread_name = next(t for j, t in calls if j == "c")
+        assert par_thread_name.startswith("cron-parallel"), par_thread_name
+
 
 # ---------------------------------------------------------------------------
 # scheduler.run_job: TERMINAL_CWD + skip_context_files wiring

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -217,7 +217,7 @@ def test_run_one_job_records_running_then_terminal(monkeypatch):
         "run_job",
         lambda job, *, defer_agent_teardown=None: (True, "output", "response", None),
     )
-    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args, **_kwargs: "/tmp/out.md")
     monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(scheduler, "mark_job_run", lambda *_args, **_kwargs: None)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -981,6 +981,15 @@ class TestCronOutputRetention:
         )
         assert jobs._cron_output_keep({"output_retention": "bogus"}, silent=True) == jobs._CRON_SILENT_OUTPUT_DEFAULT_KEEP
 
+    def test_cron_output_keep_bool_override_is_invalid_not_numeric(self, monkeypatch):
+        import cron.jobs as jobs
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"output_retention_silent": 99, "output_retention": 12}},
+        )
+        assert jobs._cron_output_keep({"output_retention": True}, silent=True) == jobs._CRON_SILENT_OUTPUT_DEFAULT_KEEP
+        assert jobs._cron_output_keep({"output_retention": False}, silent=True) == jobs._CRON_SILENT_OUTPUT_DEFAULT_KEEP
+
     def test_cron_output_keep_defaults_on_bad_config(self, monkeypatch):
         import cron.jobs as jobs
         monkeypatch.setattr(

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -904,6 +904,90 @@ class TestCronOutputRetention:
         assert _prune_job_output(d, keep=3) == 7
         assert sorted(p.name for p in d.glob("*.md")) == names[-3:]
 
+    def test_prune_noop_when_under_cap(self, tmp_path):
+        from cron.jobs import _prune_job_output
+        d = tmp_path / "job"
+        self._seed(d, 3)
+        assert _prune_job_output(d, keep=5) == 0
+        assert len(list(d.glob("*.md"))) == 3
+
+    def test_prune_disabled_when_keep_non_positive(self, tmp_path):
+        from cron.jobs import _prune_job_output
+        d = tmp_path / "job"
+        self._seed(d, 5)
+        assert _prune_job_output(d, keep=0) == 0
+        assert _prune_job_output(d, keep=-1) == 0
+        assert len(list(d.glob("*.md"))) == 5
+
+    def test_prune_ignores_non_md_and_temp_files(self, tmp_path):
+        from cron.jobs import _prune_job_output
+        d = tmp_path / "job"
+        self._seed(d, 4)
+        (d / ".output_abc.tmp").write_text("partial")
+        (d / "manifest.json").write_text("{}")
+        _prune_job_output(d, keep=2)
+        assert (d / ".output_abc.tmp").exists()
+        assert (d / "manifest.json").exists()
+        assert len(list(d.glob("*.md"))) == 2
+
+    def test_save_job_output_prunes_old_runs(self, tmp_cron_dir, monkeypatch):
+        from cron.jobs import save_job_output, _job_output_dir
+        monkeypatch.setattr("cron.jobs._cron_output_keep", lambda: 3)
+        seq = iter(
+            datetime(2026, 6, 25, 10, 0, 0, tzinfo=timezone.utc) + timedelta(seconds=i)
+            for i in range(8)
+        )
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: next(seq))
+        for _ in range(8):
+            save_job_output("job1", "report")
+        files = sorted(_job_output_dir("job1").glob("*.md"))
+        assert len(files) == 3  # only the 3 most-recent runs survive
+
+    def test_cron_output_keep_reads_config(self, monkeypatch):
+        import cron.jobs as jobs
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"cron": {"output_retention": 7}}
+        )
+        assert jobs._cron_output_keep() == 7
+
+    def test_cron_output_keep_silent_respects_job_override(self, monkeypatch):
+        import cron.jobs as jobs
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"output_retention_silent": 99, "output_retention": 12}},
+        )
+        assert jobs._cron_output_keep({"output_retention": 5}, silent=True) == 5
+
+    def test_cron_output_keep_bad_config_still_respects_job_override(self, monkeypatch):
+        import cron.jobs as jobs
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"cron": {"output_retention": "oops"}}
+        )
+        assert jobs._cron_output_keep({"output_retention": 4}, silent=True) == 4
+
+    def test_cron_output_keep_job_override_can_disable_pruning(self, monkeypatch):
+        import cron.jobs as jobs
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"cron": {"output_retention_silent": 99, "output_retention": 12}},
+        )
+        assert jobs._cron_output_keep({"output_retention": 0}, silent=True) == 0
+        assert jobs._cron_output_keep({"output_retention": -5}, silent=False) == -5
+
+    def test_cron_output_keep_corrupt_job_override_does_not_raise(self, monkeypatch):
+        import cron.jobs as jobs
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"cron": {"output_retention": "oops"}}
+        )
+        assert jobs._cron_output_keep({"output_retention": "bogus"}, silent=True) == jobs._CRON_SILENT_OUTPUT_DEFAULT_KEEP
+
+    def test_cron_output_keep_defaults_on_bad_config(self, monkeypatch):
+        import cron.jobs as jobs
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"cron": {"output_retention": "oops"}}
+        )
+        assert jobs._cron_output_keep() == jobs._CRON_OUTPUT_DEFAULT_KEEP
+
 
 # =========================================================================
 # claim_dispatch — pre-run one-shot crash safety (issue #38758)

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -23,7 +23,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         fr = final if silent_marker_in is None else silent_marker_in
         return (success, output, fr, error)
 
-    def fake_save(jid, out):
+    def fake_save(jid, out, **kwargs):
         calls.append(("save", jid))
         return f"/tmp/{jid}.txt"
 
@@ -91,7 +91,7 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
         return (True, "out", "final", None)
 
     monkeypatch.setattr(s, "run_job", fake_run_job)
-    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out, **kwargs: f"/tmp/{jid}.txt")
     monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
     monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -947,6 +947,17 @@ class TestSilentDelivery:
             tick(verbose=False)
         deliver_mock.assert_called_once()
 
+    def test_output_saved_even_when_delivery_suppressed(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None)), \
+             patch("cron.scheduler.save_job_output") as save_mock, \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            save_mock.return_value = "/tmp/out.md"
+            from cron.scheduler import tick
+            tick(verbose=False)
+        save_mock.assert_called_once_with("monitor-job", "# full output", keep=20)
+        deliver_mock.assert_not_called()
 
     def test_whitespace_only_response_is_marked_failed_not_delivered(self):
         """Whitespace-only final responses should behave like empty responses."""
@@ -965,6 +976,18 @@ class TestSilentDelivery:
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
         )
+
+    def test_run_index_write_failure_does_not_flip_success(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "done", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.append_job_run_index", side_effect=OSError("disk full")), \
+             patch("cron.scheduler._deliver_result", return_value=None), \
+             patch("cron.scheduler.mark_job_run") as mark_mock:
+            from cron.scheduler import tick
+            tick(verbose=False)
+
+        mark_mock.assert_called_once_with("monitor-job", True, None, delivery_error=None)
 
 
 class TestOneShotDispatchClaim:
@@ -1063,14 +1086,15 @@ class TestRunJobWakeGate:
         import cron.scheduler as scheduler
 
         with patch.object(scheduler, "_run_job_script",
-                          return_value=(True, '{"wakeAgent": false}')), \
+                          return_value=(True, '{"wakeAgent": false}', '')), \
              patch("run_agent.AIAgent") as agent_cls:
             success, doc, final, err = scheduler.run_job(self._make_job())
 
         assert success is True
         assert err is None
         assert final == SILENT_MARKER
-        assert "Script gate returned `wakeAgent=false`" in doc
+        assert "**Status:** silent (wakeAgent=false)" in doc
+        assert "## Gate stdout" in doc
         agent_cls.assert_not_called()
 
     def test_wake_true_runs_agent_with_injected_output(self):
@@ -1084,7 +1108,7 @@ class TestRunJobWakeGate:
             "final_response": "ok", "messages": []
         })
         with patch.object(scheduler, "_run_job_script",
-                          return_value=(True, script_output)), \
+                          return_value=(True, script_output, '')), \
              patch("run_agent.AIAgent", return_value=agent) as agent_cls:
             success, doc, final, err = scheduler.run_job(self._make_job())
 
@@ -1096,6 +1120,80 @@ class TestRunJobWakeGate:
         assert script_output in prompt_arg
         assert success is True
         assert err is None
+
+    def test_script_runs_only_once_on_wake(self):
+        """Wake-true path must not re-run the script inside _build_job_prompt
+        (script would execute twice otherwise, wasting work and risking
+        double-side-effects)."""
+        import cron.scheduler as scheduler
+
+        call_count = 0
+        def _script_stub(path):
+            nonlocal call_count
+            call_count += 1
+            return (True, "regular output", "")
+
+        agent = MagicMock()
+        agent.run_conversation = MagicMock(return_value={
+            "final_response": "ok", "messages": []
+        })
+        with patch.object(scheduler, "_run_job_script", side_effect=_script_stub), \
+             patch("run_agent.AIAgent", return_value=agent):
+            scheduler.run_job(self._make_job())
+
+        assert call_count == 1, f"script ran {call_count}x, expected exactly 1"
+
+    def test_script_failure_does_not_trigger_gate(self):
+        """If _run_job_script returns success=False, the gate is NOT evaluated
+        and the agent still runs (the failure is reported as context)."""
+        import cron.scheduler as scheduler
+
+        # Malicious or broken script whose stderr happens to contain the
+        # gate JSON — we must NOT honor it because ran_ok is False.
+        agent = MagicMock()
+        agent.run_conversation = MagicMock(return_value={
+            "final_response": "ok", "messages": []
+        })
+        with patch.object(scheduler, "_run_job_script",
+                          return_value=(False, '{"wakeAgent": false}', '')), \
+             patch("run_agent.AIAgent", return_value=agent) as agent_cls:
+            success, doc, final, err = scheduler.run_job(self._make_job())
+
+        agent_cls.assert_called_once()  # Agent DID wake despite the gate-like text
+
+    def test_no_script_path_runs_agent_normally(self):
+        """Regression: jobs without a script still work."""
+        import cron.scheduler as scheduler
+
+        agent = MagicMock()
+        agent.run_conversation = MagicMock(return_value={
+            "final_response": "ok", "messages": []
+        })
+        job = self._make_job(script=None)
+        job.pop("script", None)
+        with patch.object(scheduler, "_run_job_script") as script_fn, \
+             patch("run_agent.AIAgent", return_value=agent) as agent_cls:
+            scheduler.run_job(job)
+
+        script_fn.assert_not_called()
+        agent_cls.assert_called_once()
+
+
+class TestCronStatePaths:
+    def test_cron_state_paths_reuses_store_normalization(self):
+        from cron.scheduler import _cron_state_paths
+
+        job = {"id": "job1", "state_paths": ["~/state.json", "/tmp/state.json", "~/state.json"]}
+        paths = _cron_state_paths(job)
+        assert all(path.startswith("/") for path in paths)
+        assert len(paths) == 2
+
+    def test_cron_state_paths_ignores_invalid_relative_entries(self, caplog):
+        from cron.scheduler import _cron_state_paths
+
+        paths = _cron_state_paths({"id": "job1", "state_paths": ["relative/state.json"]})
+        assert paths == []
+        assert "invalid state_paths ignored" in caplog.text
 
 
 class TestBuildJobPromptMissingSkill:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1128,7 +1128,7 @@ class TestRunJobWakeGate:
         import cron.scheduler as scheduler
 
         call_count = 0
-        def _script_stub(path):
+        def _script_stub(path, **_kwargs):
             nonlocal call_count
             call_count += 1
             return (True, "regular output", "")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -586,6 +586,10 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("output_retention") is not None:
+        result["output_retention"] = job["output_retention"]
+    if job.get("state_paths"):
+        result["state_paths"] = job["state_paths"]
     return result
 
 
@@ -728,6 +732,8 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    output_retention: Optional[int] = None,
+    state_paths: Optional[List[str]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -801,6 +807,8 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                output_retention=output_retention,
+                state_paths=state_paths,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -980,6 +988,10 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if output_retention is not None:
+                updates["output_retention"] = output_retention
+            if state_paths is not None:
+                updates["state_paths"] = state_paths
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
@@ -1127,6 +1139,15 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "output_retention": {
+                "type": "integer",
+                "description": "Optional per-job output file retention cap. Overrides cron.output_retention for this one job. Positive integers keep only the N most recent output .md files for the job; 0 or negative disables pruning for that job. On update, omitting the field leaves the existing value unchanged; there is currently no explicit unset sentinel through the tool schema."
+            },
+            "state_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of absolute or home-relative (~/...) state file paths relevant to this job's execution. These paths are recorded in output footers and run metadata for audit/debugging; they are not automatically read or enforced. On update, pass an empty array to clear."
+            },
         },
         "required": ["action"]
     }
@@ -1184,6 +1205,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        output_retention=args.get("output_retention"),
+        state_paths=args.get("state_paths"),
         task_id=kw.get("task_id"),
     ),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## Bug Description

Cron run artifacts were missing two things that operators need once a job is running for a long time:

1. **Retention that matches the kind of run**
   - per-run cron output already had a single global retention cap, but silent heartbeats and substantive/error runs often need different retention behavior
   - there was no per-job override, so noisy jobs and important jobs could not tune retention independently

2. **Audit detail for silent and script-driven runs**
   - silent runs were intentionally not delivered, but the saved artifacts did not consistently explain why a run was silent, where delivery would have gone, or which state files were relevant
   - script stderr and delivery metadata were easy to lose, which made post-mortem debugging harder

This PR tightens both retention and observability without changing the external cron execution model.

Related context:
- Refs #52383
- Refs #39307

## Root Cause

The cron subsystem stored each run as a markdown artifact, but the retention and audit logic lived at different layers and stopped short of the information operators actually need:

- output retention was global-only and did not distinguish silent runs from substantive/error runs
- `save_job_output()` had no way to apply a per-run retention decision made by the scheduler
- `_run_job_script()` collapsed useful stdout/stderr distinctions too early
- silent runs skipped delivery correctly, but the saved artifact did not always preserve the gate/output context that explained the silence
- the cron tool schema/store path did not expose per-job retention and state-manifest fields end-to-end

## Fix

- add per-job `output_retention` validation/storage (including non-positive per-job disable values) and absolute-path `state_paths` normalization in `cron/jobs.py`
- let the scheduler choose retention based on run type via `save_job_output(..., keep=...)`
- add separate defaults for silent vs substantive/error run retention:
  - `cron.output_retention_silent` (default 20)
  - `cron.output_retention_substantive` (default 50)
- preserve script stdout/stderr separately so failed or gated runs keep useful audit detail
- write explicit silent-run artifacts for:
  - `wakeAgent=false`
  - empty script output in `no_agent` mode
  - empty script output in agentic pre-run mode
- append a delivery/state footer to saved run artifacts
- append a compact `runs.jsonl` record per run with status, duration, delivery metadata, output path, and error fields
  - `runs.jsonl` is intentionally append-only and excluded from the markdown retention cap; it stores compact JSONL records rather than full per-run markdown docs
- surface the new `output_retention` and `state_paths` fields through the cron tool formatter/schema/handler
- document the new retention defaults in `hermes_cli/config.py`
- update cron tests for the new scheduler/save-job-output contract and audit behavior

Design note:
- Delivery footers in saved cron artifacts intentionally record the job's configured destination (`platform:chat_id`, optional `thread_id`) so operators can audit where a run would have been delivered.

## How to Verify

1. Run:
   `python -m pytest tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py tests/cron/test_jobs.py tests/cron/test_scheduler.py tests/cron/test_run_one_job.py -q`
2. Confirm the suite passes and that the changed behavior is covered by tests for:
   - per-job retention override resolution
   - silent-run artifact content
   - `save_job_output(..., keep=...)` call sites
   - run-index write failures not flipping job success
   - `state_paths` normalization and tool wiring

## Test Plan

- [x] Added regression/coverage tests for the new cron retention and audit behavior
- [x] Existing targeted cron tests still pass
- [ ] Manual verification of live cron delivery/output on a running deployment

Exact run:
- `python -m pytest tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py tests/cron/test_jobs.py tests/cron/test_scheduler.py tests/cron/test_run_one_job.py -q`
  - result: `389 passed in 17.99s`

Note:
- This result comes from a clean `origin/main` worktree after resolving the upstream `run_one_job` conflict, adapting `test_run_one_job.py` to the new `save_job_output(..., keep=...)` signature, and adding explicit coverage for per-job disable values (`output_retention <= 0`) plus tool-format round-tripping of `output_retention=0`.
- Live platform delivery behavior is unchanged in design, but end-to-end operator validation on a running deployment remains a sensible follow-up.

## Related work

- Open PRs #52396, #52407, and #52402 all cover the narrower "bound cron output retention" lane. This branch includes that lane but also adds silent/substantive retention tiers, per-job overrides, stderr-preserving audit docs, delivery/state footers, and per-run JSONL indexing.
- Open PR #57556 fixes `attach_to_session` wiring in `tools/cronjob_tools.py`. That is adjacent work in the same file but not part of this diff.
- Open PRs #57688 and #57773 address `no_agent` delivery wrapping. This branch does not change the wrapper contract; it only improves saved audit artifacts and silent-run retention behavior.
- Closed issue #52383 and open feature request #39307 are the closest public motivation for the retention part of this branch.

## Risk Assessment

Medium — the patch is isolated to cron internals and focused tests are green, but it changes several adjacent scheduler/storage paths at once: retention selection, saved artifact shape, script stderr propagation, and tool schema wiring. The operational blast radius is limited to cron job execution and cron artifact persistence, not the general agent loop or gateway routing.

Current limitation:
- The tool schema can set per-job `output_retention`, including disabling pruning with `0` or a negative value, but it does not yet expose a dedicated "unset back to inherited default" sentinel on update. This is a known API limitation of the update path.