### PR TITLE
fix(tui): treat stdio EINVAL as peer disconnect

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -156,6 +156,33 @@ def test_write_json_peer_gone_oserror_on_flush_returns_false(server):
     assert written and json.loads(written[0]) == {"x": 1}
 
 
+def test_write_json_windows_einval_on_write_returns_false(server):
+    """Windows can report a detached stdout pipe as EINVAL instead of EPIPE."""
+    import errno
+
+    class _DetachedStdout:
+        def write(self, _): raise OSError(errno.EINVAL, "Invalid argument")
+        def flush(self): pass
+
+    server._real_stdout = _DetachedStdout()
+    assert server.write_json({"x": 1}) is False
+
+
+def test_write_json_windows_einval_on_flush_returns_false(server):
+    """Flush can also surface Windows detached stdout as EINVAL."""
+    import errno
+
+    written = []
+
+    class _DetachedFlush:
+        def write(self, line): written.append(line)
+        def flush(self): raise OSError(errno.EINVAL, "Invalid argument")
+
+    server._real_stdout = _DetachedFlush()
+    assert server.write_json({"x": 1}) is False
+    assert written and json.loads(written[0]) == {"x": 1}
+
+
 def test_write_json_non_peer_gone_oserror_re_raises(server):
     """Host I/O failures (ENOSPC, EACCES, EIO …) are NOT peer-gone — they
     must re-raise so the crash log records them instead of looking like

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -37,6 +37,7 @@ _PEER_GONE_ERRNOS = frozenset({
     errno.EPIPE,        # write to closed pipe (POSIX)
     errno.ECONNRESET,   # peer reset the connection
     errno.EBADF,        # fd closed under us
+    errno.EINVAL,       # Windows detached stdout can report invalid argument
     errno.ESHUTDOWN,    # transport endpoint shut down
     getattr(errno, "WSAECONNRESET", -1),  # win32 mapping (no-op on POSIX)
     getattr(errno, "WSAESHUTDOWN", -1),


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI gateway stdio transport so Windows `OSError(errno.EINVAL, "Invalid argument")` from a detached stdout is treated as a peer disconnect instead of a fatal host I/O error.

On POSIX, closed pipes usually surface as `EPIPE`. On Windows, a GUI/WebSocket sidecar can detach stdout and `stream.write()` or `stream.flush()` may raise `EINVAL`; before this change that bubbled up and closed the WebSocket with 1011.

Fixes #55119

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes

- Adds `errno.EINVAL` to `_PEER_GONE_ERRNOS` in `tui_gateway/transport.py`.
- Adds regression coverage for both write-time and flush-time `EINVAL` paths returning `False`, matching the existing peer-gone contract.
- Leaves unrelated host I/O failures (`ENOSPC`, `EACCES`, etc.) on the existing re-raise path.

## Duplicate check

Checked open and closed PRs for #55119, `_PEER_GONE_ERRNOS`, `EINVAL`, `Invalid argument`, and `tui_gateway/transport.py`; no existing PR covers this exact stdio peer-gone errno.

## How to Test

- [x] `.venv/bin/python -m pytest tests/tui_gateway/test_protocol.py -q -k windows_einval`
- [x] `.venv/bin/python -m pytest tests/tui_gateway/test_protocol.py -q`
- [x] `.venv/bin/python -m ruff check tui_gateway/transport.py tests/tui_gateway/test_protocol.py`
- [x] `git diff --check`

Platform: macOS, Python 3.13, local `.venv`.
