### PR TITLE
fix: save trajectories in Gateway, CLI and TUI mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3878,6 +3878,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self.checkpoint_max_snapshots = cp_cfg.get("max_snapshots", 20)
         self.checkpoint_max_total_size_mb = cp_cfg.get("max_total_size_mb", 500)
         self.checkpoint_max_file_size_mb = cp_cfg.get("max_file_size_mb", 10)
+        self.save_trajectories = CLI_CONFIG["agent"].get("save_trajectories", False)
         self.pass_session_id = pass_session_id
         # --ignore-rules: honor either the constructor flag or the env var set
         # by `hermes chat --ignore-rules` in hermes_cli/main.py. When true we

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12851,6 +12851,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=source.thread_id,
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     fallback_model=self._fallback_model,
+                    save_trajectories=agent_cfg.get("save_trajectories", False),
                 )
                 try:
                     return agent.run_conversation(
@@ -17508,6 +17509,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             # Refresh agent max_iterations from current config
                             # (cached agent may have been created with old config)
                             agent.max_iterations = max_iterations
+                            agent.save_trajectories = agent_cfg_local.get("save_trajectories", False)
                             logger.debug("Reusing cached agent for session %s", session_key)
                             reused_cached_agent = True
 
@@ -17564,6 +17566,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     gateway_session_key=session_key,
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     fallback_model=self._fallback_model,
+                    save_trajectories=agent_cfg_local.get("save_trajectories", False),
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -390,6 +390,7 @@ class CLIAgentSetupMixin:
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,
+                save_trajectories=getattr(self, "save_trajectories", False),
             )
             # Store reference for atexit memory provider shutdown.
             # NOTE: this MUST write to the ``cli`` module's global, not a

