### PR TITLE
fix: validate JSON type in sanitize_tool_call_arguments — reject non-dict arguments

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -304,8 +304,21 @@ def sanitize_tool_call_arguments(
                 continue
 
             try:
-                json.loads(arguments)
+                parsed = json.loads(arguments)
             except json.JSONDecodeError:
+                parsed = None
+
+            if parsed is not None and not isinstance(parsed, dict):
+                # JSON type mismatch: OpenAI spec requires dict (JSON object).
+                # Single-element array containing a dict -> unwrap.
+                # Other non-dict types -> fall back to "{}" with corruption marker.
+                if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
+                    function["arguments"] = json.dumps(parsed[0])
+                    parsed = True  # already fixed, skip repair
+                else:
+                    parsed = None  # treat as corrupted -> fall through
+
+            if parsed is None:
                 tool_call_id = tool_call.get("id")
                 function_name = function.get("name", "?")
                 preview = arguments[:80]

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -163,3 +163,59 @@ def test_non_assistant_messages_ignored():
 
     assert repaired == 0
     assert messages == original
+
+
+def test_single_element_array_unwrapped(caplog):
+    """Single-element JSON array containing a dict is unwrapped to the dict."""
+    arr_arg = '[{"mode":"replace","path":"/tmp/foo"}]'
+    messages = [
+        _assistant_message(_tool_call(arguments=arr_arg)),
+        _tool_message(content="ok"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        repaired = AIAgent._sanitize_tool_call_arguments(
+            messages,
+            logger=logging.getLogger("run_agent"),
+        )
+
+    assert repaired == 0
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == '{"mode": "replace", "path": "/tmp/foo"}'
+
+
+def test_multi_element_array_replaced_with_empty_object(caplog):
+    """Multi-element JSON array is non-dict -> fall back to '{}' with marker."""
+    arr_arg = '[{"a":1},{"b":2}]'
+    messages = [
+        _assistant_message(_tool_call(arguments=arr_arg)),
+        _tool_message(content="existing"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        repaired = AIAgent._sanitize_tool_call_arguments(
+            messages,
+            logger=logging.getLogger("run_agent"),
+            session_id="session-arr",
+        )
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert any("session=session-arr" in r.message for r in caplog.records)
+
+
+def test_non_dict_json_types_replaced(caplog):
+    """JSON string, number, boolean, null are non-dict -> fall back to '{}'."""
+    for val in ['"hello"', "42", "true", "null"]:
+        messages = [
+            _assistant_message(_tool_call(arguments=val)),
+            _tool_message(content="ok"),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            repaired = AIAgent._sanitize_tool_call_arguments(
+                messages,
+                logger=logging.getLogger("run_agent"),
+            )
+
+        assert repaired == 1, f"expected repaired=1 for value {val!r}"
+        assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"


### PR DESCRIPTION
## Summary

Fixes #58057 — `sanitize_tool_call_arguments()` only checked JSON syntax (`json.loads()`), not the parsed type. When a model emits `function.arguments` as a JSON array (e.g. `[{"mode":"replace","path":"/tmp/foo"}]`), it passed the sanitizer but caused **HTTP 400 InvalidParameter** on strict OpenAI-compatible endpoints (Volcengine Ark, glm-5.2, etc.).

## Changes

- After `json.loads()`, verify the parsed result is a `dict` (JSON object).
- **Single-element array containing a dict** → unwrap to the dict (silent fix, no corruption marker).
- **Multi-element array or other non-dict types** (string, number, boolean, null) → fall back to `"{}"` with the same corruption-marker logic as `JSONDecodeError`.

## Tests added

- `test_single_element_array_unwrapped` — single-element array with dict is unwrapped
- `test_multi_element_array_replaced_with_empty_object` — multi-element array triggers corruption repair
- `test_non_dict_json_types_replaced` — string, number, boolean, null all trigger corruption repair

All 10 tests pass (7 existing + 3 new).

## Root cause

The original code at line 307:
```python
try:
    json.loads(arguments)       # passes for arrays!
except json.JSONDecodeError:
    function["arguments"] = "{}"
```

Only validated JSON syntax. The OpenAI Chat Completions spec requires `function.arguments` to be a JSON object (dict).