### PR TITLE
fix(api): store compressed Responses transcripts

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3029,6 +3029,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_error: Optional[str] = None
         usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
         terminal_snapshot_persisted = False
+        effective_session_id = session_id
 
         def _persist_response_snapshot(
             response_env: Dict[str, Any],
@@ -3044,7 +3045,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "response": response_env,
                 "conversation_history": conversation_history_snapshot,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": effective_session_id,
             })
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
@@ -3329,6 +3330,8 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
+                if isinstance(result, dict) and result.get("session_id"):
+                    effective_session_id = result["session_id"]
                 # If the agent produced a final_response but no text
                 # deltas were streamed (e.g. some providers only emit
                 # the full response at the end), emit a single fallback
@@ -3752,6 +3755,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
         created_at = int(time.time())
+        effective_session_id = result.get("session_id") or session_id
 
         # Build the full conversation history for storage
         # (includes tool calls from the agent run)
@@ -3792,14 +3796,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "response": response_data,
                 "conversation_history": full_history,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": effective_session_id,
             })
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
 
-        response_headers = {"X-Hermes-Session-Id": session_id}
+        response_headers = {"X-Hermes-Session-Id": effective_session_id}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(response_data, headers=response_headers)
@@ -4162,6 +4166,9 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_messages = result.get("messages") if isinstance(result, dict) else None
 
         if isinstance(agent_messages, list) and agent_messages:
