### PR TITLE
fix(desktop): align Windows Hermes home fallback

### DIFF
--- a/apps/desktop/electron/hermes-home.test.ts
+++ b/apps/desktop/electron/hermes-home.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { resolveHermesHome, windowsDefaultHermesHome } from './hermes-home'
+
+function resolverOptions(options: Record<string, unknown> = {}) {
+  const existing = new Set((options.existing as string[] | undefined) || [])
+
+  return {
+    homeDir: 'C:\\Users\\ada',
+    isWindows: true,
+    pathModule: path.win32,
+    readUserEnvVar: () => null,
+    directoryExists: (target: string) => existing.has(target),
+    ...options
+  }
+}
+
+test('Windows default Hermes home uses LOCALAPPDATA when present', () => {
+  assert.equal(
+    windowsDefaultHermesHome({
+      env: { LOCALAPPDATA: 'C:\\Users\\ada\\AppData\\Local' },
+      homeDir: 'C:\\Users\\ada',
+      pathModule: path.win32
+    }),
+    'C:\\Users\\ada\\AppData\\Local\\hermes'
+  )
+})
+
+test('Windows default Hermes home falls back to AppData\\Local when LOCALAPPDATA is absent', () => {
+  assert.equal(
+    windowsDefaultHermesHome({ env: {}, homeDir: 'C:\\Users\\ada', pathModule: path.win32 }),
+    'C:\\Users\\ada\\AppData\\Local\\hermes'
+  )
+})
+
+test('resolveHermesHome honors explicit HERMES_HOME before other sources', () => {
+  assert.equal(
+    resolveHermesHome(
+      resolverOptions({
+        env: { HERMES_HOME: 'D:\\Hermes\\profiles\\work' },
+        userDataOverride: 'E:\\DesktopData',
+        readUserEnvVar: () => 'F:\\RegistryHome'
+      })
+    ),
+    'D:\\Hermes'
+  )
+})
+
+test('resolveHermesHome honors the desktop user-data override before Windows defaults', () => {
+  assert.equal(
+    resolveHermesHome(
+      resolverOptions({
+        env: { LOCALAPPDATA: 'C:\\Users\\ada\\AppData\\Local' },
+        userDataOverride: 'D:\\DesktopData',
+        readUserEnvVar: () => 'E:\\RegistryHome'
+      })
+    ),
+    'D:\\DesktopData\\hermes-home'
+  )
+})
+
+test('resolveHermesHome reads the live Windows user environment before defaults', () => {
+  assert.equal(
+    resolveHermesHome(
+      resolverOptions({
+        env: { LOCALAPPDATA: 'C:\\Users\\ada\\AppData\\Local' },
+        readUserEnvVar: (name: string) => (name === 'HERMES_HOME' ? 'E:\\Hermes' : null)
+      })
+    ),
+    'E:\\Hermes'
+  )
+})
+
+test('resolveHermesHome keeps an existing legacy Windows home when the new home does not exist', () => {
+  assert.equal(
+    resolveHermesHome(
+      resolverOptions({
+        env: { LOCALAPPDATA: 'C:\\Users\\ada\\AppData\\Local' },
+        existing: ['C:\\Users\\ada\\.hermes']
+      })
+    ),
+    'C:\\Users\\ada\\.hermes'
+  )
+})
+
+test('resolveHermesHome prefers an existing LOCALAPPDATA home over the legacy home', () => {
+  assert.equal(
+    resolveHermesHome(
+      resolverOptions({
+        env: { LOCALAPPDATA: 'C:\\Users\\ada\\AppData\\Local' },
+        existing: ['C:\\Users\\ada\\AppData\\Local\\hermes', 'C:\\Users\\ada\\.hermes']
+      })
+    ),
+    'C:\\Users\\ada\\AppData\\Local\\hermes'
+  )
+})
+
+test('resolveHermesHome aligns Windows fallback with Python when LOCALAPPDATA is missing', () => {
+  assert.equal(
+    resolveHermesHome(resolverOptions({ env: {} })),
+    'C:\\Users\\ada\\AppData\\Local\\hermes'
+  )
+})
+
+test('resolveHermesHome uses ~/.hermes on non-Windows platforms', () => {
+  assert.equal(
+    resolveHermesHome({ env: {}, homeDir: '/Users/ada', isWindows: false, pathModule: path.posix }),
+    '/Users/ada/.hermes'
+  )
+})

