### PR TITLE
fix(file-tools): cover Windows system dirs in the sensitive-path write guard

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -368,5 +368,45 @@ class TestBomHandling:
         assert raw == self.BOM.encode("utf-8") + b"import os, json\nimport sys\n"
 
 
+class TestCheckSensitivePathWindows:
+    """Verify _check_sensitive_path covers Windows system dirs — parity with the
+    macOS ``/private/etc`` coverage added in 311dac197. The POSIX prefixes never
+    match a Windows path, so before this the guard was a no-op on Windows."""
+
+    def test_windows_prefixes_derived_from_env(self, monkeypatch):
+        from tools.file_tools import _windows_system_path_prefixes
+        monkeypatch.setattr(os, "name", "nt")
+        monkeypatch.setenv("SystemRoot", "D:\\Win")
+        monkeypatch.setenv("ProgramFiles", "D:\\Apps")
+        prefixes = _windows_system_path_prefixes()
+        assert "D:\\Win\\" in prefixes
+        assert "D:\\Apps\\" in prefixes
+
+    def test_no_windows_prefixes_off_windows(self, monkeypatch):
+        from tools.file_tools import _windows_system_path_prefixes
+        monkeypatch.setattr(os, "name", "posix")
+        assert _windows_system_path_prefixes() == ()
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows system paths")
+    def test_windows_system32_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(r"C:\Windows\System32\drivers\etc\hosts") is not None
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows system paths")
+    def test_windows_block_is_case_insensitive(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(r"c:\windows\system32\config\SAM") is not None
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows system paths")
+    def test_windows_program_files_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(r"C:\Program Files\Hermes\x.dll") is not None
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows system paths")
+    def test_windows_user_file_allowed(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(r"C:\Users\me\notes.txt") is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -558,10 +558,46 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
 
 # Paths that file tools should refuse to write to without going through the
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
+def _windows_system_path_prefixes() -> tuple[str, ...]:
+    """Windows system-root / Program Files write-guard prefixes.
+
+    Derived from the environment so the drive letter and a localized
+    ``Program Files`` name are honoured; empty off Windows. The POSIX prefixes
+    below never match a Windows path, so before this the guard was a no-op on
+    Windows — this gives Windows the same coverage macOS got in 311dac197
+    (``/private/etc``). Comparison is case-insensitive (see
+    ``_check_sensitive_path``) because Windows paths are.
+    """
+    if os.name != "nt":
+        return ()
+    out: list[str] = []
+    seen: set[str] = set()
+    candidates = [
+        os.environ.get("SystemRoot"),
+        os.environ.get("windir"),
+        os.environ.get("ProgramFiles"),
+        os.environ.get("ProgramFiles(x86)"),
+        os.environ.get("ProgramW6432"),
+        # Fallbacks if the environment is unexpectedly bare.
+        "C:\\Windows",
+        "C:\\Program Files",
+        "C:\\Program Files (x86)",
+    ]
+    for raw in candidates:
+        if not raw:
+            continue
+        prefix = raw.rstrip("\\/") + "\\"
+        key = os.path.normcase(prefix)
+        if key not in seen:
+            seen.add(key)
+            out.append(prefix)
+    return tuple(out)
+
+
 _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
     "/private/etc/", "/private/var/",
-)
+) + _windows_system_path_prefixes()
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 _hermes_config_resolved: str | None = None
@@ -596,8 +632,13 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    # normcase so the Windows prefixes match case-insensitively (Windows paths
+    # are case-insensitive); a no-op on POSIX.
+    resolved_nc = os.path.normcase(resolved)
+    normalized_nc = os.path.normcase(normalized)
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
+        prefix_nc = os.path.normcase(prefix)
+        if resolved_nc.startswith(prefix_nc) or normalized_nc.startswith(prefix_nc):
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err


### PR DESCRIPTION
## What does this PR do?

`_check_sensitive_path` (the file-tool write guard) only listed POSIX prefixes
(`/etc`, `/boot`, `/usr/lib/systemd`, `/private/etc`, `/private/var`). On Windows
none of those match a resolved/normalized path, so the guard was a **no-op** —
the model could `write_file` into `C:\Windows\System32\...` or `C:\Program Files`
without being steered to the terminal tool. macOS got its `/private/etc` parity
in 311dac197; this gives Windows the same coverage.

- Windows system-root / Program Files prefixes are derived from the environment
  (`SystemRoot`, `windir`, `ProgramFiles`, `ProgramFiles(x86)`, `ProgramW6432`)
  with conventional fallbacks — empty off Windows.
- The prefix comparison now uses `os.path.normcase`, so the Windows prefixes
  match case-insensitively (Windows paths are). As a side effect the existing
  POSIX prefixes now also match a Windows-normalized path (`\etc\...` vs
  `/etc/...`), which they previously didn't on Windows. No-op on POSIX.

This is **defense-in-depth**, not a security boundary — an in-process heuristic
the terminal tool can still bypass (SECURITY.md §2.2/§3.2) — matching the
existing guard's intent and the macOS parity precedent.

## Related Issue

N/A — parity follow-up to 311dac197 (`fix(file_tools): block /private/etc writes
on macOS symlink bypass`).

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/file_tools.py` — add `_windows_system_path_prefixes()` (env-derived),
  append it to `_SENSITIVE_PATH_PREFIXES`, and compare with `os.path.normcase`
  in `_check_sensitive_path`.
- `tests/tools/test_file_write_safety.py` — add `TestCheckSensitivePathWindows`.

## How to Test

1. On Windows:
   ```python
   from tools.file_tools import _check_sensitive_path
   assert _check_sensitive_path(r"C:\Windows\System32\drivers\etc\hosts")  # blocked
   assert _check_sensitive_path(r"c:\windows\system32\config\SAM")         # case-insensitive
   assert _check_sensitive_path(r"C:\Users\me\notes.txt") is None          # normal file ok
   ```
2. Run:
   ```
   pytest tests/tools/test_file_write_safety.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Conventional Commits
- [x] I searched for existing PRs (no duplicate)
- [x] Only changes related to this fix
- [x] Ran the affected suite: `pytest tests/tools/test_file_write_safety.py -q` — new Windows tests pass; the cross-platform prefix-derivation tests pass; a few pre-existing Windows atomic-write/symlink failures are unrelated (unchanged by this diff)
- [x] Added tests


### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — Windows-specific coverage; POSIX behavior unchanged (`normcase` is a no-op on POSIX)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
C:\Windows\System32\drivers\etc\hosts blocked: True
c:\windows\system32\config\SAM blocked: True    # case-insensitive
C:\Program Files\...\x.dll blocked: True
C:\Users\me\notes.txt blocked: False            # normal file unaffected
/etc/passwd still blocked: True                 # POSIX unchanged
```