+            if APIServerAdapter._response_messages_have_compressed_summary(agent_messages):
+                return list(agent_messages)
+
             turn_start = APIServerAdapter._response_messages_turn_start_index(
                 conversation_history,
                 user_message,
@@ -4181,6 +4188,19 @@ class APIServerAdapter(BasePlatformAdapter):
         return full_history
 
     @staticmethod
+    def _response_messages_have_compressed_summary(messages: List[Dict[str, Any]]) -> bool:
+        """Return True when result["messages"] is an authoritative compacted transcript."""
+        try:
+            from agent.context_compressor import COMPRESSED_SUMMARY_METADATA_KEY
+        except Exception:
+            COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+
+        for msg in messages:
+            if isinstance(msg, dict) and bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY)):
+                return True
+        return False
+
+    @staticmethod
     def _response_messages_turn_start_index(
         conversation_history: List[Dict[str, Any]],
         user_message: Any,
@@ -4198,6 +4218,10 @@ class APIServerAdapter(BasePlatformAdapter):
             return len(expected_prefix)
         if prior and agent_messages[:len(prior)] == prior:
             return len(prior)
+        if APIServerAdapter._response_messages_have_compressed_summary(agent_messages):
+            for idx in range(len(agent_messages) - 1, -1, -1):
+                if agent_messages[idx] == current_user:
+                    return idx + 1
         return 0
 
     @classmethod

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2007,6 +2007,161 @@ class TestResponsesEndpoint:
             assert stored_history.count({"role": "user", "content": "Now add 1 more"}) == 1
 
     @pytest.mark.asyncio
+    async def test_previous_response_id_stores_compressed_transcript_without_old_history(self, adapter):
+        """Compression replaces the stored Responses history instead of appending it."""
+        prior_history = [
+            {"role": "user", "content": "Read old file"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_old",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"old.txt"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_old",
+                "content": '{"content":"old"}',
+            },
+            {"role": "assistant", "content": "old"},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": list(prior_history),
+                "session_id": "api-test-session",
+            },
+        )
+        compressed_history = [
+            {
+                "role": "user",
+                "content": "[compressed summary of earlier file-reading work]",
+                "_compressed_summary": True,
+            },
+            {"role": "user", "content": "Read new file"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_new",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path":"new.txt"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_new",
+                "content": '{"content":"new"}',
+            },
+            {"role": "assistant", "content": "new"},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {
+                        "final_response": "new",
+                        "messages": list(compressed_history),
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Read new file",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        stored_history = adapter._response_store.get(data["id"])["conversation_history"]
+        assert stored_history == compressed_history
+        assert prior_history[0] not in stored_history
+
+        output_json = json.dumps(data["output"])
+        assert "call_new" in output_json
+        assert "new.txt" in output_json
+        assert "call_old" not in output_json
+        assert "old.txt" not in output_json
+
+    @pytest.mark.asyncio
+    async def test_compressed_response_chains_from_rotated_session(self, adapter):
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": [{"role": "assistant", "content": "old"}],
+                "session_id": "session-before-compression",
+            },
+        )
+        compressed_history = [
+            {
+                "role": "user",
+                "content": "[compressed summary]",
+                "_compressed_summary": True,
+            },
+            {"role": "user", "content": "continue"},
+            {"role": "assistant", "content": "done"},
+        ]
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as run:
+                run.return_value = (
+                    {
+                        "final_response": "done",
+                        "messages": compressed_history,
+                        "session_id": "session-after-compression",
+                    },
+                    usage,
+                )
+                first = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "continue",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+                first_data = await first.json()
+
+            assert first.headers["X-Hermes-Session-Id"] == "session-after-compression"
+            stored = adapter._response_store.get(first_data["id"])
+            assert stored["session_id"] == "session-after-compression"
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as chained:
+                chained.return_value = (
+                    {
+                        "final_response": "again",
+                        "messages": [{"role": "assistant", "content": "again"}],
+                    },
+                    usage,
+                )
+                second = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "again",
+                        "previous_response_id": first_data["id"],
+                    },
+                )
+
+            assert second.status == 200
+            assert chained.call_args.kwargs["session_id"] == "session-after-compression"
+
+    @pytest.mark.asyncio
     async def test_previous_response_id_outputs_only_current_turn_items(self, adapter):
         """Response output must not replay previous tool artifacts."""
         prior_history = [
@@ -2547,6 +2702,86 @@ class TestResponsesStreaming:
         assert stored_history == expected_history
         assert stored_history.count(prior_history[0]) == 1
         assert stored_history.count({"role": "user", "content": "Now add 1 more"}) == 1
+
+    @pytest.mark.asyncio
+    async def test_streamed_compression_snapshot_chains_from_rotated_session(self, adapter):
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": [{"role": "assistant", "content": "old"}],
+                "session_id": "session-before-compression",
+            },
+        )
+        compressed_history = [
+            {
+                "role": "user",
+                "content": "[compressed summary]",
+                "_compressed_summary": True,
+            },
+            {"role": "user", "content": "continue"},
+            {"role": "assistant", "content": "streamed"},
+        ]
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+
+        async def rotated_run(**kwargs):
+            callback = kwargs.get("stream_delta_callback")
+            if callback:
+                callback("streamed")
+            return (
+                {
+                    "final_response": "streamed",
+                    "messages": compressed_history,
+                    "session_id": "session-after-compression",
+                },
+                usage,
+            )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=rotated_run):
+                streamed = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "continue",
+                        "previous_response_id": "resp_prev",
+                        "stream": True,
+                    },
+                )
+                body = await streamed.text()
+
+            completed = None
+            for line in body.splitlines():
+                if not line.startswith("data: "):
+                    continue
+                payload = json.loads(line[len("data: "):])
+                if payload.get("type") == "response.completed":
+                    completed = payload["response"]
+                    break
+
+            assert completed is not None
+            stored = adapter._response_store.get(completed["id"])
+            assert stored["session_id"] == "session-after-compression"
+            assert stored["conversation_history"] == compressed_history
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as chained:
+                chained.return_value = (
+                    {
+                        "final_response": "again",
+                        "messages": [{"role": "assistant", "content": "again"}],
+                    },
+                    usage,
+                )
+                follow_up = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "again",
+                        "previous_response_id": completed["id"],
+                    },
+                )
+
+            assert follow_up.status == 200
+            assert chained.call_args.kwargs["session_id"] == "session-after-compression"
 
     @pytest.mark.asyncio
     async def test_stream_cancelled_persists_incomplete_snapshot(self, adapter):


### PR DESCRIPTION
## Summary
- Treat an agent transcript containing compressed-summary metadata as the authoritative Responses conversation history instead of prepending stale pre-compression history.
- Adopt `result["session_id"]` after compression rotates the underlying session.
- Store and return the effective session for non-streaming responses.
- Persist the effective session in streaming terminal snapshots so `previous_response_id` continues from the post-compression head.

## Tests
- Compressed histories replace old transcript content.
- Non-streaming response storage/header use the rotated session, and the next chained request receives it.
- Streaming terminal storage uses the rotated session and the next chained request receives it.
- `.venv/bin/python -m pytest tests/gateway/test_api_server.py -q` (199 passed)
- `.venv/bin/python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py`
- `git diff --check`