### PR TITLE
fix(moa): preserve reference_max_tokens and fanout when saving MoA presets via the dashboard API

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -949,6 +949,10 @@ class MoaPresetPayload(BaseModel):
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
     max_tokens: int = 4096
+    # None = uncapped reference/advisor output, matching prior behavior.
+    reference_max_tokens: Optional[int] = None
+    # Reference fan-out cadence: "per_iteration" (default) or "user_turn".
+    fanout: str = "per_iteration"
     enabled: bool = True
 
 
@@ -963,6 +967,8 @@ class MoaConfigPayload(BaseModel):
     reference_temperature: Optional[float] = None
     aggregator_temperature: Optional[float] = None
     max_tokens: int = 4096
+    reference_max_tokens: Optional[int] = None
+    fanout: str = "per_iteration"
     enabled: bool = True
     profile: Optional[str] = None
 
@@ -4391,6 +4397,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                             "reference_temperature": preset.reference_temperature,
                             "aggregator_temperature": preset.aggregator_temperature,
                             "max_tokens": preset.max_tokens,
+                            "reference_max_tokens": preset.reference_max_tokens,
+                            "fanout": preset.fanout,
                             "enabled": preset.enabled,
                         }
                         for name, preset in body.presets.items()
@@ -4403,6 +4411,8 @@ def set_moa_models(body: MoaConfigPayload, profile: Optional[str] = None):
                     "reference_temperature": body.reference_temperature,
                     "aggregator_temperature": body.aggregator_temperature,
                     "max_tokens": body.max_tokens,
+                    "reference_max_tokens": body.reference_max_tokens,
+                    "fanout": body.fanout,
                     "enabled": body.enabled,
                 }
             normalized = normalize_moa_config(raw)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -510,6 +510,57 @@ class TestWebServerEndpoints:
         assert cfg["moa"]["reference_models"] == payload["reference_models"]
         assert cfg["moa"]["aggregator"] == payload["aggregator"]
 
+    def test_put_moa_models_preserves_fanout_and_reference_max_tokens(self):
+        from hermes_cli.config import load_config
+
+        payload = {
+            "default_preset": "default",
+            "active_preset": "default",
+            "presets": {
+                "default": {
+                    "reference_models": [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}],
+                    "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+                    "reference_temperature": 0.6,
+                    "aggregator_temperature": 0.4,
+                    "max_tokens": 4096,
+                    "reference_max_tokens": 600,
+                    "fanout": "user_turn",
+                    "enabled": True,
+                }
+            },
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        cfg = load_config()
+        preset = cfg["moa"]["presets"]["default"]
+        assert preset["reference_max_tokens"] == 600
+        assert preset["fanout"] == "user_turn"
+
+    def test_put_moa_models_flat_payload_preserves_fanout_and_reference_max_tokens(self):
+        from hermes_cli.config import load_config
+
+        payload = {
+            "reference_models": [{"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}],
+            "aggregator": {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"},
+            "reference_temperature": 0.6,
+            "aggregator_temperature": 0.4,
+            "max_tokens": 4096,
+            "reference_max_tokens": 600,
+            "fanout": "user_turn",
+            "enabled": True,
+        }
+
+        resp = self.client.put("/api/model/moa", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        cfg = load_config()
+        # The flat payload becomes the default preset.
+        preset = cfg["moa"]["presets"]["default"]
+        assert preset["reference_max_tokens"] == 600
+        assert preset["fanout"] == "user_turn"
+
     # ── GET /api/media (remote image display) ───────────────────────────
 
     def test_get_media_serves_image_in_root(self):


### PR DESCRIPTION
## What does this PR do?

The `PUT /api/model/moa` payload models (`MoaPresetPayload` / `MoaConfigPayload`) and the `set_moa_models` persistence builders never carried `reference_max_tokens` (#56756) or `fanout` (#57591). Those two features were wired into `hermes_cli/moa_config.py` and `agent/moa_loop.py`, but the web save path was never updated to accept or persist them.

Because `set_moa_models` **wholesale-overwrites** `cfg["moa"]` with `normalize_moa_config(raw)` (rather than a read-modify-write merge), and `_normalize_preset` defaults the two missing keys to `None` / `"per_iteration"`, every save through the dashboard silently reset both fields back to defaults.

`GET /api/model/moa` returns both (`moa_config.py`), and the CLI `hermes moa config` path preserves them via read-modify-write — so the dashboard/web save was the **one** path that dropped them.

## Related Issue

Persistence gap for the features filed in #56756 (`reference_max_tokens`) and #57591 (`fanout`). No separate issue for the web-save drop itself — found by comparing the `PUT /api/model/moa` builder against the GET response and the CLI RMW path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: add `reference_max_tokens: Optional[int] = None` and `fanout: str = "per_iteration"` to `MoaPresetPayload` and `MoaConfigPayload`; write both in the `set_moa_models` per-preset dict and the legacy flat `raw` dict. `_normalize_preset` already coerces/validates both (`_coerce_int_or_none` / `_coerce_fanout`), so no change was needed there.
- `tests/hermes_cli/test_web_server.py`: add `test_put_moa_models_preserves_fanout_and_reference_max_tokens` (preset branch) and `test_put_moa_models_flat_payload_preserves_fanout_and_reference_max_tokens` (legacy flat branch).

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_web_server.py -q`
2. Before the fix, both new tests fail: a PUT carrying `fanout: "user_turn"` and `reference_max_tokens: 600` round-trips back to `per_iteration` / `None`. After the fix, both persist.
3. Full `test_web_server.py` module passes (343 tests), so the legacy flat-payload branch is unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_web_server.py -q` and all tests pass (343 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (both keys already documented by their originating feature PRs; this only wires the existing keys through the web PUT)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A