### PR TITLE
fix(desktop): harden remote connection lifecycle in Electron main

### DIFF
--- a/apps/desktop/electron/liveness-streak.cjs
+++ b/apps/desktop/electron/liveness-streak.cjs
@@ -1,0 +1,66 @@
+/**
+ * liveness-streak.cjs
+ *
+ * Consecutive-failure tracking for the cached remote backend's liveness
+ * probe (hermes:connection:revalidate in main.cjs). A single slow or dropped
+ * GET /api/status — routine over Tailscale right after a wake, or while the
+ * remote host is briefly loaded — must NOT tear down the cached connection:
+ * dropping it forces a full backend teardown/rebuild on every renderer
+ * reconnect tick, producing the ready → probe-fail → restart churn seen in
+ * desktop.log. Only a STREAK of consecutive failures against the same base
+ * URL is treated as a dead remote.
+ *
+ * Kept in a standalone cjs module so it can be unit-tested with `node --test`
+ * without dragging in the electron runtime (same pattern as backend-probes.cjs
+ * and hardening.cjs).
+ */
+
+/**
+ * Create a consecutive-failure tracker.
+ *
+ * @param {object} [options]
+ * @param {number} [options.threshold] - Consecutive failures (against the
+ *   same key) required before `recordFailure` reports `drop: true`.
+ *   Clamped to >= 1; a threshold of 1 restores drop-on-first-failure.
+ * @returns {{
+ *   recordFailure(key?: string): { drop: boolean, count: number, threshold: number, firstOfStreak: boolean },
+ *   recordSuccess(): void
+ * }}
+ */
+function createLivenessStreak(options = {}) {
+  const threshold = Math.max(1, Math.floor(Number(options.threshold) || 1))
+  let count = 0
+  let streakKey = null
+
+  return {
+    /**
+     * Record one probe failure against `key` (the probed base URL). A key
+     * change means a different backend is being probed — the old streak is
+     * meaningless, so the count restarts at 1. When the streak reaches the
+     * threshold, `drop` is true and the streak resets so the next failure
+     * starts a fresh streak against the rebuilt connection.
+     */
+    recordFailure(key = '') {
+      const k = String(key || '')
+      if (k !== streakKey) {
+        streakKey = k
+        count = 0
+      }
+      count += 1
+      const result = { drop: count >= threshold, count, threshold, firstOfStreak: count === 1 }
+      if (result.drop) {
+        count = 0
+        streakKey = null
+      }
+      return result
+    },
+
+    /** A successful probe ends any in-progress streak. */
+    recordSuccess() {
+      count = 0
+      streakKey = null
+    }
+  }
+}
+
+module.exports = { createLivenessStreak }

--- a/apps/desktop/electron/liveness-streak.test.cjs
+++ b/apps/desktop/electron/liveness-streak.test.cjs
@@ -1,0 +1,62 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { createLivenessStreak } = require('./liveness-streak.cjs')
+
+test('does not drop until the threshold of consecutive failures is reached', () => {
+  const streak = createLivenessStreak({ threshold: 3 })
+
+  assert.deepEqual(streak.recordFailure('http://a'), { drop: false, count: 1, threshold: 3, firstOfStreak: true })
+  assert.deepEqual(streak.recordFailure('http://a'), { drop: false, count: 2, threshold: 3, firstOfStreak: false })
+  assert.deepEqual(streak.recordFailure('http://a'), { drop: true, count: 3, threshold: 3, firstOfStreak: false })
+})
+
+test('a success resets the streak', () => {
+  const streak = createLivenessStreak({ threshold: 3 })
+
+  streak.recordFailure('http://a')
+  streak.recordFailure('http://a')
+  streak.recordSuccess()
+
+  const next = streak.recordFailure('http://a')
+  assert.equal(next.drop, false)
+  assert.equal(next.count, 1)
+  assert.equal(next.firstOfStreak, true)
+})
+
+test('a key change restarts the streak (different backend being probed)', () => {
+  const streak = createLivenessStreak({ threshold: 2 })
+
+  streak.recordFailure('http://a')
+  const next = streak.recordFailure('http://b')
+  assert.equal(next.drop, false)
+  assert.equal(next.count, 1)
+})
+
+test('dropping resets the streak so the rebuilt connection gets a fresh budget', () => {
+  const streak = createLivenessStreak({ threshold: 2 })
+
+  streak.recordFailure('http://a')
+  assert.equal(streak.recordFailure('http://a').drop, true)
+
+  const next = streak.recordFailure('http://a')
+  assert.equal(next.drop, false)
+  assert.equal(next.count, 1)
+  assert.equal(next.firstOfStreak, true)
+})
+
+test('threshold clamps to at least 1 and tolerates junk input', () => {
+  for (const threshold of [0, -5, NaN, undefined, 'nope']) {
+    const streak = createLivenessStreak({ threshold })
+    assert.equal(streak.recordFailure('http://a').drop, true, `threshold ${threshold} should drop on first failure`)
+  }
+})
+
+test('threshold of 1 restores drop-on-first-failure', () => {
+  const streak = createLivenessStreak({ threshold: 1 })
+  const result = streak.recordFailure('http://a')
+  assert.equal(result.drop, true)
+  assert.equal(result.firstOfStreak, true)
+})

