### PR TITLE
fix(desktop): boot retry, post-reconnect busy reconciliation, refresh coalescing

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -90,6 +90,7 @@ import { ChatSidebar } from './chat/sidebar'
 import { CommandPalette } from './command-palette'
 import { useGatewayBoot } from './gateway/hooks/use-gateway-boot'
 import { useGatewayRequest } from './gateway/hooks/use-gateway-request'
+import { useReconnectReconciliation } from './gateway/hooks/use-reconnect-reconciliation'
 import { useKeybinds } from './hooks/use-keybinds'
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from './layout-constants'
 import { ModelPickerOverlay } from './model-picker-overlay'
@@ -397,19 +398,21 @@ export function DesktopController() {
     loadMoreSessionsForProfile,
     refreshCronJobs,
     refreshMessagingSessions,
-    refreshSessions
+    refreshSessions,
+    scheduleSessionsRefresh
   } = useSessionListActions({ profileScope })
 
   // Another window mutated the shared session list (e.g. a chat started in the
   // pop-out). Re-pull so the sidebar reflects it. Pop-outs have no sidebar, so
-  // only real windows bother.
+  // only real windows bother. Coalesced: a burst of completions in another
+  // window collapses to one refresh here.
   useEffect(() => {
     if (isSecondaryWindow()) {
       return
     }
 
-    return onSessionsChanged(() => void refreshSessions().catch(() => undefined))
-  }, [refreshSessions])
+    return onSessionsChanged(() => scheduleSessionsRefresh())
+  }, [scheduleSessionsRefresh])
 
   const toggleSelectedPin = useCallback(() => {
     const sessionId = $selectedStoredSessionId.get()
@@ -586,7 +589,7 @@ export function DesktopController() {
     hydrateFromStoredSession,
     queryClient,
     refreshHermesConfig,
-    refreshSessions,
+    scheduleSessionsRefresh,
     sessionStateByRuntimeIdRef,
     updateSessionState
   })
@@ -876,6 +879,11 @@ export function DesktopController() {
     return $attentionSessionIds.listen(sync)
   }, [])
 
