### PR TITLE
fix(redact): strip controls before masking secrets

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -338,9 +338,17 @@ def mask_secret(
     """
     if not value:
         return empty
+    value = "".join(ch for ch in value if not _is_display_control_char(ch))
+    if not value:
+        return empty
     if len(value) < floor:
         return placeholder
     return f"{value[:head]}...{value[-tail:]}"
+
+
+def _is_display_control_char(ch: str) -> bool:
+    codepoint = ord(ch)
+    return codepoint < 32 or codepoint == 127 or 128 <= codepoint <= 159
 
 
 def _mask_token(token: str) -> str:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import mask_secret, redact_cdp_url, redact_sensitive_text, RedactingFormatter
 
 
 @pytest.fixture(autouse=True)
@@ -66,6 +66,22 @@ class TestKnownPrefixes:
     def test_short_token_fully_masked(self):
         result = redact_sensitive_text("key=sk-short1234567")
         assert "***" in result
+
+
+class TestMaskSecretDisplay:
+    def test_mask_secret_printable_value_unchanged(self):
+        assert mask_secret("abcd0123456789zzzz") == "abcd...zzzz"
+
+    def test_mask_secret_strips_control_chars_before_masking_prefix(self):
+        result = mask_secret("ab\ncd0123456789zzzz")
+        assert result == "abcd...zzzz"
+        assert "\n" not in result
+
+    def test_mask_secret_strips_c1_and_del_controls_before_masking_suffix(self):
+        result = mask_secret("abcd0123456789zz\x85q\x7f")
+        assert result == "abcd...9zzq"
+        assert "\x85" not in result
+        assert "\x7f" not in result
 
 
 class TestEnvAssignments:


### PR DESCRIPTION
## What does this PR do?

Fixes display-time secret masking so `agent.redact.mask_secret()` strips C0/C1/DEL control characters before applying the existing visible head/tail mask.

Before this change, malformed pasted credentials could produce masked output containing newlines or invisible control bytes when those bytes landed in the preserved prefix/suffix. Printable secrets keep the same mask shape.

Fixes #55319

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes

- Adds a tiny `_is_display_control_char()` helper covering C0, DEL, and C1 controls.
- Normalizes `mask_secret()` input before the existing floor/head/tail masking logic.
- Adds focused regression coverage for prefix newline controls and suffix C1/DEL controls.
- Adds a printable-value guard to prove normal mask output remains unchanged.

## Duplicate check

Checked open PRs for #55319, `masked secret display`, `mask_secret` control characters, redaction control characters, C1, and DEL masking. The only nearby open PR is #58074, which targets save-time credential normalization in `save_env_value()`; this PR targets display-time masking in `agent.redact.mask_secret()`.

## How to Test

- [x] `.venv/bin/python -m pytest tests/agent/test_redact.py -q -k TestMaskSecretDisplay`
- [x] `.venv/bin/python -m pytest tests/agent/test_redact.py -q`
- [x] `.venv/bin/python -m ruff check agent/redact.py tests/agent/test_redact.py`
- [x] `git diff --check`

Platform: macOS, Python 3.13, local `.venv`.
