### PR TITLE
fix(agent): scan only root mount in is_container() cgroup-v2 fallback (#58135)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1124,15 +1124,24 @@ def is_container() -> bool:
                 return True
     except OSError:
         pass
-    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
-    # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. Inside a
+    # container the ROOT mount ("/") is the runtime's overlay/snapshot, so it
+    # carries a containerd/crio/kubepods marker. Scan mountinfo as a last
+    # resort, but ONLY the root-mount line: a host that merely *runs*
+    # containers exposes each container's overlay lowerdir
+    # (``lowerdir=/var/lib/containerd/...``) at non-root mount points, which
+    # previously produced a false positive that flipped subprocess HOME.
+    # See: NousResearch/hermes-agent#58135
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                # mountinfo field 5 (index 4) is the mount point.
+                fields = line.split()
+                if len(fields) < 5 or fields[4] != "/":
+                    continue
+                if any(marker in line for marker in ("kubepods", "containerd", "crio")):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1637,15 +1637,24 @@ def is_container() -> bool:
                 return True
     except OSError:
         pass
-    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
-    # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. Inside a
+    # container the ROOT mount ("/") is the runtime's overlay/snapshot, so it
+    # carries a containerd/crio/kubepods marker. Scan mountinfo as a last
+    # resort, but ONLY the root-mount line: a host that merely *runs*
+    # containers exposes each container's overlay lowerdir
+    # (``lowerdir=/var/lib/containerd/...``) at non-root mount points, which
+    # previously produced a false positive that flipped subprocess HOME.
+    # See: NousResearch/hermes-agent#58135
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                # mountinfo field 5 (index 4) is the mount point.
+                fields = line.split()
+                if len(fields) < 5 or fields[4] != "/":
+                    continue
+                if any(marker in line for marker in ("kubepods", "containerd", "crio")):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -415,6 +415,44 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", _fake_open)
         assert is_container() is True
 
+    def test_host_running_containers_not_false_positive(self, monkeypatch, tmp_path):
+        """A host that merely RUNS containers must not be classified as one.
+
+        Regression for NousResearch/hermes-agent#58135: on a cgroup-v2 host
+        with Docker's containerd image store, each running container adds an
+        overlay mount whose option string contains
+        ``lowerdir=/var/lib/containerd/...``. The marker appears only in
+        non-root mount lines, so scanning the whole file produced a false
+        positive. Only the root ('/') mount line should be inspected.
+        """
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")  # cgroup v2 — no runtime marker
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            # Root is a real block device on the host.
+            "25 1 259:2 / / rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw\n"
+            # A running container's overlay rootfs mounted elsewhere — its
+            # lowerdir references containerd but must NOT flip the host.
+            "469 554 0:94 / /var/lib/docker/rootfs/overlayfs/7dda83 rw,relatime "
+            "shared:247 - overlay overlay rw,lowerdir=/var/lib/containerd/"
+            "io.containerd.snapshotter.v1.overlayfs/snapshots/33509/fs\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -363,6 +363,44 @@ class TestIsContainer:
 
 
 
+    def test_host_running_containers_not_false_positive(self, monkeypatch, tmp_path):
+        """A host that merely RUNS containers must not be classified as one.
+
+        Regression for NousResearch/hermes-agent#58135: on a cgroup-v2 host
+        with Docker's containerd image store, each running container adds an
+        overlay mount whose option string contains
+        ``lowerdir=/var/lib/containerd/...``. The marker appears only in
+        non-root mount lines, so scanning the whole file produced a false
+        positive. Only the root ('/') mount line should be inspected.
+        """
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")  # cgroup v2 — no runtime marker
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            # Root is a real block device on the host.
+            "25 1 259:2 / / rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw\n"
+            # A running container's overlay rootfs mounted elsewhere — its
+            # lowerdir references containerd but must NOT flip the host.
+            "469 554 0:94 / /var/lib/docker/rootfs/overlayfs/7dda83 rw,relatime "
+            "shared:247 - overlay overlay rw,lowerdir=/var/lib/containerd/"
+            "io.containerd.snapshotter.v1.overlayfs/snapshots/33509/fs\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)


### PR DESCRIPTION
## Summary

- `is_container()` no longer false-positives on a Linux **host** just because it happens to be running containers.
- Fixes browser tool launches ("Chrome not found") on host installs whose subprocess HOME was wrongly switched to the empty per-profile home.

## Motivation

Closes #58135.

On a cgroup-v2 host with Docker's containerd image store (Docker Desktop default), `/proc/1/cgroup` is just `0::/`, so `is_container()` falls back to scanning `/proc/self/mountinfo` for `containerd`/`crio`/`kubepods` substrings. But every running container contributes an overlay mount whose option string contains `lowerdir=/var/lib/containerd/...`, so a plain host gets classified as "inside a container". The result is cached per-process, so the answer permanently depends on whether a container happened to be running at first call — which then flips subprocess `HOME` via `get_subprocess_home()` and breaks browser calls.

## Root cause

The marker only ever appears on **non-root** mount lines (other containers' overlay rootfs). Inside a real container the marker appears on the **root** (`/`) mount, because root *is* the runtime overlay/snapshot.

## Fix

Only inspect the root (`/`) mount line (mountinfo field 5). Host root is a real block device; container root carries the runtime marker. cgroup-v1 markers, `/.dockerenv`, `/run/.containerenv`, and `KUBERNETES_SERVICE_HOST` detection are unchanged.

## Verification

- `python3 -m pytest tests/test_hermes_constants.py -k container` — 9 passed (incl. new regression).
- New test `test_host_running_containers_not_false_positive` fails on current main (reproduces the bug) and passes with the fix.
- Did NOT change: cgroup-v1 / dockerenv / k8s-env detection paths.