### PR TITLE
fix(agent): skip continuation for short complete responses with finish_reason=length (#58087)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1821,6 +1821,29 @@ def run_conversation(
                             "error": _exhaust_error,
                         }
 
+                    # ── Short-complete-response heuristic ─────────────
+                    # Some OpenAI-compatible providers (Ollama, GLM)
+                    # report finish_reason="length" even for responses
+                    # that are naturally short and complete.  If the
+                    # response is short and ends with sentence-ending
+                    # punctuation, treat it as complete — skip
+                    # continuation to avoid spurious duplicate messages.
+                    _content_text = (_trunc_content or "").strip()
+                    if (
+                        not _trunc_has_tool_calls
+                        and len(_content_text) < 200
+                        and _content_text
+                        and _content_text[-1] in ".!?)\n`"
+                    ):
+                        agent._vprint(
+                            f"{agent.log_prefix}ℹ️  finish_reason='length' but "
+                            f"response appears complete (short, ends with "
+                            f"punctuation) — skipping continuation.",
+                            force=True,
+                        )
+                        assistant_message = _trunc_msg
+                        break
+
                     if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
                         assistant_message = _trunc_msg
                         # ── Content-filter stream stall → fallback (#32421) ──


### PR DESCRIPTION
## Problem

Some OpenAI-compatible providers (Ollama, GLM-5.2) report `finish_reason="length"` even for responses that are **naturally short and complete** (e.g. a one-line confirmation like `Kész. ~/summaries/...`). The conversation loop treats `finish_reason="length"` as always-truncated, triggering `_get_continuation_prompt()` which injects a synthetic "continue" message. The model then re-sends the same short response 2-3 times, flooding the chat with duplicate messages.

**Root cause:** No check for whether the response was actually truncated vs. naturally complete. The continuation retry loop (up to 4 attempts) fires unconditionally.

## Fix

Added a **short-complete-response heuristic** after the thinking-exhaustion check but before the continuation retry logic:

- If the response content is short (<200 chars) and ends with sentence-ending punctuation (`.`, `!`, `?`, `)`, `]`, newline, backtick)
- And has no tool calls
- Then treat it as complete and break out of the loop — skip continuation

This prevents spurious duplicate messages while preserving the existing continuation behavior for genuinely truncated long responses.

Fixes #58087