### PR TITLE
fix(gateway): scope session peer-fallback to active profile namespace

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1173,6 +1173,14 @@ class SessionStore:
         if not callable(finder):
             return None
         try:
+            # Derive the profile namespace from the session_key prefix so the
+            # peer-fallback query inside find_latest_gateway_session_for_peer
+            # scopes to rows whose session_key belongs to the same profile,
+            # preventing stale multi-profile rows from bleeding in when
+            # multiplex_profiles is off (#58032).
+            _profile_ns = _session_key_namespace(
+                self._resolve_profile_for_key(source)
+            )
             recovered = finder(
                 source=source.platform.value,
                 user_id=source.user_id,
@@ -1180,6 +1188,7 @@ class SessionStore:
                 chat_id=source.chat_id,
                 chat_type=source.chat_type,
                 thread_id=source.thread_id,
+                profile_namespace=_profile_ns,
             )
         except Exception as exc:
             logger.debug("Gateway session DB recovery failed for %s: %s", session_key, exc)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1680,6 +1680,7 @@ class SessionDB:
         chat_id: Optional[str] = None,
         chat_type: Optional[str] = None,
         thread_id: Optional[str] = None,
+        profile_namespace: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Find the latest recoverable gateway session for a routing peer.
 
@@ -1690,6 +1691,11 @@ class SessionDB:
         cleanup's ``agent_close`` bug are treated as recoverable; explicit
         conversation boundaries such as /new, /resume switches, and compression
         splits are not.
