### PR TITLE
fix(usage): avoid double-counting reasoning tokens

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -514,7 +514,6 @@ class GatewaySlashCommandsMixin:
                         + _int_value(row.get("output_tokens"))
                         + _int_value(row.get("cache_read_tokens"))
                         + _int_value(row.get("cache_write_tokens"))
-                        + _int_value(row.get("reasoning_tokens"))
                     )
             except Exception:
                 db_total_tokens = 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1355,7 +1355,6 @@ def _print_tui_exit_summary(
             + output_tokens
             + cache_read_tokens
             + cache_write_tokens
-            + reasoning_tokens
         )
     except Exception:
         return

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -152,8 +152,8 @@ async def test_status_command_reads_token_totals_from_session_db():
 
     result = await runner._handle_message(_make_event("/status"))
 
-    # 1000 + 250 + 500 + 100 + 50 = 1,900
-    assert "**Cumulative API tokens (re-sent each call):** 1,900" in result
+    # reasoning_tokens is a breakdown of output_tokens, not an additional total.
+    assert "**Cumulative API tokens (re-sent each call):** 1,850" in result
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1081,7 +1081,7 @@ def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, ca
     assert "Resume this session with:" in out
     assert "hermes --tui --resume 20260409_000001_abc123" in out
     assert 'hermes --tui -c "demo title"' in out
-    assert "Tokens:         21 (in 10, out 6, cache 4, reasoning 1)" in out
+    assert "Tokens:         20 (in 10, out 6, cache 4, reasoning 1)" in out
 
 
 def test_print_tui_exit_summary_prefers_actual_active_session_file(


### PR DESCRIPTION
## Summary
- remove reasoning_tokens from the TUI exit summary total because reasoning is already included in output_tokens
- remove the same double-count from gateway /status cumulative API token totals
- keep reasoning_tokens in the displayed breakdown so users still see the reasoning component

Fixes #57565.

## Test plan
- source .venv/bin/activate && pytest tests/hermes_cli/test_tui_resume_flow.py -q -k "exit_summary_includes_resume_and_token_totals"
- source .venv/bin/activate && pytest tests/gateway/test_status_command.py -q -k "reads_token_totals_from_session_db"
- source .venv/bin/activate && python -m py_compile hermes_cli/main.py gateway/slash_commands.py
- source .venv/bin/activate && pytest tests/gateway/test_status_command.py tests/hermes_cli/test_tui_resume_flow.py -q
- git diff --check