### PR TITLE
fix(anthropic): retry oauth code exchange rate limits

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1391,6 +1391,8 @@ _OAUTH_TOKEN_USER_AGENT = "axios/1.7.9"
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
+_OAUTH_TOKEN_EXCHANGE_MAX_429_RETRIES = 3
+_OAUTH_TOKEN_EXCHANGE_MAX_RETRY_AFTER = 30.0
 
 
 def _generate_pkce() -> tuple:
@@ -1404,6 +1406,23 @@ def _generate_pkce() -> tuple:
         hashlib.sha256(verifier.encode()).digest()
     ).rstrip(b"=").decode()
     return verifier, challenge
+
+
+def _oauth_token_exchange_retry_delay(exc: Exception, attempt: int) -> float:
+    """Return a bounded delay for OAuth token-exchange HTTP 429 retries."""
+    headers = getattr(exc, "headers", None)
+    retry_after = None
+    if headers is not None:
+        try:
+            retry_after = headers.get("Retry-After") or headers.get("retry-after")
+        except Exception:
+            retry_after = None
+    if retry_after:
+        try:
+            return min(float(retry_after), _OAUTH_TOKEN_EXCHANGE_MAX_RETRY_AFTER)
+        except (TypeError, ValueError):
+            pass
+    return min(2.0 ** max(0, attempt), _OAUTH_TOKEN_EXCHANGE_MAX_RETRY_AFTER)
 
 
 def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
@@ -1474,6 +1493,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
         return None
 
     try:
