### PR TITLE
fix(custom-provider): forward reasoning_effort at the live profile path (GLM-5.2/ARK)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -377,6 +377,22 @@ class ChatCompletionsTransport(ProviderTransport):
             if _lm_effort is not None:
                 api_kwargs["reasoning_effort"] = _lm_effort
 
+        # Custom provider (e.g. GLM-5.2 on ARK): send top-level reasoning_effort
+        # string so the upstream API receives its native parameter format.
+        if params.get("is_custom_provider", False):
+            _custom_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _custom_thinking_off:
+                _custom_effort = "medium"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _custom_effort = (
+                        reasoning_config.get("effort", "medium") or "medium"
+                    )
+                api_kwargs["reasoning_effort"] = _custom_effort
+
         # extra_body assembly
         extra_body: dict[str, Any] = {}
 
@@ -423,7 +439,10 @@ class ChatCompletionsTransport(ProviderTransport):
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning
             else:
-                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+                _effort = "medium"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _effort = reasoning_config.get("effort", "medium") or "medium"
+                extra_body["reasoning"] = {"enabled": True, "effort": _effort}
 
         if provider_name == "gemini":
             raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -377,22 +377,6 @@ class ChatCompletionsTransport(ProviderTransport):
             if _lm_effort is not None:
                 api_kwargs["reasoning_effort"] = _lm_effort
 
-        # Custom provider (e.g. GLM-5.2 on ARK): send top-level reasoning_effort
-        # string so the upstream API receives its native parameter format.
-        if params.get("is_custom_provider", False):
-            _custom_thinking_off = bool(
-                reasoning_config
-                and isinstance(reasoning_config, dict)
-                and reasoning_config.get("enabled") is False
-            )
-            if not _custom_thinking_off:
-                _custom_effort = "medium"
-                if reasoning_config and isinstance(reasoning_config, dict):
-                    _custom_effort = (
-                        reasoning_config.get("effort", "medium") or "medium"
-                    )
-                api_kwargs["reasoning_effort"] = _custom_effort
-
         # extra_body assembly
         extra_body: dict[str, Any] = {}
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -791,7 +791,7 @@ def apply_subprocess_home_env(env: dict[str, str]) -> None:
         env["HOME"] = home
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort) -> dict | None:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -797,7 +797,7 @@ VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 def parse_reasoning_effort(effort) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh".
+    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none" (aliases: "false", "disabled", and
     YAML boolean False — users write ``reasoning_effort: false``/``off``/``no``

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -1,9 +1,13 @@
 """Custom / Ollama (local) provider profile.
 
 Covers any endpoint registered as provider="custom", including local
-Ollama instances. Key quirks:
+Ollama instances and OpenAI-compatible reasoning endpoints (GLM-5.2 on
+Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
   - reasoning_config disabled → extra_body.think = False
+  - reasoning_config enabled + effort → top-level reasoning_effort
+    (the native OpenAI-compatible format GLM/ARK expect; unset omits it
+    so the endpoint's server default applies)
 """
 
 from typing import Any
@@ -23,6 +27,7 @@ class CustomProfile(ProviderProfile):
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
 
         # Ollama context window
         if ollama_num_ctx:
@@ -30,14 +35,29 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
-        # Disable thinking when reasoning is turned off
+        # Reasoning / thinking control for custom OpenAI-compatible endpoints
+        # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).
+        #
+        #   - disabled  → extra_body.think = False (Ollama's thinking-off flag)
+        #   - enabled + effort set → TOP-LEVEL reasoning_effort string, the
+        #     format GLM-5.2/ARK and other OpenAI-compatible reasoning APIs
+        #     expect (GLM documents "high" and "max"; "max" is its default).
+        #   - enabled + no effort  → omit both, so the endpoint applies its own
+        #     server-side default (do NOT force a level the user didn't pick).
+        #
+        # We deliberately do NOT emit ``think=True`` on enable: it is an
+        # Ollama-only flag and thinking is already server-default-on for these
+        # backends, so forcing it risks a 400 on GLM/vLLM endpoints that don't
+        # recognize it. Mirrors the DeepSeek/Zai profile precedent.
         if reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
                 extra_body["think"] = False
+            elif _effort:
+                top_level["reasoning_effort"] = _effort
 
