### PR TITLE
fix(vision): recover from generic image content rejection

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -44,6 +44,7 @@ from agent.message_sanitization import (
     _sanitize_structure_surrogates,
     _sanitize_surrogates,
     _sanitize_tools_non_ascii,
+    _looks_like_image_content_rejection,
     _strip_images_from_messages,
     _strip_non_ascii,
 )
@@ -2389,55 +2390,7 @@ def run_conversation(
                 except Exception:
                     pass
                 _err_status = getattr(api_error, "status_code", None)
-                _IMAGE_REJECTION_PHRASES = (
-                    "only 'text' content type is supported",
-                    "only text content type is supported",
-                    "image_url is not supported",
-                    "image content is not supported",
-                    "multimodal is not supported",
-                    "multimodal content is not supported",
-                    "multimodal input is not supported",
-                    "vision is not supported",
-                    "vision input is not supported",
-                    "does not support images",
-                    "does not support image input",
-                    "does not support multimodal",
-                    "does not support vision",
-                    "model does not support image",
-                    # ChatGPT-account Codex backend
-                    # (https://chatgpt.com/backend-api/codex) rejects
-                    # data:image/...base64 URLs in input_image fields
-                    # with HTTP 400 "Invalid 'input[N].content[K].image_url'.
-                    # Expected a valid URL, but got a value with an
-                    # invalid format." The OpenAI Responses API on the
-                    # public endpoint accepts data URLs, but the
-                    # ChatGPT-account variant does not. Without this
-                    # phrase the agent cascaded into compression /
-                    # context-too-large recovery instead of just
-                    # stripping the images. Match is narrow on
-                    # purpose — keyed on the field-path apostrophe so
-                    # we don't false-trip on other URL validation
-                    # errors. (issue #23570)
-                    "image_url'. expected",
-                    # DeepSeek's OpenAI-compatible API reports text-only
-                    # request-body variants as:
-                    # "unknown variant `image_url`, expected `text`".
-                    "unknown variant `image_url`, expected `text`",
-                    "unknown variant image_url, expected text",
-                    # OpenRouter routes a request to upstream endpoints and,
-                    # when none of the candidate endpoints for the model accept
-                    # image input, returns HTTP 404 "No endpoints found that
-                    # support image input". Without this phrase the agent never
-                    # strips the images, the retry loop re-sends the same
-                    # rejected request until exhaustion, and the gateway leaves
-                    # every subsequent message queued behind the stuck turn —
-                    # the P1 in issue #21160. The 404 passes the 4xx gate below.
-                    "no endpoints found that support image input",
-                )
-                _err_lower = _err_body.lower()
-                _looks_like_image_rejection = any(
-                    p in _err_lower for p in _IMAGE_REJECTION_PHRASES
-                )
+                _looks_like_image_rejection = _looks_like_image_content_rejection(_err_body)
                 # 4xx-only gate: never interpret 5xx/timeout as "server
                 # said no to images" — those are transient and must
                 # route to the normal retry path.

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -432,6 +432,50 @@ def _strip_images_from_messages(messages: list) -> bool:
     return found
 
 
+_IMAGE_REJECTION_PHRASES = (
+    "only 'text' content type is supported",
+    "only text content type is supported",
+    "image_url is not supported",
+    "image content is not supported",
+    "multimodal is not supported",
+    "multimodal content is not supported",
+    "multimodal input is not supported",
+    "vision is not supported",
+    "vision input is not supported",
+    "does not support images",
+    "does not support image input",
+    "does not support multimodal",
+    "does not support vision",
+    "model does not support image",
+    # Some OpenAI-compatible endpoints reject non-text content blocks with this
+    # generic body instead of naming image_url or vision support explicitly.
+    "unexpected item type in content",
+    # ChatGPT-account Codex backend (https://chatgpt.com/backend-api/codex)
+    # rejects data:image/...base64 URLs in input_image fields with HTTP 400
+    # "Invalid 'input[N].content[K].image_url'. Expected a valid URL, but got a
+    # value with an invalid format." The public OpenAI Responses API accepts
+    # data URLs, but the ChatGPT-account variant does not. Match is narrow on
+    # purpose -- keyed on the field-path apostrophe so we don't false-trip on
+    # other URL validation errors. (issue #23570)
+    "image_url'. expected",
+    # DeepSeek's OpenAI-compatible API reports text-only request-body variants
+    # as "unknown variant `image_url`, expected `text`".
+    "unknown variant `image_url`, expected `text`",
+    "unknown variant image_url, expected text",
+    # OpenRouter routes a request to upstream endpoints and, when none of the
+    # candidate endpoints for the model accept image input, returns HTTP 404
+    # "No endpoints found that support image input". The 404 passes the 4xx
+    # gate in the conversation loop.
+    "no endpoints found that support image input",
+)
+
+
+def _looks_like_image_content_rejection(error_body: str) -> bool:
+    """Return True when a provider error says image/multimodal input is unsupported."""
+    body = str(error_body or "").lower()
+    return any(phrase in body for phrase in _IMAGE_REJECTION_PHRASES)
+
+
 def _sanitize_structure_non_ascii(payload: Any) -> bool:
     """Strip non-ASCII characters from nested dict/list payloads in-place."""
     found = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -175,6 +175,7 @@ from agent.message_sanitization import (  # noqa: F401
     _strip_non_ascii,
     _sanitize_messages_non_ascii,
     _sanitize_tools_non_ascii,
+    _looks_like_image_content_rejection,
     _strip_images_from_messages,
     _sanitize_structure_non_ascii,
 )

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -6,7 +6,7 @@ verify that stripping preserves the role-alternation invariants providers
 require, and that the phrase detector fires on the expected error bodies.
 """
 
-from run_agent import _strip_images_from_messages
+from run_agent import _looks_like_image_content_rejection, _strip_images_from_messages
 
 
 class TestStripImagesPreservesAlternation:
@@ -178,29 +178,8 @@ class TestImageRejectionPhraseIsolation:
     so they route to the correct recovery handler (e.g. _try_shrink_image_parts).
     """
 
-    # Reproduces the phrase list used in run_agent.py's error-handler block.
-    _REJECTION_PHRASES = (
-        "only 'text' content type is supported",
-        "only text content type is supported",
-        "image_url is not supported",
-        "image content is not supported",
-        "multimodal is not supported",
-        "multimodal content is not supported",
-        "multimodal input is not supported",
-        "vision is not supported",
-        "vision input is not supported",
-        "does not support images",
-        "does not support image input",
-        "does not support multimodal",
-        "does not support vision",
-        "model does not support image",
-        "image_url'. expected",
-        "no endpoints found that support image input",
-    )
-
     def _matches(self, body: str) -> bool:
-        low = body.lower()
-        return any(p in low for p in self._REJECTION_PHRASES)
+        return _looks_like_image_content_rejection(body)
 
     def test_anthropic_image_too_large_does_not_trip(self):
         # From agent/error_classifier.py _IMAGE_TOO_LARGE_PATTERNS —
@@ -248,6 +227,10 @@ class TestImageRejectionPhraseIsolation:
             # OpenRouter 404 when no upstream endpoint for the model accepts
             # image input — issue #21160. The exact wording from the report.
             "HTTP 404: No endpoints found that support image input",
+            # Alibaba/OpenAI-compatible endpoints can reject image-bearing
+            # messages without naming image_url explicitly. The first failed
+            # turn should still switch to text-only/aux-vision mode (#57948).
+            "The provided messages input is invalid. The error info is [Unexpected item type in content].",
         ]
         for body in bodies:
             assert self._matches(body) is True, f"false negative on: {body}"