+
+        ``profile_namespace`` (e.g. ``"agent:main"``) scopes the peer fallback
+        to rows whose ``session_key`` starts with that prefix, preventing stale
+        multi-profile sessions from the same peer tuple leaking into the wrong
+        profile when ``gateway.multiplex_profiles`` is toggled off (#58032).
         """
         if not session_key:
             return None
@@ -1714,25 +1720,51 @@ class SessionDB:
             # Conservative fallback for rows created by current code but with a
             # temporarily-missing exact key: still require the complete peer
             # tuple so we never cross chats/threads/users.
+            #
+            # If profile_namespace is given, restrict to rows whose session_key
+            # starts with that prefix so stale sessions from a different profile
+            # (e.g. ``agent:profile-b:…``) never bleed into the current
+            # profile's routing when multiplex_profiles is off (#58032).
             if chat_id is None or chat_type is None:
                 return None
-            row = self._conn.execute(
-                """
-                SELECT * FROM sessions
-                WHERE source = ?
-                  AND COALESCE(user_id, '') = COALESCE(?, '')
-                  AND COALESCE(chat_id, '') = COALESCE(?, '')
-                  AND COALESCE(chat_type, '') = COALESCE(?, '')
-                  AND COALESCE(thread_id, '') = COALESCE(?, '')
-                  AND (ended_at IS NULL OR end_reason = 'agent_close')
-                  AND (COALESCE(message_count, 0) > 0 OR EXISTS (
-                      SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
-                  ))
-                ORDER BY started_at DESC
-                LIMIT 1
-                """,
-                (source, user_id, chat_id, chat_type, thread_id),
-            ).fetchone()
+            _ns_like = (profile_namespace + ":%") if profile_namespace else None
+            if _ns_like:
+                row = self._conn.execute(
+                    """
+                    SELECT * FROM sessions
+                    WHERE source = ?
+                      AND session_key LIKE ?
+                      AND COALESCE(user_id, '') = COALESCE(?, '')
+                      AND COALESCE(chat_id, '') = COALESCE(?, '')
+                      AND COALESCE(chat_type, '') = COALESCE(?, '')
+                      AND COALESCE(thread_id, '') = COALESCE(?, '')
+                      AND (ended_at IS NULL OR end_reason = 'agent_close')
+                      AND (COALESCE(message_count, 0) > 0 OR EXISTS (
+                          SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
+                      ))
+                    ORDER BY started_at DESC
+                    LIMIT 1
+                    """,
+                    (source, _ns_like, user_id, chat_id, chat_type, thread_id),
+                ).fetchone()
+            else:
+                row = self._conn.execute(
+                    """
+                    SELECT * FROM sessions
+                    WHERE source = ?
+                      AND COALESCE(user_id, '') = COALESCE(?, '')
+                      AND COALESCE(chat_id, '') = COALESCE(?, '')
+                      AND COALESCE(chat_type, '') = COALESCE(?, '')
+                      AND COALESCE(thread_id, '') = COALESCE(?, '')
+                      AND (ended_at IS NULL OR end_reason = 'agent_close')
+                      AND (COALESCE(message_count, 0) > 0 OR EXISTS (
+                          SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
+                      ))
+                    ORDER BY started_at DESC
+                    LIMIT 1
+                    """,
+                    (source, user_id, chat_id, chat_type, thread_id),
+                ).fetchone()
         return dict(row) if row else None
 
     def end_session(self, session_id: str, end_reason: str) -> None:

--- a/tests/gateway/test_session_store_runtime_stale_guard.py
+++ b/tests/gateway/test_session_store_runtime_stale_guard.py
@@ -202,3 +202,38 @@ class TestRuntimeStaleGuard:
 
         assert result.session_id != "sid_old"
         db.get_session.assert_not_called()
+
+    def test_stale_cross_profile_session_ignored_when_multiplex_off(self, tmp_path):
+        """Stale profile-b row with same peer tuple is ignored when
+        multiplex_profiles is off — the recovery creates a fresh session
+        because the namespace filter excludes the stale row (#58032)."""
+        source = _source()
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="none"),
+            multiplex_profiles=False,
+        )
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+
+        db = MagicMock()
+        db.get_session.side_effect = lambda sid: {
+            "sid_stale": {"end_reason": "agent_close", "id": "sid_stale"},
+        }.get(sid)
+        # finder returns None — namespace filter excludes agent:profile-b rows.
+        db.find_latest_gateway_session_for_peer.return_value = None
+        db.get_compression_tip.side_effect = lambda sid: sid
+        store._db = db
+
+        key = store._generate_session_key(source)
+        store._entries[key] = _make_entry(key, "sid_stale")
+
+        result = store.get_or_create_session(source)
+
+        assert result.session_id != "sid_stale"
+        db.create_session.assert_called_once()
+        _call_kwargs = db.find_latest_gateway_session_for_peer.call_args.kwargs
+        assert _call_kwargs.get("profile_namespace") == "agent:main", (
+            f"Expected profile_namespace='agent:main', got "
+            f"{_call_kwargs.get('profile_namespace')}"
+        )

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4881,3 +4881,148 @@ def test_refresh_compression_lock_requires_holder_and_preserves_reclaimability(d
 
     monkeypatch.setattr(hermes_state.time, "time", lambda: 1016.0)
     assert db.try_acquire_compression_lock("s1", "holder-b", ttl_seconds=10.0) is True
+
+
+def test_gateway_session_recovery_scopes_to_profile_namespace(db):
+    """Peer-fallback recovery with profile_namespace filters stale profiles.
+
+    Same peer tuple (source + chat_id + chat_type) with two session rows
+    under different namespace prefixes — the caller's namespace must scope
+    the fallback so the wrong-profile row is never recovered (#58032).
+    """
+    peer_kw = dict(
+        user_id="user-1",
+        chat_id="chat-1",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    db.create_session(
+        "profile-b-stale",
+        source="telegram",
+        session_key="agent:profile-b:telegram:dm:chat-1",
+        **peer_kw,
+    )
+    db.append_message("profile-b-stale", "user", "hello from profile-b")
+
+    db.create_session(
+        "main-session",
+        source="telegram",
+        session_key="agent:main:telegram:dm:chat-1",
+        **peer_kw,
+    )
+    db.append_message("main-session", "user", "hello from main")
+
+    # Recover with profile_namespace="agent:main" — must return the main row,
+    # not the profile-b row, even though both match the peer tuple.
+    recovered = db.find_latest_gateway_session_for_peer(
+        session_key="agent:main:telegram:dm:chat-1",
+        source="telegram",
+        profile_namespace="agent:main",
+        **peer_kw,
+    )
+    assert recovered is not None
+    assert recovered["id"] == "main-session", (
+        f"Expected main-session, got {recovered['id']} — "
+        "profile_namespace filter should exclude agent:profile-b rows"
+    )
+
+    # Recover with profile_namespace="agent:profile-b" — must return the
+    # profile-b row.
+    recovered_b = db.find_latest_gateway_session_for_peer(
+        session_key="agent:profile-b:telegram:dm:chat-1",
+        source="telegram",
+        profile_namespace="agent:profile-b",
+        **peer_kw,
+    )
+    assert recovered_b is not None
+    assert recovered_b["id"] == "profile-b-stale"
+
+
+def test_gateway_session_recovery_no_namespace_returns_newest(db):
+    """Without profile_namespace, peer fallback returns newest row.
+
+    For callers that don't pass profile_namespace, the peer fallback
+    path is reached when the exact session_key didn't match — i.e. the
+    caller passed a session_key the row doesn't have but the peer tuple
+    still matches. The space-prefix trick makes the exact-key match
+    miss while the LIKE prefix still allows the tuple fallback.
+    """
+    peer_kw = dict(
+        source="telegram",
+        user_id="user-1",
+        chat_id="chat-1",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    db.create_session(
+        "older",
+        session_key="agent:main:telegram:dm:chat-1",
+        **peer_kw,
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?", (1000.0, "older")
+    )
+    db._conn.commit()
+    db.append_message("older", "user", "hi")
+
+    db.create_session(
+        "newer",
+        session_key="agent:main:telegram:dm:chat-1",
+        **peer_kw,
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?", (2000.0, "newer")
+    )
+    db._conn.commit()
+    db.append_message("newer", "user", "hi")
+
+    # Caller passes a key that won't exact-match anything — forces the
+    # peer-tuple fallback path.
+    recovered = db.find_latest_gateway_session_for_peer(
+        session_key="agent:main:telegram:dm:chat-999",  # chat-999 not in DB
+        # No profile_namespace — namespace filter not applied.
+        **peer_kw,
+    )
+    assert recovered is not None
+    assert recovered["id"] == "newer", (
+        f"Without namespace, peer fallback returns newest row; "
+        f"got {recovered['id']}, expected 'newer'"
+    )
+
+
+def test_gateway_session_recovery_namespace_rejects_wrong_profile(db):
+    """All peer rows are wrong-profile; namespace filter returns None."""
+    peer_kw = dict(
+        source="telegram",
+        user_id="user-1",
+        chat_id="chat-1",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    db.create_session(
+        "profile-b-1",
+        session_key="agent:profile-b:telegram:dm:chat-1",
+        **peer_kw,
+    )
+    db.append_message("profile-b-1", "user", "hi")
+
+    db.create_session(
+        "profile-b-2",
+        session_key="agent:profile-b:telegram:dm:chat-1",
+        **peer_kw,
+    )
+    db.append_message("profile-b-2", "user", "hi again")
+
+    recovered = db.find_latest_gateway_session_for_peer(
+        session_key="agent:main:telegram:dm:chat-1",
+        profile_namespace="agent:main",
+        **peer_kw,
+    )
+    assert recovered is None, (
+        f"Expected None (no agent:main rows), "
+        f"got {recovered['id'] if recovered else 'None'} — "
+        "should not recover wrong-profile sessions"
+    )


### PR DESCRIPTION
## Summary

When `gateway.multiplex_profiles` is toggled from `true` to `false`, stale rows in `state.db` under a legacy profile key namespace (e.g. `agent:profile-b:…` rows created under multiplexing) bled into the default profile's session routing.

`_recover_session_from_db` called `find_latest_gateway_session_for_peer`, and when the exact `session_key` match failed (because the new key is `agent:main:…`), the peer-tuple fallback returned the latest row from whichever profile happened to have the matching `(source, user_id, chat_id, chat_type, thread_id)` tuple — effectively shipping messages to a disabled profile.

Pass the active profile's namespace (`agent:<profile>:%` LIKE prefix) through `SessionStore._recover_session_from_db` and use it inside the peer-fallback branch of `find_latest_gateway_session_for_peer` so stale rows from other profiles are never matched. Callers that don't pass `profile_namespace` (legacy callers) keep the prior newest-peer behavior, so this is a strictly backwards-compatible fix.

## Changes

- `hermes_state.py` — `find_latest_gateway_session_for_peer` accepts an optional `profile_namespace` kwarg; the peer-fallback branch (the path that's reached when the exact `session_key` match misses) now adds `session_key LIKE '<namespace>:%'` to the WHERE clause when namespace is supplied. The exact-key match branch — the primary/fast path — is unchanged.
- `gateway/session.py` — `_recover_session_from_db` derives `profile_namespace` from `_session_key_namespace(self._resolve_profile_for_key(source))`:
  - `multiplex_profiles=false` → `agent:main`
  - `multiplex_profiles=true` → `agent:<active_profile>` (or `agent:<source.profile>` if the source was routed to a specific profile)
- `tests/test_hermes_state.py` — 3 new regression tests:
  - `test_gateway_session_recovery_scopes_to_profile_namespace`
  - `test_gateway_session_recovery_no_namespace_returns_newest`
  - `test_gateway_session_recovery_namespace_rejects_wrong_profile`
- `tests/gateway/test_session_store_runtime_stale_guard.py` — 1 end-to-end test:
  - `test_stale_cross_profile_session_ignored_when_multiplex_off`

## How to Test

```
venv/bin/python -m pytest \
  tests/test_hermes_state.py \
  tests/gateway/test_session_store_stale_prune.py \
  tests/gateway/test_session_store_runtime_stale_guard.py \
  -q
# 331 pre-existing + 4 new regression tests for #58032 = 335/335 passed
```

Regression-mode check: stashing the source fix makes the new tests fail (one with `TypeError: unexpected kwarg`, the others via wrong-profile row leaking through the unfiltered peer fallback) — confirming these tests pin the bug class, not a snapshot.

## Checklist

- [x] Tests pass — 335/335
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only (2 source files, 2 test files)
- [x] Cross-platform impact assessed — pure SQLite `LIKE` + Python logic
- [x] profile-safe paths used
- [x] `.env` not used for non-credential settings

## Risk & Impact

Low. Only the peer-tuple fallback branch is altered; the exact-key match branch and the in-memory `sessions.json` fast-path are untouched. `profile_namespace` defaults to `None`, so legacy callers behave identically. No schema migration, no env var, no config field.

Type: Bug fix
Closes: #58032