### PR TITLE
fix(install): keep managed Node private for user installs

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -134,12 +134,13 @@ def _node_symlink_candidate_dirs() -> "list[Path]":
 def remove_node_symlinks(hermes_home: Path) -> list:
     """Remove the node/npm/npx symlinks the installer placed on PATH.
 
-    The POSIX installer (``scripts/install.sh`` / ``scripts/lib/node-bootstrap.sh``)
-    symlinks node/npm/npx into the same directory as the ``hermes`` command:
+    Current POSIX installers keep node/npm/npx private for user-scoped installs,
+    but root FHS installs still expose them and older user-scoped installs may
+    have left legacy links:
 
     - ``/usr/local/bin/`` on root FHS installs (Linux, uid 0)
-    - ``$PREFIX/bin/`` on Termux
-    - ``~/.local/bin/`` otherwise (the common non-root case)
+    - ``~/.local/bin/`` for legacy non-root installs
+    - ``$PREFIX/bin/`` for legacy Termux installs
 
     We check all candidate directories so that uninstall works regardless of
     how the install was done (e.g. a root FHS install that placed links in

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -465,23 +465,58 @@ get_command_link_display_dir() {
     fi
 }
 
-# Point a Hermes-managed Node's `npm install -g` at a directory that is on
-# PATH. npm's default global prefix for a bundled Node is the Node dir itself,
-# so global package binaries land in $HERMES_HOME/node/bin — which is NOT on
-# PATH (only the command link dir is) and is wiped on every Node upgrade.
-# Redirecting the prefix to the link dir's parent makes global bins resolve to
-# the command link dir (node/npm/npx live there too, already on PATH) and
-# survive upgrades. Scoped to the managed Node via its prefix-local global
-# npmrc, so the user's other Node installs and their ~/.npmrc are untouched.
-# Hermes's own global installs pass an explicit --prefix and are unaffected.
-# Idempotent and a no-op when there is no Hermes-managed npm, so calling it on
-# every install run repairs pre-existing installs, not just fresh ones.
-configure_managed_node_npm_prefix() {
-    [ -x "$HERMES_HOME/node/bin/npm" ] || return 0
+should_link_managed_node_tools() {
+    # Root FHS installs intentionally expose the bundled Node in /usr/local/bin
+    # so shared root shells can build Hermes without relying on shell rc files.
+    # User-scoped installs keep Node private to avoid shadowing nvm/fnm/proto.
+    [ "$ROOT_FHS_LAYOUT" = true ]
+}
+
+remove_private_managed_node_links() {
+    should_link_managed_node_tools && return 0
+    [ -d "$HERMES_HOME/node" ] || return 0
+
     local link_dir
     link_dir="$(get_command_link_dir)"
+    local tool link target
+    for tool in node npm npx; do
+        link="$link_dir/$tool"
+        [ -L "$link" ] || continue
+        target="$(readlink "$link" 2>/dev/null || true)"
+        case "$target" in
+            "$HERMES_HOME/node"/*)
+                rm -f "$link"
+                ;;
+        esac
+    done
+}
+
+link_managed_node_tools_if_needed() {
+    should_link_managed_node_tools || return 0
+
+    local node_link_dir
+    node_link_dir="$(get_command_link_dir)"
+    mkdir -p "$node_link_dir"
+    ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
+    ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
+    ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
+}
+
+# Point a Hermes-managed Node's `npm install -g` at the right prefix without
+# touching the user's npm config. User-scoped installs keep global bins inside
+# $HERMES_HOME/node/bin because the managed npm is private; root FHS installs
+# keep the historical command-link prefix so root-managed global bins remain on
+# PATH. Hermes's own installs pass explicit --prefix and are unaffected.
+configure_managed_node_npm_prefix() {
+    [ -x "$HERMES_HOME/node/bin/npm" ] || return 0
+    local prefix
+    if should_link_managed_node_tools; then
+        prefix="$(dirname "$(get_command_link_dir)")"
+    else
+        prefix="$HERMES_HOME/node"
+    fi
     mkdir -p "$HERMES_HOME/node/etc"
-    printf 'prefix=%s\n' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"
+    printf 'prefix=%s\n' "$prefix" > "$HERMES_HOME/node/etc/npmrc"
 }
 
 get_hermes_command_path() {
@@ -802,6 +837,7 @@ check_node() {
     # off PATH. No-op when there's no managed Node, so this is safe to run on
     # every install — including re-runs that skip the Node (re)install below.
     configure_managed_node_npm_prefix
+    remove_private_managed_node_links
 
     if command -v node &> /dev/null && node_satisfies_build "$(node --version)"; then
         log_success "Node.js $(node --version) found"
@@ -917,20 +953,16 @@ install_node() {
         return 0
     fi
 
-    # Place into ~/.hermes/node/ and symlink binaries into the same bin dir
-    # the hermes command uses (get_command_link_dir): /usr/local/bin for root
-    # FHS installs, $PREFIX/bin on Termux, ~/.local/bin otherwise.
+    # Place into ~/.hermes/node/. Root FHS installs also expose node/npm/npx in
+    # /usr/local/bin; user-scoped installs keep them private to avoid shadowing
+    # version managers in later shells.
     rm -rf "$HERMES_HOME/node"
     mkdir -p "$HERMES_HOME"
     mv "$extracted_dir" "$HERMES_HOME/node"
     rm -rf "$tmp_dir"
 
-    local node_link_dir
-    node_link_dir="$(get_command_link_dir)"
-    mkdir -p "$node_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
+    remove_private_managed_node_links
+    link_managed_node_tools_if_needed
 
     configure_managed_node_npm_prefix
 

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -44,9 +44,8 @@ _nb_is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
 
-# Where to symlink node/npm/npx so they land on PATH.
-# Mirrors get_command_link_dir() from install.sh: root FHS → /usr/local/bin,
-# Termux → $PREFIX/bin, otherwise ~/.local/bin.
+# Command link dir. Root FHS installs may expose managed node/npm/npx here;
+# user-scoped installs keep those tools private to $HERMES_HOME/node/bin.
 _nb_get_link_dir() {
     if _nb_is_termux && [ -n "${PREFIX:-}" ]; then
         echo "$PREFIX/bin"
@@ -57,17 +56,53 @@ _nb_get_link_dir() {
     fi
 }
 
-# Redirect a Hermes-managed Node's `npm install -g` to the command link dir
-# (already on PATH) instead of the default $HERMES_HOME/node/bin, which is off
-# PATH and wiped on every Node upgrade. Scoped to the managed Node via its
-# prefix-local global npmrc; the user's other Node installs / ~/.npmrc are
-# untouched. Idempotent no-op when there's no managed npm.
-_nb_configure_npm_prefix() {
-    [ -x "$HERMES_HOME/node/bin/npm" ] || return 0
+_nb_should_link_managed_node_tools() {
+    _nb_is_termux && return 1
+    [ "$(id -u)" = 0 ] && [ "$(uname -s)" = "Linux" ]
+}
+
+_nb_remove_private_managed_node_links() {
+    _nb_should_link_managed_node_tools && return 0
+    [ -d "$HERMES_HOME/node" ] || return 0
+
+    local _link_dir _tool _link _target
+    _link_dir="$(_nb_get_link_dir)"
+    for _tool in node npm npx; do
+        _link="$_link_dir/$_tool"
+        [ -L "$_link" ] || continue
+        _target="$(readlink "$_link" 2>/dev/null || true)"
+        case "$_target" in
+            "$HERMES_HOME/node"/*)
+                rm -f "$_link"
+                ;;
+        esac
+    done
+}
+
+_nb_link_managed_node_tools_if_needed() {
+    _nb_should_link_managed_node_tools || return 0
+
     local _link_dir
     _link_dir="$(_nb_get_link_dir)"
+    mkdir -p "$_link_dir"
+    ln -sf "$HERMES_HOME/node/bin/node" "$_link_dir/node"
+    ln -sf "$HERMES_HOME/node/bin/npm"  "$_link_dir/npm"
+    ln -sf "$HERMES_HOME/node/bin/npx"  "$_link_dir/npx"
+}
+
+# Keep the managed npm's prefix scoped to the managed Node. User-scoped
+# installs keep global bins private; root FHS installs keep them in the command
+# link dir so root-managed global bins stay reachable.
+_nb_configure_npm_prefix() {
+    [ -x "$HERMES_HOME/node/bin/npm" ] || return 0
+    local _prefix
+    if _nb_should_link_managed_node_tools; then
+        _prefix="$(dirname "$(_nb_get_link_dir)")"
+    else
+        _prefix="$HERMES_HOME/node"
+    fi
     mkdir -p "$HERMES_HOME/node/etc"
-    printf 'prefix=%s\n' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"
+    printf 'prefix=%s\n' "$_prefix" > "$HERMES_HOME/node/etc/npmrc"
 }
 
 _nb_node_major() {
@@ -213,12 +248,8 @@ _nb_install_bundled_node() {
     mv "$extracted" "$HERMES_HOME/node"
     rm -rf "$tmp"
 
-    local _link_dir
-    _link_dir="$(_nb_get_link_dir)"
-    mkdir -p "$_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$_link_dir/npx"
+    _nb_remove_private_managed_node_links
+    _nb_link_managed_node_tools_if_needed
 
     _nb_configure_npm_prefix
 
@@ -282,6 +313,7 @@ ensure_node() {
     # Repair pre-existing managed installs where `npm install -g` lands off
     # PATH. No-op when there's no managed Node, so it's safe to run first.
     _nb_configure_npm_prefix
+    _nb_remove_private_managed_node_links
 
     if _nb_have_modern_node; then
         _nb_ok "Node $(node --version) found"

--- a/tests/test_install_sh_node_global_prefix.py
+++ b/tests/test_install_sh_node_global_prefix.py
@@ -1,58 +1,201 @@
-"""Regression tests for the Hermes-managed Node's npm global prefix.
+"""Behavioral coverage for Hermes-managed Node exposure and npm prefixes."""
 
