### PR TITLE
Add MoA swarm approach skill

### DIFF
--- a/skills/software-development/moa-swarm-approach/SKILL.md
+++ b/skills/software-development/moa-swarm-approach/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: moa-swarm-approach
+description: Plan and verify work with MoA-guided agent swarms.
+version: 1.0.0
+author: misery-hl, Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [swarm, moa, mixture-of-agents, delegation, orchestration]
+    category: software-development
+    related_skills: [plan, requesting-code-review]
+---
+
+# MoA Swarm Approach Skill
+
+Use Mixture of Agents (MoA) to design and review evidence-gated work slices, then use scoped workers to execute only the slices that benefit from parallelism. This skill does not treat model agreement as proof or give workers authority for unapproved side effects.
+
+## When to Use
+
+Use this skill when:
+
+- a broad `/goal` needs decomposition before implementation;
+- several independent perspectives could improve a plan or review;
+- work has separable slices with explicit inputs and outputs;
+- risk, ambiguity, or breadth makes one serial pass unreliable; or
+- the user asks for an MoA swarm, mixture of agents, or multi-agent plan.
+
+Do not use it for one deterministic action, a task with no testable success condition, or a request that prioritizes minimum cost and latency. Do not fan out secrets, credentials, raw personal data, or sensitive logs; redact the context or keep the work in the parent session.
+
+## Prerequisites
+
+- Configure at least one MoA preset and its reference/aggregator providers. `/moa <prompt>` runs one prompt through the default preset and then restores the active model.
+- Configure `delegation.provider` and `delegation.model` for the native `delegate_task` workers.
+- Confirm the parent can inspect the relevant source with Hermes tools such as `read_file`, `search_files`, and `terminal`.
+- Identify any action that needs user approval before planning execution.
+
+No optional skill, plugin, or extra toolset is required; these tools ship in the standard Hermes build.
+
+If MoA is unavailable, state `MoA unavailable; using bounded fallback planning.` Use one parent planning pass or a small read-only `delegate_task` panel, and never claim that MoA ran.
+
+## How to Run
+
+1. Define the goal, done condition, non-goals, evidence, and approval boundaries.
+2. Give `/moa` a compact, redacted context pack and request an ordered slice plan.
+3. Check the plan against source evidence; obtain approval only where cost, risk, or side effects require it.
+4. Execute the next ready slice with the smallest useful `delegate_task` fan-out.
+5. Require compact worker reports, inspect their evidence, and run objective checks.
+6. Use another MoA pass for disputed or high-risk results, then advance, repeat, block, or ask the user.
+
+Run one slice at a time unless slices are independent, write-isolated, and safe to verify separately. The parent remains the overseer and owns every final success claim.
+
+## Quick Reference
+
+| Stage | Mechanism | Required output |
+|---|---|---|
+| Shape | Parent | Goal, done condition, boundaries |
+| Plan | `/moa` | Ordered slices and worker width |
+| Execute | `delegate_task` | Scoped evidence or changes |
+| Compress | Worker report | Verdict and evidence handles |
+| Review | `/moa` when warranted | PASS, BLOCK, or REQUEST_CHANGES |
+| Verify | Parent tools | Directly checked result |
+
+Choose worker width by need, not a fixed swarm size:
+
+| Need | Suggested width |
+|---|---|
+| Deterministic execution | Parent or 1 worker |
+| A few independent checks | 2-3 workers |
+| Material ambiguity or risk | 3-5 workers |
+| Broad search | More only with a stated budget and user approval |
+
+Every worker returns this compact schema:
+
+```text
+Verdict: PASS | BLOCK | REQUEST_CHANGES
+Finding: one-sentence result
+Evidence: paths, source handles, or check output
+Changes: files or artifacts, or none
+Checks: commands/checks and pass/fail
+Risks: unresolved issues
+Side effects: none, or exact list
+Confidence: low | medium | high
+```
+
+## Procedure
+
+### 1. Shape the request
+
+Write a task contract before calling MoA:
+
+```text
+Goal:
+Done means:
+Known evidence:
+Non-goals:
+Forbidden side effects:
+Approval boundaries:
+Budget or deadline:
+Open questions:
+```
+
+Resolve only questions that materially change the plan. Label unknowns instead of letting advisors invent project or runtime facts.
+
+### 2. Ask MoA to design the slices
+
+Use `/moa` with the contract and this instruction:
+
+```text
+Design the smallest evidence-gated execution plan for this goal.
+Compare advisor proposals by evidence, risk, and simplicity; do not vote.
+Do not perform actions or invent facts.
+
+For each slice return:
+- id, objective, required input, and required output
+- dependencies and non-goals
+- worker angles and suggested worker count
+- read-only or edit-capable status
+- allowed tools and forbidden side effects
+- verification evidence and completion gate
+
+Also return overall risks, user approval points, and the next ready slice.
+```
+
+Reject a plan whose slices overlap ownership, lack a completion gate, or require evidence no worker can obtain.
+
+### 3. Gate the plan
+
+The parent checks cited files, APIs, constraints, and commands before execution. MoA is advisory: consensus cannot override source-of-truth evidence.
+
+Ask the user before expensive fan-out, live external actions, persistent jobs, production changes, credential or permission changes, commits, pushes, deployments, or migrations unless the request already authorized that exact action. Do not pause for routine read-only checks or ordinary local edits already in scope.
+
+### 4. Dispatch the next ready slice
+
+Use `delegate_task` with one `tasks` entry per independent angle. Keep workers as `leaf` roles unless a slice explicitly needs nested orchestration and the configured depth allows it.
+
+Give every worker a self-contained prompt:
+
+```text
+Slice and assigned angle:
+Objective:
+Required input:
+Required output:
+Scope and owned paths:
+Read-only or edit-capable:
+Allowed tools:
+Forbidden side effects:
+Evidence required:
+Completion gate:
+Stop and report when:
+
+Return only the compact worker schema.
+```
+
+Read-only workers may inspect the same source. Editing workers must have non-overlapping ownership or isolated branches/worktrees; never allow concurrent edits to the same live files.
+
+### 5. Compress and inspect reports
+
+Do not paste raw worker transcripts into the overseer context. Preserve verdicts, disagreements, evidence handles, changed paths, checks, and side effects.
+
+For a wide slice, assign one read-only synthesis worker to deduplicate reports without deciding success. The parent opens decisive artifacts and reruns checks when the claim matters.
+
+### 6. Review and advance
+
+Use a second `/moa` pass when workers disagree, risk is high, the plan changed, or evidence is incomplete:
+
+```text
+Review the slice contract, compact reports, and parent verification.
+Judge evidence rather than vote count. Do not invent missing facts.
+Return PASS, BLOCK, or REQUEST_CHANGES; list missing evidence and the safest next step.
+```
+
+Advance only when the slice output exists and its completion gate passes:
+
+- **PASS with direct evidence:** mark the slice complete and start the next ready slice.
+- **Missing or contradictory evidence:** repeat or narrow the current slice.
+- **Changed scope, cost, or side effects:** ask the user before continuing.
+- **Blocked dependency:** report the exact blocker and the evidence needed to unblock it.
+
+After the final slice, run integration-level verification rather than assuming individually passing slices compose correctly.
+
+## Pitfalls
+
+1. **Blind fan-out:** More workers add cost and synthesis load. Start with the smallest width that produces distinct evidence.
+2. **Duplicate angles:** Rephrased copies create fake consensus. Give workers different failure modes or responsibilities.
+3. **Context flooding:** Large transcripts defeat the design. Return compact reports with drill-down handles.
+4. **Sensitive fan-out:** Advisor or worker traces may persist. Redact first or keep the task local.
+5. **Self-reported success:** Worker and MoA verdicts are inputs, not verification. The parent checks evidence directly.
+6. **Overlapping edits:** Shared write ownership causes conflicts and invalidates checks. Serialize or isolate edits.
+7. **Unbounded nesting:** Nested orchestrators multiply cost and obscure ownership. Prefer leaf workers and explicit slices.
+8. **Approval theater:** Ask only at meaningful boundaries, while respecting authority already granted by the user.
+9. **Plan drift:** If execution changes inputs, outputs, or risk, return to the affected slice gate before proceeding.
+
+## Verification
+
+Before reporting completion, confirm:
+
+- [ ] Goal, done condition, non-goals, and approval boundaries were explicit.
+- [ ] Context sent to MoA and workers was minimal and redacted.
+- [ ] Each slice had defined inputs, outputs, ownership, and a completion gate.
+- [ ] Worker width matched the task rather than a fixed preset.
+- [ ] Worker reports named evidence, checks, changes, risks, and side effects.
+- [ ] The parent inspected decisive evidence and reran relevant checks.
+- [ ] Disagreement or high-risk work received an evidence-based review.
+- [ ] No worker exceeded its scope or performed an unapproved side effect.
+- [ ] Integration verification passed after the final slice.
+- [ ] The final response distinguishes completed work, blockers, and remaining risk.