-        return extra_body, {}
+        return extra_body, top_level
 
     def fetch_models(
         self,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "huanshan5195@users.noreply.github.com": "huanshan5195",  # PR #57601 salvage (custom-provider: emit reasoning_effort at the live CustomProfile path so GLM-5.2/ARK/vLLM/Ollama endpoints receive it; + "max" reasoning level)
     "infinitycrew39@gmail.com": "infinitycrew39",  # PR #56431 salvage (honor live vLLM context limits on local endpoints)
     "jonathan.kovacs999@gmail.com": "CocaKova",  # PR #57692 salvage (cron: run jobs under the profile secret scope so get_secret does not fail-close with UnscopedSecretError under profile isolation)
     "hermes.wanderer@yahoo.com": "trismegistus-wanderer",  # PR #31856 salvage (gateway: defer idle-TTL agent-cache eviction until the session store says the session actually expired, so the expiry watcher can still fire MemoryProvider.on_session_end with the live transcript; #11205)

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -1,0 +1,118 @@
+"""Unit tests for the custom provider profile's reasoning wiring.
+
+``provider=custom`` covers any OpenAI-compatible endpoint the user points
+Hermes at — local Ollama, vLLM, llama.cpp, and hosted reasoning APIs like
+GLM-5.2 on Volcengine ARK. Before #57601's salvage, ``CustomProfile`` emitted
+nothing when reasoning was *enabled*, so a configured ``reasoning_effort``
+was silently dropped for every custom endpoint.
+
+These tests pin the wire-shape contract:
+  - disabled            → extra_body.think = False
+  - enabled + effort    → top-level reasoning_effort (native OpenAI-compat
+                          format GLM/ARK expect), passed through verbatim
+                          including ``max``/``xhigh``
+  - enabled + no effort → nothing emitted (endpoint's server default applies)
+  - ollama_num_ctx      → extra_body.options.num_ctx, orthogonal to reasoning
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def custom_profile():
+    """Resolve the registered custom profile via the global registry.
+
+    Importing ``model_tools`` triggers plugin discovery, which registers the
+    ``custom`` profile. Going through ``get_provider_profile`` keeps the test
+    honest — if the registered class is ever downgraded to a plain
+    ``ProviderProfile``, the assertions below collapse.
+    """
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("custom")
+    assert profile is not None, "custom provider profile must be registered"
+    return profile
+
+
+class TestCustomReasoningWireShape:
+    """``build_api_kwargs_extras`` produces the correct wire format."""
+
+    def test_no_reasoning_config_emits_nothing(self, custom_profile):
+        """Unset reasoning → omit everything so the endpoint's default applies."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="glm-5.2"
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_disabled_sends_think_false(self, custom_profile):
+        """enabled=False → extra_body.think = False (Ollama thinking-off flag)."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, model="glm-5.2"
+        )
+        assert eb == {"think": False}
+        assert tl == {}
+
+    def test_effort_none_sends_think_false(self, custom_profile):
+        """effort='none' is the disable alias → think=False, no effort."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"}, model="glm-5.2"
+        )
+        assert eb == {"think": False}
+        assert tl == {}
+
+    @pytest.mark.parametrize(
+        "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]
+    )
+    def test_enabled_effort_goes_top_level(self, custom_profile, effort):
+        """enabled + effort → TOP-LEVEL reasoning_effort, passed through verbatim.
+
+        GLM-5.2/ARK and OpenAI-compatible reasoning APIs read reasoning_effort
+        as a top-level string, not nested in extra_body. ``max`` is GLM's
+        native deep-reasoning level and must survive.
+        """
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort}, model="glm-5.2"
+        )
+        assert tl == {"reasoning_effort": effort}
+        assert "reasoning_effort" not in eb
+        assert "think" not in eb
+
+    def test_enabled_without_effort_emits_nothing(self, custom_profile):
+        """enabled but no effort → omit; do NOT force a level the user didn't pick."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True}, model="glm-5.2"
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_does_not_force_think_true_on_enable(self, custom_profile):
+        """We must never send think=True on enable — it's Ollama-only and
+        would 400 on GLM/vLLM endpoints that don't recognize it."""
+        eb, _ = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}, model="glm-5.2"
+        )
+        assert eb.get("think") is not True
+
+
+class TestCustomReasoningWithNumCtx:
+    """Ollama num_ctx and reasoning are independent and compose."""
+
+    def test_num_ctx_alone(self, custom_profile):
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config=None, ollama_num_ctx=8192, model="qwen3"
+        )
+        assert eb == {"options": {"num_ctx": 8192}}
+        assert tl == {}
+
+    def test_num_ctx_with_effort(self, custom_profile):
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            ollama_num_ctx=8192,
+            model="qwen3",
+        )
+        assert eb == {"options": {"num_ctx": 8192}}
+        assert tl == {"reasoning_effort": "high"}

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -473,7 +473,7 @@ class TestParseReasoningEffort:
 
     @pytest.mark.parametrize(
         "value",
-        ["bogus", "very-high", "max", "0", "off", "true", "default"],
+        ["bogus", "very-high", "0", "off", "true", "default"],
     )
     def test_unknown_levels_return_none(self, value):
         """Unrecognized strings fall back to the caller default (None)."""
