### PR TITLE
fix(env): preserve original encoding when sanitizing .env files

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -179,10 +179,23 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
     except ImportError:
         return  # early bootstrap — config module not available yet
 
-    read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
     try:
-        with open(path, **read_kw) as f:
-            original = f.readlines()
+        # Decode strictly, mirroring _load_dotenv_with_fallback's encoding
+        # chain (utf-8 first, then latin-1).  A lossy ``errors="replace"``
+        # read here would turn non-UTF-8 bytes into U+FFFD and — on any
+        # rewrite below — destroy the original bytes on disk, permanently
+        # defeating that latin-1 fallback.
+        raw = path.read_bytes()
+        write_encoding = "utf-8"
+        try:
+            text = raw.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            text = raw.decode("latin-1")
+            write_encoding = "latin-1"
+        # Match the universal-newline translation of the previous
+        # text-mode read so rewrite triggers stay identical.
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        original = text.splitlines(keepends=True)
         # Strip null bytes before _sanitize_env_lines so they never
         # reach python-dotenv (which passes them to os.environ and
         # crashes with ValueError).
@@ -194,7 +207,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
                 dir=str(path.parent), suffix=".tmp", prefix=".env_"
             )
             try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                with os.fdopen(fd, "w", encoding=write_encoding) as f:
                     f.writelines(sanitized)
                     f.flush()
                     os.fsync(f.fileno())

--- a/tests/hermes_cli/test_env_sanitize_on_load.py
+++ b/tests/hermes_cli/test_env_sanitize_on_load.py
@@ -89,3 +89,76 @@ def test_env_loader_sanitizes_before_dotenv():
         assert parsed_token == token
     finally:
         env_path.unlink(missing_ok=True)
+
+
+def test_sanitize_preserves_latin1_bytes_on_rewrite():
+    """A latin-1 .env must not be lossily rewritten as UTF-8 (U+FFFD).
+
+    _load_dotenv_with_fallback explicitly supports latin-1 .env files, but
+    the sanitizer used to read them with errors="replace" and rewrite the
+    file in UTF-8 on any normalization diff, permanently destroying the
+    original bytes and defeating that fallback.
+    """
+    from hermes_cli.env_loader import _sanitize_env_file_if_needed
+
+    # é as latin-1 (0xE9); missing trailing newline forces a rewrite.
+    raw = b"HERMES_DEVICE_NAME=Mac de B\xe9a\nTELEGRAM_BOT_TOKEN=0123456789:test"
+
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".env", delete=False) as f:
+        f.write(raw)
+        env_path = Path(f.name)
+
+    try:
+        _sanitize_env_file_if_needed(env_path)
+        data = env_path.read_bytes()
+        assert b"\xe9" in data, f"latin-1 byte destroyed: {data!r}"
+        assert b"\xef\xbf\xbd" not in data, f"U+FFFD written to disk: {data!r}"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_sanitize_latin1_value_survives_load():
+    """End to end: sanitize then load; the latin-1 value reaches os.environ."""
+    import os
+
+    from hermes_cli.env_loader import (
+        _load_dotenv_with_fallback,
+        _sanitize_env_file_if_needed,
+    )
+
+    raw = b"HERMES_DEVICE_NAME=Mac de B\xe9a\nTELEGRAM_BOT_TOKEN=0123456789:test"
+
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".env", delete=False) as f:
+        f.write(raw)
+        env_path = Path(f.name)
+
+    try:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_DEVICE_NAME", None)
+            _sanitize_env_file_if_needed(env_path)
+            _load_dotenv_with_fallback(env_path, override=True)
+            assert os.environ["HERMES_DEVICE_NAME"] == "Mac de Béa"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_sanitize_utf8_file_still_written_utf8():
+    """UTF-8 .env files keep the existing behavior: rewritten as UTF-8."""
+    from hermes_cli.env_loader import _sanitize_env_file_if_needed
+
+    token = "0123456789:test"
+    corrupted = f"TELEGRAM_BOT_TOKEN={token}ANTHROPIC_API_KEY=sk-ant-test\n"
+    raw = corrupted.encode("utf-8")
+
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".env", delete=False) as f:
+        f.write(raw)
+        env_path = Path(f.name)
+
+    try:
+        _sanitize_env_file_if_needed(env_path)
+        lines = env_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        assert lines[0] == f"TELEGRAM_BOT_TOKEN={token}"
+        assert lines[1].startswith("ANTHROPIC_API_KEY=")
+    finally:
+        env_path.unlink(missing_ok=True)


### PR DESCRIPTION
## What does this PR do?

`_sanitize_env_file_if_needed()` (hermes_cli/env_loader.py) read `.env` files with `errors="replace"` and rewrote them in UTF-8 whenever `_sanitize_env_lines` produced any normalization diff — a missing trailing newline (very common), a null byte, or a real #8908-style concatenated line.

For a non-UTF-8 (latin-1) `.env` — e.g. saved by a Windows/legacy editor — this lossily decoded real bytes into U+FFFD **and persisted them to disk**. The corruption is silent, irreversible, and self-defeating: the same module explicitly supports latin-1 files via the `_load_dotenv_with_fallback()` utf-8 → latin-1 chain, but after one sanitizer pass the file is valid UTF-8 (full of U+FFFD), so that fallback can never fire again.

**Fix:** decode strictly, mirroring the loader's own encoding chain (utf-8-sig, then latin-1), and rewrite with the encoding that won — sanitization now round-trips the original bytes. UTF-8 files keep the exact previous behavior (same normalization, same UTF-8 rewrite).

## Repro (before this fix)

```
printf 'HERMES_DEVICE_NAME=Mac de B\xe9a\nTELEGRAM_BOT_TOKEN=0123456789:test' > ~/.hermes/.env
# start hermes → .env rewritten with é → U+FFFD on disk,
# os.environ['HERMES_DEVICE_NAME'] == 'Mac de B�a'
```

Credential vars (`*_API_KEY`/`*_TOKEN`/...) are ASCII-stripped by design anyway; the damage hits non-credential values — device names, display names, prompt fragments.

## How to test

- New regression tests in `tests/hermes_cli/test_env_sanitize_on_load.py`:
  - `test_sanitize_preserves_latin1_bytes_on_rewrite` and `test_sanitize_latin1_value_survives_load` — **fail on current main** (verified), pass with this fix.
  - `test_sanitize_utf8_file_still_written_utf8` — pins the unchanged UTF-8 path.
- Full local run: `pytest tests/hermes_cli/test_env_sanitize_on_load.py tests/test_env_loader_secret_sources.py` → 14 passed. `ruff check` clean.

## Platforms tested

macOS (Apple Silicon). The change is pure-Python file I/O with no platform-specific behavior.

## Related

- #8908 (the original sanitize feature this hardens)
- Distinct from #54998 (permissions clobber in the same function — different bug, no diff overlap)