### PR TITLE
fix(cli): stop is_container() false-positive on hosts running containers

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -865,11 +865,14 @@ def is_container() -> bool:
     Kubernetes/k3s) were previously missed. To cover those, also check:
       * ``KUBERNETES_SERVICE_HOST`` env var — set in every Kubernetes pod.
       * ``kubepods`` / ``containerd`` / ``crio`` markers in ``/proc/1/cgroup``.
-      * the same markers in ``/proc/self/mountinfo`` (cgroup-v2 fallback).
+      * the same markers on the **root** mount (``/``) in
+        ``/proc/self/mountinfo`` (cgroup-v2 fallback).  Only the root mount is
+        checked, so a host running its own containers isn't misread as one
+        (see #58135).
 
     Result is cached for the process lifetime.  Import-safe — no heavy deps.
 
-    See: NousResearch/hermes-agent#47111
+    See: NousResearch/hermes-agent#47111, #58135
     """
     global _container_detected
     if _container_detected is not None:
@@ -893,15 +896,21 @@ def is_container() -> bool:
                 return True
     except OSError:
         pass
-    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
-    # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # cgroup v2 collapses /proc/1/cgroup to "0::/", so fall back to mountinfo —
+    # but only the root mount ("/") reflects our own rootfs (a runtime overlay
+    # in a container, a plain block device on a host). Containers the *host*
+    # runs put containerd/crio in other mounts' lowerdir= options; scanning the
+    # whole table matched those and misclassified the host (#58135).
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                # 5th field (index 4) is the mount point; only "/" is our rootfs.
+                fields = line.split()
+                if len(fields) > 4 and fields[4] == "/" and any(
+                    marker in line for marker in ("kubepods", "containerd", "crio")
+                ):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -415,6 +415,62 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", _fake_open)
         assert is_container() is True
 
+    def test_host_running_containers_not_flagged(self, monkeypatch, tmp_path):
+        """A host that merely runs containers is not itself a container (#58135)."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")  # cgroup v2 — no runtime marker
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            # host root: a real block device, no marker
+            "25 30 259:2 / / rw,relatime shared:1 - ext4 /dev/nvme0n1p2 rw\n"
+            # a running container's overlay: mount point is not "/", marker only
+            # in the lowerdir= options
+            "469 554 0:94 / /var/lib/docker/rootfs/overlayfs/7dda83 rw,relatime "
+            "shared:247 - overlay overlay rw,lowerdir=/var/lib/containerd/"
+            "io.containerd.snapshotter.v1.overlayfs/snapshots/33509/fs\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
+    def test_detects_containerd_root_overlay_lowerdir(self, monkeypatch, tmp_path):
+        """Marker on the process's own root ("/") overlay still counts (#58135)."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "1543 1542 0:158 / / rw,relatime - overlay overlay "
+            "rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1."
+            "overlayfs/snapshots/42/fs,upperdir=/run/containerd/x/fs\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is True
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)


### PR DESCRIPTION
## What does this PR do?

`hermes_constants.is_container()` false-positives on a plain Linux **host** whenever a Docker container is running with the containerd image store (Docker Desktop's default).

On cgroup v2, `/proc/1/cgroup` is just `0::/`, so `is_container()` falls back to scanning `/proc/self/mountinfo` for `kubepods`/`containerd`/`crio`. But every container the host *runs* with the containerd snapshotter contributes an overlay mount whose `lowerdir=/var/lib/containerd/...` option string contains the substring `containerd` — so the whole-table scan classifies the **host** as being inside a container. Because the result is cached in `_container_detected` per process, the answer permanently depends on whether any container happened to be running the first time each process called it.

Downstream, `get_subprocess_home()` under the default `terminal.home_mode: auto` then returns `{HERMES_HOME}/home` instead of the real user `HOME`, so every subprocess (browser worker, ACP/CLI executors, dep-ensure, …) gets an empty per-profile HOME and `browser_navigate` fails with **"Chrome not found."**

**Fix:** in the mountinfo fallback, inspect only the **root mount** (the line whose mount point is `/`). Inside a container that line is the runtime's overlay rootfs (containerd/crio paths); on a host it is a regular block device. Markers on any *other* mount — including the `lowerdir=` options of containers the host itself runs — no longer count. This also removes the time-dependence at its source (the signal now depends only on our own rootfs), so caching stays safe and suggestion #3 in the issue is unnecessary.

## Related Issue

Fixes #58135

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_constants.py`** — `is_container()`: the cgroup-v2 `/proc/self/mountinfo` fallback now matches `kubepods`/`containerd`/`crio` only on the **root** mount line (mount point `/`), instead of substring-scanning the entire mount table. Docstring updated.
- **`tests/test_hermes_constants.py`** — two regression tests in `TestIsContainer`:
  - `test_host_running_containers_not_flagged` — a cgroup-v2 host whose root is a block device but which runs a containerd container (overlay `lowerdir=/var/lib/containerd/...` on a *non-root* mount) is **not** flagged. (Fails on the old code, passes now.)
  - `test_detects_containerd_root_overlay_lowerdir` — a container whose own root `/` overlay carries the `containerd` marker only in its `lowerdir=` options **is** still detected (guards against over-narrowing the fix).

## How to Test

Reproduction (Linux host with Docker's containerd image store, cgroup v2):

```bash
# no containers running — correct
python -c "from hermes_constants import is_container; print(is_container())"   # False

docker run -d --rm --name idle alpine sleep 600

# new process (the cache is per-process) — WRONG before this PR
python -c "from hermes_constants import is_container; print(is_container())"   # was True, now False
```

Unit tests:

```bash
scripts/run_tests.sh tests/test_hermes_constants.py::TestIsContainer
```

All 10 `TestIsContainer` cases pass, including the two new ones.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files: the fix + its tests)
- [x] I've added tests for my changes
- [x] I've tested: reproduction on Ubuntu 24.04 (WSL2); `TestIsContainer` (all 10) green

> The change is Linux-`/proc`-specific and fully mocked in tests, so it's platform-independent. A few unrelated `TestGetHermesDir` / `TestSecureParentDir` symlink tests fail on *native* Windows without Developer Mode (per CONTRIBUTING §Cross-Platform rule #8) — they pass on the Linux CI.

### Documentation & Housekeeping

- [x] Updated the `is_container()` docstring to document the root-mount-only behavior
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow change
- [x] Considered cross-platform impact — the parsed `/proc/self/mountinfo` read is Linux-only and stays inside the existing `try/except OSError`; no behavior change on macOS/Windows
- [x] N/A — no tool schema change
