### PR TITLE
feat(whatsapp): add bridge extension seam for out-of-tree route plugins

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -388,6 +388,22 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     _DEFAULT_BRIDGE_DIR = None  # resolved in __init__
     splits_long_messages = True  # send() chunks via truncate_message()
 
+    def _bundled_bridge_dir(self) -> Path:
+        """Directory of the bundled bridge.js, independent of the launched entrypoint.
+
+        When ``bridge_script`` points at an out-of-tree wrapper, deps and the
+        bundled-source hash still belong to the in-tree bridge.js, not the
+        wrapper's parent.  Reads an instance override first (set in tests /
+        via ``__init__``) before falling back to the lazily-resolved shared
+        default, so it works even when the adapter was built via ``__new__``.
+        """
+        d = getattr(self, "_default_bridge_dir", None) or WhatsAppAdapter._DEFAULT_BRIDGE_DIR
+        if d is None:
+            from gateway.platforms.whatsapp_common import resolve_whatsapp_bridge_dir
+            WhatsAppAdapter._DEFAULT_BRIDGE_DIR = resolve_whatsapp_bridge_dir()
+            d = WhatsAppAdapter._DEFAULT_BRIDGE_DIR
+        return Path(d)
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)
         # Use shared helper for bridge directory resolution (handles read-only install tree)
@@ -396,6 +412,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             WhatsAppAdapter._DEFAULT_BRIDGE_DIR = resolve_whatsapp_bridge_dir()
         self._bridge_process: Optional[subprocess.Popen] = None
         self._bridge_port: int = config.extra.get("bridge_port", 3000)
