### PR TITLE
fix(delegate): prefer current delegation config

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,8 +11,10 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import sys
 import threading
 import time
+import types
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -34,6 +36,31 @@ from tools.delegate_tool import (
     _resolve_delegation_credentials,
     _inherit_parent_base_url,
 )
+
+
+def test_load_config_prefers_current_file_config_over_cli_snapshot(monkeypatch):
+    import tools.delegate_tool as delegate_tool
+    from hermes_cli import config as config_mod
+
+    stale_cli = types.SimpleNamespace(
+        CLI_CONFIG={
+            "delegation": {
+                "child_timeout_seconds": 600,
+                "max_spawn_depth": 4,
+            }
+        }
+    )
+    monkeypatch.setitem(sys.modules, "cli", stale_cli)
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"delegation": {"child_timeout_seconds": 900}},
+    )
+
+    cfg = delegate_tool._load_config()
+
+    assert cfg["child_timeout_seconds"] == 900
+    assert cfg["max_spawn_depth"] == 4
 
 
 def _make_mock_parent(depth=0):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3098,28 +3098,34 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load current delegation config with CLI_CONFIG as a fallback.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Persistent config is authoritative so `hermes config set delegation.*`
+    takes effect on the next delegate_task call in long-running processes.
+    ``cli.CLI_CONFIG`` remains a fallback for entry points that have not wired
+    the persistent config loader yet.
     """
-    try:
-        from cli import CLI_CONFIG
-
-        cfg = CLI_CONFIG.get("delegation") or {}
-        if cfg:
-            return cfg
-    except Exception:
-        pass
+    delegation_config: dict = {}
     try:
         from hermes_cli.config import load_config
 
         full = load_config()
-        return full.get("delegation") or {}
+        cfg = full.get("delegation") or {}
+        if isinstance(cfg, dict):
+            delegation_config.update(cfg)
     except Exception:
-        return {}
+        pass
+
+    try:
+        from cli import CLI_CONFIG
+
+        cfg = CLI_CONFIG.get("delegation") or {}
+        if isinstance(cfg, dict):
+            for key, value in cfg.items():
+                delegation_config.setdefault(key, value)
+    except Exception:
+        pass
+    return delegation_config
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make delegate_task load current persistent delegation config before stale cli.CLI_CONFIG snapshots
- keep cli.CLI_CONFIG as a fallback for keys missing from disk config
- add regression coverage for config changes overriding an old runtime snapshot

Fixes #57930.

## Tests
- `.venv/bin/python -m pytest tests/tools/test_delegate.py::test_load_config_prefers_current_file_config_over_cli_snapshot tests/tools/test_delegate.py::TestConcurrencyDefaults tests/tools/test_delegate.py::TestAsyncCapUnified tests/tools/test_delegate.py::TestMaxSpawnDepth -q`
- `.venv/bin/python -m ruff check tools/delegate_tool.py tests/tools/test_delegate.py`
- `git diff --check`