### PR TITLE
fix(cli): fall through to os.environ when get_secret returns None (#58100)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7411,9 +7411,12 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
     try:
         from agent.secret_scope import get_secret as _get_secret
 
-        return _get_secret(key)
+        val = _get_secret(key)
+        if val:
+            return val
     except Exception:
-        return os.environ.get(key)
+        pass
+    return os.environ.get(key)
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

\`get_env_value_prefer_dotenv()\` in \`hermes_cli/config.py\` returns \`None\` directly when \`get_secret(key)\` returns \`None\` (key not in profile secret scope), instead of falling through to \`os.environ.get(key)\`.

This prevents BWS-injected secrets (which live in \`os.environ\` but not in \`.env\` or the secret scope) from being found by credential resolution.

**Current behavior:**
```python
try:
    from agent.secret_scope import get_secret as _get_secret
    return _get_secret(key)  # Returns None — no fallthrough!
except Exception:
    return os.environ.get(key)  # Only reached on exception
```

The \`os.environ\` fallback is inside the \`except\` block — it only fires if \`get_secret\` raises an exception, not if it returns \`None\`.

## Fix

Added a truthiness check: if \`get_secret\` returns a falsy value (\`None\`), fall through to \`os.environ.get(key)\` instead of returning \`None\`.

```python
try:
    from agent.secret_scope import get_secret as _get_secret
    val = _get_secret(key)
    if val:
        return val
except Exception:
    pass
return os.environ.get(key)
```

## Impact

- Fixes credential resolution for ALL providers whose API keys are injected via BWS into \`os.environ\`
- Fixes cron job fallback: when primary provider fails, fallback provider can now find its API key
- Gateway sessions under a profile secret scope that doesn't include BWS secrets are also fixed

Fixes #58100