+        # Bundled bridge.js dir — used for dep install and the bundled-source
+        # half of the two-hash staleness contract, independent of any
+        # out-of-tree wrapper the entrypoint (`bridge_script`) may point at.
+        self._default_bridge_dir: Path = Path(self._DEFAULT_BRIDGE_DIR)
         self._bridge_script: Optional[str] = config.extra.get(
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
@@ -523,7 +543,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # package.json changed since the last install (e.g. after
             # `hermes update` bumps the Baileys pin).  The stamp file records
             # the package.json hash of the last successful install.
-            bridge_dir = bridge_path.parent
+            #
+            # Resolve the *bundled* bridge dir independently of the launched
+            # entrypoint.  When `bridge_script` points at an out-of-tree
+            # wrapper, the wrapper's parent has no package.json/node_modules;
+            # the deps belong next to the bundled bridge.js, which Node's
+            # module resolution walks up to find from an in-process import.
+            # For a direct launch bundled_bridge_dir == bridge_path.parent, so
+            # this is byte-identical to the previous behavior.
+            bundled_bridge_dir = self._bundled_bridge_dir()
+            bridge_dir = bundled_bridge_dir
             _pkg_json = bridge_dir / "package.json"
             _dep_stamp = bridge_dir / "node_modules" / ".hermes-pkg-hash"
             _pkg_hash = _file_content_hash(_pkg_json)
@@ -585,11 +614,30 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 # `hermes update`, so without this check it
                                 # keeps serving pre-update code forever
                                 # (e.g. no inbound media download).  Old
-                                # bridges that don't report scriptHash are
+                                # bridges that don't report a hash are
                                 # treated as stale by definition.
-                                running_hash = data.get("scriptHash", "")
-                                disk_hash = _file_content_hash(bridge_path)
-                                if running_hash and disk_hash and running_hash == disk_hash:
+                                #
+                                # Two-hash contract: verify BOTH the launched
+                                # entrypoint (entryHash vs the configured
+                                # bridge_script) AND the bundled bridge.js
+                                # (bundledHash vs the on-disk bundled file).
+                                # A wrapper launch reports entryHash=wrapper,
+                                # bundledHash=bridge.js; a direct launch reports
+                                # all three equal.  Older bridges report only
+                                # scriptHash — fall back to it for both so a
+                                # direct-launch upgrade path stays intact.
+                                running_entry = data.get("entryHash") or data.get("scriptHash", "")
+                                running_bundled = data.get("bundledHash") or data.get("scriptHash", "")
+                                entry_disk = _file_content_hash(bridge_path)
+                                bundled_disk = _file_content_hash(
+                                    self._bundled_bridge_dir() / "bridge.js"
+                                )
+                                if (
+                                    running_entry and running_bundled
+                                    and entry_disk and bundled_disk
+                                    and running_entry == entry_disk
+                                    and running_bundled == bundled_disk
+                                ):
                                     print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
@@ -598,7 +646,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                     return True
                                 print(
                                     f"[{self.name}] Running bridge is stale "
-                                    f"(running={running_hash or 'unversioned'}, disk={disk_hash}), restarting"
+                                    f"(entry running={running_entry or 'unversioned'}/disk={entry_disk}, "
+                                    f"bundled running={running_bundled or 'unversioned'}/disk={bundled_disk}), restarting"
                                 )
                             else:
                                 print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -550,6 +550,16 @@ async function startSocket() {
 const app = express();
 app.use(express.json());
 
+// Extension seam: lets an out-of-tree wrapper (platforms.whatsapp.extra.bridge_script)
+// register extra routes against the live Express app and the current Baileys socket
+// without editing this core file. Getters return live values across reconnects.
+globalThis.__hermesWaBridge = {
+  app,
+  getSock: () => sock,
+  enqueueSend,
+  get connectionState() { return connectionState; },
+};
+
 // Host-header validation — defends against DNS rebinding.
 // The bridge binds loopback-only (127.0.0.1) but a victim browser on
 // the same machine could be tricked into fetching from an attacker

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -80,14 +80,40 @@ const AUDIO_CACHE_DIR = process.env.HERMES_AUDIO_CACHE_DIR
 // restart it instead of silently reusing stale code (stale-bridge trap:
 // `hermes update` updates bridge.js on disk but a long-lived bridge process
 // keeps serving the old behavior forever).
-let SCRIPT_HASH = '';
+// Two-hash staleness contract.  BUNDLED_HASH is this bridge.js file's own
+// source, computed from import.meta.url — it catches a stale bridge.js after
+// `hermes update` even when a launching wrapper is unchanged.  ENTRY_HASH is
+// the actually-launched script (process.argv[1]): for a direct launch it is
+// bridge.js (so ENTRY_HASH === BUNDLED_HASH), for an out-of-tree wrapper
+// launch it is the wrapper.  The adapter verifies BOTH against disk so neither
+// a stale wrapper nor a stale bundled bridge can be silently reused.
+// SCRIPT_HASH is kept as an alias of BUNDLED_HASH for back-compat with older
+// adapters that only read `scriptHash`.
+function _hashFile(p) {
+  try {
+    return createHash('sha256').update(readFileSync(p)).digest('hex').slice(0, 16);
+  } catch {
+    return '';
+  }
+}
+const BUNDLED_HASH = _hashFile(fileURLToPath(import.meta.url));
+// process.argv[1] is the launched entrypoint; fall back to the bundled file
+// when it is missing/unreadable so a direct launch keeps identical semantics.
+let ENTRY_HASH = '';
 try {
-  SCRIPT_HASH = createHash('sha256')
-    .update(readFileSync(fileURLToPath(import.meta.url)))
-    .digest('hex')
-    .slice(0, 16);
+  ENTRY_HASH = process.argv[1] ? _hashFile(process.argv[1]) : '';
 } catch {}
+if (!ENTRY_HASH) ENTRY_HASH = BUNDLED_HASH;
+const SCRIPT_HASH = BUNDLED_HASH; // back-compat alias
 const PAIR_ONLY = args.includes('--pair-only');
+// Diagnostic: print the staleness-contract hashes as JSON and exit before any
+// WhatsApp connection.  Lets the wrapper integration test verify entry vs
+// bundled hashing without a live socket.  Exits non-zero if either is empty.
+if (args.includes('--print-hashes')) {
+  const ok = Boolean(ENTRY_HASH && BUNDLED_HASH);
+  process.stdout.write(JSON.stringify({ entryHash: ENTRY_HASH, bundledHash: BUNDLED_HASH }) + '\n');
+  process.exit(ok ? 0 : 1);
+}
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
@@ -806,7 +832,9 @@ app.get('/health', (req, res) => {
     status: connectionState,
     queueLength: messageQueue.length,
     uptime: process.uptime(),
-    scriptHash: SCRIPT_HASH,
+    scriptHash: SCRIPT_HASH,   // back-compat alias of bundledHash
+    entryHash: ENTRY_HASH,     // hash of the launched script (wrapper or bridge.js)
+    bundledHash: BUNDLED_HASH, // hash of this bridge.js source
   });
 });
 

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -39,8 +39,14 @@ class _AsyncCM:
 
 
 def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
