### PR TITLE
fix(config): prune stale memory provider blocks

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -27,7 +27,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, Iterable
 
 from hermes_cli.secret_prompt import masked_secret_prompt
 
@@ -6035,6 +6035,48 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
+_BUILTIN_MEMORY_PROVIDER_CONFIG_KEYS = {
+    "honcho",
+    "hindsight",
+    "holographic",
+    "mem0",
+    "openviking",
+    "retaindb",
+    "supermemory",
+    "byterover",
+}
+
+
+def prune_inactive_memory_provider_configs(
+    config: dict,
+    active_provider: str,
+    provider_names: Iterable[str] = (),
+) -> dict:
+    """Drop stale legacy ``memory.<provider>`` config blocks.
+
+    Runtime selection is controlled by ``memory.provider`` and modern provider
+    setup stores provider details under ``~/.hermes/<provider>/`` or ``.env``.
+    Legacy nested provider blocks can survive config merges and confuse paths
+    that inspect the merged ``memory`` map, so keep only the active provider's
+    block.
+    """
+    memory_config = config.get("memory")
+    if not isinstance(memory_config, dict):
+        return config
+
+    active = (active_provider or "").strip()
+    names = set(_BUILTIN_MEMORY_PROVIDER_CONFIG_KEYS)
+    names.update(str(name).strip() for name in provider_names if str(name).strip())
+
+    for name in names:
+        if name == active:
+            continue
+        if isinstance(memory_config.get(name), dict):
+            memory_config.pop(name, None)
+
+    return config
+
+
 def _strip_dotted_keys(cfg: dict, dotted_keys: set) -> Tuple[dict, set]:
     """Remove the given dotted leaf keys from a nested config dict.
 
@@ -6658,6 +6700,12 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         if managed_config:
             managed_expanded = _expand_env_vars(managed_config)
             expanded = _deep_merge(expanded, managed_expanded)
+        memory_config = expanded.get("memory")
+        if isinstance(memory_config, dict):
+            prune_inactive_memory_provider_configs(
+                expanded,
+                str(memory_config.get("provider") or ""),
+            )
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_sig is not None:
             # Cache stores a separate deepcopy so subsequent ``load_config()``

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -65,6 +65,7 @@ from hermes_cli.config import (
     save_config,
     save_env_value,
     remove_env_value,
+    prune_inactive_memory_provider_configs,
     check_config_version,
     detect_install_method,
     format_docker_update_message,
@@ -4033,6 +4034,13 @@ async def update_memory_provider_config(name: str, body: MemoryProviderConfigUpd
             memory_config = {}
             config["memory"] = memory_config
         memory_config["provider"] = provider.name
+        try:
+            from plugins.memory import discover_memory_providers
+
+            provider_names = [name for name, _d, _c in discover_memory_providers()]
+        except Exception:
+            provider_names = [provider.name]
+        prune_inactive_memory_provider_configs(config, provider.name, provider_names)
         save_config(config)
 
         path = _memory_provider_config_path(provider)
@@ -9757,10 +9765,14 @@ async def set_memory_provider(body: MemoryProviderSelect):
     if provider.lower() in {"built-in", "builtin", "none"}:
         provider = ""
 
-    if provider:
+    try:
         from plugins.memory import discover_memory_providers
 
-        valid = {name for name, _d, _c in discover_memory_providers()}
+        provider_names = [name for name, _d, _c in discover_memory_providers()]
+    except Exception:
+        provider_names = []
+    if provider:
+        valid = set(provider_names)
         if provider not in valid:
             raise HTTPException(
                 status_code=400,
@@ -9771,6 +9783,7 @@ async def set_memory_provider(body: MemoryProviderSelect):
     if not isinstance(cfg.get("memory"), dict):
         cfg["memory"] = {}
     cfg["memory"]["provider"] = provider
+    prune_inactive_memory_provider_configs(cfg, provider, provider_names)
     save_config(cfg)
     return {"ok": True, "active": provider}
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -117,6 +117,27 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_load_config_prunes_inactive_memory_provider_blocks(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            (tmp_path / "config.yaml").write_text(
+                yaml.safe_dump({
+                    "memory": {
+                        "provider": "openviking",
+                        "memory_enabled": True,
+                        "hindsight": {"base_url": "http://localhost:36813"},
+                        "openviking": {"mode": "local"},
+                    }
+                }),
+                encoding="utf-8",
+            )
+
+            config = load_config()
+
+            assert config["memory"]["provider"] == "openviking"
+            assert config["memory"]["memory_enabled"] is True
+            assert "hindsight" not in config["memory"]
+            assert config["memory"]["openviking"] == {"mode": "local"}
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -429,6 +429,38 @@ class TestWebServerEndpoints:
             "recall_budget": "high",
         }
 
+    def test_set_memory_provider_prunes_inactive_provider_config(self, monkeypatch):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "memory": {
+                "provider": "hindsight",
+                "memory_enabled": True,
+                "hindsight": {"base_url": "http://localhost:36813"},
+                "mem0": {"history_db_path": "old.db"},
+            },
+            "gateway": {"enabled": True},
+        })
+
+        monkeypatch.setattr(
+            "plugins.memory.discover_memory_providers",
+            lambda: [
+                ("hindsight", "Hindsight", True),
+                ("openviking", "OpenViking", True),
+            ],
+        )
+
+        resp = self.client.put("/api/memory/provider", json={"provider": "openviking"})
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "active": "openviking"}
+        cfg = load_config()
+        assert cfg["memory"]["provider"] == "openviking"
+        assert cfg["memory"]["memory_enabled"] is True
+        assert "hindsight" not in cfg["memory"]
+        assert "mem0" not in cfg["memory"]
+        assert cfg["gateway"]["enabled"] is True
+
     def test_put_memory_provider_config_rejects_unsupported_select_value(self):
         resp = self.client.put(
             "/api/memory/providers/hindsight/config",


### PR DESCRIPTION
## Summary
- Prune stale legacy `memory.<provider>` config blocks from merged config when `memory.provider` points at a different provider.
- Clean inactive provider blocks when dashboard memory provider selection/config writes the active provider.
- Add regression coverage for `load_config()` and dashboard provider switching.

## Root Cause
`load_config()` deep-merges config maps, so changing only `memory.provider` could leave old provider-specific nested blocks in the effective `memory` config. That allowed stale settings such as a previous `hindsight` URL to survive after switching to another memory provider.

## Tests
- `python -m pytest tests/hermes_cli/test_config.py::TestLoadConfigDefaults tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_put_memory_provider_config_writes_config_and_secret tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_set_memory_provider_prunes_inactive_provider_config tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_memory_provider_config_returns_safe_defaults -q`
- `python -m py_compile hermes_cli/config.py hermes_cli/web_server.py tests/hermes_cli/test_config.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

Fixes #58072