--- a/tests/cli/test_cli_save_trajectories_wiring.py
+++ b/tests/cli/test_cli_save_trajectories_wiring.py
@@ -1,0 +1,95 @@
+"""Regression test: save_trajectories from config.yml must reach the agent.
+
+Setting ``agent.save_trajectories: true`` in config.yml had no effect because
+the CLI never passed the value to AIAgent. Two things must hold:
+
+1. HermesCLI reads the value from CLI_CONFIG["agent"] and stores it on self.
+2. CLIAgentSetupMixin._init_agent() passes it to AIAgent.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def _make_cli(agent_cfg: dict = None, **kwargs):
+    """Create a HermesCLI instance with a controlled agent config section."""
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": agent_cfg or {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), \
+         patch.dict("os.environ", clean_env, clear=False):
+        import cli as _cli_mod
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
+             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+            return _cli_mod.HermesCLI(**kwargs)
+
+
+class TestSaveTrajectoriesConfig:
+    def test_true_when_set_in_config(self):
+        """HermesCLI.__init__ must read save_trajectories from the agent config section."""
+        cli = _make_cli(agent_cfg={"save_trajectories": True})
+        assert cli.save_trajectories is True
+
+    def test_false_by_default(self):
+        """save_trajectories defaults to False when absent from config."""
+        cli = _make_cli(agent_cfg={})
+        assert cli.save_trajectories is False
+
+
+class TestSaveTrajectoriesWiring:
+    def test_init_agent_passes_save_trajectories_to_ai_agent(self):
+        """_init_agent must forward save_trajectories=True from self to AIAgent.
+
+        The bug: all three execution paths (CLI, gateway, TUI) constructed
+        AIAgent without passing save_trajectories, so agent.save_trajectories
+        stayed False regardless of config.yml.
+        """
+        cli_instance = _make_cli(agent_cfg={"save_trajectories": True})
+        assert cli_instance.save_trajectories is True
+
+        # Prevent _init_agent from opening a real SQLite DB.
+        cli_instance._session_db = MagicMock()
+
+        import cli as cli_mod
+
+        mock_agent_cls = MagicMock()
+        with patch.object(cli_mod, "AIAgent", mock_agent_cls), \
+             patch.object(cli_mod, "_prepare_deferred_agent_startup"), \
+             patch.object(cli_instance, "_install_tool_callbacks"), \
+             patch.object(cli_instance, "_ensure_tirith_security"), \
+             patch.object(cli_instance, "_ensure_runtime_credentials", return_value=True), \
+             patch("hermes_cli.mcp_startup.wait_for_mcp_discovery"):
+            cli_instance._init_agent()
+
+        mock_agent_cls.assert_called_once()
+        _, kwargs = mock_agent_cls.call_args
+        assert kwargs.get("save_trajectories") is True

--- a/tests/test_gateway_save_trajectories_wiring.py
+++ b/tests/test_gateway_save_trajectories_wiring.py
@@ -1,0 +1,129 @@
+"""Regression tests for save_trajectories wiring through the gateway AIAgent paths.
+
+The gateway builds AIAgent in three places:
+  1. _run_background_task — fresh agent per background-task turn.
+  2. _run_agent_inner (fresh path) — when no cached agent exists for the session.
+  3. _run_agent_inner (cached path) — when a cached agent is reused across turns.
+
+The cached path is the most subtle: even after fixing the constructor calls,
+a cached agent born with save_trajectories=False would stay False forever
+without an explicit per-turn refresh alongside max_iterations. These tests
+mirror test_cached_agent_max_iterations.py, extending the same invariants to
+save_trajectories.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import textwrap
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+def _make_cached_agent(save_trajectories: bool = False) -> SimpleNamespace:
+    """Minimal stand-in for a cached agent with the attributes the helpers touch."""
+    return SimpleNamespace(
+        _last_activity_ts=time.time() - 1000,
+        _last_activity_desc="previous turn",
+        _api_call_count=42,
+        _last_flushed_db_idx=5,
+        save_trajectories=save_trajectories,
+    )
+
+
+def test_init_cached_agent_for_turn_does_not_touch_save_trajectories():
+    """The per-turn reset helper must leave save_trajectories untouched.
+
+    The gateway refreshes save_trajectories explicitly right after calling
+    this helper (mirroring max_iterations). If the helper ever reset it to
+    False, that refresh would be undone and trajectory saving would silently
+    break for all cached sessions regardless of config.
+    """
+    from gateway.run import GatewayRunner
+
+    agent = _make_cached_agent(save_trajectories=True)
+    GatewayRunner._init_cached_agent_for_turn(agent, interrupt_depth=0)
+
+    assert agent._api_call_count == 0                       # per-turn state was reset …
+    assert agent._last_activity_desc == "starting new turn (cached)"
+    assert agent.save_trajectories is True                  # … but save_trajectories was not
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a writable config.yaml and a clean module cache.
+
+    Re-importing gateway.run re-evaluates ``_hermes_home = get_hermes_home()``
+    so ``_load_gateway_config()`` reads from the tmp directory.  Module state
+    is restored on teardown so the fixture does not leak into siblings.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _saved = {
+        k: v for k, v in sys.modules.items()
+        if k.startswith(("hermes_cli", "gateway"))
+    }
+
+    def write_cfg(body: str) -> None:
+        (hermes_home / "config.yaml").write_text(textwrap.dedent(body))
+
+    def fresh_gateway():
+        for mod in list(sys.modules.keys()):
+            if mod.startswith(("hermes_cli", "gateway")):
+                del sys.modules[mod]
+        return importlib.import_module("gateway.run")
+
+    try:
+        yield write_cfg, fresh_gateway
+    finally:
+        for k in list(sys.modules.keys()):
+            if k.startswith(("hermes_cli", "gateway")):
+                del sys.modules[k]
+        sys.modules.update(_saved)
+
+
+def test_cached_agent_refresh_picks_up_save_trajectories_from_config(isolated_home):
+    """Per-turn refresh propagates save_trajectories=True from live config to a
+    cached agent that was born with save_trajectories=False.
+
+    This mirrors the max_iterations refresh contract: a long-lived cached agent
+    must always run with the *current* config value, not the one it was built with.
+    """
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg("agent:\n  save_trajectories: true\n")
+    gw = fresh_gateway()
+
+    user_config = gw._load_gateway_config()
+    agent_cfg_local = user_config.get("agent") or {}
+
+    agent = _make_cached_agent(save_trajectories=False)
+    # Simulate the per-turn refresh (gateway/run.py, after _init_cached_agent_for_turn):
+    #   agent.save_trajectories = agent_cfg_local.get("save_trajectories", False)
+    agent.save_trajectories = agent_cfg_local.get("save_trajectories", False)
+
+    assert agent.save_trajectories is True
+
+
+def test_cached_agent_refresh_reverts_stale_true_when_config_omits_key(isolated_home):
+    """When config omits save_trajectories, a cached agent with True is corrected to False.
+
+    Prevents a scenario where save_trajectories was enabled, trajectories were
+    saved, then the option was removed from config — the cached agent should
+    immediately stop saving.
+    """
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg("agent: {}\n")
+    gw = fresh_gateway()
+
+    user_config = gw._load_gateway_config()
+    agent_cfg_local = user_config.get("agent") or {}
+
+    agent = _make_cached_agent(save_trajectories=True)
+    agent.save_trajectories = agent_cfg_local.get("save_trajectories", False)
+
+    assert agent.save_trajectories is False

