### PR TITLE
fix(stt): route transcription inputs through the shared read guard

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1578,3 +1578,28 @@ class TestShellSafety:
         monkeypatch.delenv(LOCAL_STT_COMMAND_ENV, raising=False)
         use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
         assert use_shell is False
+
+
+class TestTranscribeCredentialReadGuard:
+    """transcribe_audio must refuse credential/secret stores before dispatch."""
+
+    def test_transcribe_audio_blocks_credential_read(self, tmp_path):
+        """A ``.env`` (secret-bearing) file is refused up front, so its
+        plaintext is never shipped to an external STT provider — mirroring the
+        read guard added to image-gen (587be5b5b) and xAI video-gen
+        (104232979)."""
+        from tools.transcription_tools import transcribe_audio
+        from agent.file_safety import get_read_block_error
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("OPENAI_API_KEY=sk-secret\n")
+
+        expected = get_read_block_error(str(env_file))
+        assert expected, "test setup: a .env file should be read-blocked"
+
+        result = transcribe_audio(str(env_file))
+
+        assert result["success"] is False
+        # The error is the shared read-guard message, not an audio-validation
+        # or provider error — proving the guard fired before dispatch.
+        assert result["error"] == expected

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1640,6 +1640,15 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
           - "error" (str, optional): Error message if success is False
           - "provider" (str, optional): Which provider was used
     """
+    # Refuse to feed a credential / secret store (auth.json, .env, OAuth
+    # tokens, mcp-tokens/, ...) to an STT provider: an external provider would
+    # ship its plaintext contents to a third-party API. Mirrors the local-input
+    # read guard added to image-gen (587be5b5b) and xAI video-gen (104232979).
+    from agent.file_safety import get_read_block_error
+    blocked = get_read_block_error(file_path)
+    if blocked:
+        return {"success": False, "transcript": "", "error": blocked}
+
     # Validate input
     error = _validate_audio_file(file_path)
     if error:


### PR DESCRIPTION
## What does this PR do?

`transcribe_audio` reads a local file and hands it to the configured STT
provider. For the hosted providers (Groq, OpenAI, Mistral, xAI, ElevenLabs)
that ships the file's raw bytes to a third-party API.

The shared local-input read guard (`agent.file_safety.get_read_block_error`)
was already added to image-gen (587be5b5b, *"guard local provider inputs against
credential reads"*) and xAI video-gen (104232979), but the STT tools were
missed. So the agent can still feed a `.env`, `auth.json`,
`.anthropic_oauth.json`, or a `mcp-tokens/` file to transcription and have its
plaintext leave the machine.

This routes `transcribe_audio` through the same guard (before validation and
provider dispatch), refusing those paths up front. It is **defense-in-depth,
not a security boundary** — the guard's own message says so, and the terminal
tool can still reach the file — it just restores parity with the image/video-gen
tools.

## Related Issue

N/A — no tracking issue. Parity follow-up to 587be5b5b (image-gen) and
104232979 (xai video-gen), which added the same guard to sibling tools.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/transcription_tools.py` — call `get_read_block_error(file_path)` at the
  top of `transcribe_audio`, before audio validation / provider dispatch;
  return the guard's error dict when a read is blocked.
- `tests/tools/test_transcription_tools.py` — add
  `TestTranscribeCredentialReadGuard`.

## How to Test

1. Point the STT path at a secret-bearing file:
   ```python
   from tools.transcription_tools import transcribe_audio
   r = transcribe_audio("/path/to/.env")
   assert r["success"] is False and "cannot be read" in r["error"]
   ```
2. Confirm the block happens before dispatch (the error is the read-guard
   message, not `"Unsupported format"` and not a provider error).
3. Run the tests:
   ```
   pytest tests/tools/test_transcription_tools.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suite and it passes: `pytest tests/tools/test_transcription_tools.py -q` → **107 passed, 1 skipped**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)


### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no doc-facing change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — path-agnostic; the guard resolves the same on every OS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (rejects a narrow set of secret paths; no schema change)

## Screenshots / Logs

Mutation check — without the guard, the same `.env` input instead reaches audio
validation:

```
- Access denied: .../.env is a secret-bearing environment file and cannot be
  read to prevent credential leakage. ...
+ Unsupported format: . Supported: .aac, .flac, .m4a, .mp3, .mp4, ...
```

With the guard, `transcribe_audio` returns the read-guard message before any
provider is contacted.