### PR TITLE
[codex] Add payments review dashboard and Gmail sync

### DIFF
--- a/hermes_cli/payments.py
+++ b/hermes_cli/payments.py
@@ -1,0 +1,471 @@
+"""Profile-scoped payment-request storage for the dashboard Payments page.
+
+The first slice is intentionally narrow:
+  * keep a durable, profile-local review queue of extracted payment requests
+  * expose source status (Gmail / Email / Uploads / Slack) for the dashboard
+  * support manual status transitions only; no payment initiation
+
+Actual ingestion/extraction can be layered on top of this store later without
+changing the dashboard contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from email.utils import parseaddr, parsedate_to_datetime
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any, Dict, List
+
+from hermes_constants import get_hermes_home
+from hermes_cli.config import load_env
+
+PAYMENTS_DIR = "payments"
+REQUESTS_FILE = "requests.json"
+
+PAYMENT_STATUSES = {
+    "new",
+    "needs_review",
+    "ready_to_pay",
+    "paid",
+    "ignored",
+}
+
+PAYMENT_SOURCES = (
+    ("gmail", "Gmail"),
+    ("email", "Email"),
+    ("uploads", "Uploads"),
+    ("slack", "Slack"),
+)
+
+DEFAULT_GMAIL_QUERY = (
+    'newer_than:120d (invoice OR "payment due" OR "request for payment" OR '
+    '"bank transfer" OR remittance OR billing OR statement)'
+)
+DEFAULT_GMAIL_MAX_RESULTS = 25
+
+_AMOUNT_PATTERNS = [
+    re.compile(r"\b(GBP|USD|EUR|AUD|CAD|NZD|CHF|SEK|NOK|DKK)\s?([0-9][0-9,]*(?:\.[0-9]{2})?)\b", re.I),
+    re.compile(r"([£$€])\s?([0-9][0-9,]*(?:\.[0-9]{2})?)"),
+]
+_SORT_CODE_RE = re.compile(r"\b\d{2}-\d{2}-\d{2}\b")
+_ACCOUNT_NUMBER_RE = re.compile(r"\b\d{8}\b")
+_IBAN_RE = re.compile(r"\b[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}\b")
+_SWIFT_RE = re.compile(r"\b[A-Z]{6}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b")
+_ROUTING_RE = re.compile(r"\brouting number\b[:\s]*([0-9]{9})", re.I)
+_REFERENCE_RE = re.compile(
+    r"\b(?:reference|payment reference|remittance reference)\b[:\s#-]*([A-Z0-9-]{4,})",
+    re.I,
+)
+_INVOICE_RE = re.compile(r"\b(?:invoice|inv(?:oice)? number|invoice #)\b[:\s#-]*([A-Z0-9-]{3,})", re.I)
+_DUE_RE = re.compile(
+    r"\b(?:due date|payment due|due)\b[:\s-]*("
+    r"[A-Z][a-z]{2,8}\s+\d{1,2},?\s+\d{4}"
+    r"|\d{4}-\d{2}-\d{2}"
+    r"|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}"
+    r")",
+    re.I,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _payments_dir() -> Path:
+    return get_hermes_home() / PAYMENTS_DIR
+
+
+def _requests_path() -> Path:
+    return _payments_dir() / REQUESTS_FILE
+
+
+def _google_api_script() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "skills"
+        / "productivity"
+        / "google-workspace"
+        / "scripts"
+        / "google_api.py"
+    )
+
+
+def _empty_record(payment_id: str) -> Dict[str, Any]:
+    return {
+        "id": payment_id,
+        "source": "uploads",
+        "source_label": "Uploads",
+        "status": "new",
+        "confidence": "low",
+        "received_at": None,
+        "updated_at": None,
+        "vendor": "",
+        "title": "",
+        "amount": {"value": None, "currency": "", "display": ""},
+        "due_date": None,
+        "payee_name": "",
+        "account_holder": "",
+        "account_number": "",
+        "sort_code": "",
+        "iban": "",
+        "swift": "",
+        "routing_number": "",
+        "payment_reference": "",
+        "invoice_number": "",
+        "billing_address": "",
+        "tax_details": "",
+        "preview_text": "",
+        "warnings": [],
+        "attachments": [],
+        "original": {"label": "", "url": "", "message_id": "", "thread_id": ""},
+    }
+
+
+def _normalize_record(raw: Dict[str, Any], *, index: int) -> Dict[str, Any]:
+    record = _empty_record(str(raw.get("id") or f"payment-{index + 1}"))
+    record.update({k: v for k, v in raw.items() if k in record})
+
+    amount = raw.get("amount")
+    if isinstance(amount, dict):
+        record["amount"] = {
+            "value": amount.get("value"),
+            "currency": str(amount.get("currency") or ""),
+            "display": str(amount.get("display") or ""),
+        }
+
+    original = raw.get("original")
+    if isinstance(original, dict):
+        record["original"] = {
+            "label": str(original.get("label") or ""),
+            "url": str(original.get("url") or ""),
+            "message_id": str(original.get("message_id") or ""),
+            "thread_id": str(original.get("thread_id") or ""),
+        }
+
+    status = str(record.get("status") or "new").strip()
+    record["status"] = status if status in PAYMENT_STATUSES else "needs_review"
+
+    source = str(record.get("source") or "uploads").strip()
+    record["source"] = source or "uploads"
+    record["source_label"] = str(record.get("source_label") or source.title())
+    record["confidence"] = str(record.get("confidence") or "low")
+    record["warnings"] = [
+        str(item).strip()
+        for item in (record.get("warnings") or [])
+        if str(item).strip()
+    ]
+    record["attachments"] = [
+        str(item).strip()
+        for item in (record.get("attachments") or [])
+        if str(item).strip()
+    ]
+    return record
+
+
+def _run_google_api(args: List[str]) -> Any:
+    script = _google_api_script()
+    result = subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip() or "google_api.py failed"
+        raise RuntimeError(err)
+    stdout = result.stdout.strip()
+    if not stdout:
+        return []
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Unexpected google_api.py output: {stdout[:200]}") from exc
+
+
+def _clean_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _format_vendor(sender: str) -> str:
+    name, addr = parseaddr(sender or "")
+    if name.strip():
+        return name.strip().strip('"')
+    if addr:
+        return addr.split("@", 1)[0]
+    return sender.strip()
+
+
+def _parse_amount(text: str) -> Dict[str, Any]:
+    for pattern in _AMOUNT_PATTERNS:
+        match = pattern.search(text)
+        if not match:
+            continue
+        if len(match.groups()) == 2:
+            g1, g2 = match.groups()
+            symbol_currency = {"£": "GBP", "$": "USD", "€": "EUR"}
+            currency = symbol_currency.get(g1, g1.upper())
+            display = f"{currency} {g2}"
+            try:
+                value = float(g2.replace(",", ""))
+            except ValueError:
+                value = None
+            return {"value": value, "currency": currency, "display": display}
+    return {"value": None, "currency": "", "display": ""}
+
+
+def _extract_match(pattern: re.Pattern[str], text: str) -> str:
+    match = pattern.search(text)
+    if not match:
+        return ""
+    if match.lastindex:
+        return str(match.group(1) or "").strip()
+    return str(match.group(0) or "").strip()
+
+
+def _parse_received_at(value: str) -> str | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    try:
+        return parsedate_to_datetime(text).astimezone(timezone.utc).isoformat()
+    except Exception:
+        return text
+
+
+def _confidence_for(record: Dict[str, Any]) -> str:
+    score = 0
+    if record["amount"]["display"]:
+        score += 1
+    if record.get("invoice_number"):
+        score += 1
+    if record.get("payment_reference"):
+        score += 1
+    if any(
+        record.get(key)
+        for key in ("account_number", "sort_code", "iban", "swift", "routing_number")
+    ):
+        score += 2
+    if record.get("due_date"):
+        score += 1
+    if score >= 4:
+        return "high"
+    if score >= 2:
+        return "medium"
+    return "low"
+
+
+def _warnings_for(record: Dict[str, Any]) -> List[str]:
+    warnings = []
+    if not record["amount"]["display"]:
+        warnings.append("No amount detected.")
+    if not any(
+        record.get(key)
+        for key in ("account_number", "sort_code", "iban", "swift", "routing_number")
+    ):
+        warnings.append("No bank account details detected.")
+    if not record.get("payment_reference") and not record.get("invoice_number"):
+        warnings.append("No invoice or payment reference detected.")
+    return warnings
+
+
+def _build_gmail_payment_record(summary: Dict[str, Any], detail: Dict[str, Any], existing: Dict[str, Any] | None) -> Dict[str, Any]:
+    subject = str(detail.get("subject") or summary.get("subject") or "").strip()
+    body = str(detail.get("body") or "").strip()
+    snippet = str(summary.get("snippet") or "").strip()
+    combined = "\n".join(part for part in (subject, snippet, body) if part).strip()
+    vendor = _format_vendor(str(detail.get("from") or summary.get("from") or ""))
+    amount = _parse_amount(combined)
+    record = _empty_record(f"gmail:{detail['id']}")
+    record.update(
+        {
+            "source": "gmail",
+            "source_label": "Gmail",
+            "status": existing.get("status") if existing else "needs_review",
+            "received_at": _parse_received_at(str(detail.get("date") or summary.get("date") or "")),
+            "updated_at": _now_iso(),
+            "vendor": vendor,
+            "title": subject,
+            "amount": amount,
+            "due_date": _extract_match(_DUE_RE, combined) or None,
+            "payee_name": vendor,
+            "account_holder": vendor,
+            "account_number": _extract_match(_ACCOUNT_NUMBER_RE, combined),
+            "sort_code": _extract_match(_SORT_CODE_RE, combined),
+            "iban": _extract_match(_IBAN_RE, combined),
+            "swift": _extract_match(_SWIFT_RE, combined),
+            "routing_number": _extract_match(_ROUTING_RE, combined),
+            "payment_reference": _extract_match(_REFERENCE_RE, combined),
+            "invoice_number": _extract_match(_INVOICE_RE, combined),
+            "preview_text": _clean_text(body or snippet)[:1500],
+            "attachments": existing.get("attachments", []) if existing else [],
+            "original": {
+                "label": str(detail.get("from") or summary.get("from") or ""),
+                "url": f"https://mail.google.com/mail/u/0/#all/{detail['id']}",
+                "message_id": str(detail.get("id") or ""),
+                "thread_id": str(detail.get("threadId") or summary.get("threadId") or ""),
+            },
+        }
+    )
+    record["confidence"] = _confidence_for(record)
+    record["warnings"] = _warnings_for(record)
+    return record
+
+
+def _load_requests() -> List[Dict[str, Any]]:
+    path = _requests_path()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    items = data.get("requests") if isinstance(data, dict) else data
+    if not isinstance(items, list):
+        return []
+    return [_normalize_record(item, index=i) for i, item in enumerate(items) if isinstance(item, dict)]
+
+
+def _save_requests(requests: List[Dict[str, Any]]) -> None:
+    path = _requests_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "requests": requests,
+        "updated_at": _now_iso(),
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _source_statuses() -> List[Dict[str, Any]]:
+    env = load_env()
+    home = get_hermes_home()
+
+    gmail_token = home / "google_token.json"
+    email_address = str(env.get("EMAIL_ADDRESS") or "").strip()
+    slack_token = str(env.get("SLACK_BOT_TOKEN") or "").strip()
+
+    statuses = []
+    for source_id, label in PAYMENT_SOURCES:
+        if source_id == "gmail":
+            connected = gmail_token.exists()
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": (
+                        "Google Workspace token is present."
+                        if connected
+                        else "Connect Google Workspace to scan Gmail invoices."
+                    ),
+                }
+            )
+        elif source_id == "email":
+            connected = bool(email_address)
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": email_address if connected else "Configure the Email channel to ingest invoices.",
+                }
+            )
+        elif source_id == "uploads":
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": True,
+                    "detail": "Use the Files page to stage invoice PDFs and screenshots.",
+                }
+            )
+        elif source_id == "slack":
+            connected = bool(slack_token)
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": (
+                        "Slack bot token is configured."
+                        if connected
+                        else "Slack capture can be added once the Slack channel is configured."
+                    ),
+                }
+            )
+    return statuses
+
+
+def list_payment_requests() -> Dict[str, Any]:
+    requests = _load_requests()
+    requests.sort(
+        key=lambda item: (
+            str(item.get("received_at") or ""),
+            str(item.get("updated_at") or ""),
+            str(item.get("id") or ""),
+        ),
+        reverse=True,
+    )
+    return {
+        "sources": _source_statuses(),
+        "requests": requests,
+        "storage_path": str(_requests_path()),
+    }
+
+
+def sync_gmail_payment_requests(
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+) -> Dict[str, Any]:
+    summaries = _run_google_api(["gmail", "search", query, "--max", str(max_results)])
+    if not isinstance(summaries, list):
+        raise RuntimeError("Gmail search returned an unexpected payload")
+
+    requests = _load_requests()
+    existing_by_id = {str(record.get("id")): record for record in requests}
+    imported = 0
+    updated = 0
+
+    for summary in summaries:
+        if not isinstance(summary, dict) or not summary.get("id"):
+            continue
+        detail = _run_google_api(["gmail", "get", str(summary["id"])])
+        if not isinstance(detail, dict) or not detail.get("id"):
+            continue
+        record_id = f"gmail:{detail['id']}"
+        existing = existing_by_id.get(record_id)
+        record = _build_gmail_payment_record(summary, detail, existing)
+        if existing is None:
+            requests.append(record)
+            existing_by_id[record_id] = record
+            imported += 1
+        else:
+            existing.update(record)
+            updated += 1
+
+    _save_requests(requests)
+    return {
+        "source": "gmail",
+        "query": query,
+        "fetched": len(summaries),
+        "imported": imported,
+        "updated": updated,
+        "requests": requests,
+    }
+
+
+def update_payment_status(payment_id: str, status: str) -> Dict[str, Any]:
+    normalized_status = str(status or "").strip()
+    if normalized_status not in PAYMENT_STATUSES:
+        raise ValueError(f"Unknown payment status: {status}")
+
+    requests = _load_requests()
+    for record in requests:
+        if str(record.get("id")) == payment_id:
+            record["status"] = normalized_status
+            record["updated_at"] = _now_iso()
+            _save_requests(requests)
+            return record
+    raise KeyError(payment_id)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7962,6 +7962,65 @@ async def instantiate_blueprint(body: AutomationBlueprintInstantiate, profile: s
 
 
 # ---------------------------------------------------------------------------
+# Payments dashboard endpoints — profile-scoped manual-payment review queue.
+# ---------------------------------------------------------------------------
+
+
+class PaymentStatusUpdate(BaseModel):
+    status: str
+
+
+class PaymentSyncRequest(BaseModel):
+    source: str = "gmail"
+    query: Optional[str] = None
+    max_results: Optional[int] = None
+
+
+@app.get("/api/payments")
+async def list_payments(profile: Optional[str] = None):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        return payments_store.list_payment_requests()
+
+
+@app.post("/api/payments/{payment_id}/status")
+async def update_payment_status(
+    payment_id: str,
+    body: PaymentStatusUpdate,
+    profile: Optional[str] = None,
+):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        try:
+            return payments_store.update_payment_status(payment_id, body.status)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail="Payment request not found") from exc
+
+
+@app.post("/api/payments/sync")
+async def sync_payments(body: PaymentSyncRequest, profile: Optional[str] = None):
+    from hermes_cli import payments as payments_store
+
+    source = (body.source or "gmail").strip().lower()
+    with _profile_scope(profile):
+        try:
+            if source != "gmail":
+                raise HTTPException(status_code=400, detail=f"Unsupported payment source: {source}")
+            return payments_store.sync_gmail_payment_requests(
+                query=body.query or payments_store.DEFAULT_GMAIL_QUERY,
+                max_results=int(body.max_results or payments_store.DEFAULT_GMAIL_MAX_RESULTS),
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
 # MCP server endpoints — list / add / remove / test.
 #
 # Wraps the same config data layer the CLI uses (hermes_cli.mcp_config), so

--- a/tests/hermes_cli/test_payments.py
+++ b/tests/hermes_cli/test_payments.py
@@ -1,0 +1,217 @@
+"""Tests for the dashboard Payments storage and API surface."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: home)
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: home / "config.yaml")
+    monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: home / ".env")
+    try:
+        import hermes_cli.payments as payments
+
+        monkeypatch.setattr(payments, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(
+            payments,
+            "load_env",
+            lambda: {},
+        )
+    except Exception:
+        pass
+    return home
+
+
+def _write_requests(home: Path, requests: list[dict]) -> None:
+    payments_dir = home / "payments"
+    payments_dir.mkdir(parents=True, exist_ok=True)
+    (payments_dir / "requests.json").write_text(
+        json.dumps({"requests": requests}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+class TestPaymentsStore:
+    def test_list_requests_reports_sources_and_normalizes_records(self, isolated_home):
+        (isolated_home / "google_token.json").write_text('{"token": "x"}', encoding="utf-8")
+        (isolated_home / ".env").write_text("EMAIL_ADDRESS=bills@example.test\n", encoding="utf-8")
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "source": "gmail",
+                    "source_label": "Gmail",
+                    "status": "new",
+                    "confidence": "high",
+                    "received_at": "2026-07-01T10:00:00+00:00",
+                    "vendor": "Example Vendor",
+                    "title": "July invoice",
+                    "amount": {"value": 42, "currency": "GBP", "display": "GBP 42.00"},
+                }
+            ],
+        )
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        result = payments.list_payment_requests()
+
+        gmail = next(source for source in result["sources"] if source["id"] == "gmail")
+        email = next(source for source in result["sources"] if source["id"] == "email")
+        uploads = next(source for source in result["sources"] if source["id"] == "uploads")
+
+        assert gmail["connected"] is True
+        assert email["connected"] is True
+        assert uploads["connected"] is True
+        assert result["requests"][0]["vendor"] == "Example Vendor"
+        assert result["requests"][0]["amount"]["display"] == "GBP 42.00"
+
+    def test_update_status_persists_change(self, isolated_home):
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "status": "new",
+                    "vendor": "Example Vendor",
+                }
+            ],
+        )
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        updated = payments.update_payment_status("pay-1", "paid")
+
+        assert updated["status"] == "paid"
+
+        saved = json.loads((isolated_home / "payments" / "requests.json").read_text(encoding="utf-8"))
+        assert saved["requests"][0]["status"] == "paid"
+        assert saved["requests"][0]["updated_at"]
+
+    def test_sync_gmail_payment_requests_extracts_fields(self, isolated_home, monkeypatch):
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+
+        def fake_run_google_api(args):
+            if args[:2] == ["gmail", "search"]:
+                return [
+                    {
+                        "id": "msg-1",
+                        "threadId": "thread-1",
+                        "from": "Acme Billing <billing@acme.test>",
+                        "subject": "Invoice INV-1001",
+                        "date": "Fri, 01 Jul 2026 12:00:00 +0000",
+                        "snippet": "Amount due GBP 42.00 by 2026-07-05",
+                        "labels": ["INBOX"],
+                    }
+                ]
+            if args[:2] == ["gmail", "get"]:
+                return {
+                    "id": "msg-1",
+                    "threadId": "thread-1",
+                    "from": "Acme Billing <billing@acme.test>",
+                    "subject": "Invoice INV-1001",
+                    "date": "Fri, 01 Jul 2026 12:00:00 +0000",
+                    "body": (
+                        "Invoice number: INV-1001\n"
+                        "Amount due: GBP 42.00\n"
+                        "Due date: 2026-07-05\n"
+                        "Sort code: 12-34-56\n"
+                        "Account number: 12345678\n"
+                        "Payment reference: ACME-1001\n"
+                    ),
+                }
+            raise AssertionError(args)
+
+        monkeypatch.setattr(payments, "_run_google_api", fake_run_google_api)
+
+        result = payments.sync_gmail_payment_requests(query="invoice", max_results=5)
+
+        assert result["imported"] == 1
+        saved = payments.list_payment_requests()["requests"][0]
+        assert saved["id"] == "gmail:msg-1"
+        assert saved["vendor"] == "Acme Billing"
+        assert saved["amount"]["display"] == "GBP 42.00"
+        assert saved["sort_code"] == "12-34-56"
+        assert saved["account_number"] == "12345678"
+        assert saved["payment_reference"] == "ACME-1001"
+        assert saved["invoice_number"] == "INV-1001"
+        assert saved["confidence"] in {"medium", "high"}
+
+
+class TestPaymentsApi:
+    @pytest.fixture(autouse=True)
+    def _setup_client(self, isolated_home, monkeypatch):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", isolated_home / "state.db")
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_list_and_update_payments(self, isolated_home):
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "source": "gmail",
+                    "source_label": "Gmail",
+                    "status": "needs_review",
+                    "vendor": "Example Vendor",
+                    "title": "July invoice",
+                }
+            ],
+        )
+
+        listed = self.client.get("/api/payments")
+        assert listed.status_code == 200
+        payload = listed.json()
+        assert payload["requests"][0]["id"] == "pay-1"
+
+        updated = self.client.post("/api/payments/pay-1/status", json={"status": "ready_to_pay"})
+        assert updated.status_code == 200
+        assert updated.json()["status"] == "ready_to_pay"
+
+    def test_update_rejects_unknown_status(self):
+        updated = self.client.post("/api/payments/missing/status", json={"status": "bogus"})
+        assert updated.status_code == 400
+
+    def test_sync_payments_endpoint(self, monkeypatch):
+        import hermes_cli.payments as payments
+
+        def fake_sync(query, max_results):
+            assert query == payments.DEFAULT_GMAIL_QUERY
+            assert max_results == payments.DEFAULT_GMAIL_MAX_RESULTS
+            return {
+                "source": "gmail",
+                "query": query,
+                "fetched": 1,
+                "imported": 1,
+                "updated": 0,
+                "requests": [],
+            }
+
+        monkeypatch.setattr(payments, "sync_gmail_payment_requests", fake_sync)
+        resp = self.client.post("/api/payments/sync", json={"source": "gmail"})
+        assert resp.status_code == 200
+        assert resp.json()["imported"] == 1

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,7 @@ import {
   Star,
   Terminal,
   Users,
+  Wallet,
   Webhook,
   Wrench,
   X,
@@ -81,6 +82,7 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
+import PaymentsPage from "@/pages/PaymentsPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
 import SkillsPage from "@/pages/SkillsPage";
@@ -138,6 +140,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/models": ModelsPage,
   "/logs": LogsPage,
   "/cron": CronPage,
+  "/payments": PaymentsPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
   "/mcp": McpPage,
@@ -182,6 +185,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
+  { path: "/payments", label: "Payments", icon: Wallet },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
   { path: "/mcp", label: "MCP", icon: Plug },
@@ -218,6 +222,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Database,
   Shield,
   Users,
+  Wallet,
   Wrench,
   Zap,
   Heart,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -66,6 +66,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/status",
   "/api/gateway",
   "/api/analytics",
+  "/api/payments",
   "/api/skills",
   "/api/tools/toolsets",
   "/api/config",
@@ -556,6 +557,22 @@ export const api = {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
+    }),
+
+  // Payments
+  getPayments: () =>
+    fetchJSON<PaymentsResponse>("/api/payments"),
+  syncPayments: (body?: { source?: string; query?: string; max_results?: number }) =>
+    fetchJSON<PaymentSyncResponse>("/api/payments/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    }),
+  updatePaymentStatus: (id: string, status: PaymentRequest["status"]) =>
+    fetchJSON<PaymentRequest>(`/api/payments/${encodeURIComponent(id)}/status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
     }),
 
   // Profiles
@@ -1756,6 +1773,66 @@ export interface ManagedFileWriteResponse {
   root: string | null;
   locked_root: string | null;
   can_change_path: boolean;
+}
+
+export interface PaymentSourceStatus {
+  id: string;
+  label: string;
+  connected: boolean;
+  detail: string;
+}
+
+export interface PaymentRequest {
+  id: string;
+  source: string;
+  source_label: string;
+  status: "new" | "needs_review" | "ready_to_pay" | "paid" | "ignored";
+  confidence: string;
+  received_at: string | null;
+  updated_at: string | null;
+  vendor: string;
+  title: string;
+  amount: {
+    value: number | null;
+    currency: string;
+    display: string;
+  };
+  due_date: string | null;
+  payee_name: string;
+  account_holder: string;
+  account_number: string;
+  sort_code: string;
+  iban: string;
+  swift: string;
+  routing_number: string;
+  payment_reference: string;
+  invoice_number: string;
+  billing_address: string;
+  tax_details: string;
+  preview_text: string;
+  warnings: string[];
+  attachments: string[];
+  original: {
+    label: string;
+    url: string;
+    message_id: string;
+    thread_id: string;
+  };
+}
+
+export interface PaymentsResponse {
+  sources: PaymentSourceStatus[];
+  requests: PaymentRequest[];
+  storage_path: string;
+}
+
+export interface PaymentSyncResponse {
+  source: string;
+  query: string;
+  fetched: number;
+  imported: number;
+  updated: number;
+  requests: PaymentRequest[];
 }
 
 export interface AnalyticsDailyEntry {

--- a/web/src/pages/PaymentsPage.tsx
+++ b/web/src/pages/PaymentsPage.tsx
@@ -1,0 +1,619 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Copy,
+  ExternalLink,
+  Mail,
+  RefreshCw,
+  Wallet,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Toast } from "@nous-research/ui/ui/components/toast";
+import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { api, type PaymentRequest, type PaymentsResponse } from "@/lib/api";
+import { PluginSlot } from "@/plugins";
+import { cn } from "@/lib/utils";
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+});
+
+const DATETIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const STATUS_OPTIONS: Array<{ id: PaymentRequest["status"] | "all"; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "new", label: "New" },
+  { id: "needs_review", label: "Needs review" },
+  { id: "ready_to_pay", label: "Ready to pay" },
+  { id: "paid", label: "Paid" },
+  { id: "ignored", label: "Ignored" },
+];
+
+function statusBadgeTone(status: PaymentRequest["status"]) {
+  if (status === "paid") return "success";
+  if (status === "ready_to_pay") return "warning";
+  if (status === "ignored") return "secondary";
+  return "outline";
+}
+
+function confidenceBadgeTone(confidence: string) {
+  if (confidence === "high") return "success";
+  if (confidence === "medium") return "warning";
+  return "outline";
+}
+
+function amountLabel(payment: PaymentRequest): string {
+  return payment.amount.display || "Amount missing";
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "Missing";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return DATE_FORMAT.format(date);
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "Missing";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return DATETIME_FORMAT.format(date);
+}
+
+function paymentTitle(payment: PaymentRequest): string {
+  return payment.vendor || payment.title || "Untitled payment request";
+}
+
+function searchText(payment: PaymentRequest): string {
+  return [
+    payment.vendor,
+    payment.title,
+    payment.preview_text,
+    payment.invoice_number,
+    payment.payment_reference,
+    payment.original.label,
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+function PaymentField({
+  label,
+  value,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  onCopy?: () => void;
+}) {
+  const isMissing = !value.trim() || value === "Missing";
+  return (
+    <div className="space-y-1 border-b border-border/60 pb-3 last:border-b-0 last:pb-0">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          {label}
+        </span>
+        {onCopy ? (
+          <Button
+            ghost
+            size="icon"
+            type="button"
+            onClick={() => void onCopy()}
+            aria-label={`Copy ${label}`}
+            disabled={isMissing}
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </Button>
+        ) : null}
+      </div>
+      <p className={cn("text-sm text-foreground", isMissing && "italic text-muted-foreground")}>
+        {isMissing ? "Missing" : value}
+      </p>
+    </div>
+  );
+}
+
+export default function PaymentsPage() {
+  const { toast, showToast } = useToast();
+  const { setEnd } = usePageHeader();
+  const [data, setData] = useState<PaymentsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sourceFilter, setSourceFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState<PaymentRequest["status"] | "all">("all");
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [savingStatus, setSavingStatus] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await api.getPayments();
+      setData(result);
+    } catch (error) {
+      showToast(`Failed to load payments: ${error}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    setEnd(
+      <Button
+        ghost
+        size="icon"
+        type="button"
+        onClick={() => void load()}
+        disabled={loading}
+        aria-label="Refresh payments"
+      >
+        {loading ? <Spinner /> : <RefreshCw />}
+      </Button>,
+    );
+    return () => setEnd(null);
+  }, [load, loading, setEnd]);
+
+  const filteredRequests = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return (data?.requests || []).filter((payment) => {
+      if (sourceFilter !== "all" && payment.source !== sourceFilter) return false;
+      if (statusFilter !== "all" && payment.status !== statusFilter) return false;
+      if (needle && !searchText(payment).includes(needle)) return false;
+      return true;
+    });
+  }, [data?.requests, query, sourceFilter, statusFilter]);
+
+  useEffect(() => {
+    if (!filteredRequests.length) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !filteredRequests.some((payment) => payment.id === selectedId)) {
+      setSelectedId(filteredRequests[0].id);
+    }
+  }, [filteredRequests, selectedId]);
+
+  const selectedPayment =
+    filteredRequests.find((payment) => payment.id === selectedId) || filteredRequests[0] || null;
+
+  const copyValue = useCallback(
+    async (label: string, value: string) => {
+      if (!value.trim()) return;
+      try {
+        await navigator.clipboard.writeText(value);
+        showToast(`${label} copied`, "success");
+      } catch (error) {
+        showToast(`Failed to copy ${label}: ${error}`, "error");
+      }
+    },
+    [showToast],
+  );
+
+  const updateStatus = useCallback(
+    async (status: PaymentRequest["status"]) => {
+      if (!selectedPayment) return;
+      setSavingStatus(status);
+      try {
+        const updated = await api.updatePaymentStatus(selectedPayment.id, status);
+        setData((prev) =>
+          prev
+            ? {
+                ...prev,
+                requests: prev.requests.map((item) =>
+                  item.id === updated.id ? updated : item,
+                ),
+              }
+            : prev,
+        );
+        showToast(`Payment marked ${status.replaceAll("_", " ")}`, "success");
+      } catch (error) {
+        showToast(`Failed to update payment: ${error}`, "error");
+      } finally {
+        setSavingStatus(null);
+      }
+    },
+    [selectedPayment, showToast],
+  );
+
+  const sourceFilters = data?.sources || [];
+  const gmailSource = sourceFilters.find((source) => source.id === "gmail");
+
+  const syncGmail = useCallback(async () => {
+    setSyncing(true);
+    try {
+      const result = await api.syncPayments({ source: "gmail" });
+      showToast(
+        `Gmail sync complete: ${result.imported} imported, ${result.updated} updated`,
+        "success",
+      );
+      await load();
+    } catch (error) {
+      showToast(`Failed to sync Gmail: ${error}`, "error");
+    } finally {
+      setSyncing(false);
+    }
+  }, [load, showToast]);
+
+  return (
+    <>
+      <div className="space-y-6">
+        <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {sourceFilters.map((source) => (
+            <Card key={source.id} className="border-border/70 bg-background/70">
+              <CardContent className="flex items-start justify-between gap-4 p-4">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-foreground">{source.label}</span>
+                    <Badge tone={source.connected ? "success" : "outline"}>
+                      {source.connected ? "Connected" : "Not connected"}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{source.detail}</p>
+                </div>
+                <Mail className="mt-0.5 h-4 w-4 text-muted-foreground" />
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-[21rem_minmax(0,1fr)_22rem]">
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-4 pb-4">
+              <div className="flex items-center justify-between gap-3">
+                <CardTitle>Queue</CardTitle>
+                <div className="flex items-center gap-2">
+                  <Badge tone="outline">{filteredRequests.length}</Badge>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => void syncGmail()}
+                    disabled={syncing || gmailSource?.connected === false}
+                  >
+                    {syncing ? <Spinner /> : "Sync Gmail"}
+                  </Button>
+                </div>
+              </div>
+              <Input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search vendor, invoice, reference..."
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={sourceFilter === "all" ? "default" : "secondary"}
+                  onClick={() => setSourceFilter("all")}
+                >
+                  All sources
+                </Button>
+                {sourceFilters.map((source) => (
+                  <Button
+                    key={source.id}
+                    type="button"
+                    size="sm"
+                    variant={sourceFilter === source.id ? "default" : "secondary"}
+                    onClick={() => setSourceFilter(source.id)}
+                  >
+                    {source.label}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {STATUS_OPTIONS.map((status) => (
+                  <Button
+                    key={status.id}
+                    type="button"
+                    size="sm"
+                    variant={statusFilter === status.id ? "default" : "secondary"}
+                    onClick={() => setStatusFilter(status.id)}
+                  >
+                    {status.label}
+                  </Button>
+                ))}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {loading ? (
+                <div className="grid min-h-48 place-items-center">
+                  <Spinner />
+                </div>
+              ) : filteredRequests.length === 0 ? (
+                <div className="space-y-3 rounded-xl border border-dashed border-border/80 bg-muted/20 p-5 text-sm text-muted-foreground">
+                  <div className="flex items-center gap-2 text-foreground">
+                    <Wallet className="h-4 w-4" />
+                    <span className="font-medium">No captured payment requests yet</span>
+                  </div>
+                  <p>
+                    Connect Gmail or Email, or stage invoice files for extraction. This queue
+                    will keep the manual-payment details once capture is wired in.
+                  </p>
+                  {data?.storage_path ? (
+                    <p className="font-mono-ui text-xs text-muted-foreground/80">
+                      Storage: {data.storage_path}
+                    </p>
+                  ) : null}
+                </div>
+              ) : (
+                filteredRequests.map((payment) => (
+                  <button
+                    key={payment.id}
+                    type="button"
+                    onClick={() => setSelectedId(payment.id)}
+                    className={cn(
+                      "w-full rounded-xl border px-4 py-3 text-left transition-colors",
+                      selectedPayment?.id === payment.id
+                        ? "border-foreground/20 bg-foreground/5"
+                        : "border-border/70 bg-background hover:bg-muted/25",
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate font-medium text-foreground">
+                          {paymentTitle(payment)}
+                        </p>
+                        <p className="truncate text-sm text-muted-foreground">
+                          {payment.title || payment.preview_text || "No source summary"}
+                        </p>
+                      </div>
+                      <Badge tone={statusBadgeTone(payment.status)}>
+                        {payment.status.replaceAll("_", " ")}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <Badge tone="outline">{payment.source_label}</Badge>
+                      <Badge tone={confidenceBadgeTone(payment.confidence)}>
+                        {payment.confidence} confidence
+                      </Badge>
+                      <span>{amountLabel(payment)}</span>
+                      <span>Due {formatDate(payment.due_date)}</span>
+                    </div>
+                  </button>
+                ))
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-3 pb-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle>{selectedPayment ? paymentTitle(selectedPayment) : "Invoice / Request"}</CardTitle>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {selectedPayment
+                      ? selectedPayment.title || "No subject captured yet."
+                      : "Select a captured item to inspect the source and extracted fields."}
+                  </p>
+                </div>
+                {selectedPayment ? (
+                  <Badge tone={statusBadgeTone(selectedPayment.status)}>
+                    {selectedPayment.status.replaceAll("_", " ")}
+                  </Badge>
+                ) : null}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              {selectedPayment ? (
+                <>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">From</p>
+                      <p className="text-sm text-foreground">
+                        {selectedPayment.original.label || selectedPayment.vendor || "Missing"}
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Received</p>
+                      <p className="text-sm text-foreground">{formatDateTime(selectedPayment.received_at)}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Amount</p>
+                      <p className="text-sm text-foreground">{amountLabel(selectedPayment)}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Due date</p>
+                      <p className="text-sm text-foreground">{formatDate(selectedPayment.due_date)}</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-border/70 bg-muted/20 p-4">
+                    <div className="flex items-center gap-2">
+                      <AlertTriangle className="h-4 w-4 text-warning" />
+                      <p className="font-medium text-foreground">Review summary</p>
+                    </div>
+                    <p className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">
+                      {selectedPayment.preview_text || "No preview text has been captured yet."}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="rounded-xl border border-border/70 bg-background p-4">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                        Attachments
+                      </p>
+                      {selectedPayment.attachments.length ? (
+                        <ul className="mt-3 space-y-2 text-sm text-foreground">
+                          {selectedPayment.attachments.map((attachment) => (
+                            <li key={attachment}>{attachment}</li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="mt-3 text-sm italic text-muted-foreground">No attachments recorded</p>
+                      )}
+                    </div>
+                    <div className="rounded-xl border border-border/70 bg-background p-4">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                        Warnings
+                      </p>
+                      {selectedPayment.warnings.length ? (
+                        <ul className="mt-3 space-y-2 text-sm text-foreground">
+                          {selectedPayment.warnings.map((warning) => (
+                            <li key={warning} className="flex gap-2">
+                              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+                              <span>{warning}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="mt-3 text-sm italic text-muted-foreground">
+                          No extraction warnings
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-3">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() => window.open(selectedPayment.original.url, "_blank", "noopener,noreferrer")}
+                      disabled={!selectedPayment.original.url}
+                    >
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      Open original
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="grid min-h-64 place-items-center text-sm text-muted-foreground">
+                  Select a payment request from the queue.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-3 pb-4">
+              <CardTitle>Payment Details</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Copy these fields into your banking app. No payments are sent automatically.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {selectedPayment ? (
+                <>
+                  <PaymentField
+                    label="Payee"
+                    value={selectedPayment.payee_name}
+                    onCopy={() => copyValue("payee", selectedPayment.payee_name)}
+                  />
+                  <PaymentField
+                    label="Account holder"
+                    value={selectedPayment.account_holder}
+                    onCopy={() => copyValue("account holder", selectedPayment.account_holder)}
+                  />
+                  <PaymentField
+                    label="Account number"
+                    value={selectedPayment.account_number}
+                    onCopy={() => copyValue("account number", selectedPayment.account_number)}
+                  />
+                  <PaymentField
+                    label="Sort code"
+                    value={selectedPayment.sort_code}
+                    onCopy={() => copyValue("sort code", selectedPayment.sort_code)}
+                  />
+                  <PaymentField
+                    label="IBAN"
+                    value={selectedPayment.iban}
+                    onCopy={() => copyValue("IBAN", selectedPayment.iban)}
+                  />
+                  <PaymentField
+                    label="SWIFT"
+                    value={selectedPayment.swift}
+                    onCopy={() => copyValue("SWIFT", selectedPayment.swift)}
+                  />
+                  <PaymentField
+                    label="Routing number"
+                    value={selectedPayment.routing_number}
+                    onCopy={() => copyValue("routing number", selectedPayment.routing_number)}
+                  />
+                  <PaymentField
+                    label="Amount"
+                    value={amountLabel(selectedPayment)}
+                    onCopy={() => copyValue("amount", amountLabel(selectedPayment))}
+                  />
+                  <PaymentField
+                    label="Reference"
+                    value={selectedPayment.payment_reference}
+                    onCopy={() => copyValue("reference", selectedPayment.payment_reference)}
+                  />
+                  <PaymentField
+                    label="Invoice number"
+                    value={selectedPayment.invoice_number}
+                    onCopy={() => copyValue("invoice number", selectedPayment.invoice_number)}
+                  />
+                  <PaymentField
+                    label="Due date"
+                    value={formatDate(selectedPayment.due_date)}
+                    onCopy={() => copyValue("due date", formatDate(selectedPayment.due_date))}
+                  />
+                  <PaymentField label="Billing address" value={selectedPayment.billing_address} />
+                  <PaymentField label="Tax details" value={selectedPayment.tax_details} />
+
+                  <div className="space-y-2 pt-2">
+                    <Button
+                      type="button"
+                      className="w-full"
+                      onClick={() => void updateStatus("ready_to_pay")}
+                      disabled={savingStatus !== null || selectedPayment.status === "ready_to_pay"}
+                    >
+                      {savingStatus === "ready_to_pay" ? <Spinner /> : "Mark ready to pay"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("paid")}
+                      disabled={savingStatus !== null || selectedPayment.status === "paid"}
+                    >
+                      {savingStatus === "paid" ? <Spinner /> : "Mark paid"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("needs_review")}
+                      disabled={savingStatus !== null || selectedPayment.status === "needs_review"}
+                    >
+                      {savingStatus === "needs_review" ? <Spinner /> : "Needs review"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("ignored")}
+                      disabled={savingStatus !== null || selectedPayment.status === "ignored"}
+                    >
+                      {savingStatus === "ignored" ? <Spinner /> : "Not a payment"}
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="grid min-h-64 place-items-center text-sm text-muted-foreground">
+                  Payment details will appear here.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+
+      <PluginSlot name="dashboard.payments.below" />
+
+      {toast && <Toast message={toast.message} type={toast.type} onClose={toast.hide} />}
+    </>
+  );
+}

--- a/website/docs/user-guide/features/payments.md
+++ b/website/docs/user-guide/features/payments.md
@@ -1,0 +1,153 @@
+---
+sidebar_position: 16
+title: "Payments Review"
+description: "Capture invoice and payment-request details from Gmail and other sources for manual payment in your banking app."
+---
+
+# Payments Review
+
+The **Payments** page in the web dashboard is a review queue for invoices and payment requests. Hermes does **not** send money or trigger bank transfers. Instead, it captures payment details, highlights missing fields, and gives you structured values to copy into your banking app manually.
+
+## What it does
+
+- **Captures payment requests** into a profile-scoped queue
+- **Syncs Gmail** for likely invoice / payment-due messages
+- **Stores extracted fields** such as amount, due date, invoice number, payment reference, and bank details
+- **Flags uncertainty** when important details are missing or low-confidence
+- **Tracks manual review state** so you can move items from new → ready to pay → paid
+
+## Where it lives
+
+Open the [Web Dashboard](./web-dashboard.md) and select **Payments** in the sidebar.
+
+The queue is profile-scoped, like the rest of the management dashboard. If you switch profiles, you are looking at that profile's payment-request store.
+
+## Current sources
+
+### Gmail
+
+The first real ingestion path is **Gmail**.
+
+When Google Workspace is configured, the page can run **Sync Gmail**, which:
+
+1. Searches for likely invoices and payment requests
+2. Reads candidate messages through the existing Google Workspace bridge
+3. Extracts fields such as:
+   - payee
+   - amount and currency
+   - due date
+   - invoice number
+   - payment reference
+   - sort code / account number
+   - IBAN / SWIFT / routing number when present
+4. Adds or updates queue entries in the Payments store
+
+Set up Gmail/Google Workspace first:
+
+- [Google Workspace skill](../skills/bundled/productivity/productivity-google-workspace.md)
+
+### Email
+
+The page also detects whether the built-in [Email channel](../messaging/email.md) is configured. That source is currently surfaced as a connection status and review target; the real extraction path is still Gmail-first.
+
+### Uploads
+
+Uploads are supported as a staging concept today. The page points you to the [Files](./web-dashboard.md#files) workflow so invoice PDFs or screenshots can be placed under your Hermes home for later extraction/review flows.
+
+### Slack
+
+Slack appears as a source-status card so the eventual cross-channel review model is visible in one place, but Gmail is the only fully wired sync source right now.
+
+## Page layout
+
+The Payments page is split into three areas:
+
+### Queue
+
+The left column shows captured payment requests with:
+
+- vendor / sender
+- title or subject
+- amount
+- due date
+- source
+- confidence
+- review status
+
+Filters let you narrow by source, status, or free-text search.
+
+### Invoice / Request detail
+
+The middle panel shows:
+
+- sender / source metadata
+- received time
+- amount and due date
+- extracted preview text
+- attachment list
+- warnings about missing or uncertain fields
+- a link back to the original Gmail message when available
+
+### Payment details
+
+The right panel gives you copy-ready fields for your banking app:
+
+- payee
+- account holder
+- account number
+- sort code
+- IBAN
+- SWIFT
+- routing number
+- amount
+- payment reference
+- invoice number
+- due date
+- billing address
+- tax details
+
+## Manual review states
+
+Each payment request can be moved between these states:
+
+- `new`
+- `needs_review`
+- `ready_to_pay`
+- `paid`
+- `ignored`
+
+These are review-only states. Marking an item `paid` does not send anything externally.
+
+## Storage
+
+The queue is stored under your profile's Hermes home:
+
+```text
+~/.hermes/payments/requests.json
+```
+
+If you're using multiple profiles, each profile has its own `payments/requests.json`.
+
+## Safety model
+
+The Payments workflow is intentionally conservative:
+
+- Hermes does **not** initiate transfers
+- Missing details remain visible as missing
+- Low-confidence extraction is surfaced as warnings instead of hidden
+- Gmail sync updates existing entries rather than silently duplicating every read
+
+## Current limitations
+
+As of July 4, 2026:
+
+- **Gmail sync is the only fully wired ingestion path**
+- extraction is heuristic, not OCR- or attachment-parser-driven yet
+- uploads and other channels are surfaced in the UI, but not fully ingested into the queue
+- validation against a user's real invoice examples still depends on the connected mailbox and real message content
+
+## Related
+
+- [Web Dashboard](./web-dashboard.md)
+- [Google Workspace](../skills/bundled/productivity/productivity-google-workspace.md)
+- [Files](./web-dashboard.md#files)

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 15
 title: "Web Dashboard"
-description: "Browser-based administration panel for managing configuration, API keys, MCP servers, messaging pairing, webhooks, the gateway, memory, credentials, sessions, logs, analytics, cron jobs, and skills"
+description: "Browser-based administration panel for managing configuration, API keys, MCP servers, messaging pairing, payment requests, webhooks, the gateway, memory, credentials, sessions, logs, analytics, cron jobs, and skills"
 ---
 
 # Web Dashboard
@@ -228,6 +228,19 @@ Each key shows:
 
 Advanced/rarely-used keys are hidden by default behind a toggle.
 
+### Files
+
+Browse and manage files inside the dashboard without dropping to a shell.
+
+- **Browse directories** — list files under the currently selected path
+- **Navigate** — move up the directory tree or jump directly to another path
+- **Upload** — send local files into the current directory
+- **Create folder** — add directories inline
+- **Download** — fetch any file back to your machine
+- **Delete** — remove files or folders after confirmation
+
+This is the easiest staging surface for invoice PDFs, screenshots, and other payment-request artifacts you want Hermes to review later.
+
 ### Sessions
 
 Browse and inspect all agent sessions. Each row shows the session title, source platform icon (CLI, Telegram, Discord, Slack, cron), model name, message count, tool call count, and how long ago it was active. Live sessions are marked with a pulsing badge.
@@ -273,6 +286,18 @@ Create and manage scheduled cron jobs that run agent prompts on a recurring sche
 - **Edit** — open a pre-filled modal to change a job's prompt, schedule, name, or delivery target
 - **Trigger now** — immediately execute a job outside its normal schedule
 - **Delete** — permanently remove a cron job
+
+### Payments
+
+Review captured invoices and payment requests before paying them manually in your banking app.
+
+- **Sync Gmail** — search Gmail for likely invoices / payment-due messages and import or update queue entries through the existing Google Workspace bridge
+- **Queue** — review vendor, amount, due date, source, confidence, and manual status (`new`, `needs_review`, `ready_to_pay`, `paid`, `ignored`)
+- **Detail view** — inspect the source message summary, warnings, attachments, and a link back to the original Gmail message when available
+- **Copy-ready payment fields** — payee, account holder, account number, sort code, IBAN, SWIFT, routing number, amount, reference, invoice number, due date, and other extracted details
+- **Manual-review only** — the page never initiates transfers; it organizes details for you to copy into your banking app
+
+See [Payments Review](./payments.md) for the full workflow and current limitations.
 
 ### Profiles
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -112,6 +112,7 @@ const sidebars: SidebarsConfig = {
           label: 'Management',
           items: [
             'user-guide/features/web-dashboard',
+            'user-guide/features/payments',
             'user-guide/features/extending-the-dashboard',
             'user-guide/features/api-server',
             'user-guide/features/subscription-proxy',


### PR DESCRIPTION
## Summary
- add a profile-scoped payments store and Gmail invoice sync flow for manual payment review
- expose dashboard API endpoints plus a new Payments page for queueing, inspecting, and updating payment requests
- document the workflow and add focused backend/API tests for the new surface

## Why
Hermes did not have a structured way to capture invoice and payment-request details from Gmail for later manual payment. This adds a conservative review queue that extracts payment fields, tracks status, and keeps the user in control of the actual transfer.

## Impact
Users can review likely invoices in the dashboard, copy extracted banking details into their own banking app, and sync/update items from Gmail without enabling any automatic payment execution.

## Validation
- `bash scripts/run_tests.sh tests/hermes_cli/test_payments.py`
