### PR TITLE
fix(desktop): keep repo scans on originating profile

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -6,6 +6,7 @@ import {
   $activeProjectId,
   $projectScope,
   $projectsRpcAvailable,
+  $projectTree,
   $worktreeRefreshToken,
   ALL_PROJECTS,
   createProject,
@@ -14,7 +15,8 @@ import {
   openProjectCreate,
   pickProjectFolder,
   refreshProjects,
-  refreshWorktrees
+  refreshWorktrees,
+  scanAndRecordRepos
 } from './projects'
 
 vi.mock('@/i18n', () => ({
@@ -32,6 +34,10 @@ vi.mock('@/lib/desktop-fs', () => ({
   writeDesktopFileText: vi.fn()
 }))
 
+vi.mock('@/lib/desktop-git', () => ({
+  desktopGit: vi.fn()
+}))
+
 vi.mock('@/store/gateway', () => ({
   activeGateway: vi.fn(),
   ensureActiveGatewayOpen: vi.fn()
@@ -41,6 +47,9 @@ const fs = await import('@/lib/desktop-fs')
 const desktopDefaultCwd = vi.mocked(fs.desktopDefaultCwd)
 const isDesktopFsRemoteMode = vi.mocked(fs.isDesktopFsRemoteMode)
 const selectDesktopPaths = vi.mocked(fs.selectDesktopPaths)
+
+const git = await import('@/lib/desktop-git')
+const desktopGit = vi.mocked(git.desktopGit)
 
 const gw = await import('@/store/gateway')
 const activeGateway = vi.mocked(gw.activeGateway)
@@ -192,5 +201,90 @@ describe('projects RPC capability', () => {
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'warning', message: 'sidebar.projects.staleBackend' })
     )
+  })
+})
+
+describe('repo discovery scan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('records scan results on the gateway that was active when the scan started', async () => {
+    let finishScan: (repos: Array<{ label: string; root: string }>) => void = () => undefined
+
+    const scanRepos = vi.fn(
+      () =>
+        new Promise<Array<{ label: string; root: string }>>(resolve => {
+          finishScan = resolve
+        })
+    )
+
+    const profileARequest = vi.fn(async () => ({ active_id: null, projects: [], repos: [], scoped_session_ids: [] }))
+    const profileBRequest = vi.fn(async () => ({ active_id: null, projects: [], repos: [], scoped_session_ids: [] }))
+    const profileAGateway = { connectionState: 'open', request: profileARequest }
+    const profileBGateway = { connectionState: 'open', request: profileBRequest }
+
+    desktopGit.mockReturnValue({ scanRepos } as never)
+    activeGateway.mockReturnValue(profileAGateway as never)
+
+    const pending = scanAndRecordRepos(true)
+
+    await Promise.resolve()
+
+    expect(scanRepos).toHaveBeenCalled()
+
+    activeGateway.mockReturnValue(profileBGateway as never)
+    finishScan([{ label: 'alpha', root: '/work/alpha' }])
+
+    await pending
+
+    expect(profileARequest).toHaveBeenCalledWith('projects.record_repos', {
+      repos: [{ label: 'alpha', root: '/work/alpha' }]
+    })
+    expect(profileBRequest).not.toHaveBeenCalled()
+  })
+
+  it('does not publish a late tree response after the active gateway changes', async () => {
+    let finishTree: (payload: {
+      active_id: string
+      projects: never[]
+      scoped_session_ids: string[]
+    }) => void = () => undefined
+
+    const treeResponse = new Promise<{
+      active_id: string
+      projects: never[]
+      scoped_session_ids: string[]
+    }>(resolve => {
+      finishTree = resolve
+    })
+
+    const profileARequest = vi.fn((method: string) => {
+      if (method === 'projects.tree') {
+        return treeResponse
+      }
+
+      return Promise.resolve({})
+    })
+
+    const profileAGateway = { connectionState: 'open', request: profileARequest }
+    const profileBGateway = { connectionState: 'open', request: vi.fn() }
+
+    desktopGit.mockReturnValue({ scanRepos: vi.fn(async () => []) } as never)
+    activeGateway.mockReturnValue(profileAGateway as never)
+    $projectTree.set([])
+    $activeProjectId.set('profile-b-project')
+
+    const pending = scanAndRecordRepos(true)
+
+    await vi.waitFor(() => {
+      expect(profileARequest).toHaveBeenCalledWith('projects.tree', { preview_limit: 3 })
+    })
+    activeGateway.mockReturnValue(profileBGateway as never)
+    finishTree({ active_id: 'profile-a-project', projects: [], scoped_session_ids: [] })
+    await pending
+
+    expect($activeProjectId.get()).toBe('profile-b-project')
+    expect($projectTree.get()).toEqual([])
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -28,6 +28,7 @@ export const $activeProjectId = atom<null | string>(null)
 // source of project membership — the desktop no longer derives it.
 export const $projectTree = atom<SidebarProjectTree[]>([])
 export const $projectTreeLoading = atom(false)
+let projectTreeRefreshId = 0
 
 // False when the connected backend predates the projects.* JSON-RPC surface
 // (same semver label, older install). Null until the first probe.
@@ -46,6 +47,8 @@ function markProjectsRpcFailure(err: unknown): void {
 function projectsStaleBackendError(): Error {
   return new Error(translateNow('sidebar.projects.staleBackend'))
 }
+
+type ProjectsGateway = NonNullable<ReturnType<typeof activeGateway>>
 
 // Client-side cache eviction (Apollo-style optimistic layer): ids the user just
 // deleted/archived. The backend tree is a snapshot that still lists them until
@@ -227,6 +230,28 @@ async function gatewayRequest<T>(method: string, params: Record<string, unknown>
   return gateway.request<T>(method, params)
 }
 
+async function activeProjectsGateway(): Promise<ProjectsGateway> {
+  let gateway = activeGateway()
+
+  if (!gateway || gateway.connectionState !== 'open') {
+    gateway = await ensureActiveGatewayOpen()
+  }
+
+  if (!gateway) {
+    throw new Error('Hermes gateway is not connected')
+  }
+
+  return gateway
+}
+
+async function gatewayRequestOn<T>(
+  gateway: ProjectsGateway,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<T> {
+  return gateway.request<T>(method, params)
+}
+
 function applyPayload(payload: ProjectsPayload): void {
   $projects.set(payload.projects ?? [])
   $activeProjectId.set(payload.active_id ?? null)
@@ -254,10 +279,30 @@ interface ProjectTreePayload {
 // sessions + the scoped-session-id set). Best-effort: a failure leaves the
 // cached tree intact so the sidebar doesn't flicker.
 export async function refreshProjectTree(): Promise<void> {
+  let gateway: ProjectsGateway
+
+  try {
+    gateway = await activeProjectsGateway()
+  } catch (err) {
+    markProjectsRpcFailure(err)
+
+    return
+  }
+
+  await refreshProjectTreeOn(gateway)
+}
+
+async function refreshProjectTreeOn(gateway: ProjectsGateway): Promise<void> {
+  const refreshId = ++projectTreeRefreshId
   $projectTreeLoading.set(true)
 
   try {
-    const res = await gatewayRequest<ProjectTreePayload>('projects.tree', { preview_limit: 3 })
+    const res = await gatewayRequestOn<ProjectTreePayload>(gateway, 'projects.tree', { preview_limit: 3 })
+
+    if (activeGateway() !== gateway) {
+      return
+    }
+
     // The flat Sessions list shows everything; scoped ids are only used here to
     // reconcile the optimistic eviction layer against what the server still lists.
     const scoped = new Set(res.scoped_session_ids ?? [])
@@ -280,10 +325,14 @@ export async function refreshProjectTree(): Promise<void> {
 
     markProjectsRpcSuccess()
   } catch (err) {
-    markProjectsRpcFailure(err)
+    if (activeGateway() === gateway) {
+      markProjectsRpcFailure(err)
+    }
     // Backend may not be ready; keep the last known tree.
   } finally {
-    $projectTreeLoading.set(false)
+    if (refreshId === projectTreeRefreshId) {
+      $projectTreeLoading.set(false)
+    }
   }
 }
 
@@ -318,10 +367,15 @@ export async function scanAndRecordRepos(force = false): Promise<void> {
   $reposScanning.set(true)
 
   try {
+    const gateway = await activeProjectsGateway()
     const repos = await scan([])
-    await gatewayRequest('projects.record_repos', { repos })
+
+    await gatewayRequestOn(gateway, 'projects.record_repos', { repos })
     // The disk scan may surface new zero-session repos; refold them into the tree.
-    await refreshProjectTree()
+
+    if (activeGateway() === gateway) {
+      await refreshProjectTreeOn(gateway)
+    }
   } catch {
     didScanRepos = false // let a later open retry a failed scan
   } finally {


### PR DESCRIPTION
## Summary

Addresses #58215.

The desktop project sidebar kicks off a local git repo scan in the background, then records those results through the currently active JSON-RPC gateway. If the user switches profiles while that scan is still in flight, the completion path can resolve the *new* active gateway and write the scan results into the wrong profile's `projects.db` via `projects.record_repos`.

This keeps the scan tied to the profile/gateway that was active when the scan started:

- capture the active projects gateway before starting the async disk scan
- send `projects.record_repos` back through that same gateway when the scan completes
- only refresh the visible project tree afterward if the user is still on that gateway

I kept this client-side and did not change the `discovered_repos` schema. Each profile already has its own `projects.db`; the leak fixed here is the renderer completing an async scan against a different active profile than the one that started it.

## Tests

- `NODE_OPTIONS="--localstorage-file=/tmp/hermes-vitest-localstorage.json" npm --workspace apps/desktop run test:ui -- src/store/projects.test.ts`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop exec eslint src/store/projects.ts src/store/projects.test.ts`
- `git diff --check`
