### PR TITLE
feat(guardrails): detect degenerate loops of successful mutating tool calls

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -77,6 +77,14 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    # Mutating tools get higher thresholds than idempotent reads: an identical
+    # successful call CAN be intentional (append, poll-with-side-effect), but a
+    # byte-identical args+result pair repeated many times in one turn is a
+    # degenerate generation loop (seen live: glm-4.5-flash repeating the same
+    # terminal call 30x to the iteration cap because success made it invisible
+    # to the failure-based counters).
+    mutating_no_progress_warn_after: int = 3
+    mutating_no_progress_block_after: int = 8
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
 
@@ -120,6 +128,14 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            mutating_no_progress_warn_after=_positive_int(
+                warn_after.get("mutating_no_progress", data.get("mutating_no_progress_warn_after")),
+                defaults.mutating_no_progress_warn_after,
+            ),
+            mutating_no_progress_block_after=_positive_int(
+                hard_stop_after.get("mutating_no_progress", data.get("mutating_no_progress_block_after")),
+                defaults.mutating_no_progress_block_after,
             ),
         )
 
@@ -260,11 +276,12 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
-        if self._is_idempotent(tool_name):
+        progress_class = self._progress_class(tool_name)
+        if progress_class is not None:
             record = self._no_progress.get(signature)
             if record is not None:
                 _result_hash, repeat_count = record
-                if repeat_count >= self.config.no_progress_block_after:
+                if progress_class == "idempotent" and repeat_count >= self.config.no_progress_block_after:
                     decision = ToolGuardrailDecision(
                         action="block",
                         code="idempotent_no_progress_block",
@@ -272,6 +289,22 @@ class ToolCallGuardrailController:
                             f"Blocked {tool_name}: this read-only call returned the same "
                             f"result {repeat_count} times. Stop repeating it unchanged; "
                             "use the result already provided or try a different query."
+                        ),
+                        tool_name=tool_name,
+                        count=repeat_count,
+                        signature=signature,
+                    )
+                    self._halt_decision = decision
+                    return decision
+                if progress_class == "mutating" and repeat_count >= self.config.mutating_no_progress_block_after:
+                    decision = ToolGuardrailDecision(
+                        action="block",
+                        code="mutating_no_progress_block",
+                        message=(
+                            f"Blocked {tool_name}: the same call with identical arguments "
+                            f"succeeded with identical output {repeat_count} times. This is "
+                            "a degenerate loop; act on the output you already have or change "
+                            "the command."
                         ),
                         tool_name=tool_name,
                         count=repeat_count,
@@ -347,7 +380,8 @@ class ToolCallGuardrailController:
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
-        if not self._is_idempotent(tool_name):
+        progress_class = self._progress_class(tool_name)
+        if progress_class is None:
             self._no_progress.pop(signature, None)
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -358,26 +392,47 @@ class ToolCallGuardrailController:
             repeat_count = previous[1] + 1
         self._no_progress[signature] = (result_hash, repeat_count)
 
-        if self.config.warnings_enabled and repeat_count >= self.config.no_progress_warn_after:
-            return ToolGuardrailDecision(
-                action="warn",
-                code="idempotent_no_progress_warning",
-                message=(
-                    f"{tool_name} returned the same result {repeat_count} times. "
-                    "Use the result already provided or change the query instead of "
-                    "repeating it unchanged."
-                ),
-                tool_name=tool_name,
-                count=repeat_count,
-                signature=signature,
-            )
+        if progress_class == "idempotent":
+            if self.config.warnings_enabled and repeat_count >= self.config.no_progress_warn_after:
+                return ToolGuardrailDecision(
+                    action="warn",
+                    code="idempotent_no_progress_warning",
+                    message=(
+                        f"{tool_name} returned the same result {repeat_count} times. "
+                        "Use the result already provided or change the query instead of "
+                        "repeating it unchanged."
+                    ),
+                    tool_name=tool_name,
+                    count=repeat_count,
+                    signature=signature,
+                )
+        else:
+            if self.config.warnings_enabled and repeat_count >= self.config.mutating_no_progress_warn_after:
+                return ToolGuardrailDecision(
+                    action="warn",
+                    code="mutating_no_progress_warning",
+                    message=(
+                        f"{tool_name} succeeded with identical arguments and identical "
+                        f"output {repeat_count} times. This looks like a generation loop; "
+                        "act on the output already provided, change the command, or move on."
+                    ),
+                    tool_name=tool_name,
+                    count=repeat_count,
+                    signature=signature,
+                )
 
         return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
 
     def _is_idempotent(self, tool_name: str) -> bool:
+        return self._progress_class(tool_name) == "idempotent"
+
+    def _progress_class(self, tool_name: str) -> str | None:
+        """'idempotent' | 'mutating' | None (unknown tools are not tracked)."""
         if tool_name in self.config.mutating_tools:
-            return False
-        return tool_name in self.config.idempotent_tools
+            return "mutating"
+        if tool_name in self.config.idempotent_tools:
+            return "idempotent"
+        return None
 
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -379,10 +379,16 @@ tool_loop_guardrails:
     exact_failure: 2
     same_tool_failure: 3
     idempotent_no_progress: 2
+    # Mutating tools (write_file, terminal, …) get a looser threshold than
+    # idempotent reads: an identical successful call CAN be intentional
+    # (append, poll-with-side-effect). Byte-identical args AND result many
+    # times over is still a degenerate loop.
+    mutating_no_progress: 3
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    mutating_no_progress: 8
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1326,11 +1326,13 @@ DEFAULT_CONFIG = {
             "exact_failure": 2,
             "same_tool_failure": 3,
             "idempotent_no_progress": 2,
+            "mutating_no_progress": 3,
         },
         "hard_stop_after": {
             "exact_failure": 5,
             "same_tool_failure": 8,
             "idempotent_no_progress": 5,
+            "mutating_no_progress": 8,
         },
     },
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -228,16 +228,59 @@ def test_hard_stop_enabled_blocks_idempotent_no_progress_future_repeat():
     assert blocked.code == "idempotent_no_progress_block"
 
 
