### PR TITLE
fix(compression): skip rotation on noop compaction

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -617,6 +617,25 @@ def compress_context(
         finally:
             _release_lock()
 
+    # A compressor can report success while returning the original transcript
+    # unchanged when it finds no compressible window. Rotating in that case
+    # persists the same oversized context under a fresh child session, so the
+    # next turn's preflight check repeats the same no-op indefinitely.
+    if compressed is messages or compressed == messages:
+        try:
+            logger.info(
+                "compression skipped: compressor returned unchanged transcript "
+                "for session=%s messages=%d",
+                agent.session_id or "none",
+                _pre_msg_count,
+            )
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            return messages, _existing_sp
+        finally:
+            _release_lock()
+
     try:
         summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
         if summary_error:

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -202,6 +202,55 @@ def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     agent.context_compressor.compress.assert_not_called()
 
 
+def test_noop_compression_does_not_rotate_session(tmp_path: Path) -> None:
+    """A compressor that returns the original transcript must not fork a child."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "NOOP_TEST"
+    db.create_session(parent_sid, source="cli")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(6)]
+    agent.context_compressor.compress.side_effect = None
+    agent.context_compressor.compress.return_value = messages
+
+    compressed, _sp = agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    assert compressed is messages or compressed == messages
+    assert agent.session_id == parent_sid
+    assert _count_children(db, parent_sid) == 0
+    assert db.get_session(parent_sid)["end_reason"] is None
+    assert db.get_compression_lock_holder(parent_sid) is None
+
+
+def test_same_count_compression_still_rotates_when_content_changes(tmp_path: Path) -> None:
+    """Same message count can still be real progress via token-only shrinking."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "TOKEN_ONLY_TEST"
+    db.create_session(parent_sid, source="cli")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    messages = [
+        {"role": "user", "content": "x" * 4000},
+        {"role": "assistant", "content": "y" * 4000},
+        {"role": "user", "content": "z" * 4000},
+    ]
+    shrunk = [
+        {"role": "user", "content": "summary"},
+        {"role": "assistant", "content": "recent reply"},
+        {"role": "user", "content": "tail"},
+    ]
+    agent.context_compressor.compress.side_effect = None
+    agent.context_compressor.compress.return_value = shrunk
+
+    compressed, _sp = agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    assert len(compressed) == len(messages)
+    assert compressed == shrunk
+    assert agent.session_id != parent_sid
+    assert _count_children(db, parent_sid) == 1
+    assert db.get_compression_lock_holder(parent_sid) is None
+
+
 def test_lock_refresh_keeps_owner_live_past_initial_ttl(tmp_path: Path, monkeypatch) -> None:
     """The owning compression call must keep its lease alive while it runs."""
     real_try_acquire = SessionDB.try_acquire_compression_lock


### PR DESCRIPTION
Fixes #57771.

## Summary
- skip session rotation when the compressor returns the original transcript unchanged
- release the compression lock on that no-op path
- preserve token-only compression progress by allowing same-count transcripts to rotate when their content changes

## Duplicate check
- searched open PRs for `#57771`, `infinite compression loop`, `no message reduction`, `unchanged transcript`, and `compression yielded no message reduction`; no open PR covered this issue

## Test plan
- `.venv/bin/python -m pytest tests/agent/test_compression_concurrent_fork.py::test_noop_compression_does_not_rotate_session tests/agent/test_compression_concurrent_fork.py::test_same_count_compression_still_rotates_when_content_changes tests/agent/test_compression_concurrent_fork.py::test_skipped_compression_returns_messages_unchanged -q`
- `.venv/bin/python -m pytest tests/agent/test_compression_concurrent_fork.py -q`
- `.venv/bin/python -m ruff check agent/conversation_compression.py tests/agent/test_compression_concurrent_fork.py`
- `git diff --check`