### PR TITLE
fix(video_analyze): route video to a video-capable provider + ingest page URLs via yt-dlp

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -209,8 +209,11 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             text = item.get("text")
             if isinstance(text, str) and text:
                 parts.append({"text": text})
-        elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+        elif ptype in {"image_url", "video_url"}:
+            # Gemini's native inlineData shape is identical for images and
+            # videos; only the MIME type differs. Hermes uses OpenAI-shaped
+            # image_url/video_url blocks internally, so preserve both here.
+            url = ((item.get(ptype) or {}).get("url") or "")
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1577,6 +1577,13 @@ DEFAULT_CONFIG = {
         "vision": {
             "provider": "auto",    # auto | openrouter | nous | codex | custom
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
+            # Videos require a narrower backend set than images. "auto" tries
+            # the active Gemini model, authenticated Gemini aggregators, then
+            # a direct Google AI Studio credential.
+            "video_provider": "auto",  # auto | openrouter | nous | gemini
+            "video_model": "",         # blank = provider's video-capable default
+            "ytdlp_cookies": "",       # optional Netscape cookies file for page URLs
+            "ytdlp_cookies_from_browser": "",  # optional yt-dlp browser profile
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
             "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,9 @@ mem0 = ["mem0ai==2.0.10"]
 # CLI under prompt_toolkit (#40490). This extra is kept as a no-op back-compat
 # alias so existing `pip install hermes-agent[vision]` invocations still resolve.
 vision = []
+# Page URL extraction for video_analyze. Lazy-installed on first use so the
+# fast-moving site extractor does not become a core install dependency.
+video = ["yt-dlp[default]>=2026.7.4,<2027"]
 # CVE-2026-48710 (BadHost): Starlette is pulled transitively by mcp's
 # sse-starlette / HTTP-SSE stack (and by fastapi in the `web` extra). Before
 # 1.0.1, a malformed Host header makes `request.url.path` desync from the path

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -178,6 +178,31 @@ def test_build_native_request_strips_json_schema_only_fields_from_tool_parameter
     }
 
 
+def test_build_native_request_preserves_inline_video():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this clip"},
+                {
+                    "type": "video_url",
+                    "video_url": {"url": "data:video/mp4;base64,AAEC"},
+                },
+            ],
+        }],
+        tools=[],
+        tool_choice=None,
+    )
+
+    parts = request["contents"][0]["parts"]
+    assert parts[0] == {"text": "Describe this clip"}
+    assert parts[1] == {
+        "inlineData": {"mimeType": "video/mp4", "data": "AAEC"}
+    }
+
+
 def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     from agent.gemini_native_adapter import translate_gemini_response
 

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -75,6 +75,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "honcho", "hindsight",
         "supermemory", "mem0",
         "mistral",  # mistralai — Voxtral STT/TTS, lazy-installed (stt.mistral / tts.mistral)
+        "video",  # yt-dlp — page URL extraction for video_analyze
     }
     all_extra_specs = optional_dependencies["all"]
     for extra in lazy_covered_extras:

--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -2,11 +2,19 @@
 
 import asyncio
 import json