--- a/skills/software-development/moa-swarm-approach/assets/moa-swarm-workflow.svg
+++ b/skills/software-development/moa-swarm-approach/assets/moa-swarm-workflow.svg
@@ -1,0 +1,182 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="920" viewBox="0 0 1400 920" role="img" aria-labelledby="title desc">
+  <title id="title">MoA Swarm Approach workflow</title>
+  <desc id="desc">A flow diagram showing how a task moves through context gathering, MoA planning, approval, execution substrate selection, worker fan-out, liaison synthesis, MoA result review, parent verification, and final delivery.</desc>
+  <defs>
+    <style>
+      .bg { fill: #f7f9fb; }
+      .panel { fill: #ffffff; stroke: #d6dde6; stroke-width: 2; }
+      .start { fill: #e8f3ff; stroke: #4d8fd7; }
+      .moa { fill: #f0ecff; stroke: #7b61d1; }
+      .worker { fill: #ecfbf4; stroke: #36a36f; }
+      .gate { fill: #fff6df; stroke: #cf8b18; }
+      .verify { fill: #fcecee; stroke: #d75a70; }
+      .done { fill: #eef7e8; stroke: #6ca84f; }
+      .line { stroke: #5a6776; stroke-width: 3; fill: none; }
+      .thin { stroke: #8b98a8; stroke-width: 2; fill: none; }
+      .dash { stroke: #8b98a8; stroke-width: 2; stroke-dasharray: 7 7; fill: none; }
+      .arrow { fill: #5a6776; }
+      .label { font: 700 22px Arial, Helvetica, sans-serif; fill: #182230; }
+      .sub { font: 15px Arial, Helvetica, sans-serif; fill: #405066; }
+      .tiny { font: 13px Arial, Helvetica, sans-serif; fill: #526175; }
+      .chip { font: 700 13px Arial, Helvetica, sans-serif; fill: #ffffff; }
+      .lane { font: 700 16px Arial, Helvetica, sans-serif; fill: #2c3a4c; letter-spacing: 0; }
+      .note { font: 14px Arial, Helvetica, sans-serif; fill: #344256; }
+      .mono { font: 13px "SFMono-Regular", Consolas, "Liberation Mono", monospace; fill: #344256; }
+    </style>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path class="arrow" d="M 0 0 L 12 6 L 0 12 Z" />
+    </marker>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="5" stdDeviation="7" flood-color="#1b2533" flood-opacity="0.12" />
+    </filter>
+  </defs>
+
+  <rect class="bg" width="1400" height="920" />
+
+  <text x="64" y="66" class="label" style="font-size:34px">MoA Swarm Approach</text>
+  <text x="64" y="96" class="sub">Plan with Mixture of Agents, execute with scoped workers, verify with objective evidence.</text>
+
+  <rect x="64" y="125" width="1272" height="642" rx="16" class="panel" filter="url(#shadow)" />
+  <text x="88" y="162" class="lane">Primary task flow</text>
+
+  <!-- Row 1 -->
+  <rect x="104" y="196" width="170" height="92" rx="14" class="start" stroke-width="2" />
+  <text x="130" y="232" class="label">1. Task</text>
+  <text x="130" y="258" class="sub">User asks for</text>
+  <text x="130" y="278" class="sub">complex work</text>
+
+  <path d="M 274 242 H 334" class="line" marker-end="url(#arrow)" />
+
+  <rect x="344" y="196" width="190" height="92" rx="14" class="start" stroke-width="2" />
+  <text x="370" y="226" class="label">2. Context</text>
+  <text x="370" y="252" class="sub">Facts, constraints,</text>
+  <text x="370" y="272" class="sub">risks, checks</text>
+
+  <path d="M 534 242 H 594" class="line" marker-end="url(#arrow)" />
+
+  <rect x="604" y="180" width="238" height="124" rx="16" class="moa" stroke-width="2" />
+  <rect x="628" y="202" width="60" height="22" rx="11" fill="#7b61d1" />
+  <text x="641" y="218" class="chip">MoA</text>
+  <text x="628" y="250" class="label">3. Planning</text>
+  <text x="628" y="276" class="sub">Advisors critique,</text>
+  <text x="628" y="296" class="sub">aggregator returns plan</text>
+
+  <path d="M 842 242 H 902" class="line" marker-end="url(#arrow)" />
+
+  <rect x="912" y="196" width="186" height="92" rx="14" class="gate" stroke-width="2" />
+  <text x="938" y="232" class="label">4. Gate</text>
+  <text x="938" y="258" class="sub">Approve, narrow,</text>
+  <text x="938" y="278" class="sub">or fall back</text>
+
+  <path d="M 1098 242 H 1158" class="line" marker-end="url(#arrow)" />
+
+  <rect x="1168" y="196" width="128" height="92" rx="14" class="gate" stroke-width="2" />
+  <text x="1192" y="232" class="label">5. Pick</text>
+  <text x="1192" y="258" class="sub">Smallest safe</text>
+  <text x="1192" y="278" class="sub">substrate</text>
+
+  <!-- Down connector -->
+  <path d="M 1232 288 V 350 H 1128" class="line" marker-end="url(#arrow)" />
+
+  <!-- Substrate selector -->
+  <rect x="786" y="348" width="342" height="142" rx="16" fill="#ffffff" stroke="#cbd5e1" stroke-width="2" />
+  <text x="812" y="382" class="label">Execution substrate</text>
+  <text x="812" y="410" class="tiny">Use only what the task requires.</text>
+  <g>
+    <rect x="812" y="430" width="88" height="28" rx="14" fill="#ecfbf4" stroke="#36a36f" />
+    <text x="829" y="449" class="tiny">direct</text>
+    <rect x="908" y="430" width="110" height="28" rx="14" fill="#ecfbf4" stroke="#36a36f" />
+    <text x="925" y="449" class="tiny">delegation</text>
+    <rect x="1026" y="430" width="78" height="28" rx="14" fill="#ecfbf4" stroke="#36a36f" />
+    <text x="1044" y="449" class="tiny">board</text>
+    <rect x="812" y="464" width="106" height="28" rx="14" fill="#ecfbf4" stroke="#36a36f" />
+    <text x="829" y="483" class="tiny">worktree</text>
+    <rect x="926" y="464" width="86" height="28" rx="14" fill="#ecfbf4" stroke="#36a36f" />
+    <text x="944" y="483" class="tiny">cron</text>
+    <rect x="1020" y="464" width="84" height="28" rx="14" fill="#ecfbf4" stroke="#36a36f" />
+    <text x="1038" y="483" class="tiny">mixed</text>
+  </g>
+
+  <path d="M 786 420 H 720 V 512" class="line" marker-end="url(#arrow)" />
+
+  <!-- Worker fanout -->
+  <rect x="326" y="356" width="394" height="222" rx="18" class="worker" stroke-width="2" />
+  <text x="354" y="392" class="label">6. Worker fan-out</text>
+  <text x="354" y="420" class="sub">Independent scoped workers gather evidence,</text>
+  <text x="354" y="440" class="sub">implement in isolation, or inspect one angle.</text>
+
+  <rect x="354" y="470" width="92" height="56" rx="10" fill="#ffffff" stroke="#85caa4" />
+  <text x="376" y="495" class="tiny">worker A</text>
+  <text x="374" y="515" class="mono">security</text>
+  <rect x="464" y="470" width="92" height="56" rx="10" fill="#ffffff" stroke="#85caa4" />
+  <text x="486" y="495" class="tiny">worker B</text>
+  <text x="489" y="515" class="mono">tests</text>
+  <rect x="574" y="470" width="92" height="56" rx="10" fill="#ffffff" stroke="#85caa4" />
+  <text x="596" y="495" class="tiny">worker C</text>
+  <text x="589" y="515" class="mono">edge cases</text>
+
+  <path d="M 326 468 H 250 V 612 H 326" class="thin" marker-end="url(#arrow)" />
+  <text x="124" y="586" class="tiny">guardrails:</text>
+  <text x="124" y="606" class="tiny">scope, tools,</text>
+  <text x="124" y="626" class="tiny">no side effects</text>
+
+  <path d="M 720 467 H 784" class="line" marker-end="url(#arrow)" />
+
+  <!-- Liaison -->
+  <rect x="794" y="356" width="244" height="112" rx="16" class="worker" stroke-width="2" />
+  <text x="824" y="392" class="label">7. Synthesis</text>
+  <text x="824" y="420" class="sub">Liaisons compress reports</text>
+  <text x="824" y="440" class="sub">and preserve evidence.</text>
+
+  <path d="M 916 468 V 550 H 842" class="line" marker-end="url(#arrow)" />
+
+  <!-- MoA review -->
+  <rect x="604" y="550" width="238" height="124" rx="16" class="moa" stroke-width="2" />
+  <rect x="628" y="572" width="60" height="22" rx="11" fill="#7b61d1" />
+  <text x="641" y="588" class="chip">MoA</text>
+  <text x="628" y="620" class="label">8. Result Review</text>
+  <text x="628" y="646" class="sub">PASS, BLOCK, or</text>
+  <text x="628" y="666" class="sub">REQUEST_CHANGES</text>
+
+  <path d="M 604 612 H 526" class="line" marker-end="url(#arrow)" />
+
+  <!-- Parent verify -->
+  <rect x="286" y="550" width="240" height="124" rx="16" class="verify" stroke-width="2" />
+  <text x="314" y="586" class="label">9. Verify</text>
+  <text x="314" y="612" class="sub">Parent checks files, tests,</text>
+  <text x="314" y="632" class="sub">artifacts, services, diffs.</text>
+  <text x="314" y="656" class="tiny">No self-report-only success.</text>
+
+  <path d="M 526 612 H 604" class="dash" marker-end="url(#arrow)" />
+  <text x="532" y="602" class="tiny">more evidence</text>
+
+  <path d="M 406 674 V 716 H 528" class="line" marker-end="url(#arrow)" />
+
+  <!-- Done -->
+  <rect x="538" y="704" width="324" height="92" rx="16" class="done" stroke-width="2" />
+  <text x="568" y="740" class="label">10. Deliver + Handoff</text>
+  <text x="568" y="766" class="sub">Return result, verification, blockers,</text>
+  <text x="568" y="786" class="sub">and durable state when needed.</text>
+
+  <!-- Side notes -->
+  <rect x="910" y="584" width="300" height="128" rx="14" fill="#ffffff" stroke="#d6dde6" stroke-width="2" />
+  <text x="936" y="618" class="label" style="font-size:19px">Approval boundaries</text>
+  <text x="936" y="646" class="note">Get explicit approval before live</text>
+  <text x="936" y="668" class="note">side effects, durable jobs, commits,</text>
+  <text x="936" y="690" class="note">pushes, deployments, or migrations.</text>
+
+  <!-- Footer legend -->
+  <rect x="64" y="800" width="1272" height="76" rx="14" fill="#ffffff" stroke="#d6dde6" stroke-width="2" />
+  <text x="90" y="834" class="lane">Legend</text>
+  <rect x="176" y="816" width="28" height="18" rx="5" class="moa" />
+  <text x="214" y="831" class="tiny">MoA checkpoint</text>
+  <rect x="348" y="816" width="28" height="18" rx="5" class="worker" />
+  <text x="386" y="831" class="tiny">Tool-using workers / synthesis</text>
+  <rect x="602" y="816" width="28" height="18" rx="5" class="gate" />
+  <text x="640" y="831" class="tiny">Human or policy gate</text>
+  <rect x="822" y="816" width="28" height="18" rx="5" class="verify" />
+  <text x="860" y="831" class="tiny">Parent verification</text>
+  <path d="M 1050 825 H 1110" class="dash" marker-end="url(#arrow)" />
+  <text x="1124" y="831" class="tiny">Loop back for missing evidence</text>
+  <text x="90" y="858" class="tiny">Principle: plan broadly, execute narrowly, verify directly, preserve handoff state only when it earns its keep.</text>
+</svg>

--- a/tests/skills/test_moa_swarm_approach_skill.py
+++ b/tests/skills/test_moa_swarm_approach_skill.py
@@ -1,0 +1,119 @@
+"""Contract tests for the bundled MoA swarm approach skill."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = ROOT / "skills" / "software-development" / "moa-swarm-approach"
+SKILL_PATH = SKILL_DIR / "SKILL.md"
+SVG_PATH = SKILL_DIR / "assets" / "moa-swarm-workflow.svg"
+
+
+def skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def frontmatter_value(name: str) -> str:
+    match = re.search(rf"^{re.escape(name)}:\s*(.+)$", skill_text(), re.MULTILINE)
+    assert match, f"missing frontmatter field: {name}"
+    return match.group(1).strip().strip('"\'')
+
+
+def test_required_files_exist() -> None:
+    assert SKILL_PATH.is_file()
+    assert SVG_PATH.is_file()
+
+
+def test_frontmatter_meets_hardline_metadata_rules() -> None:
+    description = frontmatter_value("description")
+    author = frontmatter_value("author")
+
+    assert frontmatter_value("name") == "moa-swarm-approach"
+    assert len(description) <= 60
+    assert description.endswith(".")
+    assert "\n" not in description
+    assert author.startswith("misery-hl")
+    assert "Hermes Agent" in author
+    assert frontmatter_value("version") == "1.0.0"
+    assert frontmatter_value("license") == "MIT"
+
+
+def test_body_uses_required_title_and_section_order() -> None:
+    text = skill_text()
+    assert "# MoA Swarm Approach Skill" in text
+
+    required = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = [text.index(section) for section in required]
+    assert positions == sorted(positions)
+    assert re.findall(r"^## .+$", text, re.MULTILINE) == required
+
+
+def test_skill_is_condensed() -> None:
+    line_count = len(skill_text().splitlines())
+    assert 150 <= line_count <= 240, f"expected a complex skill near 200 lines, got {line_count}"
+
+
+def test_related_skills_are_bundled() -> None:
+    text = skill_text()
+    match = re.search(r"related_skills:\s*\[([^]]+)]", text)
+    assert match
+    related = {item.strip() for item in match.group(1).split(",")}
+    assert related == {"plan", "requesting-code-review"}
+
+    skill_names = {
+        frontmatter.group(1)
+        for path in (ROOT / "skills").rglob("SKILL.md")
+        if (frontmatter := re.search(r"^name:\s*([^\n]+)", path.read_text(encoding="utf-8"), re.MULTILINE))
+    }
+    assert related <= skill_names
+
+
+def test_only_standard_build_surfaces_are_required() -> None:
+    text = skill_text()
+    toolsets = (ROOT / "toolsets.py").read_text(encoding="utf-8")
+    core_tools = re.search(r"_HERMES_CORE_TOOLS\s*=\s*\[(.*?)]", toolsets, re.DOTALL)
+
+    assert core_tools
+    assert '"delegate_task"' in core_tools.group(1)
+    assert "`delegation.provider`" in text
+    assert "`delegation.model`" in text
+    assert "No optional skill, plugin, or extra toolset is required" in text
+
+
+def test_skill_uses_current_hermes_surfaces() -> None:
+    text = skill_text()
+    assert "`/moa" in text
+    assert "`delegate_task`" in text
+    assert "heavy-thinking-review" not in text
+    assert "kanban-orchestrator" not in text
+
+
+def test_no_machine_or_profile_specific_paths_remain() -> None:
+    content = "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in SKILL_DIR.rglob("*")
+        if path.is_file()
+    )
+    private_path_patterns = (
+        r"/Users/[^/\s]+/",
+        r"/home/[^/\s]+/\.hermes/",
+        r"[A-Za-z]:\\Users\\[^\\\s]+\\",
+    )
+    assert not any(re.search(pattern, content) for pattern in private_path_patterns)
+
+
+def test_workflow_svg_is_valid_xml() -> None:
+    root = ET.parse(SVG_PATH).getroot()
+    assert root.tag.endswith("svg")


### PR DESCRIPTION
## Summary

Adds a general-purpose `moa-swarm-approach` skill for MoA-guided multi-agent execution in the standard Hermes build.

Once MoA reference/aggregator providers and `delegation.provider` / `delegation.model` are configured, the skill:

- uses MoA to design evidence-gated work slices
- assigns worker width according to uncertainty and risk instead of a fixed swarm size
- runs scoped workers through the native `delegate_task` tool
- keeps worker reports compact so the parent context remains usable
- requires parent verification before advancing or claiming success
- pauses for the user only at meaningful cost, scope, or side-effect boundaries

No optional skill, plugin, or extra toolset is required.

## Maintainer review updates

- Shortened the description to one sentence under 60 characters.
- Added human-first contributor credit.
- Replaced unavailable related-skill identifiers with bundled `plan` and `requesting-code-review`.
- Reworked the body into the required modern section order and condensed it to 207 lines.
- Added `tests/skills/test_moa_swarm_approach_skill.py`.
- Removed local project-specific terminology, paths, profiles, and assumptions.

## Workflow overview

```mermaid
flowchart TD
    A[Define goal and evidence] --> B[MoA designs ordered slices]
    B --> C{Plan and approval gate}
    C -->|ready| D[Run the next slice with scoped workers]
    C -->|revise| B
    D --> E[Compact worker reports]
    E --> F[Parent verifies evidence]
    F --> G{Slice gate}
    G -->|pass| H{More slices?}
    G -->|missing evidence| D
    G -->|scope or risk changed| C
    H -->|yes| D
    H -->|no| I[Integration verification and delivery]
```

The PR also includes `skills/software-development/moa-swarm-approach/assets/moa-swarm-workflow.svg`.

## Validation

- `scripts/run_tests.sh tests/skills/test_moa_swarm_approach_skill.py -q`: 9 passed
- Hermes frontmatter loader: PASS
- `git diff --check`: PASS
- SVG XML parsing: covered by the focused test
- Standard-build dependency and private-path hygiene: covered by the focused test

## Notes

This is intentionally generic and open source. It contains no local project-specific terminology or infrastructure assumptions.