### PR TITLE
fix(desktop): use main lane for non-git project folders

### DIFF
--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -273,6 +273,24 @@ def test_seeded_folder_repo_does_not_duplicate_a_session_derived_repo():
     assert [r["path"] for r in node["repos"]] == ["/www/app"]
 
 
+def test_non_git_project_folder_uses_the_standard_main_lane():
+    # Non-git project folders have no resolver/persisted repo root, but they are
+    # still main checkouts for the desktop tree. Use the same lane id the live
+    # session overlay computes, otherwise the initial snapshot shows the folder
+    # name and the overlay adds a duplicate "main" lane with the same session.
+    project = _project("p_notes", "Notes", ["/work/notes"])
+    session = _session("/work/notes")
+
+    tree = pt.build_tree([project], [session], [], resolve=None, hydrate=True)
+
+    node = next(p for p in tree["projects"] if p["id"] == "p_notes")
+    lanes = node["repos"][0]["groups"]
+
+    assert [g["id"] for g in lanes] == ["/work/notes::branch::main"]
+    assert [g["label"] for g in lanes] == ["main"]
+    assert lanes[0]["sessions"] == [session]
+
+
 def test_discovered_repo_owned_by_explicit_project_is_not_duplicated():
     project = _project("p_app", "App", ["/www/app"])
     discovered = [{"root": "/www/app", "label": "app", "sessions": 2, "last_active": 1}]

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -126,7 +126,14 @@ def _place_by_heuristic(path: str) -> Optional[dict]:
         repo_path = _with_base_name(path, m.group(1))
         return _placement(repo_path, path, m.group(2), path, False, False)
 
-    return _placement(path, path, base, path, True, False)
+    return _placement(
+        path,
+        _branch_lane_id(path, DEFAULT_BRANCH_LABEL),
+        DEFAULT_BRANCH_LABEL,
+        path,
+        True,
+        False,
+    )
 
 
 def _place(cwd: str, branch: str, resolve: Optional[Resolve], persisted_root: str) -> Optional[dict]:


### PR DESCRIPTION
## Summary
- make path-only/non-git project folders use the same `::branch::main` lane id as the desktop live-session overlay
- keep the repo node path/identity unchanged while labeling the main-checkout lane as `main`
- add a project-tree regression test for explicit non-git project folders

## Why
For explicit project folders that are not git repositories, the backend project tree previously emitted a main-checkout lane keyed by the folder path and labeled with the directory name. The desktop live overlay computes a standard main lane (`<path>::branch::main`) for the same cwd, so the initial snapshot and live overlay could show the same session under two lanes: `main` and `<directory-name>`.

This addresses #57715 by aligning the fallback backend lane identity with the renderer existing lane identity contract.

## Tests
- pytest tests/tui_gateway/test_project_tree.py -q
- ruff check tui_gateway/project_tree.py tests/tui_gateway/test_project_tree.py
- git diff --check