### PR TITLE
fix(agent): sanitize tool_call arguments that are JSON arrays, not ob…

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -304,7 +304,7 @@ def sanitize_tool_call_arguments(
                 continue
 
             try:
-                json.loads(arguments)
+                parsed = json.loads(arguments)
             except json.JSONDecodeError:
                 tool_call_id = tool_call.get("id")
                 function_name = function.get("name", "?")
@@ -345,6 +345,60 @@ def sanitize_tool_call_arguments(
                     _prepend_marker(existing_tool_msg)
 
                 repaired += 1
+            else:
+                # OpenAI-spec tool_call.arguments MUST be a JSON object.
+                # Some models (e.g. glm-5.2 on Volcengine Ark) occasionally
+                # emit a JSON array ("[{...}]") instead of an object.  Many
+                # OpenAI-compatible endpoints reject arrays with HTTP 400
+                # "InvalidParameter".  Unwrap a single-element array to its
+                # object; for multi-element or other non-dict types, fall
+                # back to "{}" so the request still succeeds.
+                if not isinstance(parsed, dict):
+                    tool_call_id = tool_call.get("id")
+                    function_name = function.get("name", "?")
+                    if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
+                        function["arguments"] = json.dumps(parsed[0], ensure_ascii=False)
+                    else:
+                        function["arguments"] = "{}"
+
+                        # Same corruption-marker logic as the JSONDecodeError
+                        # path above: mark the corresponding tool result so the
+                        # model knows the arguments were repaired, and insert
+                        # a synthetic tool result if one is missing.
+                        existing_tool_msg = None
+                        scan_index = message_index + 1
+                        while scan_index < len(messages):
+                            candidate = messages[scan_index]
+                            if not isinstance(candidate, dict) or candidate.get("role") != "tool":
+                                break
+                            if candidate.get("tool_call_id") == tool_call_id:
+                                existing_tool_msg = candidate
+                                break
+                            scan_index += 1
+
+                        if existing_tool_msg is None:
+                            messages.insert(
+                                insert_at,
+                                make_tool_result_message(
+                                    function_name if function_name != "?" else "",
+                                    marker,
+                                    tool_call_id,
+                                ),
+                            )
+                            insert_at += 1
+                        else:
+                            _prepend_marker(existing_tool_msg)
+
+                    log.warning(
+                        "Tool_call arguments was a JSON %s, not object — "
+                        "repaired before request (session=%s, tool_call_id=%s, "
+                        "function=%s)",
+                        type(parsed).__name__,
+                        session_id or "-",
+                        tool_call_id or "-",
+                        function_name,
+                    )
+                    repaired += 1
 
         message_index += 1
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3870,6 +3870,108 @@ class TestHandleMaxIterations:
             "call_123"
         ]
 
+    def test_api_sanitizer_repairs_array_arguments(self, agent):
+        """tool_call.function.arguments must be a JSON object per the OpenAI
+        Chat Completions spec.  Some models (e.g. glm-5.2 on Volcengine Ark)
+        occasionally emit a JSON array (``"[{...}]"``) instead of an object.
+        Many OpenAI-compatible endpoints reject arrays with HTTP 400
+        ``InvalidParameter``.  The sanitizer should unwrap a single-element
+        array to its object and fall back to ``"{}"`` for multi-element arrays
+        or other non-dict types — applying the same corruption-marker logic
+        as the existing JSONDecodeError path.
+        """
+        from agent.agent_runtime_helpers import sanitize_tool_call_arguments
+
+        _log = logging.getLogger(__name__)
+
+        # --- single-element array → unwrapped to object, no marker ---
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_unwrap",
+                        "type": "function",
+                        "function": {
+                            "name": "patch",
+                            "arguments": '[{"mode": "replace", "path": "f.txt"}]',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_unwrap", "content": "ok"},
+        ]
+        repaired = sanitize_tool_call_arguments(messages, logger=_log, session_id="test")
+        assert repaired == 1
+        args = json.loads(messages[0]["tool_calls"][0]["function"]["arguments"])
+        assert args == {"mode": "replace", "path": "f.txt"}
+        assert "corrupted" not in messages[1]["content"]
+
+        # --- multi-element array → "{}", marker on existing tool result ---
+        messages2 = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_multi",
+                        "type": "function",
+                        "function": {
+                            "name": "patch",
+                            "arguments": '[{"a": 1}, {"b": 2}]',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_multi", "content": "original"},
+        ]
+        repaired2 = sanitize_tool_call_arguments(messages2, logger=_log, session_id="test")
+        assert repaired2 == 1
+        assert messages2[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+        assert "corrupted" in messages2[1]["content"]
+        assert "original" in messages2[1]["content"]
+
+        # --- non-dict (number) → "{}", synthetic tool result inserted ---
+        messages3 = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_num",
+                        "type": "function",
+                        "function": {"name": "calc", "arguments": "42"},
+                    }
+                ],
+            },
+        ]
+        repaired3 = sanitize_tool_call_arguments(messages3, logger=_log, session_id="test")
+        assert repaired3 == 1
+        assert messages3[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+        assert len(messages3) == 2
+        assert messages3[1]["role"] == "tool"
+        assert messages3[1]["tool_call_id"] == "call_num"
+        assert "corrupted" in messages3[1]["content"]
+
+        # --- valid object → unchanged ---
+        messages4 = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_ok",
+                        "type": "function",
+                        "function": {"name": "patch", "arguments": '{"key": "value"}'},
+                    }
+                ],
+            },
+        ]
+        repaired4 = sanitize_tool_call_arguments(messages4, logger=_log, session_id="test")
+        assert repaired4 == 0
+        assert messages4[0]["tool_calls"][0]["function"]["arguments"] == '{"key": "value"}'
+
     def test_api_sanitizer_repairs_tool_call_with_empty_function_name(self, agent):
         """A tool_call with id but empty function.name makes the Responses-API
         adapter drop the function_call while keeping its function_call_output,


### PR DESCRIPTION
## What does this PR do?

`sanitize_tool_call_arguments()` in `agent/agent_runtime_helpers.py` only checked whether `function.arguments` could be parsed as JSON (`json.loads`), but did not validate that the parsed result was a **dict** (JSON object). When a model emits arguments as a JSON array (`[{"mode": "replace"}]`), it passed validation but was rejected by strict OpenAI-compatible endpoints with a non-retryable HTTP 400 `InvalidParameter`.

This PR adds a type check after `json.loads()`:
- **Single-element array containing a dict** → unwrapped to its object (`[{...}]` → `{...}`)
- **Multi-element array or other non-dict type** → falls back to `{}` with the same corruption-marker logic as the existing `JSONDecodeError` path (marker on existing tool result, synthetic tool result insertion if missing)

## Related Issue

Fixes #58057

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`: Added type validation in `sanitize_tool_call_arguments()` — after `json.loads()` succeeds, verify the result is a dict. Unwrap single-element arrays; fall back to `{}` for others, with corruption marker + synthetic tool result insertion (same as existing `JSONDecodeError` path).
- `tests/run_agent/test_run_agent.py`: Added `test_api_sanitizer_repairs_array_arguments` covering 4 cases: single-element array unwrap, multi-element array fallback with marker, non-dict type fallback with synthetic tool result, valid object unchanged.

## How to Test

1. Run the new test:
```
   pytest tests/run_agent/test_run_agent.py -k test_api_sanitizer_repairs_array_arguments -xvs
   ```
2. Run existing sanitizer tests (no regressions):
   ```
   pytest tests/run_agent/test_run_agent.py -k "sanitize or tool_call" -xvs
   ```
3. Reproduce the original 400 (without fix) by replaying a session where the model generated array arguments against Volcengine Ark. With the fix applied, the sanitizer unwraps the array before the API call and the request succeeds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys, no architecture changes, no tool schema changes