### PR TITLE
fix(desktop): surface exact slash aliases

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -163,6 +163,7 @@ export function useSlashCompletions(options: {
         const replaceFrom = typeof result.replace_from === 'number' ? result.replace_from : 1
         const isArgCompletion = replaceFrom > 1
         const prefix = isArgCompletion ? text.slice(0, replaceFrom) : ''
+        const exactCommandQuery = commandText(query).toLowerCase()
 
         const decorated = (result.items ?? [])
           .map(item => {
@@ -174,7 +175,13 @@ export function useSlashCompletions(options: {
 
             return { ...item, text: `${prefix}${argText}` }
           })
-          .filter(item => isArgCompletion || isDesktopSlashSuggestion(item.text))
+          .filter(
+            item =>
+              isArgCompletion ||
+              isDesktopSlashSuggestion(item.text, {
+                includeAlias: commandText(item.text).toLowerCase() === exactCommandQuery
+              })
+          )
           .map(item => ({
             ...item,
             // Arg suggestions (e.g. `/handoff <platform>`) live under one

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -87,6 +87,8 @@ describe('desktop slash command curation', () => {
 
   it('allows aliases to execute without cluttering the popover', () => {
     expect(isDesktopSlashSuggestion('/reset')).toBe(false)
+    expect(isDesktopSlashSuggestion('/reset', { includeAlias: true })).toBe(true)
+    expect(isDesktopSlashSuggestion('/memory-graph', { includeAlias: true })).toBe(true)
     expect(isDesktopSlashCommand('/reset')).toBe(true)
   })
 

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -300,12 +300,12 @@ export function isDesktopSlashCommand(command: string): boolean {
 }
 
 /** Gates discovery in the popover/completions. */
-export function isDesktopSlashSuggestion(command: string): boolean {
+export function isDesktopSlashSuggestion(command: string, options: { includeAlias?: boolean } = {}): boolean {
   const normalized = normalizeCommand(command)
 
   // Aliases stay hidden so the popover isn't cluttered with duplicates.
   if (ALIAS_TO_CANONICAL.has(normalized)) {
-    return false
+    return Boolean(options.includeAlias && isDesktopSlashCommand(normalized))
   }
 
   const spec = SPEC_BY_NAME.get(normalized)


### PR DESCRIPTION
## Summary
- keep slash aliases hidden from the empty desktop command palette so canonical commands do not duplicate
- allow an alias suggestion when the user has typed that exact alias, such as /reset
- preserve alias execution routing to the canonical desktop command surface

Fixes #57641.

## Test plan
- npm --workspace apps/desktop run test:ui -- src/lib/desktop-slash-commands.test.ts
- npm --workspace apps/desktop exec eslint -- src/lib/desktop-slash-commands.ts src/lib/desktop-slash-commands.test.ts src/app/chat/composer/hooks/use-slash-completions.ts
- git diff --check