### PR TITLE
fix(agent): recover codex pool after auth refresh

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -346,6 +346,33 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     return None
 
 
+def _timestamp_newer(candidate: Any, reference: Any) -> bool:
+    """True when both timestamps parse and candidate is strictly newer."""
+    candidate_ts = _parse_absolute_timestamp(candidate)
+    reference_ts = _parse_absolute_timestamp(reference)
+    return (
+        candidate_ts is not None
+        and reference_ts is not None
+        and candidate_ts > reference_ts
+    )
+
+
+def _with_cleared_failure_status(
+    entry: "PooledCredential",
+    **field_updates: Any,
+) -> "PooledCredential":
+    return replace(
+        entry,
+        last_status=None,
+        last_status_at=None,
+        last_error_code=None,
+        last_error_reason=None,
+        last_error_message=None,
+        last_error_reset_at=None,
+        **field_updates,
+    )
+
+
 def _normalize_custom_pool_name(name: str) -> str:
     """Normalize a custom provider name for use as a pool key suffix."""
     return name.strip().lower().replace(" ", "-")
@@ -685,10 +712,18 @@ class CredentialPool:
             # another process means our entry's pair is consumed/stale.
             entry_access = entry.access_token or ""
             entry_refresh = entry.refresh_token or ""
-            if store_access and (
+            tokens_differ = bool(store_access) and (
                 store_access != entry_access
                 or (store_refresh and store_refresh != entry_refresh)
-            ):
+            )
+            auth_refresh_after_failure = (
+                entry.last_status == STATUS_EXHAUSTED
+                and _timestamp_newer(
+                    state.get("last_refresh"),
+                    entry.last_status_at or entry.last_refresh,
+                )
+            )
+            if store_access and (tokens_differ or auth_refresh_after_failure):
                 logger.debug(
                     "Pool entry %s: syncing Codex tokens from auth.json "
                     "(refreshed by another process)",
@@ -697,16 +732,10 @@ class CredentialPool:
                 field_updates: Dict[str, Any] = {
                     "access_token": store_access,
                     "refresh_token": store_refresh or entry.refresh_token,
-                    "last_status": None,
-                    "last_status_at": None,
-                    "last_error_code": None,
-                    "last_error_reason": None,
-                    "last_error_message": None,
-                    "last_error_reset_at": None,
                 }
                 if state.get("last_refresh"):
                     field_updates["last_refresh"] = state["last_refresh"]
-                updated = replace(entry, **field_updates)
+                updated = _with_cleared_failure_status(entry, **field_updates)
                 self._replace_entry(entry, updated)
                 self._persist()
                 return updated
@@ -2044,6 +2073,37 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         if isinstance(tokens, dict) and tokens.get("access_token"):
             active_sources.add("device_code")
             custom_label = str(state.get("label") or "").strip()
+            existing_singleton = next(
+                (entry for entry in entries if entry.source == "device_code"),
+                None,
+            )
+            store_access = tokens.get("access_token", "")
+            store_refresh = tokens.get("refresh_token", "")
+            tokens_differ = existing_singleton is not None and bool(store_access) and (
+                store_access != (existing_singleton.access_token or "")
+                or (
+                    store_refresh
+                    and store_refresh != (existing_singleton.refresh_token or "")
+                )
+            )
+            auth_refresh_after_failure = existing_singleton is not None and (
+                existing_singleton.last_status == STATUS_EXHAUSTED
+                and _timestamp_newer(
+                    state.get("last_refresh"),
+                    existing_singleton.last_status_at or existing_singleton.last_refresh,
+                )
+            )
+            clear_seeded_failure = bool(
+                existing_singleton is not None
+                and (
+                    tokens_differ
+                    or auth_refresh_after_failure
+                )
+                and (
+                    existing_singleton.last_status != STATUS_DEAD
+                    or tokens_differ
+                )
+            )
             changed |= _upsert_entry(
                 entries,
                 provider,
@@ -2058,6 +2118,12 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "label": custom_label or label_from_token(tokens.get("access_token", ""), "device_code"),
                 },
             )
