### PR TITLE
fix(bitwarden): preserve profile-local secrets

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -44,7 +44,7 @@ import urllib.request
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -598,6 +598,7 @@ def apply_bitwarden_secrets(
     auto_install: bool = True,
     server_url: str = "",
     home_path: Optional[Path] = None,
+    preserve_existing: Optional[Iterable[str]] = None,
 ) -> FetchResult:
     """Pull secrets from BSM and set them on ``os.environ``.
 
@@ -609,8 +610,12 @@ def apply_bitwarden_secrets(
     (e.g. ``https://vault.bitwarden.eu`` for EU Cloud).  Empty string
     means use ``bws``'s default (US Cloud).
 
-    Parameters mirror the ``secrets.bitwarden.*`` config keys so the
-    caller can just splat the dict in.
+    ``preserve_existing`` is a narrow escape hatch for profile-local secrets
+    that must not be replaced by a shared BSM project even when
+    ``override_existing`` is true.
+
+    Parameters mirror the ``secrets.bitwarden.*`` config keys so the caller can
+    pass config values through directly.
     """
     result = FetchResult()
 
@@ -657,11 +662,18 @@ def apply_bitwarden_secrets(
     result.secrets = secrets
     result.warnings.extend(warnings)
 
+    preserve_existing_keys = {
+        name.strip() for name in (preserve_existing or ()) if isinstance(name, str)
+    }
+
     for key, value in secrets.items():
         if key == access_token_env:
             # Don't let BSM clobber the very token we used to fetch
             # itself — that would be a footgun if someone stored the
             # token as a BSM secret too.
+            result.skipped.append(key)
+            continue
+        if key in preserve_existing_keys and os.environ.get(key):
             result.skipped.append(key)
             continue
         if not override_existing and os.environ.get(key):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3039,6 +3039,11 @@ DEFAULT_CONFIG = {
             # if .env had the final say, rotating in Bitwarden wouldn't
             # take effect until you also cleared the matching .env line.
             "override_existing": True,
+            # Env var names that keep their existing .env / shell value even
+            # when override_existing is true. Useful for per-profile platform
+            # secrets that intentionally differ across profiles while other
+            # provider keys still rotate centrally through Bitwarden.
+            "preserve_existing": [],
             # When True, the bws binary is auto-downloaded into
             # ~/.hermes/bin/ on first use.  When False you must install
             # bws yourself and have it on PATH.

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -321,6 +321,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
         project_id=bw_cfg.get("project_id", ""),
         override_existing=bool(bw_cfg.get("override_existing", False)),
+        preserve_existing=bw_cfg.get("preserve_existing", []),
         cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
         auto_install=bool(bw_cfg.get("auto_install", True)),
         server_url=str(bw_cfg.get("server_url", "") or "").strip(),

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -564,6 +564,37 @@ def test_apply_override_existing(monkeypatch, tmp_path):
     assert os.environ["OPENAI_API_KEY"] == "fresh"
 
 
+def test_apply_preserve_existing_wins_over_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.t")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "profile-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "stale")
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    payload = _fake_bws_payload([
+        {"key": "FEISHU_APP_SECRET", "value": "shared-secret"},
+        {"key": "OPENAI_API_KEY", "value": "fresh"},
+    ])
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout=payload, stderr=""),
+    )
+    monkeypatch.setattr(bw, "find_bws", lambda **kw: fake_binary)
+
+    result = bw.apply_bitwarden_secrets(
+        enabled=True,
+        project_id="p",
+        override_existing=True,
+        preserve_existing=["FEISHU_APP_SECRET"],
+        auto_install=False,
+    )
+
+    assert result.ok
+    assert os.environ["FEISHU_APP_SECRET"] == "profile-secret"
+    assert os.environ["OPENAI_API_KEY"] == "fresh"
+    assert "FEISHU_APP_SECRET" in result.skipped
+    assert "OPENAI_API_KEY" in result.applied
+
+
 def test_apply_never_overrides_bootstrap_token(monkeypatch, tmp_path):
     """Even with override_existing=True, the access-token var is preserved."""
     monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.original")
@@ -632,6 +663,8 @@ def test_env_loader_calls_bsm_when_enabled(tmp_path, monkeypatch):
         "    access_token_env: 'BWS_ACCESS_TOKEN'\n"
         "    cache_ttl_seconds: 0\n"
         "    override_existing: false\n"
+        "    preserve_existing:\n"
+        "      - FEISHU_APP_SECRET\n"
         "    auto_install: false\n"
     )
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -643,6 +676,7 @@ def test_env_loader_calls_bsm_when_enabled(tmp_path, monkeypatch):
         called["n"] += 1
         assert kwargs["enabled"] is True
         assert kwargs["project_id"] == "proj-1"
