### PR TITLE
fix(doctor): warn on unenforceable docker disk caps

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -388,6 +388,36 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
 
 
+def _terminal_backend_and_disk_for_doctor() -> tuple[str, int]:
+    """Return the effective terminal backend and disk cap for doctor checks."""
+    backend = os.getenv("TERMINAL_ENV")
+    disk_raw = os.getenv("TERMINAL_CONTAINER_DISK")
+
+    try:
+        from hermes_cli.config import load_config
+
+        terminal_cfg = load_config().get("terminal") or {}
+        if isinstance(terminal_cfg, dict):
+            if not backend:
+                backend = (
+                    terminal_cfg.get("backend")
+                    or terminal_cfg.get("env_type")
+                    or "local"
+                )
+            if disk_raw is None:
+                disk_raw = terminal_cfg.get("container_disk")
+    except Exception:
+        pass
+
+    if not backend:
+        backend = "local"
+    try:
+        disk = int(disk_raw) if disk_raw is not None else 0
+    except (TypeError, ValueError):
+        disk = 0
+    return str(backend), disk
+
+
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
@@ -1437,7 +1467,7 @@ def run_doctor(args):
         check_info(f"Install for faster search: {_system_package_install_cmd('ripgrep')}")
     
     # Docker (optional)
-    terminal_env = os.getenv("TERMINAL_ENV", "local")
+    terminal_env, terminal_disk = _terminal_backend_and_disk_for_doctor()
     try:
         from hermes_constants import is_container as _is_container
         running_in_container = _is_container()
@@ -1467,6 +1497,23 @@ def run_doctor(args):
                 result = None
             if result is not None and result.returncode == 0:
                 check_ok("docker", "(daemon running)")
+                if terminal_disk > 0 and sys.platform != "darwin":
+                    try:
+                        from tools.environments.docker import DockerEnvironment
+
+                        storage_opt_supported = DockerEnvironment._storage_opt_supported()
+                    except Exception:
+                        storage_opt_supported = False
+                    if not storage_opt_supported:
+                        check_warn(
+                            "Docker container_disk is not enforceable",
+                            "(requires overlay2 on XFS with pquota)",
+                        )
+                        manual_issues.append(
+                            "terminal.container_disk is configured but Docker cannot enforce "
+                            "per-container disk quotas on this storage backend. Use XFS with "
+                            "pquota or set terminal.container_disk: 0 after adding a host-side cap."
+                        )
             else:
                 _fail_and_issue("docker daemon not running", "", "Start Docker daemon", issues)
         else:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -243,6 +243,53 @@ def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
     assert seen["interactive"] == "1"
 
 
+def test_run_doctor_warns_when_docker_disk_cap_is_unenforceable(
+    monkeypatch, tmp_path, capsys
+):
+    project_root = tmp_path / "project"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    hermes_home.mkdir()
+
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project_root)
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(hermes_home))
+    monkeypatch.setattr(doctor_mod.sys, "platform", "linux")
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_DISK", "51200")
+    monkeypatch.setattr(
+        doctor_mod,
+        "_safe_which",
+        lambda cmd: "/usr/bin/docker" if cmd == "docker" else None,
+    )
+    monkeypatch.setattr(
+        doctor_mod.subprocess,
+        "run",
+        lambda *a, **kw: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    from tools.environments.docker import DockerEnvironment
+
+    monkeypatch.setattr(
+        DockerEnvironment,
+        "_storage_opt_supported",
+        staticmethod(lambda: False),
+    )
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: (_ for _ in ()).throw(SystemExit(0)),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    with pytest.raises(SystemExit):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = capsys.readouterr().out
+    assert "Docker container_disk is not enforceable" in out
+    assert "requires overlay2 on XFS with pquota" in out
+
+
 def test_check_gateway_service_linger_warns_when_disabled(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "hermes-gateway.service"
     unit_path.write_text("[Unit]\n")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -290,6 +290,26 @@ def test_run_doctor_warns_when_docker_disk_cap_is_unenforceable(
     assert "requires overlay2 on XFS with pquota" in out
 
 
+def test_terminal_backend_and_disk_for_doctor_reads_config_yaml(
+    monkeypatch, tmp_path
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "terminal:\n"
+        "  backend: docker\n"
+        "  container_disk: 51200\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.delenv("TERMINAL_CONTAINER_DISK", raising=False)
+
+    assert doctor_mod._terminal_backend_and_disk_for_doctor() == ("docker", 51200)
+
+
 def test_check_gateway_service_linger_warns_when_disabled(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "hermes-gateway.service"
     unit_path.write_text("[Unit]\n")


### PR DESCRIPTION
## Summary
- read the effective terminal backend/container_disk for doctor from env or config
- surface a doctor warning when Docker is running but cannot enforce per-container disk quotas
- add regression coverage for the unsupported storage backend warning

Fixes #57994.

## Tests
- `.venv/bin/python -m pytest tests/hermes_cli/test_doctor.py::test_run_doctor_warns_when_docker_disk_cap_is_unenforceable -q`
- `.venv/bin/python -m ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- `git diff --check`