### PR TITLE
Fix dashboard password auth login routing

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -147,9 +147,10 @@ def _auto_sso_response(request: Request) -> Response | None:
       * the request is an HTML document navigation, not an ``/api/*`` fetch
         (a fetch() would follow the 302 into the cross-origin OAuth dance
         opaquely — same reason ``_unauth_response`` never redirects APIs);
-      * exactly ONE interactive provider is registered — with two or more we
-        can't pick for the user, so the ``/login`` chooser must render; with
-        zero there's nothing to redirect to;
+      * exactly ONE redirect-capable interactive provider is registered — with
+        two or more we can't pick for the user, so the ``/login`` chooser must
+        render; with zero there's nothing to redirect to. Password-only
+        providers are not OAuth/SSO targets and must render ``/login``;
       * the one-shot loop-guard marker is ABSENT. Its presence means we
         already bounced to the portal once and came back still
         unauthenticated (no portal session) — auto-redirecting again would
@@ -177,7 +178,14 @@ def _auto_sso_response(request: Request) -> Response | None:
 
     # list_session_providers() already filters on supports_session=True, so
     # token-only credentials (drain/service providers) are never candidates.
-    providers = list_session_providers()
+    # Password providers can be interactive session providers while still
+    # intentionally leaving start_login() as a NotImplementedError stub; they
+    # must render /login rather than being sent through /auth/login.
+    providers = [
+        p
+        for p in list_session_providers()
+        if not getattr(p, "supports_password", False)
+    ]
     if len(providers) != 1:
         # Zero → nothing to redirect to. Two+ → user must choose at /login.
         return None
@@ -458,4 +466,3 @@ def _attempt_refresh(request: Request, *, refresh_token):
         if new_session is not None:
             return new_session, provider.name
     return None
-

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -192,6 +192,14 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             status_code=404,
             detail=f"Provider does not support interactive login: {provider!r}",
         )
+    if getattr(p, "supports_password", False):
+        login_url = f"{_prefix(request)}/login"
+        safe_next = _validate_post_login_target(next)
+        if safe_next:
+            from urllib.parse import quote
+
+            login_url = f"{login_url}?next={quote(safe_next, safe='')}"
+        return RedirectResponse(url=login_url, status_code=302)
 
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -216,6 +216,55 @@ class TestProviderListFlag:
 
 
 # ---------------------------------------------------------------------------
+# Gate middleware: password providers must render /login, not auto-SSO
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordProviderGateRedirect:
+    def test_password_only_provider_does_not_auto_sso(self, gated_app):
+        resp = gated_app.get("/", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"].startswith("/login")
+        assert "/auth/login" not in resp.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# /auth/login — password providers must not enter OAuth start_login
+# ---------------------------------------------------------------------------
+
+
+class TestAuthLoginPasswordProvider:
+    def test_direct_auth_login_redirects_to_login(self, gated_app):
+        resp = gated_app.get("/auth/login?provider=testpw", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login"
+
+    def test_direct_auth_login_preserves_safe_next(self, gated_app):
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=%2F",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2F"
+
+    def test_direct_auth_login_drops_unsafe_next(self, gated_app):
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=%2F%2Fevil.example%2F",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login"
+
+    def test_direct_auth_login_can_render_login_page(self, gated_app):
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=%2F",
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert 'data-provider="testpw"' in resp.text
+
+
+# ---------------------------------------------------------------------------
 # /auth/password-login — end-to-end through the real middleware
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes a dashboard auth edge case introduced by public-bind auth hardening: password-only dashboard auth providers (`supports_password=True`) were being treated like OAuth/redirect-capable providers in two paths.

Changes:

- Skip password-only providers in dashboard auto-SSO selection so unauthenticated HTML loads render `/login` instead of redirecting to `/auth/login`.
- Make direct/stale `/auth/login?provider=<password-provider>` requests redirect back to `/login`, preserving a safe same-origin `next` target.
- Add focused regression coverage for both the auto-SSO and direct `/auth/login` cases.

## Why

A password-only provider intentionally implements form POST login via `/auth/password-login` and may leave `start_login()` as `NotImplementedError`. When it is the only interactive session provider, the existing auto-SSO path redirects root HTML requests to `/auth/login?provider=basic`, and direct/stale links to that route call `start_login()`, causing HTTP 500.

## Test plan

```bash
python -m pytest -o 'addopts=' \
  tests/hermes_cli/test_dashboard_auth_password_login.py::TestPasswordProviderGateRedirect \
  tests/hermes_cli/test_dashboard_auth_password_login.py::TestAuthLoginPasswordProvider \
  tests/hermes_cli/test_dashboard_auth_401_reauth.py::TestHtmlRedirectNext \
  -q
```

Result locally:

```text
9 passed
```

Also checked:

```bash
git diff --check -- \
  hermes_cli/dashboard_auth/middleware.py \
  hermes_cli/dashboard_auth/routes.py \
  tests/hermes_cli/test_dashboard_auth_password_login.py
```

No whitespace errors.

## Risk

Low. OAuth/redirect-capable providers keep the existing `/auth/login` flow. The new branch only affects providers advertising `supports_password=True`, which should use the login form and `/auth/password-login` route rather than OAuth `start_login()`.