-                  session_path: Path = Path("/tmp/test-wa-session")):
-    """Create a WhatsAppAdapter with test attributes (bypass __init__)."""
+                  session_path: Path = Path("/tmp/test-wa-session"),
+                  default_bridge_dir=None):
+    """Create a WhatsAppAdapter with test attributes (bypass __init__).
+
+    ``default_bridge_dir`` sets the bundled-bridge dir used by the two-hash
+    contract and dep install.  Defaults to the bridge_script's parent so a
+    direct-launch test (entrypoint == bundled bridge.js) behaves as before.
+    """
     from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
 
     adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
@@ -48,6 +54,10 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     adapter.config = MagicMock()
     adapter._bridge_port = 19876
     adapter._bridge_script = bridge_script
+    adapter._default_bridge_dir = (
+        default_bridge_dir if default_bridge_dir is not None
+        else Path(bridge_script).parent
+    )
     adapter._session_path = session_path
     adapter._bridge_log_fh = None
     adapter._bridge_log = None
@@ -223,6 +233,143 @@ class TestStaleBridgeHandshake:
         mock_popen.assert_called_once()
 
 
+class TestTwoHashContract:
+    """Wrapper-aware staleness contract: verify BOTH the launched entrypoint
+    (entryHash vs configured bridge_script) AND the bundled bridge.js
+    (bundledHash vs the on-disk bundled file).  Regression cover for the
+    wrapper-launch flow, where entrypoint != bundled bridge.js.
+    """
+
+    def _setup_wrapper(self, tmp_path: Path):
+        """Bundled bridge dir + a separate wrapper dir. Returns (bundled_dir, wrapper_path)."""
+        bundled_dir = _setup_bridge_dir(tmp_path)  # .../whatsapp-bridge/bridge.js
+        _fresh_node_modules(bundled_dir)
+        wrapper_dir = tmp_path / "custom"
+        wrapper_dir.mkdir()
+        wrapper = wrapper_dir / "wrapper.mjs"
+        wrapper.write_text("// out-of-tree wrapper importing bridge.js\n")
+        return bundled_dir, wrapper
+
+    @pytest.mark.asyncio
+    async def test_reuses_when_wrapper_and_bundled_match(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bundled_dir, wrapper = self._setup_wrapper(tmp_path)
+        adapter = _make_adapter(
+            bridge_script=str(wrapper),
+            session_path=tmp_path / "session",
+            default_bridge_dir=bundled_dir,
+        )
+        mock_client = _mock_health({
+            "status": "connected",
+            "entryHash": _file_content_hash(wrapper),
+            "bundledHash": _file_content_hash(bundled_dir / "bridge.js"),
+        })
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task") as mock_task, \
+             patch("subprocess.Popen") as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True), \
+             patch.object(adapter, "_mark_connected", create=True):
+            result = await adapter.connect()
+
+        assert result is True
+        mock_popen.assert_not_called()  # both hashes matched → reused
+        mock_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restarts_when_bundled_stale(self, tmp_path):
+        """`hermes update` bumps bridge.js; wrapper unchanged → bundledHash mismatch.
+
+        This is the exact trap an entrypoint-only hash would miss: the wrapper
+        looks fresh, but it imports a stale bundled bridge.js.
+        """
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bundled_dir, wrapper = self._setup_wrapper(tmp_path)
+        adapter = _make_adapter(
+            bridge_script=str(wrapper),
+            session_path=tmp_path / "session",
+            default_bridge_dir=bundled_dir,
+        )
+        mock_client = _mock_health({
+            "status": "connected",
+            "entryHash": _file_content_hash(wrapper),          # wrapper matches
+            "bundledHash": "staleaaaaaaaaaa0",                  # bridge.js does NOT
+        })
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()  # stale bundled bridge → restart
+
+    @pytest.mark.asyncio
+    async def test_restarts_when_wrapper_stale(self, tmp_path):
+        """Wrapper edited, bundled bridge.js unchanged → entryHash mismatch."""
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bundled_dir, wrapper = self._setup_wrapper(tmp_path)
+        adapter = _make_adapter(
+            bridge_script=str(wrapper),
+            session_path=tmp_path / "session",
+            default_bridge_dir=bundled_dir,
+        )
+        mock_client = _mock_health({
+            "status": "connected",
+            "entryHash": "staleaaaaaaaaaa0",                    # wrapper does NOT match
+            "bundledHash": _file_content_hash(bundled_dir / "bridge.js"),  # bridge.js matches
+        })
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()  # stale wrapper → restart
+
+    @pytest.mark.asyncio
+    async def test_direct_launch_scripthash_fallback_reuses(self, tmp_path):
+        """Old bridge reports only `scriptHash` (pre-contract), direct launch,
+        unchanged → both entry/bundled fall back to scriptHash and match → reuse.
+        """
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+            default_bridge_dir=bridge_dir,
+        )
+        disk = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health({"status": "connected", "scriptHash": disk})
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task") as mock_task, \
+             patch("subprocess.Popen") as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True), \
+             patch.object(adapter, "_mark_connected", create=True):
+            result = await adapter.connect()
+
+        assert result is True
+        mock_popen.assert_not_called()  # scriptHash fallback → reused
+        mock_task.assert_called_once()
+
+
 class TestDepRefreshStamp:
     @pytest.mark.asyncio
     async def test_skips_install_when_stamp_fresh(self, tmp_path):
