### PR TITLE
fix(zai): honor configured base url

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -662,16 +662,43 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
     return None
 
 
-def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> str:
+def _configured_zai_base_url() -> str:
+    """Return model.base_url when config.yaml explicitly selects the Z.AI provider."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+    except Exception:
+        return ""
+    model_cfg = cfg.get("model") if isinstance(cfg, dict) else {}
+    if not isinstance(model_cfg, dict):
+        return ""
+    provider = str(model_cfg.get("provider") or "").strip().lower()
+    if provider not in {"zai", "glm", "z-ai", "z.ai", "zhipu"}:
+        return ""
+    return str(model_cfg.get("base_url") or "").strip().rstrip("/")
+
+
+def _resolve_zai_base_url(
+    api_key: str,
+    default_url: str,
+    env_override: str,
+    config_override: str = "",
+) -> str:
     """Return the correct Z.AI base URL by probing endpoints.
 
     If the user has explicitly set GLM_BASE_URL, that always wins.
-    Otherwise, probe the candidate endpoints to find one that accepts the
-    key.  The detected endpoint is cached in provider state (auth.json) keyed
-    on a hash of the API key so subsequent starts skip the probe.
+    A matching ``model.provider: zai`` + ``model.base_url`` config value wins
+    next, so users can deliberately pick the standard vs coding endpoint in
+    config.yaml. Otherwise, probe the candidate endpoints to find one that
+    accepts the key.  The detected endpoint is cached in provider state
+    (auth.json) keyed on a hash of the API key so subsequent starts skip the
+    probe.
     """
     if env_override:
         return env_override
+    if config_override:
+        return config_override
 
     # No API key set → don't probe (would fire N×M HTTPS requests with an
     # empty Bearer token, all returning 401).  This path is hit during
@@ -6225,7 +6252,12 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     if provider_id in {"kimi-coding", "kimi-coding-cn"}:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif provider_id == "zai":
-        base_url = _resolve_zai_base_url(api_key, pconfig.inference_base_url, env_url)
+        base_url = _resolve_zai_base_url(
+            api_key,
+            pconfig.inference_base_url,
+            env_url,
+            _configured_zai_base_url(),
+        )
     elif provider_id == "copilot":
         # Resolve the Copilot API base URL from the token-exchange response
         # (endpoints.api, with a proxy-ep fallback), which is authoritative

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -999,6 +999,66 @@ class TestZaiEndpointAutoDetect:
         assert creds["base_url"] == "https://custom.example/v4"
         assert not probe_called
 
+    def test_configured_base_url_skips_probe(self, monkeypatch):
+        """model.base_url should be authoritative when model.provider is zai."""
+        monkeypatch.setenv("GLM_API_KEY", "glm-key")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "provider": "zai",
+                    "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+                }
+            },
+        )
+        probe_called = False
+
+        def _never_called(*a, **kw):
+            nonlocal probe_called
+            probe_called = True
+            return None
+
+        monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", _never_called)
+        creds = resolve_api_key_provider_credentials("zai")
+        assert creds["base_url"] == "https://open.bigmodel.cn/api/coding/paas/v4"
+        assert not probe_called
+
+    def test_env_override_wins_over_configured_base_url(self, monkeypatch):
+        """GLM_BASE_URL remains the highest-precedence explicit endpoint."""
+        monkeypatch.setenv("GLM_API_KEY", "glm-key")
+        monkeypatch.setenv("GLM_BASE_URL", "https://env.example/v4")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "provider": "zai",
+                    "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.auth.detect_zai_endpoint",
+            lambda *a, **kw: pytest.fail("configured endpoints must skip probes"),
+        )
+        creds = resolve_api_key_provider_credentials("zai")
+        assert creds["base_url"] == "https://env.example/v4"
+
+    def test_configured_base_url_ignored_for_other_provider(self, monkeypatch):
+        """A global model.base_url must not leak into Z.AI unless Z.AI is active."""
+        monkeypatch.setenv("GLM_API_KEY", "glm-key")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "provider": "openrouter",
+                    "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+                }
+            },
+        )
+        monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", lambda *a, **kw: None)
+        creds = resolve_api_key_provider_credentials("zai")
+        assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
+
     def test_no_key_skips_probe(self, monkeypatch):
         """Without an API key, no probe should occur."""
         monkeypatch.setattr("hermes_cli.auth.detect_zai_endpoint", lambda *a, **kw: None)


### PR DESCRIPTION
Fixes #58071.

## Summary
- make Z.AI endpoint resolution honor `config.yaml` when `model.provider` is `zai` and `model.base_url` is set
- preserve the existing precedence of `GLM_BASE_URL` as the highest-priority explicit override
- keep auth.json cached endpoint detection and live probing as fallbacks only when no explicit endpoint is configured

## Behavior
Endpoint priority is now:
1. `GLM_BASE_URL`
2. `model.base_url` when `model.provider` is `zai` / `glm` / `z-ai` / `z.ai` / `zhipu`
3. cached Z.AI endpoint detection in auth.json
4. live endpoint probing
5. registry default

This lets users deliberately route Z.AI traffic to the coding-plan endpoint from config.yaml without setting `GLM_BASE_URL` in every profile environment file.

## Duplicate check
- searched open and closed PRs for `58071`, `_resolve_zai_base_url`, `GLM_BASE_URL`, `model.base_url`, and `zai`
- found related provider/base-url PRs, but no PR covering config.yaml base_url precedence for Z.AI endpoint detection
- #51229 is related to endpoint cache persistence; this PR fixes the separate config override path described in #58071

## Test plan
- `.venv/bin/python -m pytest tests/hermes_cli/test_api_key_providers.py -q -k "ZaiEndpointAutoDetect or resolve_zai_with_key or resolve_with_custom_base_url or runtime_zai"` -> 10 passed, 159 deselected
- `.venv/bin/python -m pytest tests/hermes_cli/test_api_key_providers.py -q` -> 169 passed
- `.venv/bin/python -m ruff check hermes_cli/auth.py tests/hermes_cli/test_api_key_providers.py` -> passed
- `git diff --check` -> passed

Note: `.venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -k zai` selected no tests in that file (149 deselected), so the coverage above stays in the API-key provider suite where Z.AI endpoint resolution is implemented.