### PR TITLE
fix(config): fall back after scoped secret miss

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7410,8 +7410,14 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
         return val
     try:
         from agent.secret_scope import get_secret as _get_secret
+        from agent.secret_scope import is_multiplex_active as _is_multiplex_active
 
-        return _get_secret(key)
+        scoped_val = _get_secret(key)
+        if scoped_val:
+            return scoped_val
+        if not _is_multiplex_active():
+            return os.environ.get(key)
+        return None
     except Exception:
         return os.environ.get(key)
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -15,6 +15,7 @@ from hermes_cli.config import (
     get_compatible_custom_providers,
     _explicit_config_paths,
     _normalize_max_turns_config,
+    get_env_value_prefer_dotenv,
     load_config,
     load_env,
     migrate_config,
@@ -104,6 +105,36 @@ class TestEnsureHermesHome:
             with pytest.raises(FileNotFoundError, match="Named profile home does not exist"):
                 ensure_hermes_home()
         assert not profile_home.exists()
+
+
+class TestGetEnvValuePreferDotenv:
+    def test_scoped_miss_falls_back_to_environ_without_multiplexing(self, tmp_path, monkeypatch):
+        """Cron installs a profile scope, but BWS-injected keys live in os.environ."""
+        from agent import secret_scope as ss
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("XIAOMI_API_KEY", "sk-from-bws-env")
+        ss.set_multiplex_active(False)
+        token = ss.set_secret_scope({})
+        try:
+            assert get_env_value_prefer_dotenv("XIAOMI_API_KEY") == "sk-from-bws-env"
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
+    def test_scoped_miss_does_not_fall_back_to_environ_during_multiplexing(self, tmp_path, monkeypatch):
+        """A multiplexed profile scope remains authoritative for profile secrets."""
+        from agent import secret_scope as ss
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-other-profile")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({})
+        try:
+            assert get_env_value_prefer_dotenv("OPENAI_API_KEY") is None
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
 
 
 class TestLoadConfigDefaults:


### PR DESCRIPTION
## Summary
- fix get_env_value_prefer_dotenv() so a scoped secret miss can still read os.environ in non-multiplex deployments
- keep multiplexed profile scopes authoritative so a missing profile secret does not leak a process-global provider key
- add regression coverage for the BWS/cron-style scoped miss and the multiplex isolation case

Fixes #58100.

## Test plan
- source .venv/bin/activate && pytest tests/hermes_cli/test_config.py -q -k "TestGetEnvValuePreferDotenv"
- source .venv/bin/activate && pytest tests/hermes_cli/test_xiaomi_provider.py tests/hermes_cli/test_api_key_providers.py -q -k "xiaomi or env or credential or provider"
- git diff --check