### PR TITLE
chore: map lavya@loom.local -> LavyaTandel in AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1857,6 +1857,7 @@ AUTHOR_MAP = {
     "poli.koltsova@gmail.com": "wnuuee1",  # commit 9fd2b2cb PR author
     "yosapol@jitrak.dev": "Eji4h",  # direct email match
     "kiljadn@gmail.com": "designnotdrum",  # PR #56480 salvage (toolset static-inference fix)
+    "lavya@loom.local": "LavyaTandel",  # PR #57893 salvage local git identity (envelope-layout cache markers on tool/empty-assistant messages; #57845)
 }
 
 


### PR DESCRIPTION
## Summary
Adds `lavya@loom.local` → `LavyaTandel` to `AUTHOR_MAP` so the contributor-attribution audit passes when the #57845 salvage PR lands.

The contributor's commit on PR #57893 uses a local git identity (`lavya@loom.local`) that is not GitHub-resolvable. Same pattern as existing `.local` entries (e.g. `pink@PinkdeMacBook-Air.local`).

## Changes
- `scripts/release.py`: one `AUTHOR_MAP` entry.

## Why first
`contributor_audit.py` runs against `main`, so this mapping must merge before the salvage PR that carries LavyaTandel's cherry-picked commit.