+            if clear_seeded_failure:
+                for idx, entry in enumerate(entries):
+                    if entry.source == "device_code":
+                        entries[idx] = _with_cleared_failure_status(entry)
+                        changed = True
+                        break
 
     elif provider == "xai-oauth":
         # When the user logs in via ``hermes model`` -> xAI Grok OAuth,

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -24,6 +24,10 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
 
 
+def _iso_utc(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 def test_fill_first_selection_skips_recently_exhausted_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(
@@ -2630,7 +2634,12 @@ def test_nous_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch
 
 # ── OpenAI Codex OAuth cross-process sync tests ────────────────────────────
 
-def _codex_auth_store(access: str, refresh: str) -> dict:
+def _codex_sync_auth_store(
+    access: str,
+    refresh: str,
+    *,
+    last_refresh: str = "2026-04-28T00:00:00Z",
+) -> dict:
     return {
         "version": 1,
         "active_provider": "openai-codex",
@@ -2642,7 +2651,7 @@ def _codex_auth_store(access: str, refresh: str) -> dict:
                     "refresh_token": refresh,
                     "id_token": "id-" + access,
                 },
-                "last_refresh": "2026-04-28T00:00:00Z",
+                "last_refresh": last_refresh,
             }
         },
     }
@@ -2651,7 +2660,7 @@ def _codex_auth_store(access: str, refresh: str) -> dict:
 def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypatch):
     """When auth.json has newer Codex tokens, the pool entry should adopt them."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(tmp_path, _codex_auth_store("access-OLD", "refresh-OLD"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-OLD", "refresh-OLD"))
 
     from agent.credential_pool import load_pool
 
@@ -2662,7 +2671,7 @@ def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypa
     assert entry.refresh_token == "refresh-OLD"
 
     # Simulate `hermes auth openai-codex` replacing the token pair on disk.
-    _write_auth_store(tmp_path, _codex_auth_store("access-NEW", "refresh-NEW"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-NEW", "refresh-NEW"))
 
     synced = pool._sync_codex_entry_from_auth_store(entry)
     assert synced is not entry
@@ -2676,7 +2685,7 @@ def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypa
 def test_sync_codex_entry_noop_when_tokens_match(tmp_path, monkeypatch):
     """When auth.json has the same tokens, sync should be a no-op."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(tmp_path, _codex_auth_store("access-same", "refresh-same"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-same", "refresh-same"))
 
     from agent.credential_pool import load_pool
 
@@ -2686,6 +2695,142 @@ def test_sync_codex_entry_noop_when_tokens_match(tmp_path, monkeypatch):
 
     synced = pool._sync_codex_entry_from_auth_store(entry)
     assert synced is entry
