### PR TITLE
fix(mem0): silence output_format v1.0 DeprecationWarning

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -76,7 +76,12 @@ class PlatformBackend(Mem0Backend):
         infer: bool = False,
         metadata: dict | None = None,
     ) -> dict:
-        kwargs: dict[str, Any] = {"user_id": user_id, "agent_id": agent_id, "infer": infer}
+        # output_format="v1.1" avoids the SDK's per-call DeprecationWarning
+        # (add() defaults to the deprecated "v1.0" and warns otherwise).
+        kwargs: dict[str, Any] = {
+            "user_id": user_id, "agent_id": agent_id, "infer": infer,
+            "output_format": "v1.1",
+        }
         if metadata:
             kwargs["metadata"] = metadata
         return self._client.add(messages, **kwargs)


### PR DESCRIPTION
The mem0 SDK logs a DeprecationWarning when `client.add()` is called with the default `output_format='v1.0'`. This passes `output_format='v1.1'` explicitly to avoid the warning.

Both call sites are safe: `_unwrap_results` already expects the v1.1 envelope (`{"results": [...]}`).

Fixes agent logs spam with per-memory-write warnings.