-def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
+def test_unknown_tools_are_never_tracked_for_repeated_identical_success_output():
     controller = ToolCallGuardrailController(
-        ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            mutating_no_progress_warn_after=2,
+            mutating_no_progress_block_after=2,
+        )
     )
 
-    for _ in range(3):
-        assert controller.before_call("write_file", {"path": "/tmp/x", "content": "x"}).action == "allow"
-        assert controller.after_call("write_file", {"path": "/tmp/x", "content": "x"}, "ok", failed=False).action == "allow"
+    for _ in range(6):
         assert controller.before_call("custom_tool", {"x": 1}).action == "allow"
         assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
+
+
+def test_mutating_tools_warn_then_block_on_repeated_identical_success_output():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            mutating_no_progress_warn_after=2,
+            mutating_no_progress_block_after=3,
+        )
+    )
+    args = {"path": "/tmp/x", "content": "x"}
+
+    assert controller.after_call("write_file", args, "ok", failed=False).action == "allow"
+    warn = controller.after_call("write_file", args, "ok", failed=False)
+    assert warn.action == "warn"
+    assert warn.code == "mutating_no_progress_warning"
+    assert controller.after_call("write_file", args, "ok", failed=False).count == 3
+
+    blocked = controller.before_call("write_file", args)
+    assert blocked.action == "block"
+    assert blocked.code == "mutating_no_progress_block"
+    assert controller.halt_decision is blocked
+
+    # Changing output resets the streak: identical args with fresh results are
+    # legitimate repeats (append, poll-with-side-effect) and must stay allowed.
+    controller.reset_for_turn()
+    for i in range(5):
+        assert controller.before_call("write_file", args).action == "allow"
+        assert controller.after_call("write_file", args, f"ok-{i}", failed=False).action == "allow"
+
+
+def test_mutating_tools_only_warn_on_repeated_identical_success_when_hard_stop_disabled():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=False, mutating_no_progress_warn_after=2)
+    )
+    args = {"command": "echo hi"}
+
+    for i in range(1, 8):
+        assert controller.before_call("terminal", args).action == "allow"
+        decision = controller.after_call("terminal", args, '{"exit_code":0,"output":"hi"}', failed=False)
+        assert decision.action == ("warn" if i >= 2 else "allow"), (i, decision.action)
 
 
 def test_reset_for_turn_clears_bounded_guardrail_state():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -353,3 +353,121 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Mutating no-progress guardrail (#58221)
+#
+# Successful calls to a MUTATING tool were never tracked: the controller
+# cleared `_no_progress` for any non-idempotent tool, so a model repeating a
+# byte-identical `terminal` call with byte-identical output ran to the
+# iteration cap unchallenged (observed live: glm-4.5-flash, 30 repeats).
+#
+# The reviewer asked for coverage of the nested config parsing and of the
+# agent executor path, not just the controller in isolation.
+# ---------------------------------------------------------------------------
+
+TERMINAL_ARGS = {"command": "ls /tmp"}
+TERMINAL_OUTPUT = json.dumps({"exit_code": 0, "output": "same"})
+
+
+def _mutating_config(warn_after: int = 3, block_after: int = 8, hard_stop: bool = True) -> dict:
+    return {
+        "tool_loop_guardrails": {
+            "warnings_enabled": True,
+            "hard_stop_enabled": hard_stop,
+            "warn_after": {"mutating_no_progress": warn_after},
+            "hard_stop_after": {"mutating_no_progress": block_after},
+        }
+    }
+
+
+def _seed_identical_successes(agent, tool_name, args, output, count):
+    for _ in range(count):
+        agent._tool_guardrails.after_call(tool_name, args, output, failed=False)
+
+
+def test_nested_mutating_thresholds_are_parsed_from_config():
+    agent = _make_agent("terminal", config=_mutating_config(warn_after=4, block_after=9))
+
+    cfg = agent._tool_guardrails.config
+
+    assert cfg.mutating_no_progress_warn_after == 4
+    assert cfg.mutating_no_progress_block_after == 9
+
+
+def test_mutating_thresholds_fall_back_to_defaults_when_absent():
+    # A config that omits the nested keys must not disturb the shipped
+    # defaults, which is what every existing install has.
+    agent = _make_agent("terminal", config={"tool_loop_guardrails": {"warnings_enabled": True}})
+
+    cfg = agent._tool_guardrails.config
+
+    assert cfg.mutating_no_progress_warn_after == 3
+    assert cfg.mutating_no_progress_block_after == 8
+
+
+def test_runtime_warns_on_repeated_identical_successful_terminal_output():
+    agent = _make_agent("terminal", config=_mutating_config(warn_after=2, block_after=8))
+    _seed_identical_successes(agent, "terminal", TERMINAL_ARGS, TERMINAL_OUTPUT, count=1)
+    tc = _mock_tool_call("terminal", json.dumps(TERMINAL_ARGS), "c-mut-warn")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=TERMINAL_OUTPUT) as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-mut-warn")
+
+    mock_hfc.assert_called_once()
+    assert [m["role"] for m in messages] == ["tool"]
+    assert messages[0]["tool_call_id"] == "c-mut-warn"
+    assert "mutating_no_progress_warning" in messages[0]["content"]
+    assert "mutating_no_progress_block" not in messages[0]["content"]
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_runtime_blocks_repeated_identical_successful_terminal_output():
+    agent = _make_agent("terminal", config=_mutating_config(warn_after=2, block_after=3))
+    _seed_identical_successes(agent, "terminal", TERMINAL_ARGS, TERMINAL_OUTPUT, count=3)
+    tc = _mock_tool_call("terminal", json.dumps(TERMINAL_ARGS), "c-mut-block")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-mut-block")
+
+    mock_hfc.assert_not_called()
+    assert [m["role"] for m in messages] == ["tool"]
+    assert messages[0]["tool_call_id"] == "c-mut-block"
+    assert "mutating_no_progress_block" in messages[0]["content"]
+
+
+def test_runtime_changed_output_resets_the_mutating_streak():
+    # Identical arguments with a FRESH result are legitimate (append, poll with
+    # a side effect) and must never be blocked — this is the property that
+    # separates the mutating counter from the idempotent one.
+    agent = _make_agent("terminal", config=_mutating_config(warn_after=2, block_after=3))
+    _seed_identical_successes(agent, "terminal", TERMINAL_ARGS, TERMINAL_OUTPUT, count=2)
+
+    fresh = json.dumps({"exit_code": 0, "output": "different"})
+    agent._tool_guardrails.after_call("terminal", TERMINAL_ARGS, fresh, failed=False)
+
+    tc = _mock_tool_call("terminal", json.dumps(TERMINAL_ARGS), "c-mut-reset")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=fresh) as mock_hfc:
+        agent._execute_tool_calls_sequential(msg, messages, "task-mut-reset")
+
+    mock_hfc.assert_called_once()
+    assert "mutating_no_progress_block" not in messages[0]["content"]
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_idempotent_tools_keep_their_own_lower_thresholds():
+    # The mutating knobs must not bleed into the idempotent counter: a read
+    # tool repeating an identical result still trips at its own threshold.
+    agent = _make_agent("read_file", config=_mutating_config(warn_after=3, block_after=8))
+    cfg = agent._tool_guardrails.config
+
+    assert cfg.no_progress_warn_after == 2
+    assert cfg.no_progress_block_after == 5

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1356,11 +1356,19 @@ tool_loop_guardrails:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
     idempotent_no_progress: 2  # same result, no progress, N times
