### PR TITLE
fix(desktop): profile-scope cron/messaging REST calls; contain message render errors

### DIFF
--- a/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
@@ -64,17 +64,53 @@ describe('MessageRenderBoundary', () => {
     spy.mockRestore()
   })
 
-  it('re-throws unrelated errors so real bugs still surface', () => {
+  it('contains unrelated errors to an inline fallback instead of unwinding to the root', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
-    expect(() =>
-      render(
-        <MessageRenderBoundary resetKey="a">
-          <Boom error={new Error('genuine render bug')} />
-        </MessageRenderBoundary>
-      )
-    ).toThrow('genuine render bug')
+    render(
+      <MessageRenderBoundary resetKey="a">
+        <Boom error={new Error('genuine render bug')} />
+      </MessageRenderBoundary>
+    )
 
+    expect(screen.getByRole('alert').textContent).toBe('This message failed to render.')
+    expect(spy).toHaveBeenCalledWith(
+      '[message-render-boundary]',
+      expect.objectContaining({ message: 'genuine render bug' })
+    )
+    spy.mockRestore()
+  })
+
+  it('does not tag the transient lookup race in the console', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    render(
+      <MessageRenderBoundary resetKey="a">
+        <Boom error={lookupError} />
+      </MessageRenderBoundary>
+    )
+
+    const tagged = spy.mock.calls.filter(call => call[0] === '[message-render-boundary]')
+    expect(tagged).toEqual([])
+    spy.mockRestore()
+  })
+
+  it('recovers from a contained error when resetKey changes', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const { rerender } = render(
+      <MessageRenderBoundary resetKey="a">
+        <Boom error={new Error('genuine render bug')} />
+      </MessageRenderBoundary>
+    )
+
+    rerender(
+      <MessageRenderBoundary resetKey="b">
+        <div>recovered</div>
+      </MessageRenderBoundary>
+    )
+
+    expect(screen.getByText('recovered')).toBeTruthy()
     spy.mockRestore()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/message-render-boundary.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-render-boundary.tsx
@@ -1,16 +1,31 @@
 import { Component, type ReactNode } from 'react'
 
+import { useI18n } from '@/i18n'
+
 // `@assistant-ui/store`'s index-keyed child-scope lookup (`tapClientLookup`)
 // throws — rather than returning undefined — when a subscriber reads an index
 // that the message/parts list no longer has. This races during high-frequency
 // store replacement (session switch mid-stream, gateway reconnect replay): a
 // subscriber from the previous, longer list is still in React's notification
 // queue and reads one slot past the new, shorter array before it can unmount.
-// The throw is transient and self-heals on the next consistent snapshot, but
-// without a local boundary it unwinds to the root and blanks the whole app.
+// The throw is transient and self-heals on the next consistent snapshot, so it
+// is swallowed silently (no fallback flash, no log spam).
 // Upstream-tracked: assistant-ui/assistant-ui#4051, #3652.
 const isTransientLookupError = (error: unknown): boolean =>
   error instanceof Error && /tapClient(Lookup|Resource).*out of bounds/.test(error.message)
+
+function MessageRenderFallback() {
+  const { t } = useI18n()
+
+  return (
+    <p
+      className="rounded-md border border-border/65 bg-(--composer-fill) px-3 py-2 text-xs text-muted-foreground"
+      role="alert"
+    >
+      {t.assistant.thread.messageRenderFailed}
+    </p>
+  )
+}
 
 interface Props {
   // Changes whenever the message list mutates; remounting clears the caught
@@ -26,6 +41,16 @@ export class MessageRenderBoundary extends Component<Props, { error: Error | nul
     return { error }
   }
 
+  componentDidCatch(error: Error) {
+    // One malformed message must not unwind to the root boundary and blank
+    // the whole app (sidebar, composer, every other session). Contain it here
+    // and keep the cause in the console pipeline that main persists to
+    // desktop.log so real render bugs still surface.
+    if (!isTransientLookupError(error)) {
+      console.error('[message-render-boundary]', error)
+    }
+  }
+
   componentDidUpdate(prev: Props) {
     if (this.state.error && prev.resetKey !== this.props.resetKey) {
       this.setState({ error: null })
@@ -34,13 +59,7 @@ export class MessageRenderBoundary extends Component<Props, { error: Error | nul
 
   render() {
     if (this.state.error) {
-      // Only swallow the transient store race; re-throw anything else so real
-      // bugs still reach the root error boundary.
-      if (!isTransientLookupError(this.state.error)) {
-        throw this.state.error
-      }
-
-      return null
+      return isTransientLookupError(this.state.error) ? null : <MessageRenderFallback />
     }
 
     return this.props.children

--- a/apps/desktop/src/components/react-root-error-logging.test.ts
+++ b/apps/desktop/src/components/react-root-error-logging.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { reactRootErrorOptions } from './react-root-error-logging'
+
+describe('reactRootErrorOptions', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('logs the wrapped cause and component stack for recoverable errors', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const cause = new TypeError("Cannot read properties of undefined (reading 'refText')")
+    const wrapper = new Error('Minified React error #520', { cause })
+
+    reactRootErrorOptions().onRecoverableError?.(wrapper, { componentStack: '\n  at Thread' })
+
+    expect(spy).toHaveBeenCalledWith('[react:recoverable]', wrapper, 'cause:', cause, '\n  at Thread')
+  })
+
+  it('logs caught and uncaught errors without a cause', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const error = new Error('boom')
+    const options = reactRootErrorOptions()
+
+    options.onCaughtError?.(error, { componentStack: '\n  at App' })
+    options.onUncaughtError?.(error, {})
+
+    expect(spy).toHaveBeenNthCalledWith(1, '[react:caught]', error, '\n  at App')
+    expect(spy).toHaveBeenNthCalledWith(2, '[react:uncaught]', error, '')
+  })
+})

--- a/apps/desktop/src/components/react-root-error-logging.ts
+++ b/apps/desktop/src/components/react-root-error-logging.ts
@@ -1,0 +1,28 @@
+import type { RootOptions } from 'react-dom/client'
+
+// createRoot error hooks that keep minified production errors identifiable.
+// React's defaults report only the wrapper (e.g. "Minified React error #520",
+// the recoverable concurrent-render wrapper) — the real culprit rides in
+// `error.cause` and the component stack, which the defaults drop. Logging via
+// console.error lands in the console-message pipeline Electron main persists
+// to desktop.log.
+function logRootError(tag: string, error: unknown, errorInfo: { componentStack?: string }): void {
+  const cause = error instanceof Error ? error.cause : undefined
+
+  if (cause !== undefined) {
+    console.error(tag, error, 'cause:', cause, errorInfo.componentStack ?? '')
+  } else {
+    console.error(tag, error, errorInfo.componentStack ?? '')
+  }
+}
+
+export function reactRootErrorOptions(): Pick<
+  RootOptions,
+  'onCaughtError' | 'onRecoverableError' | 'onUncaughtError'
+> {
+  return {
+    onRecoverableError: (error, errorInfo) => logRootError('[react:recoverable]', error, errorInfo),
+    onCaughtError: (error, errorInfo) => logRootError('[react:caught]', error, errorInfo),
+    onUncaughtError: (error, errorInfo) => logRootError('[react:uncaught]', error, errorInfo)
+  }
+}

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,16 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  createCronJob,
+  deleteCronJob,
+  getCronJob,
+  getCronJobRuns,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
   getHermesConfig,
   getHermesConfigDefaults,
+  getMessagingPlatforms,
   getProfiles,
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  pauseCronJob,
+  resumeCronJob,
+  setApiRequestProfile,
+  testMessagingPlatform,
+  triggerCronJob,
+  updateCronJob,
+  updateMessagingPlatform
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -132,6 +144,67 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  describe('profile scoping of cron and messaging wrappers', () => {
+    afterEach(() => {
+      setApiRequestProfile(null)
+    })
+
+    it('tags every cron call with the active profile so jobs never land in "default"', async () => {
+      api.mockResolvedValue({})
+      setApiRequestProfile('xiaoxuxu')
+
+      const cronCalls: [() => Promise<unknown>, string][] = [
+        [getCronJobs, '/api/cron/jobs'],
+        [() => getCronJob('job-1'), '/api/cron/jobs/job-1'],
+        [() => getCronJobRuns('job-1'), '/api/cron/jobs/job-1/runs?limit=20'],
+        [() => createCronJob({ name: 'n', prompt: 'p', schedule: '* * * * *' }), '/api/cron/jobs'],
+        [() => updateCronJob('job-1', {}), '/api/cron/jobs/job-1'],
+        [() => pauseCronJob('job-1'), '/api/cron/jobs/job-1/pause'],
+        [() => resumeCronJob('job-1'), '/api/cron/jobs/job-1/resume'],
+        [() => triggerCronJob('job-1'), '/api/cron/jobs/job-1/trigger'],
+        [() => deleteCronJob('job-1'), '/api/cron/jobs/job-1']
+      ]
+
+      for (const [call, path] of cronCalls) {
+        api.mockClear()
+        await call()
+        expect(api).toHaveBeenCalledWith(expect.objectContaining({ path, profile: 'xiaoxuxu' }))
+      }
+    })
+
+    it('tags messaging platform calls with the active profile', async () => {
+      api.mockResolvedValue({})
+      setApiRequestProfile('xiaoxuxu')
+
+      const messagingCalls: [() => Promise<unknown>, string][] = [
+        [getMessagingPlatforms, '/api/messaging/platforms'],
+        [
+          () => updateMessagingPlatform('telegram', { clear_env: [], env: {} }),
+          '/api/messaging/platforms/telegram'
+        ],
+        [() => testMessagingPlatform('telegram'), '/api/messaging/platforms/telegram/test']
+      ]
+
+      for (const [call, path] of messagingCalls) {
+        api.mockClear()
+        await call()
+        expect(api).toHaveBeenCalledWith(expect.objectContaining({ path, profile: 'xiaoxuxu' }))
+      }
+    })
+
+    it('leaves cron and messaging unscoped for the primary profile', async () => {
+      api.mockResolvedValue({})
+      api.mockClear()
+
+      await getCronJobs()
+      await getMessagingPlatforms()
+
+      for (const [request] of api.mock.calls) {
+        expect(request).not.toHaveProperty('profile')
+      }
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -725,6 +725,7 @@ export function grantComputerUsePermissions(): Promise<ActionResponse> {
 
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }
@@ -734,6 +735,7 @@ export function updateMessagingPlatform(
   body: MessagingPlatformUpdate
 ): Promise<{ ok: boolean; platform: string }> {
   return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     method: 'PUT',
     body
@@ -742,13 +744,21 @@ export function updateMessagingPlatform(
 
 export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
   })
 }
 
+// Cron routes must be profile-scoped like config/env/skills: the backend
+// defaults POST /api/cron/jobs to profile "default" (a job created while a
+// non-default profile is active would silently land in the wrong profile) and
+// per-job routes resolve the owning profile by job-id scan, which mismatches
+// on id collisions. Unscoped (primary profile active) GET keeps the backend's
+// profile="all" default, so single-profile users see the same list as before.
 export function getCronJobs(): Promise<CronJob[]> {
   return window.hermesDesktop.api<CronJob[]>({
+    ...profileScoped(),
     path: '/api/cron/jobs',
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
@@ -756,12 +766,14 @@ export function getCronJobs(): Promise<CronJob[]> {
 
 export function getCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}`
   })
 }
 
 export async function getCronJobRuns(jobId: string, limit = 20): Promise<SessionInfo[]> {
   const { runs } = await window.hermesDesktop.api<{ runs: SessionInfo[] }>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/runs?limit=${limit}`
   })
 
@@ -770,6 +782,7 @@ export async function getCronJobRuns(jobId: string, limit = 20): Promise<Session
 
 export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: '/api/cron/jobs',
     method: 'POST',
     body
@@ -778,6 +791,7 @@ export function createCronJob(body: CronJobCreatePayload): Promise<CronJob> {
 
 export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
     method: 'PUT',
     body: { updates }
@@ -786,6 +800,7 @@ export function updateCronJob(jobId: string, updates: CronJobUpdates): Promise<C
 
 export function pauseCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/pause`,
     method: 'POST'
   })
@@ -793,6 +808,7 @@ export function pauseCronJob(jobId: string): Promise<CronJob> {
 
 export function resumeCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/resume`,
     method: 'POST'
   })
@@ -800,6 +816,7 @@ export function resumeCronJob(jobId: string): Promise<CronJob> {
 
 export function triggerCronJob(jobId: string): Promise<CronJob> {
   return window.hermesDesktop.api<CronJob>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}/trigger`,
     method: 'POST'
   })
@@ -807,6 +824,7 @@ export function triggerCronJob(jobId: string): Promise<CronJob> {
 
 export function deleteCronJob(jobId: string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
+    ...profileScoped(),
     path: `/api/cron/jobs/${encodeURIComponent(jobId)}`,
     method: 'DELETE'
   })

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2217,6 +2217,7 @@ export const en: Translations = {
     thread: {
       loadingSession: 'Loading session',
       showEarlier: 'Show earlier messages',
+      messageRenderFailed: 'This message failed to render.',
       loadingResponse: 'Hermes is loading a response',
       resumeWhenBackgroundDone: count =>
         count === 1

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2196,6 +2196,7 @@ export const ja = defineLocale({
     thread: {
       loadingSession: 'セッションを読み込み中',
       showEarlier: '以前のメッセージを表示',
+      messageRenderFailed: 'このメッセージを表示できませんでした。',
       loadingResponse: 'Hermes が応答を読み込み中',
       resumeWhenBackgroundDone: count =>
         count === 1

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1855,6 +1855,7 @@ export interface Translations {
     thread: {
       loadingSession: string
       showEarlier: string
+      messageRenderFailed: string
       loadingResponse: string
       resumeWhenBackgroundDone: (count: number) => string
       thinking: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2131,6 +2131,7 @@ export const zhHant = defineLocale({
     thread: {
       loadingSession: '正在載入工作階段',
       showEarlier: '顯示較早的訊息',
+      messageRenderFailed: '此訊息渲染失敗。',
       loadingResponse: 'Hermes 正在載入回覆',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '背景工作完成後將自動繼續' : `${count} 個背景工作完成後將自動繼續`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2383,6 +2383,7 @@ export const zh: Translations = {
     thread: {
       loadingSession: '正在加载会话',
       showEarlier: '显示更早的消息',
+      messageRenderFailed: '此消息渲染失败。',
       loadingResponse: 'Hermes 正在加载回复',
       resumeWhenBackgroundDone: count =>
         count === 1 ? '后台任务完成后将自动继续' : `${count} 个后台任务完成后将自动继续`,

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -10,6 +10,7 @@ import { HashRouter } from 'react-router-dom'
 import App from './app'
 import { ErrorBoundary } from './components/error-boundary'
 import { HapticsProvider } from './components/haptics-provider'
+import { reactRootErrorOptions } from './components/react-root-error-logging'
 import { I18nProvider } from './i18n'
 import { installClipboardShim } from './lib/clipboard'
 import { queryClient } from './lib/query-client'
@@ -32,7 +33,7 @@ if (import.meta.env.MODE !== 'production') {
 if (new URLSearchParams(window.location.search).get('win') === 'overlay') {
   void import('./app/pet-overlay/overlay-root').then(({ mountPetOverlay }) => mountPetOverlay())
 } else {
-  createRoot(document.getElementById('root')!).render(
+  createRoot(document.getElementById('root')!, reactRootErrorOptions()).render(
     <StrictMode>
       <ErrorBoundary label="root">
         <QueryClientProvider client={queryClient}>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "web"
   ],
   "scripts": {
-    "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'",
+    "postinstall": "node patches/apply-patches.cjs && echo '✅ Browser tools ready. Run: python run_agent.py --help'",
     "install:root": "npm install --workspaces=false",
     "install:web": "npm install --workspace web",
     "install:tui": "npm install --workspace ui-tui",

--- a/patches/apply-patches.cjs
+++ b/patches/apply-patches.cjs
@@ -1,0 +1,92 @@
+'use strict'
+
+// Dependency-free node_modules patcher, wired into the root postinstall so it
+// re-applies after every `npm ci`/`npm install` (which rewrite node_modules).
+// Deliberately not patch-package: that would need a lockfile entry and an
+// extra dependency for what is a one-line containment fix.
+//
+// Each patch replaces an exact source string and stamps a marker comment so
+// re-runs are no-ops. If the pinned package version changes shape (find string
+// AND marker both missing), the install fails loudly so the patch gets
+// refreshed or retired instead of silently reintroducing the bug.
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const REPO_ROOT = path.join(__dirname, '..')
+
+const PATCHES = [
+  {
+    // @assistant-ui/store 0.2.13 (pinned via root package.json overrides)
+    // throws on index-out-of-bounds lookups. During high-frequency store
+    // replacement (session switch mid-stream, gateway reconnect replay) stale
+    // subscribers read past the new, shorter list and the throw escapes React
+    // render entirely (store notification tick), blanking the desktop app.
+    // Production signature: "tapClientLookup: Index N out of bounds
+    // (length: 0)" in ~/.hermes/logs/desktop.log. Upstream:
+    // https://github.com/assistant-ui/assistant-ui/issues/4051
+    // Containment: clamp to the nearest live resource (stale-but-valid for
+    // one tick, self-heals on the next snapshot); undefined when empty.
+    file: 'node_modules/@assistant-ui/store/dist/tapClientLookup.js',
+    marker: 'hermes-patch(assistant-ui#4051)',
+    find:
+      'if (lookup.index < 0 || lookup.index >= keys.length) throw new Error(`tapClientLookup: Index ${lookup.index} out of bounds (length: ${keys.length})`);',
+    replace:
+      '/* hermes-patch(assistant-ui#4051): clamp transient out-of-bounds lookups instead of throwing */ if (lookup.index < 0 || lookup.index >= keys.length) return keys.length === 0 ? undefined : resources[Math.min(Math.max(lookup.index, 0), keys.length - 1)].methods;'
+  }
+]
+
+function applyPatchToSource(source, patch) {
+  if (source.includes(patch.marker)) {
+    return { source, status: 'already-applied' }
+  }
+
+  if (!source.includes(patch.find)) {
+    return { source, status: 'target-not-found' }
+  }
+
+  return { source: source.replace(patch.find, patch.replace), status: 'applied' }
+}
+
+function main() {
+  let failed = false
+
+  for (const patch of PATCHES) {
+    const filePath = path.join(REPO_ROOT, patch.file)
+
+    if (!fs.existsSync(filePath)) {
+      // Partial installs (e.g. `npm install --workspaces=false`) may not have
+      // the package on disk; the next full install re-runs this script.
+      console.log(`[apply-patches] skip (not installed): ${patch.file}`)
+      continue
+    }
+
+    const source = fs.readFileSync(filePath, 'utf8')
+    const result = applyPatchToSource(source, patch)
+
+    if (result.status === 'target-not-found') {
+      console.error(
+        `[apply-patches] FAILED: ${patch.file} does not contain the expected source.\n` +
+          `The installed package version has drifted — update or retire the patch in patches/apply-patches.cjs.`
+      )
+      failed = true
+      continue
+    }
+
+    if (result.status === 'applied') {
+      fs.writeFileSync(filePath, result.source)
+    }
+
+    console.log(`[apply-patches] ${result.status}: ${patch.file}`)
+  }
+
+  if (failed) {
+    process.exitCode = 1
+  }
+}
+
+module.exports = { PATCHES, applyPatchToSource }
+
+if (require.main === module) {
+  main()
+}

--- a/patches/apply-patches.test.cjs
+++ b/patches/apply-patches.test.cjs
@@ -1,0 +1,83 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const { describe, it } = require('node:test')
+
+const { PATCHES, applyPatchToSource } = require('./apply-patches.cjs')
+
+const lookupPatch = PATCHES.find(p => p.file.includes('tapClientLookup'))
+
+describe('applyPatchToSource', () => {
+  it('rewrites the target string and stamps the marker', () => {
+    const source = `before\n\t\t\t\t${lookupPatch.find}\nafter`
+    const result = applyPatchToSource(source, lookupPatch)
+
+    assert.equal(result.status, 'applied')
+    assert.ok(result.source.includes(lookupPatch.marker))
+    assert.ok(!result.source.includes('throw new Error(`tapClientLookup'))
+  })
+
+  it('is idempotent on already-patched source', () => {
+    const once = applyPatchToSource(lookupPatch.find, lookupPatch)
+    const twice = applyPatchToSource(once.source, lookupPatch)
+
+    assert.equal(twice.status, 'already-applied')
+    assert.equal(twice.source, once.source)
+  })
+
+  it('reports drift when neither marker nor target is present', () => {
+    const result = applyPatchToSource('completely different module body', lookupPatch)
+
+    assert.equal(result.status, 'target-not-found')
+  })
+})
+
+describe('tapClientLookup containment behavior', () => {
+  // Evaluate the patched bounds-check in isolation: out-of-bounds lookups must
+  // clamp to the nearest live resource and return undefined for an empty list
+  // instead of throwing (the production "Index N out of bounds (length: 0)"
+  // crash from stale subscribers during reconnect churn).
+  const patched = applyPatchToSource(lookupPatch.find, lookupPatch).source
+  const get = new Function(
+    'resources',
+    'keys',
+    'lookup',
+    `${patched}\nreturn resources[lookup.index].methods;`
+  )
+
+  it('returns undefined when the list emptied out from under a subscriber', () => {
+    assert.equal(get([], [], { index: 0 }), undefined)
+    assert.equal(get([], [], { index: 4 }), undefined)
+  })
+
+  it('clamps one-past-end reads to the last live resource', () => {
+    const resources = [{ methods: 'm0' }, { methods: 'm1' }]
+
+    assert.equal(get(resources, ['a', 'b'], { index: 2 }), 'm1')
+    assert.equal(get(resources, ['a', 'b'], { index: -1 }), 'm0')
+  })
+
+  it('leaves in-bounds lookups untouched', () => {
+    const resources = [{ methods: 'm0' }, { methods: 'm1' }]
+
+    assert.equal(get(resources, ['a', 'b'], { index: 1 }), 'm1')
+  })
+})
+
+describe('installed package', () => {
+  it('matches the patch target (or is already patched)', () => {
+    const filePath = path.join(__dirname, '..', lookupPatch.file)
+
+    if (!fs.existsSync(filePath)) {
+      return
+    }
+
+    const source = fs.readFileSync(filePath, 'utf8')
+    assert.ok(
+      source.includes(lookupPatch.marker) || source.includes(lookupPatch.find),
+      'installed @assistant-ui/store drifted from the pinned 0.2.13 shape'
+    )
+  })
+})


### PR DESCRIPTION
## Problem

1. **Cron + messaging REST wrappers never carry the profile scope.** Unlike config/env/skills/tools/model, the cron and messaging wrappers in `src/hermes.ts` omit `profileScoped()`. In global remote mode (shared backend, multiple profiles disambiguated by `?profile=`) the cron sidebar/CronView and messaging settings silently read and **mutate the default profile** while the rail shows another profile — same bug class as #47011. The backend already accepts `?profile=` on every one of these routes, and the web dashboard already sends it.
2. **One malformed message part can unmount the entire app.** `MessageRenderBoundary` deliberately re-throws anything that isn't the known transient tapClientLookup race, escalating a single bad markdown/tool-payload render to the root boundary (all UI state lost).
3. **`@assistant-ui/store` tapClientLookup throws on transient index races** during session-switch/reconnect list replacement (`tapClientLookup: Index N out of bounds`), which is exactly the error class the boundary special-cases; production logs show it still firing on 0.2.13.
4. **Minified React #520 reports are undebuggable**: the recoverable-error wrapper is logged without its `cause`, so the real culprit is invisible in packaged builds.

## Fix

- `profileScoped()` added to all 9 cron wrappers and 3 messaging wrappers. Primary profile stays unscoped (`{}`), preserving existing single-profile behavior.
- `MessageRenderBoundary` is now a catch-all: transient races still render null + auto-reset; any other error renders a compact i18n'd "This message failed to render." fallback (`role=alert`) and logs the cause with a `[message-render-boundary]` tag. Strings added for en/ja/zh/zh-hant.
- New `patches/apply-patches.cjs` (dependency-free, idempotent, loud-on-drift) rewrites the 0.2.13 `tapClientLookup` out-of-bounds throw into clamp-to-last/undefined-when-empty, wired into root `postinstall` so it survives `npm ci`.
- `createRoot` gains `onRecoverableError/onCaughtError/onUncaughtError` handlers logging the wrapper, `error.cause`, and component stack through the console pipeline the main process already persists to `desktop.log`.

## Tests

- `hermes.test.ts`: every cron/messaging wrapper carries `profile` under a non-primary active profile, and stays unscoped for the primary (10 tests).
- `message-render-boundary.test.tsx`: fallback rendering, tagged console.error, transient-race silence, resetKey recovery (6 tests).
- `patches/apply-patches.test.cjs`: apply/idempotent/drift-detection + behavioral bounds checks (7 tests).
- `react-root-error-logging.test.ts` (2 tests). Desktop typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)