### PR TITLE
feat(unbroker): draft regulator complaints for missed statutory deadlines

### DIFF
--- a/optional-skills/security/unbroker/SKILL.md
+++ b/optional-skills/security/unbroker/SKILL.md
@@ -131,6 +131,7 @@ breaks reading the dossier).
 | `$PDD tasks <subject>` | ONE consolidated human-task digest (present at END of run) |
 | `$PDD status <subject>` | Markdown status report |
 | `$PDD report <subject> --sheets` | Rows for the Google Sheets tracker |
+| `$PDD complaints <subject>` | Draft a regulator complaint for each broker that ignored a request past its statutory deadline (CCPA 45d / GDPR 30d). **Draft-only - you file it**; CA/EU-UK subjects only |
 
 ## Batch operation (two-phase: crawl-all, then delete)
 
@@ -263,7 +264,12 @@ recording `found` and before any deletion.
     verifying re-scan shows the listing gone - never off the submission flow's own confirmation page.
 7. **Wrap up (once per run).** When `next` returns no actions: present `$PDD tasks <subject>` (the
    consolidated human digest) if non-empty, then `$PDD status <subject>`; if the Sheets tracker is
-   on, append `$PDD report <subject> --sheets` rows via the `google-workspace` skill.
+   on, append `$PDD report <subject> --sheets` rows via the `google-workspace` skill. If `status`
+   flags requests **past the statutory deadline** (a broker that never confirmed removal within the
+   CCPA 45-day / GDPR 30-day window), run `$PDD complaints <subject>` to render a ready-to-file
+   regulator-complaint draft for each. These are **drafts only** - surface them in the digest for the
+   operator to review and file; unbroker never files a complaint automatically (a consequential,
+   outward-facing legal action), and only CA (CCPA) and EU/UK (GDPR) subjects can invoke one.
 8. **Schedule the next wake-up.** `next` returns `next_wake_at` (earliest due re-check). Create ONE
    `cronjob` that re-runs this skill's loop for the subject (a prompt like: *"run the
    unbroker loop for <subject_id>: `$PDD next` and execute all actions"*). Processing

