### PR TITLE
fix(desktop): refresh model settings hook tests

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -504,7 +504,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
         notifyError(err, m.defaultsFailed)
       }
     },
-    [config, m.defaultsFailed]
+    [config, m.defaultsFailed, setConfig]
   )
 
   // Paste an API key for the selected `api_key` provider, persist it, then


### PR DESCRIPTION
## Summary
- include the shared config cache setter in the model settings default writer hook dependencies
- update the model settings tests for the current React Query-backed config cache and imported desktop helpers
- keep the provider-universe assertion aligned with the current setup UI, which appears after selecting an unconfigured provider

## Test plan
- npm --workspace apps/desktop exec eslint -- src/app/settings/model-settings.tsx src/app/settings/model-settings.test.tsx
- npm --workspace apps/desktop run test:ui -- src/app/settings/model-settings.test.tsx src/app/settings/with-active.test.ts
- git diff --check