+import os
+import subprocess
+import sys
+from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
 from tools.vision_tools import (
     _detect_video_mime_type,
+    _ensure_ytdlp_available,
+    _resolve_video_provider_model,
+    _ytdlp_command,
+    _ytdlp_js_runtime_args,
     _video_to_base64_data_url,
     _handle_video_analyze,
     _MAX_VIDEO_BASE64_BYTES,
@@ -324,6 +332,112 @@ class TestVideoAnalyzeTool:
         assert content[1]["type"] == "video_url"
         assert "video_url" in content[1]
         assert content[1]["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+    def test_page_url_uses_ytdlp_and_direct_gemini(self, tmp_path):
+        """A YouTube watch page is extracted, not downloaded as HTML."""
+        extracted = tmp_path / "extracted.mp4"
+        extracted.write_bytes(b"\x00" * 100)
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "A person demonstrates a task."
+
+        with patch("tools.url_safety.async_is_safe_url", new_callable=AsyncMock, return_value=True), \
+             patch("tools.vision_tools._ensure_ytdlp_available") as ensure_ytdlp, \
+             patch("tools.vision_tools._download_video_via_ytdlp", new_callable=AsyncMock, return_value=extracted) as download, \
+             patch("tools.vision_tools._resolve_video_provider_model", return_value=("gemini", "gemini-3-flash-preview")), \
+             patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_response) as llm, \
+             patch("tools.vision_tools.extract_content_or_reasoning", return_value="A person demonstrates a task."):
+            result = self._run(video_analyze_tool(
+                "https://youtu.be/GhSdkmMt4LE?feature=shared", "What happens?"
+            ))
+
+        data = json.loads(result)
+        assert data["success"] is True
+        ensure_ytdlp.assert_called_once_with()
+        download.assert_awaited_once()
+        assert llm.await_args.kwargs["provider"] == "gemini"
+        assert llm.await_args.kwargs["model"] == "gemini-3-flash-preview"
+
+
+class TestVideoDependenciesAndRouting:
+    def test_ytdlp_child_can_import_from_lazy_target(self, tmp_path, monkeypatch):
+        target = tmp_path / "lazy-packages"
+        package = target / "yt_dlp"
+        package.mkdir(parents=True)
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        (package / "__main__.py").write_text(
+            "import json, os, sys\n"
+            "from pathlib import Path\n"
+            "Path(os.environ['YTDLP_TEST_RESULT']).write_text("
+            "json.dumps(sys.argv[1:]), encoding='utf-8')\n",
+            encoding="utf-8",
+        )
+
+        fake_module = ModuleType("yt_dlp")
+        fake_module.__file__ = str(package / "__init__.py")
+        monkeypatch.setitem(sys.modules, "yt_dlp", fake_module)
+
+        result_path = tmp_path / "result.json"
+        child_env = os.environ.copy()
+        child_env.pop("PYTHONPATH", None)
+        child_env["YTDLP_TEST_RESULT"] = str(result_path)
+        subprocess.run(
+            [*_ytdlp_command(), "--probe", "value"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=child_env,
+            stdin=subprocess.DEVNULL,
+        )
+
+        assert json.loads(result_path.read_text(encoding="utf-8")) == [
+            "--probe", "value"
+        ]
+
+    def test_ytdlp_enables_installed_node_runtime(self):
+        def which(executable):
+            return "/opt/node/bin/node" if executable == "node" else None
+
+        with patch("shutil.which", side_effect=which):
+            assert _ytdlp_js_runtime_args() == [
+                "--js-runtimes", "node:/opt/node/bin/node"
+            ]
+
+    def test_missing_ytdlp_uses_pinned_lazy_dependency(self):
+        real_import = __import__
+
+        def import_without_ytdlp(name, *args, **kwargs):
+            if name == "yt_dlp":
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=import_without_ytdlp), \
+             patch("tools.lazy_deps.ensure") as ensure:
+            _ensure_ytdlp_available()
+
+        ensure.assert_called_once_with("tool.video", prompt=False)
+
+    def test_auto_routing_falls_through_to_direct_gemini(self):
+        values = {
+            ("auxiliary", "vision", "video_provider"): "auto",
+            ("auxiliary", "vision", "video_model"): "",
+            ("model", "provider"): "openai-codex",
+            ("model", "default"): "gpt-5.6-sol",
+        }
+
+        def config_value(*path, default=""):
+            return values.get(path, default)
+
+        def resolve(*, provider, model):
+            if provider == "gemini":
+                return provider, object(), model
+            return provider, None, None
+
+        with patch("tools.vision_tools._cfg_get_safe", side_effect=config_value), \
+             patch("agent.auxiliary_client.resolve_vision_provider_client", side_effect=resolve):
+            assert _resolve_video_provider_model() == (
+                "gemini", "gemini-3-flash-preview"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -214,6 +214,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "skill.youtube": ("youtube-transcript-api==1.2.4",),
 
     # ─── Tools ─────────────────────────────────────────────────────────────
+    # Page URL extraction for video_analyze (YouTube, Vimeo, etc.).
+    "tool.video": ("yt-dlp[default]>=2026.7.4,<2027",),
     # ACP adapter (VS Code / Zed / JetBrains integration)
     "tool.acp": ("agent-client-protocol==0.9.0",),
     # Dashboard (`hermes dashboard`)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1627,6 +1627,191 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
     raise last_error
 
 
+# --- Video source ingestion + video-capable provider routing -----------------
+#
+# Two bugs this block fixes:
+#  (1) The generic vision router (task="vision") tries the user's MAIN provider
+#      first. A provider can accept IMAGES but reject a `video_url` content
+#      block (Anthropic/Claude -> 400 "Input tag 'video' ... does not match").
+#      Video is a strict subset of vision backends (Gemini family today), so we
+#      resolve one explicitly instead of letting auto pick the main provider.
+#  (2) Non-direct URLs (YouTube, X/Twitter, Vimeo, TikTok, ...) are not raw
+#      video files, so a plain HTTP GET can't fetch them. Use yt-dlp.
+
+_VIDEO_CAPABLE_PROVIDER_ORDER = ("openrouter", "nous")
+_VIDEO_CAPABLE_MAIN_PROVIDERS = {
+    "gemini", "google", "google-gemini", "google-ai-studio",
+}
+_VIDEO_PROVIDER_DEFAULT_MODELS = {
+    "openrouter": "google/gemini-3-flash-preview",
+    "nous": "google/gemini-3-flash-preview",
+    "gemini": "gemini-3-flash-preview",
+    "google": "gemini-3-flash-preview",
+}
+
+
+def _cfg_get_safe(*path: str, default: str = "") -> str:
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        return cfg_get(load_config(), *path, default=default)
+    except Exception:
+        return default
+
+
+def _resolve_video_provider_model(explicit_model: Optional[str] = None):
+    """Return (provider, model) for a video-capable backend.
+
+    Order: explicit config override -> video-capable main provider ->
+    first video-capable aggregator with working credentials. Returns
+    (None, explicit_model) if none resolve, so the caller can still try.
+    """
+    # 1. Operator override in config (auxiliary.vision.video_provider/model).
+    ov_provider = (_cfg_get_safe("auxiliary", "vision", "video_provider") or "").strip()
+    ov_model = (_cfg_get_safe("auxiliary", "vision", "video_model") or "").strip()
+    if ov_provider:
+        model = explicit_model or ov_model or _VIDEO_PROVIDER_DEFAULT_MODELS.get(ov_provider)
+        return ov_provider, model
+
+    # 2. Main provider, only when it's a known Gemini-family (video) backend.
+    main_provider = (_cfg_get_safe("model", "provider") or "").strip().lower()
+    if main_provider in _VIDEO_CAPABLE_MAIN_PROVIDERS:
+        main_model = (_cfg_get_safe("model", "default") or "").strip()
+        # strip a leading "provider/" prefix if present
+        if "/" in main_model:
+            main_model = main_model.split("/", 1)[1]
+        model = explicit_model or main_model or _VIDEO_PROVIDER_DEFAULT_MODELS.get(main_provider)
+        return main_provider, model
+
+    # 3. Auto: first video-capable aggregator whose client resolves.
+    try:
+        from agent.auxiliary_client import resolve_vision_provider_client
+    except Exception:
+        resolve_vision_provider_client = None
+    if resolve_vision_provider_client is not None:
+        for prov in _VIDEO_CAPABLE_PROVIDER_ORDER:
+            default_model = _VIDEO_PROVIDER_DEFAULT_MODELS.get(prov)
+            try:
+                _prov, client, final_model = resolve_vision_provider_client(
+                    provider=prov, model=explicit_model or default_model,
+                )
+            except Exception:
+                client, final_model = None, None
+            if client is not None:
+                return prov, (explicit_model or final_model or default_model)
+
+    return None, explicit_model
+
+
+def _is_direct_video_url(url: str) -> bool:
+    """True when the URL path ends in a known direct video extension."""
+    try:
+        p = urlparse(url).path.lower()
+    except Exception:
+        return False
+    return any(p.endswith(ext) for ext in _VIDEO_MIME_TYPES)
+
+
+def _ytdlp_available() -> bool:
+    import shutil
+    return shutil.which("yt-dlp") is not None
+
+
+def _ytdlp_cookie_args() -> list:
+    """Return yt-dlp cookie args, reusing the fleet cookies jar when available.
+
+    Resolution order:
+      1. auxiliary.vision.ytdlp_cookies (config) or YTNB_YTDLP_COOKIES (env)
+         -> --cookies <file>
+      2. auxiliary.vision.ytdlp_cookies_from_browser / YTNB_YTDLP_COOKIES_FROM_BROWSER
+         -> --cookies-from-browser <name>
+      3. ~/yt.cookies.txt (the fleet's canonical, cron-refreshed jar)
+    """
+    # 1. explicit cookies file
+    cfile = (_cfg_get_safe("auxiliary", "vision", "ytdlp_cookies")
+             or os.environ.get("YTNB_YTDLP_COOKIES") or "").strip()
+    if cfile and Path(os.path.expanduser(cfile)).is_file():
+        return ["--cookies", os.path.expanduser(cfile)]
+    # 2. cookies from a browser profile
+    cbrowser = (_cfg_get_safe("auxiliary", "vision", "ytdlp_cookies_from_browser")
+                or os.environ.get("YTNB_YTDLP_COOKIES_FROM_BROWSER") or "").strip()
+    if cbrowser:
+        return ["--cookies-from-browser", cbrowser]
+    # 3. fleet default jar
+    default_jar = Path(os.path.expanduser("~/yt.cookies.txt"))
+    if default_jar.is_file():
+        return ["--cookies", str(default_jar)]
+    return []
+
+
+async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
+    """Fetch a compact (<=480p, size-capped) mp4 for a non-direct URL via yt-dlp.
+
+    Handles YouTube, X/Twitter, Vimeo, TikTok and any other yt-dlp-supported
+    site. Caps resolution + filesize so the base64 payload stays under the API
+    limit; falls back to grabbing the first 3 minutes for long videos.
+    """
+    import shutil
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    out_tmpl = str(dest_dir / f"ytdl_{uuid.uuid4().hex}.%(ext)s")
+    # Single progressive file (no merge -> no hard ffmpeg dependency), <=480p.
+    fmt = "b[height<=480][ext=mp4]/b[ext=mp4]/b[height<=480]/b"
+    base = [
+        "yt-dlp", "-q", "--no-warnings", "--no-playlist",
+        "-f", fmt, "--max-filesize", "45M",
+        "-o", out_tmpl,
+    ]
+    # Cookie support: many sites (YouTube especially) gate anonymous fetches
+    # behind a "confirm you're not a bot" wall. Reuse the fleet cookies jar
+    # (refreshed by the yt-cookies-refresh cron) when present.
+    cookie_args = _ytdlp_cookie_args()
+    base += cookie_args
+
+    def _run(extra):
+        import subprocess
+        proc = subprocess.run(base + extra + [url], capture_output=True, text=True, timeout=180)
+        return proc
+
+    def _find_output():
+        stem = Path(out_tmpl.replace(".%(ext)s", "")).name
+        matches = [
+            p for p in sorted(dest_dir.glob(stem + ".*"))
+            # Only completed video files — skip yt-dlp partial/temp artifacts
+            # (.part, .ytdl, .f<id> fragment files, etc.).
+            if p.suffix.lower() in _VIDEO_MIME_TYPES
+        ]
+        return matches[0] if matches else None
+
+    def _clean_partials():
+        stem = Path(out_tmpl.replace(".%(ext)s", "")).name
+        for p in dest_dir.glob(stem + ".*"):
+            if p.suffix.lower() not in _VIDEO_MIME_TYPES:
+                try:
+                    p.unlink()
+                except Exception:
+                    pass
+
+    # Attempt 1: whole video within caps.
+    proc = await asyncio.to_thread(_run, [])
+    got = _find_output()
+    if got is None:
+        _clean_partials()
+        # Attempt 2: first 3 minutes (helps long talks that blow the size cap).
+        # Drop the size cap here — 3 min @ <=480p is small — and force an mp4
+        # remux so the section is finalized (not left as a .part).
+        proc = await asyncio.to_thread(
+            _run,
+            ["--download-sections", "*0-180", "--force-keyframes-at-cuts",
+             "--remux-video", "mp4"],
+        )
+        got = _find_output()
+    if got is None:
+        raise ValueError(
+            "yt-dlp could not fetch a compact video from this URL. "
+            f"stderr: {(proc.stderr or '').strip()[:300]}"
+        )
+    return got
+
+
 async def video_analyze_tool(
     video_url: str,
     user_prompt: str,
@@ -1671,14 +1856,27 @@ async def video_analyze_tool(
             logger.info("Using local video file: %s", video_url)
             temp_video_path = local_path
             should_cleanup = False
-        elif await _validate_image_url_async(video_url):
+        elif resolved_url.startswith(("http://", "https://")):
             blocked = check_website_access(video_url)
             if blocked:
                 raise PermissionError(blocked["message"])
             temp_dir = get_hermes_dir("cache/video", "temp_video_files")
-            temp_video_path = temp_dir / f"temp_video_{uuid.uuid4()}.mp4"
-            await _download_video(video_url, temp_video_path)
-            should_cleanup = True
+            if _is_direct_video_url(resolved_url) and await _validate_image_url_async(video_url):
+                # Direct video-file URL: fetch bytes over HTTP.
+                temp_video_path = temp_dir / f"temp_video_{uuid.uuid4()}.mp4"
+                await _download_video(video_url, temp_video_path)
+                should_cleanup = True
+            elif _ytdlp_available():
+                # Page URL (YouTube, X, Vimeo, TikTok, ...): extract via yt-dlp.
+                logger.info("Non-direct video URL — fetching via yt-dlp")
+                temp_video_path = await _download_video_via_ytdlp(resolved_url, temp_dir)
+                should_cleanup = True
+            else:
+                raise ValueError(
+                    "This looks like a page URL (e.g. YouTube), not a direct video "
+                    "file, and yt-dlp is not installed. Install yt-dlp or pass a "
+                    "direct video-file URL / local path."
+                )
         else:
             raise ValueError(
                 "Invalid video source. Provide an HTTP/HTTPS URL or a valid local file path."
@@ -1750,8 +1948,21 @@ async def video_analyze_tool(
             "max_tokens": 4000,
             "timeout": vision_timeout,
         }
-        if model:
+        # Video is only accepted by a subset of vision backends (Gemini family).
+        # Resolve one explicitly so the router does not pick the main provider
+        # (e.g. Claude), which accepts images but rejects video_url blocks.
+        video_provider, video_model = _resolve_video_provider_model(model)
+        if video_provider:
+            call_kwargs["provider"] = video_provider
+        if video_model:
+            call_kwargs["model"] = video_model
+        elif model:
             call_kwargs["model"] = model
+        debug_call_data["model_used"] = video_model or model
+        logger.info(
+            "Video routing: provider=%s model=%s",
+            video_provider or "auto", video_model or model or "auto",
+        )
 
         response = await async_call_llm(**call_kwargs)
         analysis = extract_content_or_reasoning(response)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1795,27 +1795,45 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
                 except Exception:
                     pass
 
-    # Attempt 1: whole video within caps.
-    proc = await asyncio.to_thread(_run, [])
-    got = _find_output()
-    if got is None:
-        _clean_partials()
-        # Attempt 2: first 3 minutes (helps long talks that blow the size cap).
-        # Drop the size cap here — 3 min @ <=480p is small — and force an mp4
-        # remux so the section is finalized (not left as a .part).
-        proc = await asyncio.to_thread(
-            _run,
-            ["--download-sections", "*0-180", "--force-keyframes-at-cuts",
-             "--remux-video", "mp4"],
-        )
+    import subprocess as _sp
+
+    async def _run_safe(extra):
+        # yt-dlp timing out raises TimeoutExpired instead of returning a proc.
+        # Never let that escape with partials still on disk — always clean.
+        try:
+            return await asyncio.to_thread(_run, extra), None
+        except _sp.TimeoutExpired as e:
+            _clean_partials()
+            return None, e
+
+    proc = None
+    try:
+        # Attempt 1: whole video within the 35M cap.
+        proc, err = await _run_safe([])
         got = _find_output()
-    if got is None:
+        if got is None:
+            _clean_partials()
+            # Attempt 2: first 3 minutes (helps long talks that blow the cap).
+            # KEEP the 35M cap here too — a section download can still exceed
+            # the base64 payload limit at high bitrate — and force an mp4 remux
+            # so the section is finalized (not left as a .part).
+            proc, err = await _run_safe(
+                ["--download-sections", "*0-180", "--force-keyframes-at-cuts",
+                 "--remux-video", "mp4"],
+            )
+            got = _find_output()
+        if got is None:
+            _clean_partials()
+            stderr = (proc.stderr or "").strip()[:300] if proc is not None else "timed out"
+            raise ValueError(
+                "yt-dlp could not fetch a compact video from this URL. "
+                f"stderr: {stderr}"
+            )
+        return got
+    except BaseException:
+        # Any failure path (incl. cancellation): don't leak partials.
         _clean_partials()
-        raise ValueError(
-            "yt-dlp could not fetch a compact video from this URL. "
-            f"stderr: {(proc.stderr or '').strip()[:300]}"
-        )
-    return got
+        raise
 
 
 async def video_analyze_tool(
@@ -1874,6 +1892,16 @@ async def video_analyze_tool(
                 should_cleanup = True
             elif _ytdlp_available():
                 # Page URL (YouTube, X, Vimeo, TikTok, ...): extract via yt-dlp.
+                # SSRF guard: resolve DNS/IP and reject private/internal targets
+                # BEFORE handing the URL to yt-dlp (mirrors the direct-download
+                # path's _validate_image_url_async, minus the image-shape check
+                # that a page URL would fail). Blocks e.g. cloud metadata IPs.
+                from tools.url_safety import async_is_safe_url
+                if not await async_is_safe_url(resolved_url):
+                    raise PermissionError(
+                        "Refusing to fetch video from a private/internal or "
+                        "unresolvable address."
+                    )
                 logger.info("Non-direct video URL — fetching via yt-dlp")
                 temp_video_path = await _download_video_via_ytdlp(resolved_url, temp_dir)
                 should_cleanup = True

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1768,7 +1768,11 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
 
     def _run(extra):
         import subprocess
-        proc = subprocess.run(base + extra + [url], capture_output=True, text=True, timeout=180)
+        proc = subprocess.run(
+            base + extra + [url],
+            stdin=subprocess.DEVNULL,
+            capture_output=True, text=True, timeout=180,
+        )
         return proc
 
     def _find_output():

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1757,7 +1757,8 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
     fmt = "b[height<=480][ext=mp4]/b[ext=mp4]/b[height<=480]/b"
     base = [
         "yt-dlp", "-q", "--no-warnings", "--no-playlist",
-        "-f", fmt, "--max-filesize", "45M",
+        # 35M raw keeps the ~1.37x base64 data-URL under _MAX_VIDEO_BASE64_BYTES (50M).
+        "-f", fmt, "--max-filesize", "35M",
         "-o", out_tmpl,
     ]
     # Cookie support: many sites (YouTube especially) gate anonymous fetches
@@ -1809,6 +1810,7 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
         )
         got = _find_output()
     if got is None:
+        _clean_partials()
         raise ValueError(
             "yt-dlp could not fetch a compact video from this URL. "
             f"stderr: {(proc.stderr or '').strip()[:300]}"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1638,7 +1638,7 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
 #  (2) Non-direct URLs (YouTube, X/Twitter, Vimeo, TikTok, ...) are not raw
 #      video files, so a plain HTTP GET can't fetch them. Use yt-dlp.
 
-_VIDEO_CAPABLE_PROVIDER_ORDER = ("openrouter", "nous")
+_VIDEO_CAPABLE_PROVIDER_ORDER = ("openrouter", "nous", "gemini")
 _VIDEO_CAPABLE_MAIN_PROVIDERS = {
     "gemini", "google", "google-gemini", "google-ai-studio",
 }
@@ -1668,7 +1668,7 @@ def _resolve_video_provider_model(explicit_model: Optional[str] = None):
     # 1. Operator override in config (auxiliary.vision.video_provider/model).
     ov_provider = (_cfg_get_safe("auxiliary", "vision", "video_provider") or "").strip()
     ov_model = (_cfg_get_safe("auxiliary", "vision", "video_model") or "").strip()
-    if ov_provider:
+    if ov_provider and ov_provider.lower() != "auto":
         model = explicit_model or ov_model or _VIDEO_PROVIDER_DEFAULT_MODELS.get(ov_provider)
         return ov_provider, model
 
@@ -1679,7 +1679,7 @@ def _resolve_video_provider_model(explicit_model: Optional[str] = None):
         # strip a leading "provider/" prefix if present
         if "/" in main_model:
             main_model = main_model.split("/", 1)[1]
-        model = explicit_model or main_model or _VIDEO_PROVIDER_DEFAULT_MODELS.get(main_provider)
+        model = explicit_model or ov_model or main_model or _VIDEO_PROVIDER_DEFAULT_MODELS.get(main_provider)
         return main_provider, model
 
     # 3. Auto: first video-capable aggregator whose client resolves.
@@ -1690,14 +1690,17 @@ def _resolve_video_provider_model(explicit_model: Optional[str] = None):
     if resolve_vision_provider_client is not None:
         for prov in _VIDEO_CAPABLE_PROVIDER_ORDER:
             default_model = _VIDEO_PROVIDER_DEFAULT_MODELS.get(prov)
+            requested_model = explicit_model or ov_model or default_model
+            if prov == "gemini" and requested_model and requested_model.startswith("google/"):
+                requested_model = requested_model.split("/", 1)[1]
             try:
                 _prov, client, final_model = resolve_vision_provider_client(
-                    provider=prov, model=explicit_model or default_model,
+                    provider=prov, model=requested_model,
                 )
             except Exception:
                 client, final_model = None, None
             if client is not None:
-                return prov, (explicit_model or final_model or default_model)
+                return prov, (requested_model or final_model or default_model)
 
     return None, explicit_model
 
@@ -1711,9 +1714,47 @@ def _is_direct_video_url(url: str) -> bool:
     return any(p.endswith(ext) for ext in _VIDEO_MIME_TYPES)
 
 
-def _ytdlp_available() -> bool:
+def _ensure_ytdlp_available() -> None:
+    """Install the pinned page extractor on first use when necessary."""
+    try:
+        import yt_dlp  # noqa: F401
+        return
+    except ImportError:
+        from tools.lazy_deps import ensure
+        ensure("tool.video", prompt=False)
+
+
+def _ytdlp_command() -> list[str]:
+    """Run the resolved yt-dlp package with the active interpreter.
+
+    Lazy dependencies may live in a target appended only to this process's
+    ``sys.path``. A fresh ``python -m yt_dlp`` child would not inherit that
+    path. Pass the resolved package root explicitly and append it in the child
+    so the core environment keeps precedence over lazy-installed packages.
+    """
+    import yt_dlp
+
+    package_root = str(Path(yt_dlp.__file__).resolve().parent.parent)
+    runner = (
+        "import runpy,sys; "
+        "sys.path.append(sys.argv.pop(1)); "
+        "runpy.run_module('yt_dlp', run_name='__main__')"
+    )
+    return [sys.executable, "-c", runner, package_root]
+
+
+def _ytdlp_js_runtime_args() -> list[str]:
+    """Enable an installed JavaScript runtime for YouTube challenges."""
     import shutil
-    return shutil.which("yt-dlp") is not None
+
+    # Deno is yt-dlp's enabled-by-default and preferred runtime.
+    if shutil.which("deno"):
+        return []
+    for runtime, executable in (("node", "node"), ("quickjs", "qjs")):
+        path = shutil.which(executable)
+        if path:
+            return ["--js-runtimes", f"{runtime}:{path}"]
+    return []
 
 
 def _ytdlp_cookie_args() -> list:
@@ -1750,17 +1791,17 @@ async def _download_video_via_ytdlp(url: str, dest_dir: Path) -> Path:
     site. Caps resolution + filesize so the base64 payload stays under the API
     limit; falls back to grabbing the first 3 minutes for long videos.
     """
-    import shutil
     dest_dir.mkdir(parents=True, exist_ok=True)
     out_tmpl = str(dest_dir / f"ytdl_{uuid.uuid4().hex}.%(ext)s")
     # Single progressive file (no merge -> no hard ffmpeg dependency), <=480p.
     fmt = "b[height<=480][ext=mp4]/b[ext=mp4]/b[height<=480]/b"
-    base = [
-        "yt-dlp", "-q", "--no-warnings", "--no-playlist",
+    base = _ytdlp_command() + [
+        "--ignore-config", "-q", "--no-warnings", "--no-playlist",
         # 35M raw keeps the ~1.37x base64 data-URL under _MAX_VIDEO_BASE64_BYTES (50M).
         "-f", fmt, "--max-filesize", "35M",
         "-o", out_tmpl,
     ]
+    base += _ytdlp_js_runtime_args()
     # Cookie support: many sites (YouTube especially) gate anonymous fetches
     # behind a "confirm you're not a bot" wall. Reuse the fleet cookies jar
     # (refreshed by the yt-cookies-refresh cron) when present.
@@ -1890,7 +1931,7 @@ async def video_analyze_tool(
                 temp_video_path = temp_dir / f"temp_video_{uuid.uuid4()}.mp4"
                 await _download_video(video_url, temp_video_path)
                 should_cleanup = True
-            elif _ytdlp_available():
+            else:
                 # Page URL (YouTube, X, Vimeo, TikTok, ...): extract via yt-dlp.
                 # SSRF guard: resolve DNS/IP and reject private/internal targets
                 # BEFORE handing the URL to yt-dlp (mirrors the direct-download
@@ -1902,15 +1943,10 @@ async def video_analyze_tool(
                         "Refusing to fetch video from a private/internal or "
                         "unresolvable address."
                     )
+                await asyncio.to_thread(_ensure_ytdlp_available)
                 logger.info("Non-direct video URL — fetching via yt-dlp")
                 temp_video_path = await _download_video_via_ytdlp(resolved_url, temp_dir)
                 should_cleanup = True
-            else:
-                raise ValueError(
-                    "This looks like a page URL (e.g. YouTube), not a direct video "
-                    "file, and yt-dlp is not installed. Install yt-dlp or pass a "
-                    "direct video-file URL / local path."
-                )
         else:
             raise ValueError(
                 "Invalid video source. Provide an HTTP/HTTPS URL or a valid local file path."
@@ -2115,13 +2151,17 @@ def _handle_video_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         "including visual content, motion, audio cues, text overlays, and scene "
         f"transitions. Then answer the following question:\n\n{question}"
     )
-    # Prefer config.yaml auxiliary.video.model (falling back to vision);
-    # env vars are a legacy override.
+    # Prefer the video-specific config. Generic image-vision models may not
+    # accept video_url blocks, so do not inherit auxiliary.vision.model here.
+    # Environment variables remain a legacy override.
     model = None
     try:
         from hermes_cli.config import cfg_get, load_config
         _cfg = load_config()
-        _vmodel = cfg_get(_cfg, "auxiliary", "video", "model") or cfg_get(_cfg, "auxiliary", "vision", "model")
+        _vmodel = (
+            cfg_get(_cfg, "auxiliary", "vision", "video_model")
+            or cfg_get(_cfg, "auxiliary", "video", "model")
+        )
         if _vmodel:
             model = str(_vmodel).strip() or None
     except Exception:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -507,6 +507,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/cc/e6be943efa9051bd15c2ee14077c2b10d6e27c9e9385fc43a03a5c4ed8b5/botocore-1.42.89.tar.gz", hash = "sha256:95ac52f472dad29942f3088b278ab493044516c16dbf9133c975af16527baa99", size = 15206290, upload-time = "2026-04-13T19:36:02.321Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/f1/90a7b8eda38b7c3a65ca7ee0075bdf310b6b471cb1b95fab6e8994323a50/botocore-1.42.89-py3-none-any.whl", hash = "sha256:d9b786c8d9db6473063b4cc5be0ba7e6a381082307bd6afb69d4216f9fa95f35", size = 14887287, upload-time = "2026-04-13T19:35:56.677Z" },
+]
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ef/f285668811a9e1ddb47a18cb0b437d5fc2760d537a2fe8a57875ad6f8448/brotli-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:15b33fe93cedc4caaff8a0bd1eb7e3dab1c61bb22a0bf5bdfdfd97cd7da79744", size = 863110, upload-time = "2025-11-05T18:38:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/50/62/a3b77593587010c789a9d6eaa527c79e0848b7b860402cc64bc0bc28a86c/brotli-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:898be2be399c221d2671d29eed26b6b2713a02c2119168ed914e7d00ceadb56f", size = 445438, upload-time = "2025-11-05T18:38:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e1/7fadd47f40ce5549dc44493877db40292277db373da5053aff181656e16e/brotli-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350c8348f0e76fff0a0fd6c26755d2653863279d086d3aa2c290a6a7251135dd", size = 1534420, upload-time = "2025-11-05T18:38:15.111Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8b/1ed2f64054a5a008a4ccd2f271dbba7a5fb1a3067a99f5ceadedd4c1d5a7/brotli-1.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e1ad3fda65ae0d93fec742a128d72e145c9c7a99ee2fcd667785d99eb25a7fe", size = 1632619, upload-time = "2025-11-05T18:38:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5a/7071a621eb2d052d64efd5da2ef55ecdac7c3b0c6e4f9d519e9c66d987ef/brotli-1.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:40d918bce2b427a0c4ba189df7a006ac0c7277c180aee4617d99e9ccaaf59e6a", size = 1426014, upload-time = "2025-11-05T18:38:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6d/0971a8ea435af5156acaaccec1a505f981c9c80227633851f2810abd252a/brotli-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2a7f1d03727130fc875448b65b127a9ec5d06d19d0148e7554384229706f9d1b", size = 1489661, upload-time = "2025-11-05T18:38:18.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/c1baca8b4ec6c96a03ef8230fab2a785e35297632f402ebb1e78a1e39116/brotli-1.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9c79f57faa25d97900bfb119480806d783fba83cd09ee0b33c17623935b05fa3", size = 1599150, upload-time = "2025-11-05T18:38:19.792Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1a/23fcfee1c324fd48a63d7ebf4bac3a4115bdb1b00e600f80f727d850b1ae/brotli-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:844a8ceb8483fefafc412f85c14f2aae2fb69567bf2a0de53cdb88b73e7c43ae", size = 1493505, upload-time = "2025-11-05T18:38:20.913Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e5/12904bbd36afeef53d45a84881a4810ae8810ad7e328a971ebbfd760a0b3/brotli-1.2.0-cp311-cp311-win32.whl", hash = "sha256:aa47441fa3026543513139cb8926a92a8e305ee9c71a6209ef7a97d91640ea03", size = 334451, upload-time = "2025-11-05T18:38:21.94Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8b/ecb5761b989629a4758c394b9301607a5880de61ee2ee5fe104b87149ebc/brotli-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24", size = 369035, upload-time = "2025-11-05T18:38:22.941Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
 ]
 
 [[package]]
@@ -1415,7 +1453,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
     { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/a0/68afd1ebad40db87dac0a28ffa120726b98bf9c7c40c481b0f63c105d298/greenlet-3.5.3-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e18619ba655ac05d78d80fc83cac4ba892bd6927b99e3b8237aee861aaacc8bb", size = 626155, upload-time = "2026-06-26T19:24:14.44Z" },
     { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7f/e327d912239ec4b3b49999e3967389bcf1ee8722b9ee9194d2752ecd558a/greenlet-3.5.3-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d27c0c653a60d9535f690226474a5cc1036a8b0d7b57504d1c4f89c44a07a80c", size = 421083, upload-time = "2026-06-26T19:25:35.804Z" },
     { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
     { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
     { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
@@ -1423,7 +1463,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
     { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
     { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
     { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
     { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
     { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
     { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
@@ -1431,7 +1473,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
     { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
     { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
     { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
     { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
     { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
     { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
@@ -1712,6 +1756,9 @@ tts-premium = [
 vertex = [
     { name = "google-auth" },
 ]
+video = [
+    { name = "yt-dlp", extra = ["default"] },
+]
 voice = [
     { name = "faster-whisper" },
     { name = "numpy" },
@@ -1852,8 +1899,9 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
+    { name = "yt-dlp", extras = ["default"], marker = "extra == 'video'", specifier = ">=2026.7.4,<2027" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "supermemory", "mem0", "vision", "video", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2607,6 +2655,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mutagen"
+version = "1.48.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/70/1675da133ea92227da41bf5b24e1c66be597ff736a1533ade41da986852f/mutagen-1.48.1.tar.gz", hash = "sha256:8f95637ab9f6f305cec6bd1294e197debe207998e3e068596563c74f86b0a173", size = 1276978, upload-time = "2026-06-25T09:47:32.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d8/a29e4e3991765e7ce4ed1f7e4074fe1ba9da03e0048639734de60f9cadb9/mutagen-1.48.1-py3-none-any.whl", hash = "sha256:4f077fe87d3fc7fba259aa63d8c026b18382ca6a42ef37c61e16f1b1b5b82fe7", size = 195706, upload-time = "2026-06-25T09:47:30.296Z" },
+]
+
+[[package]]
 name = "nemo-relay"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3246,6 +3303,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
     { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
     { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
+]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157, upload-time = "2025-05-17T17:23:41.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/00/10edb04777069a42490a38c137099d4b17ba6e36a4e6e28bdc7470e9e853/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7b37e08e3871efe2187bc1fd9320cc81d87caf19816c648f24443483005ff886", size = 2498764, upload-time = "2025-05-17T17:22:21.453Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3f/2872a9c2d3a27eac094f9ceaa5a8a483b774ae69018040ea3240d5b11154/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:91979028227543010d7b2ba2471cf1d1e398b3f183cb105ac584df0c36dac28d", size = 1643012, upload-time = "2025-05-17T17:22:23.702Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/774c2e2b4f6570fbf6a4972161adbb183aeeaa1863bde31e8706f123bf92/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8962204c47464d5c1c4038abeadd4514a133b28748bcd9fa5b6d62e3cec6fa", size = 2187643, upload-time = "2025-05-17T17:22:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a3/71065b24cb889d537954cedc3ae5466af00a2cabcff8e29b73be047e9a19/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a33986a0066860f7fcf7c7bd2bc804fa90e434183645595ae7b33d01f3c91ed8", size = 2273762, upload-time = "2025-05-17T17:22:28.313Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0b/ff6f43b7fbef4d302c8b981fe58467b8871902cdc3eb28896b52421422cc/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7947ab8d589e3178da3d7cdeabe14f841b391e17046954f2fbcd941705762b5", size = 2313012, upload-time = "2025-05-17T17:22:30.57Z" },
+    { url = "https://files.pythonhosted.org/packages/02/de/9d4772c0506ab6da10b41159493657105d3f8bb5c53615d19452afc6b315/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c25e30a20e1b426e1f0fa00131c516f16e474204eee1139d1603e132acffc314", size = 2186856, upload-time = "2025-05-17T17:22:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ad/8b30efcd6341707a234e5eba5493700a17852ca1ac7a75daa7945fcf6427/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:da4fa650cef02db88c2b98acc5434461e027dce0ae8c22dd5a69013eaf510006", size = 2347523, upload-time = "2025-05-17T17:22:35.386Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/02/16868e9f655b7670dbb0ac4f2844145cbc42251f916fc35c414ad2359849/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:58b851b9effd0d072d4ca2e4542bf2a4abcf13c82a29fd2c93ce27ee2a2e9462", size = 2272825, upload-time = "2025-05-17T17:22:37.632Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/4ca89ac737230b52ac8ffaca42f9c6f1fd07c81a6cd821e91af79db60632/pycryptodomex-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:a9d446e844f08299236780f2efa9898c818fe7e02f17263866b8550c7d5fb328", size = 1772078, upload-time = "2025-05-17T17:22:40Z" },
+    { url = "https://files.pythonhosted.org/packages/73/34/13e01c322db027682e00986873eca803f11c56ade9ba5bbf3225841ea2d4/pycryptodomex-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bc65bdd9fc8de7a35a74cab1c898cab391a4add33a8fe740bda00f5976ca4708", size = 1803656, upload-time = "2025-05-17T17:22:42.139Z" },
+    { url = "https://files.pythonhosted.org/packages/54/68/9504c8796b1805d58f4425002bcca20f12880e6fa4dc2fc9a668705c7a08/pycryptodomex-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c885da45e70139464f082018ac527fdaad26f1657a99ee13eecdce0f0ca24ab4", size = 1707172, upload-time = "2025-05-17T17:22:44.704Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9c/1a8f35daa39784ed8adf93a694e7e5dc15c23c741bbda06e1d45f8979e9e/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:06698f957fe1ab229a99ba2defeeae1c09af185baa909a31a5d1f9d42b1aaed6", size = 2499240, upload-time = "2025-05-17T17:22:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/62/f5221a191a97157d240cf6643747558759126c76ee92f29a3f4aee3197a5/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2c2537863eccef2d41061e82a881dcabb04944c5c06c5aa7110b577cc487545", size = 1644042, upload-time = "2025-05-17T17:22:49.098Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/fd/5a054543c8988d4ed7b612721d7e78a4b9bf36bc3c5ad45ef45c22d0060e/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c446e2ba8df8889e0e16f02211c25b4934898384c1ec1ec04d7889c0333587", size = 2186227, upload-time = "2025-05-17T17:22:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578, upload-time = "2025-05-17T17:22:53.676Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/bda9c49a7c1842820de674ab36c79f4fbeeee03f8ff0e4f3546c3889076b/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc69d0d3d989a1029df0eed67cc5e8e5d968f3724f4519bd03e0ec68df7543c", size = 2312166, upload-time = "2025-05-17T17:22:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/870b9bf8ca92866ca0186534801cf8d20554ad2a76ca959538041b7a7cf4/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bbcb1dd0f646484939e142462d9e532482bc74475cecf9c4903d4e1cd21f003", size = 2185467, upload-time = "2025-05-17T17:22:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e3/ce9348236d8e669fea5dd82a90e86be48b9c341210f44e25443162aba187/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:8a4fcd42ccb04c31268d1efeecfccfd1249612b4de6374205376b8f280321744", size = 2346104, upload-time = "2025-05-17T17:23:02.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038, upload-time = "2025-05-17T17:23:04.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/67/09ee8500dd22614af5fbaa51a4aee6e342b5fa8aecf0a6cb9cbf52fa6d45/pycryptodomex-3.23.0-cp37-abi3-win32.whl", hash = "sha256:189afbc87f0b9f158386bf051f720e20fa6145975f1e76369303d0f31d1a8d7c", size = 1771969, upload-time = "2025-05-17T17:23:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/69/96/11f36f71a865dd6df03716d33bd07a67e9d20f6b8d39820470b766af323c/pycryptodomex-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:52e5ca58c3a0b0bd5e100a9fbc8015059b05cffc6c66ce9d98b4b45e023443b9", size = 1803124, upload-time = "2025-05-17T17:23:09.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/93/45c1cdcbeb182ccd2e144c693eaa097763b08b38cded279f0053ed53c553/pycryptodomex-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:02d87b80778c171445d67e23d1caef279bf4b25c3597050ccd2e13970b57fd51", size = 1707161, upload-time = "2025-05-17T17:23:11.414Z" },
 ]
 
 [[package]]
@@ -4565,6 +4652,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c5/9972af4b472b0d55badf841ebafd2f98944cb0ae0f46e11d01f363ea5b91/yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432", size = 3049326, upload-time = "2026-07-04T22:42:14.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266", size = 3184705, upload-time = "2026-07-04T22:42:12.989Z" },
+]
+
+[package.optional-dependencies]
+default = [
+    { name = "brotli", marker = "implementation_name == 'cpython' and sys_platform != 'ios'" },
+    { name = "brotlicffi", marker = "implementation_name != 'cpython'" },
+    { name = "certifi" },
+    { name = "mutagen" },
+    { name = "pycryptodomex" },
+    { name = "requests" },
+    { name = "urllib3" },
+    { name = "websockets" },
+    { name = "yt-dlp-ejs" },
+]
+
+[[package]]
+name = "yt-dlp-ejs"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/e6/cceb9530e8f4e5940f6f7822d90e9d94f1b85343329a16baaf47bbbb3de1/yt_dlp_ejs-0.8.0.tar.gz", hash = "sha256:d5fa1639f63b5c4af8d932495f60689d5370f1a095782c944f7f62a303eb104e", size = 96571, upload-time = "2026-03-17T22:49:19.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/bd/520769863744b669440a924271a6159ddd82ad5ae26b4ac4d4b69e9f8d44/yt_dlp_ejs-0.8.0-py3-none-any.whl", hash = "sha256:79300e5fca7f937a1eeede11f0456862c1b41107ce1d726871e0207424f4bdb4", size = 53443, upload-time = "2026-03-17T22:49:17.736Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`video_analyze` fails on two independent counts, making it effectively unusable:

**1. Provider routing crash.** The tool calls the LLM with `task="vision"`, whose auto-router tries the user's **main provider** first. A provider can accept *images* but reject a `video_url` content block — e.g. Anthropic/Claude returns `400 "Input tag 'video' ... does not match any of the expected tags"`. Passing `model=` can't save it, because the override can't redirect the *provider*. Result: any main provider that isn't Gemini-family makes video analysis impossible.

**2. Page URLs never reach the model.** `_download_video` only did a plain HTTP GET, so only local files and *direct* video-file URLs worked. A YouTube / X / Vimeo / TikTok watch-page URL isn't a raw `.mp4`, so the fetch failed before the model ever saw it.

## Fix

1. **Resolve a video-capable backend explicitly** before the call — Gemini family via `openrouter`/`nous`, a Gemini main provider, or an operator override — instead of letting the vision auto-router pick the (image-only) main provider.
2. **Fetch non-direct http(s) URLs via `yt-dlp`** (≤480p, size-capped, first-3-min fallback for long videos), reusing an existing cookies jar (`~/yt.cookies.txt` or a config/env override) to clear the YouTube bot-gate. Partial (`.part`) artifacts are filtered so only a finalized video file is analyzed. Direct video-file URLs keep the original HTTP path.

New config knobs live in `config.yaml` (not env), per the repo's env-vs-config rule: `auxiliary.vision.video_provider`, `video_model`, `ytdlp_cookies`, `ytdlp_cookies_from_browser`. yt-dlp is used only when present (graceful message otherwise).

## Verification (E2E, real path)

- Local `testsrc` mp4 → accurate description through the real tool.
- A real YouTube watch URL → correct content (speakers/org/topic) end-to-end.
- Existing `tests/tools/test_video_analyze.py` (29 tests) still green.