--- a/optional-skills/security/unbroker/scripts/complaint.py
+++ b/optional-skills/security/unbroker/scripts/complaint.py
@@ -1,0 +1,133 @@
+"""Detect removal requests a broker has ignored past its statutory deadline, and
+build a ready-to-file regulator-complaint DRAFT for each.
+
+Filing a complaint with a regulator is a consequential, outward-facing legal action,
+so it is NEVER auto-submitted: this module produces DRAFTS the operator reviews and
+files, surfaced through the human-task lane - the same hand-off pattern as
+`render-email`. Everything here is pure (dossier + ledger in, drafts out); no network
+and no filesystem, so it is hermetically testable.
+
+Statutory response windows:
+  CCPA/CPRA        - 45 days for a business to respond to a deletion request
+                     (Cal. Civ. Code 1798.130). Past this, non-response is a violation.
+  GDPR Article 12(3) - one month (30 days) to act on an erasure request (Article 17).
+
+Honesty gate: a complaint is only generated for a jurisdiction the subject can
+truthfully invoke - CCPA for California residents, GDPR for EU/UK residents. A
+"generic" subject (neither) has no single statutory deadline or regulator, so no
+complaint is emitted for them. We never route (say) a Texan's complaint to the
+California Attorney General. Regime detection reuses autopilot.request_kind, the same
+logic the email lane already uses, so the two can never disagree.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+import autopilot
+import dossier as dossier_mod
+
+# States in which a request has been made but the broker has not confirmed deletion.
+PENDING_STATES = ("submitted", "verification_pending", "awaiting_processing")
+
+CCPA_WINDOW_DAYS = 45
+GDPR_WINDOW_DAYS = 30
+_WINDOW = {"ccpa": CCPA_WINDOW_DAYS, "gdpr": GDPR_WINDOW_DAYS}
+
+# Where each regime's complaint is filed. The GDPR authority is the subject's own
+# national DPA (the EDPB members page lists them); we cannot know which one from
+# residency alone, so we name the lane and link the directory rather than guess.
+AGENCY = {
+    "ccpa": {
+        "name": "California Attorney General / California Privacy Protection Agency",
+        "portal": "https://oag.ca.gov/report (CA AG) or https://cppa.ca.gov (CPPA)",
+    },
+    "gdpr": {
+        "name": "your national Data Protection Authority",
+        "portal": "https://edpb.europa.eu/about-edpb/about-edpb/members_en",
+    },
+}
+
+
+def _parse(ts: str | None) -> _dt.datetime | None:
+    try:
+        return _dt.datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=_dt.timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def submitted_at(case: dict) -> str | None:
+    """ISO timestamp of the FIRST transition into a submitted/pending state.
+
+    The statutory clock starts when the removal request was made, so we take the
+    earliest history entry whose target state is one a request produces. A case that
+    never reached a pending state (e.g. only `found`) has no clock start -> None.
+    """
+    for h in case.get("history") or []:
+        if h.get("to") in PENDING_STATES:
+            return h.get("at")
+    return None
+
+
+def overdue_cases(subject_id: str, dossier: dict, ledger: dict, now: _dt.datetime | None = None,
+                  ccpa_days: int = CCPA_WINDOW_DAYS, gdpr_days: int = GDPR_WINDOW_DAYS) -> list[dict]:
+    """Cases whose statutory response window has elapsed with no confirmed removal.
+
+    Pure over (dossier, ledger). Returns rows sorted most-overdue-first:
+      {broker_id, regime, window_days, submitted_at, days_overdue}
+    Only CCPA (CA) and GDPR (EU/UK) subjects yield rows; generic subjects get none
+    (see the module honesty gate). `now` is injectable for tests.
+    """
+    regime = autopilot.request_kind(dossier)
+    if regime not in _WINDOW:
+        return []
+    window = {"ccpa": ccpa_days, "gdpr": gdpr_days}[regime]
+    now = now or _dt.datetime.now(_dt.timezone.utc)
+
+    rows: list[dict] = []
+    for bid, case in (ledger or {}).items():
+        if case.get("state") not in PENDING_STATES:
+            continue
+        if case.get("removal_confirmed_at"):
+            continue  # broker complied; nothing to complain about
+        started = _parse(submitted_at(case))
+        if not started:
+            continue
+        days_overdue = (now - started).days - window
+        if days_overdue <= 0:
+            continue
+        rows.append({
+            "broker_id": bid,
+            "regime": regime,
+            "window_days": window,
+            "submitted_at": submitted_at(case),
+            "days_overdue": days_overdue,
+        })
+    rows.sort(key=lambda r: r["days_overdue"], reverse=True)
+    return rows
+
+
+def _broker_contact(broker: dict) -> str:
+    opt = (broker or {}).get("optout") or {}
+    return opt.get("url") or opt.get("email") or broker.get("email") \
+        or "(no public opt-out contact on file)"
+
+
+def complaint_context(dossier: dict, broker: dict, row: dict) -> dict:
+    """Least-disclosure {field} context for a complaint template.
+
+    Names ONLY the subject's own identity (name + contact email) plus the
+    already-filed request - no PII beyond what the removal request itself disclosed.
+    """
+    ident = dossier.get("identity", {})
+    agency = AGENCY[row["regime"]]
+    return {
+        "agency_name": agency["name"],
+        "agency_portal": agency["portal"],
+        "full_name": ident.get("full_name") or "[your name]",
+        "contact_email": dossier_mod.contact_email(dossier) or "[your email]",
+        "broker_name": (broker or {}).get("name") or row["broker_id"],
+        "broker_contact": _broker_contact(broker or {}),
+        "submitted_date": (row.get("submitted_at") or "")[:10],
+        "window_days": row["window_days"],
+        "days_overdue": row["days_overdue"],
+    }

--- a/optional-skills/security/unbroker/scripts/legal.py
+++ b/optional-skills/security/unbroker/scripts/legal.py
@@ -61,3 +61,18 @@ def render_request(kind: str, broker: dict, fields: dict) -> str:
     ctx["listing_urls"] = _join_listings(fields.get("listing_urls"))
     ctx["my_identifiers"] = _join_identifiers(fields.get("my_identifiers"))
     return render(template, ctx)
+
+
+def render_complaint(regime: str, fields: dict) -> str:
+    """Render a regulator-complaint DRAFT for a broker that ignored a request past
+    its statutory deadline. regime: ccpa (CA AG / CPPA) | gdpr (national DPA).
+
+    Draft only - the operator files it; unbroker never submits a complaint itself.
+    """
+    template = {
+        "ccpa": "emails/ccpa-complaint.txt",
+        "gdpr": "emails/gdpr-complaint.txt",
+    }.get(regime)
+    if not template:
+        raise ValueError(f"no complaint template for regime {regime!r} (expected ccpa|gdpr)")
+    return render(template, fields)

--- a/optional-skills/security/unbroker/scripts/pdd.py
+++ b/optional-skills/security/unbroker/scripts/pdd.py
@@ -33,6 +33,7 @@ import autopilot                   # noqa: E402
 import badbool                      # noqa: E402
 import cdp                          # noqa: E402
 import brokers as brokers_mod      # noqa: E402
+import complaint as complaint_mod  # noqa: E402
 import config as config_mod        # noqa: E402
 import crypto                       # noqa: E402
 import dossier as dossier_mod      # noqa: E402
@@ -731,6 +732,30 @@ def cmd_report(args) -> None:
         print(report_mod.render_markdown(args.subject))
 
 
+def cmd_complaints(args) -> None:
+    """Render regulator-complaint DRAFTS for brokers that ignored a request past its
+    statutory deadline (CCPA 45d / GDPR 30d). Draft-only: the operator files each one;
+    unbroker never submits a complaint itself (consequential outward-facing action)."""
+    d = _require_subject(args.subject)
+    dossier_mod.require_authorized(d)
+    rows = complaint_mod.overdue_cases(args.subject, d, ledger_mod.load(args.subject))
+    complaints = []
+    for row in rows:
+        b = brokers_mod.get(row["broker_id"]) or {}
+        ctx = complaint_mod.complaint_context(d, b, row)
+        complaints.append({
+            **row,
+            "agency": ctx["agency_name"],
+            "portal": ctx["agency_portal"],
+            "draft": legal.render_complaint(row["regime"], ctx),
+        })
+    _out({"subject": args.subject, "overdue_count": len(complaints), "complaints": complaints,
+          "note": "DRAFTS ONLY - review each and file it with the named regulator yourself. "
+                  "unbroker never files a complaint automatically (consequential legal action). "
+                  "A draft is not proof of a violation; confirm the broker truly did not act "
+                  "(a re-scan / poll-verification) before filing."})
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="pdd", description="unbroker helper CLI")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -899,6 +924,12 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("subject")
     s.add_argument("--sheets", action="store_true", help="emit Google Sheets rows as JSON")
     s.set_defaults(func=cmd_report)
+
+    s = sub.add_parser("complaints",
+                       help="draft regulator complaints for brokers past the CCPA/GDPR deadline "
+                            "(draft-only; you file them)")
+    s.add_argument("subject")
+    s.set_defaults(func=cmd_complaints)
     return p
 
 

--- a/optional-skills/security/unbroker/scripts/report.py
+++ b/optional-skills/security/unbroker/scripts/report.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import brokers as brokers_mod
+import complaint as complaint_mod
+import dossier as dossier_mod
 import ledger as ledger_mod
 
 STATE_LABELS = {
@@ -80,6 +82,19 @@ def render_markdown(subject_id: str) -> str:
     for state in ledger_mod.STATES:
         if counts.get(state):
             lines.append(f"| {STATE_LABELS.get(state, state)} | {counts[state]} |")
+
+    # Requests a broker has ignored past its statutory deadline (CCPA 45d / GDPR 30d).
+    # Only surfaced for CA/EU/UK subjects who can actually invoke that regulator.
+    d = dossier_mod.load(subject_id) or {}
+    overdue_complaints = complaint_mod.overdue_cases(subject_id, d, ledger) if d else []
+    if overdue_complaints:
+        lines += ["", f"## {len(overdue_complaints)} request(s) past the statutory deadline",
+                  "The broker has not confirmed removal within the legal response window. "
+                  "Run `pdd.py complaints <subject>` to draft a regulator complaint for each "
+                  "(draft-only; you file it)."]
+        for r in overdue_complaints:
+            lines.append(f"- **{r['broker_id']}** - {r['days_overdue']} day(s) past the "
+                         f"{r['window_days']}-day {r['regime'].upper()} deadline")
 
     tasks = [c for c in ledger.values() if c.get("state") == "human_task_queued"]
     if tasks:

--- a/optional-skills/security/unbroker/templates/emails/ccpa-complaint.txt
+++ b/optional-skills/security/unbroker/templates/emails/ccpa-complaint.txt
@@ -1,0 +1,27 @@
+Subject: CCPA complaint - {broker_name} failed to honor a deletion request
+
+To: {agency_name}
+File at: {agency_portal}
+
+Complainant:
+  Name:  {full_name}
+  Email: {contact_email}
+
+Business complained about: {broker_name}
+Business opt-out / privacy contact: {broker_contact}
+
+Summary of complaint:
+On {submitted_date} I submitted a request to {broker_name} to delete the personal
+information it holds about me, exercising my rights under the California Consumer
+Privacy Act (Cal. Civ. Code 1798.105 and 1798.120). The statutory response window
+is {window_days} days. As of today, {days_overdue} day(s) have elapsed beyond that
+deadline, {broker_name} has not deleted my personal information, and it has not
+provided a lawful basis for refusing.
+
+Requested action:
+I ask that {agency_name} investigate {broker_name}'s failure to comply with the
+California Consumer Privacy Act within the required {window_days}-day window and
+compel deletion of my personal information.
+
+Signed,
+{full_name}

--- a/optional-skills/security/unbroker/templates/emails/gdpr-complaint.txt
+++ b/optional-skills/security/unbroker/templates/emails/gdpr-complaint.txt
@@ -1,0 +1,27 @@
+Subject: GDPR complaint - {broker_name} failed to honor an erasure request
+
+To: {agency_name}
+File at: {agency_portal}
+
+Complainant:
+  Name:  {full_name}
+  Email: {contact_email}
+
+Controller complained about: {broker_name}
+Controller opt-out / privacy contact: {broker_contact}
+
+Summary of complaint:
+On {submitted_date} I submitted a request to {broker_name} to erase the personal
+data it holds about me, exercising my right to erasure under the General Data
+Protection Regulation (Article 17). Under Article 12(3) the controller must act
+without undue delay and within {window_days} days. As of today, {days_overdue}
+day(s) have elapsed beyond that deadline, {broker_name} has not erased my personal
+data, and it has not provided a lawful basis for refusing under Article 17(3).
+
+Requested action:
+I ask that {agency_name} investigate {broker_name}'s failure to comply with the
+General Data Protection Regulation within the required {window_days}-day window and
+compel erasure of my personal data.
+
+Signed,
+{full_name}

--- a/tests/skills/test_unbroker_skill.py
+++ b/tests/skills/test_unbroker_skill.py
@@ -37,6 +37,7 @@ import time as _time      # noqa: E402
 import badbool          # noqa: E402
 import brokers          # noqa: E402
 import cdp              # noqa: E402
+import complaint        # noqa: E402
 import config           # noqa: E402
 import crypto           # noqa: E402
 import dossier          # noqa: E402
@@ -1443,6 +1444,164 @@ def test_report_metrics_removal_rate_and_overdue():
         assert m["confirmed_removed"] == 1
         assert m["open_needs_action"] >= 1 and m["in_flight_claimed"] >= 1
         assert m["overdue_rechecks"] >= 1 and 0 < m["removal_rate"] <= 1
+
+
+# ── complaint escalation (broker ignored a request past its statutory deadline) ──
+
+
+def _ca_dossier(sid="sub_ca01"):
+    return {
+        "subject_id": sid,
+        "consent": {"authorized": True, "method": "self"},
+        "identity": {"full_name": "Jane Q. Public", "emails": ["jane@example.com"]},
+        "residency_jurisdiction": "US-CA",
+        "preferences": {},
+    }
+
+
+def _eu_dossier(sid="sub_eu01"):
+    return {
+        "subject_id": sid,
+        "consent": {"authorized": True, "method": "self"},
+        "identity": {"full_name": "Hans Müller", "emails": ["hans@example.de"]},
+        "residency_jurisdiction": "EU-DE",
+        "preferences": {},
+    }
+
+
+def _age_submitted(sid, broker_id, days_ago):
+    """Put a case into `submitted` and back-date its submission stamp by days_ago."""
+    ledger.transition(sid, broker_id, "found", found=True)
+    ledger.transition(sid, broker_id, "submitted")
+    led = ledger.load(sid)
+    import datetime as _dt
+    stamp = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=days_ago)) \
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    for h in led[broker_id]["history"]:
+        if h.get("to") == "submitted":
+            h["at"] = stamp
+    ledger.save(sid, led)
+    return stamp
+
+
+def test_complaint_submitted_at_reads_first_submitted_transition():
+    with temp_env():
+        sid = "sub_ca01"
+        _age_submitted(sid, "radaris", days_ago=60)
+        case = ledger.load(sid)["radaris"]
+        assert complaint.submitted_at(case) is not None
+        # a case never submitted has no clock start
+        ledger.transition(sid, "spokeo", "found", found=True)
+        assert complaint.submitted_at(ledger.load(sid)["spokeo"]) is None
+
+
+def test_complaint_overdue_ccpa_past_45_days():
+    with temp_env():
+        d = _ca_dossier()
+        sid = d["subject_id"]
+        _age_submitted(sid, "radaris", days_ago=50)     # 50 > 45 → overdue
+        _age_submitted(sid, "spokeo", days_ago=10)       # 10 < 45 → not overdue
+        rows = complaint.overdue_cases(sid, d, ledger.load(sid))
+        ids = {r["broker_id"] for r in rows}
+        assert "radaris" in ids and "spokeo" not in ids
+        row = next(r for r in rows if r["broker_id"] == "radaris")
+        assert row["regime"] == "ccpa" and row["window_days"] == 45
+        assert row["days_overdue"] == 5
+
+
+def test_complaint_overdue_gdpr_uses_30_day_window():
+    with temp_env():
+        d = _eu_dossier()
+        sid = d["subject_id"]
+        _age_submitted(sid, "radaris", days_ago=40)      # 40 > 30 → overdue under GDPR
+        rows = complaint.overdue_cases(sid, d, ledger.load(sid))
+        assert len(rows) == 1
+        assert rows[0]["regime"] == "gdpr" and rows[0]["window_days"] == 30
+        assert rows[0]["days_overdue"] == 10
+
+
+def test_complaint_generic_subject_yields_no_complaints():
+    # A non-CA US resident (e.g. Texas) can't truthfully invoke CCPA/GDPR: no
+    # statutory-deadline regulator, so no complaint is generated (honesty gate).
+    with temp_env():
+        d = _ca_dossier("sub_tx01")
+        d["residency_jurisdiction"] = "US-TX"
+        sid = d["subject_id"]
+        _age_submitted(sid, "radaris", days_ago=120)
+        assert complaint.overdue_cases(sid, d, ledger.load(sid)) == []
+
+
+def test_complaint_confirmed_removed_is_not_overdue():
+    with temp_env():
+        d = _ca_dossier()
+        sid = d["subject_id"]
+        _age_submitted(sid, "radaris", days_ago=90)
+        ledger.transition(sid, "radaris", "awaiting_processing")
+        ledger.transition(sid, "radaris", "confirmed_removed")
+        assert complaint.overdue_cases(sid, d, ledger.load(sid)) == []
+
+
+def test_complaint_rows_sorted_most_overdue_first():
+    with temp_env():
+        d = _ca_dossier()
+        sid = d["subject_id"]
+        _age_submitted(sid, "radaris", days_ago=60)      # 15 overdue
+        _age_submitted(sid, "spokeo", days_ago=100)      # 55 overdue
+        rows = complaint.overdue_cases(sid, d, ledger.load(sid))
+        assert [r["broker_id"] for r in rows] == ["spokeo", "radaris"]
+
+
+def test_render_complaint_ccpa_fills_placeholders_and_names_the_law():
+    with temp_env():
+        d = _ca_dossier()
+        row = {"broker_id": "radaris", "regime": "ccpa", "window_days": 45,
+               "submitted_at": "2026-05-01T00:00:00Z", "days_overdue": 20}
+        ctx = complaint.complaint_context(d, {"name": "Radaris"}, row)
+        text = legal.render_complaint("ccpa", ctx)
+        assert "Radaris" in text
+        assert "Jane Q. Public" in text
+        assert "45" in text and "20" in text
+        assert "California Consumer Privacy Act" in text
+        assert "{" not in text          # every placeholder resolved
+
+
+def test_render_complaint_gdpr_names_article_17():
+    with temp_env():
+        d = _eu_dossier()
+        row = {"broker_id": "radaris", "regime": "gdpr", "window_days": 30,
+               "submitted_at": "2026-05-01T00:00:00Z", "days_overdue": 8}
+        ctx = complaint.complaint_context(d, {"name": "Radaris"}, row)
+        text = legal.render_complaint("gdpr", ctx)
+        assert "Hans Müller" in text
+        assert "General Data Protection Regulation" in text or "GDPR" in text
+        assert "{" not in text
+
+
+def test_cli_complaints_returns_drafts_and_flags_draft_only():
+    with temp_env():
+        d = _ca_dossier()
+        # persist the dossier the CLI will load
+        dossier.save(d)
+        sid = d["subject_id"]
+        _age_submitted(sid, "radaris", days_ago=50)
+        out = _run(["complaints", sid])
+        assert out["overdue_count"] == 1
+        c = out["complaints"][0]
+        assert c["broker_id"] == "radaris" and c["regime"] == "ccpa"
+        assert "draft" in c and "Radaris" in c["draft"]
+        assert "agency" in c and "portal" in c
+        # never auto-files: the note must make the draft-only contract explicit
+        assert "draft" in out["note"].lower() and "yourself" in out["note"].lower()
+
+
+def test_cli_complaints_none_overdue_is_empty():
+    with temp_env():
+        d = _ca_dossier()
+        dossier.save(d)
+        sid = d["subject_id"]
+        _age_submitted(sid, "radaris", days_ago=10)      # within window
+        out = _run(["complaints", sid])
+        assert out["overdue_count"] == 0 and out["complaints"] == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

The `unbroker` skill already tracks overdue rechecks (`report.metrics()` → `overdue_rechecks`) and documents the CCPA 45-day / GDPR 30-day response windows (`references/legal/ccpa.md`), but nothing escalates when a broker actually **blows** that statutory deadline - the autonomous loop just keeps re-scanning forever.

This adds the missing escalation lever: **`$PDD complaints <subject>`** scans the ledger for cases in a pending state (`submitted` / `verification_pending` / `awaiting_processing`) whose statutory response window has elapsed with no confirmed removal, and renders a ready-to-file **regulator-complaint draft** for each (CCPA → CA AG / CPPA; GDPR → the subject's national DPA).

It extends the existing legal lane + ledger rather than adding a new subsystem, and it deliberately follows the skill's existing contracts:

- **Draft-only.** Filing a complaint with a regulator is a consequential, outward-facing legal action, so it is **never auto-submitted** - it is handed off for the operator to review and file, the same pattern as `render-email`. The `next` autonomy contract routes consequential work to the human digest; this respects that.
- **Honesty gate.** A complaint is generated only for a jurisdiction the subject can *truthfully* invoke: CCPA for California residents, GDPR for EU/UK. A `generic` subject yields **none** (never route a Texan's complaint to the California AG). Regime detection reuses `autopilot.request_kind`, so it can never disagree with the email lane.
- **Least-disclosure.** The complaint names only the subject's own identity (name + contact email) plus the already-filed request - no new PII beyond what the removal request itself disclosed.
- **Discoverable.** `status` gains a one-line pointer when any request is past its deadline.

## Related Issue

No existing issue - happy to open one if the maintainers prefer to track it there. Raised originally from the [SHL0MS/Teknium thread](https://x.com/Teknium1) inviting upstreaming of related data-broker opt-out work.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `scripts/complaint.py` (new) - pure overdue-detection (`overdue_cases`, `submitted_at`) + agency metadata + least-disclosure `complaint_context`. No network, no filesystem.
- `scripts/legal.py` - `render_complaint(regime, fields)` mapping `ccpa`/`gdpr` to the new templates.
- `templates/emails/ccpa-complaint.txt`, `templates/emails/gdpr-complaint.txt` (new) - `{field}`-placeholder drafts matching the existing template style.
- `scripts/pdd.py` - `complaints` subcommand + `cmd_complaints` handler (draft-only output with an explicit never-auto-files note).
- `scripts/report.py` - `render_markdown` surfaces a pointer when requests are past their statutory deadline.
- `SKILL.md` - quick-reference row + wrap-up step.
- `tests/skills/test_unbroker_skill.py` - 10 hermetic tests.

## How to Test

1. `python3 -m pytest tests/skills/test_unbroker_skill.py -q` → **107 passed** (97 existing + 10 new).
2. End-to-end:
   ```bash
   export PDD_DATA_DIR=$(mktemp -d)/pdd
   SID=$(python3 scripts/pdd.py intake --full-name "Jane Q. Public" --email jane@example.com --state CA --residency US-CA --consent | python3 -c 'import sys,json;print(json.load(sys.stdin)["subject_id"])')
   python3 scripts/pdd.py record "$SID" radaris found --found true
   python3 scripts/pdd.py record "$SID" radaris submitted
   # back-date the submitted stamp >45 days, then:
   python3 scripts/pdd.py complaints "$SID"   # → CCPA complaint draft for Radaris
   python3 scripts/pdd.py status "$SID"        # → "N request(s) past the statutory deadline" pointer
   ```
3. A `generic` (non-CA/EU) subject correctly yields **no** complaints; a `confirmed_removed` case is excluded.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(unbroker): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass (107 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (SKILL.md quick-reference + procedure)
- [x] `cli-config.yaml.example` - N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` - N/A (no architecture change)
- [x] Cross-platform: pure-stdlib, no OS-specific calls; templates are plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)