### PR TITLE
fix(agent): require object tool-call arguments

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -286,6 +286,48 @@ def sanitize_tool_call_arguments(
             continue
 
         insert_at = message_index + 1
+
+        def _replace_with_empty_object(tool_call: dict, function: dict, arguments: str) -> None:
+            nonlocal insert_at
+
+            tool_call_id = tool_call.get("id")
+            function_name = function.get("name", "?")
+            preview = arguments[:80]
+            log.warning(
+                "Corrupted tool_call arguments repaired before request "
+                "(session=%s, message_index=%s, tool_call_id=%s, function=%s, preview=%r)",
+                session_id or "-",
+                message_index,
+                tool_call_id or "-",
+                function_name,
+                preview,
+            )
+            function["arguments"] = "{}"
+
+            existing_tool_msg = None
+            scan_index = message_index + 1
+            while scan_index < len(messages):
+                candidate = messages[scan_index]
+                if not isinstance(candidate, dict) or candidate.get("role") != "tool":
+                    break
+                if candidate.get("tool_call_id") == tool_call_id:
+                    existing_tool_msg = candidate
+                    break
+                scan_index += 1
+
+            if existing_tool_msg is None:
+                messages.insert(
+                    insert_at,
+                    make_tool_result_message(
+                        function_name if function_name != "?" else "",
+                        marker,
+                        tool_call_id,
+                    ),
+                )
+                insert_at += 1
+            else:
+                _prepend_marker(existing_tool_msg)
+
         for tool_call in tool_calls:
             if not isinstance(tool_call, dict):
                 continue
@@ -304,47 +346,25 @@ def sanitize_tool_call_arguments(
                 continue
 
             try:
-                json.loads(arguments)
+                parsed_arguments = json.loads(arguments)
             except json.JSONDecodeError:
-                tool_call_id = tool_call.get("id")
-                function_name = function.get("name", "?")
-                preview = arguments[:80]
-                log.warning(
-                    "Corrupted tool_call arguments repaired before request "
-                    "(session=%s, message_index=%s, tool_call_id=%s, function=%s, preview=%r)",
-                    session_id or "-",
-                    message_index,
-                    tool_call_id or "-",
-                    function_name,
-                    preview,
-                )
-                function["arguments"] = "{}"
-
-                existing_tool_msg = None
-                scan_index = message_index + 1
-                while scan_index < len(messages):
-                    candidate = messages[scan_index]
-                    if not isinstance(candidate, dict) or candidate.get("role") != "tool":
-                        break
-                    if candidate.get("tool_call_id") == tool_call_id:
-                        existing_tool_msg = candidate
-                        break
-                    scan_index += 1
-
-                if existing_tool_msg is None:
-                    messages.insert(
-                        insert_at,
-                        make_tool_result_message(
-                            function_name if function_name != "?" else "",
-                            marker,
-                            tool_call_id,
-                        ),
-                    )
-                    insert_at += 1
-                else:
-                    _prepend_marker(existing_tool_msg)
-
+                _replace_with_empty_object(tool_call, function, arguments)
                 repaired += 1
+                continue
+
+            if isinstance(parsed_arguments, dict):
+                continue
+            if (
+                isinstance(parsed_arguments, list)
+                and len(parsed_arguments) == 1
+                and isinstance(parsed_arguments[0], dict)
+            ):
+                function["arguments"] = json.dumps(parsed_arguments[0], separators=(",", ":"))
+                repaired += 1
+                continue
+
+            _replace_with_empty_object(tool_call, function, arguments)
+            repaired += 1
 
         message_index += 1
 

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -71,6 +71,52 @@ def test_truncated_arguments_replaced_with_empty_object(caplog):
     )
 
 
+def test_single_object_array_arguments_unwrapped():
+    messages = [
+        _assistant_message(
+            _tool_call(arguments='[{"path": "/tmp/foo", "mode": "replace"}]')
+        ),
+        _tool_message(content="done"),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    assert (
+        messages[0]["tool_calls"][0]["function"]["arguments"]
+        == '{"path":"/tmp/foo","mode":"replace"}'
+    )
+    assert messages[1]["content"] == "done"
+
+
+def test_non_object_json_arguments_replaced_with_empty_object():
+    marker = AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
+    messages = [
+        _assistant_message(_tool_call(arguments='[{"path": "/tmp/foo"}, {"path": "/tmp/bar"}]')),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert messages[1]["tool_call_id"] == "call_1"
+    assert messages[1]["content"] == marker
+
+
+def test_scalar_json_arguments_replaced_with_empty_object():
+    marker = AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
+    messages = [
+        _assistant_message(_tool_call(arguments='"not an object"')),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert messages[1]["tool_call_id"] == "call_1"
+    assert messages[1]["content"] == marker
+
+
 def test_marker_appended_to_existing_tool_message():
     marker = AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
     messages = [


### PR DESCRIPTION
## Summary
- validate sanitized tool-call arguments are JSON objects, not just syntactically valid JSON
- unwrap a single-object JSON array back into the object the provider expects
- replace multi-object arrays and scalar JSON values with `{}` while preserving the existing corruption marker/tool-result repair path

Closes #58057

## Tests
- `.venv/bin/python -m pytest tests/run_agent/test_tool_call_args_sanitizer.py`
- `.venv/bin/python -m ruff check agent/agent_runtime_helpers.py tests/run_agent/test_tool_call_args_sanitizer.py`
- `git diff --check`

## Duplicate check
Searched current open PRs for `#58057`, `sanitize_tool_call_arguments`, `array arguments`, and the touched test/file paths before opening; no open PR matched this sanitizer bug class.