--- a/apps/desktop/electron/main-stability.test.cjs
+++ b/apps/desktop/electron/main-stability.test.cjs
@@ -1,0 +1,239 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ELECTRON_DIR = __dirname
+
+function readElectronFile(name) {
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
+}
+
+// ---------------------------------------------------------------------------
+// A1: the revalidate liveness probe must require a streak of consecutive
+// failures (default 3) before dropping the cached remote connection, and must
+// give each probe 8s (env-tunable) instead of the old 2.5s hair trigger.
+// ---------------------------------------------------------------------------
+
+test('revalidate probe uses the tunable timeout, not the old 2.5s hair trigger', () => {
+  const source = readElectronFile('main.cjs')
+
+  assert.match(
+    source,
+    /HERMES_DESKTOP_REVALIDATE_TIMEOUT_MS\) \|\| 8_000/,
+    'probe timeout should default to 8s with an env override'
+  )
+  assert.match(
+    source,
+    /HERMES_DESKTOP_REVALIDATE_FAILURES\) \|\| 3/,
+    'failure streak should default to 3 with an env override'
+  )
+  assert.doesNotMatch(
+    source,
+    /api\/status`, \{ timeoutMs: 2_500 \}/,
+    'no /api/status probe should still use the 2.5s timeout'
+  )
+
+  const probeCount = (source.match(/timeoutMs: REVALIDATE_PROBE_TIMEOUT_MS/g) || []).length
+  assert.ok(
+    probeCount >= 2,
+    `primary + pooled probes should both use REVALIDATE_PROBE_TIMEOUT_MS (found ${probeCount})`
+  )
+})
+
+test('revalidate drops the cached connection only after a failure streak', () => {
+  const source = readElectronFile('main.cjs')
+
+  assert.match(source, /require\('\.\/liveness-streak\.cjs'\)/, 'main.cjs should use the liveness-streak module')
+  assert.match(
+    source,
+    /createLivenessStreak\(\{ threshold: REVALIDATE_FAILURE_STREAK \}\)/,
+    'streak tracker should be built from the tunable threshold'
+  )
+
+  const fnStart = source.indexOf('async function revalidatePrimaryConnection(')
+  assert.notEqual(fnStart, -1, 'revalidatePrimaryConnection function not found')
+  const fnBody = source.slice(fnStart, fnStart + 2400)
+
+  assert.match(fnBody, /primaryLivenessStreak\.recordSuccess\(\)/, 'a successful probe must reset the streak')
+  assert.match(fnBody, /primaryLivenessStreak\.recordFailure\(base\)/, 'a failed probe must feed the streak')
+
+  // The drop log + reset must be gated behind the streak verdict.
+  const dropIdx = fnBody.indexOf('failed liveness probe; dropping stale connection')
+  const guardIdx = fnBody.indexOf('if (!failure.drop)')
+  assert.ok(guardIdx !== -1, 'drop must be guarded on the streak verdict')
+  assert.ok(dropIdx > guardIdx, 'drop log/reset must come after the non-drop early return')
+
+  // Intermediate failures log at most once per streak.
+  assert.match(fnBody, /failure\.firstOfStreak/, 'intermediate failures should log only on the first of a streak')
+})
+
+// ---------------------------------------------------------------------------
+// A2: only HTTP 401/403 from the ws-ticket mint means "session expired";
+// transport failures must rethrow as retryable (no needsOauthLogin).
+// ---------------------------------------------------------------------------
+
+test('buildRemoteConnection classifies ticket-mint failures by statusCode', () => {
+  const source = readElectronFile('main.cjs')
+
+  const fnStart = source.indexOf('async function buildRemoteConnection(')
+  assert.notEqual(fnStart, -1, 'buildRemoteConnection function not found')
+  const fnBody = source.slice(fnStart, source.indexOf('async function resolveRemoteBackend('))
+
+  assert.match(
+    fnBody,
+    /const status = Number\(error\?\.statusCode\)/,
+    'the mint catch must inspect the underlying statusCode'
+  )
+  assert.match(fnBody, /status !== 401 && status !== 403/, 'only 401/403 may be classified as an expired session')
+  assert.match(
+    fnBody,
+    /Could not reach the remote Hermes gateway/,
+    'non-auth failures must surface as a retryable unreachable-backend error'
+  )
+
+  // The retryable branch must not flag needsOauthLogin: the only two
+  // needsOauthLogin assignments in the OAuth path are the not-signed-in
+  // early-out and the confirmed-401/403 expiry.
+  const flagCount = (fnBody.match(/err\.needsOauthLogin = true/g) || []).length
+  assert.equal(flagCount, 2, `expected exactly 2 needsOauthLogin assignments, found ${flagCount}`)
+  const retryableIdx = fnBody.indexOf('Could not reach the remote Hermes gateway')
+  const expiredIdx = fnBody.indexOf('Your remote gateway session has expired')
+  assert.ok(retryableIdx < expiredIdx, 'retryable rethrow must short-circuit before the expiry classification')
+})
+
+// ---------------------------------------------------------------------------
+// A3a: in app-global remote mode, profiles without their own remote override
+// must NOT register reapable pool entries — they ride the shared descriptor.
+// ---------------------------------------------------------------------------
+
+test('ensureBackend short-circuits global-remote profiles past the pool', () => {
+  const source = readElectronFile('main.cjs')
+
+  const fnStart = source.indexOf('async function ensureBackend(')
+  assert.notEqual(fnStart, -1, 'ensureBackend function not found')
+  const fnBody = source.slice(fnStart, fnStart + 2200)
+
+  const shortCircuitIdx = fnBody.indexOf('globalRemoteActive() && !profileHasRemoteOverride(key)')
+  const poolIdx = fnBody.indexOf('backendPool.get(key)')
+  assert.notEqual(shortCircuitIdx, -1, 'ensureBackend must short-circuit global-remote profiles')
+  assert.ok(shortCircuitIdx < poolIdx, 'short-circuit must run before any pool registration/lookup')
+
+  // The shared descriptor must still be tagged with the profile so fs/git
+  // REST calls and ?profile= injection keep working.
+  assert.match(fnBody, /\{ \.\.\.conn, profile: key \}/, 'shared descriptor must carry the requested profile')
+})
+
+// ---------------------------------------------------------------------------
+// A3c: revalidate must also probe pooled REMOTE descriptors (process === null)
+// and delete dead ones.
+// ---------------------------------------------------------------------------
+
+test('revalidate probes pooled remote descriptors and drops dead ones', () => {
+  const source = readElectronFile('main.cjs')
+
+  const fnStart = source.indexOf('async function revalidatePooledRemoteBackends(')
+  assert.notEqual(fnStart, -1, 'revalidatePooledRemoteBackends function not found')
+  const fnBody = source.slice(fnStart, fnStart + 1200)
+
+  assert.match(fnBody, /!entry\.process && entry\.remoteBaseUrl/, 'only process-less remote descriptors are probed')
+  assert.match(fnBody, /stopPoolBackend\(profile\)/, 'a dead pooled remote must be dropped from the pool')
+
+  // The handler runs both checks.
+  assert.match(
+    source,
+    /Promise\.all\(\[revalidatePrimaryConnection\(\), revalidatePooledRemoteBackends\(\)\]\)/,
+    'the revalidate IPC handler must run primary and pooled checks together'
+  )
+
+  // spawnPoolBackend records the base URL for later probing.
+  assert.match(source, /entry\.remoteBaseUrl = remote\.baseUrl/, 'remote pool entries must record their base URL')
+})
+
+// ---------------------------------------------------------------------------
+// A4: mergeRemoteProfileSessions must use the authMode-aware helper for the
+// primary list (raw token-header fetchJson 401s against an OAuth primary).
+// ---------------------------------------------------------------------------
+
+test('mergeRemoteProfileSessions routes the primary list through fetchJsonForProfile', () => {
+  const source = readElectronFile('main.cjs')
+
+  const fnStart = source.indexOf('async function mergeRemoteProfileSessions(')
+  assert.notEqual(fnStart, -1, 'mergeRemoteProfileSessions function not found')
+  const fnBody = source.slice(fnStart, fnStart + 2400)
+
+  assert.match(
+    fnBody,
+    /fetchJsonForProfile\(null, `\/api\/profiles\/sessions\?\$\{searchParams\}`\)/,
+    'primary list must go through the authMode-aware helper'
+  )
+  assert.doesNotMatch(
+    fnBody,
+    /fetchJson\(`\$\{primary\.baseUrl\}/,
+    'the raw token-header fetchJson against the primary must be gone'
+  )
+})
+
+// ---------------------------------------------------------------------------
+// A5: global error handlers + no unhandled loadURL promises.
+// ---------------------------------------------------------------------------
+
+test('main process installs uncaughtException/unhandledRejection forensics', () => {
+  const source = readElectronFile('main.cjs')
+
+  const uncaughtIdx = source.indexOf("process.on('uncaughtException'")
+  const rejectionIdx = source.indexOf("process.on('unhandledRejection'")
+  assert.notEqual(uncaughtIdx, -1, 'uncaughtException handler not found')
+  assert.notEqual(rejectionIdx, -1, 'unhandledRejection handler not found')
+
+  // Both handlers must record AND flush synchronously so the log survives.
+  for (const [name, idx] of [
+    ['uncaughtException', uncaughtIdx],
+    ['unhandledRejection', rejectionIdx]
+  ]) {
+    const body = source.slice(idx, idx + 400)
+    assert.match(body, /rememberLog\(/, `${name} handler must rememberLog`)
+    assert.match(body, /flushDesktopLogBufferSync\(\)/, `${name} handler must flush the log buffer`)
+  }
+})
+
+test('every loadURL call handles rejection', () => {
+  const source = readElectronFile('main.cjs')
+
+  // Every `.loadURL(...)` call expression must be followed by a `.catch(` (or
+  // an options-object continuation that itself ends in `.catch(`). Walk each
+  // occurrence and scan past its balanced parens for the catch.
+  const sites = []
+  const re = /\.loadURL\(/g
+  let m
+  while ((m = re.exec(source)) !== null) sites.push(m.index)
+  assert.ok(sites.length >= 5, `expected at least 5 loadURL sites, found ${sites.length}`)
+
+  for (const site of sites) {
+    let depth = 0
+    let i = site + '.loadURL'.length
+    do {
+      const ch = source[i]
+      if (ch === '(') depth += 1
+      else if (ch === ')') depth -= 1
+      i += 1
+    } while (depth > 0 && i < source.length)
+
+    const after = source.slice(i, i + 40).replace(/\s+/g, '')
+    const line = source.slice(0, site).split('\n').length
+    assert.ok(
+      after.startsWith('.catch(') || after.startsWith(',{') || after.startsWith('.then('),
+      `loadURL at line ${line} must chain .catch (got: ${after.slice(0, 20)})`
+    )
+    if (after.startsWith(',{')) continue // multi-arg form handled below
+    if (after.startsWith('.then(')) {
+      assert.match(source.slice(i, i + 400), /\.catch\(/, `loadURL at line ${line} .then chain must end in .catch`)
+    }
+  }
+
+  // The multi-argument form (link-title window) already catches; assert it
+  // stays that way rather than special-casing silently.
+  assert.match(source, /\.loadURL\(rawUrl, \{[\s\S]{0,200}\}\)\s*\.catch\(/, 'multi-arg loadURL must keep its .catch')
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -42,6 +42,7 @@ const {
   readLinkTitleWindowTitle
 } = require('./link-title-window.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
+const { createLivenessStreak } = require('./liveness-streak.cjs')
 const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
 const { waitForDashboardPortAnnouncement } = require('./backend-ready.cjs')
 const { dashboardFallbackArgs, sourceDeclaresServe } = require('./backend-command.cjs')
@@ -946,6 +947,21 @@ function rememberLog(chunk) {
 
   scheduleDesktopLogFlush()
 }
+
+// Last-chance forensics. Electron's main process doesn't die on these by
+// default (it pre-installs its own uncaughtException listener and only warns
+// on unhandled rejections), but without our own handlers the reason lands on
+// stderr alone — lost entirely when the app is launched from Finder. Record
+// and flush synchronously so desktop.log always carries the trail.
+process.on('uncaughtException', error => {
+  rememberLog(`[main] Uncaught exception: ${(error && (error.stack || error.message)) || error}`)
+  flushDesktopLogBufferSync()
+})
+process.on('unhandledRejection', reason => {
+  const detail = reason instanceof Error ? reason.stack || reason.message : String(reason)
+  rememberLog(`[main] Unhandled rejection: ${detail}`)
+  flushDesktopLogBufferSync()
+})
 
 function openExternalUrl(rawUrl) {
   const raw = String(rawUrl || '').trim()
@@ -4899,6 +4915,20 @@ async function buildRemoteConnection(rawUrl, authMode, token, source) {
     try {
       ticket = await mintGatewayWsTicket(baseUrl)
     } catch (error) {
+      // Only an actual auth rejection means the session expired. A transport
+      // failure (timeout, DNS, refused — routine over Tailscale after a wake)
+      // carries no statusCode and says nothing about the session, so surface
+      // it as a retryable connection error and let the renderer's backoff
+      // keep dialing instead of demanding a re-sign-in.
+      const status = Number(error?.statusCode)
+      if (status !== 401 && status !== 403) {
+        const err = new Error(
+          `Could not reach the remote Hermes gateway at ${baseUrl}. ` +
+            'Check that the backend is running and reachable, then retry.'
+        )
+        err.cause = error
+        throw err
+      }
       const err = new Error(
         'Your remote gateway session has expired. ' + 'Open Settings → Gateway and click "Sign in" again.'
       )
@@ -5228,6 +5258,18 @@ async function ensureBackend(profile) {
     return startHermes()
   }
 
+  // App-global remote mode: ONE shared backend serves every profile via
+  // ?profile=, so a profile without its own remote override rides the primary
+  // descriptor. Registering a pool entry here would only cache a process-less
+  // clone of it that the idle reaper "reaps" and the next call re-probes,
+  // forever ("Reaping idle profile backend" spam + a redundant liveness probe
+  // per cycle). Tag the profile so callers (fs/git REST, ?profile= injection)
+  // still know which profile this connection is serving.
+  if (globalRemoteActive() && !profileHasRemoteOverride(key)) {
+    const conn = await startHermes()
+    return { ...conn, profile: key }
+  }
+
   const existing = backendPool.get(key)
   if (existing) {
     existing.lastActiveAt = Date.now()
@@ -5306,6 +5348,9 @@ async function spawnPoolBackend(profile, entry) {
   const remote = await resolveRemoteBackend(profile)
   if (remote) {
     await waitForHermes(remote.baseUrl, remote.token)
+    // Recorded on the entry so revalidate can probe this descriptor without
+    // awaiting connectionPromise (a local spawn may be mid-flight for a while).
+    entry.remoteBaseUrl = remote.baseUrl
     return {
       ...remote,
       profile,
@@ -5765,14 +5810,16 @@ function spawnSecondaryWindow({ sessionId, watch, newSession } = {}) {
 
   wireCommonWindowHandlers(win)
 
-  win.loadURL(
-    buildSessionWindowUrl(sessionId, {
-      devServer: DEV_SERVER,
-      rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
-      watch,
-      newSession
-    })
-  )
+  win
+    .loadURL(
+      buildSessionWindowUrl(sessionId, {
+        devServer: DEV_SERVER,
+        rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
+        watch,
+        newSession
+      })
+    )
+    .catch(error => rememberLog(`Session window failed to load: ${error.stack || error.message}`))
 
   return win
 }
@@ -5891,7 +5938,9 @@ function spawnPetOverlayWindow(bounds) {
     }
   })
 
-  win.loadURL(petOverlayUrl())
+  win
+    .loadURL(petOverlayUrl())
+    .catch(error => rememberLog(`Pet overlay failed to load: ${error.stack || error.message}`))
 
   return win
 }
@@ -6045,9 +6094,13 @@ function createWindow() {
   })
 
   if (DEV_SERVER) {
-    mainWindow.loadURL(DEV_SERVER)
+    mainWindow
+      .loadURL(DEV_SERVER)
+      .catch(error => rememberLog(`Renderer failed to load: ${error.stack || error.message}`))
   } else {
-    mainWindow.loadURL(pathToFileURL(resolveRendererIndex()).toString())
+    mainWindow
+      .loadURL(pathToFileURL(resolveRendererIndex()).toString())
+      .catch(error => rememberLog(`Renderer failed to load: ${error.stack || error.message}`))
   }
 
   mainWindow.webContents.once('did-finish-load', () => {
@@ -6067,7 +6120,23 @@ ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(pro
 // to confirm the cached PRIMARY backend is still reachable; if a remote one is
 // not, we drop the cache so the next getConnection() rebuilds it. Local backends
 // self-heal via their child 'exit' handler, so we never touch them here.
+//
+// A single slow /api/status — routine over Tailscale right after a wake or
+// while the remote host is loaded — must not tear down the cached connection
+// (each drop forces a full rebuild on the next reconnect tick, i.e. the
+// ready → probe-fail → restart churn). Require a streak of consecutive
+// failures before dropping, and give each probe the same headroom the
+// settings-UI auth probe gets (8s) instead of the old 2.5s hair trigger.
+const REVALIDATE_PROBE_TIMEOUT_MS = Math.max(1_000, Number(process.env.HERMES_DESKTOP_REVALIDATE_TIMEOUT_MS) || 8_000)
+const REVALIDATE_FAILURE_STREAK = Math.max(1, Number(process.env.HERMES_DESKTOP_REVALIDATE_FAILURES) || 3)
+const primaryLivenessStreak = createLivenessStreak({ threshold: REVALIDATE_FAILURE_STREAK })
+
 ipcMain.handle('hermes:connection:revalidate', async () => {
+  const [result] = await Promise.all([revalidatePrimaryConnection(), revalidatePooledRemoteBackends()])
+  return result
+})
+
+async function revalidatePrimaryConnection() {
   if (!connectionPromise) {
     return { ok: true, rebuilt: false }
   }
@@ -6087,9 +6156,22 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
 
   const base = conn.baseUrl.replace(/\/+$/, '')
   try {
-    await fetchPublicJson(`${base}/api/status`, { timeoutMs: 2_500 })
+    await fetchPublicJson(`${base}/api/status`, { timeoutMs: REVALIDATE_PROBE_TIMEOUT_MS })
+    primaryLivenessStreak.recordSuccess()
     return { ok: true, rebuilt: false }
   } catch {
+    const failure = primaryLivenessStreak.recordFailure(base)
+    if (!failure.drop) {
+      // Keep the cached connection while the streak builds; log once per
+      // streak so a flapping probe can't spam desktop.log.
+      if (failure.firstOfStreak) {
+        rememberLog(
+          `Cached remote Hermes backend failed a liveness probe (1/${failure.threshold}); ` +
+            'keeping the connection unless failures persist.'
+        )
+      }
+      return { ok: true, rebuilt: false }
+    }
     // Unreachable remote: drop the stale cache so the renderer's next reconnect
     // tick rebuilds a fresh, reachable descriptor. resetHermesConnection only
     // nulls connectionPromise for a remote (no child to SIGTERM).
@@ -6097,7 +6179,27 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
     resetHermesConnection()
     return { ok: true, rebuilt: true }
   }
-})
+}
+
+// Pooled REMOTE descriptors (entry.process === null) have no child 'exit'
+// handler to clear them when their host dies, and the renderer's 60s
+// keepalive touch defeats the idle reaper — so a dead descriptor would be
+// re-served forever. Probe each one and drop the dead ones so the next
+// ensureBackend() rebuilds fresh.
+async function revalidatePooledRemoteBackends() {
+  const remoteEntries = [...backendPool.entries()].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
+  await Promise.all(
+    remoteEntries.map(async ([profile, entry]) => {
+      const base = String(entry.remoteBaseUrl).replace(/\/+$/, '')
+      try {
+        await fetchPublicJson(`${base}/api/status`, { timeoutMs: REVALIDATE_PROBE_TIMEOUT_MS })
+      } catch {
+        rememberLog(`Pooled remote backend for profile "${profile}" failed liveness probe; dropping stale descriptor.`)
+        stopPoolBackend(profile)
+      }
+    })
+  )
+}
 ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
   touchPoolBackend(profile)
   return { ok: true }
@@ -6462,11 +6564,14 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   const offset = Math.max(0, Number(searchParams.get('offset')) || 0)
   const order = searchParams.get('order') === 'created' ? 'started_at' : 'last_active'
 
-  const primary = await ensureBackend(null)
-  const base = await fetchJson(`${primary.baseUrl}/api/profiles/sessions?${searchParams}`, primary.token, {
-    method: 'GET',
-    timeoutMs: DEFAULT_FETCH_TIMEOUT_MS
-  }).catch(() => ({ sessions: [], total: 0, profile_totals: {} }))
+  // The primary may be an OAuth remote (token === null) — route through the
+  // authMode-aware helper so the request carries the session cookie instead
+  // of a literal "null" token header that the gateway 401s.
+  const base = await fetchJsonForProfile(null, `/api/profiles/sessions?${searchParams}`).catch(() => ({
+    sessions: [],
+    total: 0,
+    profile_totals: {}
+  }))
 
   // Over-fetch each remote from offset 0 (limit+offset rows) so the merged window
   // is correct for this page — mirrors the primary's per-profile over-fetch.


### PR DESCRIPTION
## Problem

Running Desktop in global remote mode against a backend over a WireGuard/Tailscale link surfaces four connection-lifecycle defects (all reproduced from production `desktop.log` on such a setup):

1. **Liveness-probe flap loop** (dominant signature, 100+ occurrences/day): the revalidate probe hits `/api/status` with a single 2.5s timeout. One slow response over a tunnel and the cached connection is dropped and fully rebuilt — cycling every few seconds under load (`Remote Hermes backend is ready` → `failed liveness probe; dropping stale connection` → rebuild → repeat).
2. **Transport errors misreported as session expiry** (75 occurrences): `buildRemoteConnection` wraps *any* `mintGatewayWsTicket` failure — including plain network timeouts — into `Your remote gateway session has expired… Sign in again` with `needsOauthLogin=true`, without inspecting the status code. Log analysis shows most of these later recovered via plain retry with no re-login, i.e. they were never auth failures.
3. **Pool churn in global remote mode**: profile-scoped calls register per-profile pool entries that are just cached remote descriptors; the idle reaper then "reaps" them every 60s (`Reaping idle profile backend "x" (idle > 600s)` spam) and each recreation pays a fresh `waitForHermes`. Additionally `hermes:connection:revalidate` never probes pooled remote descriptors, so a dead one persists under the renderer's 60s keepalive touch.
4. **OAuth-gated primary + per-profile override**: `mergeRemoteProfileSessions` fetches the primary `/api/profiles/sessions` with the token-header helper regardless of `authMode`; against an OAuth primary the token is null, the 401 is swallowed by the empty-list `.catch`, and the sidebar silently loses the base session list.

## Fix

- Liveness drops now require **3 consecutive probe failures** (new `liveness-streak.cjs`, per-base-URL streak, reset on success/key change) with an **8s probe timeout**. Tunables: `HERMES_DESKTOP_REVALIDATE_TIMEOUT_MS`, `HERMES_DESKTOP_REVALIDATE_FAILURES`. Intermediate failures log once per streak; the drop log line is unchanged and only emitted on a real drop.
- `buildRemoteConnection` classifies reauth **only on statusCode 401/403**; anything else rethrows as a retryable `Could not reach the remote Hermes gateway…` error (with `cause`), so the renderer backoff keeps retrying instead of demanding sign-in.
- `ensureBackend` short-circuits non-override profiles to the shared `startHermes()` descriptor when `globalRemoteActive()` — no reapable pool entries, no reaper spam, no redundant probes. `revalidatePooledRemoteBackends()` now probes remaining pooled remote descriptors (per-profile overrides) alongside the primary and drops dead ones.
- `mergeRemoteProfileSessions` routes through the authMode-aware `fetchJsonForProfile`.
- Bonus hardening: `process.on('uncaughtException'/'unhandledRejection')` forensic logging (rememberLog + sync flush), and `.catch` on the four previously-unhandled `loadURL` calls.

## Tests

- `electron/liveness-streak.test.cjs` — 6 unit tests for the streak module.
- `electron/main-stability.test.cjs` — 8 source-assertion tests for the main.cjs wiring (same pattern as `profile-delete-respawn.test.cjs`).
- Full `electron/*.test.cjs` suite: 328 tests, 0 failures (1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)