### PR TITLE
fix(gateway): add Signal to platform_group_user_env_map for group message auth

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -365,6 +365,7 @@ class GatewayAuthorizationMixin:
         }
         platform_group_user_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_USERS",
+            Platform.SIGNAL: "SIGNAL_GROUP_ALLOWED_USERS",
         }
         platform_group_chat_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",


### PR DESCRIPTION
## What

Adds `Platform.SIGNAL: "SIGNAL_GROUP_ALLOWED_USERS"` to `platform_group_user_env_map` in `gateway/authz_mixin.py`.

## Why

Signal group messages that pass the adapter-level filter (group allowlist + mention check) are rejected by `_is_user_authorized()` because `Platform.SIGNAL` is missing from `platform_group_user_env_map`. When `SIGNAL_ALLOWED_USERS` is set (e.g. to restrict DM access), the auth layer *only* checks the sender against `SIGNAL_ALLOWED_USERS` and skips the adapter-policy path — effectively blocking all group messages from known senders.

## Fix

Adding `Platform.SIGNAL: "SIGNAL_GROUP_ALLOWED_USERS"` makes the authorization layer also check the group-specific sender allowlist for Signal group messages, consistent with Telegram's `TELEGRAM_GROUP_ALLOWED_USERS` handling. Users can then add sender phone numbers to `SIGNAL_GROUP_ALLOWED_USERS` alongside the group IDs already there.

## How to test

1. Set `SIGNAL_GROUP_ALLOWED_USERS=<group_id>,<sender_number>` in `.env`
2. Have a known sender mention the bot in the group
3. The message should now be authorized instead of being silently dropped

## Related

Fixes #58175

## Platforms tested

- Linux (Debian) — code change is a one-line dict entry, no platform-specific behavior