### PR TITLE
fix(cron): coerce schedule string in list display (no more AttributeError)

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -116,7 +116,28 @@ def cron_list(show_all: bool = False):
     for job in jobs:
         job_id = job.get("id", "?")
         name = job.get("name", "(unnamed)")
-        schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
+        # Coerce legacy / hand-edited nullable schedule fields safely.  The
+        # inline form `job.get("schedule", {}).get("value", "?")` crashed on
+        # legacy entries whose `schedule` was a bare string such as
+        # "55 23 * * *" with AttributeError: 'str' object has no attribute 'get'.
+        # Mirrors cron/jobs.py:_schedule_display_for_job.
+        _sched = job.get("schedule_display")
+        if _sched:
+            schedule = str(_sched).strip()
+        else:
+            _sched = job.get("schedule")
+            if isinstance(_sched, dict):
+                for _k in ("display", "value", "expr", "run_at"):
+                    _v = _sched.get(_k)
+                    if _v:
+                        schedule = str(_v).strip()
+                        break
+                else:
+                    schedule = "?"
+            elif _sched is not None:
+                schedule = str(_sched).strip()
+            else:
+                schedule = "?"
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
         next_run = job.get("next_run_at", "?")
 


### PR DESCRIPTION
## Bug
`hermes cron list` crashes with `AttributeError: 'str' object has no attribute 'get'` when jobs.json contains legacy entries whose `schedule` field is a bare string (e.g. `"55 23 * * *"`).

The crash happens at `hermes_cli/cron.py:119`:
```python
schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
```
which assumes `schedule` is a dict containing a `value` field.  Bare-string `schedule`s (e.g. legacy / hand-edited entries) fail the `.get("value", ...)` call.

## Fix
Inline a 3-branch coercion mirroring the existing `cron/jobs.py:_schedule_display_for_job` helper:
- `schedule_display` first (fast path)
- dict `schedule` (try `display`/`value`/`expr`/`run_at` keys)
- bare string `schedule` (just `str(...).strip()`)
- None → `"?"`

This matches the existing defensive coalesce patterns at line 126 (`repeat`) and line 135 (`deliver`), which already handle nullable fields rather than relying on dict-default.

## Test
``$
hermes cron list
```
Now lists 16+ active jobs including legacy entries without crashing.

## Origin
Reported 2026-07-04 in `deyi2026/SYAGI` commit `7afc4e0` (bridge `agi_cron_job_migrate_legacy.py`).  That bridge now also does the data-level migration so this defensive guard is belt-and-suspenders.