### PR TITLE
fix(desktop): dedupe live sidebar sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -571,6 +571,45 @@ describe('overlayLiveLanes', () => {
     expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['dup'])
   })
 
+  it('does not mirror a snapshot session into another inferred live lane', () => {
+    // Older/pre-git-context rows can already be present in the backend's real
+    // repo lane while the live cache still carries a fallback cwd that would
+    // infer a second lane (the Windows "main" + "default" duplicate report).
+    const snapshot = makeSession('/home/user/.hermes/hermes-agent', { id: 'dup', git_branch: 'main' })
+    const live = makeSession('/home/user/default', { id: 'dup' })
+
+    const project = projectNode({
+      id: '/home/user/.hermes/hermes-agent',
+      repos: [
+        {
+          id: '/home/user/.hermes/hermes-agent',
+          label: 'hermes-agent',
+          path: '/home/user/.hermes/hermes-agent',
+          sessionCount: 1,
+          groups: [
+            lane({
+              id: '/home/user/.hermes/hermes-agent::branch::main',
+              label: 'main',
+              isMain: true,
+              path: '/home/user/.hermes/hermes-agent',
+              sessions: [snapshot]
+            }),
+            lane({
+              id: '/home/user/default::branch::default',
+              label: 'default',
+              isMain: true,
+              path: '/home/user/default'
+            })
+          ]
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [live])
+
+    expect(overlaid.repos[0].groups.flatMap(g => g.sessions.map(s => s.id))).toEqual(['dup'])
+  })
+
   it('adds a new session to an existing worktree lane keyed by a divergent id (matches by path)', () => {
     // Backend keyed the worktree lane off a branch-style id (no live git probe),
     // but the lane PATH is the worktree dir. A new session under that worktree

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -495,7 +495,17 @@ export function overlayRepoLanes(
       }
     }
 
+    const laneHasSession = lane.sessions.some(row => row.id === session.id)
+
+    const existsInAnotherLane =
+      !laneHasSession && lanes.some(g => g !== lane && g.sessions.some(row => row.id === session.id))
+
+    if (existsInAnotherLane) {
+      continue
+    }
+
     lane.sessions = upsertSession(lane.sessions, session)
+
     changed = true
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop projects/sidebar live-session overlay so a session that already exists in one backend snapshot lane is not mirrored into a second lane inferred from the live session cache.

This targets the single-profile duplicate sidebar report where the same sessions can appear under both the live git branch lane, for example `main`, and a fallback cwd-derived lane, for example `default`. The backend tree remains authoritative for membership; the desktop overlay now only updates the lane that already owns a session id instead of copying that id into another inferred lane.

## Related Issue

Fixes #55684

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation
- [ ] Refactor

## Changes

- Adds cross-lane session-id de-duping in `overlayRepoLanes()` before live rows are upserted.
- Keeps same-lane live updates working, while skipping only the duplicate mirror case.
- Adds a regression test for the reported `main` plus `default` duplicate session scenario.

## Duplicate Check

I checked for existing PRs with:

- `gh pr list --state all --search "55684 OR duplicate sessions main default worktree groups single-profile"`
- `gh pr list --state all --search "workspace-groups overlayLiveLanes duplicate session sidebar"`

No open duplicate fix showed up; only the previously merged projects/sidebar feature PR appeared in the issue-number search.

## How to Test

- [x] `npm --workspace apps/desktop run test:ui -- workspace-groups.test.ts`
- [x] `npm --workspace apps/desktop exec eslint src/app/chat/sidebar/projects/workspace-groups.ts src/app/chat/sidebar/projects/workspace-groups.test.ts`
- [x] `git diff --check`

Platform: macOS local checkout, Node workspace install.