+    mutating_no_progress: 3    # same for mutating tools (write_file, terminal, …)
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    mutating_no_progress: 8
 ```
+
+Mutating tools carry looser thresholds than idempotent reads: an identical
+successful call *can* be intentional (an append, a poll with a side effect).
+Byte-identical arguments **and** byte-identical output repeated many times in
+one turn is a degenerate generation loop, which the failure-based counters
+above cannot see because every call "succeeded".
 
 `hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
 


### PR DESCRIPTION
## Problem

The tool-loop guardrails count **failed** calls (`exact_failure`, `same_tool_failure`) and no-progress repeats of **idempotent** tools. A successful identical call of a *mutating* tool explicitly resets tracking (`after_call` pops the signature). A model stuck in a degenerate generation loop that repeats the same *successful* mutating call is therefore invisible to the circuit breaker.

Live incident: `glm-4.5-flash` repeated one byte-identical `terminal` call (exit 0, byte-identical output) **30 times straight** to the iteration cap — every repeat succeeded, so no counter ever fired. The turn burned 30 API calls and fell into the max-iterations fallback path.

## Change

New `mutating_no_progress` category: track `(signature, result-hash)` streaks for tools in `MUTATING_TOOL_NAMES`, warn after 3 identical successes, hard-block after 8. Config mirrors the existing knobs (hard-block still requires `hard_stop_enabled`):

```yaml
tool_loop_guardrails:
  warn_after:
    mutating_no_progress: 3
  hard_stop_after:
    mutating_no_progress: 8
```

Design notes:

- Default thresholds are deliberately **higher** than the idempotent ones (3/8 vs 2/5): an identical successful mutating call *can* be intentional (append, poll-with-side-effect).
- A changed output resets the streak, so legitimate identical-args repeats with fresh results stay allowed.
- Unknown tools (in neither set) remain untracked; failure paths and idempotent behavior are byte-for-byte unchanged.

## Tests

- Replaced `test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default` — it froze the blind spot — with three tests: unknown tools never tracked; warn→block for mutating identical successes incl. streak reset on changed output; warn-only when `hard_stop_enabled` is off.
- Full module suite passes: 15/15.
- Running patched in production on our instance since 2026-07-04 (thresholds 3/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
