### PR TITLE
fix(tools): report files_written for finished subagents

### DIFF
--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -191,6 +191,33 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         out = file_state.writes_since("parent", since, [p])
         self.assertEqual(out, {})
 
+    def test_writes_since_empty_paths_returns_all_writes(self):
+        """An empty ``paths`` means no path filter.
+
+        This is the exact call ``_run_single_child`` makes to build the
+        ``files_written`` field of the subagent completion event
+        (``writes_since("", wall_start, [])``).  With the old strict
+        whitelist an empty list matched nothing, so ``files_written``
+        was permanently empty in the TUI overlay.
+        """
+        p = self._mk()
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write("sa-0-child", p)
+        out = file_state.writes_since("", since, [])
+        self.assertEqual(out, {"sa-0-child": [p]})
+
+    def test_writes_since_empty_paths_still_honors_exclude_and_ts(self):
+        p = self._mk()
+        q = self._mk()
+        file_state.note_write("old-writer", q)  # before ``since``
+        time.sleep(0.01)
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write("parent", p)  # excluded writer
+        out = file_state.writes_since("parent", since, [])
+        self.assertEqual(out, {})
+
     def test_kill_switch_env_var(self):
         p = self._mk()
         os.environ["HERMES_DISABLE_FILE_STATE_GUARD"] = "1"

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -224,8 +224,12 @@ class FileStateRegistry:
         """Return ``{writer_task_id: [paths]}`` for writes done after
         ``since_ts`` by agents OTHER than ``exclude_task_id``.
 
+        ``paths`` restricts the result to those paths; an empty ``paths``
+        means no path filter (all written paths are returned).
+
         Used by delegate_task to append a "subagent modified files the
-        parent previously read" reminder to the delegation result.
+        parent previously read" reminder to the delegation result, and to
+        report ``files_written`` in the subagent completion event.
         """
         if _disabled():
             return {}
@@ -237,8 +241,9 @@ class FileStateRegistry:
                     continue
                 if ts < since_ts:
                     continue
-                if p in paths_set:
-                    out[writer_tid].append(p)
+                if paths_set and p not in paths_set:
+                    continue
+                out[writer_tid].append(p)
         return dict(out)
 
     def known_reads(self, task_id: str) -> List[str]:


### PR DESCRIPTION
## What does this PR do?

The subagent completion event builds its `files_written` payload with:

```python
_files_written_map = file_state.writes_since(
    "", wall_start, []
)  # all writes since wall_start
```

The inline comment says *all writes since wall_start*, but `FileStateRegistry.writes_since()` treats its `paths` argument as a strict whitelist (`if p in paths_set`). An empty list matches nothing, so the map is always `{}` and `files_written` in the `subagent.complete` event is **permanently empty** — the `/agents` overlay's per-branch "files written" detail can never show anything, no matter what the child wrote.

**Fix:** treat an empty `paths` as "no path filter" (`if paths_set and p not in paths_set: continue`), which is what the only empty-list caller intends. The other call site — the parent-staleness reminder — is guarded by a non-empty `parent_reads_snapshot` and is unaffected; its behavior is pinned by the existing whitelist tests.

Verified empirically against main: after `note_write("sa-0-x", path)`, `writes_since("", t0, [])` returns `{}` on main and `{"sa-0-x": [path]}` with this fix.

## How to test

- New regression tests in `tests/tools/test_file_state_registry.py`:
  - `test_writes_since_empty_paths_returns_all_writes` — **fails on current main** (verified), passes with this fix. It makes the exact call `_run_single_child` makes.
  - `test_writes_since_empty_paths_still_honors_exclude_and_ts` — pins that the exclude-writer and since-ts guards still apply with no path filter.
- `pytest tests/tools/test_file_state_registry.py`: all unit tests pass. Note: two `FileToolsIntegrationTests` cases fail on **pristine main** on macOS (temp dirs under `/var/folders/` are rejected as "sensitive system path" by the write tool) — pre-existing, out of this diff, passes in Linux CI.
- `ruff check` clean.

## Platforms tested

macOS (Apple Silicon); pure-Python, no platform-specific behavior.

## Related

- Complements #52329 (terminal status for finished subagents in the same event/overlay); no diff overlap (that PR touches `delegate_tool.py`'s registry lifecycle, this one touches `file_state.py`'s query).