### PR TITLE
fix(dashboard): allow provider oauth with cookie auth

### DIFF
--- a/web/src/lib/api-oauth-auth.test.ts
+++ b/web/src/lib/api-oauth-auth.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const SESSION_HEADER = "X-Hermes-Session-Token";
+
+function stubWindow(overrides: Record<string, unknown> = {}) {
+  vi.stubGlobal("window", {
+    location: {
+      assign: vi.fn(),
+      pathname: "/",
+      reload: vi.fn(),
+      search: "",
+    },
+    ...overrides,
+  });
+}
+
+function stubJsonFetch(payload: unknown = { ok: true }) {
+  const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("provider OAuth API auth", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("starts provider OAuth in gated cookie-auth mode without a session token", async () => {
+    stubWindow({ __HERMES_AUTH_REQUIRED__: true });
+    const fetchMock = stubJsonFetch({ session_id: "oauth-session" });
+
+    const { api } = await import("./api");
+
+    await expect(api.startOAuthLogin("nous")).resolves.toEqual({
+      session_id: "oauth-session",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/providers/oauth/nous/start");
+    expect(init.credentials).toBe("include");
+    expect(new Headers(init.headers).has(SESSION_HEADER)).toBe(false);
+  });
+
+  it("lets fetchJSON attach the legacy token in loopback mode", async () => {
+    stubWindow({ __HERMES_SESSION_TOKEN__: "loopback-token" });
+    const fetchMock = stubJsonFetch({ ok: true });
+
+    const { api } = await import("./api");
+
+    await api.disconnectOAuthProvider("nous");
+    await api.submitOAuthCode("nous", "session-1", "code-1");
+    await api.cancelOAuthSession("session-1");
+
+    for (const [, init] of fetchMock.mock.calls as [string, RequestInit][]) {
+      expect(new Headers(init.headers).get(SESSION_HEADER)).toBe("loopback-token");
+      expect(init.credentials).toBe("include");
+    }
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -752,58 +752,42 @@ export const api = {
   // OAuth provider management
   getOAuthProviders: () =>
     fetchJSON<OAuthProvidersResponse>("/api/providers/oauth"),
-  disconnectOAuthProvider: async (providerId: string) => {
-    const token = await getSessionToken();
-    return fetchJSON<{ ok: boolean; provider: string }>(
+  disconnectOAuthProvider: (providerId: string) =>
+    fetchJSON<{ ok: boolean; provider: string }>(
       `/api/providers/oauth/${encodeURIComponent(providerId)}`,
       {
         method: "DELETE",
-        headers: { [SESSION_HEADER]: token },
       },
-    );
-  },
-  startOAuthLogin: async (providerId: string) => {
-    const token = await getSessionToken();
-    return fetchJSON<OAuthStartResponse>(
+    ),
+  startOAuthLogin: (providerId: string) =>
+    fetchJSON<OAuthStartResponse>(
       `/api/providers/oauth/${encodeURIComponent(providerId)}/start`,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          [SESSION_HEADER]: token,
-        },
+        headers: { "Content-Type": "application/json" },
         body: "{}",
       },
-    );
-  },
-  submitOAuthCode: async (providerId: string, sessionId: string, code: string) => {
-    const token = await getSessionToken();
-    return fetchJSON<OAuthSubmitResponse>(
+    ),
+  submitOAuthCode: (providerId: string, sessionId: string, code: string) =>
+    fetchJSON<OAuthSubmitResponse>(
       `/api/providers/oauth/${encodeURIComponent(providerId)}/submit`,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          [SESSION_HEADER]: token,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ session_id: sessionId, code }),
       },
-    );
-  },
+    ),
   pollOAuthSession: (providerId: string, sessionId: string) =>
     fetchJSON<OAuthPollResponse>(
       `/api/providers/oauth/${encodeURIComponent(providerId)}/poll/${encodeURIComponent(sessionId)}`,
     ),
-  cancelOAuthSession: async (sessionId: string) => {
-    const token = await getSessionToken();
-    return fetchJSON<{ ok: boolean }>(
+  cancelOAuthSession: (sessionId: string) =>
+    fetchJSON<{ ok: boolean }>(
       `/api/providers/oauth/sessions/${encodeURIComponent(sessionId)}`,
       {
         method: "DELETE",
-        headers: { [SESSION_HEADER]: token },
       },
-    );
-  },
+    ),
 
   // Messaging platforms (gateway channels)
   getMessagingPlatforms: () =>


### PR DESCRIPTION
## Summary

Closes #58207.

Dashboard provider OAuth helpers were manually requiring the legacy injected `X-Hermes-Session-Token` before calling `fetchJSON`. In gated dashboard auth mode that token is intentionally absent because auth is cookie-based, so the provider login modal failed client-side before reaching `/api/providers/oauth/<provider>/start`.

This routes the provider OAuth start/submit/cancel/disconnect helpers through `fetchJSON` without a preflight `getSessionToken()` call. Loopback mode still gets the legacy header from `fetchJSON`, while gated mode uses `credentials: "include"` and lets the backend authorize the cookie session.

## Testing

- `npm test -- --run src/lib/api-oauth-auth.test.ts`
- `npm run typecheck`
- `npm test`