### PR TITLE
fix(fallback): detect dot-namespaced GPT-5 ids (openai.gpt-5.5) as Responses-API models

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1349,9 +1349,18 @@ class AIAgent:
         which provider is serving the model.
         """
         m = model.lower()
-        # Strip vendor prefix (e.g. "openai/gpt-5.4" → "gpt-5.4")
+        # Strip vendor prefix. Two namespacing conventions are in the wild:
+        #   "openai/gpt-5.4"  (OpenRouter-style slash)
+        #   "openai.gpt-5.5"  (AWS Bedrock / Mantle dot-namespace)
+        # The version itself uses a dot ("gpt-5.5"), so only strip a leading
+        # vendor token followed by a dot — never the version dot. Without the
+        # dot case, Bedrock GPT-5 ids fell through as chat_completions and got
+        # rejected with HTTP 400 "does not support /v1/chat/completions"
+        # (notably on the fallback path, which re-derives api_mode).
         if "/" in m:
             m = m.rsplit("/", 1)[-1]
+        elif re.match(r"^[a-z0-9_-]+\.gpt-5", m):
+            m = m.split(".", 1)[-1]
         return m.startswith("gpt-5")
 
     @staticmethod


### PR DESCRIPTION
## Summary

`_model_requires_responses_api()` fails to detect GPT-5 models that use a **dot-namespaced** vendor prefix (e.g. AWS Bedrock / Mantle's `openai.gpt-5.5`). It strips a `/`-style prefix (`openai/gpt-5.4`) but not a `.`-style one, so `"openai.gpt-5.5".startswith("gpt-5")` is `False`. The model is then treated as a chat-completions model and the request is sent to `/v1/chat/completions`, which these responses-only models reject:

```
HTTP 400: The model 'openai.gpt-5.5' does not support the '/v1/chat/completions' API
```

## Where it bites

The **fallback activation path** (`agent/chat_completion_helpers.py`, `_try_activate_fallback`, ~L1303–1339) does not read the fallback provider's configured `api_mode`; it re-derives `api_mode` from scratch and relies on `_provider_model_requires_responses_api()` → `_model_requires_responses_api()` to catch GPT-5. A custom provider explicitly configured with `api_mode: codex_responses` (correct for Bedrock Mantle) therefore still falls through to `chat_completions` on the fallback path and 400s — even though the direct path (`hermes chat --provider custom:mantle`) works, because that path reads the configured `api_mode`.

Repro (deterministic, no network):

```python
from run_agent import AIAgent
AIAgent._model_requires_responses_api('openai.gpt-5.5')  # False (bug); should be True
AIAgent._model_requires_responses_api('openai/gpt-5.4')  # True (slash form already handled)
```

## Fix

Also strip a leading `<vendor>.` prefix, but **only** when it is immediately followed by `gpt-5`, so the version dot in `gpt-5.5` is never touched:

```python
if "/" in m:
    m = m.rsplit("/", 1)[-1]
elif re.match(r"^[a-z0-9_-]+\.gpt-5", m):
    m = m.split(".", 1)[-1]
return m.startswith("gpt-5")
```

`re` is already imported in `run_agent.py`.

## Test matrix (all pass after fix)

| input | expected |
|---|---|
| `openai.gpt-5.5` | True |
| `gpt-5.5` | True |
| `openai/gpt-5.4` | True |
| `gpt-5` | True |
| `gpt-4o` | False |
| `anthropic.claude-opus-4-8` | False |

The `\.gpt-5` guard is deliberate: a naive `split(".")` would corrupt the `gpt-5.5` version dot, and an unguarded dot-strip would wrongly fire on non-GPT-5 dot-namespaced ids like `anthropic.claude-opus-4-8`.

## Impact

Affects every dot-namespaced GPT-5 id on the fallback path — i.e. all Bedrock/Mantle GPT-5 models used as a fallback target. Low blast radius: the change only widens vendor-prefix stripping for the `gpt-5` family.
