### PR TITLE
fix(gateway): resolve terminal.cwd placeholder per backend and mount mode

### DIFF
--- a/gateway/cwd_placeholder.py
+++ b/gateway/cwd_placeholder.py
@@ -1,0 +1,49 @@
+"""Resolve gateway ``terminal.cwd`` placeholder values to ``TERMINAL_CWD``.
+
+When ``terminal.cwd`` is unset or a placeholder (``.``, ``auto``, ``cwd``),
+the gateway must not blindly map host ``Path.home()`` into container backends.
+Docker with workspace mounting still needs an explicit host path signal
+(``MESSAGING_CWD`` or an absolute config path) for ``terminal_tool`` to map
+``/host/project`` → ``/workspace``.
+"""
+
+from __future__ import annotations
+
+CWD_PLACEHOLDERS = frozenset({".", "auto", "cwd"})
+
+
+def _truthy_env(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"true", "1", "yes"}
+
+
+def resolve_placeholder_terminal_cwd(
+    *,
+    configured_cwd: str,
+    terminal_backend: str,
+    messaging_cwd: str | None,
+    docker_mount_cwd_to_workspace: bool,
+    home_fallback: str,
+) -> str | None:
+    """Return the ``TERMINAL_CWD`` value to set, or ``None`` to leave it unset.
+
+    Cases:
+      - **local** + placeholder → ``MESSAGING_CWD`` or ``home_fallback``
+      - **docker** + placeholder + mount on + host ``MESSAGING_CWD`` → host path
+        (for ``terminal_tool`` ``/workspace`` mapping)
+      - **docker** + placeholder + mount off → ``None`` (sandbox default)
+      - other non-local backends + placeholder → ``None``
+    """
+    if configured_cwd and configured_cwd not in CWD_PLACEHOLDERS:
+        return configured_cwd
+
+    backend = (terminal_backend or "local").strip().lower()
+    if backend == "local":
+        messaging = (messaging_cwd or "").strip()
+        return messaging or home_fallback
+
+    if backend == "docker" and docker_mount_cwd_to_workspace:
+        messaging = (messaging_cwd or "").strip()
+        if messaging and messaging not in CWD_PLACEHOLDERS:
+            return messaging
+
+    return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1660,16 +1660,27 @@ os.environ["HERMES_EXEC_ASK"] = "1"
 
 # Set terminal working directory for messaging platforms.
 # config.yaml terminal.cwd is the canonical source (bridged to TERMINAL_CWD
-# by the config bridge above).  When it's unset or a placeholder, default
-# to home directory.  MESSAGING_CWD is accepted as a backward-compat
-# fallback (deprecated — the warning above tells users to migrate).
+# by the config bridge above).  Placeholder values are resolved per-backend —
+# see gateway/cwd_placeholder.py for the three-case contract (local vs docker
+# mount-off vs docker mount-on).  MESSAGING_CWD is a backward-compat fallback.
+from gateway.cwd_placeholder import CWD_PLACEHOLDERS, resolve_placeholder_terminal_cwd
+
 _configured_cwd = os.environ.get("TERMINAL_CWD", "")
-if not _configured_cwd or _configured_cwd in {".", "auto", "cwd"}:
-    if os.environ.get("TERMINAL_ENV", "").strip().lower() == "ssh":
+if not _configured_cwd or _configured_cwd in CWD_PLACEHOLDERS:
+    _resolved_cwd = resolve_placeholder_terminal_cwd(
+        configured_cwd=_configured_cwd,
+        terminal_backend=os.environ.get("TERMINAL_ENV", ""),
+        messaging_cwd=os.getenv("MESSAGING_CWD"),
+        docker_mount_cwd_to_workspace=os.getenv(
+            "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false"
+        ).lower()
+        in {"true", "1", "yes"},
+        home_fallback=str(Path.home()),
+    )
+    if _resolved_cwd is None:
         os.environ.pop("TERMINAL_CWD", None)
     else:
