### PR TITLE
fix(kanban): correct tuple unpack in goal-judge completion gate

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -621,7 +621,7 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
     def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
-        return "continue", "missing verification evidence", False
+        return "continue", "missing verification evidence", False, None
 
     monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
     monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -602,7 +602,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 verdict = "done"
                 reason = ""
                 try:
-                    verdict, reason, _ = judge_goal(
+                    verdict, reason, _, _ = judge_goal(
                         goal=f"{task.title}\n\n{task.body or ''}".strip(),
                         last_response=(summary or result or "").strip(),
                     )


### PR DESCRIPTION
## Problem

`kanban_tools.py` `_handle_complete()` unpacks the return of `judge_goal()` into 3 targets, but `judge_goal()` returns a 4-tuple `(verdict, reason, parse_failed, wait_directive)` (`hermes_cli/goals.py`). Completing any `goal_mode` task with a reachable judge raises:

```
ValueError: too many values to unpack (expected 3)
```

The surrounding `except Exception` fail-open handler catches it, so the practical effect is that the goal-judge gate is silently bypassed on every goal-mode completion — tasks complete without ever being judged.

## Fix

Unpack all four values (the trailing two are unused at this call site). Test updated to match the real signature.

Observed in production on 0.18.0 (gateway-embedded dispatcher, goal-mode worker completing via `kanban_complete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)