### PR TITLE
fix(bedrock): correct displayed context length for 1M-beta models

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1296,11 +1296,23 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
+    # Anthropic Claude models on Bedrock.
+    # NOTE: Opus 4.6/4.7/4.8, Sonnet 4.6/5, and Fable 5 support a 1M context
+    # window on Bedrock, but only when the request carries the
+    # ``context-1m-2025-08-07`` beta header (see build_anthropic_bedrock_client
+    # in anthropic_adapter.py, which attaches it unconditionally on the
+    # Bedrock path). This table only affects the *displayed* context length
+    # in /model — it must match what the client actually requests, so these
+    # entries reflect the 1M beta-gated value, not the un-opted-in 200K cap.
+    "anthropic.claude-fable-5":      1_000_000,
+    "anthropic.claude-opus-4-8":     1_000_000,
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-opus-4-6":     1_000_000,
+    "anthropic.claude-sonnet-5":     1_000_000,
+    "anthropic.claude-sonnet-4-6":   1_000_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
+    "anthropic.claude-opus-4-1":     200_000,
     "anthropic.claude-opus-4":       200_000,
     "anthropic.claude-sonnet-4":     200_000,
     "anthropic.claude-3-5-sonnet":   200_000,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1166,12 +1166,30 @@ class TestBedrockContextLength:
     """Test Bedrock model context length lookup."""
 
     def test_claude_opus_4_6(self):
+        # Opus 4.6+ gets the 1M-context beta unconditionally on the Bedrock
+        # path (see build_anthropic_bedrock_client) — the displayed context
+        # length must match what the client actually requests.
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 200_000
+        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 1_000_000
 
     def test_claude_sonnet_versioned(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 200_000
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 1_000_000
+
+    def test_claude_sonnet_5(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-sonnet-5") == 1_000_000
+        assert get_bedrock_context_length("global.anthropic.claude-sonnet-5") == 1_000_000
+
+    def test_claude_opus_4_8(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-opus-4-8") == 1_000_000
+
+    def test_claude_sonnet_4_5_stays_200k(self):
+        # Sonnet 4.5 does NOT get the 1M beta — confirm it's unaffected by
+        # the 4-6/5 fix (longest-prefix matching must not conflate them).
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-5-20250929-v1:0") == 200_000
 
     def test_nova_pro(self):
         from agent.bedrock_adapter import get_bedrock_context_length
@@ -1188,7 +1206,7 @@ class TestBedrockContextLength:
     def test_inference_profile_resolves(self):
         from agent.bedrock_adapter import get_bedrock_context_length
         # Cross-region inference profiles contain the base model ID
-        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 1_000_000
 
     def test_longest_prefix_wins(self):
         from agent.bedrock_adapter import get_bedrock_context_length


### PR DESCRIPTION
## Problem

`/model` reports 128K context for `global.anthropic.claude-sonnet-5` on Bedrock, even though the real limit is 1M (models.dev confirms `context: 1000000` for this model on `amazon-bedrock`).

## Root cause

`agent/bedrock_adapter.py::BEDROCK_CONTEXT_LENGTHS` is a static lookup table consulted **before** any other resolution path (models.dev cache, live probes) whenever `provider == "bedrock"`. The table had no entry matching `claude-sonnet-5`, so `get_bedrock_context_length()` fell through to `BEDROCK_DEFAULT_CONTEXT_LENGTH = 128_000`.

Separately, the table also *undersold* several models that already get the `context-1m-2025-08-07` beta header unconditionally on the Bedrock client path (`build_anthropic_bedrock_client` in `agent/anthropic_adapter.py`) — `claude-opus-4-6/4-7/4-8`, `claude-sonnet-4-6`, and `claude-fable-5` were all hardcoded to `200_000` in the display table despite the client actually requesting (and Bedrock serving) 1M for these once the beta header is attached.

## Fix

Updated `BEDROCK_CONTEXT_LENGTHS` so the displayed context length matches what the client actually requests:

| model | before | after |
|---|---|---|
| `claude-sonnet-5` | 128K (unmatched → default) | **1M** |
| `claude-opus-4-6` | 200K | **1M** |
| `claude-opus-4-7` | (unmatched → default 128K) | **1M** |
| `claude-opus-4-8` | (unmatched → default 128K) | **1M** |
| `claude-sonnet-4-6` | 200K | **1M** |
| `claude-fable-5` | (unmatched → default 128K) | **1M** |
| `claude-opus-4-1` | 200K (via prefix match on `claude-opus-4`) | 200K (explicit, no behavior change) |
| `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4`, `claude-sonnet-4`, `claude-3-5-*`, `claude-3-*` | 200K | 200K (unchanged — no 1M beta for these) |

## Testing

Updated stale assertions in `tests/agent/test_bedrock_adapter.py::TestBedrockContextLength` that hardcoded the old 200K value for opus-4-6/sonnet-4-6, and added:
- `test_claude_sonnet_5` (the reported bug)
- `test_claude_opus_4_8`
- `test_claude_sonnet_4_5_stays_200k` (regression guard — confirms longest-prefix matching doesn't accidentally promote 4-5 to 1M)

```
$ pytest tests/agent/test_bedrock_adapter.py::TestBedrockContextLength tests/agent/test_bedrock_1m_context.py -v
12 passed in 0.20s

$ pytest tests/agent/test_bedrock_adapter.py tests/agent/test_model_metadata.py -q
253 passed in 4.60s
```

No behavior change to the actual API requests — `build_anthropic_bedrock_client` already attaches the 1M beta header unconditionally; this PR only fixes the value shown in `/model` and used for local context-budget bookkeeping.