@@ -482,11 +482,11 @@ class TestParseReasoningEffort:
     def test_known_supported_levels_are_documented(self):
         """Guard against silently dropping a documented level.
 
-        The docstring promises "minimal", "low", "medium", "high", "xhigh".
-        If someone removes one from VALID_REASONING_EFFORTS without updating
-        the docstring, this test will fail and force the call out.
+        The docstring promises "minimal", "low", "medium", "high", "xhigh",
+        "max". If someone removes one from VALID_REASONING_EFFORTS without
+        updating the docstring, this test will fail and force the call out.
         """
-        documented = {"minimal", "low", "medium", "high", "xhigh"}
+        documented = {"minimal", "low", "medium", "high", "xhigh", "max"}
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
 
 


### PR DESCRIPTION
## Summary
Makes `reasoning_effort` actually reach `provider=custom` OpenAI-compatible endpoints (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp), where it was silently dropped — salvaged from @huanshan5195's #57601, relocated to the live code path plus tests.

Root cause: the fix must live in `CustomProfile.build_api_kwargs_extras()`, not the legacy `build_kwargs` branch #57601 originally patched. `provider=custom` resolves to `CustomProfile`, so `chat_completion_helpers` takes the profile path and returns early — #57601's branch was **unreachable dead code** for every custom endpoint (verified E2E).

## Changes
- `plugins/model-providers/custom/__init__.py`: on reasoning **enabled + effort**, emit a **top-level** `reasoning_effort` (the OpenAI-compatible format GLM/ARK expect), passed through verbatim incl. `max`/`xhigh`; **disabled** still sends `extra_body.think=False`; **enabled + no effort** omits both so the endpoint's server default applies. Follows the DeepSeek/Zai profile precedent — does *not* force `think=True` on enable (Ollama-only flag, risks 400 on GLM/vLLM).
- `hermes_constants.py`: add `"max"` to `VALID_REASONING_EFFORTS` (GLM-5.2's native deep-reasoning level) — from #57601.
- `agent/transports/chat_completions.py`: stop hardcoding `effort:"medium"` in the legacy `extra_body.reasoning` fallback; use the user's configured effort — from #57601.
- Removed #57601's unreachable `is_custom_provider` legacy branch.
- Tests: new `tests/plugins/model_providers/test_custom_profile.py` (13 cases); updated `tests/test_hermes_constants.py` doc-sync guards for `max`.

## Validation
| provider=custom | Before (main) | After |
|---|---|---|
| `reasoning_effort: high` | *(nothing sent)* | top-level `reasoning_effort: high` |
| `reasoning_effort: max` | *(rejected → nothing)* | top-level `reasoning_effort: max` |
| `reasoning_effort: none` | `think: False` | `think: False` |
| *(unset)* | *(nothing)* | *(nothing — server default)* |

Verified end-to-end through the real profile dispatch with a temp `HERMES_HOME` (16/16 smoke cases incl. dirty/whitespace/uppercase effort strings). Targeted suites green: 254 tests (`test_custom_profile`, `test_hermes_constants`, `test_chat_completions`, `test_provider_profiles`, `test_transport_parity`). ruff clean; ty net-new = 0.

## Review notes (hermes-pr-review Phase 2c)
- **`"max"` effort passthrough is a widened value set on a pre-existing tolerant path, not a new failure mode.** The OpenRouter profile's non-Anthropic route already passed `xhigh` verbatim into `extra_body.reasoning` before this PR; `max` now rides the same path. OpenRouter clamps/ignores unknown effort rather than 400-ing. No live `max` probe on a non-Anthropic OpenRouter route — the safety argument rests on OpenRouter's documented tolerance and the pre-existing `xhigh` precedent. The un-hardcoded legacy `extra_body.reasoning` branch is reached by no *registered* provider (all resolve via profiles; LM Studio is explicitly excluded).
- **Verbatim effort passthrough (vs DeepSeek's `xhigh/max→max` normalization) is a deliberate choice for a generic custom endpoint** — the profile can't know an arbitrary backend's effort vocabulary, and GLM's native levels are `high`/`max`. Documented in the code.
- **Sibling gap (out of scope):** the native `provider=zai` path still drops effort-on-enable (`ZaiProfile` emits only `thinking={enabled|disabled}`). That's the other half of #55276, already tracked by #50696 and PRs #48004/#46446 — not addressed here.

Addresses the custom-provider half of #55276. Closes #57601 (salvaged, authorship preserved).

Co-authored-by: huanshan5195 <huanshan5195@users.noreply.github.com>
