### PR TITLE
fix(prompt-caching): land envelope cache breakpoints on honored carriers during tool loops (#57845)

### DIFF
--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -65,7 +65,11 @@ def _can_carry_marker(msg: dict, native_anthropic: bool) -> bool:
     if content is None or content == "":
         return False
     if isinstance(content, list):
-        return any(isinstance(part, dict) for part in content)
+        # _apply_cache_marker only marks the LAST content part, so the carrier
+        # predicate must agree: a list whose last element isn't a dict cannot
+        # actually receive a marker and would waste a breakpoint. Mirror the
+        # `content` truthiness + last-element-dict check in _apply_cache_marker.
+        return bool(content) and isinstance(content[-1], dict)
     return isinstance(content, str)
 
 

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -17,12 +17,23 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
     role = msg.get("role", "")
     content = msg.get("content")
 
-    if role == "tool":
-        if native_anthropic:
-            msg["cache_control"] = cache_marker
+    if role == "tool" and native_anthropic:
+        # Native Anthropic layout: top-level marker; the adapter moves it
+        # inside the tool_result block.
+        msg["cache_control"] = cache_marker
         return
 
     if content is None or content == "":
+        if role == "tool" and not native_anthropic:
+            # OpenRouter rejects top-level cache_control on role:tool (silent
+            # hang) and an empty message has no content part to carry the
+            # marker — skip. Non-empty tool content falls through below and
+            # gets the marker on a content part, which OpenRouter honors.
+            return
+        if role == "assistant" and not native_anthropic:
+            # Empty assistant turns are pure tool_calls. A top-level marker
+            # here is ignored on the envelope layout, so skip.
+            return
         msg["cache_control"] = cache_marker
         return
 
@@ -36,6 +47,26 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
         last = content[-1]
         if isinstance(last, dict):
             last["cache_control"] = cache_marker
+
+
+def _can_carry_marker(msg: dict, native_anthropic: bool) -> bool:
+    """True if a marker on this message is actually honored by the provider.
+
+    On the native Anthropic layout every message works (top-level markers are
+    relocated by the adapter). On the envelope layout (OpenRouter et al.) only
+    markers inside content parts are honored: empty-content messages (e.g.
+    assistant turns that are pure tool_calls) and empty tool messages would
+    receive a top-level marker the provider ignores — wasting one of the four
+    breakpoints. Skip those so the breakpoints land on messages that count.
+    """
+    if native_anthropic:
+        return True
+    content = msg.get("content")
+    if content is None or content == "":
+        return False
+    if isinstance(content, list):
+        return any(isinstance(part, dict) for part in content)
+    return isinstance(content, str)
 
 
 def _build_marker(ttl: str) -> Dict[str, str]:
@@ -72,7 +103,12 @@ def apply_anthropic_cache_control(
         breakpoints_used += 1
 
     remaining = 4 - breakpoints_used
-    non_sys = [i for i in range(len(messages)) if messages[i].get("role") != "system"]
+    non_sys = [
+        i
+        for i in range(len(messages))
+        if messages[i].get("role") != "system"
+        and _can_carry_marker(messages[i], native_anthropic=native_anthropic)
+    ]
     for idx in non_sys[-remaining:]:
         _apply_cache_marker(messages[idx], marker, native_anthropic=native_anthropic)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1857,6 +1857,7 @@ AUTHOR_MAP = {
     "poli.koltsova@gmail.com": "wnuuee1",  # commit 9fd2b2cb PR author
     "yosapol@jitrak.dev": "Eji4h",  # direct email match
     "kiljadn@gmail.com": "designnotdrum",  # PR #56480 salvage (toolset static-inference fix)
+    "lavya@loom.local": "LavyaTandel",  # PR #57893 salvage local git identity (envelope-layout cache markers on tool/empty-assistant messages; #57845)
 }
 
 

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -3,6 +3,7 @@
 
 from agent.prompt_caching import (
     _apply_cache_marker,
+    _can_carry_marker,
     apply_anthropic_cache_control,
 )
 
@@ -23,18 +24,37 @@ class TestApplyCacheMarker:
         _apply_cache_marker(msg, MARKER, native_anthropic=False)
         assert "cache_control" not in msg
 
-    def test_none_content_gets_top_level_marker(self):
-        msg = {"role": "assistant", "content": None}
-        _apply_cache_marker(msg, MARKER)
+    def test_tool_message_wraps_non_empty_content_on_openrouter(self):
+        """Non-empty tool content should be wrapped so the marker lands on a content part."""
+        msg = {"role": "tool", "content": "tool result bytes"}
+        _apply_cache_marker(msg, MARKER, native_anthropic=False)
+        assert "cache_control" not in msg
+        assert isinstance(msg["content"], list)
+        assert msg["content"][0]["cache_control"] == MARKER
+
+    def test_empty_assistant_message_skips_marker_on_openrouter(self):
+        """OpenRouter path: empty assistant turns are pure tool_calls, marker would be ignored."""
+        msg = {"role": "assistant", "content": ""}
+        _apply_cache_marker(msg, MARKER, native_anthropic=False)
+        assert "cache_control" not in msg
+
+    def test_native_anthropic_empty_assistant_gets_top_level_marker(self):
+        """Native Anthropic layout can still carry top-level marker on empty content."""
+        msg = {"role": "assistant", "content": ""}
+        _apply_cache_marker(msg, MARKER, native_anthropic=True)
         assert msg["cache_control"] == MARKER
 
-    def test_empty_string_content_gets_top_level_marker(self):
-        """Empty text blocks cannot have cache_control (Anthropic rejects them)."""
-        msg = {"role": "assistant", "content": ""}
-        _apply_cache_marker(msg, MARKER)
+    def test_none_content_skips_marker_on_openrouter(self):
+        """OpenRouter path: None-content assistant turns are ignored."""
+        msg = {"role": "assistant", "content": None}
+        _apply_cache_marker(msg, MARKER, native_anthropic=False)
+        assert "cache_control" not in msg
+
+    def test_none_content_gets_top_level_marker_on_native_anthropic(self):
+        """Native Anthropic path: None content still gets top-level marker."""
+        msg = {"role": "assistant", "content": None}
+        _apply_cache_marker(msg, MARKER, native_anthropic=True)
         assert msg["cache_control"] == MARKER
-        # Must NOT wrap into [{"type": "text", "text": "", "cache_control": ...}]
-        assert msg["content"] == ""
 
     def test_string_content_wrapped_in_list(self):
         msg = {"role": "user", "content": "Hello"}
@@ -61,6 +81,22 @@ class TestApplyCacheMarker:
         msg = {"role": "user", "content": []}
         # Should not crash on empty list
         _apply_cache_marker(msg, MARKER)
+
+
+class TestCanCarryMarker:
+    def test_native_anthropic_always_true(self):
+        assert _can_carry_marker({"role": "assistant", "content": ""}, native_anthropic=True) is True
+        assert _can_carry_marker({"role": "tool", "content": ""}, native_anthropic=True) is True
+
+    def test_openrouter_content_parts_carry_marker(self):
+        assert _can_carry_marker({"role": "user", "content": "text"}, native_anthropic=False) is True
+        assert _can_carry_marker({"role": "user", "content": [{"type": "text", "text": "a"}]}, native_anthropic=False) is True
+
+    def test_openrouter_empty_or_none_does_not_carry_marker(self):
+        assert _can_carry_marker({"role": "assistant", "content": ""}, native_anthropic=False) is False
+        assert _can_carry_marker({"role": "assistant", "content": None}, native_anthropic=False) is False
+        assert _can_carry_marker({"role": "tool", "content": "result"}, native_anthropic=False) is True
+        assert _can_carry_marker({"role": "tool", "content": ""}, native_anthropic=False) is False
 
 
 class TestApplyAnthropicCacheControl:
@@ -139,3 +175,32 @@ class TestApplyAnthropicCacheControl:
             elif "cache_control" in msg:
                 count += 1
         assert count <= 4
+
+    def test_tool_loop_empty_assistant_and_tool_messages_do_not_consume_breakpoints(self):
+        """Tool loops should keep breakpoints on messages that can carry markers."""
+        msgs = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "run tool 1", "cache_control": MARKER},
+            {"role": "assistant", "content": "", "tool_calls": [{"type": "function"}]},
+            {"role": "tool", "content": "tool result 1"},
+            {"role": "user", "content": "run tool 2", "cache_control": MARKER},
+            {"role": "assistant", "content": "", "tool_calls": [{"type": "function"}]},
+            {"role": "tool", "content": "tool result 2"},
+        ]
+        result = apply_anthropic_cache_control(msgs, native_anthropic=False)
+        # Empty assistant/tool turns should not get broken markers
+        assert "cache_control" not in result[2]
+        assert "cache_control" not in result[3]
+        assert "cache_control" not in result[5]
+        assert "cache_control" not in result[6]
+
+    def test_tool_message_marker_lands_on_content_part_on_openrouter(self):
+        """Non-empty tool content should be wrapped so the marker lands on a content part."""
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "tool", "content": "tool output"},
+        ]
+        result = apply_anthropic_cache_control(msgs, native_anthropic=False)
+        assert isinstance(result[1]["content"], list)
+        assert result[1]["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in result[1]

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -98,6 +98,25 @@ class TestCanCarryMarker:
         assert _can_carry_marker({"role": "tool", "content": "result"}, native_anthropic=False) is True
         assert _can_carry_marker({"role": "tool", "content": ""}, native_anthropic=False) is False
 
+    def test_openrouter_list_carrier_requires_last_part_dict(self):
+        """Carrier predicate must agree with _apply_cache_marker, which only marks
+        the LAST content part. A list whose last element isn't a dict cannot carry
+        a marker and must not consume a breakpoint."""
+        # Last part is a dict -> carrier.
+        assert _can_carry_marker(
+            {"role": "user", "content": [{"type": "text", "text": "a"}]},
+            native_anthropic=False,
+        ) is True
+        # Last part is a non-dict (stray raw string) -> NOT a carrier, even though
+        # an earlier part is a dict. Previously this passed the gate but got no
+        # marker, wasting a breakpoint.
+        assert _can_carry_marker(
+            {"role": "user", "content": [{"type": "text", "text": "a"}, "trailing raw"]},
+            native_anthropic=False,
+        ) is False
+        # Empty list -> not a carrier.
+        assert _can_carry_marker({"role": "user", "content": []}, native_anthropic=False) is False
+
 
 class TestApplyAnthropicCacheControl:
     def test_empty_messages(self):


### PR DESCRIPTION
## Summary
Cache breakpoints now land on messages OpenRouter actually honors during tool loops, so the growing prefix (including large tool results) is cache-read on subsequent calls instead of re-billed at full price. Fixes a ~2× input-token cost regression on tool-heavy OpenRouter + Claude sessions.

Root cause: on the envelope layout (`native_anthropic=False`), `role:"tool"` messages were skipped entirely by `_apply_cache_marker`, and empty-content assistant turns (pure `tool_calls`) received a top-level `cache_control` that OpenRouter ignores on the OpenAI-wire path. In an agentic loop the trailing messages are almost always tool results + empty-assistant turns, so all three conversation breakpoints silently no-op and only the system-prompt breakpoint is effective.

## Changes
- `agent/prompt_caching.py`:
  - `_apply_cache_marker`: on the envelope layout, wrap a tool message's string content as `[{"type": "text", "text": ..., "cache_control": ...}]` (the form OpenRouter honors — verified live) instead of skipping. Empty/None tool content still skips (no carrier). Top-level `cache_control` is never set on `role:"tool"` on the envelope layout (that form causes a documented silent hang). Empty-content assistant turns are also skipped on the envelope layout.
  - New `_can_carry_marker()`: filters non-carrier messages (empty-content assistant/tool turns) out of the last-3 breakpoint selection on the envelope layout, so breakpoints land on messages that count.
  - Native Anthropic layout behavior is unchanged (top-level markers, adapter relocates them).
- Follow-up commit (ours): `_can_carry_marker` originally used `any(isinstance(part, dict))`, but `_apply_cache_marker` only marks the **last** content part — a list whose last element is a non-dict passed the carrier gate yet got no marker, wasting a breakpoint. Tightened the predicate to require `content[-1]` to be a dict, mirroring the apply logic, + regression test.
- `scripts/release.py`: AUTHOR_MAP entry `lavya@loom.local → LavyaTandel` (the contributor's commit uses a local git identity that isn't GitHub-resolvable), so `check-attribution` passes.

## Validation
| Scenario (envelope layout, realistic tool-loop tail) | Before (main) | After |
|---|---|---|
| System breakpoint | honored | honored |
| 3 conversation breakpoints | 2× tool (skipped, no marker) + empty-assistant (top-level, **ignored**) | 3× tool-result **content-part markers (honored)** |
| Effective cached prefix | system prompt only | system + all tool results |

- 47/47 prompt-caching tests pass (`tests/agent/test_prompt_caching.py` + `tests/run_agent/test_anthropic_prompt_cache_policy.py`).
- E2E: ran the patched `apply_anthropic_cache_control` over a realistic 8-message tool loop — all 4 breakpoints land on honored content-parts; `tool_call_id`/`name` preserved when tool content is wrapped; native layout byte-identical to before.
- 3-agent parallel review (code-reuse/quality, efficiency/edge-cases, Hermes invariants): no Critical, no Warnings — one flagged predicate mismatch fixed in the follow-up commit above.
- Reporter live-verified the content-part form produces real OpenRouter cache reads (no hang, no 400) on `anthropic/claude-haiku-4.5`.
- `ruff check`: clean. `ty`: zero net-new on both changed files.

## Credit
Cherry-picked from @LavyaTandel's PR #57893 (branch `fix/prompt-caching-markers-option-b-clean`) with authorship preserved. @Ahmett101 independently reached the same fix and deferred to #57893. Original report + live verification + proposed patch by @jeff-mettel in #57845.

Closes #57845
