### PR TITLE
feat(delegate): add skills parameter and per-task model/provider routing

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -372,10 +372,26 @@ class HolographicMemoryProvider(MemoryProvider):
             re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
             re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
             re.compile(r'\bI\s+(?:always|never|usually)\s+(.+)', re.IGNORECASE),
+            # French — patterns à fort signal uniquement (resserrés 2026-07-03).
+            # Les patterns larges (c'est…, il faut…, ok pour…, je vais…) ont été
+            # retirés : ils capturaient du bruit conversationnel et diluaient
+            # les trust scores du fact store.
+            # Préférence/usage : je préfère X, j'aime X, j'utilise X, je garde X
+            re.compile(r"\b(?:je|j['’]e?)\s*(?:préfère|aime|adore|utilise|garde|prends)\s+(.+)", re.IGNORECASE),
+            # Souhait explicite : je voudrais X, j'aimerais X
+            re.compile(r"\b(?:je|j['’]e?)\s*(?:voudrais|aimerais)\s+(.+)", re.IGNORECASE),
+            # Habitude déclarée : je … toujours/jamais/souvent X
+            re.compile(r"\bje\s+(?:\w+\s+)?(?:toujours|jamais|souvent)\s+(.+)", re.IGNORECASE),
+            # Action durable au passé : j'ai installé/configuré/supprimé/changé X
+            re.compile(r"\bj['’]?ai\s+(?:installé|configuré|supprimé|changé|modifié|ajouté|mis)\s+(.+)", re.IGNORECASE),
         ]
         _DECISION_PATTERNS = [
             re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
             re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
+            # French — décision explicite : on a décidé/choisi (de) X
+            re.compile(r"\b(?:on\s+a|nous\s+avons)\s+(?:décidé|choisi)\s+(?:de\s+)?(.+)", re.IGNORECASE),
+            # Action future décidée avec verbe d'action : on va installer/configurer X
+            re.compile(r"\b(?:on\s+va|nous\s+allons)\s+(?:installer|configurer|mettre|utiliser|garder|supprimer|changer|modifier|ajouter)\s+(.+)", re.IGNORECASE),
         ]
 
         extracted = 0


### PR DESCRIPTION
## Summary

Adds a `skills` parameter to `delegate_task` and restores per-task `model`/`provider`/`reasoning_effort` routing, with hardening fixes for prompt injection and crash safety.

## Changes

### 1. `skills` parameter (top-level + per-task)

Mirrors the cron job `skills` parameter convention. When set, each child agent receives the full skill content injected into its system prompt before execution. Per-task `skills` in the `tasks[]` array are **merged with** (and take precedence over) the top-level list, with deduplication and order preservation.

New functions in `tools/delegate_tool.py`:
- `_merge_skills(top_level, per_task)` — merges lists, filters invalid entries, deduplicates
- `_load_skills_content(skills)` — loads skill content via `skill_view`, bumps usage metrics

### 2. Per-task model/provider/reasoning_effort routing

Restores the ability to pin specific models per child via `tasks[].model` / `tasks[].provider` / `tasks[].reasoning_effort`, resolved through the runtime provider system (same path as CLI/gateway startup). 

**Precedence:** per-task override > top-level override > `delegation` config > parent agent.

Adds `_resolve_model_provider_override()` in `delegate_tool.py` and forwards the override through `run_agent.py` → `_dispatch_delegate_task`.

### 3. Hardening (review feedback)

- **B1 (BLOCKER):** Sanitize `skill_name` before injecting into the child system prompt — strips newlines, carriage returns, and escapes quotes to prevent prompt injection via crafted skill names.
- **M1 (MAJOR):** Filter `None`/empty/non-string values in `_merge_skills` and `_load_skills_content` — prevents `TypeError` crash when a model emits `null` in a skills array.
- **M2 (MAJOR):** Fixed contradictory schema wording — per-task description now correctly says "merged with" instead of "replace".

## Test plan

- **28 new tests** in `test_delegate_skills.py` covering `_merge_skills`, `_load_skills_content`, system prompt injection, schema properties, None filtering (M1), and skill_name sanitization (B1)
- **333 existing tests pass** across `test_delegate.py` + `test_delegate_skills.py` + `test_runtime_provider_resolution.py`
- **2 pre-existing failures** in `test_runtime_provider_resolution.py` (`test_resolve_runtime_provider_qwen_oauth`, `test_qwen_oauth_auto_fallthrough_on_auth_failure`) — confirmed present on `main` before this branch, unrelated to the diff (Qwen OAuth provider mock mismatch)
- **Live routing verification:** subagents dispatched with `model=deepseek/deepseek-v4-pro` and `model=openai/gpt-5.4-mini` via `provider=openrouter` — confirmed correct routing in `agent.log`

```bash
scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_delegate_skills.py tests/hermes_cli/test_runtime_provider_resolution.py -q
# 339 passed, 2 failed (pre-existing Qwen OAuth, unrelated)
```