### PR TITLE
fix(qqbot, hindsight): is_reconnect param, model passthrough, config comparison, eager recall

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -278,7 +278,7 @@ class QQAdapter(BasePlatformAdapter):
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
@@ -1690,7 +1690,6 @@ class QQAdapter(BasePlatformAdapter):
             )
 
             if self._is_voice_content_type(ct, filename):
-                # Voice: use QQ's asr_refer_text first, then voice_wav_url, then STT.
                 asr_refer = (
                     str(att.get("asr_refer_text", "")).strip()
                     if isinstance(att.get("asr_refer_text"), str)
@@ -1847,7 +1846,7 @@ class QQAdapter(BasePlatformAdapter):
 
         Returns the transcript text, or None on failure.
         """
-        # 1. Use QQ's built-in ASR text if available
+        # 1. Prefer QQ's built-in ASR if available — free and no extra API call
         if asr_refer_text:
             logger.debug(
                 "[%s] STT: using QQ asr_refer_text: %r", self._log_tag, asr_refer_text[:100]
@@ -2203,12 +2202,7 @@ class QQAdapter(BasePlatformAdapter):
         return None
 
     async def _call_stt(self, wav_path: str) -> Optional[str]:
-        """Call an OpenAI-compatible STT API to transcribe a wav file.
-
-        Uses the provider configured in ``channels.qqbot.stt`` config,
-        falling back to QQ's built-in ``asr_refer_text`` if not configured.
-        Returns None if STT is not configured or the call fails.
-        """
+        """Call an OpenAI-compatible STT API endpoint."""
         stt_cfg = self._resolve_stt_config()
         if not stt_cfg:
             logger.warning(

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -539,6 +539,25 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+    # Support custom embedding model via config.json 'embeddings_local_model' field
+    # or HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL env var
+    embed_model = config.get("embeddings_local_model") or os.environ.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL", "")
+    if embed_model:
+        env_values["HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL"] = str(embed_model)
+    # Support custom reranker model via config.json 'reranker_local_model' field
+    # or HINDSIGHT_API_RERANKER_LOCAL_MODEL env var
+    reranker_model = config.get("reranker_local_model") or os.environ.get("HINDSIGHT_API_RERANKER_LOCAL_MODEL", "")
+    if reranker_model:
+        env_values["HINDSIGHT_API_RERANKER_LOCAL_MODEL"] = str(reranker_model)
+    # Pass through trust_remote_code for models that need it (e.g. BAAI/bge-reranker-v2-m3)
+    # via config.json 'reranker_local_trust_remote_code' or env var
+    reranker_trust = config.get("reranker_local_trust_remote_code") or os.environ.get("HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE", "")
+    if reranker_trust:
+        env_values["HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE"] = str(reranker_trust)
+    # Pass through llm_reasoning_effort for LM Studio toggle models
+    llm_reasoning = config.get("llm_reasoning_effort") or os.environ.get("HINDSIGHT_API_LLM_REASONING_EFFORT", "")
+    if llm_reasoning:
+        env_values["HINDSIGHT_API_LLM_REASONING_EFFORT"] = str(llm_reasoning)
     return env_values
 
 
@@ -1050,6 +1069,19 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._idle_timeout = idle_timeout
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
+
+                # 0.8.0 HindsightEmbedded doesn't accept embedding/reranker model
+                # parameters — inject them into the client's config dict so the
+                # daemon picks them up on startup.
+                embed_model = self._config.get("embeddings_local_model") or os.environ.get("HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL", "")
+                if embed_model:
+                    self._client.config["HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL"] = str(embed_model)
+                reranker_model = self._config.get("reranker_local_model") or os.environ.get("HINDSIGHT_API_RERANKER_LOCAL_MODEL", "")
+                if reranker_model:
+                    self._client.config["HINDSIGHT_API_RERANKER_LOCAL_MODEL"] = str(reranker_model)
+                reranker_trust = self._config.get("reranker_local_trust_remote_code") or os.environ.get("HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE", "")
+                if reranker_trust:
+                    self._client.config["HINDSIGHT_API_RERANKER_LOCAL_TRUST_REMOTE_CODE"] = str(reranker_trust)
             else:
                 _ensure_cloud_client_dependency()
                 from hindsight_client import Hindsight
@@ -1421,7 +1453,13 @@ class HindsightMemoryProvider(MemoryProvider):
                     profile_env = _embedded_profile_env_path(self._config)
                     expected_env = _build_embedded_profile_env(self._config)
                     saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
+                    # Compare only HINDSIGHT_API_* keys — daemon_embed_manager's
+                    # _register_profile() overwrites the .env file with only those
+                    # keys (HINDSIGHT_EMBED_* keys are dropped), so comparing the
+                    # full dict would always differ and cause a restart loop.
+                    expected_api = {k: v for k, v in expected_env.items() if k.startswith("HINDSIGHT_API_")}
+                    saved_api = {k: v for k, v in saved.items() if k.startswith("HINDSIGHT_API_")}
+                    config_changed = saved_api != expected_api
 
                     if config_changed:
                         profile_env = _materialize_embedded_profile_env(self._config)
@@ -1471,6 +1509,21 @@ class HindsightMemoryProvider(MemoryProvider):
             result = self._prefetch_result
             self._prefetch_result = ""
         if not result:
+            # No cached result from a previous turn.
+            # If no background prefetch thread is running, this is the first
+            # turn of a new session — do a synchronous recall so the model
+            # still sees relevant memories on turn 1.
+            has_thread = self._prefetch_thread and self._prefetch_thread.is_alive()
+            if not has_thread and self._auto_recall:
+                logger.debug("Prefetch: first-turn eager recall (no cached result, no background thread)")
+                text = self._sync_recall(query)
+                if text:
+                    header = self._recall_prompt_preamble or (
+                        "# Hindsight Memory (persistent cross-session context)\n"
+                        "Use this to answer questions about the user and prior sessions. "
+                        "Do not call tools to look up information that is already present here."
+                    )
+                    return f"{header}\n\n{text}"
             logger.debug("Prefetch: no results available")
             return ""
         logger.debug("Prefetch: returning %d chars of context", len(result))
@@ -1480,6 +1533,38 @@ class HindsightMemoryProvider(MemoryProvider):
             "Do not call tools to look up information that is already present here."
         )
         return f"{header}\n\n{result}"
+
+    def _sync_recall(self, query: str) -> str:
+        """Perform a synchronous recall for first-turn eager prefetch."""
+        if self._shutting_down.is_set():
+            return ""
+        # Truncate query to max chars
+        if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
+            query = query[:self._recall_max_input_chars]
+        try:
+            if self._prefetch_method == "reflect":
+                resp = self._run_hindsight_operation(
+                    lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget)
+                )
+                return resp.text or ""
+            else:
+                recall_kwargs: dict = {
+                    "bank_id": self._bank_id, "query": query,
+                    "budget": self._budget, "max_tokens": self._recall_max_tokens,
+                }
+                if self._recall_tags:
+                    recall_kwargs["tags"] = self._recall_tags
+                    recall_kwargs["tags_match"] = self._recall_tags_match
+                if self._recall_types:
+                    recall_kwargs["types"] = self._recall_types
+                logger.debug("Prefetch: sync recall (bank=%s, query_len=%d, budget=%s)",
+                             self._bank_id, len(query), self._budget)
+                resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+                if resp.results:
+                    return "\n".join(f"- {r.text}" for r in resp.results if r.text)
+        except Exception as e:
+            logger.debug("Hindsight sync recall failed: %s", e, exc_info=True)
+        return ""
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         if self._memory_mode == "tools":


### PR DESCRIPTION
## Summary

This PR contains two sets of fixes that have been running in production and verified:

### 1. QQ Bot `is_reconnect` parameter (`gateway/platforms/qqbot/adapter.py`)

- **Problem:** v0.18.0 `run.py` changed to pass `is_reconnect=True` to all adapter `connect()` calls for the new drain/reconnect coordination feature. `qqbot/adapter.py` `connect()` signature was not updated to accept the parameter, causing:
  ```
  QQAdapter.connect() got an unexpected keyword argument is_reconnect
  ```
- **Fix:** Added `*, is_reconnect: bool = False` to `QQAdapter.connect()` signature (L281)
- **Also included:** Minor comment cleanups (voice/content-type comment, STT docstring)

### 2. Hindsight plugin (`plugins/memory/hindsight/__init__.py`)

#### 2a. Model passthrough in `_build_embedded_profile_env` (L542-560)
- **Problem:** `config.json` fields `embeddings_local_model`, `reranker_local_model`, `reranker_local_trust_remote_code`, and `llm_reasoning_effort` were not forwarded to the daemon environment, so custom models were ignored.
- **Fix:** Forward all four config fields (and corresponding `HINDSIGHT_API_*` env vars) to the daemon env.

#### 2b. `client.config` injection (L1076-1084)
- **Problem:** `HindsightEmbedded` 0.8.0 does not accept embedding/reranker model parameters as constructor kwargs.
- **Fix:** After `HindsightEmbedded` instantiation, manually inject model parameters into `self._client.config` so the daemon picks them up on startup.

#### 2c. Config comparison fix (L1460-1462)
- **Problem:** Comparing the full env dict (`saved != expected_env`) always differs because `daemon_embed_manager._register_profile()` drops `HINDSIGHT_EMBED_*` keys, causing an infinite restart loop.
- **Fix:** Compare only `HINDSIGHT_API_*` keys, which are the ones the daemon actually uses.

#### 2d. First-turn eager recall (L1517-1519, L1537-1567)
- **Problem:** New sessions could not see relevant memories on turn 1 because recall runs asynchronously via background prefetch. The model on the first turn had no cached result and no background thread yet.
- **Fix:** When no cached result exists and no background thread is running (i.e., first turn), perform a synchronous `_sync_recall()` so the model sees memories immediately.

## Verification

All fixes have been verified in production (v0.18.0) across multiple profiles (default, learner):
- QQ Bot connects and reconnects without `is_reconnect` errors
- Hindsight daemon starts with correct custom models (BAAI/bge-m3, bge-reranker-v2-m3)
- No restart loop after config comparison fix
- First-turn eager recall confirmed via daemon logs (recall completes before first response)

## Testing

- [ ] Unit tests for `_sync_recall`
- [ ] Test that `is_reconnect` parameter is properly handled during reconnect flows
- [ ] Verify config comparison with minimal `HINDSIGHT_API_*` keys
