### PR TITLE
fix(agent): sanitize max-iterations summary with canonical strip_think_blocks

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1668,8 +1668,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = (_summary_result.content or "").strip()
 
         if final_response:
-            if "<think>" in final_response:
-                final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+            # Use the canonical sanitizer instead of an inline <think>-only
+            # regex: strip_think_blocks() also removes leaked tool-call XML
+            # (<tool_call>/<function_call>/...) that toolless summary calls
+            # provoke from open models -- e.g. GLM emits its native tool-call
+            # template as plain content when no tools are bound, and this text
+            # is otherwise delivered to the user verbatim.
+            final_response = agent._strip_think_blocks(final_response).strip()
             if final_response:
                 messages.append({"role": "assistant", "content": final_response})
             else:
@@ -1711,8 +1716,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 final_response = (_retry_result.content or "").strip()
 
             if final_response:
-                if "<think>" in final_response:
-                    final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                # Same canonical sanitizer as the first-attempt branch above.
+                final_response = agent._strip_think_blocks(final_response).strip()
                 if final_response:
                     messages.append({"role": "assistant", "content": final_response})
                 else:

--- a/tests/agent/test_max_iterations_summary_sanitize.py
+++ b/tests/agent/test_max_iterations_summary_sanitize.py
@@ -1,0 +1,121 @@
+"""Regression tests for max-iterations summary sanitization (#58220).
+
+``handle_max_iterations`` asks the model for a closing summary with no tools
+bound. Open-weight models (z.ai/GLM in particular) answer that by emitting
+their native tool-call template as plain content, so the summary that reaches
+the user carries raw ``<tool_call>`` / ``<function_call>`` XML.
+
+The old inline regex only understood ``<think>``. Both summary branches now
+route through the canonical ``agent._strip_think_blocks()``, which also strips
+leaked tool-call XML.
+
+Two branches exist and both are covered here — the review on #58220 asked
+specifically for the retry path, which earlier attempts left untested:
+
+* initial branch — the first summary call returns usable content
+* retry branch   — the first call returns empty, so a second call is made
+
+The retry test asserts a second call really happened, so it cannot silently
+degrade into re-testing the initial branch.
+"""
+
+import types
+
+import pytest
+
+
+LEAKY_SUMMARY = (
+    "<think>I should call the tool again</think>"
+    "Here is what I found.\n"
+    '<tool_call>{"name": "read_file", "arguments": {"path": "/tmp/x"}}</tool_call>'
+)
+
+
+def _make_agent(summary_contents):
+    """Real AIAgent with only the network edge stubbed.
+
+    ``summary_contents`` is consumed one entry per summary call, so passing
+    two entries drives the empty-then-retry path.
+    """
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cached_system_prompt = "SYS"
+    agent.model = "glm-4.7-flash"
+    agent.provider = "zai"
+    agent.max_iterations = 60
+
+    calls = {"n": 0}
+    remaining = list(summary_contents)
+
+    class _Completions:
+        def create(self, **_kwargs):
+            calls["n"] += 1
+            return "RAW-RESPONSE"
+
+    agent._ensure_primary_openai_client = lambda reason=None: types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=_Completions())
+    )
+    agent._get_transport = lambda: types.SimpleNamespace(
+        normalize_response=lambda _r: types.SimpleNamespace(
+            content=remaining.pop(0) if remaining else ""
+        )
+    )
+    return agent, calls
+
+
+def _run(agent):
+    from agent.chat_completion_helpers import handle_max_iterations
+
+    return handle_max_iterations(agent, [], api_call_count=1)
+
+
+def test_initial_summary_branch_strips_leaked_tool_call_xml():
+    agent, calls = _make_agent([LEAKY_SUMMARY])
+
+    result = _run(agent)
+
+    assert "Here is what I found." in result
+    assert "<tool_call>" not in result
+    assert "<think>" not in result
+    assert calls["n"] == 1, "expected the initial branch only"
+
+
+def test_retry_summary_branch_strips_leaked_tool_call_xml():
+    # The first attempt yields nothing usable, so the retry branch runs — that
+    # branch's sanitizer is what this test pins.
+    agent, calls = _make_agent(["", LEAKY_SUMMARY])
+
+    result = _run(agent)
+
+    assert calls["n"] == 2, "retry branch did not run; test would not cover it"
+    assert "Here is what I found." in result
+    assert "<tool_call>" not in result
+    assert "<think>" not in result
+
+
+@pytest.mark.parametrize("contents", [[LEAKY_SUMMARY], ["", LEAKY_SUMMARY]])
+def test_summary_never_leaks_xml_on_either_branch(contents):
+    agent, _calls = _make_agent(contents)
+
+    result = _run(agent)
+
+    for marker in ("<tool_call>", "</tool_call>", "<function_call>", "<think>"):
+        assert marker not in result
+
+
+def test_summary_that_is_only_leaked_xml_falls_back_to_plain_notice():
+    # Sanitizing can empty the summary entirely; the user must still get a
+    # sentence rather than an empty message.
+    agent, _calls = _make_agent(['<tool_call>{"name": "x"}</tool_call>'])
+
+    result = _run(agent)
+
+    assert result.strip()
+    assert "<tool_call>" not in result


### PR DESCRIPTION
## Problem

When a turn hits `max_iterations`, `handle_max_iterations()` makes a final summary call **without tools bound** and cleans the response with an inline `<think>`-only regex — bypassing the canonical `strip_think_blocks()` sanitizer used on the normal response path.

Open models emit their native tool-call template as plain content when they "want" to call a tool but none are bound. Observed live with `glm-4.5-flash` (z.ai, provider `zai`): after 30 tool iterations the summary call returned

```
🌙 ...greeting text...
<tool_call>terminal
<arg_key>command</arg_key>
<arg_value>python3 .../knowledge.py ...</arg_value>
</tool_call>
```

The `<think>`-only cleanup left this untouched and the raw template was delivered to the end user verbatim (Telegram cron delivery). During the 30 in-loop calls (tools bound) the same model returned clean structured `tool_calls` — the leak is specific to the toolless summary path.

## Fix

Both summary branches (first attempt and retry) now run the canonical `agent._strip_think_blocks()`, which already strips `<tool_call>`/`<function_call>`/`<tool_result>`-style blocks plus all reasoning-tag variants — a strict superset of the old inline regex.

## Verification

- `strip_think_blocks(None, <the real leaked message>)` returns the clean greeting only (no `<tool_call`, no `<arg_key>`), verified against the exact delivered string.
- `python -m py_compile agent/chat_completion_helpers.py` passes.
- Running patched in production on our instance since 2026-07-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