### PR DESCRIPTION
## What does this PR do?

Fixes image-bearing turns where an OpenAI-compatible provider rejects multimodal content with the generic 400 wording `Unexpected item type in content` instead of explicitly mentioning `image_url` or vision support. The conversation loop now recognizes that body as an image-content rejection, strips image parts, marks the session text-only, and retries so non-vision main models can fall back to auxiliary vision on the first turn.

While touching this path, the image rejection phrase detector moved from an inline tuple in `conversation_loop.py` into `agent.message_sanitization`, so production code and regression tests use the same matcher instead of maintaining a copied phrase list.

## Related Issue

Fixes #57948

## Duplicate check

- Searched open PRs for `57948`, `vision_analyze first call auxiliary vision fallback native vision model lacks vision qwen unexpected item type`, and `Unexpected item type in content image content rejection vision`.
- No open PR matched this issue, error wording, or code path.

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Changes

- Adds `unexpected item type in content` to the image-content rejection detector.
- Reuses a single helper from the conversation loop and the regression tests.
- Adds coverage for the exact 400 body reported in #57948.

## How to Test

- [x] `.venv/bin/python -m pytest tests/run_agent/test_image_rejection_fallback.py -q`
- [x] `.venv/bin/python -m pytest tests/run_agent/test_image_rejection_fallback.py tests/agent/test_vision_routing_31179.py -q`
- [x] `.venv/bin/python -m ruff check agent/message_sanitization.py agent/conversation_loop.py run_agent.py tests/run_agent/test_image_rejection_fallback.py`
- [x] `git diff --check`
- [ ] `pytest tests/ -q`

Note: ruff emitted an existing warning about an unrelated invalid `# noqa` directive on `run_agent.py:107`, but all requested files passed the check.

Platform: macOS, Python 3.13, local `.venv`.