@@ -339,3 +486,102 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_IMAGE_CACHE_DIR"] == str(get_image_cache_dir())
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
+
+
+class TestBundledDepInstallDir:
+    """When bridge_script points at an out-of-tree wrapper, npm install must
+    run in the bundled bridge.js dir (where package.json lives), not the
+    wrapper's parent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_deps_install_in_bundled_dir(self, tmp_path):
+        bundled_dir = _setup_bridge_dir(tmp_path)  # has package.json, no node_modules
+        wrapper_dir = tmp_path / "custom"
+        wrapper_dir.mkdir()
+        wrapper = wrapper_dir / "wrapper.mjs"
+        wrapper.write_text("// wrapper\n")
+        adapter = _make_adapter(
+            bridge_script=str(wrapper),
+            session_path=tmp_path / "session",
+            default_bridge_dir=bundled_dir,
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        def _npm_install(*args, **kwargs):
+            (bundled_dir / "node_modules").mkdir(exist_ok=True)
+            return MagicMock(returncode=0)
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.run", side_effect=_npm_install) as mock_run, \
+             patch("subprocess.Popen", return_value=mock_proc), \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_run.assert_called_once()
+        # cwd must be the bundled bridge dir, NOT the wrapper's parent
+        assert mock_run.call_args.kwargs["cwd"] == str(bundled_dir)
+
+
+class TestBridgePrintHashes:
+    """Node-level integration test for the two-hash contract via --print-hashes.
+
+    Spawns the real bridge.js and a wrapper .mjs, no WhatsApp connection.
+    Skips cleanly when node isn't available.
+    """
+
+    @pytest.mark.asyncio
+    async def test_print_hashes_direct_vs_wrapper(self, tmp_path):
+        import hashlib
+        import json
+        import shutil
+        import subprocess as _sp
+
+        node = shutil.which("node")
+        if not node:
+            pytest.skip("node not available")
+
+        repo_root = Path(__file__).resolve().parents[2]
+        bridge_js = repo_root / "scripts" / "whatsapp-bridge" / "bridge.js"
+        if not bridge_js.exists():
+            pytest.skip("bridge.js not found")
+        # bridge.js imports Baileys at module load; skip when deps aren't installed
+        if not (bridge_js.parent / "node_modules" / "@whiskeysockets").exists():
+            pytest.skip("whatsapp bridge node_modules not installed")
+
+        def _hash16(p: Path) -> str:
+            return hashlib.sha256(p.read_bytes()).hexdigest()[:16]
+
+        # Direct launch: entryHash == bundledHash == hash(bridge.js)
+        out = _sp.run(
+            [node, str(bridge_js), "--print-hashes"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert out.returncode == 0, out.stderr
+        direct = json.loads(out.stdout.strip())
+        bridge_hash = _hash16(bridge_js)
+        assert direct["entryHash"] == bridge_hash
+        assert direct["bundledHash"] == bridge_hash
+        assert direct["entryHash"] == direct["bundledHash"]
+
+        # Wrapper launch: wrapper imports bridge.js; entryHash == hash(wrapper),
+        # bundledHash == hash(bridge.js).
+        wrapper = tmp_path / "wrapper.mjs"
+        wrapper.write_text(
+            f"import {json.dumps(bridge_js.as_posix())};\n"
+        )
+        out2 = _sp.run(
+            [node, str(wrapper), "--print-hashes"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert out2.returncode == 0, out2.stderr
+        wrapped = json.loads(out2.stdout.strip())
+        assert wrapped["entryHash"] == _hash16(wrapper)
+        assert wrapped["bundledHash"] == bridge_hash
+        assert wrapped["entryHash"] != wrapped["bundledHash"]


### PR DESCRIPTION
## What

Adds a small extension seam to the WhatsApp bridge so out-of-tree code can register extra Express routes against the live Baileys socket **without editing `bridge.js`**, plus a wrapper-aware staleness contract so a wrapper-launched bridge is correctly reused/restarted and gets the bundled deps.

```js
globalThis.__hermesWaBridge = {
  app,                                       // the Express app
  getSock: () => sock,                       // getter → live socket across reconnects
  enqueueSend,                               // existing send-serialization queue
  get connectionState() { return connectionState; },
};
```

## Why

The bridge owns the single Baileys socket and Express app as module-scoped locals with no export. Today, the only way to add capabilities that need the socket (group admin: list participants, add/remove members, read join-request waitlist) is to edit `bridge.js` directly — which conflicts or gets clobbered on every `hermes update`.

This seam lets operators point `platforms.whatsapp.extra.bridge_script` at a wrapper `.mjs` that runs the real bridge in-process and attaches its own routes, keeping all customization outside the git tree. `bridge_script` is already an honored config key (`adapter.py`).

## Staleness + deps for the wrapper flow

Review (thanks @teknium1) surfaced that the wrapper flow could not satisfy the existing single-hash handshake, and would miss the bundled deps. Both are fixed here:

**Two-hash staleness contract.** Previously `bridge.js` self-hashed `import.meta.url` while the adapter compared that against `_file_content_hash(bridge_script)` — a wrapper and `bridge.js` are distinct files, so a wrapper-launched bridge was always restarted as stale. Now `/health` reports:
- `entryHash` — hash of `process.argv[1]` (the launched script: wrapper on a wrapper launch, `bridge.js` on a direct launch)
- `bundledHash` — hash of `bridge.js`'s own source
- `scriptHash` — kept as a back-compat alias of `bundledHash`

The adapter verifies **both**: `entryHash` vs the configured `bridge_script`, `bundledHash` vs the on-disk bundled `bridge.js`. A single entrypoint hash would miss `hermes update` bumping `bridge.js` under an unchanged wrapper — the two-hash check catches it (`bundledHash` mismatch → restart). Direct launch collapses all three to one hash → no behavior change. Bridges reporting only `scriptHash` fall back for both.

**Bundled deps.** Dep install / `node_modules` / `package.json` now resolve to `_bundled_bridge_dir()`, independent of the entrypoint, so a wrapper outside `scripts/whatsapp-bridge/` still gets the bundled Baileys deps that its in-process import of `bridge.js` needs. For a direct launch this dir equals `bridge_path.parent`, so behavior is unchanged.

Design notes:
- `getSock()` is a **getter**, not a snapshot — `sock` is reassigned on every reconnect in `startSocket()`, so a captured value would go stale.
- `connectionState` is exposed via a live getter for the same reason.
- `enqueueSend` is exposed so wrapper-added mutating calls (e.g. `groupParticipantsUpdate`) serialize on the same queue as `/send`.

## Impact

- **No behavior change** for the default direct-launch path (all three hashes equal, dep dir unchanged) — additive for the wrapper flow.
- `node --check scripts/whatsapp-bridge/bridge.js` passes.

## Testing

- `node --check scripts/whatsapp-bridge/bridge.js` passes.
- `pytest tests/gateway/test_whatsapp_stale_bridge.py` — 17 passed. New cases: wrapper+bundled match → reuse; bundled stale → restart; entry stale → restart; `scriptHash` fallback → reuse; dep-install resolves to bundled dir.
- Node-level integration test via a new `--print-hashes` flag (exits before any WA connection): asserts direct-launch `entryHash == bundledHash` and wrapper-launch `entryHash != bundledHash`.
