### PR TITLE
fix(email): extract SMTP recipient from session keys

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -243,6 +243,16 @@ def _extract_email_address(raw: str) -> str:
     return raw.strip().lower()
 
 
+def _recipient_email_address(raw: str) -> str:
+    """Extract a deliverable SMTP recipient from raw chat/session ids."""
+    value = _extract_email_address(raw)
+    matches = re.findall(
+        r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
+        value,
+    )
+    return matches[-1].lower() if matches else value
+
+
 def _domain_of(address: str) -> str:
     """Return the lowercased domain part of an email address, or ''."""
     _, _, domain = address.rpartition("@")
@@ -925,12 +935,15 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
+        recipient = _recipient_email_address(to_addr)
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
+        msg["To"] = recipient
 
         # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_context.get(recipient, {}) or self._thread_context.get(
+            to_addr, {}
+        )
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -1040,11 +1053,14 @@ class EmailAdapter(BasePlatformAdapter):
         file_paths: List[str],
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
+        recipient = _recipient_email_address(to_addr)
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
+        msg["To"] = recipient
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_context.get(recipient, {}) or self._thread_context.get(
+            to_addr, {}
+        )
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -1120,11 +1136,14 @@ class EmailAdapter(BasePlatformAdapter):
         file_name: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
+        recipient = _recipient_email_address(to_addr)
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
+        msg["To"] = recipient
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_context.get(recipient, {}) or self._thread_context.get(
+            to_addr, {}
+        )
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -1216,9 +1235,10 @@ async def _standalone_send(
         return {"error": "Email not configured (EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_SMTP_HOST required)"}
 
     try:
+        recipient = _recipient_email_address(chat_id)
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
-        msg["To"] = chat_id
+        msg["To"] = recipient
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
@@ -1227,7 +1247,7 @@ async def _standalone_send(
         server.login(address, password)
         server.send_message(msg)
         server.quit()
-        return {"success": True, "platform": "email", "chat_id": chat_id}
+        return {"success": True, "platform": "email", "chat_id": recipient}
     except Exception as e:
         try:
             from tools.send_message_tool import _error as _e

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -123,6 +123,13 @@ class TestHelperFunctions(unittest.TestCase):
             "john@example.com"
         )
 
+    def test_recipient_email_address_extracts_from_session_key(self):
+        from plugins.platforms.email.adapter import _recipient_email_address
+        self.assertEqual(
+            _recipient_email_address("agent:main:email:dm:John@Example.COM"),
+            "john@example.com",
+        )
+
     def test_strip_html_basic(self):
         from plugins.platforms.email.adapter import _strip_html
         html = "<p>Hello <b>world</b></p>"
@@ -891,6 +898,28 @@ class TestSendMethods(unittest.TestCase):
             mock_server.send_message.assert_called_once()
             mock_server.quit.assert_called_once()
 
+    def test_send_extracts_recipient_from_compound_session_key(self):
+        """Compound gateway session keys should not become SMTP To: addresses."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Cron result",
+            "message_id": "<original@test.com>",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(
+                adapter.send("agent:main:email:dm:user@test.com", "Hello from Hermes!")
+            )
+
+            self.assertTrue(result.success)
+            sent_msg = mock_server.send_message.call_args[0][0]
+            self.assertEqual(sent_msg["To"], "user@test.com")
+            self.assertEqual(sent_msg["Subject"], "Re: Cron result")
+
     def test_send_failure_returns_error(self):
         """SMTP failure should return SendResult with error."""
         import asyncio
@@ -923,10 +952,14 @@ class TestSendMethods(unittest.TestCase):
         self.assertIn("My photo", body)
 
     def test_send_document_with_attachment(self):
-        """send_document should send email with file attachment."""
+        """Document SMTP delivery normalizes a defensive compound recipient."""
         import asyncio
         import tempfile
         adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Requested document",
+            "message_id": "<original@test.com>",
+        }
 
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
             f.write(b"Test document content")
@@ -938,12 +971,18 @@ class TestSendMethods(unittest.TestCase):
                 mock_smtp.return_value = mock_server
 
                 result = asyncio.run(
-                    adapter.send_document("user@test.com", tmp_path, "Here is the file")
+                    adapter.send_document(
+                        "agent:main:email:dm:user@test.com",
+                        tmp_path,
+                        "Here is the file",
+                    )
                 )
 
                 self.assertTrue(result.success)
                 mock_server.send_message.assert_called_once()
                 sent_msg = mock_server.send_message.call_args[0][0]
+                self.assertEqual(sent_msg["To"], "user@test.com")
+                self.assertEqual(sent_msg["Subject"], "Re: Requested document")
                 # Should be multipart with attachment
                 parts = list(sent_msg.walk())
                 has_attachment = any(
@@ -951,6 +990,37 @@ class TestSendMethods(unittest.TestCase):
                     for p in parts
                 )
                 self.assertTrue(has_attachment)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_send_multiple_attachments_normalizes_compound_recipient(self):
+        """Multi-attachment SMTP delivery uses the same recipient contract."""
+        import tempfile
+
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Requested images",
+            "message_id": "<original@test.com>",
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(b"not-a-real-image")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                adapter._send_email_with_attachments(
+                    "agent:main:email:dm:user@test.com",
+                    "Here are the images",
+                    [tmp_path],
+                )
+
+                sent_msg = mock_server.send_message.call_args[0][0]
+                self.assertEqual(sent_msg["To"], "user@test.com")
+                self.assertEqual(sent_msg["Subject"], "Re: Requested images")
         finally:
             os.unlink(tmp_path)
 
@@ -1220,7 +1290,11 @@ class TestSendEmailStandalone(unittest.TestCase):
             mock_smtp.return_value = mock_server
 
             result = asyncio.run(
-                _send_email({"address": "hermes@test.com", "smtp_host": "smtp.test.com"}, "user@test.com", "Hello")
+                _send_email(
+                    {"address": "hermes@test.com", "smtp_host": "smtp.test.com"},
+                    "agent:main:email:dm:user@test.com",
+                    "Hello",
+                )
             )
 
             self.assertTrue(result["success"])
@@ -1232,6 +1306,7 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertIn("Date", send_call)
             self.assertEqual(send_call["To"], "user@test.com")
             self.assertEqual(send_call["From"], "hermes@test.com")
+            self.assertEqual(result["chat_id"], "user@test.com")
 
     @patch.dict(os.environ, {
         "EMAIL_ADDRESS": "hermes@test.com",


### PR DESCRIPTION
## Summary
- Defensively normalize SMTP recipients at the email adapter boundary, so a compound chat/session identifier cannot be written verbatim into a `To:` header.
- Apply the same normalization to ordinary replies, standalone sends, single-file attachments, and multi-file attachments.
- Preserve thread-context lookup by preferring the normalized address and falling back to the raw identifier.

Explicit email delivery currently strips supported `email:user@example.com` identifiers before reaching SMTP. This change intentionally hardens the low-level builders as well, rather than claiming a currently supported high-level route always forwards a compound key.

## Tests
- `.venv/bin/python -m pytest tests/gateway/test_email.py -q` (91 passed)
- `.venv/bin/python -m ruff check plugins/platforms/email/adapter.py tests/gateway/test_email.py`
- `git diff --check`