### PR TITLE
fix: _category now handles non-dict frontmatter gracefully

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -66,6 +66,8 @@ def _related(fm: dict[str, Any]) -> list[str]:
 
 
 def _category(fm: dict[str, Any], skill_md: Path) -> str:
+    if not isinstance(fm, dict):
+        fm = {}
     cat = fm.get("category") or _hermes_meta(fm).get("category")
     if cat:
         return str(cat)


### PR DESCRIPTION
Fixes issue where _category would crash when fm.get('metadata', {}).get('hermes', {}) was called on a non-dict fm (e.g., when metadata is a string like 'oops').

The fix adds a guard to ensure fm is a dict before calling .get().

Fixes #57986