### PR TITLE
fix(desktop): honor scalar-string MCP tools.include/exclude like the backend

### DIFF
--- a/apps/desktop/src/lib/mcp-tool-filter.test.ts
+++ b/apps/desktop/src/lib/mcp-tool-filter.test.ts
@@ -13,6 +13,11 @@ describe('readToolsFilter', () => {
       include: ['a', 'b']
     })
   })
+
+  it('coerces a scalar-string include/exclude to a single-element array like the backend', () => {
+    expect(readToolsFilter({ tools: { include: 'foo' } })).toEqual({ exclude: undefined, include: ['foo'] })
+    expect(readToolsFilter({ tools: { exclude: 'secret' } })).toEqual({ exclude: ['secret'], include: undefined })
+  })
 })
 
 describe('isToolEnabled', () => {
@@ -30,6 +35,18 @@ describe('isToolEnabled', () => {
     const server = { tools: { exclude: ['b'] } }
     expect(isToolEnabled(server, 'a')).toBe(true)
     expect(isToolEnabled(server, 'b')).toBe(false)
+  })
+
+  it('honors a scalar-string include as a one-tool whitelist', () => {
+    const server = { tools: { include: 'foo' } }
+    expect(isToolEnabled(server, 'foo')).toBe(true)
+    expect(isToolEnabled(server, 'bar')).toBe(false)
+  })
+
+  it('honors a scalar-string exclude as a one-tool denylist', () => {
+    const server = { tools: { exclude: 'secret' } }
+    expect(isToolEnabled(server, 'secret')).toBe(false)
+    expect(isToolEnabled(server, 'other')).toBe(true)
   })
 })
 
@@ -52,6 +69,11 @@ describe('toggleToolInServer', () => {
   it('respects include mode: re-enabling adds back to include', () => {
     const next = toggleToolInServer({ tools: { include: ['b'] } }, 'a')
     expect(next.tools).toEqual({ include: ['b', 'a'] })
+  })
+
+  it('migrates a scalar-string include to an array on toggle without dropping it', () => {
+    const next = toggleToolInServer({ tools: { include: 'foo' } }, 'bar')
+    expect(next.tools).toEqual({ include: ['foo', 'bar'] })
   })
 
   it('preserves sibling tools keys like resources/prompts', () => {

--- a/apps/desktop/src/lib/mcp-tool-filter.ts
+++ b/apps/desktop/src/lib/mcp-tool-filter.ts
@@ -11,7 +11,11 @@ export interface McpToolsFilter {
 type ServerConfig = Record<string, unknown>
 
 const asNames = (value: unknown): string[] | undefined =>
-  Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : undefined
+  typeof value === 'string'
+    ? [value]
+    : Array.isArray(value)
+      ? value.filter((v): v is string => typeof v === 'string')
+      : undefined
 
 const toolsObject = (server: ServerConfig | null | undefined): Record<string, unknown> => {
   const tools = server?.tools


### PR DESCRIPTION
## What does this PR do?

The desktop MCP tool-gating helper (`apps/desktop/src/lib/mcp-tool-filter.ts`) dropped a scalar-string `tools.include` / `tools.exclude`, diverging from the agent backend that actually runs the tools. `asNames` accepted only an array, so a config like `tools: { include: "foo" }` returned `undefined` and the filter was treated as absent.

The backend coerces a bare string to a one-element set: `_normalize_name_filter` in `tools/mcp_tool.py` returns `{value}` for a string, and `_register_server_tools` uses it — so `include: "foo"` registers exactly one tool on the agent.

The result was a correctness + data-loss divergence in the MCP Tools panel:
- with `tools: { include: "foo" }`, the panel showed **all** tools enabled (inflated count) even though the agent registers only `foo`;
- the first per-tool toggle silently **wiped** the user's scalar filter, because `toggleToolInServer` saw the scalar as an absent filter and rebuilt from an empty list.

The fix widens `asNames` to accept a scalar string (`[value]`), mirroring the backend. This one-line change fixes `readToolsFilter`, `isToolEnabled`, `countEnabledTools`, and `toggleToolInServer` (which now migrates a scalar into a proper array on toggle instead of discarding it).

## Related Issue

No filed issue — divergence found by comparing the desktop helper against its documented mirror `_register_server_tools` in `tools/mcp_tool.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/mcp-tool-filter.ts`: widen `asNames` to accept a scalar string (`typeof value === 'string' ? [value] : ...`), mirroring `_normalize_name_filter`.
- `apps/desktop/src/lib/mcp-tool-filter.test.ts`: add regression cases covering scalar `include`/`exclude` in `readToolsFilter`, `isToolEnabled`, and a `toggleToolInServer` case proving the scalar is migrated to an array (not dropped) on toggle.

## How to Test

1. `cd apps/desktop && npx vitest run --environment jsdom src/lib/mcp-tool-filter.test.ts`
2. Before the fix, the four new scalar-string cases fail (a scalar `include`/`exclude` is dropped, so every tool reads as enabled and toggling wipes the filter). After the fix, all 16 cases pass.
3. Manual: set an MCP server's `tools: { include: "foo" }`; the MCP Tools panel now shows only `foo` enabled, matching the agent, and toggling another tool preserves the original entry.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched suite (`vitest run --environment jsdom src/lib/mcp-tool-filter.test.ts`) and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure TS logic, no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A