### PR TITLE
feat(agent): per-turn outcome telemetry for the pre_llm_call hook

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2115,6 +2115,10 @@ def init_agent(
     # activates during a turn, the next turn restores these values so the
     # preferred model gets a fresh attempt each time.  Uses a single dict
     # so new state fields are easy to add without N individual attributes.
+    # Retrospective per-turn outcome record (agent/turn_telemetry.py). Stamped
+    # at finalization each turn; read by the next turn's pre_llm_call hook as
+    # last_turn=. None until the first turn completes.
+    agent._last_turn_telemetry = None
     _cc = agent.context_compressor
     agent._primary_runtime = {
         "model": agent.model,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -518,6 +518,7 @@ def build_turn_context(
     plugin_user_context = ""
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
+        from agent.turn_telemetry import empty_telemetry as _empty_turn_telemetry
         _pre_results = _invoke_hook(
             "pre_llm_call",
             session_id=agent.session_id,
@@ -529,6 +530,10 @@ def build_turn_context(
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            # Retrospective self-observation: what the PREVIOUS turn did
+            # (provider used, fallback, tool failures, tools offered). Empty
+            # on the first turn. See agent/turn_telemetry.py for the schema.
+            last_turn=getattr(agent, "_last_turn_telemetry", None) or _empty_turn_telemetry(),
         )
         _ctx_parts: list[str] = []
         # Spill oversized per-hook context to disk so a runaway plugin

--- a/agent/turn_telemetry.py
+++ b/agent/turn_telemetry.py
@@ -1,0 +1,145 @@
+"""Per-turn outcome telemetry — a retrospective self-observation channel.
+
+The ``pre_llm_call`` plugin hook fires in the turn *prologue*, before the model
+call, so a plugin can see what a turn is *about* but never what a turn *did*:
+which provider actually answered, whether the call fell back to a backup, how
+tool calls failed. Those outcomes are produced during the turn and then wiped at
+the top of the next one (``restore_primary_runtime`` clears the fallback flag;
+``reset_for_turn`` zeroes the guardrail counts) — so by the time a hook could
+read them, they're gone.
+
+This module captures a small, stable record of the turn's *outcome* and stashes
+it on ``agent._last_turn_telemetry``; the next turn's ``pre_llm_call`` hook
+receives it as ``last_turn=``. That lets a plugin reason about the agent's own
+recent behavior — "last turn ran on the backup endpoint" — self-perception the
+agent otherwise lacks.
+
+**Where it is captured (this matters):** in the ``AIAgent.run_conversation``
+forwarder's ``finally`` — NOT at the top of ``finalize_turn``. ``run_conversation``
+has many early-return paths (interrupts, failed calls, policy blocks) that never
+reach ``finalize_turn``; those are exactly the turns a self-observation plugin
+most wants to see. Capturing in the forwarder's ``finally`` runs on every
+exit — every return and every exception — reading the agent state the turn left
+behind (fallback flag and guardrail counts are only reset at the *next* turn's
+prologue, so they still describe the turn that just ended).
+
+Design contract (deliberately minimal and stable — it is a hook API):
+- **Purely additive & inert.** Nothing in core reads the record; it only feeds
+  the hook kwarg. Absent a consumer it is one small dict built per turn.
+- **Never raises.** Every field read defensively; capture is exception-guarded.
+- **Retrospective.** It describes the turn that just finished; a consumer must
+  treat it as "last turn", never "this turn".
+- **Additive schema.** Fields may be ADDED in future; consumers should ``.get``.
+
+Schema of the returned dict (all keys always present):
+    has_data          bool   False only for the first-turn empty sentinel
+    turn_id           str    the finished turn's id
+    provider          str    provider whose runtime was active at turn end
+    model             str    model whose runtime was active at turn end
+    base_url          str    endpoint active at turn end (see note on cred-pool)
+    was_fallback      bool   True if the turn ran on a fallback runtime
+    primary_provider  str    the configured primary provider (backup-vs-home)
+    primary_model     str    the configured primary model
+    on_primary        bool   True if the active runtime matched the primary
+    api_calls         int    API calls made this turn (best-effort from result)
+    interrupted       bool   user interrupted this turn (best-effort from result)
+    tool_failures     dict   {exact:int, same_tool:int, halted:bool} — counts of
+                             tool calls STILL FAILING at turn end (a tool that
+                             failed then succeeded is cleared by the guardrail
+                             and does not appear here; this is "unresolved at
+                             turn end", not a lifetime hammer count).
+
+Note (credential-pool fallback): a fallback that reuses the same ``base_url``
+with a different key sets ``was_fallback=True`` (via the flag) but leaves
+``base_url``/``provider`` equal to the primary's — so those fields are "the
+endpoint routed to", which for a cred-pool fallback is the same host.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def empty_telemetry() -> Dict[str, Any]:
+    """The record a consumer sees before any turn has completed (first turn).
+
+    ``has_data`` is False so a consumer can tell this sentinel from a real
+    capture and decline to act on it.
+    """
+    return {
+        "has_data": False,
+        "turn_id": "",
+        "provider": "",
+        "model": "",
+        "base_url": "",
+        "was_fallback": False,
+        "primary_provider": "",
+        "primary_model": "",
+        "on_primary": True,
+        "api_calls": 0,
+        "interrupted": False,
+        "tool_failures": {"exact": 0, "same_tool": 0, "halted": False},
+    }
+
+
+def _tool_failures(agent) -> Dict[str, Any]:
+    """Tool-call failures STILL UNRESOLVED at turn end (see module docstring)."""
+    out = {"exact": 0, "same_tool": 0, "halted": False}
+    try:
+        ctrl = getattr(agent, "_tool_guardrails", None)
+        if ctrl is None:
+            return out
+        exact = getattr(ctrl, "_exact_failure_counts", {}) or {}
+        same = getattr(ctrl, "_same_tool_failure_counts", {}) or {}
+        out["exact"] = len(exact)
+        out["same_tool"] = sum(int(v) for v in same.values())
+        out["halted"] = getattr(ctrl, "halt_decision", None) is not None
+    except Exception:
+        pass
+    return out
+
+
+def capture_turn_telemetry(agent, *, result: Any = None) -> Dict[str, Any]:
+    """Build the outcome record for the turn that just finished. Never raises.
+
+    Call from the ``run_conversation`` forwarder's ``finally`` so it runs on
+    every exit path. Core fields (fallback/provider/tool-failures) are read from
+    the agent, which still reflects the just-finished turn at this point; the
+    ``result`` dict (may be ``None`` on an exception) supplies best-effort turn
+    metadata (``api_calls``, ``interrupted``).
+    """
+    res = result if isinstance(result, dict) else {}
+    try:
+        primary = getattr(agent, "_primary_runtime", None) or {}
+        provider = str(getattr(agent, "provider", "") or "")
+        model = str(getattr(agent, "model", "") or "")
+        base_url = str(getattr(agent, "base_url", "") or "")
+        primary_provider = str(primary.get("provider", "") or "")
+        primary_model = str(primary.get("model", "") or "")
+
+        # `_fallback_activated` is authoritative and still set here (the next
+        # turn's restore clears it). The runtime comparison is a cross-check
+        # covering divergence the flag might miss.
+        flag_fallback = bool(getattr(agent, "_fallback_activated", False))
+        primary_base = str(primary.get("base_url", "") or "")
+        runtime_diverged = bool(primary_base) and base_url != primary_base
+        on_primary = (not flag_fallback) and (not runtime_diverged)
+
+        return {
+            "has_data": True,
+            "turn_id": str(getattr(agent, "_current_turn_id", "") or ""),
+            "provider": provider,
+            "model": model,
+            "base_url": base_url,
+            "was_fallback": flag_fallback or runtime_diverged,
+            "primary_provider": primary_provider,
+            "primary_model": primary_model,
+            "on_primary": on_primary,
+            "api_calls": int(res.get("api_calls", 0) or 0),
+            "interrupted": bool(res.get("interrupted", False)),
+            "tool_failures": _tool_failures(agent),
+        }
+    except Exception:
+        # A broken capture must never break a turn: fall back to the sentinel,
+        # marked has_data=False so no consumer acts on an unreliable record.
+        return empty_telemetry()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1908,6 +1908,14 @@ class PluginManager:
         system prompt stays identical across turns so cached tokens
         are reused.  All injected context is ephemeral — never
         persisted to session DB.
+
+        ``pre_llm_call`` also receives ``last_turn=`` — a retrospective
+        record of what the PREVIOUS turn did (provider/model used, whether
+        it fell back, tool-failure counts, tools offered). It is empty on
+        the first turn. See :mod:`agent.turn_telemetry` for the schema. Use
+        it to reason about the agent's own recent behavior (e.g. "last turn
+        ran on a fallback endpoint"); treat it as *last* turn, never *this*
+        turn.
         """
         kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
         callbacks = self._hooks.get(hook_name, [])

--- a/run_agent.py
+++ b/run_agent.py
@@ -5889,17 +5889,33 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
-        return run_conversation(
-            self,
-            user_message,
-            system_message,
-            conversation_history,
-            task_id,
-            stream_callback,
-            persist_user_message,
-            persist_user_timestamp=persist_user_timestamp,
-            moa_config=moa_config,
-        )
+        _tt_result = None
+        try:
+            _tt_result = run_conversation(
+                self,
+                user_message,
+                system_message,
+                conversation_history,
+                task_id,
+                stream_callback,
+                persist_user_message,
+                persist_user_timestamp=persist_user_timestamp,
+                moa_config=moa_config,
+            )
+            return _tt_result
+        finally:
+            # Capture the turn's OUTCOME on EVERY exit path — every return and
+            # every exception. run_conversation has many early returns
+            # (interrupts, failed calls, policy blocks) that never reach
+            # finalize_turn; those are exactly the turns a self-observation
+            # plugin most wants. The agent still reflects this turn's state here
+            # (fallback flag / guardrail counts reset only at the *next* turn's
+            # prologue). Never allowed to affect the turn's result.
+            try:
+                from agent.turn_telemetry import capture_turn_telemetry
+                self._last_turn_telemetry = capture_turn_telemetry(self, result=_tt_result)
+            except Exception:  # pragma: no cover - defensive
+                pass
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -194,6 +194,33 @@ def test_applies_agent_side_effects():
     assert agent._current_turn_id
 
 
+def test_registered_pre_llm_hook_observes_first_turn_then_prior_outcome(monkeypatch):
+    import hermes_cli.plugins as plugins
+    from agent.turn_telemetry import capture_turn_telemetry
+
+    manager = plugins.PluginManager()
+    observed = []
+
+    def observe(**kwargs):
+        observed.append(kwargs["last_turn"])
+
+    manager._hooks.setdefault("pre_llm_call", []).append(observe)
+    monkeypatch.setattr(plugins, "_plugin_manager", manager)
+
+    agent = _FakeAgent()
+    agent._last_turn_telemetry = None
+    _build(agent)
+    assert observed[-1]["has_data"] is False
+
+    agent._last_turn_telemetry = capture_turn_telemetry(
+        agent, result={"api_calls": 3, "interrupted": False}
+    )
+    _build(agent)
+    assert observed[-1]["has_data"] is True
+    assert observed[-1]["api_calls"] == 3
+    assert observed[-1]["provider"] == "openrouter"
+
+
 def test_task_id_passthrough():
     agent = _FakeAgent()
     ctx = _build(agent, task_id="fixed-task")
@@ -416,4 +443,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-

--- a/tests/agent/test_turn_telemetry.py
+++ b/tests/agent/test_turn_telemetry.py
@@ -1,0 +1,171 @@
+"""Tests for the per-turn outcome telemetry primitive (agent/turn_telemetry.py).
+
+The record is the retrospective self-observation channel: captured in the
+run_conversation forwarder's finally (every exit path), it tells the next turn's
+pre_llm_call hook what the previous turn DID. Contract: always the full schema,
+never raises, describes the finished turn — including failed/interrupted turns.
+"""
+
+from __future__ import annotations
+
+import types
+
+from agent.turn_telemetry import capture_turn_telemetry, empty_telemetry
+
+
+_SCHEMA_KEYS = {
+    "has_data", "turn_id", "provider", "model", "base_url", "was_fallback",
+    "primary_provider", "primary_model", "on_primary", "api_calls",
+    "interrupted", "tool_failures",
+}
+
+
+def _guardrails(exact=None, same=None, halted=False):
+    return types.SimpleNamespace(
+        _exact_failure_counts=exact or {},
+        _same_tool_failure_counts=same or {},
+        halt_decision=(object() if halted else None),
+    )
+
+
+def _agent(**over):
+    base = dict(
+        provider="onyx", model="qwen", base_url="http://127.0.0.1:8020",
+        _current_turn_id="turn-42",
+        _fallback_activated=False,
+        _primary_runtime={"provider": "onyx", "model": "qwen", "base_url": "http://127.0.0.1:8020"},
+        _tool_guardrails=_guardrails(),
+    )
+    base.update(over)
+    return types.SimpleNamespace(**base)
+
+
+def test_schema_always_complete():
+    rec = capture_turn_telemetry(_agent(), result={})
+    assert set(rec) == _SCHEMA_KEYS
+    assert set(empty_telemetry()) == _SCHEMA_KEYS
+
+
+def test_has_data_true_on_real_capture_false_on_empty():
+    assert capture_turn_telemetry(_agent(), result={})["has_data"] is True
+    assert empty_telemetry()["has_data"] is False
+
+
+def test_on_primary_when_active_matches_primary():
+    rec = capture_turn_telemetry(_agent(), result={})
+    assert rec["was_fallback"] is False and rec["on_primary"] is True
+
+
+def test_fallback_flag_detected_reports_active_and_primary():
+    a = _agent(_fallback_activated=True, provider="anthropic", model="claude",
+               base_url="https://api.anthropic.com")
+    rec = capture_turn_telemetry(a, result={})
+    assert rec["was_fallback"] is True and rec["on_primary"] is False
+    assert rec["provider"] == "anthropic"       # active runtime
+    assert rec["primary_provider"] == "onyx"    # primary preserved (backup-vs-home)
+
+
+def test_runtime_divergence_detected_without_flag():
+    a = _agent(_fallback_activated=False, base_url="http://100.111.117.39:8011")
+    rec = capture_turn_telemetry(a, result={})
+    assert rec["was_fallback"] is True and rec["on_primary"] is False
+
+
+def test_tool_failures_are_unresolved_at_turn_end():
+    a = _agent(_tool_guardrails=_guardrails(
+        exact={("read_file",): 1, ("terminal",): 1}, same={"read_file": 4}, halted=True))
+    rec = capture_turn_telemetry(a, result={})
+    assert rec["tool_failures"] == {"exact": 2, "same_tool": 4, "halted": True}
+
+
+def test_metadata_from_result_dict():
+    rec = capture_turn_telemetry(_agent(), result={"api_calls": 7, "interrupted": True})
+    assert rec["api_calls"] == 7 and rec["interrupted"] is True
+    assert rec["turn_id"] == "turn-42"  # from agent, not result
+
+
+def test_none_result_is_safe():
+    # forwarder passes result=None when run_conversation raised
+    rec = capture_turn_telemetry(_agent(), result=None)
+    assert rec["has_data"] is True and rec["api_calls"] == 0 and rec["interrupted"] is False
+
+
+def test_bare_agent_captures_empty_values_without_raising():
+    # every field is read defensively, so a bare agent yields a complete record
+    # with empty values (not the exception sentinel).
+    rec = capture_turn_telemetry(types.SimpleNamespace(), result={})
+    assert set(rec) == _SCHEMA_KEYS
+    assert rec["has_data"] is True
+    assert rec["was_fallback"] is False and rec["provider"] == ""
+
+
+def test_capture_exception_returns_unactionable_sentinel():
+    # a genuinely hostile shape (_primary_runtime is not a dict) makes .get raise;
+    # capture must fall back to the has_data=False sentinel, never propagate.
+    a = _agent(_primary_runtime="not-a-dict")
+    rec = capture_turn_telemetry(a, result={})
+    assert rec["has_data"] is False
+    assert set(rec) == _SCHEMA_KEYS
+
+
+def test_never_raises_on_hostile_guardrails():
+    class Hostile:
+        @property
+        def _exact_failure_counts(self):
+            raise RuntimeError("boom")
+    rec = capture_turn_telemetry(_agent(_tool_guardrails=Hostile()), result={})
+    assert rec["tool_failures"] == {"exact": 0, "same_tool": 0, "halted": False}
+    assert rec["provider"] == "onyx"       # the rest of the record survives
+
+
+def test_no_tools_offered_field():
+    # dropped from v1 (was only for a deferred consumer); schema stays minimal
+    assert "tools_offered" not in capture_turn_telemetry(_agent(), result={})
+
+
+def test_hook_contract_consumer_can_read_last_turn():
+    a = _agent(_fallback_activated=True, provider="anthropic", model="claude")
+    last_turn = capture_turn_telemetry(a, result={})
+
+    def consumer(**kwargs):
+        lt = kwargs.get("last_turn") or {}
+        if lt.get("has_data") and lt.get("was_fallback"):
+            return {"context": f"last turn ran off-primary on {lt.get('provider')}"}
+        return None
+
+    assert consumer(last_turn=last_turn) == {"context": "last turn ran off-primary on anthropic"}
+    # first-turn sentinel must NOT trigger the consumer (has_data False)
+    assert consumer(last_turn=empty_telemetry()) is None
+
+
+def test_forwarder_stamps_on_every_exit_path(monkeypatch):
+    """C1 regression: the record is stamped even when run_conversation raises
+    (an early-return/exception turn), not only on the happy finalize path."""
+    import agent.conversation_loop as cl
+
+    captured = {}
+
+    class _Agent:
+        provider = "onyx"; model = "qwen"; base_url = "http://127.0.0.1:8020"
+        _current_turn_id = "t1"
+        _fallback_activated = True  # this failing turn fell back
+        _primary_runtime = {"provider": "onyx", "model": "qwen", "base_url": "http://127.0.0.1:8020"}
+        _tool_guardrails = _guardrails(same={"terminal": 3})
+        # bind the real forwarder as a method
+        from run_agent import AIAgent as _AI
+        run_conversation = _AI.run_conversation
+
+    def _boom(*a, **k):
+        raise RuntimeError("turn blew up before finalize_turn")
+
+    monkeypatch.setattr(cl, "run_conversation", _boom)
+    ag = _Agent()
+    try:
+        ag.run_conversation("hi")
+    except RuntimeError:
+        pass
+    # the failed turn was still observed
+    assert ag._last_turn_telemetry is not None
+    assert ag._last_turn_telemetry["has_data"] is True
+    assert ag._last_turn_telemetry["was_fallback"] is True
+    assert ag._last_turn_telemetry["tool_failures"]["same_tool"] == 3

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -599,7 +599,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | ignored |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
-| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
+| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str, last_turn: dict` | [context injection](#pre_llm_call-context-injection) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | [`on_session_start`](/user-guide/features/hooks#on_session_start) | New session created (first turn only) | `session_id: str, model: str, platform: str` | ignored |
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -527,6 +527,13 @@ def my_callback(session_id: str, user_message: str, conversation_history: list,
 | `is_first_turn` | `bool` | `True` if this is the first turn of a new session, `False` on subsequent turns |
 | `model` | `str` | The model identifier (e.g. `"anthropic/claude-sonnet-4.6"`) |
 | `platform` | `str` | Where the session is running: `"cli"`, `"telegram"`, `"discord"`, etc. |
+| `last_turn` | `dict` | Outcome telemetry for the previous turn on this agent instance; `has_data` is `False` on the first turn |
+
+`last_turn` includes the provider/model used, fallback state, API-call count,
+interrupt state, and unresolved tool-failure counts. It is intentionally
+instance-scoped: request surfaces that create a fresh agent for each request
+(including the API server) receive the first-turn sentinel unless the caller
+reuses the same agent. It is not persisted as session history.
 
 **Fires:** In `run_agent.py`, inside `run_conversation()`, after context compression but before the main `while` loop. Fires once per `run_conversation()` call (i.e. once per user turn), not once per API call within the tool loop.
 


### PR DESCRIPTION
## What does this PR do?

The `pre_llm_call` plugin hook fires in the turn **prologue**, before the model call, so a plugin can see what a turn is *about* but never what a turn *did*: which provider actually answered, whether the call fell back to a backup endpoint, how tool calls failed. Those outcomes are produced during the turn and then wiped at the top of the next one — `restore_primary_runtime` clears `_fallback_activated`; `reset_for_turn` zeroes the guardrail counts — so a hook has no channel to read them. A plugin can perceive the environment; it cannot perceive the agent's own recent behavior.

This adds a small, stable **turn-outcome record**, passed to the next turn's `pre_llm_call` as a new `last_turn=` kwarg, so a plugin can reason about "last turn ran on a fallback endpoint" or "last turn burned calls on a failing tool" and adapt.

**Why captured in the `run_conversation` forwarder's `finally` (not at `finalize_turn`):** `run_conversation` has many early-return paths (interrupts, failed calls, policy blocks) that never reach `finalize_turn` — and those failure/interrupt turns are precisely the ones a self-observation plugin most wants to see. Capturing in the sole forwarder's `finally` runs on every exit (every return and every exception). The agent still reflects the just-finished turn's state there, since fallback/guardrail state is reset only at the *next* turn's prologue.

Purely additive and inert: nothing in core reads the record; absent a consumer it is one small dict built per turn, and existing `**kwargs` `pre_llm_call` consumers are unaffected. It never raises — a capture failure yields a `has_data=False` sentinel rather than a broken turn.

## Related Issue

Fixes #58217

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`agent/turn_telemetry.py`** (new): `capture_turn_telemetry(agent, *, result=None)` builds the record; `empty_telemetry()` is the first-turn sentinel. Documents the stable, additive schema (`has_data, turn_id, provider, model, base_url, was_fallback, primary_provider, primary_model, on_primary, api_calls, interrupted, tool_failures{exact,same_tool,halted}`). `tool_failures` counts tools *unresolved at turn end*.
- **`run_agent.py`** (`AIAgent.run_conversation` forwarder): wrap the call in `try/finally`; stamp `self._last_turn_telemetry` in the `finally` (every exit path). Sole entry point — all callers (gateway, api_server, background_review, curator, codex) route through this method.
- **`agent/turn_context.py`**: pass `last_turn=getattr(agent, "_last_turn_telemetry", None) or empty_telemetry()` into the `pre_llm_call` `invoke_hook` call.
- **`agent/agent_init.py`**: init `agent._last_turn_telemetry = None`.
- **`hermes_cli/plugins.py`**: document the new `last_turn=` kwarg in the `invoke_hook` contract.
- **`tests/agent/test_turn_telemetry.py`** (new): 14 tests.

## How to Test

1. `pytest tests/agent/test_turn_telemetry.py -q` → 14 passing, including `test_forwarder_stamps_on_every_exit_path` (the record is stamped even when `run_conversation` raises, i.e. a failure/interrupt turn).
2. Regression: `pytest tests/agent/test_turn_finalizer_*.py tests/agent/test_turn_context.py -q` → green (25).
3. Consumer smoke: a `pre_llm_call` plugin reading `kwargs["last_turn"]` sees `{has_data, was_fallback, provider, ...}` describing the previous turn; empty (`has_data=False`) on the first turn.

## Checklist

- [x] Additive and backward-compatible (existing `pre_llm_call` consumers unaffected)
- [x] Never raises into the turn loop (defensive reads + `has_data=False` sentinel)
- [x] Tests added; existing turn-loop suites still green
- [x] Schema documented in `agent/turn_telemetry.py`
