### PR TITLE
fix: Bedrock model picker deduplicates inference profile IDs (#58185)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -398,7 +398,15 @@ def bedrock_model_ids_or_none() -> Optional[List[str]]:
     try:
         discovered = discover_bedrock_models(resolve_bedrock_region())
         if discovered:
-            return [m["id"] for m in discovered]
+            ids = [m["id"] for m in discovered]
+            _PROFILE_PREFIXES = ("us.", "global.", "eu.", "ap.", "jp.")
+            profile_bases = {
+                mid.split(".", 1)[1] for mid in ids if mid.startswith(_PROFILE_PREFIXES)
+            }
+            return [
+                mid for mid in ids
+                if mid.startswith(_PROFILE_PREFIXES) or mid not in profile_bases
+            ]
     except Exception:
         pass
     return None


### PR DESCRIPTION
Fixes #58185

## Description
The Bedrock model picker was showing bare foundation-model IDs alongside their inference-profile counterparts, leading to invalid selections on on-demand accounts.

The fix modifies `agent/bedrock_adapter.py:bedrock_model_ids_or_none` to deduplicate discovered model IDs by preferring inference-profile IDs (us., global., eu., ap., jp.) over bare IDs when a profile exists for the same model.

## Verification
- Unit tests pass: `tests/agent/test_bedrock_adapter.py` and `tests/hermes_cli/test_bedrock_model_picker.py`
- No secrets or personal references introduced (secrets scan clean)
- Conventional commit message
- Focused change: only the target function modified