### PR TITLE
fix(telephony): wrap malformed JSON responses

### DIFF
--- a/optional-skills/productivity/telephony/scripts/telephony.py
+++ b/optional-skills/productivity/telephony/scripts/telephony.py
@@ -260,7 +260,10 @@ def _json_request(
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             payload = resp.read().decode("utf-8")
-            return json.loads(payload) if payload else {}
+            try:
+                return json.loads(payload) if payload else {}
+            except json.JSONDecodeError as exc:
+                raise TelephonyError(f"Malformed JSON response from {url}") from exc
     except urllib.error.HTTPError as exc:
         body_text = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
         try:

--- a/tests/skills/test_telephony_skill.py
+++ b/tests/skills/test_telephony_skill.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[2]
@@ -163,6 +165,25 @@ def test_twilio_inbox_marks_seen_checkpoint(tmp_path: Path):
     assert result["count"] == 1
     assert result["messages"][0]["sid"] == "SM3"
     assert state["twilio"]["last_inbound_message_sid"] == "SM3"
+
+
+def test_json_request_wraps_malformed_success_json(monkeypatch):
+    mod = load_module()
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"<html>not json"
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", lambda req, timeout=30: FakeResponse())
+
+    with pytest.raises(mod.TelephonyError, match="Malformed JSON response"):
+        mod._json_request("GET", "https://api.example.test/resource")
 
 
 def test_vapi_import_twilio_number_saves_phone_number_id(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Fixes #56540
- Wrap malformed JSON returned from successful 2xx telephony API responses in `TelephonyError`.
- Leave existing HTTP error parsing, connection errors, request construction, and provider behavior unchanged.

## Duplicate check
I checked open PRs for `#56540`, `telephony.py`, `_json_request`, `JSONDecodeError`, and malformed telephony JSON before opening this; no matching open PR appeared.

## Tests
- `.venv/bin/python -m pytest tests/skills/test_telephony_skill.py -q`
- `.venv/bin/python -m ruff check optional-skills/productivity/telephony/scripts/telephony.py tests/skills/test_telephony_skill.py`
- `.venv/bin/python -m py_compile optional-skills/productivity/telephony/scripts/telephony.py tests/skills/test_telephony_skill.py`
- `git diff --check`

Note: `ruff format --check` wants broad pre-existing formatting changes in these files, so I left formatting churn out of this bug fix.