### PR TITLE
fix(cli): quote the editor fallback path for cmd.exe on Windows

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2320,9 +2320,18 @@ class CLICommandsMixin:
             try:
                 subprocess.call([*shlex.split(editor), path])
             except Exception:
-                # Fall back to a bare invocation (editor value may not be a
-                # simple argv-splittable string on some platforms).
-                subprocess.call(f"{editor} {shlex.quote(path)}", shell=True)
+                # The list-form invocation failed (editor value isn't
+                # argv-splittable on this platform). Fall back to the shell,
+                # quoting the path for the platform's shell. ``shlex.quote`` is
+                # POSIX-only: cmd.exe treats its single quotes literally, so a
+                # temp path containing spaces or ``&`` (e.g. a Windows profile
+                # dir like ``C:\Users\A & B\...``) would be split or start a
+                # second command. cmd.exe treats a double-quoted string's
+                # contents literally, so quote with ``"..."`` on Windows.
+                if os.name == "nt":
+                    subprocess.call(f'{editor} "{path}"', shell=True)
+                else:
+                    subprocess.call(f"{editor} {shlex.quote(path)}", shell=True)
             with open(path, "r", encoding="utf-8") as fh:
                 raw = fh.read()
         finally:

--- a/tests/hermes_cli/test_prompt_compose_command.py
+++ b/tests/hermes_cli/test_prompt_compose_command.py
@@ -74,3 +74,47 @@ def test_empty_buffer_does_not_seed(monkeypatch):
     s = _Stub()
     s._handle_prompt_compose_command("/prompt")
     assert s._pending_agent_seed is None
+
+
+def test_editor_fallback_quotes_windows_path_for_cmd(monkeypatch, tmp_path):
+    """On Windows the shell=True editor fallback must double-quote the temp path.
+
+    ``shlex.quote`` is POSIX-only — cmd.exe treats its single quotes as literal
+    characters, so a temp path with spaces or ``&`` (e.g. a Windows profile dir
+    ``C:\\Users\\A & B\\...``) would be split into arguments or start a second
+    command. The fallback runs only when the primary list-form invocation
+    raises, so this simulates that.
+    """
+    import subprocess
+
+    spaced_dir = tmp_path / "A & B"
+    spaced_dir.mkdir()
+    fake_path = str(spaced_dir / "hermes_prompt_test.md")
+
+    def fake_mkstemp(*_a, **_k):
+        fd = os.open(fake_path, os.O_CREAT | os.O_WRONLY, 0o600)
+        return fd, fake_path
+
+    monkeypatch.setattr(tempfile, "mkstemp", fake_mkstemp)
+
+    captured = {}
+
+    def fake_call(cmd, *_a, **_k):
+        if isinstance(cmd, list):
+            # Force the primary list-form invocation to fall through.
+            raise FileNotFoundError("simulate non-argv-splittable editor")
+        captured["shell"] = cmd
+        return 0
+
+    monkeypatch.setattr(subprocess, "call", fake_call)
+    monkeypatch.setattr(os, "name", "nt")  # exercise the Windows branch anywhere
+    monkeypatch.setenv("EDITOR", "notepad")
+
+    _Stub()._compose_in_editor("")
+
+    assert "shell" in captured, "the shell=True fallback should have run"
+    shell_cmd = captured["shell"]
+    # cmd.exe-safe: the path is double-quoted, so spaces / '&' stay literal ...
+    assert f'"{fake_path}"' in shell_cmd
+    # ... and NOT wrapped in shlex.quote's POSIX single quotes.
+    assert "'" not in shell_cmd


### PR DESCRIPTION
## What does this PR do?

`_compose_in_editor` (the `/prompt` helper) launches the editor via a list-form
`subprocess.call([*shlex.split(editor), path])`, and falls back to a shell
invocation when the editor value isn't argv-splittable. The fallback quoted the
temp path with `shlex.quote`, which is **POSIX-only** — cmd.exe treats its
single quotes as literal characters. So on Windows a temp path containing spaces
or `&` (e.g. a profile dir like `C:\Users\A & B\AppData\...`) is split into
arguments, or the shell starts a second command at the `&`. `/prompt` then
crashes or runs something unintended for those users.

On Windows the path is now wrapped in `"..."` (cmd.exe treats a double-quoted
string's contents literally); POSIX keeps `shlex.quote`.

## Related Issue

N/A — no tracking issue.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/cli_commands_mixin.py` — in `_compose_in_editor`, quote the
  fallback path with `"..."` on Windows instead of `shlex.quote`.
- `tests/hermes_cli/test_prompt_compose_command.py` — regression test.

## How to Test

1. On Windows, run under a profile dir containing a space and `&`
   (e.g. `C:\Users\A & B`), set an `EDITOR` that isn't argv-splittable so the
   shell fallback runs, and invoke `/prompt` — it opens the editor instead of
   crashing / running a stray command.
2. Run the tests:
   ```
   pytest tests/hermes_cli/test_prompt_compose_command.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suite: `pytest tests/hermes_cli/test_prompt_compose_command.py -q` (the new test passes; two pre-existing failures use a bash `.sh` fake editor that can't run on Windows and are unrelated)
- [x] I've added a test for my change


### Documentation & Housekeeping

- [x] Documentation (README, `docs/`, docstrings) — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the fix is Windows-specific; POSIX path unchanged
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Mutation check — without the fix the fallback single-quotes the path (cmd.exe
would break on the `&`):

```
- notepad "C:\Users\...\A & B\hermes_prompt_test.md"   # fixed (double quotes)
+ notepad 'C:\Users\...\A & B\hermes_prompt_test.md'   # old (shlex single quotes)
```