--- a/tests/test_tui_save_trajectories_wiring.py
+++ b/tests/test_tui_save_trajectories_wiring.py
@@ -1,0 +1,96 @@
+"""Regression test: save_trajectories config must reach the TUI gateway AIAgent.
+
+The TUI runs agent turns inside tui_gateway.slash_worker subprocesses. Each
+worker calls _make_agent() in tui_gateway.server to construct the AIAgent.
+That function reads agent_cfg from _load_cfg(), but save_trajectories was
+never forwarded to AIAgent(), so the config setting had no effect for --tui
+sessions.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def tui_home(tmp_path):
+    """Isolated HERMES_HOME pointing to a tmp directory.
+
+    Uses set_hermes_home_override so _load_cfg() inside tui_gateway.server
+    reads the fixture's config.yaml without reimporting the module.
+    """
+    from tui_gateway import server as server_mod
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    token = set_hermes_home_override(str(home))
+    # Bust the mtime/path cache so _load_cfg() reads the new file.
+    prev = (server_mod._cfg_cache, server_mod._cfg_mtime, server_mod._cfg_path)
+    server_mod._cfg_cache = None
+    server_mod._cfg_mtime = None
+    server_mod._cfg_path = None
+
+    yield home, server_mod
+
+    server_mod._cfg_cache = prev[0]
+    server_mod._cfg_mtime = prev[1]
+    server_mod._cfg_path = prev[2]
+    reset_hermes_home_override(token)
+
+
+def _call_make_agent(server_mod, mock_agent_cls):
+    """Call server._make_agent with the minimum mocking to reach AIAgent(...)."""
+    with patch.object(
+        server_mod,
+        "_resolve_startup_runtime",
+        return_value=("anthropic/claude-sonnet-4-6", "openrouter"),
+    ), patch.object(
+        server_mod,
+        "_resolve_runtime_with_fallback",
+        return_value={
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-test",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+            "credential_pool": None,
+        },
+    ), patch(
+        "run_agent.AIAgent", mock_agent_cls
+    ):
+        server_mod._make_agent(
+            sid="test-sid",
+            key="test-key",
+            session_db=MagicMock(),  # skip _get_db() DB init
+        )
+
+
+class TestMakeAgentSaveTrajectoriesWiring:
+    def test_passes_save_trajectories_true_from_config(self, tui_home):
+        """_make_agent must forward save_trajectories=True when config says so."""
+        home, server_mod = tui_home
+        (home / "config.yaml").write_text("agent:\n  save_trajectories: true\n")
+
+        mock_agent_cls = MagicMock()
+        _call_make_agent(server_mod, mock_agent_cls)
+
+        mock_agent_cls.assert_called_once()
+        _, kwargs = mock_agent_cls.call_args
+        assert kwargs.get("save_trajectories") is True
+
+    def test_passes_save_trajectories_false_by_default(self, tui_home):
+        """When config omits save_trajectories, _make_agent must pass False."""
+        home, server_mod = tui_home
+        (home / "config.yaml").write_text("agent: {}\n")
+
+        mock_agent_cls = MagicMock()
+        _call_make_agent(server_mod, mock_agent_cls)
+
+        mock_agent_cls.assert_called_once()
+        _, kwargs = mock_agent_cls.call_args
+        assert kwargs.get("save_trajectories") is False

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4385,6 +4385,7 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        save_trajectories=agent_cfg.get("save_trajectories", False),
         **_agent_cbs(sid),
     )
 


### PR DESCRIPTION
## What does this PR do?

Per the documentation (https://hermes-agent.nousresearch.com/docs/developer-guide/trajectory-format), jsonl trajectory files are configurable via `config.yml` with:
```
agent:
  save_trajectories: true 
```

However, the value was never read in neither Gateway, CLI or TUI modes. I manually tested CLI and TUI and they both work. Don't know exactly how to test the Gateway mode.

All code was created by Claude with some steering to create tests that look to really exercise the fix.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #58200

## Type of Change

<!-- Check the one that applies. -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Made the 3 possible paths (CLI, TUI and gateway) honor the configuration.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Enable trajectory saving. 
2. Start a session in CLI or TUI mode.
3. The *.jsonl files will appear on the working dir.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Fedora

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

None are applicable to my fix.

- [] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No new logs. Just the trajectory files are created now in the working this as per the documentation.