+        assert kwargs["preserve_existing"] == ["FEISHU_APP_SECRET"]
         os.environ["MY_BSM_KEY"] = "from-bsm"
         return bw.FetchResult(
             secrets={"MY_BSM_KEY": "from-bsm"},

--- a/website/docs/user-guide/secrets/bitwarden.md
+++ b/website/docs/user-guide/secrets/bitwarden.md
@@ -87,6 +87,7 @@ secrets:
     server_url: ""
     cache_ttl_seconds: 300
     override_existing: true
+    preserve_existing: []
     auto_install: true
 ```
 
@@ -98,6 +99,7 @@ secrets:
 | `server_url` | `""` | Bitwarden region or self-hosted endpoint. Empty = `bws` default (US Cloud, `https://vault.bitwarden.com`). Set to `https://vault.bitwarden.eu` for EU Cloud, or your own URL for self-hosted. Plumbed into the `bws` subprocess as `BWS_SERVER_URL`. |
 | `cache_ttl_seconds` | `300` | How long an in-process fetch result is reused. Set to `0` to disable caching. Cache is per-process; new `hermes` invocations start fresh. |
 | `override_existing` | `true` | When true, Bitwarden values overwrite anything already in env (so rotation in the web app actually takes effect). Flip to `false` if you want `.env` / shell exports to win locally. |
+| `preserve_existing` | `[]` | Env var names that keep their existing `.env` / shell value even when `override_existing` is true. Use this for per-profile platform secrets, for example `FEISHU_APP_SECRET`, while other shared keys still rotate through Bitwarden. |
 | `auto_install` | `true` | When true, `bws` is auto-downloaded into `~/.hermes/bin/` on first use. |
 
 ## Failure modes

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/secrets/bitwarden.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/secrets/bitwarden.md
@@ -87,6 +87,7 @@ secrets:
     server_url: ""
     cache_ttl_seconds: 300
     override_existing: true
+    preserve_existing: []
     auto_install: true
 ```
 
@@ -98,6 +99,7 @@ secrets:
 | `server_url` | `""` | Bitwarden 区域或自托管端点。为空时使用 `bws` 默认值（US Cloud，`https://vault.bitwarden.com`）。欧盟云设为 `https://vault.bitwarden.eu`，自托管则填写自己的 URL。以 `BWS_SERVER_URL` 形式传递给 `bws` 子进程。 |
 | `cache_ttl_seconds` | `300` | 进程内拉取结果的复用时长。设为 `0` 可禁用缓存。缓存按进程隔离；新的 `hermes` 调用从头开始。 |
 | `override_existing` | `true` | 为 true 时，Bitwarden 的值会覆盖环境中已有的任何值（使 Web 应用中的轮换真正生效）。如果希望本地 `.env` / shell 导出优先，设为 `false`。 |
+| `preserve_existing` | `[]` | 即使 `override_existing` 为 true，也保留现有 `.env` / shell 值的环境变量名列表。适合各 profile 必须不同的平台密钥，例如 `FEISHU_APP_SECRET`，同时其他共享密钥仍由 Bitwarden 统一轮换。 |
 | `auto_install` | `true` | 为 true 时，首次使用时自动将 `bws` 下载到 `~/.hermes/bin/`。 |
 
 ## 故障模式


### PR DESCRIPTION
Fixes #58073.

## Summary
- add `secrets.bitwarden.preserve_existing`, a config.yaml list of env var names that keep their current `.env` / shell value even when `override_existing: true`
- pass that list through the startup env loader into Bitwarden secret application
- document the option in the Bitwarden guide, including the multi-profile `FEISHU_APP_SECRET` use case

## Why this shape
`override_existing: true` is still useful for centralized Bitwarden rotation, so this does not change its default behavior globally. Multi-profile deployments can now protect only the platform secrets that intentionally differ per profile while continuing to rotate shared provider keys through BSM.

Example:

```yaml
secrets:
  bitwarden:
    enabled: true
    override_existing: true
    preserve_existing:
      - FEISHU_APP_SECRET
```

## Duplicate check
- searched open PRs for `58073`, `override_existing`, `BWS`, `FEISHU_APP_SECRET`, `profile-specific secrets`, and related Bitwarden/profile-secret wording
- found adjacent profile/secret-scope PRs, but no open or closed PR covering this Bitwarden override escape hatch for #58073

## Test plan
- `.venv/bin/python -m pytest tests/test_bitwarden_secrets.py -q` -> 43 passed
- `.venv/bin/python -m pytest tests/test_env_loader_secret_sources.py -q` -> 8 passed
- `.venv/bin/python -m ruff check agent/secret_sources/bitwarden.py hermes_cli/env_loader.py hermes_cli/config.py tests/test_bitwarden_secrets.py` -> passed
- `git diff --check` -> passed