### PR TITLE
fix(bedrock): dedup profile-covered bare model IDs in /model picker (#58185)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -394,14 +394,46 @@ def bedrock_model_ids_or_none() -> Optional[List[str]]:
     This helper consolidates the discover → extract-ids → fallback
     pattern that was previously duplicated across ``provider_model_ids``,
     ``list_authenticated_providers`` section 2, and section 3.
+
+    Bare foundation-model IDs that are covered by a discovered inference
+    profile are dropped: on on-demand Bedrock accounts the bare ID is not
+    invokable (HTTP 400, "Retry ... with the ID or ARN of an inference
+    profile"), so offering it in the ``/model`` picker persists an
+    un-invokable model to config. This mirrors the profile-preferring
+    dedup the setup wizard already applies in ``model_setup_flows.py``.
     """
     try:
         discovered = discover_bedrock_models(resolve_bedrock_region())
         if discovered:
-            return [m["id"] for m in discovered]
+            return _dedup_profile_covered_ids([m["id"] for m in discovered])
     except Exception:
         pass
     return None
+
+
+# Regional inference-profile prefixes. A profile ID like
+# ``us.anthropic.claude-fable-5`` covers the bare foundation model
+# ``anthropic.claude-fable-5`` (its base ID with the prefix stripped).
+_PROFILE_PREFIXES = ("us.", "global.", "eu.", "ap.", "jp.")
+
+
+def _dedup_profile_covered_ids(ids: List[str]) -> List[str]:
+    """Drop bare foundation-model IDs that a discovered profile already covers.
+
+    Given a mix of inference-profile IDs (``us.anthropic.claude-fable-5``)
+    and bare foundation-model IDs (``anthropic.claude-fable-5``), keep every
+    profile ID and every bare ID that has no profile sibling, but drop bare
+    IDs whose profile counterpart is present. Order is preserved.
+    """
+    profile_bases = {
+        mid.split(".", 1)[1]
+        for mid in ids
+        if mid.startswith(_PROFILE_PREFIXES)
+    }
+    return [
+        mid for mid in ids
+        if mid.startswith(_PROFILE_PREFIXES) or mid not in profile_bases
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -299,12 +299,47 @@ def resolve_bedrock_runtime_region(config: Optional[Dict[str, Any]] = None) -> s
 
 
 def bedrock_model_ids_or_none() -> Optional[List[str]]:
-    """Live-discover Bedrock model IDs; None on failure/empty so callers use the static list."""
+    """Live-discover Bedrock model IDs; None on failure/empty so callers use the static list.
+
+    Bare foundation-model IDs that are covered by a discovered inference
+    profile are dropped: on on-demand Bedrock accounts the bare ID is not
+    invokable (HTTP 400, "Retry ... with the ID or ARN of an inference
+    profile"), so offering it in the ``/model`` picker persists an
+    un-invokable model to config. This mirrors the profile-preferring
+    dedup the setup wizard already applies in ``model_setup_flows.py``.
+    """
     with suppress(Exception):
         discovered = discover_bedrock_models(resolve_bedrock_runtime_region())
         if discovered:
-            return merge_bedrock_openai_model_ids([m["id"] for m in discovered])
+            return merge_bedrock_openai_model_ids(
+                _dedup_profile_covered_ids([m["id"] for m in discovered])
+            )
     return None
+
+
+# Regional inference-profile prefixes. A profile ID like
+# ``us.anthropic.claude-fable-5`` covers the bare foundation model
+# ``anthropic.claude-fable-5`` (its base ID with the prefix stripped).
+_PROFILE_PREFIXES = ("us.", "global.", "eu.", "ap.", "jp.")
+
+
+def _dedup_profile_covered_ids(ids: List[str]) -> List[str]:
+    """Drop bare foundation-model IDs that a discovered profile already covers.
+
+    Given a mix of inference-profile IDs (``us.anthropic.claude-fable-5``)
+    and bare foundation-model IDs (``anthropic.claude-fable-5``), keep every
+    profile ID and every bare ID that has no profile sibling, but drop bare
+    IDs whose profile counterpart is present. Order is preserved.
+    """
+    profile_bases = {
+        mid.split(".", 1)[1]
+        for mid in ids
+        if mid.startswith(_PROFILE_PREFIXES)
+    }
+    return [
+        mid for mid in ids
+        if mid.startswith(_PROFILE_PREFIXES) or mid not in profile_bases
+    ]
 
 
 # --- Tool-calling / prompt-cache capability detection ---

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -2015,3 +2015,70 @@ class TestBearerTokenRoutesToConverse:
         runtime = self._resolve(monkeypatch, bearer=False)
         assert runtime["api_mode"] == "anthropic_messages"
         assert runtime.get("bedrock_anthropic") is True
+
+
+# ---------------------------------------------------------------------------
+# Inference-profile dedup for the /model picker (#58185)
+# ---------------------------------------------------------------------------
+
+class TestDedupProfileCoveredIds:
+    """Bare foundation-model IDs covered by a profile must be dropped."""
+
+    def test_drops_bare_id_when_profile_present(self):
+        from agent.bedrock_adapter import _dedup_profile_covered_ids
+
+        ids = [
+            "global.anthropic.claude-fable-5",
+            "anthropic.claude-fable-5",
+        ]
+        result = _dedup_profile_covered_ids(ids)
+        assert "global.anthropic.claude-fable-5" in result
+        assert "anthropic.claude-fable-5" not in result
+
+    def test_keeps_uncovered_bare_ids(self):
+        from agent.bedrock_adapter import _dedup_profile_covered_ids
+
+        # No profile sibling for the titan model → keep it.
+        ids = [
+            "us.anthropic.claude-sonnet-4-6",
+            "anthropic.claude-sonnet-4-6",
+            "amazon.titan-text-express-v1",
+        ]
+        result = _dedup_profile_covered_ids(ids)
+        assert result == [
+            "us.anthropic.claude-sonnet-4-6",
+            "amazon.titan-text-express-v1",
+        ]
+
+    def test_dedups_across_all_regional_prefixes(self):
+        from agent.bedrock_adapter import _dedup_profile_covered_ids
+
+        ids = [
+            "eu.anthropic.claude-opus-4-6",
+            "anthropic.claude-opus-4-6",
+            "ap.amazon.nova-pro",
+            "amazon.nova-pro",
+        ]
+        result = _dedup_profile_covered_ids(ids)
+        assert result == ["eu.anthropic.claude-opus-4-6", "ap.amazon.nova-pro"]
+
+    def test_preserves_order_and_noop_without_profiles(self):
+        from agent.bedrock_adapter import _dedup_profile_covered_ids
+
+        ids = ["amazon.titan-text-express-v1", "cohere.command-r-v1:0"]
+        assert _dedup_profile_covered_ids(ids) == ids
+
+    def test_helper_applied_by_bedrock_model_ids_or_none(self):
+        from agent import bedrock_adapter
+
+        discovered = [
+            {"id": "global.anthropic.claude-fable-5", "provider": "inference-profile"},
+            {"id": "anthropic.claude-fable-5", "provider": "Anthropic"},
+        ]
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models", return_value=discovered
+        ), patch.object(
+            bedrock_adapter, "resolve_bedrock_region", return_value="us-east-1"
+        ):
+            result = bedrock_adapter.bedrock_model_ids_or_none()
+        assert result == ["global.anthropic.claude-fable-5"]

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1421,3 +1421,77 @@ class TestBearerTokenRoutesToConverse:
         runtime = self._resolve(monkeypatch, bearer=False)
         assert runtime["api_mode"] == "anthropic_messages"
         assert runtime.get("bedrock_anthropic") is True
+
+
+# ---------------------------------------------------------------------------
+# Inference-profile dedup for the /model picker (#58185)
+# ---------------------------------------------------------------------------
+
+class TestDedupProfileCoveredIds:
+    """Bare foundation-model IDs covered by a profile must be dropped."""
+
+    def test_drops_bare_id_when_profile_present(self):
+        from agent.bedrock_adapter import _dedup_profile_covered_ids
+
+        ids = [
+            "global.anthropic.claude-fable-5",
+            "anthropic.claude-fable-5",
+        ]
+        result = _dedup_profile_covered_ids(ids)
+        assert "global.anthropic.claude-fable-5" in result
+        assert "anthropic.claude-fable-5" not in result
+
+    def test_keeps_uncovered_bare_ids(self):
+        from agent.bedrock_adapter import _dedup_profile_covered_ids
+
+        # No profile sibling for the titan model → keep it.
+        ids = [
+            "us.anthropic.claude-sonnet-4-6",
+            "anthropic.claude-sonnet-4-6",
+            "amazon.titan-text-express-v1",
+        ]
+        result = _dedup_profile_covered_ids(ids)
+        assert result == [
+            "us.anthropic.claude-sonnet-4-6",
+            "amazon.titan-text-express-v1",
+        ]
+
+    def test_dedups_across_all_regional_prefixes(self):
+        from agent.bedrock_adapter import _dedup_profile_covered_ids
+
+        ids = [
+            "eu.anthropic.claude-opus-4-6",
+            "anthropic.claude-opus-4-6",
+            "ap.amazon.nova-pro",
+            "amazon.nova-pro",
+        ]
+        result = _dedup_profile_covered_ids(ids)
+        assert result == ["eu.anthropic.claude-opus-4-6", "ap.amazon.nova-pro"]
+
+    def test_preserves_order_and_noop_without_profiles(self):
+        from agent.bedrock_adapter import _dedup_profile_covered_ids
+
+        ids = ["amazon.titan-text-express-v1", "cohere.command-r-v1:0"]
+        assert _dedup_profile_covered_ids(ids) == ids
+
+    def test_helper_applied_by_bedrock_model_ids_or_none(self):
+        from agent import bedrock_adapter
+        from agent.bedrock_adapter import BEDROCK_OPENAI_RESPONSES_MODEL_IDS
+
+        discovered = [
+            {"id": "global.anthropic.claude-fable-5", "provider": "inference-profile"},
+            {"id": "anthropic.claude-fable-5", "provider": "Anthropic"},
+        ]
+        with patch.object(
+            bedrock_adapter, "discover_bedrock_models", return_value=discovered
+        ), patch.object(
+            bedrock_adapter, "resolve_bedrock_runtime_region", return_value="us-east-1"
+        ):
+            result = bedrock_adapter.bedrock_model_ids_or_none()
+        # The bare ``anthropic.claude-fable-5`` is dropped as profile-covered,
+        # then ``merge_bedrock_openai_model_ids`` appends the Mantle-only
+        # OpenAI Responses models the control-plane discovery doesn't enumerate.
+        assert result == [
+            "global.anthropic.claude-fable-5",
+            *BEDROCK_OPENAI_RESPONSES_MODEL_IDS,
+        ]


### PR DESCRIPTION
## What does this PR do?

On on-demand Bedrock accounts, the in-session `/model` picker offers **bare foundation-model IDs alongside their inference-profile counterparts**. The bare IDs are not invokable — selecting one persists it to `config.yaml` (`model.default`), and every subsequent call in every future session fails with:

```
HTTP 400: Invocation of model ID anthropic.claude-fable-5 with on-demand throughput
isn't supported. Retry your request with the ID or ARN of an inference profile that
contains this model.
```

The setup wizard (`hermes_cli/model_setup_flows.py`) already deduplicates discovery output, preferring `us.*`/`global.*` inference profiles and hiding covered bare IDs. But the `/model` picker path — `cached_provider_model_ids("bedrock")` → `bedrock_model_ids_or_none()` (`agent/bedrock_adapter.py`) — returned the raw discovery list with no such dedup, so the picker showed both forms of the same model.

`bedrock_model_ids_or_none()` is the shared source for `provider_model_ids`, the CLI/gateway pickers, and validation suggestions, so applying the dedup there fixes all of them in one place (Footprint Ladder — extends the existing chokepoint, no new surface). The dedup keeps every inference profile and every bare ID with no profile sibling, and drops bare IDs a discovered profile already covers.

## Related Issue

Fixes #58185

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py`: add `_dedup_profile_covered_ids()` and apply it inside `bedrock_model_ids_or_none()` before returning the discovery list. Regional profile prefixes covered: `us.`, `global.`, `eu.`, `ap.`, `jp.` (matches `is_anthropic_bedrock_model`).
- `tests/agent/test_bedrock_adapter.py`: add `TestDedupProfileCoveredIds` — drops covered bare IDs, keeps uncovered bare models (e.g. `amazon.titan-*`), dedups across all regional prefixes, no-ops without profiles, and verifies `bedrock_model_ids_or_none()` applies it.

## How to Test

```
scripts/run_tests.sh tests/agent/test_bedrock_adapter.py -q
```

Result: `137 passed`. Ruff and `check-windows-footguns.py` pass on the changed files.

End-to-end: with `bedrock.discovery.enabled: true` on an on-demand account, `/model` → Bedrock now lists only `global.anthropic.claude-fable-5` (not the bare `anthropic.claude-fable-5`), so selecting a Claude model persists an invokable profile ID.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring on `bedrock_model_ids_or_none()` updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure string logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before: picker shows both `global.anthropic.claude-fable-5` (works) and `anthropic.claude-fable-5` (400s on invoke).
After: picker shows only `global.anthropic.claude-fable-5`; uncovered bare models like `amazon.titan-*` still listed.

## Acknowledgements

Diagnosis and the profile-preferring dedup approach are from @lianghong's issue report (#58185) — this PR implements that suggestion inside the shared `bedrock_model_ids_or_none()` chokepoint (widening the prefix set to `eu.`/`ap.`/`jp.` to match `is_anthropic_bedrock_model`) and adds regression tests.
