### PR TITLE
fix(agent): stop repeated length continuations

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -453,6 +453,31 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
         )
 
 
+def _is_length_continuation_prompt(message: Dict) -> bool:
+    if message.get("role") != "user":
+        return False
+    content = message.get("content")
+    if not isinstance(content, str):
+        return False
+    return content.startswith(
+        (
+            "[System: Your previous response was truncated by the output length limit.",
+            "[System: The previous response was cut off by a network error mid-stream.",
+            "[System: Your previous tool call ",
+        )
+    )
+
+
+def _length_continuation_made_no_progress(
+    truncated_response_parts: List[str],
+    content: Optional[str],
+) -> bool:
+    """Return True when a continuation retry only repeats the last partial text."""
+    if not truncated_response_parts or not content:
+        return False
+    return truncated_response_parts[-1].strip() == content.strip()
+
+
 # Shared recovery hint appended to every content-policy refusal message. Both
 # the HTTP-200 refusal path (``finish_reason=content_filter``) and the
 # exception path (a provider moderation error classified as
@@ -1785,6 +1810,31 @@ def run_conversation(
                                 force=True,
                             )
                         if assistant_message is not None and not _trunc_has_tool_calls:
+                            if _length_continuation_made_no_progress(
+                                truncated_response_parts,
+                                assistant_message.content,
+                            ):
+                                if messages and _is_length_continuation_prompt(messages[-1]):
+                                    messages.pop()
+                                if messages and messages[-1].get("role") == "assistant":
+                                    messages[-1]["finish_reason"] = "stop"
+                                partial_response = agent._strip_think_blocks(
+                                    "".join(truncated_response_parts)
+                                ).strip()
+                                agent._vprint(
+                                    f"{agent.log_prefix}↻ Continuation repeated the same text; "
+                                    "treating the prior response as complete.",
+                                    force=True,
+                                )
+                                agent._cleanup_task_resources(effective_task_id)
+                                agent._persist_session(messages, conversation_history)
+                                return {
+                                    "final_response": partial_response or assistant_message.content,
+                                    "messages": messages,
+                                    "api_calls": api_call_count,
+                                    "completed": True,
+                                }
+
                             length_continue_retries += 1
                             interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
                             messages.append(interim_msg)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3941,6 +3941,31 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_length_continuation_no_progress_returns_single_response(self, agent):
+        self._setup_agent(agent)
+        final_text = "Kész. ~/summaries/all_in_podcast/report.md"
+        length_resp = _mock_response(content=final_text, finish_reason="length")
+        agent.client.chat.completions.create.side_effect = [length_resp, length_resp]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("finish the podcast summary")
+
+        assert result["completed"] is True
+        assert result["final_response"] == final_text
+        assert result["api_calls"] == 2
+        assert agent.client.chat.completions.create.call_count == 2
+        assert [m["role"] for m in result["messages"]] == ["user", "assistant"]
+        assert result["messages"][-1]["content"] == final_text
+        assert result["messages"][-1]["finish_reason"] == "stop"
+        assert all(
+            "Your previous response was truncated" not in (m.get("content") or "")
+            for m in result["messages"]
+        )
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"


### PR DESCRIPTION
Fixes #58087.

## Summary
- detect when a `finish_reason="length"` continuation retry returns the exact same text as the previous partial response
- treat that no-progress retry as a provider-misreported complete response instead of injecting more continuation prompts
- remove the synthetic continuation prompt from persisted messages and mark the prior assistant message as `stop` so future turns do not inherit the false truncation state

## Why this shape
Some OpenAI-compatible providers can report `finish_reason="length"` for a short, already-complete final answer. I avoided guessing completeness on the first response based on punctuation or length. The guard only fires after Hermes has already asked for a continuation and the provider returns identical content, which is the loop that causes duplicate Telegram deliveries. Real continuations that add different text keep using the existing retry path.

## Duplicate check
- searched open PRs for `58087`, `finish_reason length conversation_loop.py`, `_get_continuation_prompt`, and `length_continue_retries`
- searched closed PRs for `58087`
- found related finish_reason/provider work, but no open/closed PR covering the no-progress continuation loop for #58087

## Test plan
- `.venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestRunConversation::test_length_continuation_no_progress_returns_single_response -q` -> 1 passed
- `.venv/bin/python -m pytest tests/run_agent/test_run_agent.py -q -k "length or truncated or finish_reason or continuation"` -> 15 passed, 400 deselected
- `.venv/bin/python -m ruff check agent/conversation_loop.py tests/run_agent/test_run_agent.py` -> passed
- `git diff --check` -> passed