### PR TITLE
fix(profiles): skip dangling skill symlinks when cloning

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -196,6 +196,20 @@ def _clone_all_copytree_ignore(source_dir: Path):
     return _ignore
 
 
+def _ignore_dangling_symlinks(directory: str, names: List[str]) -> List[str]:
+    """Return symlink entries whose targets are missing from this copytree dir."""
+    ignored: list[str] = []
+    base = Path(directory)
+    for name in names:
+        candidate = base / name
+        try:
+            if candidate.is_symlink() and not candidate.exists():
+                ignored.append(name)
+        except OSError:
+            ignored.append(name)
+    return ignored
+
+
 # Directories/files to exclude when exporting the default (~/.hermes) profile.
 # The default profile contains infrastructure (repo checkout, worktrees, DBs,
 # caches, binaries) that named profiles don't have.  We exclude those so the
@@ -1039,11 +1053,17 @@ def create_profile(
 
     if clone_all and source_dir:
         # Full copy of source profile (exclude sibling ~/.hermes/profiles/)
-        shutil.copytree(
-            source_dir,
-            profile_dir,
-            ignore=_clone_all_copytree_ignore(source_dir),
-        )
+        try:
+            shutil.copytree(
+                source_dir,
+                profile_dir,
+                ignore=_clone_all_copytree_ignore(source_dir),
+                ignore_dangling_symlinks=True,
+            )
+        except Exception:
+            if profile_dir.exists():
+                shutil.rmtree(profile_dir, ignore_errors=True)
+            raise
         # Strip runtime files
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)
@@ -1076,7 +1096,18 @@ def create_profile(
             # same agent capabilities as the source profile.
             source_skills = source_dir / "skills"
             if source_skills.is_dir():
-                shutil.copytree(source_skills, profile_dir / "skills", dirs_exist_ok=True)
+                try:
+                    shutil.copytree(
+                        source_skills,
+                        profile_dir / "skills",
+                        dirs_exist_ok=True,
+                        ignore=_ignore_dangling_symlinks,
+                        symlinks=True,
+                    )
+                except Exception:
+                    if profile_dir.exists():
+                        shutil.rmtree(profile_dir, ignore_errors=True)
+                    raise
 
             # Clone memory and other subdirectory files
             for relpath in _CLONE_SUBDIR_FILES:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -254,6 +254,48 @@ class TestCreateProfile:
             / "SKILL.md"
         ).read_text() == "---\nname: installed-skill\n---\n"
 
+    def test_clone_config_skips_dangling_skill_symlink_and_preserves_valid_symlink(self, profile_env):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        skills = default_home / "skills" / "custom"
+        real_skill = skills / "real-skill"
+        real_skill.mkdir(parents=True)
+        (real_skill / "SKILL.md").write_text("---\nname: real-skill\n---\n")
+
+        valid_link = skills / "linked-skill"
+        dangling_link = skills / "missing-skill"
+        try:
+            valid_link.symlink_to(real_skill, target_is_directory=True)
+            dangling_link.symlink_to(skills / "does-not-exist", target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        cloned_valid = profile_dir / "skills" / "custom" / "linked-skill"
+        cloned_dangling = profile_dir / "skills" / "custom" / "missing-skill"
+        assert cloned_valid.is_symlink()
+        assert cloned_valid.resolve() == real_skill.resolve()
+        assert not cloned_dangling.exists()
+        assert not cloned_dangling.is_symlink()
+
+    def test_clone_config_copytree_failure_removes_partial_profile(self, profile_env, monkeypatch):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        skill_dir = default_home / "skills" / "custom" / "installed-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: installed-skill\n---\n")
+
+        def fail_copytree(*args, **kwargs):
+            raise shutil.Error("copy failed")
+
+        monkeypatch.setattr(profiles.shutil, "copytree", fail_copytree)
+
+        with pytest.raises(shutil.Error, match="copy failed"):
+            create_profile("coder", clone_config=True, no_alias=True)
+
+        assert not get_profile_dir("coder").exists()
+
     def test_clone_all_copies_entire_tree(self, profile_env):
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary
- skip only dangling symlinks while copying cloned profile skills
- preserve valid symlinked skills by copying skill symlinks as symlinks
- clean up a newly-created profile directory if clone-time copytree fails
- let clone-all ignore dangling symlinks during the full tree copy

## Why
`hermes profile create --clone` copies the source profile skills tree into an already-created target profile. A dangling symlink in `skills/` can make `shutil.copytree` fail and leave a partial profile directory behind. Valid symlinked skills should keep working, while unusable dangling links should not block profile creation.

This addresses #56821. It is separate from #58022, which strips cloned gateway/platform credentials rather than fixing filesystem copy failures.

## Tests
- pytest tests/hermes_cli/test_profiles.py::TestCreateProfile -q
- ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py
- git diff --check