### PR TITLE
fix(search): detect truncation with overflow sentinel

### DIFF
--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -73,6 +73,69 @@ def test_rg_count_timeout_returns_partial_counts(ops, monkeypatch):
     assert result.counts == {"src/a.py": 3, "src/b.py": 5}
 
 
+@pytest.mark.parametrize("command", ["rg", "grep"])
+@pytest.mark.parametrize(("row_count", "truncated"), [(50, False), (51, True)])
+def test_content_search_uses_overflow_sentinel(ops, monkeypatch, command, row_count, truncated):
+    lines = [f"src/file_{i}.py:10:foo" for i in range(row_count)]
+    ops.env.execute.side_effect = path_exists_or("\n".join(lines), returncode=0)
+    monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == command)
+
+    result = ops.search("foo", path="/big", target="content", limit=50, offset=0)
+
+    assert result.error is None
+    assert len(result.matches) == 50
+    assert result.truncated is truncated
+
+
+@pytest.mark.parametrize("command", ["rg", "grep"])
+@pytest.mark.parametrize(("row_count", "truncated"), [(50, False), (51, True)])
+def test_files_only_search_uses_overflow_sentinel(ops, monkeypatch, command, row_count, truncated):
+    lines = [f"src/file_{i}.py" for i in range(row_count)]
+    ops.env.execute.side_effect = path_exists_or("\n".join(lines), returncode=0)
+    monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == command)
+
+    result = ops.search("foo", path="/big", target="content", output_mode="files_only", limit=50, offset=0)
+
+    assert result.error is None
+    assert result.files == lines[:50]
+    assert result.truncated is truncated
+
+
+@pytest.mark.parametrize("command", ["rg", "grep"])
+@pytest.mark.parametrize(("row_count", "truncated"), [(50, False), (51, True)])
+def test_count_search_uses_overflow_sentinel(ops, monkeypatch, command, row_count, truncated):
+    lines = [f"src/file_{i}.py:1" for i in range(row_count)]
+    ops.env.execute.side_effect = path_exists_or("\n".join(lines), returncode=0)
+    monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == command)
+
+    result = ops.search("foo", path="/big", target="content", output_mode="count", limit=50, offset=0)
+
+    assert result.error is None
+    assert len(result.counts) == 50
+    assert result.truncated is truncated
+
+
+@pytest.mark.parametrize("command", ["rg", "grep"])
+def test_content_search_sentinel_accounts_for_offset(ops, monkeypatch, command):
+    lines = [f"src/file_{i}.py:10:foo" for i in range(4)]
+    commands = []
+
+    def execute(shell_command, **kwargs):
+        if "test -e" in shell_command:
+            return {"output": "exists", "returncode": 0}
+        commands.append(shell_command)
+        return {"output": "\n".join(lines), "returncode": 0}
+
+    ops.env.execute.side_effect = execute
+    monkeypatch.setattr(ops, "_has_command", lambda cmd: cmd == command)
+
+    result = ops.search("foo", path="/big", target="content", limit=2, offset=1)
+
+    assert [match.path for match in result.matches] == ["src/file_1.py", "src/file_2.py"]
+    assert result.truncated is True
+    assert "head -n 4" in commands[0]
+
+
 def test_rg_file_timeout_does_not_retry_unsorted(ops, monkeypatch):
     calls = 0
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2287,10 +2287,14 @@ class ShellFileOperations(FileOperations):
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
-        # Fetch extra rows so we can report the true total before slicing.
-        # For context mode, rg emits separator lines ("--") between groups,
-        # so we grab generously and filter in Python.
-        fetch_limit = limit + offset + 200 if context > 0 else limit + offset
+        # Fetch one logical row beyond the requested page as a sentinel. An
+        # exact page is not proof that more results exist. Context output also
+        # contains separator/context rows, so retain the existing raw-row
+        # allowance before filtering those in Python.
+        page_end = offset + limit
+        fetch_limit = page_end + 1
+        if context > 0 and output_mode == "content":
+            fetch_limit += 200
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
         
         # `set -o pipefail` so rg's exit status propagates through `| head`.
