### PR TITLE
fix(config): strip control chars from saved credentials

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7148,6 +7148,30 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
     return sanitized
 
 
+def _check_ascii_control_credential(key: str, value: str) -> str:
+    """Warn and strip ASCII control characters from credential values."""
+    bad_chars: list[str] = []
+    for i, ch in enumerate(value):
+        codepoint = ord(ch)
+        if codepoint < 32 or codepoint == 127:
+            bad_chars.append(f"  position {i}: U+{codepoint:04X}")
+
+    if not bad_chars:
+        return value
+
+    sanitized = "".join(ch for ch in value if ord(ch) >= 32 and ord(ch) != 127)
+    print(
+        f"\n  Warning: {key} contains ASCII control characters that will break API requests.\n"
+        f"  This usually happens when copying credentials with hidden terminal or editor artifacts.\n"
+        + "\n".join(f"  {line}" for line in bad_chars[:5])
+        + ("\n  ... and more" if len(bad_chars) > 5 else "")
+        + f"\n\n  The control characters have been stripped automatically.\n"
+        f"  If authentication fails, re-copy the key from the provider's dashboard.\n",
+        file=sys.stderr,
+    )
+    return sanitized
+
+
 def _quote_env_value(value: str) -> str:
     """Quote .env values containing characters with special dotenv meaning."""
     if value == "":
@@ -7185,8 +7209,9 @@ def save_env_value(key: str, value: str):
     if not _ENV_VAR_NAME_RE.match(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
     _reject_denylisted_env_var(key)
-    value = value.replace("\n", "").replace("\r", "")
-    # API keys / tokens must be ASCII — strip non-ASCII with a warning.
+    # API keys / tokens must be printable ASCII — strip copy-paste artifacts
+    # before writing .env or mutating os.environ.
+    value = _check_ascii_control_credential(key, value)
     value = _check_non_ascii_credential(key, value)
     ensure_hermes_home()
     env_path = get_env_path()

--- a/tests/hermes_cli/test_non_ascii_credential.py
+++ b/tests/hermes_cli/test_non_ascii_credential.py
@@ -8,7 +8,7 @@ httpx tries to encode the Authorization header as ASCII.
 import os
 
 
-from hermes_cli.config import _check_non_ascii_credential
+from hermes_cli.config import _check_ascii_control_credential, _check_non_ascii_credential, save_env_value
 
 
 class TestCheckNonAsciiCredential:
@@ -45,6 +45,43 @@ class TestCheckNonAsciiCredential:
         assert result == "all-ascii-value-123"
         captured = capsys.readouterr()
         assert captured.err == ""
+
+
+class TestCheckAsciiControlCredential:
+    """Tests for _check_ascii_control_credential()."""
+
+    def test_printable_ascii_key_unchanged(self, capsys):
+        key = "sk-proj-abc123"
+        result = _check_ascii_control_credential("TEST_API_KEY", key)
+        assert result == key
+        assert capsys.readouterr().err == ""
+
+    def test_strips_ascii_control_chars(self, capsys):
+        result = _check_ascii_control_credential("OPENAI_API_KEY", "sk-\x00live\tkey\x7f")
+        assert result == "sk-livekey"
+        captured = capsys.readouterr()
+        assert "ASCII control characters" in captured.err
+        assert "U+0000" in captured.err
+        assert "U+0009" in captured.err
+        assert "U+007F" in captured.err
+
+
+class TestSaveEnvValueCredentialSanitization:
+    """Tests for save-time credential normalization."""
+
+    def test_save_env_value_strips_control_chars_before_write_and_environ(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        save_env_value("OPENAI_API_KEY", "sk-\x00live\tkey\x7f\nnext\r")
+
+        assert os.environ["OPENAI_API_KEY"] == "sk-livekeynext"
+        env_bytes = (tmp_path / ".env").read_bytes()
+        assert env_bytes == b"OPENAI_API_KEY=sk-livekeynext\n"
+        assert b"\x00" not in env_bytes
+        assert b"\t" not in env_bytes
+        assert b"\x7f" not in env_bytes
+        assert "ASCII control characters" in capsys.readouterr().err
 
 
 class TestEnvLoaderSanitization:


### PR DESCRIPTION
## What does this PR do?

Fixes save-time credential normalization so `save_env_value()` strips ASCII control characters before writing `~/.hermes/.env` and before mutating `os.environ`. This prevents copied API keys/tokens containing hidden bytes such as NUL, TAB, or DEL from leaving a malformed `.env` behind or crashing with `ValueError: embedded null character`.

Fixes #55335

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes

- Adds `_check_ascii_control_credential()` beside the existing non-ASCII credential sanitizer.
- Routes `save_env_value()` through the printable-ASCII sanitizer before `.env` serialization and `os.environ` assignment.
- Adds regression coverage proving NUL/TAB/DEL are stripped from both the persisted `.env` bytes and the process environment.
- Leaves existing `.env` load-time non-ASCII sanitizer semantics unchanged; this PR targets the save path described in the issue.

## How to Test

- [x] `.venv/bin/python -m pytest tests/hermes_cli/test_non_ascii_credential.py -q`
- [x] `.venv/bin/python -m pytest tests/hermes_cli/test_env_load_cache.py tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_config.py -q -k "env or credential or API_KEY or denylisted"`
- [x] `.venv/bin/python -m ruff check hermes_cli/config.py tests/hermes_cli/test_non_ascii_credential.py`
- [x] `git diff --check`

Platform: macOS, Python 3.13, local `.venv`.
