### PR TITLE
fix(update): skip unsupported Matrix lazy refresh on native Windows

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "yingwaizhiying@gmail.com": "msh01",  # PR #58250 salvage (telegram: wall-clock init timeout via daemon-thread deadline + abandon the shielded initialize task on timeout so the retry ladder advances instead of hanging on attempt 1/8 under s6 supervision; #58236). Also covers PR #58276 salvage (compression: preserve a real user turn after compaction; #55677).
+    "danilo@falcao.org": "danilofalcao",  # PR #56674 salvage (update: skip unsupported platform.matrix lazy refresh on native Windows — python-olm has no Windows wheel)
     "huanshan5195@users.noreply.github.com": "huanshan5195",  # PR #57601 salvage (custom-provider: emit reasoning_effort at the live CustomProfile path so GLM-5.2/ARK/vLLM/Ollama endpoints receive it; + "max" reasoning level)
     "infinitycrew39@gmail.com": "infinitycrew39",  # PR #56431 salvage (honor live vLLM context limits on local endpoints)
     "jonathan.kovacs999@gmail.com": "CocaKova",  # PR #57692 salvage (cron: run jobs under the profile secret scope so get_secret does not fail-close with UnscopedSecretError under profile isolation)

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -332,6 +332,50 @@ class TestRefreshActiveFeatures:
         monkeypatch.setattr(ld, "active_features", lambda: [])
         assert ld.refresh_active_features() == {}
 
+    def test_windows_matrix_refresh_is_skipped_before_pip(self, monkeypatch):
+        # Matrix E2EE pulls python-olm, which has no native Windows wheel/build
+        # path. `hermes update` must not retry that doomed install every run.
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+        monkeypatch.setattr(ld, "active_features", lambda: ["platform.matrix"])
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called for unsupported Matrix on Windows"),
+        )
+
+        result = ld.refresh_active_features()
+
+        assert result["platform.matrix"].startswith("skipped:")
+        assert "unsupported on Windows" in result["platform.matrix"]
+
+    def test_windows_matrix_ensure_fails_before_pip(self, monkeypatch):
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called for unsupported Matrix on Windows"),
+        )
+
+        with pytest.raises(ld.FeatureUnavailable, match="unsupported on Windows"):
+            ld.ensure("platform.matrix", prompt=False)
+
+    def test_windows_matrix_already_satisfied_still_works(self, monkeypatch):
+        # Do not break users who already have a working Matrix dependency set;
+        # only the impossible Windows install/refresh path should be blocked.
+        monkeypatch.setattr(ld.sys, "platform", "win32")
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called when Matrix deps are current"),
+        )
+
+        ld.ensure("platform.matrix", prompt=False)
+
     def test_already_current_is_noop(self, monkeypatch):
         monkeypatch.setattr(ld, "active_features", lambda: ["test.feat"])
         monkeypatch.setitem(ld.LAZY_DEPS, "test.feat", ("zzzfake==1.0.0",))

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -453,6 +453,22 @@ def _allow_lazy_installs() -> bool:
     return True
 
 
+def _unsupported_feature_reason(feature: str) -> Optional[str]:
+    """Return why a lazy feature cannot work on this host, or ``None``.
+
+    This is a platform capability gate, not a security policy gate. It keeps
+    known-impossible installs out of both first-use lazy installation and the
+    ``hermes update`` lazy-refresh pass.
+    """
+    if sys.platform == "win32" and feature == "platform.matrix":
+        return (
+            "unsupported on Windows: Matrix E2EE depends on python-olm, "
+            "which has no Windows wheel and requires make + libolm to build "
+            "from sdist. Run Hermes under WSL to use Matrix on Windows."
+        )
+    return None
+
+
 def _spec_is_safe(spec: str) -> bool:
     """Reject pip specs that contain URLs, paths, or shell metacharacters."""
     if not spec or len(spec) > 200:
@@ -739,6 +755,10 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
     if not missing:
         return
 
+    unsupported = _unsupported_feature_reason(feature)
+    if unsupported:
+        raise FeatureUnavailable(feature, missing, unsupported)
+
     # Validate every spec against the allowlist + safety regex. Belt and
     # braces — the keys-in-LAZY_DEPS check above already constrains this.
     for spec in missing:
@@ -869,13 +889,24 @@ def refresh_active_features(*, prompt: bool = False) -> dict[str, str]:
         if not missing:
             results[feature] = "current"
             continue
+
+        unsupported = _unsupported_feature_reason(feature)
+        if unsupported:
+            results[feature] = f"skipped: {unsupported}"
+            continue
+
         try:
             ensure(feature, prompt=prompt)
             results[feature] = "refreshed"
         except FeatureUnavailable as e:
-            # Distinguish "user opted out" from "install failed" so the
-            # update command can render the right message.
-            if "lazy installs disabled" in str(e) or "declined" in str(e):
+            # Distinguish "user opted out" or platform-incompatible features
+            # from install failures so the update command can render the
+            # right non-error message.
+            if (
+                "lazy installs disabled" in str(e)
+                or "declined" in str(e)
+                or e.reason.startswith("unsupported ")
+            ):
                 results[feature] = f"skipped: {e.reason}"
             else:
                 results[feature] = f"failed: {e.reason}"


### PR DESCRIPTION
## Summary
`hermes update` no longer retries the doomed `platform.matrix` reinstall on native Windows — the lazy refresh now reports `skipped: unsupported on Windows` instead of a noisy pip failure on every update.

Salvage of #56674 by @danilofalcao (authorship preserved via cherry-pick), rebased onto current main.

Root cause: the aiohttp CVE floor bump (6c37b2c78) marks `platform.matrix` stale, and `refresh_active_features()` had no host capability gate — so Windows installs attempted `mautrix[encryption]` → `python-olm`, which has no Windows wheel and needs `make` + libolm to build from sdist. Matrix is already hidden from Windows setup surfaces (`hermes_cli/gateway.py`); this closes the one remaining path that ignored that.

## Changes
- `tools/lazy_deps.py`: new `_unsupported_feature_reason()` capability gate; consulted by `ensure()` and `refresh_active_features()` only after the already-satisfied probe, so working Matrix environments are untouched. Message points users at WSL.
- `tests/tools/test_lazy_deps.py`: 3 regression tests (win32 refresh skips before pip, win32 ensure raises before pip, already-satisfied win32 is a no-op).
- `scripts/release.py`: AUTHOR_MAP entry for @danilofalcao.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_lazy_deps.py` | 64/64 pass |
| E2E (real imports, temp HERMES_HOME): win32 refresh | `skipped: unsupported on Windows…`, pip never called |
| E2E: win32 `ensure()` | raises `FeatureUnavailable`, pip never called |
| E2E: win32 already-satisfied | no-op, reported `current` |
| E2E: linux gate | returns `None` — non-Windows paths unchanged |

Fixes the "platform.matrix failed to refresh" warning reported on Windows 11.

Closes #56674.

## Infographic

![matrix-windows-refresh-skip](https://v3b.fal.media/files/b/0aa0e1d0/JlBtVbCbfAOVfuv6UPiwm_oUmZY5Ks.png)
