### PR TITLE
fix(schema): inline local tool schema refs

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -201,8 +201,8 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
-def test_ref_with_default_sibling_stripped():
-    """Strict backends reject ``default`` alongside ``$ref``."""
+def test_ref_with_default_sibling_inlined_without_default():
+    """Strict backends reject refs/defaults; inline local refs and drop default."""
     tools = [_tool("t", {
         "type": "object",
         "properties": {
@@ -217,7 +217,8 @@ def test_ref_with_default_sibling_stripped():
     })]
     out = sanitize_tool_schemas(tools)
     payload = out[0]["function"]["parameters"]["properties"]["payload"]
-    assert payload == {"$ref": "#/$defs/Payload"}
+    assert payload == {"type": "object", "properties": {"q": {"type": "string"}}}
+    assert "$defs" not in out[0]["function"]["parameters"]
 
 
 def test_nullable_union_collapse_does_not_leave_default_on_ref():
@@ -242,13 +243,15 @@ def test_nullable_union_collapse_does_not_leave_default_on_ref():
     })]
     out = sanitize_tool_schemas(tools)
     prop = out[0]["function"]["parameters"]["properties"]["input"]
-    assert prop["$ref"] == "#/$defs/Payload"
+    assert prop["type"] == "object"
+    assert prop["properties"] == {"q": {"type": "string"}}
     assert "default" not in prop
     assert prop.get("nullable") is True
+    assert "$defs" not in out[0]["function"]["parameters"]
 
 
 def test_ref_description_preserved():
-    """Annotation siblings that strict backends allow should survive."""
+    """Annotation siblings that strict backends allow should survive inlining."""
     tools = [_tool("t", {
         "type": "object",
         "properties": {
@@ -264,7 +267,43 @@ def test_ref_description_preserved():
     out = sanitize_tool_schemas(tools)
     payload = out[0]["function"]["parameters"]["properties"]["payload"]
     assert payload["description"] == "The payload"
-    assert payload["$ref"] == "#/$defs/Payload"
+    assert payload["type"] == "object"
+    assert payload["properties"] == {}
+    assert "$ref" not in payload
+
+
+def test_nested_internal_refs_are_inlined_recursively():
+    tools = [_tool("browser", {
+        "type": "object",
+        "properties": {
+            "cookies": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/SetCookieParam"},
+            },
+        },
+        "$defs": {
+            "SetCookieParam": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "sameSite": {"$ref": "#/$defs/SameSite"},
+                },
+                "required": ["name"],
+            },
+            "SameSite": {"type": "string", "enum": ["Strict", "Lax", "None"]},
+        },
+    })]
+
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]
+    item = params["properties"]["cookies"]["items"]
+
+    assert "$defs" not in params
+    assert "$ref" not in item
+    assert item["properties"]["sameSite"] == {
+        "type": "string",
+        "enum": ["Strict", "Lax", "None"],
+    }
 
 
 def test_empty_tools_list_returns_empty():

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -27,6 +27,10 @@ The failure modes we've seen in the wild:
   after nullable-union collapse::
 
       {"$ref": "#/$defs/Foo", "default": null}
+* Internal ``#/$defs/...`` / ``#/definitions/...`` references — some strict
+  OpenAI-compatible endpoints (notably Fireworks) fail while resolving local
+  refs in function schemas, so resolvable local refs are inlined before the
+  request leaves Hermes.
 
 This module walks the final tool schema tree (after MCP-level normalization
 and any per-tool dynamic rebuilds) and fixes the known-hostile constructs
@@ -97,6 +101,7 @@ def _sanitize_single_tool(tool: dict) -> dict:
         fn["parameters"], path=fn.get("name", "<tool>")
     )
     fn["parameters"] = _strip_ref_siblings(fn["parameters"])
+    fn["parameters"] = _inline_internal_refs(fn["parameters"])
     return out
 
 
@@ -125,6 +130,83 @@ def _strip_ref_siblings(node: Any) -> Any:
         for key in _REF_FORBIDDEN_SIBLINGS:
             if key in out:
                 out.pop(key, None)
+    return out
+
+
+def _decode_json_pointer_part(part: str) -> str:
+    return part.replace("~1", "/").replace("~0", "~")
+
+
+def _resolve_local_ref(root: dict, ref: str) -> Any:
+    """Resolve a local JSON pointer (``#/...``) inside ``root``.
+
+    Returns ``None`` when the pointer cannot be resolved. ``None`` is safe here
+    because JSON Schema fragments we care about are objects/lists, not literal
+    null schemas.
+    """
+    if not ref.startswith("#/"):
+        return None
+
+    cur: Any = root
+    for raw_part in ref[2:].split("/"):
+        part = _decode_json_pointer_part(raw_part)
+        if isinstance(cur, dict):
+            if part not in cur:
+                return None
+            cur = cur[part]
+        elif isinstance(cur, list):
+            try:
+                cur = cur[int(part)]
+            except (ValueError, IndexError):
+                return None
+        else:
+            return None
+    return cur
+
+
+def _inline_internal_refs(schema: Any) -> Any:
+    """Inline resolvable local ``$ref`` nodes and remove now-unused defs.
+
+    Fireworks' OpenAI-compatible endpoint has rejected tool schemas with an
+    internal reference such as ``#/$defs/SetCookieParam`` before the model can
+    run. OpenAI accepts these refs, but Hermes' tool schemas are more portable
+    if the final request carries the concrete schema where possible.
+
+    Only local JSON pointers are inlined. Remote/unknown refs are left in place
+    rather than guessed.
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    root = copy.deepcopy(schema)
+
+    def _walk(node: Any, resolving: tuple[str, ...]) -> Any:
+        if isinstance(node, list):
+            return [_walk(item, resolving) for item in node]
+        if not isinstance(node, dict):
+            return node
+
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/"):
+            target = _resolve_local_ref(root, ref)
+            if target is not None and ref not in resolving:
+                merged = _walk(copy.deepcopy(target), (*resolving, ref))
+                if isinstance(merged, dict):
+                    for key, value in node.items():
+                        if key != "$ref":
+                            merged[key] = _walk(value, resolving)
+                    return merged
+            # If a local ref is missing or recursive, remove the unusable ref
+            # but keep any annotation siblings so strict endpoints do not fail
+            # the whole tool schema on a dangling pointer.
+            return {key: _walk(value, resolving) for key, value in node.items() if key != "$ref"}
+
+        return {key: _walk(value, resolving) for key, value in node.items()}
+
+    out = _walk(root, ())
+    if isinstance(out, dict):
+        out.pop("$defs", None)
+        out.pop("definitions", None)
     return out
 
 


### PR DESCRIPTION
## Summary
- inline resolvable local JSON Schema refs (`#/$defs/...` and `#/definitions/...`) in sanitized tool schemas
- remove top-level defs after inlining so strict OpenAI-compatible endpoints never have to resolve them
- preserve annotation siblings such as descriptions and keep dangling/recursive local refs from leaking to providers

## Why
Fireworks custom OpenAI-compatible endpoints can reject Hermes tool schemas before the first response when a built-in tool includes an internal `$defs` reference, for example `#/$defs/SetCookieParam`. Hermes already strips strict-backend-hostile `$ref` siblings, but the final request could still carry the local `$ref` itself.

This addresses the shared schema-sanitization path called out in #56979 and keeps tools enabled for strict providers instead of requiring users to disable browser/tool schemas.

## Tests
- pytest tests/tools/test_schema_sanitizer.py -q
- ruff check tools/schema_sanitizer.py tests/tools/test_schema_sanitizer.py
- git diff --check