### PR TITLE
fix(dashboard-auth): rotate audit log

### DIFF
--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -22,6 +22,8 @@ from typing import Any
 
 _log = logging.getLogger(__name__)
 _write_lock = threading.Lock()
+_MAX_LOG_BYTES = 5 * 1024 * 1024
+_BACKUP_COUNT = 3
 
 # Field names that must never appear in the log raw. Any kwarg matching
 # these is silently dropped.
@@ -62,6 +64,29 @@ def _resolve_log_path() -> Path:
     return Path(home) / "logs" / "dashboard-auth.log"
 
 
+def _rotate_log_if_needed(path: Path, incoming_bytes: int) -> None:
+    """Rotate dashboard-auth.log using the standard ``.1``/``.2`` suffixes."""
+    if _MAX_LOG_BYTES <= 0 or _BACKUP_COUNT <= 0 or not path.exists():
+        return
+    try:
+        if path.stat().st_size + incoming_bytes <= _MAX_LOG_BYTES:
+            return
+    except OSError:
+        return
+
+    oldest = path.with_name(f"{path.name}.{_BACKUP_COUNT}")
+    try:
+        oldest.unlink()
+    except FileNotFoundError:
+        pass
+
+    for index in range(_BACKUP_COUNT - 1, 0, -1):
+        src = path.with_name(f"{path.name}.{index}")
+        if src.exists():
+            src.rename(path.with_name(f"{path.name}.{index + 1}"))
+    path.rename(path.with_name(f"{path.name}.1"))
+
+
 def audit_log(event: AuditEvent, **fields: Any) -> None:
     """Append one event to the audit log.
 
@@ -83,6 +108,7 @@ def audit_log(event: AuditEvent, **fields: Any) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with _write_lock:
+            _rotate_log_if_needed(path, len(line.encode("utf-8")))
             with open(path, "a", encoding="utf-8") as f:
                 f.write(line)
     except Exception as e:

--- a/tests/hermes_cli/test_dashboard_auth_audit.py
+++ b/tests/hermes_cli/test_dashboard_auth_audit.py
@@ -79,3 +79,31 @@ def test_audit_creates_logs_dir_if_missing(tmp_path, monkeypatch):
     audit_log(AuditEvent.LOGIN_START, provider="nous")
     assert (home / "logs").is_dir()
     assert (home / "logs" / "dashboard-auth.log").exists()
+
+
+def test_audit_rotates_log_when_size_cap_is_reached(profile_home, monkeypatch):
+    from hermes_cli.dashboard_auth import audit as audit_mod
+
+    monkeypatch.setattr(audit_mod, "_MAX_LOG_BYTES", 120)
+    monkeypatch.setattr(audit_mod, "_BACKUP_COUNT", 2)
+
+    log_path = profile_home / "logs" / "dashboard-auth.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("older-login-line\n" * 8, encoding="utf-8")
+    (profile_home / "logs" / "dashboard-auth.log.1").write_text(
+        "previous-backup\n", encoding="utf-8",
+    )
+    (profile_home / "logs" / "dashboard-auth.log.2").write_text(
+        "oldest-backup\n", encoding="utf-8",
+    )
+
+    audit_log(AuditEvent.LOGIN_START, provider="nous")
+
+    current = log_path.read_text(encoding="utf-8")
+    rotated = (profile_home / "logs" / "dashboard-auth.log.1").read_text(encoding="utf-8")
+    second_backup = (profile_home / "logs" / "dashboard-auth.log.2").read_text(encoding="utf-8")
+
+    assert "login_start" in current
+    assert "older-login-line" not in current
+    assert "older-login-line" in rotated
+    assert second_backup == "previous-backup\n"


### PR DESCRIPTION
Fixes #57749.

## Summary
- add self-contained size-based rotation for `dashboard-auth.log`
- keep the lightweight dashboard-auth audit module free of `hermes_logging` / `hermes_constants` imports
- preserve the existing JSONL writer and token-field dropping behavior

## Duplicate check
- searched open PRs for `#57749`, `dashboard-auth.log`, `dashboard auth log rotation`, `RotatingFileHandler`, and `hermes_cli/dashboard_auth/audit.py`; no existing open PR covered this issue or file path

## Test plan
- `.venv/bin/python -m pytest tests/hermes_cli/test_dashboard_auth_audit.py -q`
- `.venv/bin/python -m ruff check hermes_cli/dashboard_auth/audit.py tests/hermes_cli/test_dashboard_auth_audit.py`
- `git diff --check`