+
+
+def test_codex_exhausted_entry_recovers_when_auth_refresh_postdates_429(tmp_path, monkeypatch):
+    """A same-token Codex reauth after a 429 should clear stale exhaustion."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+
+    failed_at = time.time() - 600
+    auth_refreshed_at = failed_at + 60
+    _write_auth_store(
+        tmp_path,
+        {
+            **_codex_sync_auth_store(
+                "access-same",
+                "refresh-same",
+                last_refresh=_iso_utc(auth_refreshed_at),
+            ),
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "seeded-codex",
+                        "label": "seeded",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "access-same",
+                        "refresh_token": "refresh-same",
+                        "last_refresh": _iso_utc(failed_at - 60),
+                        "last_status": STATUS_EXHAUSTED,
+                        "last_status_at": failed_at,
+                        "last_error_code": 429,
+                        "last_error_reset_at": failed_at + 7 * 24 * 60 * 60,
+                    }
+                ]
+            },
+        },
+    )
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.id == "seeded-codex"
+    assert entry.last_status is None
+    assert entry.last_error_reset_at is None
+    assert entry.last_refresh == _iso_utc(auth_refreshed_at)
+
+    # The same auth refresh timestamp is consumed; a later 429 should not be
+    # immediately cleared again by stale evidence.
+    pool.mark_exhausted_and_rotate(status_code=429)
+    reloaded = load_pool("openai-codex")
+    assert reloaded.select() is None
+
+
+def test_codex_exhausted_entry_ignores_auth_refresh_before_failure(tmp_path, monkeypatch):
+    """A stale/equal auth refresh timestamp must not clear a newer 429."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+
+    failed_at = time.time() - 600
+    _write_auth_store(
+        tmp_path,
+        {
+            **_codex_sync_auth_store(
+                "access-same",
+                "refresh-same",
+                last_refresh=_iso_utc(failed_at - 60),
+            ),
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "seeded-codex",
+                        "label": "seeded",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "access-same",
+                        "refresh_token": "refresh-same",
+                        "last_refresh": _iso_utc(failed_at - 60),
+                        "last_status": STATUS_EXHAUSTED,
+                        "last_status_at": failed_at,
+                        "last_error_code": 429,
+                        "last_error_reset_at": failed_at + 7 * 24 * 60 * 60,
+                    }
+                ]
+            },
+        },
+    )
+
+    pool = load_pool("openai-codex")
+
+    assert pool.select() is None
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert persisted["credential_pool"]["openai-codex"][0]["last_status"] == STATUS_EXHAUSTED
+
+
+def test_codex_dead_entry_ignores_same_token_auth_refresh(tmp_path, monkeypatch):
+    """A newer same-token refresh must not revive terminal Codex auth failures."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool, STATUS_DEAD
+
+    failed_at = time.time() - 600
+    _write_auth_store(
+        tmp_path,
+        {
+            **_codex_sync_auth_store(
+                "revoked-access",
+                "revoked-refresh",
+                last_refresh=_iso_utc(failed_at + 60),
+            ),
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "seeded-dead",
+                        "label": "seeded-dead",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "revoked-access",
+                        "refresh_token": "revoked-refresh",
+                        "last_refresh": _iso_utc(failed_at - 60),
+                        "last_status": STATUS_DEAD,
+                        "last_status_at": failed_at,
+                        "last_error_code": 401,
+                        "last_error_reason": "token_invalidated",
+                    }
+                ]
+            },
+        },
+    )
+
+    pool = load_pool("openai-codex")
+
+    assert pool.select() is None
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert persisted["credential_pool"]["openai-codex"][0]["last_status"] == STATUS_DEAD
 
 
 def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch):
@@ -2701,7 +2846,7 @@ def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatc
     from agent.credential_pool import load_pool, STATUS_EXHAUSTED
     from dataclasses import replace as dc_replace
 
-    _write_auth_store(tmp_path, _codex_auth_store("access-OLD", "refresh-OLD"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-OLD", "refresh-OLD"))
 
     pool = load_pool("openai-codex")
     entry = pool.select()
@@ -2727,7 +2872,7 @@ def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatc
     assert available_before == []
 
     # Simulate `hermes model` / `hermes auth` refreshing the tokens.
-    _write_auth_store(tmp_path, _codex_auth_store("access-FRESH", "refresh-FRESH"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-FRESH", "refresh-FRESH"))
 
     available = pool._available_entries(clear_expired=True, refresh=False)
     assert len(available) == 1
@@ -2745,7 +2890,7 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     from agent.credential_pool import load_pool, STATUS_EXHAUSTED
     from dataclasses import replace as dc_replace
 
-    _write_auth_store(tmp_path, _codex_auth_store("access-same", "refresh-same"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-same", "refresh-same"))
 
     pool = load_pool("openai-codex")
     entry = pool.select()


### PR DESCRIPTION
## What changed
- Recovered `openai-codex` singleton/device-code pool entries after a successful auth refresh that happened after a 429 exhaustion event.
- Treats `providers.openai-codex.last_refresh` as recovery evidence even when the access/refresh token strings are unchanged.
- Clears stale exhaustion metadata only once for that refresh, so a subsequent 429 is not immediately re-cleared by old evidence.

## Why
A Codex OAuth re-auth/refresh can happen after Hermes marks the singleton pool entry `exhausted`. If the provider reuses the same token strings, the old pool logic left the entry stuck behind the stale 429/reset window even though auth state had been refreshed.

## How to test
Reproduction path:
1. Create a temp `HERMES_HOME/auth.json` with an `openai-codex` `device_code` pool entry marked `exhausted` by 429.
2. Set `providers.openai-codex.last_refresh` later than the 429 failure while keeping token values the same.
3. Load `load_pool("openai-codex")` and select an entry.
4. Verify the pool entry becomes selectable and stale exhaustion/reset metadata is cleared.
5. Mark it exhausted again and verify the same consumed refresh timestamp does not re-clear the new failure.

## Tests run
- `python -m py_compile agent/credential_pool.py tests/agent/test_credential_pool.py` ✅
- `scripts/run_tests.sh tests/agent/test_credential_pool.py` ✅ `88 passed`
- `git diff --check origin/main..HEAD` ✅

## Manual smoke
Temp `HERMES_HOME` direct-path smoke, outside pytest:

```text
SMOKE_PR58186_OK selected=seeded-codex last_status=None last_refresh=2026-07-04T16:36:30.452894Z
```

## Platforms tested
- Linux `ablott-S42E` / Ubuntu 24.04 kernel `6.17.0-35-generic` / x86_64
- Python `3.11.14`
- Rebased onto `origin/main` `7203898ce`

## Security / data notes
- No new dependencies, no network calls, no new user-facing config.
- Tests and smoke use dummy token strings only; no real credentials are persisted or printed.
- Keeps `dead`/terminal auth failures excluded; this recovery applies to same-token Codex refresh evidence after a recoverable 429, not revoked-token states.

## Related issues / prior art
- No directly linked issue in the PR body.
- Prior-art search checked for existing Codex pool auth-refresh/exhaustion fixes before updating this PR.