@@ -2326,24 +2330,26 @@ class ShellFileOperations(FileOperations):
             return SearchResult(
                 files=page,
                 total_count=total,
-                truncated=bool(limit_reason),
+                truncated=total > page_end or bool(limit_reason),
                 limit_reason=limit_reason,
             )
         
         elif output_mode == "count":
-            counts = {}
+            all_counts = {}
             for line in stdout.strip().split('\n'):
                 if ':' in line:
                     parts = line.rsplit(':', 1)
                     if len(parts) == 2:
                         try:
-                            counts[parts[0]] = int(parts[1])
+                            all_counts[parts[0]] = int(parts[1])
                         except ValueError:
                             pass
+            count_items = list(all_counts.items())
+            counts = dict(count_items[offset:page_end])
             return SearchResult(
                 counts=counts,
-                total_count=sum(counts.values()),
-                truncated=bool(limit_reason),
+                total_count=sum(all_counts.values()),
+                truncated=len(all_counts) > page_end or bool(limit_reason),
                 limit_reason=limit_reason,
             )
         
@@ -2386,7 +2392,7 @@ class ShellFileOperations(FileOperations):
             return SearchResult(
                 matches=page,
                 total_count=total,
-                truncated=total > offset + limit or bool(limit_reason),
+                truncated=total > page_end or bool(limit_reason),
                 limit_reason=limit_reason,
             )
     
@@ -2417,8 +2423,13 @@ class ShellFileOperations(FileOperations):
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
-        # Fetch generously so we can compute total before slicing
-        fetch_limit = limit + offset + (200 if context > 0 else 0)
+        # Fetch one logical row beyond the page so exact fits remain
+        # untruncated. Context mode needs extra raw rows for group separators
+        # and surrounding lines that are filtered after the command returns.
+        page_end = offset + limit
+        fetch_limit = page_end + 1
+        if context > 0 and output_mode == "content":
+            fetch_limit += 200
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
         
         # `set -o pipefail` so grep's exit status propagates through `| head`
@@ -2452,24 +2463,26 @@ class ShellFileOperations(FileOperations):
             return SearchResult(
                 files=page,
                 total_count=total,
-                truncated=bool(limit_reason),
+                truncated=total > page_end or bool(limit_reason),
                 limit_reason=limit_reason,
             )
         
         elif output_mode == "count":
-            counts = {}
+            all_counts = {}
             for line in stdout.strip().split('\n'):
                 if ':' in line:
                     parts = line.rsplit(':', 1)
                     if len(parts) == 2:
                         try:
-                            counts[parts[0]] = int(parts[1])
+                            all_counts[parts[0]] = int(parts[1])
                         except ValueError:
                             pass
+            count_items = list(all_counts.items())
+            counts = dict(count_items[offset:page_end])
             return SearchResult(
                 counts=counts,
-                total_count=sum(counts.values()),
-                truncated=bool(limit_reason),
+                total_count=sum(all_counts.values()),
+                truncated=len(all_counts) > page_end or bool(limit_reason),
                 limit_reason=limit_reason,
             )
         
@@ -2509,6 +2522,6 @@ class ShellFileOperations(FileOperations):
             return SearchResult(
                 matches=page,
                 total_count=total,
-                truncated=total > offset + limit or bool(limit_reason),
+                truncated=total > page_end or bool(limit_reason),
                 limit_reason=limit_reason,
             )


### PR DESCRIPTION
## Summary
- Fetch `offset + limit + 1` logical rows for ripgrep and grep content searches.
- Use the extra row only as an overflow sentinel, keeping exact page fits untruncated.
- Apply the same pagination contract to `content`, `files_only`, and `count` output modes without exposing the sentinel in returned results.
- Preserve timeout-driven truncation and the extra raw-row allowance needed for context output.

## Tests
- Exact-fit and one-row-overflow boundaries for rg and grep across all three output modes.
- Nonzero-offset regression proving the command fetches `offset + limit + 1` rows and returns only the requested page.
- `.venv/bin/python -m pytest tests/tools/test_search_budget_truncation.py tests/tools/test_search_error_guard.py tests/tools/test_file_operations.py -q` (142 passed)
- `.venv/bin/python -m ruff check tools/file_operations.py tests/tools/test_search_budget_truncation.py`
- `git diff --check`