### PR TITLE
fix(redact): match full SendGrid 3-part key including secret segment (#58167)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -88,7 +88,7 @@ _PREFIX_PATTERNS = [
     r"sk_live_[A-Za-z0-9]{10,}",        # Stripe secret key (live)
     r"sk_test_[A-Za-z0-9]{10,}",        # Stripe secret key (test)
     r"rk_live_[A-Za-z0-9]{10,}",        # Stripe restricted key
-    r"SG\.[A-Za-z0-9_-]{10,}",          # SendGrid API key
+    r"SG\.[A-Za-z0-9_-]{10,}(?:\.[A-Za-z0-9_-]{10,})?",  # SendGrid API key (2- or 3-part)
     r"hf_[A-Za-z0-9]{10,}",             # HuggingFace token
     r"r8_[A-Za-z0-9]{10,}",             # Replicate API token
     r"npm_[A-Za-z0-9]{10,}",            # npm access token


### PR DESCRIPTION
## Problem

`_PREFIX_PATTERNS` in `agent/redact.py` matches SendGrid keys with:

```python
r"SG\.[A-Za-z0-9_-]{10,}",          # SendGrid API key
```

SendGrid API keys are three-part: `SG.<key-id>.<key-secret>` (e.g. `SG.abc...xyz.def...uvw`, 69 chars total). The character class excludes `.`, so the match stops at the second dot — only `SG.<key-id>` is masked, and **the entire `<key-secret>` segment (where the actual secret entropy lives) stays in cleartext** in logs, transcripts, and everywhere `redact_sensitive_text` is the only protection.

```
>>> redact_sensitive_text("SG." + "a"*22 + "." + "b"*22)
SG.aa...aaaa.bbbbbbbbbbbbbbbbbbbbbb   # secret segment fully visible
```

## Fix

Match the optional secret segment too:

```python
r"SG\.[A-Za-z0-9_-]{10,}(?:\.[A-Za-z0-9_-]{10,})?",  # SendGrid API key (2- or 3-part)
```

The optional group keeps partial/2-part matches working; the trailing `(?![A-Za-z0-9_-])` guard in `_PREFIX_RE` composes fine since `.` is not in that class.

Fixes #58167