### PR TITLE
fix(gateway): keep fence text inside code blocks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -36,6 +36,17 @@ _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
 
 
+def _markdown_backtick_fence(line: str, *, in_code: bool) -> str | None:
+    """Return the opening info string or closing marker for a backtick fence."""
+    stripped = line.strip()
+    if not stripped.startswith("```"):
+        return None
+    tail = stripped[3:]
+    if in_code:
+        return "" if tail.strip() == "" else None
+    return tail.strip()
+
+
 def _platform_name(platform) -> str:
     """Normalize a Platform enum / raw string into a lowercase name."""
     value = getattr(platform, "value", platform)
@@ -5594,15 +5605,14 @@ class BasePlatformAdapter(ABC):
             in_code = carry_lang is not None
             lang = carry_lang or ""
             for line in chunk_body.split("\n"):
-                stripped = line.strip()
-                if stripped.startswith("```"):
+                fence = _markdown_backtick_fence(line, in_code=in_code)
+                if fence is not None:
                     if in_code:
                         in_code = False
                         lang = ""
                     else:
                         in_code = True
-                        tag = stripped[3:].strip()
-                        lang = tag.split()[0] if tag else ""
+                        lang = fence.split()[0] if fence else ""
 
             if in_code:
                 # Close the orphaned fence so the chunk is valid on its own

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1500,6 +1500,22 @@ class TestTruncateMessage:
                 "No continuation chunk reopened with language tag"
             )
 
+    def test_code_line_with_trailing_fence_text_is_not_closing_fence(self):
+        adapter = self._adapter()
+        msg = (
+            "Before\n"
+            "```text\n"
+            "``` not a close\n"
+            + "inside line\n" * 80
+            + "```\n"
+            "After"
+        )
+        chunks = adapter.truncate_message(msg, max_length=180)
+        assert len(chunks) > 1
+        assert any(chunk.startswith("```text\n") for chunk in chunks[1:]), (
+            "continuation chunks should reopen the still-active text fence"
+        )
+
     def test_continuation_chunks_have_balanced_fences(self):
         """Regression: continuation chunks must close reopened code blocks."""
         adapter = self._adapter()


### PR DESCRIPTION
## What does this PR do?

Fixes `BasePlatformAdapter.truncate_message()` so a line inside a fenced code block that starts with triple backticks but has trailing non-whitespace text is treated as code content, not as a closing fence.

Under CommonMark, a closing backtick fence may only be followed by whitespace. Before this change, `truncate_message()` used `stripped.startswith("```")`, so a content line like ` ``` not a close` closed the tracked code block early. Later chunks were then emitted without reopening the still-active fence.

Fixes #55292

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes

- Adds a small `_markdown_backtick_fence()` helper to distinguish opening fences from valid closing fences.
- Keeps opening-fence language detection behavior for lines like ` ```python`.
- Requires closing fences inside an active code block to have only whitespace after the backticks.
- Adds regression coverage for ` ``` not a close` inside a `text` fence before a chunk boundary.

## Duplicate check

I checked open PRs for #55292 and the exact symptom (`trailing fence text`, `not a close`, `invalid closing fence`, `boundary detector`). Nearby PRs touch chunk indicators and split placement in `truncate_message`, but this PR targets the separate fence-boundary detector bug described in #55292.

## How to Test

- [x] `.venv/bin/python -m pytest tests/gateway/test_platform_base.py -q -k trailing_fence_text`
- [x] `.venv/bin/python -m pytest tests/gateway/test_platform_base.py -q`
- [x] `.venv/bin/python -m ruff check gateway/platforms/base.py tests/gateway/test_platform_base.py`
- [x] `git diff --check`

Platform: macOS, Python 3.13, local `.venv`.
