### PR TITLE
fix(yuanbao): wait for adapter reconnect before delivery

### DIFF
--- a/tests/tools/test_send_message_yuanbao_retry.py
+++ b/tests/tools/test_send_message_yuanbao_retry.py
@@ -1,0 +1,52 @@
+"""Yuanbao-specific send_message delivery retries."""
+
+import asyncio
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tools.send_message_tool import _send_yuanbao
+
+
+def test_send_yuanbao_waits_for_adapter_to_reappear(monkeypatch):
+    adapter = object()
+    adapters = [None, adapter]
+    fake_mod = ModuleType("gateway.platforms.yuanbao")
+    fake_mod.get_active_adapter = MagicMock(side_effect=lambda: adapters.pop(0))
+    fake_mod.send_yuanbao_direct = AsyncMock(return_value={"success": True, "message_id": "m1"})
+    monkeypatch.setitem(sys.modules, "gateway.platforms.yuanbao", fake_mod)
+
+    async def run_test():
+        with patch("tools.send_message_tool.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = await _send_yuanbao("direct:alice", "hello")
+            return result, sleep_mock
+
+    result, sleep_mock = asyncio.run(run_test())
+
+    assert result == {"success": True, "message_id": "m1"}
+    sleep_mock.assert_awaited_once_with(2.0)
+    fake_mod.send_yuanbao_direct.assert_awaited_once_with(
+        adapter,
+        "direct:alice",
+        "hello",
+        media_files=None,
+    )
+
+
+def test_send_yuanbao_returns_not_running_after_retry_window(monkeypatch):
+    fake_mod = ModuleType("gateway.platforms.yuanbao")
+    fake_mod.get_active_adapter = MagicMock(return_value=None)
+    fake_mod.send_yuanbao_direct = AsyncMock()
+    monkeypatch.setitem(sys.modules, "gateway.platforms.yuanbao", fake_mod)
+
+    async def run_test():
+        with patch("tools.send_message_tool.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = await _send_yuanbao("direct:alice", "hello")
+            return result, sleep_mock
+
+    result, sleep_mock = asyncio.run(run_test())
+
+    assert "error" in result
+    assert "Yuanbao adapter is not running" in result["error"]
+    assert sleep_mock.await_count == 2
+    fake_mod.send_yuanbao_direct.assert_not_awaited()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -73,6 +73,7 @@ _GENERIC_SECRET_ASSIGN_RE = re.compile(
     r"\b(access_token|api[_-]?key|auth[_-]?token|signature|sig)\s*=\s*([^\s,;]+)",
     re.IGNORECASE,
 )
+_YUANBAO_ADAPTER_WAIT_DELAYS = (2.0, 2.0)
 
 
 def _sanitize_error_text(text) -> str:
@@ -1768,6 +1769,19 @@ async def _send_yuanbao(chat_id, message, media_files=None):
         return _error("Yuanbao adapter module not available.")
 
     adapter = get_active_adapter()
+    for attempt, delay in enumerate(_YUANBAO_ADAPTER_WAIT_DELAYS, start=1):
+        if adapter is not None:
+            break
+        logger.warning(
+            "Yuanbao adapter is not running for send to %s; retrying in %.1fs "
+            "(attempt %d/%d)",
+            chat_id,
+            delay,
+            attempt,
+            len(_YUANBAO_ADAPTER_WAIT_DELAYS),
+        )
+        await asyncio.sleep(delay)
+        adapter = get_active_adapter()
     if adapter is None:
         return _error(
             "Yuanbao adapter is not running. "


### PR DESCRIPTION
## Summary
- retry Yuanbao delivery briefly when the live WebSocket adapter is temporarily absent
- keep the existing clear error when the adapter never comes back
- cover the retry and permanent-missing cases with a dependency-light unit test

Fixes #58184.

## Notes
This only retries before a Yuanbao adapter is found. It does not retry after `send_yuanbao_direct()` starts, so it avoids duplicating messages that may already be in flight.

## Tests
- .venv/bin/python -m pytest tests/tools/test_send_message_yuanbao_retry.py
- .venv/bin/python -m pytest tests/cron/test_scheduler.py -k "deliver_result or standalone or delivery"
- .venv/bin/python -m ruff check tools/send_message_tool.py tests/tools/test_send_message_yuanbao_retry.py
- .venv/bin/python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_yuanbao_retry.py
- git diff --check

`tests/tools/test_send_message_tool.py -k "send_to_platform or CheckSendMessage"` was attempted, but this checkout skips that whole file because optional `python-telegram-bot` is not installed; the new Yuanbao test is separate so it still runs in a bare env.