+        import urllib.error
         import urllib.request
 
         exchange_data = json.dumps({
@@ -1494,23 +1514,43 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
         result = None
         last_error = None
         for endpoint in _OAUTH_TOKEN_URLS:
-            req = urllib.request.Request(
-                endpoint,
-                data=exchange_data,
-                headers={
-                    "Content-Type": "application/json",
-                    "User-Agent": _OAUTH_TOKEN_USER_AGENT,
-                },
-                method="POST",
-            )
-            try:
-                with urllib.request.urlopen(req, timeout=15) as resp:
-                    result = json.loads(resp.read().decode())
+            attempt = 0
+            while True:
+                req = urllib.request.Request(
+                    endpoint,
+                    data=exchange_data,
+                    headers={
+                        "Content-Type": "application/json",
+                        "User-Agent": _OAUTH_TOKEN_USER_AGENT,
+                    },
+                    method="POST",
+                )
+                try:
+                    with urllib.request.urlopen(req, timeout=15) as resp:
+                        result = json.loads(resp.read().decode())
+                    break
+                except urllib.error.HTTPError as exc:
+                    last_error = exc
+                    if exc.code == 429:
+                        if attempt >= _OAUTH_TOKEN_EXCHANGE_MAX_429_RETRIES:
+                            raise
+                        delay = _oauth_token_exchange_retry_delay(exc, attempt)
+                        logger.debug(
+                            "Anthropic token exchange rate-limited at %s; retrying in %.1fs",
+                            endpoint,
+                            delay,
+                        )
+                        time.sleep(delay)
+                        attempt += 1
+                        continue
+                    logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
+                    break
+                except Exception as exc:
+                    last_error = exc
+                    logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
+                    break
+            if result is not None:
                 break
-            except Exception as exc:
-                last_error = exc
-                logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
-                continue
 
         if result is None:
             raise last_error if last_error is not None else ValueError(

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -253,6 +253,143 @@ def test_login_token_exchange_falls_back_to_console_host(monkeypatch, tmp_path):
     ], "login must try platform.claude.com first, then fall back to console"
 
 
+def test_login_token_exchange_retries_429_before_fallback(monkeypatch, tmp_path):
+    """A transient token-endpoint 429 must retry in place before falling back.
+
+    Authorization codes are single-use. Falling through to another host after a
+    transient 429 wastes the code and forces the user through the browser flow
+    again, so the platform endpoint must get its retry budget first.
+    """
+    import urllib.error
+    import urllib.request
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_url: Dict[str, str] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="placeholder",
+        capture_auth_url=captured_url,
+    )
+
+    attempts: list[str] = []
+    sleeps: list[float] = []
+
+    class _FakeResponse:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return self._body
+
+    class _Headers(dict):
+        def get(self, key, default=None):
+            return super().get(key, default)
+
+    def fake_urlopen(req, *_a, **_kw):
+        attempts.append(req.full_url)
+        if len(attempts) == 1:
+            raise urllib.error.HTTPError(
+                req.full_url,
+                429,
+                "Too Many Requests",
+                _Headers({"Retry-After": "0.25"}),
+                None,
+            )
+        body = json.dumps(
+            {
+                "access_token": "sk-ant-test-access",
+                "refresh_token": "sk-ant-test-refresh",
+                "expires_in": 3600,
+            }
+        ).encode()
+        return _FakeResponse(body)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("time.sleep", lambda delay: sleeps.append(delay))
+
+    import builtins
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url.get("url", "")).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+
+    assert result is not None, "login should recover from a transient 429"
+    assert attempts == [
+        "https://platform.claude.com/v1/oauth/token",
+        "https://platform.claude.com/v1/oauth/token",
+    ], "429 retry must stay on the same endpoint before considering fallback"
+    assert sleeps == [0.25]
+
+
+def test_login_token_exchange_exhausts_429_without_console_fallback(monkeypatch, tmp_path):
+    """Persistent 429s should fail after bounded in-place retries.
+
+    The legacy console endpoint is not a useful fallback for a rate-limited live
+    endpoint and can turn the failure into a misleading 404.
+    """
+    import urllib.error
+    import urllib.request
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured_url: Dict[str, str] = {}
+    _patch_oauth_flow(
+        monkeypatch,
+        callback_code="placeholder",
+        capture_auth_url=captured_url,
+    )
+
+    attempts: list[str] = []
+    sleeps: list[float] = []
+
+    def fake_urlopen(req, *_a, **_kw):
+        attempts.append(req.full_url)
+        raise urllib.error.HTTPError(req.full_url, 429, "Too Many Requests", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("time.sleep", lambda delay: sleeps.append(delay))
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._OAUTH_TOKEN_EXCHANGE_MAX_429_RETRIES",
+        2,
+    )
+
+    import builtins
+
+    def fake_input(*_a, **_kw):
+        qs = parse_qs(urlparse(captured_url.get("url", "")).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+
+    assert result is None
+    assert attempts == [
+        "https://platform.claude.com/v1/oauth/token",
+        "https://platform.claude.com/v1/oauth/token",
+        "https://platform.claude.com/v1/oauth/token",
+    ]
+    assert all(url.startswith("https://platform.claude.com") for url in attempts)
+    assert sleeps == [1.0, 2.0]
+
+
 def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):
     """If the state returned in the callback does not match the one we sent
     in the authorization URL, the flow must abort before exchanging the code.


### PR DESCRIPTION
## Summary

Closes #58013.

Anthropic OAuth authorization codes are single-use, but the login token exchange treated HTTP 429 like any other endpoint failure. A transient rate limit on the live platform token endpoint could immediately fall through to the legacy console endpoint and fail, wasting the pasted authorization code.

This adds bounded in-place retries for HTTP 429 during the login code exchange, honoring `Retry-After` when present. Non-429 endpoint failures keep the existing platform-to-console fallback behavior. Persistent 429s fail after the retry budget instead of masking the rate limit behind a legacy fallback error.

## Testing

- `.venv/bin/python -m pytest tests/agent/test_anthropic_oauth_pkce.py -q`
- `.venv/bin/python -m pytest tests/agent/test_anthropic_oauth_ua_prefix.py tests/agent/test_anthropic_oauth_pkce.py -q`
- `.venv/bin/python -m py_compile agent/anthropic_adapter.py tests/agent/test_anthropic_oauth_pkce.py`
- `git diff --check`