### PR TITLE
fix(desktop): preserve unknown html-like markdown tokens

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -202,6 +202,36 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('<https://example.com/a_b/c~d/page>')
   })
 
+  it('escapes unknown html-shaped prose tags so markdown rendering cannot swallow the tail', () => {
+    const input =
+      'The proxy emits <tool_call> before parameters, <observation status="ok"> after results, and <think> in reasoning prose.'
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('&lt;tool_call&gt; before parameters')
+    expect(output).toContain('&lt;observation status="ok"&gt; after results')
+    expect(output).toContain('&lt;think&gt; in reasoning prose.')
+  })
+
+  it('keeps known html tags and markdown autolinks intact while escaping unknown tags', () => {
+    const input = 'Use <kbd>Esc</kbd>, open <https://example.com/path>, then inspect <parameters>.'
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('<kbd>Esc</kbd>')
+    expect(output).toContain('<https://example.com/path>')
+    expect(output).toContain('&lt;parameters&gt;.')
+  })
+
+  it('does not escape unknown html-shaped tokens inside inline code', () => {
+    const input = 'Render `<tool_call>` literally, but escape <tool_call> in prose.'
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('`<tool_call>`')
+    expect(output).toContain('&lt;tool_call&gt; in prose')
+  })
+
   it('handles a fenced block larger than V8 spread-argument limit', () => {
     // A single huge code block (e.g. a logged minified bundle) used to throw
     // `RangeError: Maximum call stack size exceeded` via `out.push(...lines)`.

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -21,6 +21,20 @@ const LOCAL_PREVIEW_ONLY_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|
 const URL_ONLY_LINE_RE = /^\s*https?:\/\/\S+\s*$/i
 const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*\d+)*)\](?!\()/gu
 
+const HTML_TAG_NAME_RE = /^\/?([a-z][a-z0-9_-]*)(?=[\s/>]|$)/i
+const MARKDOWN_AUTOLINK_RE = /^(?:https?:\/\/|mailto:|[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+)/i
+
+const KNOWN_HTML_TAGS = new Set(
+  [
+    'a abbr address area article aside audio b base bdi bdo blockquote br button canvas caption cite code col colgroup',
+    'data datalist dd del details dfn dialog div dl dt em figcaption figure footer h1 h2 h3 h4 h5 h6 head header hr html',
+    'i img ins kbd label li main mark nav ol p picture pre q rp rt ruby s samp section small source span strong sub summary',
+    'sup table tbody td tfoot th thead time tr track u ul var video wbr'
+  ]
+    .join(' ')
+    .split(' ')
+)
+
 /**
  * Returns true when `body` contains a line that's exactly `marker` (modulo
  * leading/trailing horizontal whitespace) — i.e. an unambiguous close fence
@@ -138,6 +152,69 @@ function autoLinkRawUrls(text: string): string {
   })
 }
 
+function escapeUnknownHtmlTags(text: string): string {
+  let out = ''
+  let cursor = 0
+
+  while (cursor < text.length) {
+    const start = text.indexOf('<', cursor)
+
+    if (start === -1) {
+      out += text.slice(cursor)
+
+      break
+    }
+
+    out += text.slice(cursor, start)
+
+    const rest = text.slice(start + 1)
+
+    if (
+      rest.startsWith('!--') ||
+      rest.startsWith('!DOCTYPE') ||
+      rest.startsWith('![CDATA[') ||
+      rest.startsWith('?') ||
+      MARKDOWN_AUTOLINK_RE.test(rest)
+    ) {
+      out += '<'
+      cursor = start + 1
+
+      continue
+    }
+
+    const tagMatch = rest.match(HTML_TAG_NAME_RE)
+
+    if (!tagMatch) {
+      out += '<'
+      cursor = start + 1
+
+      continue
+    }
+
+    const end = text.indexOf('>', start + 1)
+
+    if (end === -1) {
+      out += '&lt;'
+      cursor = start + 1
+
+      continue
+    }
+
+    const tagName = (tagMatch[1] || '').toLowerCase()
+    const rawTag = text.slice(start, end + 1)
+
+    if (KNOWN_HTML_TAGS.has(tagName)) {
+      out += rawTag
+    } else {
+      out += `&lt;${text.slice(start + 1, end)}&gt;`
+    }
+
+    cursor = end + 1
+  }
+
+  return out
+}
+
 function normalizeVisibleProse(text: string): string {
   return text
     .split(INLINE_CODE_SPLIT_RE)
@@ -145,7 +222,9 @@ function normalizeVisibleProse(text: string): string {
       part.startsWith('`')
         ? part
         : autoLinkRawUrls(
-            part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            escapeUnknownHtmlTags(
+              part.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+            )
           )
     )
     .join('')


### PR DESCRIPTION
## Summary

Fixes #53953.

Desktop markdown preprocessing now escapes unknown HTML-shaped prose tokens before they reach the HTML-aware Streamdown/rehype pipeline. This prevents assistant text such as `<tool_call>`, `<observation status="ok">`, `<parameters>`, or `<think>` from being interpreted as unclosed raw HTML and silently swallowing the rest of the visible message.

The guard is deliberately narrow:

- fenced code blocks still pass through untouched
- inline code spans still pass through untouched
- known HTML tags such as `<kbd>Esc</kbd>` stay intact
- markdown autolinks such as `<https://example.com/path>` stay intact
- ordinary non-tag angle brackets are left alone

## Changes

- Add `escapeUnknownHtmlTags()` in `apps/desktop/src/lib/markdown-preprocess.ts` for prose segments only.
- Keep a compact allow-list of standard HTML tags so existing supported HTML rendering is preserved.
- Add regression coverage for unknown tool/proxy tokens, allowed HTML tags, markdown autolinks, and inline code spans.

## Validation

- `npm --workspace apps/desktop run test:ui -- src/components/assistant-ui/markdown-text.test.ts src/lib/remend-tail.test.ts src/lib/markdown-code.test.ts` — 27 passed
- `npm --workspace apps/desktop exec eslint -- src/lib/markdown-preprocess.ts src/components/assistant-ui/markdown-text.test.ts`
- `npm --workspace apps/desktop run typecheck`
- `git diff --check` / `git diff --cached --check`

## Duplicate Check

Searched open PRs for `#53953`, `markdown renderer`, `unknown html`, `tool_call`, and `markdown-preprocess`; no open PR directly covers this Desktop markdown truncation path.

## Notes

This stays entirely in the Desktop renderer preprocessing layer. It does not change provider output, saved transcripts, or backend message handling.