+  const reconcileBusySessions = useReconnectReconciliation({
+    sessionStateByRuntimeIdRef,
+    updateSessionState
+  })
+
   useGatewayBoot({
     handleGatewayEvent: handleDesktopGatewayEvent,
     onConnectionReady: c => {
@@ -884,6 +892,7 @@ export function DesktopController() {
     onGatewayReady: g => {
       gatewayRef.current = g
     },
+    reconcileBusySessions,
     refreshHermesConfig,
     refreshSessions
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -104,11 +104,16 @@ function fakeDesktop() {
   }
 }
 
-function Harness() {
+function Harness({
+  reconcileBusySessions
+}: {
+  reconcileBusySessions?: (gateway: unknown, profile: string) => Promise<void>
+} = {}) {
   useGatewayBoot({
     handleGatewayEvent: () => undefined,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
+    reconcileBusySessions,
     refreshHermesConfig: async () => undefined,
     refreshSessions: async () => undefined
   })
@@ -262,6 +267,120 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     // The remote comes back: next reconnect attempt opens.
     FakeWebSocket.mode = 'open'
     await advanceBackoff()
+
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('runs the busy-state reconciliation after a successful reconnect', async () => {
+    const reconcile = vi.fn(async (_gateway: unknown, _profile: string) => undefined)
+    render(<Harness reconcileBusySessions={reconcile} />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    // The initial boot is not a reconnect — nothing to reconcile yet.
+    expect(reconcile).not.toHaveBeenCalled()
+
+    act(() => FakeWebSocket.instances[0].drop())
+    await flushAsync()
+    await advanceBackoff()
+
+    expect($gatewayState.get()).toBe('open')
+    expect(reconcile).toHaveBeenCalledTimes(1)
+    expect(reconcile.mock.calls[0][1]).toBe('default')
+  })
+})
+
+describe('useGatewayBoot dead-at-launch boot retry (B2)', () => {
+  it('retries a transport-failed boot on backoff until the backend comes back', async () => {
+    // Backend unreachable at launch: getConnection rejects with the
+    // waitForHermes timeout twice, then the tunnel comes up.
+    const desktop = fakeDesktop()
+    const realGetConnection = desktop.getConnection
+    let failures = 2
+    desktop.getConnection = vi.fn(async () => {
+      if (failures > 0) {
+        failures -= 1
+        throw new Error('Hermes backend did not become ready: Timed out connecting to Hermes backend after 15000ms')
+      }
+
+      return realGetConnection()
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    // First boot failed → failure overlay up, retry scheduled.
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+
+    // First retry (~5s + jitter) also fails.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(7_000)
+    })
+    expect(desktop.getConnection).toHaveBeenCalledTimes(2)
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    // Second retry (~15s + jitter) succeeds → boot completes, error clears.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+    expect(desktop.getConnection.mock.calls.length).toBeGreaterThanOrEqual(3)
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('latches a genuine auth failure: no automatic retry, sign-in stays required', async () => {
+    const desktop = fakeDesktop()
+    desktop.getConnection = vi.fn(async () => {
+      throw new Error('Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.')
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBeTruthy()
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+
+    // Minutes pass: a transport failure would have retried many times by now.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60_000)
+    })
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+
+    // Wake/online nudges must not thrash the latched auth failure either.
+    await act(async () => {
+      window.dispatchEvent(new Event('online'))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('a wake/online nudge retries a transport-failed boot immediately', async () => {
+    const desktop = fakeDesktop()
+    const realGetConnection = desktop.getConnection
+    let failures = 1
+    desktop.getConnection = vi.fn(async () => {
+      if (failures > 0) {
+        failures -= 1
+        throw new Error('Timed out connecting to Hermes backend after 15000ms')
+      }
+
+      return realGetConnection()
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($desktopBoot.get().error).toBeTruthy()
+
+    // Network comes back well before the 5s backoff timer would fire.
+    await act(async () => {
+      window.dispatchEvent(new Event('online'))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    await flushAsync()
 
     expect($gatewayState.get()).toBe('open')
     expect($desktopBoot.get().error).toBeNull()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -1,4 +1,4 @@
-import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
+import { isGatewayAuthShapedError, isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
 import { useEffect, useRef } from 'react'
 
 import type { HermesConnection } from '@/global'
@@ -47,12 +47,29 @@ import type { RpcEvent } from '@/types/hermes'
 // dead end. The next successful reconnect clears it.
 const RECONNECT_ESCALATE_AFTER = 6
 
+// Backoff for re-attempting a FAILED initial boot (backend dead at launch —
+// e.g. the Tailscale tunnel isn't up yet when the app starts). Without this the
+// failure overlay sat there forever waiting for a manual Retry click even
+// though the backend came back seconds later. Capped at the last entry; ±20%
+// jitter so a fleet of windows doesn't stampede the backend in lockstep.
+const BOOT_RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000]
+
+const bootRetryDelay = (attempt: number): number => {
+  const base = BOOT_RETRY_DELAYS_MS[Math.min(attempt, BOOT_RETRY_DELAYS_MS.length - 1)]
+
+  return Math.round(base * (0.8 + Math.random() * 0.4))
+}
+
 interface GatewayBootOptions {
   handleGatewayEvent: (event: RpcEvent) => void
   onConnectionReady: (
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
   onGatewayReady: (gateway: HermesGateway | null) => void
+  /** Clear stale per-session busy state after a socket reconnect (the turns
+   *  whose message.complete died with the dropped socket). Optional so
+   *  lightweight harnesses (tests, pop-outs) can omit it. */
+  reconcileBusySessions?: (gateway: HermesGateway, profile: string) => Promise<void>
   refreshHermesConfig: () => Promise<void>
   refreshSessions: () => Promise<void>
 }
@@ -61,6 +78,7 @@ export function useGatewayBoot({
   handleGatewayEvent,
   onConnectionReady,
   onGatewayReady,
+  reconcileBusySessions,
   refreshHermesConfig,
   refreshSessions
 }: GatewayBootOptions) {
@@ -68,6 +86,7 @@ export function useGatewayBoot({
     handleGatewayEvent,
     onConnectionReady,
     onGatewayReady,
+    reconcileBusySessions,
     refreshHermesConfig,
     refreshSessions
   })
@@ -76,6 +95,7 @@ export function useGatewayBoot({
     handleGatewayEvent,
     onConnectionReady,
     onGatewayReady,
+    reconcileBusySessions,
     refreshHermesConfig,
     refreshSessions
   }
@@ -105,6 +125,18 @@ export function useGatewayBoot({
     // signals that fire around wake (power resume, network online, the window
     // becoming visible).
     let bootCompleted = false
+    // Failed-boot recovery (dead backend at launch): while the boot overlay
+    // shows a failure we keep re-attempting boot() on a bounded backoff — and
+    // on the wake/online/visibility nudges — instead of waiting for a manual
+    // Retry click. A genuine auth failure latches instead: no retry can
+    // succeed until the user signs in, and auto-resetting just thrashed the
+    // failure loop (the "session has expired" reset churn in the logs).
+    let bootFailed = false
+    let bootAuthLatched = false
+    let bootInProgress = false
+    let bootFailureNotified = false
+    let bootRetryTimer: ReturnType<typeof setTimeout> | null = null
+    let bootRetryAttempt = 0
     let reconnecting = false
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
     let reconnectAttempt = 0
@@ -127,6 +159,26 @@ export function useGatewayBoot({
         clearTimeout(reconnectTimer)
         reconnectTimer = null
       }
+    }
+
+    const clearBootRetryTimer = () => {
+      if (bootRetryTimer !== null) {
+        clearTimeout(bootRetryTimer)
+        bootRetryTimer = null
+      }
+    }
+
+    function scheduleBootRetry() {
+      if (cancelled || bootRetryTimer !== null || bootAuthLatched) {
+        return
+      }
+
+      const delay = bootRetryDelay(bootRetryAttempt)
+      bootRetryAttempt += 1
+      bootRetryTimer = setTimeout(() => {
+        bootRetryTimer = null
+        void boot()
+      }, delay)
     }
 
     const attemptReconnect = async () => {
@@ -169,6 +221,12 @@ export function useGatewayBoot({
         // Resync state that may have moved on the backend while we were asleep.
         await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
         await callbacksRef.current.refreshSessions().catch(() => undefined)
+        // The drop may have swallowed message.complete events for in-flight
+        // turns, leaving sessions latched busy ("Thinking…") forever. Ask the
+        // rebuilt gateway what is genuinely still running and clear the rest.
+        await callbacksRef.current
+          .reconcileBusySessions?.(gateway, normalizeProfileKey($activeGatewayProfile.get()))
+          .catch(() => undefined)
       } catch (err) {
         // OAuth session expired mid-reconnect: surface the actionable "sign in
         // again" message once instead of silently looping the backoff against a
@@ -207,7 +265,22 @@ export function useGatewayBoot({
     }
 
     const reconnectNow = () => {
-      if (cancelled || !bootCompleted) {
+      if (cancelled) {
+        return
+      }
+
+      if (!bootCompleted) {
+        // Boot never succeeded. If it FAILED on a transport error, a wake /
+        // network-online / focus signal is exactly when a retry is likely to
+        // succeed — re-drive boot() immediately (it no-ops while one is in
+        // flight). An auth-latched failure stays latched: only the sign-in
+        // flow can fix it. A boot still in progress is left alone.
+        if (bootFailed && !bootAuthLatched) {
+          clearBootRetryTimer()
+          bootRetryAttempt = 0
+          void boot()
+        }
+
         return
       }
 
@@ -237,7 +310,13 @@ export function useGatewayBoot({
     callbacksRef.current.onGatewayReady(gateway)
     setPrimaryGateway(gateway, normalizeProfileKey($activeGatewayProfile.get()))
     // Secondary (background-profile) sockets funnel into the same handler.
-    configureGatewayRegistry({ onEvent: event => callbacksRef.current.handleGatewayEvent(event) })
+    // Their reconnects run the same stale-busy reconciliation as the primary,
+    // scoped to the reconnected profile's sessions.
+    configureGatewayRegistry({
+      onEvent: event => callbacksRef.current.handleGatewayEvent(event),
+      onReconnected: (profile, secondary) =>
+        void callbacksRef.current.reconcileBusySessions?.(secondary, profile).catch(() => undefined)
+    })
 
     const offState = gateway.onState(st => {
       // Mirror to the composer only while the primary is the active profile —
@@ -332,6 +411,12 @@ export function useGatewayBoot({
     })
 
     async function boot() {
+      if (cancelled || bootInProgress || bootCompleted) {
+        return
+      }
+
+      bootInProgress = true
+
       try {
         const conn = await desktop.getConnection()
 
@@ -397,13 +482,34 @@ export function useGatewayBoot({
         await callbacksRef.current.refreshSessions()
         completeDesktopBoot()
         bootCompleted = true
+        bootFailed = false
+        bootAuthLatched = false
+        bootFailureNotified = false
+        bootRetryAttempt = 0
+        clearBootRetryTimer()
       } catch (err) {
         if (!cancelled) {
+          bootFailed = true
+          bootAuthLatched = isGatewayAuthShapedError(err)
           const message = err instanceof Error ? err.message : String(err)
           failDesktopBoot(message)
-          notifyError(err, translateNow('boot.errors.desktopBootFailed'))
+
+          // Toast once per failure episode, not on every backoff retry —
+          // identical error toasts (and their haptics) would otherwise stack
+          // every few seconds while the backend is down.
+          if (!bootFailureNotified) {
+            bootFailureNotified = true
+            notifyError(err, translateNow('boot.errors.desktopBootFailed'))
+          }
+
           setSessionsLoading(false)
+
+          if (!bootAuthLatched) {
+            scheduleBootRetry()
+          }
         }
+      } finally {
+        bootInProgress = false
       }
     }
 
@@ -412,6 +518,7 @@ export function useGatewayBoot({
     return () => {
       cancelled = true
       clearReconnectTimer()
+      clearBootRetryTimer()
       clearInterval(keepaliveTimer)
       offWorking()
       offAttention()

--- a/apps/desktop/src/app/gateway/hooks/use-reconnect-reconciliation.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-reconnect-reconciliation.test.tsx
@@ -1,0 +1,164 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import type { HermesGateway } from '@/hermes'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $sessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { useReconnectReconciliation } from './use-reconnect-reconciliation'
+
+// The B3 fix: after a socket drop + reconnect, per-session busy latches whose
+// message.complete died with the old socket must be cleared from the fresh
+// gateway's live-session snapshot — while genuinely running turns stay busy.
+
+type Reconcile = (gateway: HermesGateway, profile: string) => Promise<void>
+
+const sessionRow = (id: string, profile?: string): SessionInfo => ({ id, profile }) as unknown as SessionInfo
+
+const busyState = (storedSessionId: string | null): ClientSessionState => ({
+  ...createClientSessionState(storedSessionId),
+  busy: true,
+  awaitingResponse: true,
+  streamId: 'assistant-stream-1',
+  turnStartedAt: Date.now()
+})
+
+function makeHarness(initial: Record<string, ClientSessionState>) {
+  const cache = new Map<string, ClientSessionState>(Object.entries(initial))
+  let reconcile: Reconcile = async () => undefined
+
+  function Harness() {
+    const sessionStateByRuntimeIdRef = useRef(cache)
+
+    reconcile = useReconnectReconciliation({
+      sessionStateByRuntimeIdRef,
+      updateSessionState: (sessionId, updater) => {
+        const current = cache.get(sessionId) ?? createClientSessionState()
+        const next = updater(current)
+        cache.set(sessionId, next)
+
+        return next
+      }
+    })
+
+    return null
+  }
+
+  render(<Harness />)
+
+  return { cache, reconcile: (gateway: HermesGateway, profile: string) => reconcile(gateway, profile) }
+}
+
+const gatewayWith = (rows: unknown[] | Error): HermesGateway =>
+  ({
+    request: vi.fn(async (method: string) => {
+      expect(method).toBe('session.active_list')
+
+      if (rows instanceof Error) {
+        throw rows
+      }
+
+      return { sessions: rows }
+    })
+  }) as unknown as HermesGateway
+
+describe('useReconnectReconciliation', () => {
+  beforeEach(() => {
+    $sessions.set([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    $sessions.set([])
+  })
+
+  it('clears busy state for a session the gateway no longer knows (turn died with the socket)', async () => {
+    const { cache, reconcile } = makeHarness({ 'rt-1': busyState('stored-1') })
+
+    await reconcile(gatewayWith([]), 'default')
+
+    await waitFor(() => {
+      const state = cache.get('rt-1')!
+      expect(state.busy).toBe(false)
+      expect(state.awaitingResponse).toBe(false)
+      expect(state.streamId).toBeNull()
+      expect(state.turnStartedAt).toBeNull()
+    })
+  })
+
+  it('clears busy state when the live session reports idle', async () => {
+    const { cache, reconcile } = makeHarness({ 'rt-1': busyState('stored-1') })
+
+    await reconcile(gatewayWith([{ id: 'rt-1', session_key: 'stored-1', status: 'idle' }]), 'default')
+
+    expect(cache.get('rt-1')!.busy).toBe(false)
+  })
+
+  it('keeps a genuinely running turn busy (running:true stays busy)', async () => {
+    const { cache, reconcile } = makeHarness({ 'rt-1': busyState('stored-1') })
+
+    await reconcile(gatewayWith([{ id: 'rt-1', session_key: 'stored-1', status: 'working' }]), 'default')
+
+    expect(cache.get('rt-1')!.busy).toBe(true)
+    expect(cache.get('rt-1')!.awaitingResponse).toBe(true)
+  })
+
+  it('keeps a turn blocked on a user prompt (waiting) busy with its needsInput intact', async () => {
+    const { cache, reconcile } = makeHarness({
+      'rt-1': { ...busyState('stored-1'), needsInput: true }
+    })
+
+    await reconcile(gatewayWith([{ id: 'rt-1', status: 'waiting' }]), 'default')
+
+    expect(cache.get('rt-1')!.busy).toBe(true)
+    expect(cache.get('rt-1')!.needsInput).toBe(true)
+  })
+
+  it('matches live rows by stored session key when the runtime id rotated', async () => {
+    const { cache, reconcile } = makeHarness({ 'rt-old': busyState('stored-1') })
+
+    await reconcile(gatewayWith([{ id: 'rt-new', session_key: 'stored-1', status: 'working' }]), 'default')
+
+    expect(cache.get('rt-old')!.busy).toBe(true)
+  })
+
+  it("leaves another profile's sessions to that profile's own reconnect", async () => {
+    $sessions.set([sessionRow('stored-james', 'pm-james')])
+    const { cache, reconcile } = makeHarness({ 'rt-james': busyState('stored-james') })
+
+    await reconcile(gatewayWith([]), 'default')
+
+    expect(cache.get('rt-james')!.busy).toBe(true)
+  })
+
+  it('reconciles a session whose profile matches the reconnected gateway', async () => {
+    $sessions.set([sessionRow('stored-james', 'pm-james')])
+    const { cache, reconcile } = makeHarness({ 'rt-james': busyState('stored-james') })
+
+    await reconcile(gatewayWith([]), 'pm-james')
+
+    expect(cache.get('rt-james')!.busy).toBe(false)
+  })
+
+  it('keeps every latch when the live-session probe fails (half-open socket)', async () => {
+    const { cache, reconcile } = makeHarness({ 'rt-1': busyState('stored-1') })
+
+    await reconcile(gatewayWith(new Error('request timed out: session.active_list')), 'default')
+
+    expect(cache.get('rt-1')!.busy).toBe(true)
+  })
+
+  it('does not touch idle sessions and skips the probe entirely when nothing is busy', async () => {
+    const idle = createClientSessionState('stored-1')
+    const { cache, reconcile } = makeHarness({ 'rt-1': idle })
+    const gateway = gatewayWith([])
+
+    await reconcile(gateway, 'default')
+
+    expect(cache.get('rt-1')).toBe(idle)
+    expect((gateway as unknown as { request: ReturnType<typeof vi.fn> }).request).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/gateway/hooks/use-reconnect-reconciliation.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-reconnect-reconciliation.ts
@@ -1,0 +1,127 @@
+import { type MutableRefObject, useCallback } from 'react'
+
+import type { HermesGateway } from '@/hermes'
+import { normalizeProfileKey } from '@/store/profile'
+import { $sessions } from '@/store/session'
+
+import type { ClientSessionState } from '../../types'
+
+// A dropped socket swallows the terminal events (message.complete / error) of
+// any in-flight turn, leaving its ClientSessionState latched busy — the
+// "composer stuck on Thinking… until manual Stop" bug. After a successful
+// reconnect we ask the gateway which runtime sessions are GENUINELY still
+// occupied (session.active_list reports live status per in-memory session) and
+// clear the stale busy/awaitingResponse latches for everything else. Turns the
+// backend kept running through the drop stay busy — their next events stream
+// in over the fresh socket.
+
+// Live statuses that keep the client-side busy latch: the turn is still
+// running ('working'), the agent is still building ('starting'), or the turn
+// is blocked on a user prompt ('waiting'). Anything else — including a session
+// the gateway no longer knows (grace-reaped or backend restarted) — means the
+// turn's completion can never arrive, so busy must be cleared.
+const LIVE_BUSY_STATUSES = new Set(['starting', 'waiting', 'working'])
+
+interface LiveSessionRow {
+  id?: string
+  session_key?: string
+  status?: string
+}
+
+interface ReconnectReconciliationOptions {
+  sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}
+
+/** Profile that owns a cached session, resolved through the sidebar list (the
+ *  runtime cache doesn't record it). Null when the row isn't loaded — treated
+ *  as belonging to the reconciling gateway, since sessions started in this
+ *  window always ride the profile socket that created them. */
+function cachedSessionProfile(storedSessionId: string | null): null | string {
+  if (!storedSessionId) {
+    return null
+  }
+
+  const row = $sessions.get().find(s => s.id === storedSessionId || s._lineage_root_id === storedSessionId)
+
+  return row ? normalizeProfileKey(row.profile) : null
+}
+
+export function useReconnectReconciliation({
+  sessionStateByRuntimeIdRef,
+  updateSessionState
+}: ReconnectReconciliationOptions) {
+  return useCallback(
+    async (gateway: HermesGateway, profile: string) => {
+      const profileKey = normalizeProfileKey(profile)
+
+      const stuck = [...sessionStateByRuntimeIdRef.current.entries()].filter(
+        ([, state]) => state.busy || state.awaitingResponse
+      )
+
+      if (stuck.length === 0) {
+        return
+      }
+
+      // If the probe itself fails we keep every latch: better a lingering
+      // spinner (the next reconnect retries) than clearing a genuinely
+      // running turn on a half-open socket.
+      let rows: LiveSessionRow[]
+
+      try {
+        const result = await gateway.request<{ sessions?: LiveSessionRow[] }>('session.active_list', {})
+        rows = Array.isArray(result?.sessions) ? result.sessions : []
+      } catch {
+        return
+      }
+
+      const statusByRuntimeId = new Map<string, string>()
+      const statusByStoredKey = new Map<string, string>()
+
+      for (const row of rows) {
+        const status = typeof row.status === 'string' ? row.status : ''
+
+        if (row.id) {
+          statusByRuntimeId.set(row.id, status)
+        }
+
+        if (row.session_key) {
+          statusByStoredKey.set(row.session_key, status)
+        }
+      }
+
+      for (const [runtimeId, state] of stuck) {
+        // Sessions owned by another profile's socket are that socket's problem
+        // — its own reconnect runs this reconciliation with its profile key.
+        const owner = cachedSessionProfile(state.storedSessionId)
+
+        if (owner !== null && owner !== profileKey) {
+          continue
+        }
+
+        const status =
+          statusByRuntimeId.get(runtimeId) ??
+          (state.storedSessionId ? statusByStoredKey.get(state.storedSessionId) : undefined)
+
+        if (status && LIVE_BUSY_STATUSES.has(status)) {
+          continue
+        }
+
+        updateSessionState(runtimeId, current => ({
+          ...current,
+          awaitingResponse: false,
+          busy: false,
+          needsInput: false,
+          pendingBranchGroup: null,
+          streamId: null,
+          turnStartedAt: null
+        }))
+      }
+    },
+    [sessionStateByRuntimeIdRef, updateSessionState]
+  )
+}

--- a/apps/desktop/src/app/session/hooks/refresh-coalescer.test.ts
+++ b/apps/desktop/src/app/session/hooks/refresh-coalescer.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTrailingCoalescer } from './refresh-coalescer'
+
+describe('createTrailingCoalescer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('collapses a burst of schedule() calls into one trailing run', async () => {
+    const run = vi.fn(async () => undefined)
+    const coalescer = createTrailingCoalescer(run, 1_500)
+
+    coalescer.schedule()
+    coalescer.schedule()
+    coalescer.schedule()
+
+    expect(run).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_500)
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs again after the window for schedules in a later burst', async () => {
+    const run = vi.fn(async () => undefined)
+    const coalescer = createTrailingCoalescer(run, 1_500)
+
+    coalescer.schedule()
+    await vi.advanceTimersByTimeAsync(1_500)
+    expect(run).toHaveBeenCalledTimes(1)
+
+    coalescer.schedule()
+    await vi.advanceTimersByTimeAsync(1_500)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('queues at most one follow-up while a run is in flight (single-flight)', async () => {
+    let release: () => void = () => undefined
+
+    const run = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          release = resolve
+        })
+    )
+
+    const coalescer = createTrailingCoalescer(run, 100)
+
+    coalescer.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(1)
+
+    // Three more bursts land while the first run is still awaiting its fetch.
+    coalescer.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+    coalescer.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(run).toHaveBeenCalledTimes(1)
+
+    release()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Exactly one chained follow-up, not one per burst.
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('swallows run() rejections and keeps working', async () => {
+    const run = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValue(undefined)
+    const coalescer = createTrailingCoalescer(run, 100)
+
+    coalescer.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(1)
+
+    coalescer.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancel() drops the pending timer and queued follow-up', async () => {
+    const run = vi.fn(async () => undefined)
+    const coalescer = createTrailingCoalescer(run, 100)
+
+    coalescer.schedule()
+    coalescer.cancel()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(run).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/refresh-coalescer.ts
+++ b/apps/desktop/src/app/session/hooks/refresh-coalescer.ts
@@ -1,0 +1,68 @@
+// Trailing coalescer for gateway-event-driven refreshes. At swarm scale every
+// session heartbeat / turn completion wants to re-fetch some REST surface;
+// firing them 1:1 turns N busy sessions into an O(N) request storm against the
+// (possibly remote, Tailscale'd) backend. schedule() arms a single trailing
+// timer — repeat calls inside the window coalesce into one run — and the run
+// itself is single-flight: calls arriving while a run is in flight queue at
+// most ONE follow-up run after it settles, so results can't interleave.
+
+export interface TrailingCoalescer {
+  /** Ask for a run. Coalesces with any already-pending request. */
+  schedule: () => void
+  /** Drop the pending timer + queued follow-up (unmount cleanup). */
+  cancel: () => void
+}
+
+export function createTrailingCoalescer(run: () => Promise<unknown> | unknown, delayMs: number): TrailingCoalescer {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let inFlight = false
+  let rerunQueued = false
+  let cancelled = false
+
+  const execute = (): void => {
+    if (cancelled) {
+      return
+    }
+
+    if (inFlight) {
+      rerunQueued = true
+
+      return
+    }
+
+    inFlight = true
+    void Promise.resolve()
+      .then(run)
+      .catch(() => undefined)
+      .then(() => {
+        inFlight = false
+
+        if (rerunQueued && !cancelled) {
+          rerunQueued = false
+          execute()
+        }
+      })
+  }
+
+  return {
+    schedule() {
+      if (cancelled || timer !== null) {
+        return
+      }
+
+      timer = setTimeout(() => {
+        timer = null
+        execute()
+      }, delayMs)
+    },
+    cancel() {
+      cancelled = true
+      rerunQueued = false
+
+      if (timer !== null) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+  }
+}

--- a/apps/desktop/src/app/session/hooks/use-message-stream/config-refresh.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/config-refresh.test.tsx
@@ -1,0 +1,114 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+// B4(a): session.info used to trigger an immediate, unconditional
+// refreshHermesConfig() (= /api/config + /api/config/defaults) per event.
+// The handler must now debounce the refetch and skip events that can't have
+// changed config-derived state (background session, no personality/cwd field).
+
+const ACTIVE_SID = 'session-active'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let refreshHermesConfig: ReturnType<typeof vi.fn>
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(ACTIVE_SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: refreshHermesConfig as unknown as () => Promise<void>,
+    scheduleSessionsRefresh: vi.fn(),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+const sessionInfo = (sessionId: string, payload: Record<string, unknown> = {}) =>
+  act(() => handleEvent!({ payload, session_id: sessionId, type: 'session.info' }))
+
+describe('session.info config-refresh damping', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    handleEvent = null
+    refreshHermesConfig = vi.fn(async () => undefined)
+    render(<Harness />)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('debounces a burst of active-session heartbeats into one trailing refetch', async () => {
+    sessionInfo(ACTIVE_SID, { running: true })
+    sessionInfo(ACTIVE_SID, { running: true })
+    sessionInfo(ACTIVE_SID, { running: false })
+
+    expect(refreshHermesConfig).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    expect(refreshHermesConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips background-session events that carry no config-backed fields', async () => {
+    sessionInfo('session-background', { running: false })
+    sessionInfo('session-background', { usage: { total: 1 } })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+    })
+
+    expect(refreshHermesConfig).not.toHaveBeenCalled()
+  })
+
+  it('still refetches when a background event carries a config-backed field (personality)', async () => {
+    sessionInfo('session-background', { personality: 'hacker' })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    expect(refreshHermesConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches again for events after the debounce window', async () => {
+    sessionInfo(ACTIVE_SID, { running: true })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+    expect(refreshHermesConfig).toHaveBeenCalledTimes(1)
+
+    sessionInfo(ACTIVE_SID, { running: false })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+    expect(refreshHermesConfig).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -1,5 +1,5 @@
 import type { QueryClient } from '@tanstack/react-query'
-import { type MutableRefObject, useCallback } from 'react'
+import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { writeAgentTerminalChunk } from '@/app/right-sidebar/terminal/agent-terminal-stream'
 import { readActiveTerminal } from '@/app/right-sidebar/terminal/buffer'
@@ -46,6 +46,16 @@ import type { ClientSessionState } from '../../../types'
 
 import { hasSessionInfoStatePatch, sessionInfoStatePatch, SUBAGENT_EVENT_TYPES, toTodoPayload } from './utils'
 
+// Trailing-debounce window for session.info-driven config refetches. Every
+// session.info used to fire an immediate /api/config + /api/config/defaults
+// pair; with many concurrent sessions (each emitting session.info at turn
+// boundaries and settings changes, across every profile socket) that's a
+// steady 2-requests-per-event drip against the shared backend. One trailing
+// refetch per window keeps config-derived state fresh enough — the fields the
+// composer needs immediately (model/provider/personality/cwd) are applied
+// straight from the event payload above, not from the refetch.
+const CONFIG_REFRESH_DEBOUNCE_MS = 5_000
+
 interface GatewayEventDeps {
   activeSessionIdRef: MutableRefObject<string | null>
   compactedTurnRef: MutableRefObject<Set<string>>
@@ -90,6 +100,31 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
     updateSessionState,
     upsertToolCall
   } = deps
+
+  const configRefreshTimerRef = useRef<null | ReturnType<typeof setTimeout>>(null)
+  const refreshHermesConfigRef = useRef(refreshHermesConfig)
+  refreshHermesConfigRef.current = refreshHermesConfig
+
+  const scheduleConfigRefresh = useCallback(() => {
+    if (configRefreshTimerRef.current !== null) {
+      return
+    }
+
+    configRefreshTimerRef.current = setTimeout(() => {
+      configRefreshTimerRef.current = null
+      void refreshHermesConfigRef.current()
+    }, CONFIG_REFRESH_DEBOUNCE_MS)
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (configRefreshTimerRef.current !== null) {
+        clearTimeout(configRefreshTimerRef.current)
+        configRefreshTimerRef.current = null
+      }
+    },
+    []
+  )
 
   return useCallback(
     (event: RpcEvent) => {
@@ -216,7 +251,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           requestDesktopOnboarding(payload.credential_warning)
         }
 
-        void refreshHermesConfig()
+        // Refetch config only when this event can actually change
+        // config-derived state: it carries a config-backed field
+        // (personality / cwd) or it targets the session on screen. A
+        // background profile's turn-boundary heartbeat changes neither.
+        if (isActiveEvent || typeof payload?.personality === 'string' || typeof payload?.cwd === 'string') {
+          scheduleConfigRefresh()
+        }
 
         if (modelChanged || providerChanged) {
           void queryClient.invalidateQueries({
@@ -646,7 +687,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       lastCwdInfoSessionRef,
       nativeSubagentSessionsRef,
       queryClient,
-      refreshHermesConfig,
+      scheduleConfigRefresh,
       sessionInterrupted,
       updateSessionState,
       upsertToolCall

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -39,7 +39,10 @@ interface MessageStreamOptions {
   ) => Promise<void>
   queryClient: QueryClient
   refreshHermesConfig: () => Promise<void>
-  refreshSessions: () => Promise<void>
+  /** Coalesced sidebar refresh — every message.complete asks for one, so the
+   *  callback must debounce/single-flight internally (scheduleSessionsRefresh),
+   *  not fire a full 4-fetch fan-out per completed turn. */
+  scheduleSessionsRefresh: () => void
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
   updateSessionState: (
     sessionId: string,
@@ -58,7 +61,7 @@ export function useMessageStream({
   hydrateFromStoredSession,
   queryClient,
   refreshHermesConfig,
-  refreshSessions,
+  scheduleSessionsRefresh,
   sessionStateByRuntimeIdRef,
   updateSessionState
 }: MessageStreamOptions) {
@@ -444,7 +447,7 @@ export function useMessageStream({
         }
       })
 
-      void refreshSessions().catch(() => undefined)
+      scheduleSessionsRefresh()
       // Sync the freshly-titled row to other windows (e.g. main, when the turn
       // ran in the pop-out).
       broadcastSessionsChanged()
@@ -464,7 +467,7 @@ export function useMessageStream({
         title: translateNow('notifications.native.turnDoneTitle')
       })
     },
-    [hydrateFromStoredSession, refreshSessions, updateSessionState]
+    [hydrateFromStoredSession, scheduleSessionsRefresh, updateSessionState]
   )
 
   const failAssistantMessage = useCallback(

--- a/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/todo-cleanup.test.tsx
@@ -26,7 +26,7 @@ function Harness() {
     hydrateFromStoredSession: vi.fn(async () => undefined),
     queryClient: queryClientRef.current,
     refreshHermesConfig: vi.fn(async () => undefined),
-    refreshSessions: vi.fn(async () => undefined),
+    scheduleSessionsRefresh: vi.fn(),
     sessionStateByRuntimeIdRef,
     updateSessionState: (sessionId, updater) => {
       const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -1,0 +1,99 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSessionListActions } from './use-session-list-actions'
+
+// B4(b): every message.complete used to fire a full 4-request sidebar refresh
+// (recents + cron sessions + cron jobs + messaging). scheduleSessionsRefresh
+// must coalesce bursts into one trailing refresh, and the ancillary fan-out
+// must be bounded to its own longer interval.
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCronJobs: vi.fn(async () => []),
+  listAllProfileSessions: vi.fn(async () => ({ sessions: [], total: 0, profile_totals: {} }))
+}))
+
+const { getCronJobs, listAllProfileSessions } = await import('@/hermes')
+
+type Actions = ReturnType<typeof useSessionListActions>
+
+let actions: Actions | null = null
+
+function Harness() {
+  actions = useSessionListActions({ profileScope: 'default' })
+
+  return null
+}
+
+describe('useSessionListActions refresh coalescing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(listAllProfileSessions).mockClear()
+    vi.mocked(getCronJobs).mockClear()
+    actions = null
+    render(<Harness />)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('collapses a burst of scheduleSessionsRefresh calls into one trailing refresh', async () => {
+    await act(async () => {
+      actions!.scheduleSessionsRefresh()
+      actions!.scheduleSessionsRefresh()
+      actions!.scheduleSessionsRefresh()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(listAllProfileSessions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_500)
+    })
+
+    // One recents fetch + the first ancillary fan-out (cron sessions +
+    // messaging slice), NOT one fetch per scheduled call.
+    expect(vi.mocked(listAllProfileSessions).mock.calls).toHaveLength(3)
+    expect(getCronJobs).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the ancillary fan-out for refreshes inside the throttle window', async () => {
+    await act(async () => {
+      actions!.scheduleSessionsRefresh()
+      await vi.advanceTimersByTimeAsync(1_500)
+    })
+
+    expect(getCronJobs).toHaveBeenCalledTimes(1)
+    const callsAfterFirst = vi.mocked(listAllProfileSessions).mock.calls.length
+
+    // A second completed turn 5s later: recents refresh only.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+      actions!.scheduleSessionsRefresh()
+      await vi.advanceTimersByTimeAsync(1_500)
+    })
+
+    expect(vi.mocked(listAllProfileSessions).mock.calls).toHaveLength(callsAfterFirst + 1)
+    expect(getCronJobs).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-runs the ancillary fan-out once the throttle interval has elapsed', async () => {
+    await act(async () => {
+      actions!.scheduleSessionsRefresh()
+      await vi.advanceTimersByTimeAsync(1_500)
+    })
+
+    expect(getCronJobs).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000)
+      actions!.scheduleSessionsRefresh()
+      await vi.advanceTimersByTimeAsync(1_500)
+    })
+
+    expect(getCronJobs).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { getCronJobs, listAllProfileSessions, type SessionInfo } from '@/hermes'
 import {
@@ -31,6 +31,8 @@ import {
 
 import { sameCronSignature } from '../../desktop-controller-utils'
 
+import { createTrailingCoalescer, type TrailingCoalescer } from './refresh-coalescer'
+
 // The recents list is local-only: cron rows have their own section, and each
 // messaging platform (telegram, discord, …) is fetched separately into its own
 // self-managed sidebar section (refreshMessagingSessions). Excluding both here
@@ -40,6 +42,19 @@ const SIDEBAR_EXCLUDED_SOURCES = ['cron', 'subagent', 'tool', ...MESSAGING_SESSI
 // The messaging slice is the inverse: drop cron + every local source so only
 // external-platform conversations remain, then split per platform in the UI.
 const MESSAGING_EXCLUDED_SOURCES = ['cron', ...LOCAL_SESSION_SOURCE_IDS]
+
+// Trailing window for coalescing event-driven refreshes (message.complete,
+// cross-window sessions-changed). With a swarm of concurrent sessions each
+// completed turn fired its own full refresh; one refresh per window of
+// completions is plenty for a sidebar.
+const SESSIONS_REFRESH_DEBOUNCE_MS = 1_500
+
+// The ancillary sections (cron runs/jobs + messaging slices) change far more
+// slowly than local recents, and cron jobs additionally ride their own poll
+// (CRON_POLL_INTERVAL_MS). Re-fetching all three on every refreshSessions
+// turned each completed turn into a 4-request fan-out — bound them to at most
+// once per interval instead.
+const ANCILLARY_REFRESH_MIN_INTERVAL_MS = 30_000
 
 // Rows a session refresh must preserve even if the aggregator omits them:
 // in-flight first turns (message_count 0), pinned rows aged off the page, the
@@ -76,6 +91,7 @@ interface UseSessionListActionsArgs {
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
   const refreshSessionsRequestRef = useRef(0)
+  const lastAncillaryRefreshAtRef = useRef(0)
 
   // Cron-job sessions as their own list (latest N). Independent of the recents
   // page so the two never compete for slots. Cheap + bounded. Kept (even though
@@ -188,10 +204,41 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       }
     }
 
-    void refreshCronSessions()
-    void refreshCronJobs()
-    void refreshMessagingSessions()
+    const now = Date.now()
+
+    if (now - lastAncillaryRefreshAtRef.current >= ANCILLARY_REFRESH_MIN_INTERVAL_MS) {
+      lastAncillaryRefreshAtRef.current = now
+      void refreshCronSessions()
+      void refreshCronJobs()
+      void refreshMessagingSessions()
+    }
   }, [profileScope, refreshCronSessions, refreshCronJobs, refreshMessagingSessions])
+
+  // Event-driven refreshes (every message.complete, every cross-window
+  // sessions-changed broadcast) go through this coalesced entry point instead
+  // of calling refreshSessions directly: one trailing run per burst, single
+  // flight so concurrent responses can't race. Deliberate user actions (boot,
+  // paging, profile switch) keep the immediate awaited refreshSessions().
+  const refreshSessionsLatestRef = useRef<() => Promise<void>>(refreshSessions)
+  refreshSessionsLatestRef.current = refreshSessions
+
+  const coalescerRef = useRef<TrailingCoalescer | null>(null)
+
+  useEffect(
+    () => () => {
+      coalescerRef.current?.cancel()
+      coalescerRef.current = null
+    },
+    []
+  )
+
+  const scheduleSessionsRefresh = useCallback(() => {
+    coalescerRef.current ??= createTrailingCoalescer(
+      () => refreshSessionsLatestRef.current(),
+      SESSIONS_REFRESH_DEBOUNCE_MS
+    )
+    coalescerRef.current.schedule()
+  }, [])
 
   const loadMoreSessions = useCallback(async () => {
     bumpSessionsLimit()
@@ -226,6 +273,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     loadMoreSessionsForProfile,
     refreshCronJobs,
     refreshMessagingSessions,
-    refreshSessions
+    refreshSessions,
+    scheduleSessionsRefresh
   }
 }

--- a/apps/desktop/src/lib/gateway-ws-url.test.ts
+++ b/apps/desktop/src/lib/gateway-ws-url.test.ts
@@ -1,4 +1,9 @@
-import { GatewayReauthRequiredError, isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
+import {
+  GatewayReauthRequiredError,
+  isGatewayAuthShapedError,
+  isGatewayReauthRequired,
+  resolveGatewayWsUrl
+} from '@hermes/shared'
 import { describe, expect, it, vi } from 'vitest'
 
 const oauthConn = { authMode: 'oauth' as const, wsUrl: 'ws://host/api/ws?ticket=stale' }
@@ -37,6 +42,47 @@ describe('resolveGatewayWsUrl', () => {
       expect(result).toBe('threw')
       expect(result).not.toBe(oauthConn.wsUrl)
     })
+
+    it('rethrows a transport timeout as-is instead of misreporting an expired session', async () => {
+      const cause = new Error('Timed out connecting to Hermes backend after 8000ms')
+      const getGatewayWsUrl = vi.fn().mockRejectedValue(cause)
+      const error = await resolveGatewayWsUrl({ getGatewayWsUrl }, oauthConn).catch(e => e)
+      expect(error).toBe(cause)
+      expect(isGatewayReauthRequired(error)).toBe(false)
+    })
+
+    it('rethrows connection-refused / unreachable-host mint failures as retryable', async () => {
+      const cause = new Error('net::ERR_CONNECTION_REFUSED')
+      const getGatewayWsUrl = vi.fn().mockRejectedValue(cause)
+      await expect(resolveGatewayWsUrl({ getGatewayWsUrl }, oauthConn)).rejects.toBe(cause)
+    })
+
+    it('maps a 401-status mint failure to a reauth error', async () => {
+      const getGatewayWsUrl = vi.fn().mockRejectedValue(new Error('401: {"detail":"session cookie expired"}'))
+      await expect(resolveGatewayWsUrl({ getGatewayWsUrl }, oauthConn)).rejects.toBeInstanceOf(
+        GatewayReauthRequiredError
+      )
+    })
+
+    it('maps an error carrying statusCode 403 to a reauth error', async () => {
+      const cause = Object.assign(new Error('Forbidden'), { statusCode: 403 })
+      const getGatewayWsUrl = vi.fn().mockRejectedValue(cause)
+      await expect(resolveGatewayWsUrl({ getGatewayWsUrl }, oauthConn)).rejects.toBeInstanceOf(
+        GatewayReauthRequiredError
+      )
+    })
+
+    it('maps an IPC-flattened main-process reauth message to a reauth error', async () => {
+      const cause = new Error(
+        "Error invoking remote method 'hermes:gateway:ws-url': Error: " +
+          'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
+      )
+
+      const getGatewayWsUrl = vi.fn().mockRejectedValue(cause)
+      await expect(resolveGatewayWsUrl({ getGatewayWsUrl }, oauthConn)).rejects.toBeInstanceOf(
+        GatewayReauthRequiredError
+      )
+    })
   })
 
   describe('token / local mode', () => {
@@ -73,5 +119,30 @@ describe('isGatewayReauthRequired', () => {
     expect(isGatewayReauthRequired(new Error('connection closed'))).toBe(false)
     expect(isGatewayReauthRequired(null)).toBe(false)
     expect(isGatewayReauthRequired('string')).toBe(false)
+  })
+})
+
+describe('isGatewayAuthShapedError', () => {
+  it('accepts explicit reauth markers, auth status codes, and canonical reauth phrasings', () => {
+    expect(isGatewayAuthShapedError(new GatewayReauthRequiredError('x'))).toBe(true)
+    expect(isGatewayAuthShapedError({ needsOauthLogin: true })).toBe(true)
+    expect(isGatewayAuthShapedError(Object.assign(new Error('nope'), { statusCode: 401 }))).toBe(true)
+    expect(isGatewayAuthShapedError(new Error('403: forbidden'))).toBe(true)
+    expect(isGatewayAuthShapedError(new Error('Your remote gateway session has expired. Sign in again.'))).toBe(true)
+    expect(isGatewayAuthShapedError(new Error('Remote Hermes gateway uses OAuth, but you are not signed in.'))).toBe(
+      true
+    )
+  })
+
+  it('rejects transport failures', () => {
+    expect(isGatewayAuthShapedError(new Error('Timed out connecting to Hermes backend after 15000ms'))).toBe(false)
+    expect(isGatewayAuthShapedError(new Error('net::ERR_CONNECTION_REFUSED'))).toBe(false)
+    expect(isGatewayAuthShapedError(new Error('Could not connect to Hermes gateway'))).toBe(false)
+    expect(isGatewayAuthShapedError(null)).toBe(false)
+  })
+
+  it('does not false-positive on incidental digit runs containing 401/403', () => {
+    expect(isGatewayAuthShapedError(new Error('backend pid 84012 exited'))).toBe(false)
+    expect(isGatewayAuthShapedError(new Error('http://host:64013 unreachable'))).toBe(false)
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -27,6 +27,9 @@ export const $gateway = atom<HermesGateway | null>(null)
 
 interface RegistryConfig {
   onEvent: (event: GatewayEvent) => void
+  /** A secondary's socket came back after a drop. Lets the owner reconcile
+   *  per-session busy state whose terminal events died with the old socket. */
+  onReconnected?: (profile: string, gateway: HermesGateway) => void
 }
 
 let config: RegistryConfig | null = null
@@ -139,6 +142,7 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
   try {
     await openSecondary(entry)
     entry.reconnectAttempt = 0
+    config?.onReconnected?.(entry.profile, entry.gateway)
   } catch {
     // Transport failure → fall through to the backoff below.
   } finally {

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -11,6 +11,7 @@ export {
 export {
   GatewayReauthRequiredError,
   buildHermesWebSocketUrl,
+  isGatewayAuthShapedError,
   isGatewayReauthRequired,
   resolveGatewayWsUrl,
   type GatewayAuthMode,

--- a/apps/shared/src/websocket-url.ts
+++ b/apps/shared/src/websocket-url.ts
@@ -31,6 +31,37 @@ export function isGatewayReauthRequired(error: unknown): error is GatewayReauthR
   )
 }
 
+// HTTP auth statuses embedded in gateway/main-process error messages, e.g.
+// "401: {...}" from fetchJson or "status 403" from the HTML guard. Errors that
+// cross Electron's IPC bridge keep only their message (statusCode and
+// needsOauthLogin are stripped), so message inspection is the only renderer-side
+// signal. Word-boundary anchored so ports/ids containing "401" don't match.
+const AUTH_STATUS_PATTERN = /(?:^|[^0-9])(?:401|403)(?:[^0-9]|$)/
+// Canonical reauth phrasings the main process throws only for genuine
+// sign-in-required failures (buildRemoteConnection / mintGatewayWsTicket).
+const AUTH_MESSAGE_PATTERN = /session has expired|not signed in|sign in/i
+
+/** True when an error (possibly IPC-flattened to just a message) indicates the
+ *  gateway rejected our credentials — as opposed to a transport failure
+ *  (timeout, unreachable host) that a retry can recover from. */
+export function isGatewayAuthShapedError(error: unknown): boolean {
+  if (isGatewayReauthRequired(error)) {
+    return true
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const statusCode = (error as { statusCode?: unknown }).statusCode
+
+    if (statusCode === 401 || statusCode === 403) {
+      return true
+    }
+  }
+
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
+
+  return AUTH_STATUS_PATTERN.test(message) || AUTH_MESSAGE_PATTERN.test(message)
+}
+
 export async function resolveGatewayWsUrl(deps: ResolveGatewayWsUrlDeps, conn: GatewayWsConnection): Promise<string> {
   const mint = deps.getGatewayWsUrl
   const profile = conn.profile ?? null
@@ -45,10 +76,19 @@ export async function resolveGatewayWsUrl(deps: ResolveGatewayWsUrlDeps, conn: G
     try {
       return await mint(profile)
     } catch (error) {
-      throw new GatewayReauthRequiredError(
-        'Your remote gateway session has expired. Open Settings -> Gateway and click "Sign in" again.',
-        { cause: error }
-      )
+      // Only a credential rejection means the OAuth session is dead. A
+      // transport failure (Tailscale blip, sleep/wake race, backend restart)
+      // must stay a plain retryable error — wrapping it as reauth here sent
+      // users to a needless re-sign-in while the backoff loop would have
+      // recovered on its own.
+      if (isGatewayAuthShapedError(error)) {
+        throw new GatewayReauthRequiredError(
+          'Your remote gateway session has expired. Open Settings -> Gateway and click "Sign in" again.',
+          { cause: error }
+        )
+      }
+
+      throw error
     }
   }
 


### PR DESCRIPTION
## Problem

Three renderer lifecycle gaps, reproduced on a Desktop running in global remote mode with many concurrent sessions:

1. **Dead-at-launch is unrecoverable without a click**: `reconnectNow()` early-returns while `!bootCompleted`, and a failed `boot()` only latches the failure — so a backend unreachable at app start (VPN tunnel not yet up after login) leaves the boot-failure overlay until a manual retry, even after the network comes back.
2. **Mid-stream disconnect strands the composer on 'Thinking…' forever**: on reconnect only `refreshHermesConfig()`+`refreshSessions()` run. Nothing resets per-session `busy`/`awaitingResponse` for turns whose `message.complete` died with the socket; the 8-min watchdog clears only sidebar spinners; the `running:false` guard deliberately skips pre-first-delta turns.
3. **Event-driven refresh storms**: every `session.info` triggers an unthrottled `/api/config` + `/api/config/defaults` double-fetch, and every `message.complete` from any profile socket triggers a 4-request sidebar fan-out (recents + cron sessions + cron jobs + messaging). With N busy sessions this is O(N) request storms at the backend.

Plus the renderer twin of the main-process misclassification fixed in #58108: `resolveGatewayWsUrl` wraps *any* ticket-mint failure into `GatewayReauthRequiredError`.

## Fix

- `resolveGatewayWsUrl` (apps/shared/websocket-url.ts) wraps mint failures as reauth **only when auth-shaped** (new `isGatewayAuthShapedError`: needsOauthLogin / statusCode 401-403 / word-bounded 401|403 markers / canonical reauth phrasings — IPC-flatten-safe); transport errors rethrow unchanged so every caller keeps its backoff.
- Failed initial boot auto-retries on **5s/15s/30s/60s-cap backoff with ±20% jitter**, and wake/online/visibility nudges re-drive `boot()` immediately when the previous failure was transport-shaped. Genuine auth failures **latch** (sign-in overlay stays; no thrash). Double-boot guarded; retry timer cleaned on unmount.
- New `useReconnectReconciliation`: after a successful reconnect (primary or secondary socket), queries `session.active_list` on that gateway and clears `busy`/`awaitingResponse`/`streamId` for cached-busy sessions that are no longer working/starting/waiting — composer included. Probe failure keeps every latch (conservative). Secondary sockets get the same treatment via a new optional `onReconnected` registry hook.
- New `createTrailingCoalescer` (trailing coalesce + single-flight + at-most-one queued follow-up): `refreshSessions` coalesced at 1.5s with the cron/messaging ancillary fan-out throttled to once per 30s; `session.info` config refetch debounced at 5s and gated to events that can actually change config-derived state.

## Tests

31 new/updated vitest cases across `gateway-ws-url.test.ts` (20), `use-gateway-boot.test.tsx` (transport-retry/auth-latch/nudge/reconcile-once), `use-reconnect-reconciliation.test.tsx` (9), `refresh-coalescer.test.ts` (5), `use-session-list-actions.test.tsx` (3), `config-refresh.test.tsx` (4). Full desktop typecheck + lint clean; no regressions in the suite (verified against a stash baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)