### PR TITLE
fix(agent): validate JSON type in sanitize_tool_call_arguments (#58057)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -304,7 +304,14 @@ def sanitize_tool_call_arguments(
                 continue
 
             try:
-                json.loads(arguments)
+                parsed = json.loads(arguments)
+                if not isinstance(parsed, dict):
+                    # JSON type mismatch: OpenAI spec requires a JSON object.
+                    # Unwrap single-element arrays; otherwise fall back to {}.
+                    if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
+                        function["arguments"] = json.dumps(parsed[0])
+                    else:
+                        raise json.JSONDecodeError("non-dict JSON type", arguments, 0)
             except json.JSONDecodeError:
                 tool_call_id = tool_call.get("id")
                 function_name = function.get("name", "?")


### PR DESCRIPTION
## Problem

\`sanitize_tool_call_arguments()\` in \`agent/agent_runtime_helpers.py\` only checks whether \`function.arguments\` can be parsed as JSON (\`json.loads\`), but does not validate that the parsed result is a dict (JSON object).

When a model emits arguments as a JSON array (\`[{"mode": "replace"}]\`), it passes validation but is rejected by strict OpenAI-compatible endpoints with a non-retryable HTTP 400 \`InvalidParameter\`.

**Current behavior:**
```python
try:
    json.loads(arguments)       # ← passes for arrays!
except json.JSONDecodeError:
    function["arguments"] = "{}"
```

The malformed tool_call is persisted to \`state.db\` and replayed on every subsequent API call, killing the conversation session permanently.

## Fix

After \`json.loads\` succeeds, add a type check:
- **Single-element array containing a dict**: unwrap to the dict (e.g., \`[{"path": "x"}]\` → \`{"path": "x"}\`)
- **Other non-dict types** (multi-element arrays, strings, numbers): fall back to \`"{}"\` with corruption marker (same as JSONDecodeError path)

```python
try:
    parsed = json.loads(arguments)
    if not isinstance(parsed, dict):
        if isinstance(parsed, list) and len(parsed) == 1 and isinstance(parsed[0], dict):
            function["arguments"] = json.dumps(parsed[0])
        else:
            raise json.JSONDecodeError("non-dict JSON type", arguments, 0)
except json.JSONDecodeError:
    # existing corruption repair logic
```

## Impact

- Fixes HTTP 400 on strict OpenAI-compatible providers (Volcengine Ark, etc.) when models emit array arguments
- Observed with glm-5.2 but affects any model that occasionally wraps arguments in an array
- Prevents permanent session death from persisted malformed tool_calls

Fixes #58057