-        _fallback = os.getenv("MESSAGING_CWD") or str(Path.home())
-        os.environ["TERMINAL_CWD"] = _fallback
+        os.environ["TERMINAL_CWD"] = _resolved_cwd
 
 from gateway.config import (
     ChannelOverride,

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -12,6 +12,7 @@ asserting the expected env var outcomes.
 import os
 import json
 
+from gateway.cwd_placeholder import CWD_PLACEHOLDERS, resolve_placeholder_terminal_cwd
 from tools.terminal_tool import _is_ssh_remote_tilde_cwd
 
 
@@ -42,6 +43,7 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
             "container_cpu": "TERMINAL_CONTAINER_CPU",
             "container_memory": "TERMINAL_CONTAINER_MEMORY",
             "container_disk": "TERMINAL_CONTAINER_DISK",
+            "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         }
         for cfg_key, env_var in terminal_env_map.items():
             if cfg_key in terminal_cfg:
@@ -75,14 +77,23 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
                     alias_val = os.path.expanduser(alias_val)
                 env[alias_env] = alias_val.strip()
 
-    # --- Replicate lines 144-147: MESSAGING_CWD fallback ---
+    # --- Replicate gateway/run.py placeholder TERMINAL_CWD resolution ---
     configured_cwd = env.get("TERMINAL_CWD", "")
-    if not configured_cwd or configured_cwd in {".", "auto", "cwd"}:
-        if env.get("TERMINAL_ENV", "").strip().lower() == "ssh":
+    if not configured_cwd or configured_cwd in CWD_PLACEHOLDERS:
+        resolved = resolve_placeholder_terminal_cwd(
+            configured_cwd=configured_cwd,
+            terminal_backend=env.get("TERMINAL_ENV", ""),
+            messaging_cwd=env.get("MESSAGING_CWD"),
+            docker_mount_cwd_to_workspace=env.get(
+                "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false"
+            ).lower()
+            in {"true", "1", "yes"},
+            home_fallback="/root",
+        )
+        if resolved is None:
             env.pop("TERMINAL_CWD", None)
         else:
-            messaging_cwd = env.get("MESSAGING_CWD") or "/root"  # Path.home() for root
-            env["TERMINAL_CWD"] = messaging_cwd
+            env["TERMINAL_CWD"] = resolved
 
     return env
 
@@ -225,7 +236,44 @@ class TestNestedTerminalCwdPlaceholderSkip:
         result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/from/env"})
         assert result["TERMINAL_ENV"] == "docker"
         assert result["TERMINAL_TIMEOUT"] == "300"
-        assert result["TERMINAL_CWD"] == "/from/env"
+        assert result.get("TERMINAL_CWD") is None
+
+    def test_docker_placeholder_does_not_inherit_host_home(self):
+        """terminal.cwd: '.' + docker + mount off must not resolve to host home."""
+        cfg = {
+            "terminal": {
+                "cwd": ".",
+                "backend": "docker",
+                "docker_mount_cwd_to_workspace": False,
+            },
+        }
+        result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/home/user"})
+        assert "TERMINAL_CWD" not in result
+
+    def test_docker_placeholder_mount_on_preserves_messaging_cwd(self):
+        """Mount-enabled docker still needs the host cwd signal for /workspace."""
+        cfg = {
+            "terminal": {
+                "cwd": ".",
+                "backend": "docker",
+                "docker_mount_cwd_to_workspace": True,
+            },
+        }
+        result = _simulate_config_bridge(
+            cfg, {"MESSAGING_CWD": "/host/project"}
+        )
+        assert result["TERMINAL_CWD"] == "/host/project"
+        assert result["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] == "True"
+
+    def test_ssh_placeholder_does_not_inherit_host_home(self):
+        cfg = {"terminal": {"cwd": "auto", "backend": "ssh"}}
+        result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/home/user"})
+        assert "TERMINAL_CWD" not in result
+
+    def test_local_placeholder_still_falls_back_to_messaging_cwd(self):
+        cfg = {"terminal": {"cwd": ".", "backend": "local"}}
+        result = _simulate_config_bridge(cfg, {"MESSAGING_CWD": "/home/user"})
+        assert result["TERMINAL_CWD"] == "/home/user"
 
     def test_terminal_home_mode_bridges_to_env(self):
         cfg = {"terminal": {"home_mode": "profile"}}

--- a/tests/gateway/test_cwd_placeholder.py
+++ b/tests/gateway/test_cwd_placeholder.py
@@ -1,0 +1,68 @@
+"""Unit tests for gateway.cwd_placeholder.resolve_placeholder_terminal_cwd."""
+
+from gateway.cwd_placeholder import resolve_placeholder_terminal_cwd
+
+
+class TestResolvePlaceholderTerminalCwd:
+    def test_local_placeholder_uses_messaging_cwd(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd=".",
+            terminal_backend="local",
+            messaging_cwd="/home/user/project",
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) == "/home/user/project"
+
+    def test_local_placeholder_falls_back_to_home(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd="auto",
+            terminal_backend="local",
+            messaging_cwd=None,
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) == "/home/user"
+
+    def test_docker_placeholder_mount_off_unset(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd=".",
+            terminal_backend="docker",
+            messaging_cwd="/home/user",
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) is None
+
+    def test_docker_placeholder_mount_on_preserves_host_path(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd=".",
+            terminal_backend="docker",
+            messaging_cwd="/host/project",
+            docker_mount_cwd_to_workspace=True,
+            home_fallback="/home/user",
+        ) == "/host/project"
+
+    def test_docker_placeholder_mount_on_without_messaging_cwd_unset(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd=".",
+            terminal_backend="docker",
+            messaging_cwd=None,
+            docker_mount_cwd_to_workspace=True,
+            home_fallback="/home/user",
+        ) is None
+
+    def test_ssh_placeholder_unset(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd="cwd",
+            terminal_backend="ssh",
+            messaging_cwd="/home/user",
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) is None
+
+    def test_explicit_configured_cwd_passthrough(self):
+        assert resolve_placeholder_terminal_cwd(
+            configured_cwd="/explicit/path",
+            terminal_backend="docker",
+            messaging_cwd="/home/user",
+            docker_mount_cwd_to_workspace=False,
+            home_fallback="/home/user",
+        ) == "/explicit/path"


### PR DESCRIPTION
## Summary
Gateway placeholder `terminal.cwd` values (`"."`, `"auto"`, `"cwd"`) no longer resolve to host `Path.home()` for container backends — docker/ssh/modal sandboxes now start in their own default (`/root` / `/workspace`) instead of trying to cd into the host user's home.

Salvage of #56440 by @infinitycrew39 (cherry-picked onto current main, authorship preserved). Root cause reported by Numerlor on Discord.

## Behavior contract (three cases, per review by Gille)
| Backend + config | Result |
|---|---|
| local + placeholder | `MESSAGING_CWD` or host home (unchanged) |
| docker + placeholder + `docker_mount_cwd_to_workspace: true` | host `MESSAGING_CWD` preserved in `TERMINAL_CWD` so terminal_tool maps it to `/workspace` |
| docker (mount off) / ssh / modal / other non-local + placeholder | `TERMINAL_CWD` left unset → sandbox default |

Explicit absolute paths in `terminal.cwd` pass through untouched in all cases.

## Changes
- `gateway/cwd_placeholder.py` (new): `resolve_placeholder_terminal_cwd()` — pure, testable resolution of the contract above
- `gateway/run.py`: startup placeholder block uses the resolver instead of the blind `MESSAGING_CWD or Path.home()` fallback; rebased over the SSH-tilde fix (#57920 salvage) which the general non-local rule now subsumes at this call site
- `tests/gateway/test_cwd_placeholder.py` (new) + `tests/gateway/test_config_cwd_bridge.py`: cover all three paths and the config-bridge simulation

## Validation
- `scripts/run_tests.sh tests/gateway/test_cwd_placeholder.py tests/gateway/test_config_cwd_bridge.py tests/tools/test_terminal_tool.py tests/tools/test_container_cwd_sanitize.py` — all pass
- E2E via real imports: docker+placeholder+mount-off → `cwd=/root`, docker+placeholder+mount-on+real host dir → `cwd=/workspace, host_cwd=<host dir>`, local placeholder → MESSAGING_CWD, ssh placeholder → unset, explicit `/workspace` passthrough
- Live-tested by @Cthulhu on the Docker side (per Discord thread)

Closes #56440.

## Infographic

![gateway-cwd-placeholder-fix](https://v3b.fal.media/files/b/0aa0e1db/tOYADMh-CiYfohMmfG9Zv_EAivk6uo.png)