-When the installer falls back to a bundled Node under ``$HERMES_HOME/node``,
-npm's default global prefix is that Node dir, so ``npm install -g <pkg>``
-drops the package binary in ``$HERMES_HOME/node/bin`` — which is NOT on PATH
-(only the command link dir is) and is wiped on every Node upgrade. Users then
-report "I can ``npm i -g`` but the package isn't usable on the command line".
-
-The fix redirects the bundled Node's global prefix to the command link dir's
-parent (so global bins land in the already-on-PATH link dir alongside
-node/npm/npx), scoped to the bundled Node via its prefix-local global npmrc.
-"""
-
+import os
+import subprocess
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 NODE_BOOTSTRAP = REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh"
+SCRIPT_CASES = (
+    pytest.param("installer", INSTALL_SH, id="installer"),
+    pytest.param("bootstrap", NODE_BOOTSTRAP, id="lazy-bootstrap"),
+)
 
 
-def test_install_sh_redirects_bundled_npm_global_prefix_to_link_dir() -> None:
-    text = INSTALL_SH.read_text()
-
-    # The redirect must target the link dir's PARENT so global bins resolve to
-    # <parent>/bin == the command link dir (node/npm/npx live there and it is
-    # guaranteed on PATH by the installer's PATH setup).
-    assert "configure_managed_node_npm_prefix()" in text
-    assert 'printf \'prefix=%s\\n\' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"' in text
+def _write_executable(path: Path, body: str = "#!/bin/sh\nexit 0\n") -> None:
+    path.write_text(body)
+    path.chmod(0o755)
 
 
-def test_install_sh_repairs_existing_managed_node_on_rerun() -> None:
-    """The redirect must run on every install (not just fresh Node installs),
-    so re-running the installer repairs pre-existing managed installs whose
-    Node is already up to date and would otherwise skip install_node."""
-    text = INSTALL_SH.read_text()
+def _run_shell(
+    script_kind: str,
+    script_path: Path,
+    body: str,
+    *,
+    home: Path,
+    hermes_home: Path,
+    path: str | None = None,
+    link_dir: Path | None = None,
+) -> None:
+    source = (
+        'source "$SCRIPT_UNDER_TEST" --manifest >/dev/null'
+        if script_kind == "installer"
+        else 'source "$SCRIPT_UNDER_TEST"'
+    )
+    harness = f"""
+set -e
+{source}
+{body}
+"""
+    env = os.environ.copy()
+    env.pop("PYTHONHOME", None)
+    env.pop("PYTHONPATH", None)
+    env.update(
+        {
+            "HOME": str(home),
+            "HERMES_HOME": str(hermes_home),
+            "SCRIPT_KIND": script_kind,
+            "SCRIPT_UNDER_TEST": str(script_path),
+            "TERMUX_VERSION": "",
+            "PREFIX": "",
+        }
+    )
+    if path is not None:
+        env["PATH"] = path
+    if link_dir is not None:
+        env["LINK_DIR"] = str(link_dir)
 
-    check_node_body = text.split("check_node()", 1)[1].split("\ninstall_node()", 1)[0]
-    assert "configure_managed_node_npm_prefix" in check_node_body
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
 
-    # No-op guard so it's safe to call when there is no managed Node.
-    assert '[ -x "$HERMES_HOME/node/bin/npm" ] || return 0' in text
+    assert result.returncode == 0, result.stderr
 
 
-def test_node_bootstrap_redirects_bundled_npm_global_prefix_to_link_dir() -> None:
-    text = NODE_BOOTSTRAP.read_text()
+@pytest.mark.parametrize(("script_kind", "script_path"), SCRIPT_CASES)
+def test_user_install_repairs_legacy_links_and_keeps_npm_private(
+    tmp_path: Path,
+    script_kind: str,
+    script_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes"
+    managed_bin = hermes_home / "node" / "bin"
+    link_dir = home / ".local" / "bin"
+    fake_bin = tmp_path / "fake-bin"
+    managed_bin.mkdir(parents=True)
+    link_dir.mkdir(parents=True)
+    fake_bin.mkdir()
 
-    assert "_nb_configure_npm_prefix()" in text
-    assert 'printf \'prefix=%s\\n\' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"' in text
+    for tool in ("node", "npm", "npx"):
+        _write_executable(managed_bin / tool)
+        (link_dir / tool).symlink_to(managed_bin / tool)
+    _write_executable(fake_bin / "node", "#!/bin/sh\necho v22.13.0\n")
 
-    # Runs at the top of ensure_node so existing managed installs are repaired
-    # even when a modern Node is already present (early return path).
-    ensure_node_body = text.split("ensure_node()", 1)[1]
-    assert "_nb_configure_npm_prefix" in ensure_node_body
-    assert '[ -x "$HERMES_HOME/node/bin/npm" ] || return 0' in text
-    assert "heal_managed_node()" in text
-    assert "_nb_managed_tool_broken" in text
-    assert "for tool in node npm npx" in text
+    body = """
+if [ "$SCRIPT_KIND" = installer ]; then
+    ROOT_FHS_LAYOUT=false
+    check_node
+else
+    ensure_node
+fi
+"""
+    _run_shell(
+        script_kind,
+        script_path,
+        body,
+        home=home,
+        hermes_home=hermes_home,
+        path=f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+    )
+
+    assert (hermes_home / "node" / "etc" / "npmrc").read_text() == (
+        f"prefix={hermes_home / 'node'}\n"
+    )
+    for tool in ("node", "npm", "npx"):
+        assert not (link_dir / tool).is_symlink()
+
+
+@pytest.mark.parametrize(("script_kind", "script_path"), SCRIPT_CASES)
+def test_root_fhs_install_exposes_managed_tools_and_shared_prefix(
+    tmp_path: Path,
+    script_kind: str,
+    script_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes"
+    managed_bin = hermes_home / "node" / "bin"
+    link_dir = tmp_path / "usr-local" / "bin"
+    managed_bin.mkdir(parents=True)
+
+    for tool in ("node", "npm", "npx"):
+        _write_executable(managed_bin / tool)
+
+    body = """
+if [ "$SCRIPT_KIND" = installer ]; then
+    ROOT_FHS_LAYOUT=true
+    get_command_link_dir() { printf '%s\n' "$LINK_DIR"; }
+    link_managed_node_tools_if_needed
+    configure_managed_node_npm_prefix
+else
+    id() {
+        if [ "${1:-}" = -u ]; then printf '0\n'; else command id "$@"; fi
+    }
+    uname() {
+        if [ "${1:-}" = -s ]; then printf 'Linux\n'; else command uname "$@"; fi
+    }
+    _nb_get_link_dir() { printf '%s\n' "$LINK_DIR"; }
+    _nb_link_managed_node_tools_if_needed
+    _nb_configure_npm_prefix
+fi
+"""
+    _run_shell(
+        script_kind,
+        script_path,
+        body,
+        home=home,
+        hermes_home=hermes_home,
+        link_dir=link_dir,
+    )
+
+    for tool in ("node", "npm", "npx"):
+        assert (link_dir / tool).is_symlink()
+        assert (link_dir / tool).resolve() == (managed_bin / tool).resolve()
+    assert (hermes_home / "node" / "etc" / "npmrc").read_text() == (
+        f"prefix={link_dir.parent}\n"
+    )
+
+
+@pytest.mark.parametrize(("script_kind", "script_path"), SCRIPT_CASES)
+def test_user_install_preserves_non_hermes_tool_link(
+    tmp_path: Path,
+    script_kind: str,
+    script_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes"
+    link_dir = home / ".local" / "bin"
+    user_bin = tmp_path / "user-node" / "bin"
+    (hermes_home / "node").mkdir(parents=True)
+    link_dir.mkdir(parents=True)
+    user_bin.mkdir(parents=True)
+    _write_executable(user_bin / "node")
+    (link_dir / "node").symlink_to(user_bin / "node")
+
+    body = """
+if [ "$SCRIPT_KIND" = installer ]; then
+    ROOT_FHS_LAYOUT=false
+    remove_private_managed_node_links
+else
+    _nb_should_link_managed_node_tools() { return 1; }
+    _nb_remove_private_managed_node_links
+fi
+"""
+    _run_shell(
+        script_kind,
+        script_path,
+        body,
+        home=home,
+        hermes_home=hermes_home,
+    )
+
+    assert (link_dir / "node").is_symlink()
+    assert (link_dir / "node").resolve() == (user_bin / "node").resolve()


### PR DESCRIPTION
## What does this PR do?

Keeps the Hermes-managed Node private for user-scoped POSIX installs so it does not shadow a user's version manager in later shells.

The current installer adds the Hermes command dir to shell PATH for user-scoped installs. When the bundled Node fallback also writes `node`, `npm`, and `npx` into that same dir (`~/.local/bin` on macOS/non-root POSIX), a later shell can resolve Hermes's Node before `nvm`/`fnm`/`proto`.

This PR narrows the exposure rule:

- user-scoped installs keep `node/npm/npx` private under `$HERMES_HOME/node/bin`
- root FHS installs still expose `node/npm/npx` in `/usr/local/bin`, preserving the shared-root-shell behavior from #38889
- existing legacy user-scoped `~/.local/bin/{node,npm,npx}` links are removed only when they still point into this `$HERMES_HOME/node`
- Hermes subprocesses can still find the private managed Node through the existing `$HERMES_HOME/node/bin` helpers/env handling

The iTerm/TCC disk-access part of #57997 is intentionally left out: the issue's uploaded Hermes logs do not contain enough evidence to attribute that macOS Privacy state change to this installer path.

## Related Issue

Fixes #57997

Refs #18357
Refs #47897
Refs #38889

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `scripts/install.sh`
  - Adds a layout gate so managed `node/npm/npx` are linked only for root FHS installs.
  - Removes legacy user-scoped managed-node links when they still point into this Hermes home.
  - Keeps the managed npm prefix scoped to the managed Node for user installs, while preserving the root FHS command-link prefix.
- `scripts/lib/node-bootstrap.sh`
  - Mirrors the installer behavior for lazy Node provisioning.
  - Prevents lazy ensure from reintroducing user-scoped `~/.local/bin` managed-node links.
- `hermes_cli/uninstall.py`
  - Updates the uninstall comment to distinguish current root FHS links from legacy user-scoped links.
- `tests/test_install_sh_node_global_prefix.py`
  - Adds regression coverage for private user-scoped managed Node behavior and legacy-link cleanup.

## How to Test

Before this patch, the new regression tests fail on current `main` because `install_node()` and `_nb_install_bundled_node()` unconditionally write managed `node/npm/npx` links into the command link dir:

```bash
scripts/run_tests.sh tests/test_install_sh_node_global_prefix.py
# 2 failed, 3 passed
```

After this patch:

```bash
scripts/run_tests.sh tests/test_install_sh_node_global_prefix.py tests/hermes_cli/test_uninstall_node_symlinks.py tests/test_hermes_constants.py
# 98 passed, 0 failed

bash -n scripts/install.sh scripts/lib/node-bootstrap.sh

python -m ruff check tests/test_install_sh_node_global_prefix.py hermes_cli/uninstall.py
# All checks passed

git diff --check
```

Tested on macOS with the branch based on `5445e42b87b9918d5b1bfa9f4eadd8e4bb10ff37`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted tests and checks; see "How to Test"
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, only an internal uninstall comment changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
