### PR TITLE
fix(email): tolerate malformed encoded headers

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -173,11 +173,19 @@ def check_email_requirements() -> bool:
 
 def _decode_header_value(raw: str) -> str:
     """Decode an RFC 2047 encoded email header into a plain string."""
-    parts = decode_header(raw)
+    try:
+        parts = decode_header(raw)
+    except Exception:  # noqa: BLE001 - malformed sender-controlled headers
+        logger.debug("[Email] Failed to decode RFC 2047 header; using raw value", exc_info=True)
+        return str(raw)
+
     decoded = []
     for part, charset in parts:
         if isinstance(part, bytes):
-            decoded.append(part.decode(charset or "utf-8", errors="replace"))
+            try:
+                decoded.append(part.decode(charset or "utf-8", errors="replace"))
+            except LookupError:
+                decoded.append(part.decode("utf-8", errors="replace"))
         else:
             decoded.append(part)
     return " ".join(decoded)

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -102,6 +102,18 @@ class TestHelperFunctions(unittest.TestCase):
         result = _decode_header_value(encoded)
         self.assertEqual(result, "Merhaba")
 
+    def test_decode_header_malformed_encoded_word_falls_back_raw(self):
+        from plugins.platforms.email.adapter import _decode_header_value
+
+        raw = "=?utf-8?B?a?="
+
+        self.assertEqual(_decode_header_value(raw), raw)
+
+    def test_decode_header_unknown_charset_uses_replacement(self):
+        from plugins.platforms.email.adapter import _decode_header_value
+
+        self.assertEqual(_decode_header_value("=?x-unknown?Q?hello?="), "hello")
+
     def test_extract_email_address_with_name(self):
         from plugins.platforms.email.adapter import _extract_email_address
         self.assertEqual(
@@ -1145,6 +1157,37 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["sender_addr"], "john@test.com")
         self.assertEqual(results[0]["sender_name"], "John Doe")
+
+    def test_fetch_survives_malformed_encoded_subject(self):
+        """One malformed RFC 2047 header should not abort the IMAP batch."""
+        adapter = self._make_adapter()
+
+        raw_email = (
+            b"From: user@test.com\r\n"
+            b"Subject: =?utf-8?B?a?=\r\n"
+            b"Message-ID: <bad-subject@test.com>\r\n"
+            b"Content-Type: text/plain; charset=utf-8\r\n"
+            b"\r\n"
+            b"Hello\r\n"
+        )
+
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email)])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["sender_addr"], "user@test.com")
+        self.assertEqual(results[0]["subject"], "=?utf-8?B?a?=")
 
 
 class TestPollLoop(unittest.TestCase):


### PR DESCRIPTION
## Summary
- keep malformed RFC 2047 email headers from aborting inbound IMAP fetches
- fall back to the raw header when `decode_header()` cannot parse an encoded-word
- decode unknown charset labels as UTF-8 with replacement instead of raising
- add helper and IMAP-fetch regression coverage

Fixes #55381.

## Tests
- `.venv/bin/python -m pytest tests/gateway/test_email.py -q`
- `.venv/bin/python -m ruff check plugins/platforms/email/adapter.py tests/gateway/test_email.py`
- `git diff --check`

## Duplicate check
Searched open PRs for `#55381`, `_decode_header_value`, `malformed RFC 2047`, `HeaderParseError`, `unknown charset`, and related email header crash terms before pushing; no open PR matched this fix path.