### PR TITLE
fix: surface reasoning/thinking content as response instead of '(empty)'

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4884,8 +4884,15 @@ def run_conversation(
                         )
                         agent._emit_status(
                             "⚠️ Model produced reasoning but no visible "
-                            "response after all retries. Returning empty."
+                            "response — surfacing reasoning as response."
                         )
+                        # Surface reasoning/thinking content as the response
+                        # instead of "(empty)".  Models that put their entire
+                        # reply inside <think>/<thinking> blocks or return
+                        # content only via reasoning_content/reasoning_details
+                        # API fields would otherwise show blank to the user
+                        # and cause infinite retry loops (#58117).
+                        final_response = reasoning_text
                     else:
                         logger.warning(
                             "Empty response (no content or reasoning) "
@@ -4899,8 +4906,7 @@ def run_conversation(
                             + (" and fallback attempts." if agent._fallback_chain else
                                ". No fallback providers configured.")
                         )
-
-                    final_response = "(empty)"
+                        final_response = "(empty)"
                     break
                 
                 # Reset retry counter/signature on successful content

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4211,9 +4211,9 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("answer me")
         assert result["completed"] is True
-        # #34452: explanation replaces the bare "(empty)" sentinel.
+        # #58117: reasoning content is surfaced as the response instead of "(empty)".
         assert result["final_response"] != "(empty)"
-        assert "No reply:" in result["final_response"]
+        assert result["final_response"] == "structured reasoning answer"
         assert result["api_calls"] == 6  # 1 original + 2 prefill + 3 retries
 
     def test_reasoning_only_prefill_succeeds_on_continuation(self, agent):


### PR DESCRIPTION
Fixes #58117

## Description

When a thinking model (e.g. DeepSeek V4 Flash) returns a response where all
content is inside a reasoning/thinking block — or where `content` is empty
and only `reasoning_content` is populated — the agent exhausts its prefill
and empty-response retries and eventually sets `final_response = "(empty)"`.

This causes:
- **Blank responses** — the user sees nothing despite the model having
  produced reasoning content
- **Infinite cron heartbeat loops** — cron jobs keep firing because the
  response is empty, wasting $30-80+ in API costs

## Fix

When retries are exhausted and reasoning/thinking content IS available,
surface it as `final_response` instead of `"(empty)"`. The reasoning
text (from `reasoning_content`, `reasoning`, or `reasoning_details`
fields) is the model's actual response — it was just delivered through the
thinking channel rather than visible content.

## Verification

- Change is 9 lines in `agent/conversation_loop.py`
- No new dependencies
- Compile-check passes
- Only the reasoning-exhaustion exit path is affected — successful responses
  with visible content are unchanged