--- a/apps/desktop/electron/hermes-home.ts
+++ b/apps/desktop/electron/hermes-home.ts
@@ -1,0 +1,67 @@
+import os from 'node:os'
+import path from 'node:path'
+
+import { normalizeHermesHomeRoot } from './backend-env'
+import { readWindowsUserEnvVar } from './windows-user-env'
+
+interface HermesHomeOptions {
+  env?: NodeJS.ProcessEnv
+  userDataOverride?: string
+  isWindows?: boolean
+  homeDir?: string
+  directoryExists?: (target: string) => boolean
+  readUserEnvVar?: (name: string) => string | null
+  pathModule?: typeof path.win32
+  normalizeRoot?: typeof normalizeHermesHomeRoot
+}
+
+function windowsDefaultHermesHome({
+  env = process.env,
+  homeDir = os.homedir(),
+  pathModule = path.win32
+}: Pick<HermesHomeOptions, 'env' | 'homeDir' | 'pathModule'> = {}): string {
+  const localAppData = String(env.LOCALAPPDATA || '').trim()
+  const base = localAppData || pathModule.join(homeDir, 'AppData', 'Local')
+
+  return pathModule.join(base, 'hermes')
+}
+
+function resolveHermesHome({
+  env = process.env,
+  userDataOverride = env.HERMES_DESKTOP_USER_DATA_DIR,
+  isWindows = process.platform === 'win32',
+  homeDir = os.homedir(),
+  directoryExists = () => false,
+  readUserEnvVar = readWindowsUserEnvVar,
+  pathModule = isWindows ? path.win32 : path.posix,
+  normalizeRoot = normalizeHermesHomeRoot
+}: HermesHomeOptions = {}): string {
+  if (env.HERMES_HOME) {
+    return normalizeRoot(env.HERMES_HOME, { pathModule })
+  }
+
+  if (userDataOverride) {
+    return pathModule.join(pathModule.resolve(userDataOverride), 'hermes-home')
+  }
+
+  if (isWindows) {
+    const fromRegistry = readUserEnvVar('HERMES_HOME')
+
+    if (fromRegistry) {
+      return normalizeRoot(fromRegistry, { pathModule })
+    }
+
+    const localAppData = windowsDefaultHermesHome({ env, homeDir, pathModule })
+    const legacy = pathModule.join(homeDir, '.hermes')
+
+    if (!directoryExists(localAppData) && directoryExists(legacy)) {
+      return legacy
+    }
+
+    return localAppData
+  }
+
+  return pathModule.join(homeDir, '.hermes')
+}
+
+export { resolveHermesHome, windowsDefaultHermesHome }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -30,7 +30,7 @@ import nodePty from 'node-pty'
 
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
-import { buildDesktopBackendEnv, normalizeHermesHomeRoot } from './backend-env'
+import { buildDesktopBackendEnv } from './backend-env'
 import { canImportHermesCli, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } from './bootstrap-platform'
@@ -99,6 +99,7 @@ import {
   resolveTimeoutMs,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
+import { resolveHermesHome } from './hermes-home'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
@@ -138,7 +139,6 @@ import {
   getVenvSitePackagesEntries,
   resolveVenvHermesCommand
 } from './windows-hermes-path'
-import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
@@ -301,46 +301,12 @@ if (INSTALL_STAMP) {
 // HERMES_DESKTOP_USER_DATA_DIR (used by test:desktop:fresh) puts the sandbox
 // HERMES_HOME beneath the throwaway userData dir so a fresh-install run never
 // touches the user's real ~/.hermes / %LOCALAPPDATA%\hermes.
-function resolveHermesHome() {
-  if (process.env.HERMES_HOME) {
-    return normalizeHermesHomeRoot(process.env.HERMES_HOME)
-  }
-
-  if (USER_DATA_OVERRIDE) {
-    return path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home')
-  }
-
-  if (IS_WINDOWS) {
-    // A GUI app launched from Explorer inherits the environment block captured
-    // at login, so a HERMES_HOME set via `setx` AFTER login is invisible in
-    // process.env even though the CLI (a fresh shell) sees it. Without this the
-    // backend silently falls back to %LOCALAPPDATA%\hermes and reports "No
-    // inference provider configured" despite a valid configured home (#45471).
-    // Consult the live User-scoped registry value before the default below.
-    const fromRegistry = readWindowsUserEnvVar('HERMES_HOME')
-
-    if (fromRegistry) {
-      return normalizeHermesHomeRoot(fromRegistry)
-    }
-  }
-
-  if (IS_WINDOWS && process.env.LOCALAPPDATA) {
-    const localappdata = path.join(process.env.LOCALAPPDATA, 'hermes')
-    const legacy = path.join(app.getPath('home'), '.hermes')
-
-    // Migrate transparently to LOCALAPPDATA, but honour an existing legacy
-    // ~/.hermes setup (no LOCALAPPDATA install yet) so users don't lose state.
-    if (!directoryExists(localappdata) && directoryExists(legacy)) {
-      return legacy
-    }
-
-    return localappdata
-  }
-
-  return path.join(app.getPath('home'), '.hermes')
-}
-
-const HERMES_HOME = resolveHermesHome()
+const HERMES_HOME = resolveHermesHome({
+  homeDir: app.getPath('home'),
+  isWindows: IS_WINDOWS,
+  userDataOverride: USER_DATA_OVERRIDE,
+  directoryExists
+})
 
 function hermesManagedNodePathEntries() {
   // NOTE: keep this ordering in sync with iter_hermes_node_dirs() in
@@ -6802,12 +6768,11 @@ async function startHermes() {
           ...process.env,
           // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
           // resolves to the SAME location our resolveHermesHome() picked. Without
-          // this pin, Python falls back to ~/.hermes on every platform — fine on
-          // mac/linux (where our default matches), but on Windows our default is
-          // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
-          // Mismatch would split config / sessions / .env / logs across two
-          // directories. install.ps1 sets HERMES_HOME via setx; the desktop
-          // can't reliably do that, so we set it inline for every spawn.
+          // this pin, Python falls back to its platform-native default; if this
+          // process ever resolves a different root, config / sessions / .env /
+          // logs split across two directories. install.ps1 sets HERMES_HOME via
+          // setx; the desktop can't reliably do that, so we set it inline for
+          // every spawn.
           HERMES_HOME,
           ...backend.env,
           TERMINAL_CWD: hermesCwd,


### PR DESCRIPTION
## Summary
- extract desktop HERMES_HOME resolution into a testable helper
- keep explicit HERMES_HOME, live Windows user env, and legacy ~/.hermes precedence intact
- fall back to C:\Users\<user>\AppData\Local\hermes when LOCALAPPDATA is missing, matching Python get_hermes_home()

Fixes #57897.

## Tests
- node --test apps/desktop/electron/hermes-home.test.cjs apps/desktop/electron/backend-env.test.cjs apps/desktop/electron/windows-user-env.test.cjs
- npm --workspace apps/desktop run test:desktop:platforms
- npm --workspace apps/desktop exec eslint electron/main.cjs electron/hermes-home.cjs electron/hermes-home.test.cjs
- git diff --check