### PR TITLE
fix(api-server): run agent turns on daemon executor

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -61,6 +61,9 @@ from gateway.platforms.base import (
     validate_media_delivery_path,
 )
 from agent.redact import redact_sensitive_text
+from tools.daemon_pool import DaemonThreadPoolExecutor
+
+_AGENT_EXECUTOR = DaemonThreadPoolExecutor(thread_name_prefix="api-server-agent")
 
 logger = logging.getLogger(__name__)
 
@@ -4084,7 +4087,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         self._inflight_agent_runs += 1
         try:
-            return await loop.run_in_executor(None, _run)
+            return await loop.run_in_executor(_AGENT_EXECUTOR, _run)
         finally:
             self._inflight_agent_runs -= 1
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -293,6 +293,41 @@ class TestAdapterInit:
         assert adapter._api_key == ""
         assert adapter.platform == Platform.API_SERVER
 
+    @pytest.mark.asyncio
+    async def test_run_agent_uses_daemon_executor(self, monkeypatch):
+        from tools.daemon_pool import DaemonThreadPoolExecutor
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        real_loop = asyncio.get_running_loop()
+        captured = {}
+
+        class FakeLoop:
+            def run_in_executor(self, executor, func):
+                captured["executor"] = executor
+                fut = real_loop.create_future()
+                fut.set_result(func())
+                return fut
+
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 2
+            session_total_tokens = 3
+            session_id = "api-session"
+
+            def run_conversation(self, **kwargs):
+                return {"response": "ok"}
+
+        monkeypatch.setattr(asyncio, "get_running_loop", lambda: FakeLoop())
+        monkeypatch.setattr(adapter, "_bind_api_server_session", lambda **kwargs: [])
+        monkeypatch.setattr(adapter, "_create_agent", lambda **kwargs: FakeAgent())
+
+        result, usage = await adapter._run_agent("hello", [])
+
+        assert isinstance(captured["executor"], DaemonThreadPoolExecutor)
+        assert result["response"] == "ok"
+        assert result["session_id"] == "api-session"
+        assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+
     def test_custom_config_from_extra(self):
         config = PlatformConfig(
             enabled=True,


### PR DESCRIPTION
## What does this PR do?

Runs API-server agent turns on Hermes' `DaemonThreadPoolExecutor` instead of the event loop's default stdlib executor.

This is a follow-up to the bounded-exit/daemon-pool hardening in #57000 and the ACP agent-turn follow-up in #57676. API-server chat/responses requests also run synchronous `AIAgent.run_conversation()` inside an executor; if that worker wedges during provider/tool/subagent work, stdlib executor workers can keep the interpreter alive at shutdown. Using the shared daemon executor preserves the existing offloaded execution path while avoiding an unbounded process-exit join.

## Related Issue

Follow-up to #57000 and #57676. No dedicated issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - Adds a module-level `DaemonThreadPoolExecutor` for API-server agent turns.
  - Passes that executor to `_run_agent()` instead of `run_in_executor(None, ...)`.
- `tests/gateway/test_api_server.py`
  - Adds a regression test that captures the executor used by `_run_agent()` and asserts it is the daemon executor while preserving result/usage handling.

## How to Test

1. Run targeted API-server executor test:
   ```bash
   python -m pytest tests/gateway/test_api_server.py::TestAdapterInit::test_run_agent_uses_daemon_executor -q
   ```
2. Run adjacent API-server tests:
   ```bash
   python -m pytest tests/gateway/test_api_server.py::TestAdapterInit tests/gateway/test_api_server_runs.py -q
   ```
3. Run lint on changed files:
   ```bash
   python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
   ```

Validation from this branch:

```text
python -m pytest tests/gateway/test_api_server.py::TestAdapterInit::test_run_agent_uses_daemon_executor -q
1 passed in 0.34s

python -m pytest tests/gateway/test_api_server.py::TestAdapterInit tests/gateway/test_api_server_runs.py -q
32 passed, 23 warnings in 4.44s

python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
All checks passed!
```

I also ran:

```bash
python -m ty check gateway/platforms/api_server.py tests/gateway/test_api_server.py
```

`ty` still reports pre-existing diagnostics in `gateway/platforms/api_server.py` / existing tests (nullable defaults, optional cron imports, broad `_cron_create(**kwargs)` typing, etc.); none are introduced by this diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not UI-facing. Relevant logs are included in the test section.
