### PR TITLE
fix(auxiliary): preserve OpenRouter max tokens

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5781,6 +5781,10 @@ def _build_call_kwargs(
         # 200 with an empty choices[] payload when max_tokens is omitted. The main
         # NVIDIA chat path already sends an output cap via the provider profile;
         # preserve it on the auxiliary path too.
+        #
+        # OpenRouter is a third exception: omitting max_tokens lets OpenRouter
+        # apply its own high model cap, which can turn tiny auxiliary calls like
+        # title generation into confusing credit-limit failures.
         _effective_base = base_url or (
             _current_custom_base_url() if provider == "custom" else ""
         )
@@ -5789,9 +5793,14 @@ def _build_call_kwargs(
             _provider_norm in {"nvidia", "nvidia-nim", "nim", "build-nvidia", "nemotron"}
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
+        _is_openrouter = (
+            _provider_norm == "openrouter"
+            or base_url_host_matches(_effective_base, "openrouter.ai")
+        )
         if (
             _is_anthropic_compat_endpoint(provider, _effective_base)
             or _is_nvidia_nim
+            or _is_openrouter
         ):
             kwargs["max_tokens"] = max_tokens
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -185,7 +185,6 @@ class TestBuildCallKwargsMaxTokens:
             ("copilot", "gpt-5.4", "https://api.githubcopilot.com"),
             ("copilot", "gpt-5.5", "https://api.githubcopilot.com"),
             ("custom", "gpt-5", "https://api.openai.com/v1"),
-            ("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1"),
             ("nous", "hermes-4", "https://inference-api.nousresearch.com/v1"),
             ("custom", "qwen", "http://localhost:8080/v1"),
             ("zai", "glm-4v-flash", "https://open.bigmodel.cn/api/paas/v4"),
@@ -235,6 +234,25 @@ class TestBuildCallKwargsMaxTokens:
             base_url="https://integrate.api.nvidia.com/v1",
         )
         assert kwargs["max_tokens"] == 4096
+
+    @pytest.mark.parametrize(
+        "provider,base_url",
+        [
+            ("openrouter", "https://openrouter.ai/api/v1"),
+            ("custom", "https://openrouter.ai/api/v1"),
+        ],
+    )
+    def test_keeps_max_tokens_for_openrouter(self, provider, base_url):
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider=provider,
+            model="anthropic/claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+            base_url=base_url,
+        )
+        assert kwargs["max_tokens"] == 500
 
 
 class TestNousTagsScoping:


### PR DESCRIPTION
## Summary
- Fixes #56901
- Preserve explicit auxiliary `max_tokens` when the selected/fallback client is OpenRouter, including custom endpoints pointed at `openrouter.ai`.
- Keeps the existing default of omitting `max_tokens` for generic OpenAI-compatible providers, so Copilot/OpenAI/ZAI behavior is unchanged.

## Why this is not the custom-provider max_tokens cluster
Related OpenRouter/custom-provider PRs such as #57548 handle startup/session `model.max_tokens` resolution in `agent_init.py`. This PR changes the auxiliary request builder only: `agent/auxiliary_client.py::_build_call_kwargs` was dropping the `max_tokens=500` that title generation already passed, causing OpenRouter fallback requests to inherit OpenRouter's high default cap.

## Tests
- `python -m pytest tests/agent/test_auxiliary_client.py::TestBuildCallKwargsMaxTokens -q`
- `python -m ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `git diff --check`

Note: `ruff format --check` currently wants broad pre-existing reformatting in these large files, so I did not apply unrelated formatting churn.