### PR TITLE
fix(qqbot): accept is_reconnect kwarg in QQAdapter.connect

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,8 +278,13 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        """Authenticate, obtain gateway URL, and open the WebSocket."""
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Authenticate, obtain gateway URL, and open the WebSocket.
+
+        Args:
+            is_reconnect: True when the gateway reconnects after a
+                transient failure; False on cold boot.
+        """
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
             self._set_fatal_error("qq_missing_dependency", message, retryable=True)


### PR DESCRIPTION
## Summary

`QQAdapter.connect()` violated the `BasePlatformAdapter.connect(*, is_reconnect: bool = False)` contract introduced in #52844 — it was bare `async def connect(self)`. The gateway's reconnect watcher (`gateway/run.py`) recovers a platform after a **fatal adapter error** by building a fresh adapter and calling `connect(is_reconnect=True)`. For QQBot, that call raised:

```
TypeError: connect() got an unexpected keyword argument 'is_reconnect'
```

so the watcher could never re-establish QQBot through the fatal-recovery path.

## Live symptom

After a fatal QQBot adapter error (e.g. WebSocket close that exhausts the in-process retry ladder), the watcher's `Reconnecting qqbot (attempt N)...` step crashes with the `TypeError`. QQBot never comes back online, and the bot stops responding to messages until a full gateway restart.

## Why QQBot doesn't need special reconnect logic for the flag (contract conformance only)

`is_reconnect` exists so adapters with a **server-side update queue** (e.g. Telegram's Bot API) preserve that queue across an outage instead of dropping it (#52844). QQBot has no such queue — the QQ gateway delivers messages over the live WebSocket connection, and the adapter re-authenticates with a fresh `/gateway` request on every connect(). There is no server-side state to preserve, and the watcher already disconnects the old adapter (cancelling the WebSocket supervisor) before building a fresh one.

So QQBot must **accept** the kwarg for contract conformance, and correctly has nothing special to do with it at the adapter layer — the existing `connect()` body already handles both cold boot and reconnect correctly once the `TypeError` is removed.

## Changes

- `gateway/platforms/qqbot/adapter.py`: Added `*, is_reconnect: bool = False` to `QQAdapter.connect()` to match the `BasePlatformAdapter` contract. Updated docstring to document the parameter.

## Tests

Existing `test_connect_uses_redirect_guard_hook` calls `adapter.connect()` without `is_reconnect`, which continues to work (the parameter defaults to `False`). No regression risk.
