### PR TITLE
fix(desktop): skip self-update in remote backend mode

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -23,6 +23,7 @@ import {
   cookiesHaveLiveSession,
   cookiesHavePrivySession,
   cookiesHaveSession,
+  isRemoteBackendConnection,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normAuthMode,
@@ -122,6 +123,48 @@ test('profileRemoteOverride tolerates a missing/!object profiles map', () => {
   assert.equal(profileRemoteOverride({}, 'coder'), null)
   assert.equal(profileRemoteOverride({ profiles: null }, 'coder'), null)
   assert.equal(profileRemoteOverride(null, 'coder'), null)
+})
+
+// --- isRemoteBackendConnection ---
+
+test('isRemoteBackendConnection is false for local desktop backends', () => {
+  assert.equal(isRemoteBackendConnection({ mode: 'local', remote: {}, profiles: {} }, 'default', {}), false)
+  assert.equal(isRemoteBackendConnection({}, 'default', {}), false)
+})
+
+test('isRemoteBackendConnection detects global remote mode', () => {
+  assert.equal(
+    isRemoteBackendConnection({ mode: 'remote', remote: { url: 'https://gateway.example.com' } }, 'default', {}),
+    true
+  )
+})
+
+test('isRemoteBackendConnection detects global cloud mode', () => {
+  assert.equal(
+    isRemoteBackendConnection({ mode: 'cloud', remote: { url: 'https://agent.example.com' } }, 'default', {}),
+    true
+  )
+})
+
+test('isRemoteBackendConnection detects env-forced remote mode', () => {
+  assert.equal(
+    isRemoteBackendConnection({ mode: 'local', remote: {}, profiles: {} }, 'default', {
+      HERMES_DESKTOP_REMOTE_URL: ' http://127.0.0.1:9119 '
+    }),
+    true
+  )
+})
+
+test('isRemoteBackendConnection detects primary profile remote overrides', () => {
+  const config = {
+    mode: 'local',
+    profiles: {
+      work: { mode: 'remote', url: 'https://work.example.com' }
+    }
+  }
+
+  assert.equal(isRemoteBackendConnection(config, 'work', {}), true)
+  assert.equal(isRemoteBackendConnection(config, 'default', {}), false)
 })
 
 // --- pathWithGlobalRemoteProfile ---

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -197,6 +197,23 @@ function profileRemoteOverride(config, profile) {
 }
 
 /**
+ * True when the desktop's primary backend is resolved to a remote gateway.
+ * In that mode the Electron shell is a client of another Hermes lifecycle
+ * manager, so local desktop self-update checks must not git-fetch/pull/rebuild.
+ */
+function isRemoteBackendConnection(config, profile = null, env = process.env) {
+  if (profileRemoteOverride(config, profile)) {
+    return true
+  }
+
+  if (String(env?.HERMES_DESKTOP_REMOTE_URL || '').trim()) {
+    return true
+  }
+
+  return modeIsRemoteLike(config?.mode)
+}
+
+/**
  * In global-remote mode one backend serves every Desktop profile, so REST calls
  * that are scoped by renderer-side `request.profile` must carry that scope as a
  * query parameter. Local pooled backends and per-profile remote overrides do not
@@ -337,6 +354,7 @@ export {
   cookiesHaveLiveSession,
   cookiesHavePrivySession,
   cookiesHaveSession,
+  isRemoteBackendConnection,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normAuthMode,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -43,6 +43,7 @@ import {
   cookiesHaveLiveSession,
   cookiesHavePrivySession,
   cookiesHaveSession,
+  isRemoteBackendConnection,
   modeIsRemoteLike,
   normalizeRemoteBaseUrl,
   normAuthMode,
@@ -2045,6 +2046,16 @@ async function resolveHealedBranch(updateRoot, branch) {
 }
 
 async function checkUpdates() {
+  if (isRemoteBackendConnection(readDesktopConnectionConfig(), primaryProfileKey())) {
+    return {
+      supported: false,
+      reason: 'remote-backend',
+      message: 'Desktop self-update is skipped while connected to a remote Hermes backend.',
+      branch: readDesktopUpdateConfig().branch,
+      fetchedAt: Date.now()
+    }
+  }
+
   const updateRoot = resolveUpdateRoot()
   let { branch } = readDesktopUpdateConfig()
   const gitDir = path.join(updateRoot, '.git')
@@ -2418,6 +2429,15 @@ async function releaseBackendLock(updateRoot, tag) {
 // Detection (checkUpdates / commit changelog / "N behind") stays in the UI;
 // only this apply action changed.
 async function applyUpdates(opts = {}) {
+  if (isRemoteBackendConnection(readDesktopConnectionConfig(), primaryProfileKey())) {
+    return {
+      ok: false,
+      skipped: true,
+      error: 'remote-backend',
+      message: 'Desktop self-update is skipped while connected to a remote Hermes backend.'
+    }
+  }
+
   if (updateInFlight) {
     throw new Error('An update is already in progress.')
   }

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -44,6 +44,7 @@ vi.mock('@/hermes', () => ({
 const {
   maybeNotifyUpdateAvailable,
   checkBackendUpdates,
+  checkUpdates,
   $backendUpdateStatus,
   applyBackendUpdate,
   $backendUpdateApply,
@@ -475,6 +476,7 @@ describe('startUpdatePoller', () => {
       targetSha: 'sha-abc',
       fetchedAt: 0
     })
+    setConnection({ baseUrl: 'http://local.example.com', mode: 'local' } as never)
     $updateStatus.set(null)
     ;(globalThis as unknown as { window: unknown }).window = {
       hermesDesktop: { updates: { check: checkMock, onProgress: onProgressMock } },
@@ -526,4 +528,17 @@ describe('startUpdatePoller', () => {
 
     expect(checkMock).toHaveBeenCalled()
   })
+
+  it('skips desktop client update checks in remote mode', async () => {
+    setConnection({ baseUrl: 'http://remote.example.com', mode: 'remote' } as never)
+
+    await checkUpdates()
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000)
+    listeners['focus']?.()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(checkMock).not.toHaveBeenCalled()
+  })
+
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -328,6 +328,10 @@ export async function checkBackendUpdates(): Promise<DesktopUpdateStatus | null>
 }
 
 export async function checkUpdates(): Promise<DesktopUpdateStatus | null> {
+  if (isRemoteMode()) {
+    return $updateStatus.get()
+  }
+
   const bridge = window.hermesDesktop?.updates
 
   if (!bridge || $updateChecking.get()) {


### PR DESCRIPTION
## Summary

Fixes #57762. When Hermes Desktop is connected to a remote backend, the Electron shell is a WebSocket client of a backend lifecycle managed elsewhere (Docker/s6/systemd/etc.). It should not run the local desktop self-update check/apply path, which can git-fetch/pull/rebuild and release backend locks from the client machine.

This PR makes remote-backend mode a first-class update gate:

- add a pure `isRemoteBackendConnection()` helper that mirrors existing backend resolution inputs: per-profile remote override, `HERMES_DESKTOP_REMOTE_URL`, and global remote mode
- short-circuit Electron `checkUpdates()` before any `resolveUpdateRoot()`, git fetch/ls-remote, or local checkout inspection
- short-circuit Electron `applyUpdates()` before updater handoff / in-app update / backend lock release
- make the renderer client-update poller no-op in remote mode, while leaving the existing backend update/contract path intact

## Duplicate check

I searched open PRs for #57762 and for remote-backend/update/self-update phrases. The closest open Desktop remote PRs are for unrelated remote artifact previews/profile/workspace behavior; I did not find another PR that gates Desktop self-update in remote-backend mode.

## Tests

- `node --test apps/desktop/electron/connection-config.test.cjs`
- `node --check apps/desktop/electron/main.cjs`
- `npm --workspace apps/desktop run test:ui -- src/store/updates.test.ts`
- `npm --workspace apps/desktop exec eslint -- src/store/updates.ts src/store/updates.test.ts`
- `git diff --check`

Note: `npm --workspace apps/desktop run lint -- src/store/updates.ts src/store/updates.test.ts` also completed with 0 errors, but the package script always scans all `src/ electron/` and reports one pre-existing warning in `src/app/settings/model-settings.tsx` (`react-hooks/exhaustive-deps`), unrelated to this change.